### PR TITLE
Add deep researcher subagent with web search

### DIFF
--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,0 +1,105 @@
+---
+name: researcher
+description: Deep research agent — searches web for similar projects, best practices, and reads factory vault for prior knowledge
+tools: WebSearch, WebFetch, Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the Factory Researcher. Your job is to deeply investigate a project and its domain to inform the Strategist's hypotheses.
+
+## Process
+
+### 1. Local Analysis
+
+Run `uv run python -m factory study "$PROJECT_PATH"` to gather:
+- Interaction logs (user requests, errors)
+- Shallow GitHub search results
+- Prior Obsidian vault notes
+
+Read the output from `$PROJECT_PATH/.factory/strategy/observations.md`.
+
+### 2. Project Context
+
+Read these files to understand the project:
+- README.md or CLAUDE.md
+- pyproject.toml / package.json
+- Recent experiment history: `uv run python -m factory history "$PROJECT_PATH"`
+- Current strategy: `$PROJECT_PATH/.factory/strategy/current.md`
+- Factory config: `$PROJECT_PATH/factory.md`
+
+### 3. External Research
+
+Use WebSearch to find:
+- Similar projects on GitHub (query: project type + key technologies)
+- Best practices for the project's domain
+- Common patterns and anti-patterns
+- Relevant blog posts, documentation, or papers
+
+For the top 3-5 most promising results, use WebFetch to read them in detail.
+
+### 4. Vault Knowledge
+
+Read the factory vault for cross-project knowledge:
+- `~/obsidian-vaults/factory/10-Projects/` — prior experiments from other projects
+- `~/obsidian-vaults/factory/00-Factory/Patterns.md` — recurring patterns
+- `~/obsidian-vaults/factory/20-Knowledge/Concepts/` — concept notes
+
+Use `obsidian search query="<term>" vault="factory"` if Obsidian is running, otherwise read files directly.
+
+### 5. Output
+
+Write a structured research report to `$PROJECT_PATH/.factory/strategy/research.md`:
+
+```markdown
+# Research Report — {project_name}
+Date: {date}
+
+## Project Summary
+{brief description of what the project does}
+
+## External Research
+
+### Similar Projects
+- [project-name](url) — {description}, {what we can learn}
+
+### Best Practices
+- {practice}: {detail from web research}
+
+### Relevant Techniques
+- {technique}: {how it applies to this project}
+
+## Prior Knowledge (from Vault)
+{cross-project patterns and prior experiment learnings}
+
+## Recommended Focus Areas
+1. {area}: {why, based on research}
+```
+
+Write any new external references to the factory vault using obsidian-cli:
+```bash
+obsidian create vault="factory" name="Sources/{source-name}" content="---
+tags:
+  - factory
+  - source
+  - {project}
+url: {url}
+date_found: {date}
+---
+
+# {source title}
+
+## Key Takeaways
+{summary of what we learned}
+" silent
+```
+
+If Obsidian isn't running, write the file directly to `~/obsidian-vaults/factory/20-Knowledge/Sources/`.
+
+## Rules
+
+- Always run the local study first — it's fast and provides baseline context
+- Limit WebSearch to 5-8 queries to avoid wasting tokens
+- Limit WebFetch to 3-5 pages (only the most promising results)
+- If the vault doesn't exist, skip vault reading gracefully
+- Write the research report even if external search fails — include local findings
+- Focus on actionable insights that can become hypotheses, not academic summaries

--- a/SKILL.md
+++ b/SKILL.md
@@ -210,13 +210,44 @@ The factory is initialized. Run the inner improvement loop using all 6 agent rol
 
 ### Step 0: Observe (Researcher Agent)
 
-The Researcher reads interaction logs, git history, and prior experiment outcomes, then writes structured observations for the Strategist.
+The Researcher performs both local analysis and deep external research.
+
+**Step 0a: Local Study**
 
 ```bash
 uv run python -m factory study "$PROJECT_PATH"
 ```
 
