### PR TITLE
Add factory study command

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -174,6 +174,21 @@ def cmd_notify(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_study(args: argparse.Namespace) -> int:
+    from factory.study import study_project
+
+    project_path = Path(args.path)
+    summary = study_project(project_path)
+
+    # Write to .factory/strategy/observations.md
+    obs_path = project_path / ".factory" / "strategy" / "observations.md"
+    obs_path.parent.mkdir(parents=True, exist_ok=True)
+    obs_path.write_text(summary)
+
+    print(summary)
+    return 0
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     project_path = Path(args.path).resolve()
     try:
@@ -250,6 +265,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("notify", help="Send Telegram digest")
     p.add_argument("path", help="Path to the project")
 
+    # study
+    p = sub.add_parser("study", help="Read interaction logs and write observations")
+    p.add_argument("path", help="Path to the project")
+
     # run
     p = sub.add_parser("run", help="Cron entry: invoke claude -p with factory skill")
     p.add_argument("path", help="Path to the project")
@@ -275,6 +294,7 @@ def main(argv: list[str] | None = None) -> int:
         "finalize": cmd_finalize,
         "history": cmd_history,
         "notify": cmd_notify,
+        "study": cmd_study,
         "run": cmd_run,
     }
 

--- a/factory/study.py
+++ b/factory/study.py
@@ -1,0 +1,114 @@
+"""Study prior interaction logs to inform factory hypotheses."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _path_to_slug(project_path: Path) -> str:
+    """Convert a project path to Claude's directory slug format.
+
+    Claude replaces all non-alphanumeric chars (except -) with -.
+    e.g. /Users/akash/cursor-projects/cloud-gateway
+      -> -Users-akash-cursor-projects-cloud-gateway
+    """
+    return "".join(c if c.isalnum() or c == "-" else "-" for c in str(project_path))
+
+
+def _find_log_files(project_path: Path) -> list[Path]:
+    """Find Claude conversation logs matching this project."""
+    claude_projects = Path.home() / ".claude" / "projects"
+    slug = _path_to_slug(project_path.resolve())
+
+    project_dir = claude_projects / slug
+    if not project_dir.exists():
+        logger.warning("No Claude project directory found at %s", project_dir)
+        return []
+
+    return sorted(project_dir.glob("*.jsonl"))
+
+
+def _extract_messages(log_file: Path) -> list[dict]:
+    """Extract user messages and errors from a JSONL log file."""
+    messages: list[dict] = []
+    with open(log_file) as f:
+        for line in f:
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            msg_type = msg.get("type", "")
+            content = msg.get("message", {}).get("content", "")
+
+            text = ""
+            if isinstance(content, str):
+                text = content
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text += block["text"]
+
+            text = text.strip()
+            if not text or len(text) > 2000:
+                continue
+
+            # Skip system prompts and skill loads
+            if text.startswith("Base directory") or text.startswith("<task-notification"):
+                continue
+
+            if msg_type == "user":
+                messages.append({"role": "user", "text": text[:500]})
+            elif msg_type == "assistant":
+                # Extract error mentions
+                error_keywords = ["error", "failed", "bug", "fix", "broken"]
+                if any(kw in text.lower() for kw in error_keywords):
+                    error_lines = [
+                        line.strip()
+                        for line in text.split("\n")
+                        if any(kw in line.lower() for kw in error_keywords)
+                        and line.strip()
+                        and len(line.strip()) < 300
+                    ]
+                    for el in error_lines[:3]:
+                        messages.append({"role": "error", "text": el})
+
+    return messages
+
+
+def study_project(project_path: Path) -> str:
+    """Read interaction logs and produce an observations summary."""
+    log_files = _find_log_files(project_path)
+    if not log_files:
+        return "No interaction logs found."
+
+    all_messages: list[dict] = []
+    for lf in log_files:
+        all_messages.extend(_extract_messages(lf))
+
+    # Categorize
+    user_msgs = [m for m in all_messages if m["role"] == "user"]
+    errors = [m for m in all_messages if m["role"] == "error"]
+
+    lines = [
+        f"# Interaction Study — {project_path.name}",
+        "",
+        f"Analyzed {len(log_files)} conversation log(s), {len(all_messages)} relevant messages.",
+        "",
+        f"## User Messages ({len(user_msgs)})",
+    ]
+    for m in user_msgs:
+        lines.append(f"- {m['text'][:200]}")
+
+    lines.extend([
+        "",
+        f"## Errors and Issues ({len(errors)})",
+    ])
+    for m in errors:
+        lines.append(f"- {m['text'][:200]}")
+
+    return "\n".join(lines)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1,0 +1,231 @@
+"""Tests for factory.study — interaction log reading."""
+
+import json
+from pathlib import Path
+
+from factory.study import _path_to_slug, _find_log_files, _extract_messages, study_project
+
+
+class TestPathToSlug:
+    def test_simple_unix_path(self):
+        result = _path_to_slug(Path("/Users/akash/projects/my-app"))
+        assert result == "-Users-akash-projects-my-app"
+
+    def test_preserves_hyphens(self):
+        result = _path_to_slug(Path("/home/user/my-project"))
+        assert result == "-home-user-my-project"
+
+    def test_replaces_dots(self):
+        result = _path_to_slug(Path("/home/user/app.v2"))
+        assert result == "-home-user-app-v2"
+
+    def test_replaces_underscores(self):
+        result = _path_to_slug(Path("/home/user/my_project"))
+        assert result == "-home-user-my-project"
+
+    def test_replaces_spaces(self):
+        result = _path_to_slug(Path("/home/user/my project"))
+        assert result == "-home-user-my-project"
+
+
+class TestFindLogFiles:
+    def test_no_project_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = _find_log_files(tmp_path / "nonexistent")
+        assert result == []
+
+    def test_finds_jsonl_files(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project_path = tmp_path / "myapp"
+        project_path.mkdir()
+
+        slug = _path_to_slug(project_path.resolve())
+        log_dir = tmp_path / ".claude" / "projects" / slug
+        log_dir.mkdir(parents=True)
+
+        (log_dir / "conv1.jsonl").write_text("")
+        (log_dir / "conv2.jsonl").write_text("")
+        (log_dir / "other.txt").write_text("")  # should be ignored
+
+        result = _find_log_files(project_path)
+        assert len(result) == 2
+        assert all(f.suffix == ".jsonl" for f in result)
+
+    def test_returns_sorted(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project_path = tmp_path / "myapp"
+        project_path.mkdir()
+
+        slug = _path_to_slug(project_path.resolve())
+        log_dir = tmp_path / ".claude" / "projects" / slug
+        log_dir.mkdir(parents=True)
+
+        (log_dir / "b.jsonl").write_text("")
+        (log_dir / "a.jsonl").write_text("")
+
+        result = _find_log_files(project_path)
+        assert result[0].name == "a.jsonl"
+        assert result[1].name == "b.jsonl"
+
+
+class TestExtractMessages:
+    def test_extracts_user_messages(self, tmp_path):
+        log_file = tmp_path / "test.jsonl"
+        lines = [
+            json.dumps({"type": "user", "message": {"content": "Fix the login bug"}}),
+            json.dumps({"type": "user", "message": {"content": "Add dark mode"}}),
+        ]
+        log_file.write_text("\n".join(lines))
+
+        messages = _extract_messages(log_file)
+        user_msgs = [m for m in messages if m["role"] == "user"]
+        assert len(user_msgs) == 2
+        assert user_msgs[0]["text"] == "Fix the login bug"
+        assert user_msgs[1]["text"] == "Add dark mode"
+
+    def test_extracts_error_mentions(self, tmp_path):
+        log_file = tmp_path / "test.jsonl"
+        lines = [
+            json.dumps({
+                "type": "assistant",
+                "message": {"content": "I found an error in the config.\nThe import failed."},
+            }),
+        ]
+        log_file.write_text("\n".join(lines))
+
+        messages = _extract_messages(log_file)
+        errors = [m for m in messages if m["role"] == "error"]
+        assert len(errors) == 2
+        assert "error" in errors[0]["text"].lower()
+        assert "failed" in errors[1]["text"].lower()
+
+    def test_handles_content_blocks(self, tmp_path):
+        log_file = tmp_path / "test.jsonl"
+        lines = [
+            json.dumps({
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "Hello "},
+                        {"type": "text", "text": "world"},
+                    ],
+                },
+            }),
+        ]
+        log_file.write_text("\n".join(lines))
+
+        messages = _extract_messages(log_file)
+        assert len(messages) == 1
+        assert messages[0]["text"] == "Hello world"
+
+    def test_skips_invalid_json(self, tmp_path):
+        log_file = tmp_path / "test.jsonl"
+        log_file.write_text("not valid json\n{also bad")
+
+        messages = _extract_messages(log_file)
+        assert messages == []
+
+    def test_skips_long_messages(self, tmp_path):
+        log_file = tmp_path / "test.jsonl"
+        lines = [
+            json.dumps({"type": "user", "message": {"content": "x" * 2001}}),
+        ]
+        log_file.write_text("\n".join(lines))
+
+        messages = _extract_messages(log_file)
+        assert messages == []
+
+    def test_skips_system_prompts(self, tmp_path):
+        log_file = tmp_path / "test.jsonl"
+        lines = [
+            json.dumps({
+                "type": "user",
+                "message": {"content": "Base directory: /foo/bar"},
+            }),
+            json.dumps({
+                "type": "user",
+                "message": {"content": "<task-notification>something</task-notification>"},
+            }),
+        ]
+        log_file.write_text("\n".join(lines))
+
+        messages = _extract_messages(log_file)
+        assert messages == []
+
+    def test_truncates_user_text_to_500(self, tmp_path):
+        log_file = tmp_path / "test.jsonl"
+        long_text = "a" * 600
+        lines = [
+            json.dumps({"type": "user", "message": {"content": long_text}}),
+        ]
+        log_file.write_text("\n".join(lines))
+
+        messages = _extract_messages(log_file)
+        assert len(messages[0]["text"]) == 500
+
+
+class TestStudyProject:
+    def test_no_logs_returns_message(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        result = study_project(tmp_path / "nonexistent")
+        assert result == "No interaction logs found."
+
+    def test_produces_summary(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project_path = tmp_path / "myapp"
+        project_path.mkdir()
+
+        slug = _path_to_slug(project_path.resolve())
+        log_dir = tmp_path / ".claude" / "projects" / slug
+        log_dir.mkdir(parents=True)
+
+        lines = [
+            json.dumps({"type": "user", "message": {"content": "Add tests"}}),
+            json.dumps({
+                "type": "assistant",
+                "message": {"content": "The build failed due to a missing import."},
+            }),
+        ]
+        (log_dir / "conv.jsonl").write_text("\n".join(lines))
+
+        result = study_project(project_path)
+        assert "# Interaction Study" in result
+        assert "myapp" in result
+        assert "1 conversation log(s)" in result
+        assert "Add tests" in result
+        assert "Errors and Issues" in result
+
+
+class TestCmdStudy:
+    def test_study_cli_subcommand(self):
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["study", "/some/path"])
+        assert args.command == "study"
+        assert args.path == "/some/path"
+
+    def test_study_writes_observations(self, tmp_path, monkeypatch, capsys):
+        from factory.cli import main
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project_path = tmp_path / "myapp"
+        project_path.mkdir()
+
+        slug = _path_to_slug(project_path.resolve())
+        log_dir = tmp_path / ".claude" / "projects" / slug
+        log_dir.mkdir(parents=True)
+
+        lines = [
+            json.dumps({"type": "user", "message": {"content": "Hello world"}}),
+        ]
+        (log_dir / "conv.jsonl").write_text("\n".join(lines))
+
+        result = main(["study", str(project_path)])
+        assert result == 0
+
+        obs_path = project_path / ".factory" / "strategy" / "observations.md"
+        assert obs_path.exists()
+        content = obs_path.read_text()
+        assert "Hello world" in content
+        assert "Hello world" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Add `factory study <path>` command that reads Claude conversation logs from `~/.claude/projects/` and extracts user messages and error mentions
- Writes observations summary to `.factory/strategy/observations.md`
- 19 new tests covering slug encoding, log file discovery, JSONL parsing, and CLI integration

Factory experiment #5. Closes #11.

## Test plan
- [x] All 148 tests pass (`uv run pytest -v`)
- [x] Ruff lint passes
- [x] Mypy type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)