### PR TITLE
Add web search and Obsidian notes to factory study

### DIFF
--- a/factory/study.py
+++ b/factory/study.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import subprocess
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -80,11 +82,144 @@ def _extract_messages(log_file: Path) -> list[dict]:
     return messages
 
 
+def _extract_keywords(project_path: Path) -> list[str]:
+    """Extract search keywords from a project's README or pyproject.toml."""
+    # Try README first
+    readme = project_path / "README.md"
+    if readme.exists():
+        text = readme.read_text(errors="replace")[:2000]
+        # Use the first heading and first paragraph as keyword source
+        lines = [ln.strip() for ln in text.split("\n") if ln.strip()]
+        # Strip markdown heading markers
+        lines = [re.sub(r"^#+\s*", "", ln) for ln in lines[:5]]
+        text = " ".join(lines)
+    else:
+        # Fall back to pyproject.toml name + description
+        pyproject = project_path / "pyproject.toml"
+        if pyproject.exists():
+            content = pyproject.read_text(errors="replace")
+            name_match = re.search(r'name\s*=\s*"([^"]+)"', content)
+            desc_match = re.search(r'description\s*=\s*"([^"]+)"', content)
+            parts = []
+            if name_match:
+                parts.append(name_match.group(1).replace("-", " "))
+            if desc_match:
+                parts.append(desc_match.group(1))
+            text = " ".join(parts) if parts else ""
+        else:
+            text = project_path.name.replace("-", " ").replace("_", " ")
+
+    if not text:
+        return []
+
+    # Remove common stop words and short tokens, keep meaningful words
+    stop_words = {
+        "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+        "have", "has", "had", "do", "does", "did", "will", "would", "could",
+        "should", "may", "might", "shall", "can", "to", "of", "in", "for",
+        "on", "with", "at", "by", "from", "as", "into", "through", "and",
+        "but", "or", "nor", "not", "so", "yet", "both", "either", "neither",
+        "this", "that", "these", "those", "it", "its", "my", "your", "his",
+        "her", "our", "their", "what", "which", "who", "whom", "how",
+    }
+    words = re.findall(r"[a-zA-Z]{3,}", text.lower())
+    keywords = [w for w in words if w not in stop_words]
+    # Deduplicate while preserving order, return up to 5
+    seen: set[str] = set()
+    unique: list[str] = []
+    for w in keywords:
+        if w not in seen:
+            seen.add(w)
+            unique.append(w)
+        if len(unique) >= 5:
+            break
+    return unique
+
+
+def _search_similar_projects(project_path: Path) -> list[dict]:
+    """Search GitHub for similar projects using `gh search repos`.
+
+    Returns top 5 results as dicts with keys: name, url, description, stars.
+    Gracefully returns empty list if gh is not available or search fails.
+    """
+    keywords = _extract_keywords(project_path)
+    if not keywords:
+        return []
+
+    query = " ".join(keywords)
+    try:
+        result = subprocess.run(
+            [
+                "gh", "search", "repos", query,
+                "--limit", "5",
+                "--json", "fullName,url,description,stargazersCount",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        logger.debug("gh CLI not available or search timed out")
+        return []
+
+    if result.returncode != 0:
+        logger.debug("gh search repos failed: %s", result.stderr)
+        return []
+
+    try:
+        repos = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    return [
+        {
+            "name": r.get("fullName", ""),
+            "url": r.get("url", ""),
+            "description": (r.get("description") or "")[:200],
+            "stars": r.get("stargazersCount", 0),
+        }
+        for r in repos[:5]
+    ]
+
+
+def _read_obsidian_notes(project_name: str) -> list[str]:
+    """Read Obsidian vault notes for this project.
+
+    Returns a list of note summaries (first 200 chars of each note).
+    Gracefully returns empty list if vault doesn't exist.
+    """
+    from factory.obsidian.notes import _get_vault_path, _FACTORY_DIR
+
+    vault = _get_vault_path()
+    if not vault.exists():
+        return []
+
+    # Search across Experiments, Projects, and Strategies
+    summaries: list[str] = []
+    for subdir in ["Experiments", "Projects", "Strategies"]:
+        notes_dir = vault / _FACTORY_DIR / subdir
+        if not notes_dir.exists():
+            continue
+        for note_path in sorted(notes_dir.glob(f"{project_name}*.md")):
+            try:
+                content = note_path.read_text(errors="replace")
+                # Skip frontmatter
+                if content.startswith("---"):
+                    end = content.find("---", 3)
+                    if end != -1:
+                        content = content[end + 3:].strip()
+                summary = content[:200].strip()
+                if summary:
+                    summaries.append(summary)
+            except OSError:
+                continue
+
+    return summaries
+
+
 def study_project(project_path: Path) -> str:
     """Read interaction logs and produce an observations summary."""
     log_files = _find_log_files(project_path)
-    if not log_files:
-        return "No interaction logs found."
 
     all_messages: list[dict] = []
     for lf in log_files:
@@ -97,18 +232,47 @@ def study_project(project_path: Path) -> str:
     lines = [
         f"# Interaction Study — {project_path.name}",
         "",
-        f"Analyzed {len(log_files)} conversation log(s), {len(all_messages)} relevant messages.",
-        "",
-        f"## User Messages ({len(user_msgs)})",
     ]
-    for m in user_msgs:
-        lines.append(f"- {m['text'][:200]}")
 
-    lines.extend([
-        "",
-        f"## Errors and Issues ({len(errors)})",
-    ])
-    for m in errors:
-        lines.append(f"- {m['text'][:200]}")
+    if log_files:
+        lines.append(
+            f"Analyzed {len(log_files)} conversation log(s), "
+            f"{len(all_messages)} relevant messages."
+        )
+        lines.append("")
+        lines.append(f"## User Messages ({len(user_msgs)})")
+        for m in user_msgs:
+            lines.append(f"- {m['text'][:200]}")
+
+        lines.extend([
+            "",
+            f"## Errors and Issues ({len(errors)})",
+        ])
+        for m in errors:
+            lines.append(f"- {m['text'][:200]}")
+    else:
+        lines.append("No interaction logs found.")
+
+    # Similar projects from GitHub
+    similar = _search_similar_projects(project_path)
+    lines.extend(["", "## Similar Projects"])
+    if similar:
+        for proj in similar:
+            stars = proj.get("stars", 0)
+            desc = proj.get("description", "")
+            desc_part = f" — {desc}" if desc else ""
+            lines.append(f"- [{proj['name']}]({proj['url']}) ({stars} stars){desc_part}")
+    else:
+        lines.append("No similar projects found.")
+
+    # Prior knowledge from Obsidian vault
+    project_name = project_path.name
+    notes = _read_obsidian_notes(project_name)
+    lines.extend(["", "## Prior Knowledge (Obsidian)"])
+    if notes:
+        for note in notes:
+            lines.append(f"- {note}")
+    else:
+        lines.append("No prior notes found.")
 
     return "\n".join(lines)

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1,9 +1,19 @@
 """Tests for factory.study — interaction log reading."""
 
 import json
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
-from factory.study import _path_to_slug, _find_log_files, _extract_messages, study_project
+from factory.study import (
+    _extract_keywords,
+    _extract_messages,
+    _find_log_files,
+    _path_to_slug,
+    _read_obsidian_notes,
+    _search_similar_projects,
+    study_project,
+)
 
 
 class TestPathToSlug:
@@ -167,8 +177,11 @@ class TestExtractMessages:
 class TestStudyProject:
     def test_no_logs_returns_message(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        result = study_project(tmp_path / "nonexistent")
-        assert result == "No interaction logs found."
+        with patch("factory.study._search_similar_projects", return_value=[]):
+            result = study_project(tmp_path / "nonexistent")
+        assert "No interaction logs found." in result
+        assert "## Similar Projects" in result
+        assert "## Prior Knowledge (Obsidian)" in result
 
     def test_produces_summary(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -188,12 +201,54 @@ class TestStudyProject:
         ]
         (log_dir / "conv.jsonl").write_text("\n".join(lines))
 
-        result = study_project(project_path)
+        with patch("factory.study._search_similar_projects", return_value=[]):
+            result = study_project(project_path)
         assert "# Interaction Study" in result
         assert "myapp" in result
         assert "1 conversation log(s)" in result
         assert "Add tests" in result
         assert "Errors and Issues" in result
+        assert "## Similar Projects" in result
+        assert "## Prior Knowledge (Obsidian)" in result
+
+    def test_includes_similar_projects(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        project_path = tmp_path / "myapp"
+        project_path.mkdir()
+
+        similar = [
+            {
+                "name": "org/cool-project",
+                "url": "https://github.com/org/cool-project",
+                "description": "A cool project",
+                "stars": 42,
+            },
+        ]
+        with patch("factory.study._search_similar_projects", return_value=similar):
+            result = study_project(project_path)
+        assert "## Similar Projects" in result
+        assert "org/cool-project" in result
+        assert "42 stars" in result
+        assert "A cool project" in result
+
+    def test_includes_obsidian_notes(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "vault"))
+
+        project_path = tmp_path / "myapp"
+        project_path.mkdir()
+
+        # Create an Obsidian note
+        notes_dir = tmp_path / "vault" / "Work" / "Factory" / "Projects"
+        notes_dir.mkdir(parents=True)
+        (notes_dir / "myapp.md").write_text(
+            "---\ntags:\n  - factory\n---\n\n# Dashboard for myapp\nSome content here."
+        )
+
+        with patch("factory.study._search_similar_projects", return_value=[]):
+            result = study_project(project_path)
+        assert "## Prior Knowledge (Obsidian)" in result
+        assert "Dashboard for myapp" in result
 
 
 class TestCmdStudy:
@@ -221,7 +276,8 @@ class TestCmdStudy:
         ]
         (log_dir / "conv.jsonl").write_text("\n".join(lines))
 
-        result = main(["study", str(project_path)])
+        with patch("factory.study._search_similar_projects", return_value=[]):
+            result = main(["study", str(project_path)])
         assert result == 0
 
         obs_path = project_path / ".factory" / "strategy" / "observations.md"
@@ -229,3 +285,216 @@ class TestCmdStudy:
         content = obs_path.read_text()
         assert "Hello world" in content
         assert "Hello world" in capsys.readouterr().out
+
+
+class TestExtractKeywords:
+    def test_from_readme(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text("# Cloud Gateway\nA lightweight API gateway.\n")
+        keywords = _extract_keywords(project)
+        assert "cloud" in keywords
+        assert "gateway" in keywords
+        assert len(keywords) <= 5
+
+    def test_from_pyproject(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "pyproject.toml").write_text(
+            '[project]\nname = "data-pipeline"\n'
+            'description = "Stream processing toolkit"\n'
+        )
+        keywords = _extract_keywords(project)
+        assert "data" in keywords
+        assert "pipeline" in keywords
+
+    def test_fallback_to_dirname(self, tmp_path):
+        project = tmp_path / "my-cool-tool"
+        project.mkdir()
+        keywords = _extract_keywords(project)
+        assert "cool" in keywords
+        assert "tool" in keywords
+
+    def test_filters_stop_words(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text(
+            "# The Project\nThis is a tool for the web.\n"
+        )
+        keywords = _extract_keywords(project)
+        assert "the" not in keywords
+        assert "this" not in keywords
+        assert "project" in keywords
+
+    def test_returns_max_five(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text(
+            "# Alpha Beta Gamma Delta Epsilon Zeta Eta Theta\n"
+        )
+        keywords = _extract_keywords(project)
+        assert len(keywords) <= 5
+
+    def test_deduplicates(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text("# Factory Factory Factory\n")
+        keywords = _extract_keywords(project)
+        assert keywords.count("factory") == 1
+
+
+class TestSearchSimilarProjects:
+    def test_success(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text("# Task Runner\nRun tasks efficiently.\n")
+
+        gh_output = json.dumps([
+            {
+                "fullName": "org/task-runner",
+                "url": "https://github.com/org/task-runner",
+                "description": "A fast task runner",
+                "stargazersCount": 100,
+            },
+            {
+                "fullName": "user/runner2",
+                "url": "https://github.com/user/runner2",
+                "description": None,
+                "stargazersCount": 50,
+            },
+        ])
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=gh_output, stderr=""
+        )
+        with patch("factory.study.subprocess.run", return_value=mock_result):
+            results = _search_similar_projects(project)
+
+        assert len(results) == 2
+        assert results[0]["name"] == "org/task-runner"
+        assert results[0]["stars"] == 100
+        assert results[0]["description"] == "A fast task runner"
+        # None description should become empty string
+        assert results[1]["description"] == ""
+
+    def test_gh_not_found(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text("# Some Project\n")
+
+        with patch(
+            "factory.study.subprocess.run", side_effect=FileNotFoundError("gh not found")
+        ):
+            results = _search_similar_projects(project)
+        assert results == []
+
+    def test_gh_timeout(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text("# Some Project\n")
+
+        with patch(
+            "factory.study.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=15),
+        ):
+            results = _search_similar_projects(project)
+        assert results == []
+
+    def test_gh_nonzero_exit(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text("# Some Project\n")
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="auth required"
+        )
+        with patch("factory.study.subprocess.run", return_value=mock_result):
+            results = _search_similar_projects(project)
+        assert results == []
+
+    def test_no_keywords(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        # Empty README
+        (project / "README.md").write_text("")
+        results = _search_similar_projects(project)
+        assert results == []
+
+    def test_invalid_json_output(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "README.md").write_text("# Some Project\n")
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="not json", stderr=""
+        )
+        with patch("factory.study.subprocess.run", return_value=mock_result):
+            results = _search_similar_projects(project)
+        assert results == []
+
+
+class TestReadObsidianNotes:
+    def test_reads_notes(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+
+        experiments_dir = vault / "Work" / "Factory" / "Experiments"
+        experiments_dir.mkdir(parents=True)
+        (experiments_dir / "myapp-001.md").write_text(
+            "---\ntags:\n  - factory\n---\n\n# Experiment #1\nImproved performance."
+        )
+
+        summaries = _read_obsidian_notes("myapp")
+        assert len(summaries) == 1
+        assert "Experiment #1" in summaries[0]
+
+    def test_multiple_subdirs(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+
+        for subdir in ["Experiments", "Projects", "Strategies"]:
+            d = vault / "Work" / "Factory" / subdir
+            d.mkdir(parents=True)
+            (d / "myapp-note.md").write_text(f"---\n---\n\n# {subdir} note")
+
+        summaries = _read_obsidian_notes("myapp")
+        assert len(summaries) == 3
+
+    def test_empty_vault(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+
+        summaries = _read_obsidian_notes("myapp")
+        assert summaries == []
+
+    def test_no_vault(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "nonexistent"))
+        summaries = _read_obsidian_notes("myapp")
+        assert summaries == []
+
+    def test_skips_frontmatter(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+
+        projects_dir = vault / "Work" / "Factory" / "Projects"
+        projects_dir.mkdir(parents=True)
+        (projects_dir / "myapp.md").write_text(
+            "---\ntags:\n  - factory\n  - project\ndate: 2026-04-11\n---\n\nActual content here."
+        )
+
+        summaries = _read_obsidian_notes("myapp")
+        assert len(summaries) == 1
+        assert "tags:" not in summaries[0]
+        assert "Actual content here." in summaries[0]
+
+    def test_truncates_to_200_chars(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+
+        projects_dir = vault / "Work" / "Factory" / "Projects"
+        projects_dir.mkdir(parents=True)
+        (projects_dir / "myapp.md").write_text("x" * 500)
+
+        summaries = _read_obsidian_notes("myapp")
+        assert len(summaries) == 1
+        assert len(summaries[0]) == 200


### PR DESCRIPTION
## Summary
- Add `_search_similar_projects()` that uses `gh search repos` to find similar GitHub projects based on keywords extracted from README/pyproject.toml
- Add `_read_obsidian_notes()` that reads existing vault notes for the project across Experiments, Projects, and Strategies directories
- Extend `study_project()` output with "Similar Projects" and "Prior Knowledge (Obsidian)" sections
- Add 20 new tests covering keyword extraction, GitHub search (mocked), and Obsidian note reading

Closes #22
Experiment: 19

## Test plan
- [x] All 253 tests pass (`uv run pytest -v`)
- [x] Lint passes (`uv run ruff check .`)
- [x] `_search_similar_projects` tested with mocked subprocess (success, gh not found, timeout, nonzero exit, invalid JSON, no keywords)
- [x] `_read_obsidian_notes` tested with mock vault (notes exist across subdirs, empty vault, no vault, frontmatter skipping, truncation)
- [x] `study_project` tested for "Similar Projects" and "Prior Knowledge" sections in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)