### PR TITLE
Add dedicated factory Obsidian vault with per-project structure

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -237,6 +237,7 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 def cmd_archive(args: argparse.Namespace) -> int:
     from factory.obsidian.notes import (
+        update_memory_index,
         write_experiment_note,
         write_project_dashboard,
         write_strategy_note,
@@ -276,10 +277,21 @@ def cmd_archive(args: argparse.Namespace) -> int:
     if strategy_text:
         write_strategy_note(project_name, strategy_text)
 
+    # Update MEMORY.md index
+    update_memory_index()
+
     from factory.obsidian.notes import _get_vault_path
 
     vault_path = _get_vault_path()
     print(f"Archived {len(records)} experiments to {vault_path}")
+    return 0
+
+
+def cmd_vault_init(args: argparse.Namespace) -> int:
+    from factory.obsidian.notes import init_vault
+
+    vault_path = init_vault()
+    print(f"Factory vault initialized at {vault_path}")
     return 0
 
 
@@ -473,6 +485,9 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("archive", help="Write experiment notes to Obsidian vault")
     p.add_argument("path", help="Path to the project")
 
+    # vault-init
+    p = sub.add_parser("vault-init", help="Create the factory Obsidian vault")
+
     # run
     p = sub.add_parser("run", help="Cron entry: invoke claude -p with factory skill")
     p.add_argument("path", help="Path to the project or GitHub URL")
@@ -519,6 +534,7 @@ def main(argv: list[str] | None = None) -> int:
         "study": cmd_study,
         "status": cmd_status,
         "archive": cmd_archive,
+        "vault-init": cmd_vault_init,
         "run": cmd_run,
     }
 

--- a/factory/obsidian/notes.py
+++ b/factory/obsidian/notes.py
@@ -3,13 +3,110 @@
 from __future__ import annotations
 
 import os
+import re
 from datetime import datetime
 from pathlib import Path
 
 from factory.models import CompositeScore, ExperimentRecord
 
-_DEFAULT_VAULT = Path.home() / "Library" / "Mobile Documents" / "iCloud~md~obsidian" / "Documents" / "memories"
-_FACTORY_DIR = "Work/Factory"
+_DEFAULT_VAULT = Path.home() / "obsidian-vaults" / "factory"
+
+_PROJECTS_DIR = "10-Projects"
+_KNOWLEDGE_DIR = "20-Knowledge"
+_FACTORY_META_DIR = "00-Factory"
+_TEMPLATES_DIR = "_templates"
+
+# ── Template content ──────────────────────────────────────────
+
+_TEMPLATE_EXPERIMENT = """\
+---
+tags:
+  - factory
+  - experiment
+  - {{project}}
+project: {{project}}
+experiment_id: {{id}}
+verdict: {{verdict}}
+score_delta: {{delta}}
+date: {{date}}
+source: factory-evaluator
+---
+
+# Experiment #{{id}}: {{hypothesis}}
+
+## Hypothesis
+{{hypothesis}}
+
+## Result
+**{{verdict}}** — score changed from {{before}} to {{after}} ({{delta}})
+
+## What Changed
+{{summary}}
+
+## Links
+- [[{{project}}]]
+"""
+
+_TEMPLATE_DECISION = """\
+---
+tags:
+  - factory
+  - decision
+  - {{project}}
+project: {{project}}
+date: {{date}}
+context: {{context}}
+outcome: {{outcome}}
+source: factory-orchestrator
+---
+
+# Decision: {{title}}
+
+## Context
+{{context}}
+
+## Alternatives Considered
+{{alternatives}}
+
+## Decision
+{{decision}}
+
+## Outcome
+{{outcome}}
+"""
+
+_TEMPLATE_STRATEGY = """\
+---
+tags:
+  - factory
+  - strategy
+  - {{project}}
+date: {{date}}
+source: factory-strategist
+---
+
+# Strategy: {{project}} — {{date}}
+
+{{content}}
+"""
+
+_TEMPLATE_PROJECT = """\
+---
+tags:
+  - factory
+  - project
+  - {{project}}
+---
+
+# Factory: {{project}}
+
+## Status
+- **State**: {{state}}
+- **Current Score**: {{score}}
+
+## Recent Experiments
+(populated by archivist)
+"""
 
 
 def _get_vault_path() -> Path:
