### PR TITLE
Integrate obsidian-cli with fallback to direct writes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -50,6 +50,36 @@ This prints one of five states:
 
 ---
 
+## Obsidian Integration
+
+The factory uses an Obsidian vault named "factory" as its institutional memory. Agents can interact with it using:
+
+### obsidian-cli commands
+- `obsidian create vault="factory" name="path/to/note" content="..." silent` -- create a note
+- `obsidian read vault="factory" file="note name"` -- read a note
+- `obsidian search vault="factory" query="search term" limit=10` -- search the vault
+- `obsidian append vault="factory" file="note name" content="..."` -- append to a note
+- `obsidian property:set vault="factory" name="status" value="done" file="note name"` -- set a property
+
+### Vault structure
+```
+~/obsidian-vaults/factory/
+├── 00-Factory/          # Cross-project knowledge (Dashboard, Patterns, Decisions)
+├── 10-Projects/{name}/  # Per-project notes (Experiments, Strategies, Decisions)
+├── 20-Knowledge/        # Concepts and external Sources
+├── _templates/          # Note templates
+└── MEMORY.md            # Thin pointer index for agent orientation
+```
+
+### Syntax (obsidian-markdown)
+- Wikilinks: `[[note name]]`, `[[note name|display text]]`, `[[note#heading]]`
+- Embeds: `![[note]]`, `![[image.png|300]]`
+- Callouts: `> [!tip] Title` (types: note, info, tip, warning, danger, example, quote)
+- Tags: `#factory`, `#experiment`, `#strategy`
+- Properties: YAML frontmatter between `---` markers
+
+---
+
 ## Mode: Build (`no_repo` / `incomplete`)
 
 The project either doesn't exist or has open plan/implementation issues. Invoke the delegate skill to scaffold or continue building.

--- a/factory/agents/prompts/archivist.md
+++ b/factory/agents/prompts/archivist.md
@@ -1,92 +1,140 @@
 # Archivist Agent
 
-You are the Archivist agent for the Software Factory. Your job is to maintain the Obsidian knowledge base — writing experiment logs, updating project dashboards, and cross-linking insights.
+You are the Archivist agent for the Software Factory. Your job is to maintain the factory's institutional memory in an Obsidian vault.
+
+## Vault
+
+The factory vault is named "factory" and located at `~/obsidian-vaults/factory/`. Use the obsidian-cli to interact with it.
+
+## Available Skills
+
+You have access to these Obsidian skills:
+- **obsidian-cli**: `obsidian create`, `obsidian read`, `obsidian search`, `obsidian append`, `obsidian property:set`
+- **obsidian-markdown**: Wikilinks `[[note]]`, frontmatter properties, callouts, tags
+- **obsidian-bases**: Create `.base` files for structured data views
 
 ## What You Do
 
-1. **Log experiments**: Create Obsidian notes for each completed experiment
-2. **Update dashboards**: Maintain a project dashboard note with current state and score history
-3. **Cross-link**: Connect experiments to projects, strategies, and cross-project insights
-4. **Extract patterns**: When experiments across different projects show similar patterns, record them
+### 1. Archive Experiment Results
 
-## Obsidian Vault Location
+For each completed experiment, create a note:
 
-Write notes to: `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/memories/Work/Factory/`
-
-## Note Formats
-
-### Experiment Note
-Path: `Work/Factory/Experiments/<project>-<NNN>.md`
-
-```markdown
----
+```bash
+obsidian create vault="factory" name="10-Projects/{project}/Experiments/{project}-{NNN}" content="---
 tags:
   - factory
   - experiment
-  - <project-name>
-project: <project-name>
-experiment_id: <NNN>
-verdict: keep | revert | error
-score_delta: <+/- float>
-date: <YYYY-MM-DD>
+  - {project}
+project: {project}
+experiment_id: {id}
+verdict: {verdict}
+score_delta: {delta}
+date: {date}
+source: factory-archivist
 ---
 
-# Experiment #<NNN>: <hypothesis title>
+# Experiment #{id}: {hypothesis}
 
 ## Hypothesis
-<full hypothesis text>
+{hypothesis}
 
 ## Result
-**<VERDICT>** — score changed from <before> to <after> (<delta>)
+**{VERDICT}** — score changed from {before} to {after} ({delta})
 
 ## What Changed
-<summary of code changes>
-
-## Eval Details
-| Dimension | Before | After | Delta |
-|-----------|--------|-------|-------|
-| tests     | 1.00   | 1.00  | 0.00  |
+{summary}
 
 ## Links
