### PR TITLE
Increase test coverage above 80%

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,8 @@
 """Tests for factory.cli — CLI subcommand routing."""
 
 import json
-
+import subprocess
+from unittest.mock import patch
 
 from factory.cli import main, build_parser
 
@@ -83,3 +84,118 @@ class TestCmdHistory:
         result = main(["history", str(tmp_project)])
         assert result == 0
         assert "No experiments" in capsys.readouterr().out
+
+    def test_history_with_records(self, tmp_project, capsys, sample_config):
+        """history displays formatted table when records exist."""
+        import asyncio
+        from datetime import datetime
+        from factory.store import ExperimentStore
+        from factory.models import ExperimentRecord
+
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+        exp_id = asyncio.run(store.begin("Test hypothesis"))
+        record = ExperimentRecord(
+            id=exp_id,
+            timestamp=datetime.now(),
+            hypothesis="Test hypothesis",
+            change_summary="Changed stuff",
+            issue_number=None,
+            pr_number=None,
+            score_before=0.80,
+            score_after=0.85,
+            delta=0.05,
+            verdict="keep",
+            cost_usd=1.23,
+            notes="",
+        )
+        asyncio.run(store.finalize(exp_id, record))
+        result = main(["history", str(tmp_project)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "keep" in out
+        assert "Test hypothesis" in out
+
+
+class TestCmdRun:
+    def test_run_missing_claude_binary(self, tmp_path, capsys):
+        """cmd_run returns 1 when claude CLI is not found."""
+        with patch("factory.cli.subprocess.run", side_effect=FileNotFoundError):
+            result = main(["run", str(tmp_path)])
+        assert result == 1
+        assert "not found" in capsys.readouterr().err
+
+    def test_run_claude_nonzero_exit(self, tmp_path, capsys):
+        """cmd_run returns 1 when claude CLI exits non-zero."""
+        with patch(
+            "factory.cli.subprocess.run",
+            side_effect=subprocess.CalledProcessError(2, "claude"),
+        ):
+            result = main(["run", str(tmp_path)])
+        assert result == 1
+        assert "exited with code 2" in capsys.readouterr().err
+
+    def test_run_success(self, tmp_path):
+        """cmd_run returns 0 when claude CLI succeeds."""
+        with patch("factory.cli.subprocess.run") as mock_run:
+            result = main(["run", str(tmp_path)])
+        assert result == 0
+        mock_run.assert_called_once()
+
+
+class TestCmdEval:
+    def test_eval_failing(self, tmp_project, capsys, sample_config):
+        """cmd_eval returns 1 when eval fails."""
+        import asyncio
+        from factory.store import ExperimentStore
+
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+
+        # The eval_command won't exist, so this will fail
+        result = main(["eval", str(tmp_project)])
+        assert result == 1
+
+
+class TestCmdNotify:
+    def test_notify_no_config(self, tmp_project, capsys, caplog, sample_config):
+        """cmd_notify warns when telegram is not configured."""
+        import asyncio
+        import logging
+        from factory.store import ExperimentStore
+
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+
+        with caplog.at_level(logging.WARNING):
+            result = main(["notify", str(tmp_project)])
+        assert result == 0
+        assert "Digest sent" in capsys.readouterr().out
+
+
+class TestCmdInit:
+    def test_init_missing_factory_md(self, tmp_project, capsys):
+        """cmd_init returns 1 when factory.md is missing."""
+        result = main(["init", str(tmp_project)])
+        assert result == 1
+        assert "factory.md not found" in capsys.readouterr().err
+
+    def test_init_with_factory_md(self, tmp_project, capsys):
+        """cmd_init succeeds when factory.md exists."""
+        (tmp_project / "factory.md").write_text(
+            "# Factory\n\n## Goal\nBuild stuff\n\n## Scope\n- src/\n\n"
+            "## Guards\n- no deletes\n\n## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n## Constraints\n- small changes\n"
+        )
+        result = main(["init", str(tmp_project)])
+        assert result == 0
+        assert "Initialized" in capsys.readouterr().out
+
+
+class TestMainErrorHandling:
+    def test_main_catches_exception(self, capsys):
+        """main catches exceptions from handlers and returns 1."""
+        with patch("factory.cli.cmd_detect", side_effect=RuntimeError("boom")):
+            result = main(["detect", "/some/path"])
+        assert result == 1
+        assert "boom" in capsys.readouterr().err

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,10 +1,10 @@
 """Tests for factory.state — project state detection."""
 
 import json
-
+from unittest.mock import patch
 
 from factory.models import ProjectState
-from factory.state import detect_state
+from factory.state import _has_open_plan_issues, detect_state
 
 
 class TestDetectState:
@@ -64,3 +64,72 @@ class TestDetectState:
             "human_reviewed": True,
         }))
         assert detect_state(tmp_project) == ProjectState.HAS_FACTORY
