### PR TITLE
Add --loop heartbeat mode to factory run

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import signal
 import subprocess
 import sys
 import tempfile
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -287,27 +289,14 @@ def _is_github_url(path: str) -> bool:
 
 
 
-def cmd_run(args: argparse.Namespace) -> int:
-    path = args.path
-
-    # If a GitHub URL is provided, clone into a temp directory
-    if _is_github_url(path):
-        tmp_dir = tempfile.mkdtemp(prefix="factory-")
-        subprocess.run(["git", "clone", path, tmp_dir], check=True)
-        print(f"Cloned {path} to {tmp_dir}")
-        project_path = Path(tmp_dir).resolve()
-    else:
-        project_path = Path(path).resolve()
-
-    # Read the SKILL.md from the remote-factory repo root
+def _run_single_cycle(project_path: Path, mode: str) -> int:
+    """Execute a single factory run cycle. Returns 0 on success, 1 on error."""
     skill_path = Path(__file__).resolve().parent.parent / "SKILL.md"
     try:
         skill_content = skill_path.read_text()
     except FileNotFoundError:
         print(f"Error: SKILL.md not found at {skill_path}", file=sys.stderr)
         return 1
-
-    mode = getattr(args, "mode", "improve")
 
     if mode == "discover":
         prompt = (
@@ -341,6 +330,74 @@ def cmd_run(args: argparse.Namespace) -> int:
     except subprocess.CalledProcessError as e:
         print(f"Error: claude exited with code {e.returncode}", file=sys.stderr)
         return 1
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    path = args.path
+
+    # If a GitHub URL is provided, clone into a temp directory
+    if _is_github_url(path):
+        tmp_dir = tempfile.mkdtemp(prefix="factory-")
+        subprocess.run(["git", "clone", path, tmp_dir], check=True)
+        print(f"Cloned {path} to {tmp_dir}")
+        project_path = Path(tmp_dir).resolve()
+    else:
+        project_path = Path(path).resolve()
+
+    mode = getattr(args, "mode", "improve")
+    loop = getattr(args, "loop", False)
+
+    if not loop:
+        return _run_single_cycle(project_path, mode)
+
+    # Heartbeat loop mode
+    interval: int = getattr(args, "interval", 1800)
+    max_cycles: int | None = getattr(args, "max_cycles", None)
+    shutdown_requested = False
+
+    def _shutdown_handler(signum: int, frame: object) -> None:
+        nonlocal shutdown_requested
+        shutdown_requested = True
+
+    old_sigterm = signal.signal(signal.SIGTERM, _shutdown_handler)
+    old_sigint = signal.signal(signal.SIGINT, _shutdown_handler)
+
+    cycle = 0
+    start_time = time.monotonic()
+
+    try:
+        while True:
+            cycle += 1
+            ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            print(f"[factory] Cycle {cycle} started at {ts}")
+
+            _run_single_cycle(project_path, mode)
+
+            if shutdown_requested:
+                break
+
+            if max_cycles is not None and cycle >= max_cycles:
+                break
+
+            print(f"[factory] Cycle {cycle} completed. Sleeping for {interval}s...")
+
+            try:
+                time.sleep(interval)
+            except (KeyboardInterrupt, SystemExit):
+                shutdown_requested = True
+
+            if shutdown_requested:
+                break
+    finally:
+        signal.signal(signal.SIGTERM, old_sigterm)
+        signal.signal(signal.SIGINT, old_sigint)
+
+    elapsed = time.monotonic() - start_time
+    print(
+        f"[factory] Shutting down gracefully after {cycle} cycles."
+        f" Total runtime: {elapsed:.0f}s"
+    )
     return 0
 
 
@@ -424,6 +481,18 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["discover", "improve"],
         default="improve",
         help="Run mode: discover (auto-detect evals) or improve (default improvement loop)",
+    )
+    p.add_argument(
+        "--loop", action="store_true", default=False,
+        help="Enable heartbeat mode: run continuously with sleep between cycles",
+    )
+    p.add_argument(
+        "--interval", type=int, default=1800,
+        help="Seconds to sleep between cycles (default: 1800)",
+    )
+    p.add_argument(
+        "--max-cycles", type=int, default=None,
+        help="Maximum number of cycles (default: unlimited)",
     )
 
     return parser

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+import os
+import signal
 import subprocess
 from datetime import datetime
 from unittest.mock import patch, call
@@ -432,3 +434,113 @@ class TestMainErrorHandling:
             result = main(["detect", "/some/path"])
         assert result == 1
         assert "boom" in capsys.readouterr().err