-This writes observations to `$PROJECT_PATH/.factory/strategy/observations.md`. If the command fails (non-zero exit), log the error and proceed to Step 1 -- the Strategist can still function without observations, but the hypotheses will be less informed.
+This writes local observations to `$PROJECT_PATH/.factory/strategy/observations.md`.
+
+**Step 0b: Deep Research (via Subagent)**
+
+Spawn the researcher subagent to perform web-based research and vault knowledge synthesis:
+
+```bash
+claude -p "$(cat <<'PROMPT'
+You are the Researcher agent for the Software Factory.
+Load your base prompt from ~/cursor-projects/remote-factory/factory/agents/prompts/researcher.md — use Mode 2 (Research).
+
+Project: $PROJECT_PATH
+
+## Context
+$(cat "$PROJECT_PATH/factory.md" 2>/dev/null || echo "No factory.md")
+$(cat "$PROJECT_PATH/.factory/strategy/observations.md" 2>/dev/null || echo "No local observations")
+$(uv run python -m factory history "$PROJECT_PATH" 2>/dev/null || echo "No experiments yet")
+
+## Task
+1. Read the local observations already generated
+2. Use WebSearch to find 5-10 relevant external resources for this project
+3. Use WebFetch to deeply read the top 3-5 results
+4. Read the factory vault for prior knowledge: ~/obsidian-vaults/factory/
+5. Write comprehensive research report to $PROJECT_PATH/.factory/strategy/research.md
+6. Write any new external source notes to ~/obsidian-vaults/factory/20-Knowledge/Sources/
+PROMPT
+)" --dangerously-skip-permissions
+```
+
+If the deep research subagent fails, proceed to Step 1 — the Strategist can work from local observations alone.
 
 ### Step 1: Hypothesize (Strategist Agent)
 
