### PR TITLE
Fix experiment state persistence

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -189,6 +189,49 @@ def cmd_study(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_status(args: argparse.Namespace) -> int:
+    from factory.state import detect_state
+    from factory.store import ExperimentStore
+
+    project_path = Path(args.path).resolve()
+    state = detect_state(project_path)
+    print(f"Project: {project_path}")
+    print(f"State: {state.value}")
+
+    if state.value == "has_factory":
+        store = ExperimentStore(project_path)
+        try:
+            config = _run(store.read_config())
+        except FileNotFoundError:
+            config = None
+
+        # Try to read latest eval score
+        profile = _run(store.read_eval_profile())
+        if profile:
+            dims = ", ".join(d.name for d in profile.dimensions)
+            print(f"Eval dimensions: {dims}")
+
+        records = _run(store.load_history())
+        if records:
+            kept = sum(1 for r in records if r.verdict == "keep")
+            reverted = sum(1 for r in records if r.verdict == "revert")
+            total = len(records)
+            print(f"Experiments: {total} total ({kept} kept, {reverted} reverted)")
+            last = records[-1]
+            print(f'Last experiment: #{last.id} — "{last.hypothesis}" ({last.verdict})')
+            scores = [r.score_after for r in records if r.score_after is not None]
+            if scores:
+                print(f"Latest score: {scores[-1]:.3f}")
+        else:
+            print("Experiments: none")
+
+        if config:
+            print(f"Goal: {config.goal}")
+
+    return 0
+
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     project_path = Path(args.path).resolve()
     try:
@@ -269,6 +312,11 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("study", help="Read interaction logs and write observations")
     p.add_argument("path", help="Path to the project")
 
+    # status
+    p = sub.add_parser("status", help="Print project status summary")
+    p.add_argument("path", help="Path to the project")
+
+
     # run
     p = sub.add_parser("run", help="Cron entry: invoke claude -p with factory skill")
     p.add_argument("path", help="Path to the project")
@@ -295,6 +343,7 @@ def main(argv: list[str] | None = None) -> int:
         "history": cmd_history,
         "notify": cmd_notify,
         "study": cmd_study,
+        "status": cmd_status,
         "run": cmd_run,
     }
 

--- a/factory/store.py
+++ b/factory/store.py
@@ -129,11 +129,17 @@ class ExperimentStore:
         return max(ids) + 1 if ids else 1
 
     async def begin(self, hypothesis: str) -> int:
-        """Create experiments/NNN/hypothesis.md, return the experiment ID."""
+        """Create experiments/NNN/hypothesis.md, return the experiment ID.
+
+        Idempotent: if the next experiment dir already exists (e.g. from a
+        previous interrupted run), return its ID without crashing.
+        """
         exp_id = await self.next_id()
         exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