+
+    def test_malformed_eval_profile_json(self, tmp_project):
+        """detect_state handles malformed eval_profile.json gracefully."""
+        factory_dir = tmp_project / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "eval_profile.json").write_text("NOT VALID JSON {{{")
+        # Should not raise — malformed JSON means human_reviewed check returns False
+        state = detect_state(tmp_project)
+        # Falls through to NO_FACTORY since config.json doesn't exist
+        assert state == ProjectState.NO_FACTORY
+
+    def test_eval_profile_missing_human_reviewed_key(self, tmp_project):
+        """eval_profile.json without human_reviewed defaults to pending review."""
+        factory_dir = tmp_project / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "eval_profile.json").write_text(json.dumps({
+            "project_type": "bot",
+            "dimensions": [],
+            "tier": "discovered",
+            "confidence": 0.8,
+            # no human_reviewed key — .get defaults to False, treated as pending
+        }))
+        assert detect_state(tmp_project) == ProjectState.EVALS_PENDING_REVIEW
+
+
+class TestHasOpenPlanIssues:
+    def test_returns_false_when_gh_not_found(self, tmp_project):
+        """_has_open_plan_issues returns False when gh CLI is not available."""
+        with patch(
+            "factory.state.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            assert _has_open_plan_issues(tmp_project) is False
+
+    def test_returns_false_on_timeout(self, tmp_project):
+        """_has_open_plan_issues returns False on subprocess timeout."""
+        import subprocess as sp
+
+        with patch(
+            "factory.state.subprocess.run",
+            side_effect=sp.TimeoutExpired("gh", 15),
+        ):
+            assert _has_open_plan_issues(tmp_project) is False
+
+    def test_returns_false_on_empty_response(self, tmp_project):
+        """_has_open_plan_issues returns False when gh returns empty list."""
+        mock_result = type("R", (), {"returncode": 0, "stdout": "[]"})()
+        with patch("factory.state.subprocess.run", return_value=mock_result):
+            assert _has_open_plan_issues(tmp_project) is False
+
+    def test_returns_true_on_open_issues(self, tmp_project):
+        """_has_open_plan_issues returns True when gh returns issues."""
+        mock_result = type("R", (), {"returncode": 0, "stdout": '[{"number": 1}]'})()
+        with patch("factory.state.subprocess.run", return_value=mock_result):
+            assert _has_open_plan_issues(tmp_project) is True
+
+    def test_returns_false_on_nonzero_returncode(self, tmp_project):
+        """_has_open_plan_issues returns False when gh returns non-zero."""
+        mock_result = type("R", (), {"returncode": 1, "stdout": ""})()
+        with patch("factory.state.subprocess.run", return_value=mock_result):
+            assert _has_open_plan_issues(tmp_project) is False
+
+
+class TestDetectStateWithIssues:
+    def test_repo_incomplete_with_open_issues(self, tmp_project):
+        """detect_state returns REPO_INCOMPLETE when plan issues exist."""
+        mock_result = type("R", (), {"returncode": 0, "stdout": '[{"number": 1}]'})()
+        with patch("factory.state.subprocess.run", return_value=mock_result):
+            assert detect_state(tmp_project) == ProjectState.REPO_INCOMPLETE

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,0 +1,209 @@
+"""Tests for factory.notify.telegram — Telegram notifier with mocked urllib."""
+
+from __future__ import annotations
+
+import logging
+import urllib.error
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from factory.models import CompositeScore, ExperimentRecord
+from factory.notify.telegram import TelegramNotifier
+
+
+def _make_record(
+    *,
+    id: int = 1,
+    verdict: str = "keep",
+    delta: float | None = 0.05,
+    cost_usd: float | None = 1.23,
+    hypothesis: str = "Improve caching",
+) -> ExperimentRecord:
+    return ExperimentRecord(
+        id=id,
+        timestamp=datetime(2025, 1, 1),
+        hypothesis=hypothesis,
+        change_summary="Refactored cache layer",
+        issue_number=None,
+        pr_number=None,
+        score_before=0.80,
+        score_after=0.85,
+        delta=delta,
+        verdict=verdict,
+        cost_usd=cost_usd,
+        notes="",
+    )
+
+
+class TestTelegramNotifier:
+    """Tests for TelegramNotifier."""
+
+    def test_not_configured_skips(self, caplog):
+        """When env vars are missing, send_digest logs warning and returns."""
+        import asyncio
+
+        notifier = TelegramNotifier()
+        with caplog.at_level(logging.WARNING):
+            asyncio.run(notifier.send_digest("my-project", [], None))
+        assert "Telegram not configured" in caplog.text
+
+    def test_is_configured_returns_false_without_env(self):
+        notifier = TelegramNotifier()
+        assert notifier._is_configured() is False
+
+    @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "tok", "TELEGRAM_CHAT_ID": "123"})
+    def test_is_configured_returns_true_with_env(self):
+        notifier = TelegramNotifier()
+        assert notifier._is_configured() is True
+
+    @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "tok", "TELEGRAM_CHAT_ID": "123"})
+    @patch("factory.notify.telegram.urllib.request.urlopen")
+    def test_send_digest_with_records(self, mock_urlopen):
+        """send_digest formats and posts message for experiment records."""
+        import asyncio
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        notifier = TelegramNotifier()
+        records = [
+            _make_record(id=1, verdict="keep", delta=0.05, cost_usd=1.23),
+            _make_record(id=2, verdict="revert", delta=-0.02, cost_usd=0.50),
+        ]
+        asyncio.run(notifier.send_digest("my-project", records, None))
+
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert b"my-project" in req.data
+        assert b"#1" in req.data
+        assert b"#2" in req.data
+        assert b"KEEP" in req.data
+        assert b"REVERT" in req.data
+
+    @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "tok", "TELEGRAM_CHAT_ID": "123"})
+    @patch("factory.notify.telegram.urllib.request.urlopen")
+    def test_send_digest_with_empty_records(self, mock_urlopen):
+        """send_digest handles empty records list."""
+        import asyncio
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        notifier = TelegramNotifier()
+        asyncio.run(notifier.send_digest("empty-project", [], None))
+
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert b"empty-project" in req.data
+
+    @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "tok", "TELEGRAM_CHAT_ID": "123"})
+    @patch("factory.notify.telegram.urllib.request.urlopen")
+    def test_send_digest_with_composite(self, mock_urlopen):
+        """send_digest includes composite score when provided."""
+        import asyncio
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        notifier = TelegramNotifier()
+        composite = CompositeScore(
+            total=0.85,
+            results=[],
+            guard_violations=[],
+            passed=True,
+        )
+        asyncio.run(notifier.send_digest("proj", [_make_record()], composite))
+
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        assert b"PASS" in req.data
+        assert b"0.8500" in req.data
+
+    @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "tok", "TELEGRAM_CHAT_ID": "123"})
+    @patch("factory.notify.telegram.urllib.request.urlopen")
+    def test_send_digest_with_composite_fail_and_violations(self, mock_urlopen):
+        """send_digest includes guard violations when composite fails."""
+        import asyncio
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        notifier = TelegramNotifier()
+        composite = CompositeScore(
+            total=0.40,
+            results=[],
+            guard_violations=["test_deleted", "scope_exceeded"],
+            passed=False,
+        )
+        asyncio.run(notifier.send_digest("proj", [], composite))
+
+        req = mock_urlopen.call_args[0][0]
+        assert b"FAIL" in req.data
+        assert b"test_deleted" in req.data
+        assert b"scope_exceeded" in req.data
+
+    @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "tok", "TELEGRAM_CHAT_ID": "123"})
+    @patch("factory.notify.telegram.urllib.request.urlopen")
+    def test_post_failure_logs_error(self, mock_urlopen, caplog):
+        """_post logs error when urllib raises URLError."""
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+
+        notifier = TelegramNotifier()
+        with caplog.at_level(logging.ERROR):
+            notifier._post("test message")
+
+        assert "Telegram send failed" in caplog.text
+
+    def test_format_message_with_none_delta_and_cost(self):
+        """_format_message handles None delta and cost gracefully."""
+        notifier = TelegramNotifier()
+        notifier._token = "tok"
+        notifier._chat_id = "123"
+
+        record = _make_record(delta=None, cost_usd=None)
+        msg = notifier._format_message("proj", [record], None)
+
+        assert "n/a" in msg
+        assert "#1" in msg
+
+    def test_format_message_truncates_long_hypothesis(self):
+        """_format_message truncates hypothesis to 80 chars."""
+        notifier = TelegramNotifier()
+        notifier._token = "tok"
+        notifier._chat_id = "123"
+
+        long_hyp = "A" * 200
+        record = _make_record(hypothesis=long_hyp)
+        msg = notifier._format_message("proj", [record], None)
+
+        # The hypothesis line should contain at most 80 chars of the original
+        for line in msg.split("\n"):
+            if "AAAA" in line:
+                # The hypothesis portion is truncated to 80
+                assert len(line.strip()) <= 80 + 10  # some padding for indent
+                break
+
+    def test_format_message_different_verdicts(self):
+        """_format_message correctly uppercases all verdict types."""
+        notifier = TelegramNotifier()
+        notifier._token = "tok"
+        notifier._chat_id = "123"
+
+        records = [
+            _make_record(id=1, verdict="keep"),
+            _make_record(id=2, verdict="revert"),
+            _make_record(id=3, verdict="error"),
+        ]
+        msg = notifier._format_message("proj", records, None)
+
+        assert "KEEP" in msg
+        assert "REVERT" in msg
+        assert "ERROR" in msg

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,131 @@
+"""Tests for factory.obsidian.templates — tag generation and frontmatter constants."""
+
+from factory.obsidian.templates import (
+    EXPERIMENT_FRONTMATTER,
+    EXPERIMENT_TAG,
+    FACTORY_TAG,
+    PROJECT_FRONTMATTER,
+    PROJECT_TAG,
+    STRATEGY_FRONTMATTER,
+    STRATEGY_TAG,
+    experiment_tags,
+    project_tags,
+    strategy_tags,
+)
+
+
+class TestConstants:
+    """Verify frontmatter tag constants."""
+
+    def test_factory_tag(self):
+        assert FACTORY_TAG == "factory"
+
+    def test_experiment_tag(self):
+        assert EXPERIMENT_TAG == "experiment"
+
+    def test_project_tag(self):
+        assert PROJECT_TAG == "project"
+
+    def test_strategy_tag(self):
+        assert STRATEGY_TAG == "strategy"
+
+
+class TestExperimentFrontmatter:
+    """Verify experiment frontmatter has required fields."""
+
+    def test_contains_tags(self):
+        assert "tags" in EXPERIMENT_FRONTMATTER
+
+    def test_contains_project(self):
+        assert "project" in EXPERIMENT_FRONTMATTER
+
+    def test_contains_experiment_id(self):
+        assert "experiment_id" in EXPERIMENT_FRONTMATTER
+
+    def test_contains_verdict(self):
+        assert "verdict" in EXPERIMENT_FRONTMATTER
+
+    def test_contains_score_delta(self):
+        assert "score_delta" in EXPERIMENT_FRONTMATTER
+
+    def test_contains_date(self):
+        assert "date" in EXPERIMENT_FRONTMATTER
+
+    def test_has_six_fields(self):
+        assert len(EXPERIMENT_FRONTMATTER) == 6
+
+
+class TestProjectFrontmatter:
+    def test_contains_tags(self):
+        assert "tags" in PROJECT_FRONTMATTER
+
+    def test_has_one_field(self):
+        assert len(PROJECT_FRONTMATTER) == 1
+
+
+class TestStrategyFrontmatter:
+    def test_contains_tags(self):
+        assert "tags" in STRATEGY_FRONTMATTER
+
+    def test_contains_date(self):
+        assert "date" in STRATEGY_FRONTMATTER
+
+    def test_has_two_fields(self):
+        assert len(STRATEGY_FRONTMATTER) == 2
+
+
+class TestExperimentTags:
+    def test_returns_list(self):
+        result = experiment_tags("my-proj")
+        assert isinstance(result, list)
+
+    def test_includes_factory_tag(self):
+        result = experiment_tags("my-proj")
+        assert FACTORY_TAG in result
+
+    def test_includes_experiment_tag(self):
+        result = experiment_tags("my-proj")
+        assert EXPERIMENT_TAG in result
+
+    def test_includes_project_name(self):
+        result = experiment_tags("my-proj")
+        assert "my-proj" in result
+
+    def test_has_three_tags(self):
+        assert len(experiment_tags("x")) == 3
+
+
+class TestProjectTags:
+    def test_returns_list(self):
+        result = project_tags("my-proj")
+        assert isinstance(result, list)
+
+    def test_includes_factory_tag(self):
+        assert FACTORY_TAG in project_tags("my-proj")
+
+    def test_includes_project_tag(self):
+        assert PROJECT_TAG in project_tags("my-proj")
+
+    def test_includes_project_name(self):
+        assert "my-proj" in project_tags("my-proj")
+
+    def test_has_three_tags(self):
+        assert len(project_tags("x")) == 3
+
+
+class TestStrategyTags:
+    def test_returns_list(self):
+        result = strategy_tags("my-proj")
+        assert isinstance(result, list)
+
+    def test_includes_factory_tag(self):
+        assert FACTORY_TAG in strategy_tags("my-proj")
+
+    def test_includes_strategy_tag(self):
+        assert STRATEGY_TAG in strategy_tags("my-proj")
+
+    def test_includes_project_name(self):
+        assert "my-proj" in strategy_tags("my-proj")
+
+    def test_has_three_tags(self):
+        assert len(strategy_tags("x")) == 3


### PR DESCRIPTION
Factory experiment #8. Closes #14.

## Summary
- Added comprehensive tests for `factory/notify/telegram.py` (0% → 100%): mocked urllib, tested message formatting, digest generation, error handling
- Added tests for `factory/obsidian/templates.py` (0% → 100%): tag generation functions, frontmatter constants
- Extended tests for `factory/cli.py` (53% → 83%): cmd_run error paths, cmd_eval, cmd_init, cmd_notify, error handling
- Extended tests for `factory/state.py` (81% → 100%): gh CLI unavailable, timeouts, malformed JSON, open issues detection

**Overall coverage: 75% → 88%** (target was 82%)

## Test plan
- [x] All 188 tests pass
- [x] ruff check clean
- [x] No source code modified — only test files created/updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)