+
+
+class TestHeartbeatParserFlags:
+    def test_loop_flag_default_false(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path"])
+        assert args.loop is False
+
+    def test_loop_flag_enabled(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--loop"])
+        assert args.loop is True
+
+    def test_interval_default_1800(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path"])
+        assert args.interval == 1800
+
+    def test_interval_custom(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--interval", "60"])
+        assert args.interval == 60
+
+    def test_max_cycles_default_none(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path"])
+        assert args.max_cycles is None
+
+    def test_max_cycles_custom(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--max-cycles", "5"])
+        assert args.max_cycles == 5
+
+
+class TestHeartbeatLoop:
+    def test_no_loop_single_run(self, tmp_path):
+        """Without --loop, cmd_run executes exactly one cycle."""
+        with patch("factory.cli.subprocess.run") as mock_run:
+            result = main(["run", str(tmp_path)])
+        assert result == 0
+        mock_run.assert_called_once()
+
+    def test_loop_exits_after_max_cycles(self, tmp_path, capsys):
+        """With --loop --max-cycles=3, runs exactly 3 cycles then exits."""
+        with patch("factory.cli.subprocess.run") as mock_run, \
+             patch("factory.cli.time.sleep") as mock_sleep:
+            result = main([
+                "run", str(tmp_path), "--loop", "--max-cycles", "3", "--interval", "10",
+            ])
+        assert result == 0
+        # 3 cycles = 3 subprocess calls (claude)
+        assert mock_run.call_count == 3
+        # sleep called between cycles: after cycle 1 and 2, not after cycle 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(10)
+
+        out = capsys.readouterr().out
+        assert "[factory] Cycle 1 started at" in out
+        assert "[factory] Cycle 2 started at" in out
+        assert "[factory] Cycle 3 started at" in out
+        assert "[factory] Shutting down gracefully after 3 cycles." in out
+
+    def test_loop_single_cycle(self, tmp_path, capsys):
+        """--max-cycles=1 runs one cycle, no sleep, then exits."""
+        with patch("factory.cli.subprocess.run"):
+            result = main([
+                "run", str(tmp_path), "--loop", "--max-cycles", "1",
+            ])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[factory] Cycle 1 started at" in out
+        assert "[factory] Shutting down gracefully after 1 cycles." in out
+
+    def test_loop_graceful_sigterm(self, tmp_path, capsys):
+        """SIGTERM during sleep causes clean exit."""
+        def _interrupt_during_sleep(interval: int) -> None:
+            # Simulate SIGTERM arriving during sleep
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        with patch("factory.cli.subprocess.run"), \
+             patch("factory.cli.time.sleep", side_effect=_interrupt_during_sleep):
+            result = main(["run", str(tmp_path), "--loop", "--interval", "5"])
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[factory] Shutting down gracefully after 1 cycles." in out
+
+    def test_loop_graceful_sigint(self, tmp_path, capsys):
+        """SIGINT during sleep causes clean exit."""
+        def _interrupt_during_sleep(interval: int) -> None:
+            os.kill(os.getpid(), signal.SIGINT)
+
+        with patch("factory.cli.subprocess.run"), \
+             patch("factory.cli.time.sleep", side_effect=_interrupt_during_sleep):
+            result = main(["run", str(tmp_path), "--loop", "--interval", "5"])
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[factory] Shutting down gracefully after 1 cycles." in out
+
+    def test_loop_logs_sleep_message(self, tmp_path, capsys):
+        """Verify the sleep log message appears between cycles."""
+        with patch("factory.cli.subprocess.run"), \
+             patch("factory.cli.time.sleep"):
+            result = main([
+                "run", str(tmp_path), "--loop", "--max-cycles", "2", "--interval", "60",
+            ])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[factory] Cycle 1 completed. Sleeping for 60s..." in out


### PR DESCRIPTION
## Summary
- Adds `--loop`, `--interval`, and `--max-cycles` flags to `factory run` for persistent autonomous operation
- Factory runs its improvement cycle, sleeps for the configured interval, then runs again
- Handles SIGTERM/SIGINT gracefully: finishes current work, prints summary (cycles completed, total runtime), then exits cleanly
- Refactors cycle execution into `_run_single_cycle()` to keep the heartbeat logic clean

## Test plan
- [x] Parser flags parsed correctly (`--loop`, `--interval` default 1800, `--max-cycles` default None)
- [x] Loop exits after `--max-cycles` with correct cycle count
- [x] SIGTERM during sleep triggers graceful shutdown
- [x] SIGINT during sleep triggers graceful shutdown
- [x] Without `--loop`, behavior is unchanged (single run)
- [x] Sleep log messages appear between cycles
- [x] All 245 tests pass, ruff lint clean

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)