-        exp_dir.mkdir(parents=True)
-        (exp_dir / "hypothesis.md").write_text(hypothesis)
+        exp_dir.mkdir(parents=True, exist_ok=True)
+        hyp_path = exp_dir / "hypothesis.md"
+        if not hyp_path.exists():
+            hyp_path.write_text(hypothesis)
         return exp_id
 
     async def save_eval(
@@ -162,8 +168,12 @@ class ExperimentStore:
         (exp_dir / "changes.diff").write_text(result.stdout)
 
     async def finalize(self, exp_id: int, record: ExperimentRecord) -> None:
-        """Write verdict.json and append row to results.tsv."""
+        """Write verdict.json and append row to results.tsv.
+
+        Creates the experiment directory if it is missing (e.g. after git clean).
+        """
         exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
+        exp_dir.mkdir(parents=True, exist_ok=True)
         (exp_dir / "verdict.json").write_text(
             json.dumps(record.model_dump(), indent=2, default=str) + "\n"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,14 @@
 """Tests for factory.cli — CLI subcommand routing."""
 
+import asyncio
 import json
 import subprocess
+from datetime import datetime
 from unittest.mock import patch
 
 from factory.cli import main, build_parser
+from factory.models import ExperimentRecord
+from factory.store import ExperimentStore
 
 
 class TestParser:
@@ -73,6 +77,55 @@ class TestCmdDiscover:
         output = json.loads(capsys.readouterr().out)
         assert output["project"]["language"] == "python"
         assert output["eval_profile"]["tier"] in ("discovered", "researched", "fallback")
+
+
+class TestCmdStatus:
+    def test_status_parser(self):
+        parser = build_parser()
+        args = parser.parse_args(["status", "/some/path"])
+        assert args.command == "status"
+
+    def test_status_no_factory(self, tmp_project, capsys):
+        result = main(["status", str(tmp_project)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "no_factory" in out
+        assert str(tmp_project) in out
+
+    def test_status_with_factory(self, tmp_project, capsys, sample_config):
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+        exp_id = asyncio.run(store.begin("Improve performance"))
+        record = ExperimentRecord(
+            id=exp_id, timestamp=datetime.now(),
+            hypothesis="Improve performance",
+            change_summary="Optimized hot path",
+            issue_number=None, pr_number=None,
+            score_before=0.8, score_after=0.95, delta=0.15,
+            verdict="keep", cost_usd=None, notes="",
+        )
+        asyncio.run(store.finalize(exp_id, record))
+
+        result = main(["status", str(tmp_project)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "has_factory" in out
+        assert "1 total" in out
+        assert "1 kept" in out
+        assert "0 reverted" in out
+        assert "Improve performance" in out
+        assert "0.950" in out
+        assert sample_config.goal in out
+
+    def test_status_with_factory_no_experiments(self, tmp_project, capsys, sample_config):
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+
+        result = main(["status", str(tmp_project)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "has_factory" in out
+        assert "Experiments: none" in out
 
 
 class TestCmdHistory:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -133,6 +133,89 @@ class TestEvalProfile:
         assert await store.read_eval_profile() is None
 
 
+class TestStatePersistence:
+    """Tests for experiment state persistence edge cases (issue #12)."""
+
+    async def test_finalize_missing_experiment_dir(self, store, sample_config):
+        """finalize() should create the experiment dir if it was deleted (e.g. git clean)."""
+        await store.init(sample_config)
+        exp_id = await store.begin("H1")
+        # Simulate git clean wiping the experiment dir
+        exp_dir = store.factory_dir / "experiments" / f"{exp_id:03d}"
+        import shutil
+        shutil.rmtree(exp_dir)
+        assert not exp_dir.exists()
+
+        record = ExperimentRecord(
+            id=exp_id, timestamp=datetime.now(),
+            hypothesis="H1", change_summary="stuff",
+            issue_number=None, pr_number=None,
+            score_before=0.8, score_after=0.9, delta=0.1,
+            verdict="keep", cost_usd=None, notes="",
+        )
+        # Should NOT raise FileNotFoundError
+        await store.finalize(exp_id, record)
+        assert (exp_dir / "verdict.json").exists()
+
+    async def test_begin_idempotent_no_crash(self, store, sample_config):
+        """begin() does not crash if the experiment dir already exists."""
+        await store.init(sample_config)
+        exp_id = await store.begin("H1")
+        exp_dir = store.factory_dir / "experiments" / f"{exp_id:03d}"
+        assert exp_dir.exists()
+        # Calling begin() again should succeed (creates next experiment)
+        exp_id2 = await store.begin("H2")
+        assert exp_id2 == exp_id + 1
+
+    async def test_begin_does_not_overwrite_hypothesis(self, store, sample_config):
+        """begin() should not overwrite an existing hypothesis.md in the dir."""
+        await store.init(sample_config)
+        exp_id = await store.begin("Original")
+        exp_dir = store.factory_dir / "experiments" / f"{exp_id:03d}"
+        assert exp_dir.exists()
+        assert (exp_dir / "hypothesis.md").read_text() == "Original"
+        # Simulate a re-run: delete the hypothesis and call begin with same dir
+        # Since next_id skips past existing dirs, we test the mkdir exist_ok path
+        # by pre-creating the next dir before calling begin
+        next_id = exp_id + 1
+        next_dir = store.factory_dir / "experiments" / f"{next_id:03d}"
+        next_dir.mkdir(parents=True, exist_ok=True)
+        (next_dir / "hypothesis.md").write_text("Pre-existing")
+        # next_id() will see dirs 001 and 002, return 3
+        id3 = await store.begin("Third")
+        assert id3 == next_id + 1
+        # Pre-existing hypothesis should be untouched
+        assert (next_dir / "hypothesis.md").read_text() == "Pre-existing"
+
+    async def test_finalize_then_load_history_roundtrip(self, store, sample_config):
+        """finalize() followed by load_history() should return the same data."""
+        await store.init(sample_config)
+        exp_id = await store.begin("Increase coverage")
+        record = ExperimentRecord(
+            id=exp_id, timestamp=datetime(2025, 1, 15, 12, 0, 0),
+            hypothesis="Increase coverage",
+            change_summary="Added tests for edge cases",
+            issue_number=42, pr_number=99,
+            score_before=0.75, score_after=0.92, delta=0.17,
+            verdict="keep", cost_usd=1.23, notes="All green",
+        )
+        await store.finalize(exp_id, record)
+        history = await store.load_history()
+        assert len(history) == 1
+        loaded = history[0]
+        assert loaded.id == exp_id
+        assert loaded.hypothesis == "Increase coverage"
+        assert loaded.change_summary == "Added tests for edge cases"
+        assert loaded.issue_number == 42
+        assert loaded.pr_number == 99
+        assert loaded.score_before == 0.75
+        assert loaded.score_after == 0.92
+        assert loaded.delta == 0.17
+        assert loaded.verdict == "keep"
+        assert loaded.cost_usd == 1.23
+        assert loaded.notes == "All green"
+
+
 class TestStrategy:
     async def test_write_and_read_strategy(self, store, sample_config):
         await store.init(sample_config)


### PR DESCRIPTION
## Summary
- Make `store.finalize()` create experiment dir if missing (prevents `FileNotFoundError` after `git clean`)
- Make `store.begin()` idempotent with `exist_ok=True` and skip overwriting existing `hypothesis.md`
- Add `factory status` command showing project state, experiment summary, and latest score

## Test plan
- [x] `finalize()` with missing experiment dir creates dir and succeeds
- [x] `begin()` called when dir exists does not crash
- [x] `begin()` does not overwrite existing `hypothesis.md`
- [x] `finalize()` then `load_history()` roundtrip preserves all fields
- [x] `factory status` on project with factory prints state, experiments, score, goal
- [x] `factory status` on project without factory prints state
- [x] All 137 tests pass, ruff clean

Factory experiment #6. Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)