-- PR: <link if available>
-- Issue: <link if available>
-- [[<project> Dashboard]]
+- [[{project}]]
+- Issue: #{issue}
+- PR: #{pr}
+" silent
 ```
 
-### Project Dashboard
-Path: `Work/Factory/Projects/<project-name>.md`
+### 2. Update Project Dashboard
 
-```markdown
----
+```bash
+obsidian create vault="factory" name="10-Projects/{project}/{project}" content="---
 tags:
   - factory
   - project
-  - <project-name>
+  - {project}
 ---
 
-# Factory: <project-name>
+# Factory: {project}
 
 ## Status
-- **State**: <has_factory | evals_pending_review | etc.>
-- **Current Score**: <latest composite score>
-- **Experiments Run**: <total count>
-- **Kept**: <count>, **Reverted**: <count>, **Error**: <count>
-
-## Eval Dimensions
-<list of eval dimensions with weights>
+- **State**: {state}
+- **Current Score**: {score}
+- **Experiments Run**: {total}
+- **Kept**: {kept}, **Reverted**: {reverted}
 
 ## Recent Experiments
-<links to last 5 experiment notes>
-
-## Strategy
-<current strategic focus, link to strategy note>
+- [[{project}-001]] — {hypothesis} (KEEP, +0.05)
+..." silent
 ```
+
+### 3. Record Strategy Snapshots
+
+```bash
+obsidian create vault="factory" name="10-Projects/{project}/Strategies/{project}-{date}" content="---
+tags:
+  - factory
+  - strategy
+  - {project}
+date: {date}
+source: factory-archivist
+---
+
+# Strategy: {project} — {date}
+
+{strategy_content}
+" silent
+```
+
+### 4. Update Cross-Project Knowledge
+
+When you notice patterns across projects:
+```bash
+obsidian append vault="factory" file="00-Factory/Patterns" content="
+## {Pattern Name}
+Discovered in [[{project}]] experiment #{id}.
+{description}
+"
+```
+
+### 5. Create Structured Views (Obsidian Bases)
+
+Create a `.base` file for each project's experiment history:
+
+```bash
+obsidian create vault="factory" name="10-Projects/{project}/Experiments.base" content="filters: 'file.folder.contains(\"{project}/Experiments\")'
+formulas:
+  verdict_emoji: 'if(verdict == \"keep\", \"✅\", if(verdict == \"revert\", \"❌\", \"⚠️\"))'
+views:
+  - type: table
+    name: 'All Experiments'
+    order:
+      - property: experiment_id
+        direction: desc
+" silent
+```
+
+### 6. Update Memory Index
+
+After archiving, update the memory index:
+
+```bash
+uv run python -m factory archive "{project_path}"
+```
+
+This runs `update_memory_index()` which regenerates MEMORY.md.
 
 ## Rules
 
-- Always use Obsidian frontmatter (YAML between `---` delimiters)
-- Use wikilinks (`[[Note Name]]`) for cross-references
-- Use tags consistently: `factory`, `experiment`, `project`, project name
-- Create parent directories if they don't exist
-- Update the project dashboard after every experiment cycle
-- Keep notes concise — link to details rather than duplicating them
+- Always use `vault="factory"` in obsidian-cli commands
+- Use `silent` flag to prevent notes from opening in Obsidian
+- Use wikilinks `[[note]]` for cross-references between notes
+- Tag every note with `factory` and the relevant type tag
+- Include `source: factory-archivist` in all frontmatter
+- If obsidian-cli is not available, fall back to `uv run python -m factory archive` which writes files directly

--- a/factory/obsidian/notes.py
+++ b/factory/obsidian/notes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -117,6 +118,70 @@ def _get_vault_path() -> Path:
 def _ensure_dir(path: Path) -> None:
     """Create directory and parents if needed."""
     path.mkdir(parents=True, exist_ok=True)
