### PR TITLE
Fix command parsing in eval script generator

### DIFF
--- a/factory/discovery/generate.py
+++ b/factory/discovery/generate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 from factory.models import EvalDimension, EvalProfile
@@ -31,7 +32,7 @@ import sys
 def _generate_eval_function(dim: EvalDimension) -> str:
     """Generate a Python function for one eval dimension."""
     fn_name = f"eval_{dim.name}"
-    parts = dim.command.split()
+    parts = shlex.split(dim.command)
     cmd_list = repr(parts)
 
     return f'''\

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,6 +5,7 @@
 from factory.discovery.introspect import introspect_project
 from factory.discovery.profile import build_eval_profile
 from factory.discovery.generate import generate_eval_script, write_eval_script
+from factory.models import EvalDimension, EvalProfile
 
 
 class TestIntrospect:
@@ -125,3 +126,39 @@ class TestGenerateEvalScript:
         script = generate_eval_script(profile)
         for dim in profile.dimensions:
             assert f"eval_{dim.name}" in script
+
+    def test_command_with_quoted_args(self):
+        dim = EvalDimension(
+            name="integration",
+            command='uv run pytest -k "test_integration"',
+            weight=1.0,
+            parser="exit_code",
+            description="Run integration tests",
+            source="discovered",
+        )
+        profile = EvalProfile(
+            project_type="cli_tool",
+            dimensions=[dim],
+            tier="discovered",
+            confidence=0.8,
+        )
+        script = generate_eval_script(profile)
+        assert "['uv', 'run', 'pytest', '-k', 'test_integration']" in script
+
+    def test_simple_command(self):
+        dim = EvalDimension(
+            name="unit",
+            command="uv run pytest -v",
+            weight=1.0,
+            parser="exit_code",
+            description="Run unit tests",
+            source="discovered",
+        )
+        profile = EvalProfile(
+            project_type="cli_tool",
+            dimensions=[dim],
+            tier="discovered",
+            confidence=0.8,
+        )
+        script = generate_eval_script(profile)
+        assert "['uv', 'run', 'pytest', '-v']" in script


### PR DESCRIPTION
## Summary
- Replace `command.split()` with `shlex.split(command)` in `factory/discovery/generate.py` to correctly handle quoted arguments in eval commands
- Add two test cases: one for commands with quoted args (`pytest -k "test_integration"`), one regression test for simple commands

## Test plan
- [x] All 17 tests pass (`uv run pytest tests/test_discovery.py -v`)
- [x] Ruff clean
- [x] Mypy clean

Factory experiment #4. Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)