@@ -235,6 +266,8 @@ $(uv run python -m factory history "$PROJECT_PATH" 2>/dev/null || echo "No exper
 $(cat "$PROJECT_PATH/factory.md")
 
 $(cat "$PROJECT_PATH/.factory/strategy/observations.md" 2>/dev/null || echo "No observations from Researcher")
+
+$(cat "$PROJECT_PATH/.factory/strategy/research.md" 2>/dev/null || echo "No deep research available")
 
 $(cat "$PROJECT_PATH/.factory/strategy/current.md" 2>/dev/null || echo "No prior strategy")
 

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -1,45 +1,52 @@
 # Researcher Agent
 
-You are the Researcher agent for the Software Factory. Your job is to deeply understand a project and determine how to evaluate improvements to it.
+You are the Researcher agent for the Software Factory. You have two modes of operation depending on how you are invoked.
 
-## What You Do
+## Mode 1: Discovery (used in Discover mode)
 
+Deeply understand a project and determine how to evaluate improvements to it.
+
+### What You Do
 1. **Introspect the project**: Read README.md, CLAUDE.md, pyproject.toml / package.json, source code structure, test files, CI configuration
-2. **Identify the project type**: Is this a CLI tool, library, web app, bot, service, or something else?
-3. **Discover existing evaluation tools**: What test runners, linters, type checkers, and CI checks already exist?
-4. **Research best practices**: For the specific project type, what metrics and evaluation approaches are standard?
-5. **Generate eval dimensions**: Produce a concrete list of eval functions that can measure improvement
-6. **Write agent overrides**: Tailor the other agents (Strategist, Reviewer, etc.) to this specific project
+2. **Identify the project type**: CLI tool, library, web app, bot, service, etc.
+3. **Discover existing evaluation tools**: Test runners, linters, type checkers, CI checks
+4. **Generate eval dimensions**: Concrete list of eval functions that measure improvement
+5. **Write agent overrides**: Tailor other agents to this project
 
-## Output
+### Output (Discovery)
+1. `.factory/eval_profile.json` — eval dimensions with weights and commands
+2. `eval/score.py` — standalone eval script outputting JSON
+3. `.factory/agents/<role>.md` overrides (optional)
 
-You must produce three artifacts:
+### Rules (Discovery)
+- Be thorough but practical — don't add dimensions the project can't run
+- Weight tests highest (0.4-0.5), lint second (0.2-0.3)
+- Set `human_reviewed: false`
 
-### 1. eval_profile.json
-Write to `.factory/eval_profile.json` with this format:
-```json
-{
-  "project_type": "bot",
-  "dimensions": [
-    {"name": "tests", "command": "uv run pytest -v", "weight": 0.5, "parser": "exit_code", "regex_pattern": null, "description": "Run test suite", "source": "discovered"}
-  ],
-  "tier": "discovered",
-  "confidence": 0.8,
-  "human_reviewed": false
-}
-```
+## Mode 2: Research (used in Improve mode)
 
-### 2. eval/score.py
-Generate a standalone eval script that wraps each discovered dimension. It must output JSON to stdout.
+Deeply investigate the project's domain to inform the Strategist's hypotheses.
 
-### 3. .factory/agents/ overrides (optional)
-If you see project-specific patterns that should shape how other agents behave, write override prompts to `.factory/agents/<role>.md`. For example:
-- A bot project's Reviewer should check async patterns and error handling
-- A library's Strategist should prioritize API surface coverage and documentation
+### What You Do
+1. **Run local study**: `uv run python -m factory study "$PROJECT_PATH"` for interaction logs + shallow search
+2. **Read project context**: README, pyproject.toml, experiment history, current strategy
+3. **Search externally**: Use WebSearch for similar projects, best practices, relevant techniques
+4. **Read deeply**: Use WebFetch on the top 3-5 most promising search results
+5. **Check vault knowledge**: Read factory vault for cross-project patterns and prior learnings
+6. **Synthesize**: Write structured research report
 
-## Rules
+### Output (Research)
+Write to `$PROJECT_PATH/.factory/strategy/research.md`:
+- Project summary
+- External research findings (similar projects, best practices, techniques)
+- Prior knowledge from vault
+- Recommended focus areas (actionable insights for the Strategist)
 
-- Be thorough but practical — don't add eval dimensions the project can't actually run
-- Verify commands work before recommending them (try running them)
-- Weight tests highest (0.4-0.5), lint second (0.2-0.3), other dimensions lower
-- Set `human_reviewed: false` — the factory will flag this for human review
+Optionally write new source notes to `~/obsidian-vaults/factory/20-Knowledge/Sources/`.
+
+### Rules (Research)
+- Always run local study first — it's fast baseline context
+- Limit WebSearch to 5-8 queries
+- Limit WebFetch to 3-5 pages
+- Focus on actionable insights, not academic summaries
+- Write report even if external search fails — include local findings

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -44,6 +44,14 @@ Write `.factory/strategy/current.md` with this format:
 - <changes that failed before and why — learn from history>
 ```
 
+## Research Input
+
+When the Researcher provides a research report (at `.factory/strategy/research.md`), use the external findings to:
+- Identify patterns from similar projects that could improve this one
+- Rank hypotheses that address gaps revealed by best practices
+- Reference specific external projects or techniques in hypothesis rationale
+- Avoid reinventing solutions that already exist in the ecosystem
+
 ## Rules
 
 - Each hypothesis must be scoped to one PR's worth of work

--- a/factory/study.py
+++ b/factory/study.py
@@ -217,8 +217,8 @@ def _read_obsidian_notes(project_name: str) -> list[str]:
     return summaries
 
 
-def study_project(project_path: Path) -> str:
-    """Read interaction logs and produce an observations summary."""
+def study_project_local(project_path: Path) -> str:
+    """Read interaction logs and produce an observations summary (local only)."""
     log_files = _find_log_files(project_path)
 
     all_messages: list[dict] = []
@@ -276,3 +276,8 @@ def study_project(project_path: Path) -> str:
         lines.append("No prior notes found.")
 
     return "\n".join(lines)
+
+
+def study_project(project_path: Path) -> str:
+    """Study a project — local analysis. Deep research available via researcher subagent."""
+    return study_project_local(project_path)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,9 +1,14 @@
 """Tests for factory.agents — prompt loading and resolution."""
 
+from pathlib import Path
 
 import pytest
 
 from factory.agents.runner import resolve_prompt, AgentRole, _PROMPTS_DIR
+
+
+# Path to the project root (parent of factory/)
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 
 class TestResolvePrompt:
@@ -51,3 +56,48 @@ class TestResolvePrompt:
         for role in roles:
             prompt = resolve_prompt(role)
             assert prompt.startswith("# "), f"Prompt for {role} should start with '# '"
+
+
+class TestResearcherPromptModes:
+    """Verify the researcher prompt contains both Discovery and Research modes."""
+
+    def test_has_mode_1_discovery(self):
+        prompt = resolve_prompt("researcher")
+        assert "Mode 1" in prompt
+        assert "Discovery" in prompt
+
+    def test_has_mode_2_research(self):
+        prompt = resolve_prompt("researcher")
+        assert "Mode 2" in prompt
+        assert "Research" in prompt
+
+    def test_has_discovery_output(self):
+        prompt = resolve_prompt("researcher")
+        assert "Output (Discovery)" in prompt
+
+    def test_has_research_output(self):
+        prompt = resolve_prompt("researcher")
+        assert "Output (Research)" in prompt
+
+
+class TestClaudeAgentsResearcher:
+    """Verify the .claude/agents/researcher.md subagent definition exists and is valid."""
+
+    def test_subagent_file_exists(self):
+        agent_file = _PROJECT_ROOT / ".claude" / "agents" / "researcher.md"
+        assert agent_file.exists(), (
+            f"Expected .claude/agents/researcher.md at {agent_file}"
+        )
+
+    def test_subagent_has_frontmatter(self):
+        agent_file = _PROJECT_ROOT / ".claude" / "agents" / "researcher.md"
+        content = agent_file.read_text()
+        assert content.startswith("---"), "Subagent file should start with YAML frontmatter"
+        # Find closing frontmatter delimiter
+        end = content.find("---", 3)
+        assert end != -1, "Subagent file should have closing frontmatter delimiter"
+        frontmatter = content[3:end]
+        assert "name:" in frontmatter
+        assert "researcher" in frontmatter
+        assert "tools:" in frontmatter
+        assert "WebSearch" in frontmatter

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -13,6 +13,7 @@ from factory.study import (
     _read_obsidian_notes,
     _search_similar_projects,
     study_project,
+    study_project_local,
 )
 
 
@@ -174,11 +175,11 @@ class TestExtractMessages:
         assert len(messages[0]["text"]) == 500
 
 
-class TestStudyProject:
+class TestStudyProjectLocal:
     def test_no_logs_returns_message(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         with patch("factory.study._search_similar_projects", return_value=[]):
-            result = study_project(tmp_path / "nonexistent")
+            result = study_project_local(tmp_path / "nonexistent")
         assert "No interaction logs found." in result
         assert "## Similar Projects" in result
         assert "## Prior Knowledge (Obsidian)" in result
@@ -202,7 +203,7 @@ class TestStudyProject:
         (log_dir / "conv.jsonl").write_text("\n".join(lines))
 
         with patch("factory.study._search_similar_projects", return_value=[]):
-            result = study_project(project_path)
+            result = study_project_local(project_path)
         assert "# Interaction Study" in result
         assert "myapp" in result
         assert "1 conversation log(s)" in result
@@ -225,7 +226,7 @@ class TestStudyProject:
             },
         ]
         with patch("factory.study._search_similar_projects", return_value=similar):
-            result = study_project(project_path)
+            result = study_project_local(project_path)
         assert "## Similar Projects" in result
         assert "org/cool-project" in result
         assert "42 stars" in result
@@ -246,9 +247,25 @@ class TestStudyProject:
         )
 
         with patch("factory.study._search_similar_projects", return_value=[]):
-            result = study_project(project_path)
+            result = study_project_local(project_path)
         assert "## Prior Knowledge (Obsidian)" in result
         assert "Dashboard for myapp" in result
+
+
+class TestStudyProject:
+    def test_delegates_to_local(self, tmp_path, monkeypatch):
+        """study_project() delegates to study_project_local() for backward compat."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch("factory.study._search_similar_projects", return_value=[]):
+            local_result = study_project_local(tmp_path / "nonexistent")
+            wrapper_result = study_project(tmp_path / "nonexistent")
+        assert local_result == wrapper_result
+
+    def test_no_logs_returns_message(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with patch("factory.study._search_similar_projects", return_value=[]):
+            result = study_project(tmp_path / "nonexistent")
+        assert "No interaction logs found." in result
 
 
 class TestCmdStudy:


### PR DESCRIPTION
## Summary
- Rewrite researcher agent prompt with dual-mode architecture (Discovery + Research)
- Create `.claude/agents/researcher.md` subagent definition with WebSearch, WebFetch, Read, Grep, Glob, Bash tools
- Update SKILL.md Step 0 to spawn researcher subagent for deep external research
- Wire research.md into Strategist context block
- Rename `study_project()` → `study_project_local()` with backward-compatible wrapper

## Test plan
- [x] 273 tests pass
- [x] Lint clean
- [x] Researcher prompt has Mode 1 and Mode 2 sections
- [x] `.claude/agents/researcher.md` has valid frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)