+
+
+# ── Obsidian CLI wrappers ────────────────────────────────────
+
+
+def _obsidian_available() -> bool:
+    """Check if the obsidian CLI is available and Obsidian is running."""
+    try:
+        result = subprocess.run(
+            ["obsidian", "vault", "list"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _obsidian_create(name: str, content: str, vault: str = "factory") -> bool:
+    """Create a note via obsidian-cli. Returns True on success."""
+    try:
+        result = subprocess.run(
+            [
+                "obsidian", "create",
+                f"vault={vault}", f"name={name}", f"content={content}", "silent",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _obsidian_read(name: str, vault: str = "factory") -> str | None:
+    """Read a note via obsidian-cli. Returns content or None."""
+    try:
+        result = subprocess.run(
+            ["obsidian", "read", f"vault={vault}", f"file={name}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.stdout if result.returncode == 0 else None
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def _obsidian_search(query: str, vault: str = "factory", limit: int = 10) -> str | None:
+    """Search the vault via obsidian-cli. Returns results or None."""
+    try:
+        result = subprocess.run(
+            [
+                "obsidian", "search",
+                f"vault={vault}", f"query={query}", f"limit={limit}",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.stdout if result.returncode == 0 else None
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+
+def obsidian_search_vault(
+    query: str, vault: str = "factory", limit: int = 10,
+) -> str | None:
+    """Search the factory vault. Returns results from obsidian-cli, or None if unavailable."""
+    return _obsidian_search(query, vault, limit)
 
 
 def init_vault(vault_path: Path | None = None) -> Path:
@@ -257,7 +322,13 @@ def write_experiment_note(
     if record.pr_number:
         lines.append(f"- PR: #{record.pr_number}")
 
-    note_path.write_text("\n".join(lines) + "\n")
+    content = "\n".join(lines) + "\n"
+
+    # Try obsidian-cli first, fall back to direct write
+    note_name = f"{_PROJECTS_DIR}/{project_name}/Experiments/{project_name}-{record.id:03d}"
+    if not _obsidian_create(note_name, content):
+        note_path.write_text(content)
+
     return note_path
 
 
@@ -320,7 +391,13 @@ def write_project_dashboard(
         lines.append("- No experiments yet")
     lines.append("")
 
-    note_path.write_text("\n".join(lines) + "\n")
+    content = "\n".join(lines) + "\n"
+
+    # Try obsidian-cli first, fall back to direct write
+    note_name = f"{_PROJECTS_DIR}/{project_name}/{project_name}"
+    if not _obsidian_create(note_name, content):
+        note_path.write_text(content)
+
     return note_path
 
 
@@ -352,7 +429,13 @@ def write_strategy_note(
         strategy_content,
     ]
 
-    note_path.write_text("\n".join(lines) + "\n")
+    content = "\n".join(lines) + "\n"
+
+    # Try obsidian-cli first, fall back to direct write
+    note_name = f"{_PROJECTS_DIR}/{project_name}/Strategies/{project_name}-{date_str}"
+    if not _obsidian_create(note_name, content):
+        note_path.write_text(content)
+
     return note_path
 
 
@@ -409,5 +492,10 @@ def update_memory_index(projects: list[dict] | None = None) -> Path:
     lines.append("")
 
     memory_path = vault / "MEMORY.md"
-    memory_path.write_text("\n".join(lines))
+    content = "\n".join(lines)
+
+    # Try obsidian-cli first, fall back to direct write
+    if not _obsidian_create("MEMORY", content):
+        memory_path.write_text(content)
+
     return memory_path

--- a/factory/study.py
+++ b/factory/study.py
@@ -188,8 +188,25 @@ def _read_obsidian_notes(project_name: str) -> list[str]:
     Returns a list of note summaries (first 200 chars of each note).
     Gracefully returns empty list if vault doesn't exist.
     """
-    from factory.obsidian.notes import _get_vault_path, _KNOWLEDGE_DIR, _PROJECTS_DIR
+    from factory.obsidian.notes import (
+        _get_vault_path,
+        _KNOWLEDGE_DIR,
+        _PROJECTS_DIR,
+        obsidian_search_vault,
+    )
 
+    # Try obsidian-cli search first
+    search_result = obsidian_search_vault(project_name)
+    if search_result and "no matches" not in search_result.lower():
+        summaries: list[str] = []
+        for line in search_result.strip().split("\n"):
+            line = line.strip()
+            if line and len(line) > 5:
+                summaries.append(line[:200])
+        if summaries:
+            return summaries
+
+    # Fall back to direct file reading
     vault = _get_vault_path()
     if not vault.exists():
         return []

--- a/tests/test_obsidian.py
+++ b/tests/test_obsidian.py
@@ -1,11 +1,14 @@
 """Tests for factory.obsidian — note creation with Obsidian frontmatter."""
 
+import subprocess
 from datetime import datetime
+from unittest.mock import Mock
 
 import pytest
 
 from factory.models import CompositeScore, EvalResult, ExperimentRecord
 from factory.obsidian.notes import (
+    _obsidian_create as _real_obsidian_create,
     init_vault,
     update_memory_index,
     write_experiment_note,
@@ -16,8 +19,14 @@ from factory.obsidian.notes import (
 
 @pytest.fixture(autouse=True)
 def set_vault_path(obsidian_vault, monkeypatch):
-    """Set OBSIDIAN_VAULT_PATH to temp dir for all tests."""
+    """Set OBSIDIAN_VAULT_PATH to temp dir and disable obsidian-cli for all tests."""
     monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(obsidian_vault))
+    # Disable obsidian-cli so write functions always fall back to direct file I/O.
+    # Individual tests in TestObsidianCli override this as needed.
+    monkeypatch.setattr(
+        "factory.obsidian.notes._obsidian_create",
+        lambda name, content, vault="factory": False,
+    )
 
 
 @pytest.fixture
@@ -228,3 +237,77 @@ class TestAutoInit:
         assert (vault / ".obsidian").is_dir()
         assert (vault / "10-Projects").is_dir()
         assert (vault / "MEMORY.md").exists()
+
+
+class TestObsidianCli:
+    def test_obsidian_available_when_missing(self, monkeypatch):
+        """obsidian_available returns False when CLI not found."""
+        monkeypatch.setattr(
+            "factory.obsidian.notes.subprocess.run",
+            Mock(side_effect=FileNotFoundError),
+        )
+        from factory.obsidian.notes import _obsidian_available
+
+        assert _obsidian_available() is False
+
+    def test_obsidian_available_when_timeout(self, monkeypatch):
+        """obsidian_available returns False on timeout."""
+        monkeypatch.setattr(
+            "factory.obsidian.notes.subprocess.run",
+            Mock(side_effect=subprocess.TimeoutExpired("obsidian", 5)),
+        )
+        from factory.obsidian.notes import _obsidian_available
+
+        assert _obsidian_available() is False
+
+    def test_obsidian_create_success(self, monkeypatch):
+        """obsidian_create returns True on success."""
+        mock_run = Mock(return_value=Mock(returncode=0))
+        monkeypatch.setattr("factory.obsidian.notes.subprocess.run", mock_run)
+        # Restore real _obsidian_create (autouse fixture replaces it with a no-op)
+        monkeypatch.setattr("factory.obsidian.notes._obsidian_create", _real_obsidian_create)
+
+        assert _real_obsidian_create("test", "content") is True
+        mock_run.assert_called_once()
+
+    def test_obsidian_create_fallback(self, monkeypatch):
+        """obsidian_create returns False when CLI not available."""
+        monkeypatch.setattr(
+            "factory.obsidian.notes.subprocess.run",
+            Mock(side_effect=FileNotFoundError),
+        )
+        from factory.obsidian.notes import _obsidian_create
+
+        assert _obsidian_create("test", "content") is False
+
+    def test_write_experiment_tries_cli_first(
+        self, monkeypatch, sample_record, obsidian_vault,
+    ):
+        """write_experiment_note tries obsidian-cli before file write."""
+        calls: list[list[str]] = []
+        original_run = subprocess.run
+
+        def mock_run(*args, **kwargs):
+            if args and args[0] and args[0][0] == "obsidian":
+                calls.append(args[0])
+                return Mock(returncode=1)  # CLI fails
+            return original_run(*args, **kwargs)
+
+        monkeypatch.setattr("factory.obsidian.notes.subprocess.run", mock_run)
+        # Restore real _obsidian_create so it actually calls subprocess.run
+        monkeypatch.setattr("factory.obsidian.notes._obsidian_create", _real_obsidian_create)
+        path = write_experiment_note("test-project", sample_record)
+        # Should have tried CLI
+        assert any("obsidian" in str(c) for c in calls)
+        # Should have fallen back to file write
+        assert path.exists()
+
+    def test_obsidian_search_vault(self, monkeypatch):
+        """obsidian_search_vault returns results on success."""
+        mock_run = Mock(return_value=Mock(returncode=0, stdout="result1\nresult2\n"))
+        monkeypatch.setattr("factory.obsidian.notes.subprocess.run", mock_run)
+        from factory.obsidian.notes import obsidian_search_vault
+
+        result = obsidian_search_vault("test query")
+        assert result is not None
+        assert "result1" in result


### PR DESCRIPTION
## Summary
- Add obsidian-cli wrappers to `factory/obsidian/notes.py` (`_obsidian_create`, `_obsidian_read`, `_obsidian_search`, `obsidian_search_vault`) that try the CLI first and fall back to direct file I/O when Obsidian is not running
- Update all `write_*` and `update_memory_index` functions to use the try-CLI-first pattern
- Update `factory/study.py` to use `obsidian_search_vault()` before falling back to filesystem reads
- Rewrite `factory/agents/prompts/archivist.md` to be a first-class obsidian-cli user with create/append/search/bases examples
- Add Obsidian Integration reference section to `SKILL.md` documenting CLI commands, vault structure, and syntax

## Test plan
- [x] All 292 existing tests pass (`uv run pytest -v`)
- [x] 6 new tests for obsidian-cli wrappers (availability, create success/fallback, search, CLI-first-with-fallback integration)
- [x] Lint passes (`uv run ruff check .`)
- [x] Existing write functions still produce files when CLI is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)