### PR TITLE
Wire up Obsidian integration with factory archive command

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -232,6 +232,54 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 
 
+def cmd_archive(args: argparse.Namespace) -> int:
+    from factory.obsidian.notes import (
+        write_experiment_note,
+        write_project_dashboard,
+        write_strategy_note,
+    )
+    from factory.state import detect_state
+    from factory.store import ExperimentStore
+
+    project_path = Path(args.path)
+    store = ExperimentStore(project_path)
+    records = _run(store.load_history())
+
+    if not records:
+        print("Nothing to archive.")
+        return 0
+
+    project_name = project_path.name
+    state = detect_state(project_path).value
+
+    # Write experiment notes
+    for record in records:
+        write_experiment_note(project_name, record)
+
+    # Build eval_dimensions list for dashboard
+    eval_dimensions: list[dict] | None = None
+    profile = _run(store.read_eval_profile())
+    if profile:
+        eval_dimensions = [d.model_dump() for d in profile.dimensions]
+
+    # Current score from latest experiment
+    scores = [r.score_after for r in records if r.score_after is not None]
+    current_score = scores[-1] if scores else None
+
+    write_project_dashboard(project_name, state, current_score, records, eval_dimensions)
+
+    # Write strategy note if strategy exists
+    strategy_text = _run(store.read_strategy())
+    if strategy_text:
+        write_strategy_note(project_name, strategy_text)
+
+    from factory.obsidian.notes import _get_vault_path
+
+    vault_path = _get_vault_path()
+    print(f"Archived {len(records)} experiments to {vault_path}")
+    return 0
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     project_path = Path(args.path).resolve()
 
@@ -335,6 +383,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("path", help="Path to the project")
 
 
+    # archive
+    p = sub.add_parser("archive", help="Write experiment notes to Obsidian vault")
+    p.add_argument("path", help="Path to the project")
+
     # run
     p = sub.add_parser("run", help="Cron entry: invoke claude -p with factory skill")
     p.add_argument("path", help="Path to the project")
@@ -362,6 +414,7 @@ def main(argv: list[str] | None = None) -> int:
         "notify": cmd_notify,
         "study": cmd_study,
         "status": cmd_status,
+        "archive": cmd_archive,
         "run": cmd_run,
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -245,6 +245,76 @@ class TestCmdInit:
         assert "Initialized" in capsys.readouterr().out
 
 
+class TestCmdArchive:
+    def test_archive_parser(self):
+        parser = build_parser()
+        args = parser.parse_args(["archive", "/some/path"])
+        assert args.command == "archive"
+        assert args.path == "/some/path"
+
+    def test_archive_no_experiments(self, tmp_project, capsys, sample_config):
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+        result = main(["archive", str(tmp_project)])
+        assert result == 0
+        assert "Nothing to archive" in capsys.readouterr().out
+
+    def test_archive_with_experiments(self, tmp_project, capsys, sample_config):
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+        exp_id = asyncio.run(store.begin("Improve throughput"))
+        record = ExperimentRecord(
+            id=exp_id, timestamp=datetime.now(),
+            hypothesis="Improve throughput",
+            change_summary="Optimized pipeline",
+            issue_number=None, pr_number=None,
+            score_before=0.7, score_after=0.85, delta=0.15,
+            verdict="keep", cost_usd=0.5, notes="",
+        )
+        asyncio.run(store.finalize(exp_id, record))
+
+        with patch("factory.obsidian.notes.write_experiment_note") as mock_exp, \
+             patch("factory.obsidian.notes.write_project_dashboard") as mock_dash, \
+             patch("factory.obsidian.notes.write_strategy_note") as mock_strat, \
+             patch("factory.obsidian.notes._get_vault_path",
+                   return_value=tmp_project / "vault"):
+            result = main(["archive", str(tmp_project)])
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Archived 1 experiments" in out
+        mock_exp.assert_called_once()
+        mock_dash.assert_called_once()
+        mock_strat.assert_not_called()
+
+    def test_archive_with_strategy(self, tmp_project, capsys, sample_config):
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+        exp_id = asyncio.run(store.begin("Test hypothesis"))
+        record = ExperimentRecord(
+            id=exp_id, timestamp=datetime.now(),
+            hypothesis="Test hypothesis",
+            change_summary="Changed stuff",
+            issue_number=None, pr_number=None,
+            score_before=0.8, score_after=0.85, delta=0.05,
+            verdict="keep", cost_usd=None, notes="",
+        )
+        asyncio.run(store.finalize(exp_id, record))
+        asyncio.run(store.write_strategy("Focus on reliability."))
+
+        with patch("factory.obsidian.notes.write_experiment_note") as mock_exp, \
+             patch("factory.obsidian.notes.write_project_dashboard") as mock_dash, \
+             patch("factory.obsidian.notes.write_strategy_note") as mock_strat, \
+             patch("factory.obsidian.notes._get_vault_path",
+                   return_value=tmp_project / "vault"):
+            result = main(["archive", str(tmp_project)])
+
+        assert result == 0
+        mock_exp.assert_called_once()
+        mock_dash.assert_called_once()
+        mock_strat.assert_called_once()
+
+
 class TestMainErrorHandling:
     def test_main_catches_exception(self, capsys):
         """main catches exceptions from handlers and returns 1."""


### PR DESCRIPTION
## Summary
- Add `factory archive <path>` CLI command that writes experiment notes, project dashboard, and strategy notes to the configured Obsidian vault
- Reads experiment history via `ExperimentStore`, calls `write_experiment_note()` for each record, `write_project_dashboard()` with current state/score/eval dimensions, and `write_strategy_note()` if a strategy exists
- Prints summary: "Archived N experiments to {vault_path}"
- Add 4 tests: parser validation, empty history ("Nothing to archive"), experiments-only (mocked writes), and experiments-with-strategy (mocked writes)

Closes #21

## Test plan
- [x] `uv run pytest -v` — all 219 tests pass
- [x] `uv run ruff check .` — clean on project files
- [ ] Manual: run `factory archive <project-path>` with a real project and verify notes appear in Obsidian vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)