@@ -22,6 +119,72 @@ def _ensure_dir(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
 
 
+def init_vault(vault_path: Path | None = None) -> Path:
+    """Create the full factory vault structure. Returns the vault path."""
+    vault = vault_path if vault_path is not None else _get_vault_path()
+
+    # .obsidian/
+    _ensure_dir(vault / ".obsidian")
+
+    # 00-Factory/
+    factory_meta = vault / _FACTORY_META_DIR
+    _ensure_dir(factory_meta)
+    _ensure_dir(factory_meta / "Decisions")
+
+    dashboard_path = factory_meta / "Dashboard.md"
+    if not dashboard_path.exists():
+        dashboard_path.write_text(
+            "# Factory Dashboard\n\nCentral hub for all factory-managed projects.\n"
+        )
+
+    patterns_path = factory_meta / "Patterns.md"
+    if not patterns_path.exists():
+        patterns_path.write_text(
+            "# Cross-Project Patterns\n\nRecurring patterns discovered across projects.\n"
+        )
+
+    # 10-Projects/
+    _ensure_dir(vault / _PROJECTS_DIR)
+
+    # 20-Knowledge/
+    _ensure_dir(vault / _KNOWLEDGE_DIR / "Concepts")
+    _ensure_dir(vault / _KNOWLEDGE_DIR / "Sources")
+
+    # _templates/
+    templates = vault / _TEMPLATES_DIR
+    _ensure_dir(templates)
+
+    template_files = {
+        "experiment.md": _TEMPLATE_EXPERIMENT,
+        "decision.md": _TEMPLATE_DECISION,
+        "strategy.md": _TEMPLATE_STRATEGY,
+        "project.md": _TEMPLATE_PROJECT,
+    }
+    for name, content in template_files.items():
+        tpath = templates / name
+        if not tpath.exists():
+            tpath.write_text(content)
+
+    # MEMORY.md
+    memory_path = vault / "MEMORY.md"
+    if not memory_path.exists():
+        memory_path.write_text(
+            "# Factory Memory Index\n\n"
+            "Pointer file for factory agents.\n\n"
+            "## Projects\n\n(none yet)\n"
+        )
+
+    return vault
+
+
+def _auto_init_vault() -> Path:
+    """Get vault path and auto-create structure if needed."""
+    vault = _get_vault_path()
+    if not (vault / ".obsidian").exists():
+        init_vault(vault)
+    return vault
+
+
 def write_experiment_note(
     project_name: str,
     record: ExperimentRecord,
@@ -29,8 +192,8 @@ def write_experiment_note(
     score_after: CompositeScore | None = None,
 ) -> Path:
     """Create an Obsidian note for a completed experiment."""
-    vault = _get_vault_path()
-    experiments_dir = vault / _FACTORY_DIR / "Experiments"
+    vault = _auto_init_vault()
+    experiments_dir = vault / _PROJECTS_DIR / project_name / "Experiments"
     _ensure_dir(experiments_dir)
 
     filename = f"{project_name}-{record.id:03d}.md"
@@ -52,6 +215,7 @@ def write_experiment_note(
         f"verdict: {record.verdict}",
         f"score_delta: {record.delta if record.delta is not None else 0.0}",
         f"date: {date_str}",
+        "source: factory-evaluator",
         "---",
         "",
         f"# Experiment #{record.id}: {record.hypothesis[:80]}",
@@ -105,8 +269,8 @@ def write_project_dashboard(
     eval_dimensions: list[dict] | None = None,
 ) -> Path:
     """Create or update the project dashboard note."""
-    vault = _get_vault_path()
-    projects_dir = vault / _FACTORY_DIR / "Projects"
+    vault = _auto_init_vault()
+    projects_dir = vault / _PROJECTS_DIR / project_name
     _ensure_dir(projects_dir)
 
     filename = f"{project_name}.md"
@@ -138,7 +302,10 @@ def write_project_dashboard(
     if eval_dimensions:
         lines.append("## Eval Dimensions")
         for dim in eval_dimensions:
-            lines.append(f"- {dim.get('name', '?')} ({dim.get('weight', 0):.1%} weight) — {dim.get('description', '')}")
+            lines.append(
+                f"- {dim.get('name', '?')} ({dim.get('weight', 0):.1%} weight)"
+                f" — {dim.get('description', '')}"
+            )
         lines.append("")
 
     # Recent experiments (last 5)
@@ -146,7 +313,9 @@ def write_project_dashboard(
     recent = records[-5:] if records else []
     for r in reversed(recent):
         delta = f"{r.delta:+.4f}" if r.delta is not None else "n/a"
-        lines.append(f"- [[{project_name}-{r.id:03d}]] — {r.hypothesis[:50]} ({r.verdict.upper()}, {delta})")
+        lines.append(
+            f"- [[{project_name}-{r.id:03d}]] — {r.hypothesis[:50]} ({r.verdict.upper()}, {delta})"
+        )
     if not recent:
         lines.append("- No experiments yet")
     lines.append("")
@@ -160,8 +329,8 @@ def write_strategy_note(
     strategy_content: str,
 ) -> Path:
     """Write a strategy snapshot to Obsidian."""
-    vault = _get_vault_path()
-    strategies_dir = vault / _FACTORY_DIR / "Strategies"
+    vault = _auto_init_vault()
+    strategies_dir = vault / _PROJECTS_DIR / project_name / "Strategies"
     _ensure_dir(strategies_dir)
 
     date_str = datetime.now().strftime("%Y-%m-%d")
@@ -175,6 +344,7 @@ def write_strategy_note(
         "  - strategy",
         f"  - {project_name}",
         f"date: {date_str}",
+        "source: factory-strategist",
         "---",
         "",
         f"# Strategy: {project_name} — {date_str}",
@@ -184,3 +354,60 @@ def write_strategy_note(
 
     note_path.write_text("\n".join(lines) + "\n")
     return note_path
+
+
+def update_memory_index(projects: list[dict] | None = None) -> Path:
+    """Regenerate MEMORY.md at vault root with project listing.
+
+    If *projects* is None, scans ``10-Projects/`` for subdirectories and
+    reads each dashboard note for the latest score.
+    """
+    vault = _get_vault_path()
+
+    if projects is None:
+        projects = []
+        projects_root = vault / _PROJECTS_DIR
+        if projects_root.exists():
+            for subdir in sorted(projects_root.iterdir()):
+                if not subdir.is_dir():
+                    continue
+                name = subdir.name
+                dashboard = subdir / f"{name}.md"
+                score = "n/a"
+                exp_count = 0
+                if dashboard.exists():
+                    content = dashboard.read_text(errors="replace")
+                    score_match = re.search(r"\*\*Current Score\*\*:\s*(\S+)", content)
+                    if score_match:
+                        score = score_match.group(1)
+                    exp_match = re.search(r"\*\*Experiments Run\*\*:\s*(\d+)", content)
+                    if exp_match:
+                        exp_count = int(exp_match.group(1))
+                projects.append({
+                    "name": name,
+                    "score": score,
+                    "experiments": exp_count,
+                })
+
+    lines = [
+        "# Factory Memory Index",
+        "",
+        "Pointer file for factory agents.",
+        "",
+        "## Projects",
+        "",
+    ]
+
+    if projects:
+        for p in projects:
+            lines.append(
+                f"- [[{p['name']}]] — score: {p['score']}, {p['experiments']} experiments"
+            )
+    else:
+        lines.append("(none yet)")
+
+    lines.append("")
+
+    memory_path = vault / "MEMORY.md"
+    memory_path.write_text("\n".join(lines))
+    return memory_path

--- a/factory/obsidian/templates.py
+++ b/factory/obsidian/templates.py
@@ -7,6 +7,9 @@ FACTORY_TAG = "factory"
 EXPERIMENT_TAG = "experiment"
 PROJECT_TAG = "project"
 STRATEGY_TAG = "strategy"
+DECISION_TAG = "decision"
+CONCEPT_TAG = "concept"
+SOURCE_TAG = "source"
 
 # Required frontmatter fields per note type
 EXPERIMENT_FRONTMATTER = [
@@ -27,6 +30,14 @@ STRATEGY_FRONTMATTER = [
     "date",
 ]
 
+DECISION_FRONTMATTER = [
+    "tags",
+    "project",
+    "date",
+    "context",
+    "outcome",
+]
+
 
 def experiment_tags(project_name: str) -> list[str]:
     """Return standard tags for an experiment note."""
@@ -41,3 +52,13 @@ def project_tags(project_name: str) -> list[str]:
 def strategy_tags(project_name: str) -> list[str]:
     """Return standard tags for a strategy note."""
     return [FACTORY_TAG, STRATEGY_TAG, project_name]
+
+
+def decision_tags(project_name: str) -> list[str]:
+    """Return standard tags for a decision note."""
+    return [FACTORY_TAG, DECISION_TAG, project_name]
+
+
+def wikilink(title: str) -> str:
+    """Return an Obsidian wikilink."""
+    return f"[[{title}]]"

--- a/factory/study.py
+++ b/factory/study.py
@@ -188,22 +188,55 @@ def _read_obsidian_notes(project_name: str) -> list[str]:
     Returns a list of note summaries (first 200 chars of each note).
     Gracefully returns empty list if vault doesn't exist.
     """
-    from factory.obsidian.notes import _get_vault_path, _FACTORY_DIR
+    from factory.obsidian.notes import _get_vault_path, _KNOWLEDGE_DIR, _PROJECTS_DIR
 
     vault = _get_vault_path()
     if not vault.exists():
         return []
 
-    # Search across Experiments, Projects, and Strategies
     summaries: list[str] = []
-    for subdir in ["Experiments", "Projects", "Strategies"]:
-        notes_dir = vault / _FACTORY_DIR / subdir
+
+    # Project-specific notes
+    project_dir = vault / _PROJECTS_DIR / project_name
+    for subdir in ["Experiments", "Strategies"]:
+        notes_dir = project_dir / subdir
         if not notes_dir.exists():
             continue
         for note_path in sorted(notes_dir.glob(f"{project_name}*.md")):
             try:
                 content = note_path.read_text(errors="replace")
                 # Skip frontmatter
+                if content.startswith("---"):
+                    end = content.find("---", 3)
+                    if end != -1:
+                        content = content[end + 3:].strip()
+                summary = content[:200].strip()
+                if summary:
+                    summaries.append(summary)
+            except OSError:
+                continue
+
+    # Project dashboard
+    dashboard = project_dir / f"{project_name}.md"
+    if dashboard.exists():
+        try:
+            content = dashboard.read_text(errors="replace")
+            if content.startswith("---"):
+                end = content.find("---", 3)
+                if end != -1:
+                    content = content[end + 3:].strip()
+            summary = content[:200].strip()
+            if summary:
+                summaries.append(summary)
+        except OSError:
+            pass
+
+    # Cross-project knowledge
+    knowledge_dir = vault / _KNOWLEDGE_DIR / "Concepts"
+    if knowledge_dir.exists():
+        for note_path in sorted(knowledge_dir.glob("*.md")):
+            try:
+                content = note_path.read_text(errors="replace")
                 if content.startswith("---"):
                     end = content.find("---", 3)
                     if end != -1:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,6 +278,7 @@ class TestCmdArchive:
         with patch("factory.obsidian.notes.write_experiment_note") as mock_exp, \
              patch("factory.obsidian.notes.write_project_dashboard") as mock_dash, \
              patch("factory.obsidian.notes.write_strategy_note") as mock_strat, \
+             patch("factory.obsidian.notes.update_memory_index"), \
              patch("factory.obsidian.notes._get_vault_path",
                    return_value=tmp_project / "vault"):
             result = main(["archive", str(tmp_project)])
@@ -307,6 +308,7 @@ class TestCmdArchive:
         with patch("factory.obsidian.notes.write_experiment_note") as mock_exp, \
              patch("factory.obsidian.notes.write_project_dashboard") as mock_dash, \
              patch("factory.obsidian.notes.write_strategy_note") as mock_strat, \
+             patch("factory.obsidian.notes.update_memory_index"), \
              patch("factory.obsidian.notes._get_vault_path",
                    return_value=tmp_project / "vault"):
             result = main(["archive", str(tmp_project)])
@@ -316,6 +318,21 @@ class TestCmdArchive:
         mock_dash.assert_called_once()
         mock_strat.assert_called_once()
 
+
+
+class TestCmdVaultInit:
+    def test_vault_init_parser(self):
+        parser = build_parser()
+        args = parser.parse_args(["vault-init"])
+        assert args.command == "vault-init"
+
+    def test_vault_init_calls_init_vault(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "vault"))
+        result = main(["vault-init"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Factory vault initialized" in out
+        assert (tmp_path / "vault" / ".obsidian").is_dir()
 
 
 class TestGitHubUrlDetection:

--- a/tests/test_obsidian.py
+++ b/tests/test_obsidian.py
@@ -6,6 +6,8 @@ import pytest
 
 from factory.models import CompositeScore, EvalResult, ExperimentRecord
 from factory.obsidian.notes import (
+    init_vault,
+    update_memory_index,
     write_experiment_note,
     write_project_dashboard,
     write_strategy_note,
@@ -35,6 +37,10 @@ class TestExperimentNote:
         path = write_experiment_note("cloud-gateway", sample_record)
         assert path.exists()
         assert "cloud-gateway-001.md" in path.name
+        # Should be under 10-Projects/cloud-gateway/Experiments/
+        assert "10-Projects" in str(path)
+        assert "cloud-gateway" in str(path.parent.parent.name)
+        assert path.parent.name == "Experiments"
 
     def test_note_has_frontmatter(self, sample_record, obsidian_vault):
         path = write_experiment_note("cloud-gateway", sample_record)
@@ -46,6 +52,7 @@ class TestExperimentNote:
         assert "  - cloud-gateway" in content
         assert "verdict: keep" in content
         assert "experiment_id: 1" in content
+        assert "source: factory-evaluator" in content
 
     def test_note_has_hypothesis(self, sample_record, obsidian_vault):
         path = write_experiment_note("cloud-gateway", sample_record)
@@ -76,6 +83,9 @@ class TestProjectDashboard:
         path = write_project_dashboard("cloud-gateway", "has_factory", 0.87, [])
         assert path.exists()
         assert "cloud-gateway.md" in path.name
+        # Should be under 10-Projects/cloud-gateway/
+        assert "10-Projects" in str(path)
+        assert path.parent.name == "cloud-gateway"
 
     def test_dashboard_has_frontmatter(self, obsidian_vault):
         path = write_project_dashboard("cloud-gateway", "has_factory", 0.87, [])
@@ -103,9 +113,118 @@ class TestStrategyNote:
         path = write_strategy_note("cloud-gateway", "## Strategy\nFocus on reliability.")
         assert path.exists()
         assert "cloud-gateway-" in path.name
+        # Should be under 10-Projects/cloud-gateway/Strategies/
+        assert "10-Projects" in str(path)
+        assert path.parent.name == "Strategies"
 
     def test_strategy_has_frontmatter(self, obsidian_vault):
         path = write_strategy_note("cloud-gateway", "content")
         content = path.read_text()
         assert "  - strategy" in content
         assert "  - cloud-gateway" in content
+        assert "source: factory-strategist" in content
+
+
+class TestInitVault:
+    def test_creates_vault_structure(self, obsidian_vault):
+        vault = init_vault(obsidian_vault)
+        assert vault == obsidian_vault
+        assert (vault / "10-Projects").is_dir()
+        assert (vault / "20-Knowledge" / "Concepts").is_dir()
+        assert (vault / "20-Knowledge" / "Sources").is_dir()
+        assert (vault / "00-Factory").is_dir()
+        assert (vault / "00-Factory" / "Decisions").is_dir()
+
+    def test_creates_obsidian_dir(self, obsidian_vault):
+        init_vault(obsidian_vault)
+        assert (obsidian_vault / ".obsidian").is_dir()
+
+    def test_creates_templates(self, obsidian_vault):
+        init_vault(obsidian_vault)
+        templates = obsidian_vault / "_templates"
+        assert templates.is_dir()
+        template_files = list(templates.glob("*.md"))
+        assert len(template_files) == 4
+        names = {f.name for f in template_files}
+        assert names == {"experiment.md", "decision.md", "strategy.md", "project.md"}
+
+    def test_creates_memory_md(self, obsidian_vault):
+        init_vault(obsidian_vault)
+        memory = obsidian_vault / "MEMORY.md"
+        assert memory.exists()
+        content = memory.read_text()
+        assert "Factory Memory Index" in content
+        assert "(none yet)" in content
+
+    def test_creates_dashboard(self, obsidian_vault):
+        init_vault(obsidian_vault)
+        dashboard = obsidian_vault / "00-Factory" / "Dashboard.md"
+        assert dashboard.exists()
+        content = dashboard.read_text()
+        assert "Factory Dashboard" in content
+
+    def test_idempotent(self, obsidian_vault):
+        init_vault(obsidian_vault)
+        # Write custom content to Dashboard.md
+        dashboard = obsidian_vault / "00-Factory" / "Dashboard.md"
+        dashboard.write_text("Custom content")
+
+        # Second call should not overwrite existing files
+        init_vault(obsidian_vault)
+        assert dashboard.read_text() == "Custom content"
+
+
+class TestUpdateMemoryIndex:
+    def test_empty_vault(self, obsidian_vault):
+        init_vault(obsidian_vault)
+        path = update_memory_index()
+        content = path.read_text()
+        assert "(none yet)" in content
+
+    def test_with_projects(self, obsidian_vault):
+        init_vault(obsidian_vault)
+        # Create a project with a dashboard
+        proj_dir = obsidian_vault / "10-Projects" / "my-app"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "my-app.md").write_text(
+            "---\ntags:\n  - factory\n---\n\n# Factory: my-app\n\n## Status\n"
+            "- **State**: has_factory\n- **Current Score**: 0.9725\n"
+            "- **Experiments Run**: 5\n"
+        )
+
+        path = update_memory_index()
+        content = path.read_text()
+        assert "[[my-app]]" in content
+        assert "0.9725" in content
+        assert "5 experiments" in content
+
+    def test_with_explicit_projects(self, obsidian_vault):
+        init_vault(obsidian_vault)
+        projects = [{"name": "proj-a", "score": "0.95", "experiments": 3}]
+        path = update_memory_index(projects=projects)
+        content = path.read_text()
+        assert "[[proj-a]]" in content
+        assert "0.95" in content
+        assert "3 experiments" in content
+
+
+class TestAutoInit:
+    def test_auto_creates_vault_on_write(self, tmp_path, monkeypatch):
+        """Writing a note to nonexistent vault creates the vault structure."""
+        vault = tmp_path / "new-vault"
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        assert not vault.exists()
+
+        record = ExperimentRecord(
+            id=1, timestamp=datetime(2026, 4, 11, 12, 0),
+            hypothesis="Test auto-init",
+            change_summary="Auto-init test",
+            issue_number=None, pr_number=None,
+            score_before=0.5, score_after=0.6, delta=0.1,
+            verdict="keep", cost_usd=None, notes="",
+        )
+        path = write_experiment_note("test-project", record)
+        assert path.exists()
+        assert (vault / ".obsidian").is_dir()
+        assert (vault / "10-Projects").is_dir()
+        assert (vault / "MEMORY.md").exists()

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -238,8 +238,8 @@ class TestStudyProject:
         project_path = tmp_path / "myapp"
         project_path.mkdir()
 
-        # Create an Obsidian note
-        notes_dir = tmp_path / "vault" / "Work" / "Factory" / "Projects"
+        # Create an Obsidian note under the new per-project structure
+        notes_dir = tmp_path / "vault" / "10-Projects" / "myapp"
         notes_dir.mkdir(parents=True)
         (notes_dir / "myapp.md").write_text(
             "---\ntags:\n  - factory\n---\n\n# Dashboard for myapp\nSome content here."
@@ -437,7 +437,7 @@ class TestReadObsidianNotes:
         vault = tmp_path / "vault"
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
 
-        experiments_dir = vault / "Work" / "Factory" / "Experiments"
+        experiments_dir = vault / "10-Projects" / "myapp" / "Experiments"
         experiments_dir.mkdir(parents=True)
         (experiments_dir / "myapp-001.md").write_text(
             "---\ntags:\n  - factory\n---\n\n# Experiment #1\nImproved performance."
@@ -451,10 +451,14 @@ class TestReadObsidianNotes:
         vault = tmp_path / "vault"
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
 
-        for subdir in ["Experiments", "Projects", "Strategies"]:
-            d = vault / "Work" / "Factory" / subdir
+        project_dir = vault / "10-Projects" / "myapp"
+        for subdir in ["Experiments", "Strategies"]:
+            d = project_dir / subdir
             d.mkdir(parents=True)
             (d / "myapp-note.md").write_text(f"---\n---\n\n# {subdir} note")
+        # Also create dashboard
+        project_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "myapp.md").write_text("---\n---\n\n# Dashboard note")
 
         summaries = _read_obsidian_notes("myapp")
         assert len(summaries) == 3
@@ -476,9 +480,9 @@ class TestReadObsidianNotes:
         vault = tmp_path / "vault"
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
 
-        projects_dir = vault / "Work" / "Factory" / "Projects"
-        projects_dir.mkdir(parents=True)
-        (projects_dir / "myapp.md").write_text(
+        project_dir = vault / "10-Projects" / "myapp"
+        project_dir.mkdir(parents=True)
+        (project_dir / "myapp.md").write_text(
             "---\ntags:\n  - factory\n  - project\ndate: 2026-04-11\n---\n\nActual content here."
         )
 
@@ -491,10 +495,24 @@ class TestReadObsidianNotes:
         vault = tmp_path / "vault"
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
 
-        projects_dir = vault / "Work" / "Factory" / "Projects"
-        projects_dir.mkdir(parents=True)
-        (projects_dir / "myapp.md").write_text("x" * 500)
+        project_dir = vault / "10-Projects" / "myapp"
+        project_dir.mkdir(parents=True)
+        (project_dir / "myapp.md").write_text("x" * 500)
 
         summaries = _read_obsidian_notes("myapp")
         assert len(summaries) == 1
         assert len(summaries[0]) == 200
+
+    def test_cross_project_knowledge(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+
+        concepts_dir = vault / "20-Knowledge" / "Concepts"
+        concepts_dir.mkdir(parents=True)
+        (concepts_dir / "caching.md").write_text(
+            "---\ntags:\n  - concept\n---\n\n# Caching patterns for APIs"
+        )
+
+        summaries = _read_obsidian_notes("myapp")
+        assert len(summaries) == 1
+        assert "Caching patterns" in summaries[0]


### PR DESCRIPTION
## Summary
- Restructure Obsidian integration to use a dedicated vault at `~/obsidian-vaults/factory/` with per-project subdirectories (`10-Projects/`, `20-Knowledge/`, `00-Factory/`, `_templates/`)
- Add `init_vault()` with full vault scaffolding, `_auto_init_vault()` for lazy creation on first write, and `update_memory_index()` for MEMORY.md regeneration
- Add `vault-init` CLI command, provenance tags (`source: factory-evaluator/strategist/orchestrator`), cross-project knowledge reading in `study.py`, and template files for experiment/decision/strategy/project notes

## Test plan
- [x] All 278 tests pass (`uv run pytest -v`)
- [x] Lint passes (`uv run ruff check .`)
- [x] New test classes: `TestInitVault`, `TestUpdateMemoryIndex`, `TestAutoInit`, `TestCmdVaultInit`, cross-project knowledge test
- [x] Existing tests updated for new directory structure (`10-Projects/<project>/Experiments/` etc.)
- [ ] Manual: run `uv run python -m factory vault-init` and verify vault structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)