### PR TITLE
Fix mypy error + add factory digest command

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -236,6 +236,20 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 
 
+def cmd_digest(args: argparse.Namespace) -> int:
+    from factory.digest import format_digest, scan_vault
+
+    target_date = None
+    if args.date:
+        from datetime import date as date_cls
+        target_date = date_cls.fromisoformat(args.date)
+
+    projects = scan_vault(target_date=target_date, days=args.days)
+    output = format_digest(projects, target_date=target_date, days=args.days)
+    print(output)
+    return 0
+
+
 def cmd_archive(args: argparse.Namespace) -> int:
     from factory.obsidian.notes import (
         update_memory_index,
@@ -650,6 +664,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("path", help="Path to the project")
 
 
+    # digest
+    p = sub.add_parser("digest", help="Summarize recent factory activity across projects")
+    p.add_argument("--date", default=None, help="Show activity for a specific date (YYYY-MM-DD)")
+    p.add_argument("--days", type=int, default=7, help="Number of days to look back (default: 7)")
+
     # archive
     p = sub.add_parser("archive", help="Write experiment notes to Obsidian vault")
     p.add_argument("path", help="Path to the project")
@@ -726,6 +745,7 @@ def main(argv: list[str] | None = None) -> int:
         "notify": cmd_notify,
         "study": cmd_study,
         "status": cmd_status,
+        "digest": cmd_digest,
         "archive": cmd_archive,
         "vault-init": cmd_vault_init,
         "run": cmd_run,

--- a/factory/digest.py
+++ b/factory/digest.py
@@ -1,0 +1,229 @@
+"""Vault digest — scan the Obsidian vault and summarize factory activity."""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+from factory.obsidian.notes import _get_vault_path, _PROJECTS_DIR
+
+
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    """Extract YAML frontmatter key-value pairs from a markdown note."""
+    if not text.startswith("---"):
+        return {}
+    end = text.find("---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end].strip()
+    result: dict[str, str] = {}
+    for line in block.splitlines():
+        line = line.strip()
+        if line.startswith("- "):
+            continue  # skip list items (e.g. tags)
+        if ":" in line:
+            key, _, value = line.partition(":")
+            result[key.strip()] = value.strip()
+    return result
+
+
+def _parse_dashboard(text: str) -> dict[str, str]:
+    """Extract key fields from a project dashboard note."""
+    info: dict[str, str] = {}
+
+    m = re.search(r"\*\*State\*\*:\s*(.+)", text)
+    if m:
+        info["state"] = m.group(1).strip()
+
+    m = re.search(r"\*\*Current Score\*\*:\s*(\S+)", text)
+    if m:
+        info["score"] = m.group(1)
+
+    m = re.search(r"\*\*Experiments Run\*\*:\s*(\d+)", text)
+    if m:
+        info["experiments"] = m.group(1)
+
+    m = re.search(r"\*\*Kept\*\*:\s*(\d+)", text)
+    if m:
+        info["kept"] = m.group(1)
+
+    m = re.search(r"## Description\n(.+?)(?:\n##|\Z)", text, re.DOTALL)
+    if m:
+        info["description"] = m.group(1).strip().split("\n")[0]
+
+    return info
+
+
+def _parse_experiment_note(text: str) -> dict[str, str]:
+    """Extract key fields from an experiment note."""
+    fm = _parse_frontmatter(text)
+    info: dict[str, str] = {}
+    info["date"] = fm.get("date", "")
+    info["verdict"] = fm.get("verdict", "")
+    info["experiment_id"] = fm.get("experiment_id", "")
+
+    # Get hypothesis from heading
+    m = re.search(r"# Experiment #\d+:\s*(.+)", text)
+    if m:
+        info["hypothesis"] = m.group(1).strip()
+
+    # Get result line — handles both "—" and "--" separators
+    m = re.search(r"\*\*(\w+)\*\*\s*(?:—|--)\s*score changed from (\S+) to (\S+) \(([^)]+)\)", text)
+    if m:
+        info["score_before"] = m.group(2)
+        info["score_after"] = m.group(3)
+        info["delta"] = m.group(4)
+
+    # Get change summary
+    m = re.search(r"## What Changed\n(.+?)(?:\n##|\Z)", text, re.DOTALL)
+    if m:
+        info["summary"] = m.group(1).strip()
+
+    return info
+
+
+def scan_vault(
+    target_date: date | None = None,
+    days: int = 7,
+    vault_path: Path | None = None,
+) -> dict[str, dict]:
+    """Scan the Obsidian vault and collect project summaries.
+
+    Args:
+        target_date: If set, only include experiments from this specific date.
+        days: If target_date is None, include experiments from the last N days.
+        vault_path: Override vault path (for testing). Uses default if None.
+
+    Returns:
+        Dict mapping project name to project info with filtered experiments.
+    """
+    vault = vault_path if vault_path is not None else _get_vault_path()
+    projects_dir = vault / _PROJECTS_DIR
+    if not projects_dir.exists():
+        return {}
+
+    if target_date is not None:
+        start_date = target_date
+        end_date = target_date
+    else:
+        end_date = date.today()
+        start_date = end_date - timedelta(days=days)
+
+    projects: dict[str, dict] = {}
+
+    for project_dir in sorted(projects_dir.iterdir()):
+        if not project_dir.is_dir():
+            continue
+
+        project_name = project_dir.name
+
+        # Read dashboard
+        dashboard_path = project_dir / f"{project_name}.md"
+        dashboard_info: dict[str, str] = {}
+        if dashboard_path.exists():
+            dashboard_info = _parse_dashboard(dashboard_path.read_text(errors="replace"))
+
+        # Read experiment notes
+        experiments_dir = project_dir / "Experiments"
+        experiments: list[dict[str, str]] = []
+        if experiments_dir.exists():
+            for note_path in sorted(experiments_dir.iterdir()):
+                if not note_path.suffix == ".md":
+                    continue
+                text = note_path.read_text(errors="replace")
+                exp = _parse_experiment_note(text)
+                if not exp.get("date"):
+                    continue
+
+                try:
+                    exp_date = datetime.strptime(exp["date"], "%Y-%m-%d").date()
+                except ValueError:
+                    continue
+
+                if start_date <= exp_date <= end_date:
+                    experiments.append(exp)
+
+        if experiments or target_date is None:
+            projects[project_name] = {
+                "dashboard": dashboard_info,
+                "experiments": experiments,
+            }
+
+    return projects
+
+
+def format_digest(
+    projects: dict[str, dict],
+    target_date: date | None = None,
+    days: int = 7,
+) -> str:
+    """Format the scanned vault data into a readable digest."""
+    if target_date is not None:
+        title = f"Factory Digest — {target_date.isoformat()}"
+    else:
+        end = date.today()
+        start = end - timedelta(days=days)
+        title = f"Factory Digest — {start.isoformat()} to {end.isoformat()}"
+
+    lines = [f"# {title}", ""]
+
+    if not projects:
+        lines.append("No projects found in the vault.")
+        return "\n".join(lines)
+
+    active_count = sum(1 for p in projects.values() if p["experiments"])
+    total_exps = sum(len(p["experiments"]) for p in projects.values())
+
+    lines.append(f"**{len(projects)} projects** in vault, "
+                 f"**{active_count}** with activity, "
+                 f"**{total_exps}** experiments in period")
+    lines.append("")
+
+    for name, info in projects.items():
+        dash = info["dashboard"]
+        exps = info["experiments"]
+
+        lines.append(f"## {name}")
+
+        if dash.get("description"):
+            lines.append(f"_{dash['description']}_")
+            lines.append("")
+
+        status_parts = []
+        if dash.get("score"):
+            status_parts.append(f"Score: {dash['score']}")
+        if dash.get("experiments"):
+            status_parts.append(f"{dash['experiments']} total experiments")
+        if dash.get("kept"):
+            status_parts.append(f"{dash['kept']} kept")
+        if status_parts:
+            lines.append(f"**Status**: {', '.join(status_parts)}")
+            lines.append("")
+
+        if not exps:
+            lines.append("_No experiments in this period._")
+        else:
+            lines.append(f"### Built ({len(exps)} experiments)")
+            lines.append("")
+            for exp in exps:
+                verdict = exp.get("verdict", "?").upper()
+                hyp = exp.get("hypothesis", "?")
+                exp_id = exp.get("experiment_id", "?")
+                delta = exp.get("delta", "")
+                summary = exp.get("summary", "")
+
+                lines.append(f"- **#{exp_id}** [{verdict}] {hyp}")
+                if delta:
+                    lines.append(f"  - Delta: {delta}")
+                if summary:
+                    # Collapse multi-line markdown into a single line
+                    flat = re.sub(r"\n[-*]\s*", "; ", summary)
+                    flat = re.sub(r"\n+", " ", flat).strip()
+                    flat = flat.lstrip("-* ")
+                    short = flat[:120] + "..." if len(flat) > 120 else flat
+                    lines.append(f"  - {short}")
+
+        lines.append("")
+
+    return "\n".join(lines)

--- a/factory/study.py
+++ b/factory/study.py
@@ -490,7 +490,7 @@ def _read_obsidian_notes(project_name: str) -> list[str]:
     if not vault.exists():
         return []
 
-    summaries: list[str] = []
+    file_summaries: list[str] = []
 
     # Project-specific notes
     project_dir = vault / _PROJECTS_DIR / project_name
@@ -508,7 +508,7 @@ def _read_obsidian_notes(project_name: str) -> list[str]:
                         content = content[end + 3:].strip()
                 summary = content[:200].strip()
                 if summary:
-                    summaries.append(summary)
+                    file_summaries.append(summary)
             except OSError:
                 continue
 
@@ -523,7 +523,7 @@ def _read_obsidian_notes(project_name: str) -> list[str]:
                     content = content[end + 3:].strip()
             summary = content[:200].strip()
             if summary:
-                summaries.append(summary)
+                file_summaries.append(summary)
         except OSError:
             pass
 
@@ -539,11 +539,11 @@ def _read_obsidian_notes(project_name: str) -> list[str]:
                         content = content[end + 3:].strip()
                 summary = content[:200].strip()
                 if summary:
-                    summaries.append(summary)
+                    file_summaries.append(summary)
             except OSError:
                 continue
 
-    return summaries
+    return file_summaries
 
 
 def study_project_local(project_path: Path) -> str:

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -1,0 +1,291 @@
+"""Tests for factory digest — vault scanning and summary formatting."""
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from factory.cli import main
+from factory.digest import (
+    _parse_dashboard,
+    _parse_experiment_note,
+    _parse_frontmatter,
+    format_digest,
+    scan_vault,
+)
+
+
+# ── frontmatter parsing ─────────────────────────────────────
+
+
+class TestParseFrontmatter:
+    def test_basic(self):
+        text = "---\ndate: 2026-04-11\nverdict: keep\n---\n# Hello"
+        fm = _parse_frontmatter(text)
+        assert fm["date"] == "2026-04-11"
+        assert fm["verdict"] == "keep"
+
+    def test_skips_list_items(self):
+        text = "---\ntags:\n  - factory\n  - experiment\ndate: 2026-04-11\n---\n"
+        fm = _parse_frontmatter(text)
+        assert fm["date"] == "2026-04-11"
+        assert fm.get("tags") == ""  # tags: line has empty value, list items skipped
+
+    def test_no_frontmatter(self):
+        assert _parse_frontmatter("# Just a heading") == {}
+
+    def test_unclosed_frontmatter(self):
+        assert _parse_frontmatter("---\ndate: 2026-04-11\n# Heading") == {}
+
+
+# ── dashboard parsing ────────────────────────────────────────
+
+
+class TestParseDashboard:
+    def test_full_dashboard(self):
+        text = (
+            "## Status\n"
+            "- **State**: has_factory\n"
+            "- **Current Score**: 0.986\n"
+            "- **Experiments Run**: 15\n"
+            "- **Kept**: 14, **Reverted**: 0, **Error**: 1\n"
+            "\n"
+            "## Description\n"
+            "A Telegram bot that bridges messages.\n"
+            "\n"
+            "## Architecture\n"
+        )
+        info = _parse_dashboard(text)
+        assert info["state"] == "has_factory"
+        assert info["score"] == "0.986"
+        assert info["experiments"] == "15"
+        assert info["kept"] == "14"
+        assert info["description"] == "A Telegram bot that bridges messages."
+
+    def test_missing_fields(self):
+        info = _parse_dashboard("# Project\nSome text\n")
+        assert info == {}
+
+
+# ── experiment note parsing ──────────────────────────────────
+
+
+class TestParseExperimentNote:
+    def test_full_note(self):
+        text = (
+            "---\n"
+            "tags:\n  - factory\n  - experiment\n"
+            "date: 2026-04-11\n"
+            "verdict: keep\n"
+            "experiment_id: 5\n"
+            "---\n\n"
+            "# Experiment #5: Add test coverage\n\n"
+            "## Hypothesis\nAdd test coverage\n\n"
+            "## Result\n"
+            "**KEEP** — score changed from 0.934 to 0.956 (+0.022)\n\n"
+            "## What Changed\n"
+            "12 new tests. Coverage 67% -> 78%.\n"
+        )
+        exp = _parse_experiment_note(text)
+        assert exp["date"] == "2026-04-11"
+        assert exp["verdict"] == "keep"
+        assert exp["experiment_id"] == "5"
+        assert exp["hypothesis"] == "Add test coverage"
+        assert exp["score_before"] == "0.934"
+        assert exp["score_after"] == "0.956"
+        assert exp["delta"] == "+0.022"
+        assert "12 new tests" in exp["summary"]
+
+    def test_missing_fields(self):
+        text = "---\ndate: 2026-04-11\n---\n# Experiment #1: Fix bug\n"
+        exp = _parse_experiment_note(text)
+        assert exp["date"] == "2026-04-11"
+        assert exp["hypothesis"] == "Fix bug"
+
+
+# ── vault scanning ───────────────────────────────────────────
+
+
+def _make_experiment_note(
+    project: str, exp_id: int, exp_date: str, verdict: str = "keep",
+    hypothesis: str = "Test hypothesis",
+) -> str:
+    return (
+        f"---\n"
+        f"tags:\n  - factory\n  - experiment\n  - {project}\n"
+        f"date: {exp_date}\n"
+        f"verdict: {verdict}\n"
+        f"experiment_id: {exp_id}\n"
+        f"---\n\n"
+        f"# Experiment #{exp_id}: {hypothesis}\n\n"
+        f"## Hypothesis\n{hypothesis}\n\n"
+        f"## Result\n"
+        f"**{verdict.upper()}** — score changed from 0.8 to 0.9 (+0.1)\n\n"
+        f"## What Changed\nSome changes were made.\n"
+    )
+
+
+def _make_dashboard(project: str, score: str = "0.9", experiments: int = 5) -> str:
+    return (
+        f"---\ntags:\n  - factory\n  - project\n  - {project}\n---\n\n"
+        f"# Factory: {project}\n\n"
+        f"## Status\n"
+        f"- **State**: has_factory\n"
+        f"- **Current Score**: {score}\n"
+        f"- **Experiments Run**: {experiments}\n"
+        f"- **Kept**: {experiments}, **Reverted**: 0\n\n"
+        f"## Description\nA test project.\n"
+    )
+
+
+@pytest.fixture
+def populated_vault(tmp_path: Path) -> Path:
+    """Create a vault with two projects and experiments across dates."""
+    vault = tmp_path / "vault"
+    today = date.today().isoformat()
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+    old = (date.today() - timedelta(days=30)).isoformat()
+
+    # Project A — has recent activity
+    proj_a = vault / "10-Projects" / "project-a"
+    (proj_a / "Experiments").mkdir(parents=True)
+    (proj_a / "project-a.md").write_text(_make_dashboard("project-a", "0.95", 3))
+    (proj_a / "Experiments" / "project-a-001.md").write_text(
+        _make_experiment_note("project-a", 1, today, "keep", "Add auth module")
+    )
+    (proj_a / "Experiments" / "project-a-002.md").write_text(
+        _make_experiment_note("project-a", 2, yesterday, "keep", "Fix rate limiter")
+    )
+    (proj_a / "Experiments" / "project-a-003.md").write_text(
+        _make_experiment_note("project-a", 3, old, "revert", "Old change")
+    )
+
+    # Project B — only old activity
+    proj_b = vault / "10-Projects" / "project-b"
+    (proj_b / "Experiments").mkdir(parents=True)
+    (proj_b / "project-b.md").write_text(_make_dashboard("project-b", "0.8", 1))
+    (proj_b / "Experiments" / "project-b-001.md").write_text(
+        _make_experiment_note("project-b", 1, old, "keep", "Ancient experiment")
+    )
+
+    return vault
+
+
+class TestScanVault:
+    def test_scan_recent(self, populated_vault: Path):
+        projects = scan_vault(days=7, vault_path=populated_vault)
+        assert "project-a" in projects
+        # project-a should have 2 recent experiments (today + yesterday), not the old one
+        exps = projects["project-a"]["experiments"]
+        assert len(exps) == 2
+        hypotheses = {e["hypothesis"] for e in exps}
+        assert "Add auth module" in hypotheses
+        assert "Fix rate limiter" in hypotheses
+        assert "Old change" not in hypotheses
+
+    def test_scan_specific_date(self, populated_vault: Path):
+        today = date.today()
+        projects = scan_vault(target_date=today, vault_path=populated_vault)
+        exps = projects["project-a"]["experiments"]
+        assert len(exps) == 1
+        assert exps[0]["hypothesis"] == "Add auth module"
+
+    def test_scan_old_date(self, populated_vault: Path):
+        old = date.today() - timedelta(days=30)
+        projects = scan_vault(target_date=old, vault_path=populated_vault)
+        # Both projects had activity on the old date
+        assert "project-a" in projects
+        assert "project-b" in projects
+        assert len(projects["project-a"]["experiments"]) == 1
+        assert projects["project-a"]["experiments"][0]["hypothesis"] == "Old change"
+
+    def test_scan_empty_vault(self, tmp_path: Path):
+        vault = tmp_path / "empty-vault"
+        vault.mkdir()
+        projects = scan_vault(vault_path=vault)
+        assert projects == {}
+
+    def test_scan_no_experiments_dir(self, tmp_path: Path):
+        vault = tmp_path / "vault"
+        proj = vault / "10-Projects" / "bare-project"
+        proj.mkdir(parents=True)
+        (proj / "bare-project.md").write_text(_make_dashboard("bare-project"))
+        projects = scan_vault(vault_path=vault)
+        assert "bare-project" in projects
+        assert projects["bare-project"]["experiments"] == []
+
+    def test_includes_dashboard_for_inactive_projects(self, populated_vault: Path):
+        """Projects with no recent experiments still appear when scanning all."""
+        projects = scan_vault(days=7, vault_path=populated_vault)
+        assert "project-b" in projects
+        assert projects["project-b"]["experiments"] == []
+
+
+# ── digest formatting ────────────────────────────────────────
+
+
+class TestFormatDigest:
+    def test_empty(self):
+        output = format_digest({})
+        assert "No projects found" in output
+
+    def test_with_projects(self, populated_vault: Path):
+        projects = scan_vault(days=7, vault_path=populated_vault)
+        output = format_digest(projects)
+        assert "project-a" in output
+        assert "Add auth module" in output
+        assert "Fix rate limiter" in output
+        assert "2 experiments" in output
+
+    def test_specific_date_title(self):
+        output = format_digest({}, target_date=date(2026, 4, 11))
+        assert "2026-04-11" in output
+
+    def test_date_range_title(self):
+        output = format_digest({}, days=7)
+        assert " to " in output
+
+    def test_truncates_long_summary(self):
+        projects = {
+            "test": {
+                "dashboard": {},
+                "experiments": [{
+                    "experiment_id": "1",
+                    "verdict": "keep",
+                    "hypothesis": "Long one",
+                    "delta": "+0.1",
+                    "summary": "x" * 200,
+                }],
+            },
+        }
+        output = format_digest(projects)
+        assert "..." in output
+
+
+# ── CLI integration ──────────────────────────────────────────
+
+
+class TestCmdDigest:
+    def test_digest_default(self, populated_vault: Path, monkeypatch, capsys):
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(populated_vault))
+        result = main(["digest"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Factory Digest" in out
+        assert "project-a" in out
+
+    def test_digest_specific_date(self, populated_vault: Path, monkeypatch, capsys):
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(populated_vault))
+        today = date.today().isoformat()
+        result = main(["digest", "--date", today])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert today in out
+        assert "Add auth module" in out
+
+    def test_digest_no_vault(self, tmp_path: Path, monkeypatch, capsys):
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "nonexistent"))
+        result = main(["digest"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No projects found" in out


### PR DESCRIPTION
## Summary
- Fix mypy `no-redef` error in `factory/study.py` — renamed shadowed `summaries` variable to `file_summaries`
- Land the `factory digest` command — scans Obsidian vault and summarizes factory activity across projects by date range
- 22 new tests for the digest module, all passing
- Full suite: 316 tests pass, 0 mypy errors, lint clean

## Test plan
- [x] `uv run mypy factory/ --no-error-summary` — 0 errors
- [x] `uv run pytest tests/test_digest.py -v` — 22 passed
- [x] `uv run pytest -v` — 316 passed
- [x] `uv run ruff check .` — all checks passed

Factory experiment #26. Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)