### PR TITLE
Accept GitHub URL in factory run

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import subprocess
 import sys
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -280,8 +281,23 @@ def cmd_archive(args: argparse.Namespace) -> int:
     return 0
 
 
+def _is_github_url(path: str) -> bool:
+    """Return True if path looks like a GitHub URL."""
+    return path.startswith("https://github.com/") or path.startswith("git@github.com:")
+
+
+
 def cmd_run(args: argparse.Namespace) -> int:
-    project_path = Path(args.path).resolve()
+    path = args.path
+
+    # If a GitHub URL is provided, clone into a temp directory
+    if _is_github_url(path):
+        tmp_dir = tempfile.mkdtemp(prefix="factory-")
+        subprocess.run(["git", "clone", path, tmp_dir], check=True)
+        print(f"Cloned {path} to {tmp_dir}")
+        project_path = Path(tmp_dir).resolve()
+    else:
+        project_path = Path(path).resolve()
 
     # Read the SKILL.md from the remote-factory repo root
     skill_path = Path(__file__).resolve().parent.parent / "SKILL.md"
@@ -291,14 +307,27 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"Error: SKILL.md not found at {skill_path}", file=sys.stderr)
         return 1
 
-    prompt = (
-        "You are the Factory orchestrator. "
-        "Follow the skill instructions below to run the factory loop on the project.\n\n"
-        "IMPORTANT: All factory CLI commands must use `uv run python -m factory` "
-        "(not bare `python -m factory`) because pydantic is not in the system Python.\n\n"
-        f"Project path: {project_path}\n\n"
-        f"--- SKILL.md ---\n{skill_content}\n--- END SKILL.md ---"
-    )
+    mode = getattr(args, "mode", "improve")
+
+    if mode == "discover":
+        prompt = (
+            "You are the Factory orchestrator. "
+            "Run Discover mode: introspect the project, auto-detect eval dimensions, "
+            "and generate the eval harness. Do NOT run the Improve loop.\n\n"
+            "IMPORTANT: All factory CLI commands must use `uv run python -m factory` "
+            "(not bare `python -m factory`) because pydantic is not in the system Python.\n\n"
+            f"Project path: {project_path}\n\n"
+            f"--- SKILL.md ---\n{skill_content}\n--- END SKILL.md ---"
+        )
+    else:
+        prompt = (
+            "You are the Factory orchestrator. "
+            "Follow the skill instructions below to run the factory loop on the project.\n\n"
+            "IMPORTANT: All factory CLI commands must use `uv run python -m factory` "
+            "(not bare `python -m factory`) because pydantic is not in the system Python.\n\n"
+            f"Project path: {project_path}\n\n"
+            f"--- SKILL.md ---\n{skill_content}\n--- END SKILL.md ---"
+        )
 
     try:
         subprocess.run(
@@ -389,7 +418,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     # run
     p = sub.add_parser("run", help="Cron entry: invoke claude -p with factory skill")
-    p.add_argument("path", help="Path to the project")
+    p.add_argument("path", help="Path to the project or GitHub URL")
+    p.add_argument(
+        "--mode",
+        choices=["discover", "improve"],
+        default="improve",
+        help="Run mode: discover (auto-detect evals) or improve (default improvement loop)",
+    )
 
     return parser
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,9 +4,9 @@ import asyncio
 import json
 import subprocess
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import patch, call
 
-from factory.cli import main, build_parser
+from factory.cli import main, build_parser, _is_github_url
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -313,6 +313,116 @@ class TestCmdArchive:
         mock_exp.assert_called_once()
         mock_dash.assert_called_once()
         mock_strat.assert_called_once()
+
+
+
+class TestGitHubUrlDetection:
+    def test_https_url_detected(self):
+        assert _is_github_url("https://github.com/user/repo") is True
+
+    def test_https_url_with_git_suffix(self):
+        assert _is_github_url("https://github.com/user/repo.git") is True
+
+    def test_ssh_url_detected(self):
+        assert _is_github_url("git@github.com:user/repo.git") is True
+
+    def test_local_path_not_detected(self):
+        assert _is_github_url("/some/local/path") is False
+
+    def test_relative_path_not_detected(self):
+        assert _is_github_url("./relative/path") is False
+
+    def test_other_url_not_detected(self):
+        assert _is_github_url("https://gitlab.com/user/repo") is False
+
+
+class TestRunModeFlag:
+    def test_mode_default_is_improve(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path"])
+        assert args.mode == "improve"
+
+    def test_mode_discover(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--mode", "discover"])
+        assert args.mode == "discover"
+
+    def test_mode_improve_explicit(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--mode", "improve"])
+        assert args.mode == "improve"
+
+
+class TestRunWithGitHubUrl:
+    def test_run_clones_https_url(self, capsys):
+        """cmd_run clones a GitHub HTTPS URL into a temp dir and invokes claude."""
+        url = "https://github.com/user/repo"
+        with patch("factory.cli.subprocess.run") as mock_run, \
+             patch("factory.cli.tempfile.mkdtemp", return_value="/tmp/factory-abc"):
+            result = main(["run", url])
+
+        assert result == 0
+        assert mock_run.call_count == 2
+        # First call: git clone
+        clone_call = mock_run.call_args_list[0]
+        assert clone_call == call(
+            ["git", "clone", url, "/tmp/factory-abc"], check=True,
+        )
+        # Second call: claude -p
+        claude_call = mock_run.call_args_list[1]
+        assert claude_call[0][0][0] == "claude"
+
+        out = capsys.readouterr().out
+        assert "Cloned https://github.com/user/repo to /tmp/factory-abc" in out
+
+    def test_run_clones_ssh_url(self, capsys):
+        """cmd_run clones a GitHub SSH URL into a temp dir."""
+        url = "git@github.com:user/repo.git"
+        with patch("factory.cli.subprocess.run") as mock_run, \
+             patch("factory.cli.tempfile.mkdtemp", return_value="/tmp/factory-xyz"):
+            result = main(["run", url])
+
+        assert result == 0
+        clone_call = mock_run.call_args_list[0]
+        assert clone_call == call(
+            ["git", "clone", url, "/tmp/factory-xyz"], check=True,
+        )
+        out = capsys.readouterr().out
+        assert f"Cloned {url} to /tmp/factory-xyz" in out
+
+    def test_run_local_path_no_clone(self, tmp_path):
+        """cmd_run with a local path does not clone."""
+        with patch("factory.cli.subprocess.run") as mock_run:
+            result = main(["run", str(tmp_path)])
+
+        assert result == 0
+        # Only one subprocess call (claude), no git clone
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[0] == "claude"
+
+    def test_run_discover_mode_prompt(self, tmp_path):
+        """cmd_run with --mode=discover uses the Discover mode prompt."""
+        with patch("factory.cli.subprocess.run") as mock_run:
+            result = main(["run", str(tmp_path), "--mode", "discover"])
+
+        assert result == 0
+        claude_call = mock_run.call_args
+        prompt = claude_call[0][0][2]  # ["claude", "-p", prompt, ...]
+        assert "Discover mode" in prompt
+        assert "Do NOT run the Improve loop" in prompt
+
+    def test_run_improve_mode_prompt(self, tmp_path):
+        """cmd_run with --mode=improve (default) uses the Improve mode prompt."""
+        with patch("factory.cli.subprocess.run") as mock_run:
+            result = main(["run", str(tmp_path), "--mode", "improve"])
+
+        assert result == 0
+        claude_call = mock_run.call_args
+        prompt = claude_call[0][0][2]
+        assert "Follow the skill instructions below" in prompt
+        # The improve prompt should NOT start with the discover preamble
+        assert prompt.startswith("You are the Factory orchestrator. Follow the skill")
 
 
 class TestMainErrorHandling:


### PR DESCRIPTION
## Summary
- `factory run` now accepts a GitHub URL (HTTPS or SSH) in addition to a local path. When a URL is detected, the repo is cloned to a temp directory (`tempfile.mkdtemp(prefix="factory-")`) and that directory is used as the project path.
- Added `--mode` flag to the `run` subparser with choices `discover` and `improve` (default: `improve`). Discover mode sends a prompt that tells Claude to introspect the project and generate evals without running the Improve loop.
- Backward compatible: `factory run ./local/path` works exactly as before.

Closes #20

## Test plan
- [x] URL detection tests (`_is_github_url`) for HTTPS, SSH, local paths, non-GitHub URLs
- [x] `--mode` flag parser tests (default, explicit discover, explicit improve)
- [x] Mock subprocess tests for clone+run flow (HTTPS clone, SSH clone, local path skips clone)
- [x] Prompt content tests verifying discover vs improve mode prompt text
- [x] All 229 tests pass (`uv run pytest -v`)
- [x] Lint clean (`uv run ruff check .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)