### PR TITLE
Add structlog logging to 5 uninstrumented factory modules

### DIFF
--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -1,0 +1,9 @@
+"""Remote Factory — domain-agnostic multi-agent software evolution loop."""
+
+import sys
+
+import structlog
+
+structlog.configure(
+    logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+)

--- a/factory/digest.py
+++ b/factory/digest.py
@@ -6,7 +6,11 @@ import re
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
+import structlog
+
 from factory.obsidian.notes import _get_vault_path, _PROJECTS_DIR
+
+log = structlog.get_logger()
 
 
 def _parse_frontmatter(text: str) -> dict[str, str]:
@@ -100,7 +104,9 @@ def scan_vault(
     """
     vault = vault_path if vault_path is not None else _get_vault_path()
     projects_dir = vault / _PROJECTS_DIR
+    log.debug("scan_vault_start", vault=str(vault), days=days, target_date=str(target_date))
     if not projects_dir.exists():
+        log.debug("scan_vault_no_projects_dir", path=str(projects_dir))
         return {}
 
     if target_date is not None:
@@ -150,6 +156,11 @@ def scan_vault(
                 "experiments": experiments,
             }
 
+    log.info(
+        "scan_vault_complete",
+        project_count=len(projects),
+        experiment_count=sum(len(p["experiments"]) for p in projects.values()),
+    )
     return projects
 
 
@@ -166,6 +177,7 @@ def format_digest(
         start = end - timedelta(days=days)
         title = f"Factory Digest — {start.isoformat()} to {end.isoformat()}"
 
+    log.debug("format_digest", project_count=len(projects), target_date=str(target_date))
     lines = [f"# {title}", ""]
 
     if not projects:

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import structlog
+
 from factory.models import ProjectProfile
+
+log = structlog.get_logger()
 
 
 def _read_json(path: Path) -> dict:
@@ -33,20 +37,24 @@ def _read_toml_rough(path: Path) -> dict[str, str]:
 def _detect_language(project_path: Path) -> str:
     """Detect primary language from project files."""
     if (project_path / "pyproject.toml").exists() or (project_path / "setup.py").exists():
-        return "python"
-    if (project_path / "package.json").exists():
-        return "typescript"
-    if (project_path / "Cargo.toml").exists():
-        return "rust"
-    if (project_path / "go.mod").exists():
-        return "go"
-    if (project_path / "Package.swift").exists():
-        return "swift"
-    return "unknown"
+        lang = "python"
+    elif (project_path / "package.json").exists():
+        lang = "typescript"
+    elif (project_path / "Cargo.toml").exists():
+        lang = "rust"
+    elif (project_path / "go.mod").exists():
+        lang = "go"
+    elif (project_path / "Package.swift").exists():
+        lang = "swift"
+    else:
+        lang = "unknown"
+    log.debug("detect_language", language=lang)
+    return lang
 
 
 def _detect_project_type(project_path: Path, language: str) -> str:
     """Infer project type from README, directory structure, and config files."""
+    log.debug("detect_project_type_start", language=language)
     readme_text = ""
     for name in ("README.md", "README.rst", "README.txt", "README"):
         readme_path = project_path / name
@@ -56,35 +64,44 @@ def _detect_project_type(project_path: Path, language: str) -> str:
 
     # Check for bot indicators
     if any(kw in readme_text for kw in ("telegram", "discord", "slack bot", "chatbot")):
+        log.debug("detect_project_type_result", project_type="bot")
         return "bot"
 
     # Check for web app indicators
     if (project_path / "next.config.js").exists() or (project_path / "next.config.ts").exists():
+        log.debug("detect_project_type_result", project_type="web_app")
         return "web_app"
     if any(kw in readme_text for kw in ("fastapi", "django", "flask", "web app", "webapp")):
+        log.debug("detect_project_type_result", project_type="web_app")
         return "web_app"
 
     # Check for CLI indicators
     if language == "python":
         toml_data = _read_toml_rough(project_path / "pyproject.toml")
         if "scripts" in str(toml_data):
+            log.debug("detect_project_type_result", project_type="cli_tool")
             return "cli_tool"
     if any(kw in readme_text for kw in ("cli", "command-line", "command line")):
+        log.debug("detect_project_type_result", project_type="cli_tool")
         return "cli_tool"
 
     # Check for library indicators
     if any(kw in readme_text for kw in ("library", "sdk", "package", "pip install", "npm install")):
+        log.debug("detect_project_type_result", project_type="library")
         return "library"
 
     # Check for service indicators
     if any(kw in readme_text for kw in ("service", "api", "server", "daemon")):
+        log.debug("detect_project_type_result", project_type="service")
         return "service"
 
+    log.debug("detect_project_type_result", project_type="unknown")
     return "unknown"
 
 
 def _detect_framework(project_path: Path, language: str) -> str | None:
     """Detect framework from dependencies."""
+    log.debug("detect_framework_start", language=language)
     if language == "python":
         toml_text = ""
         if (project_path / "pyproject.toml").exists():
@@ -185,6 +202,7 @@ def _has_ci(project_path: Path) -> bool:
 
 def introspect_project(project_path: Path) -> ProjectProfile:
     """Analyze a project directory and return its profile."""
+    log.info("introspect_project_start", project=str(project_path))
     language = _detect_language(project_path)
     project_type = _detect_project_type(project_path, language)
     framework = _detect_framework(project_path, language)
@@ -213,7 +231,7 @@ def introspect_project(project_path: Path) -> ProjectProfile:
         else:
             package_manager = "npm"
 
-    return ProjectProfile(
+    profile = ProjectProfile(
         name=project_path.name,
         language=language,
         framework=framework,
@@ -227,3 +245,14 @@ def introspect_project(project_path: Path) -> ProjectProfile:
         type_check_command=type_check_cmd,
         package_manager=package_manager,
     )
+    log.info(
+        "introspect_project_complete",
+        name=profile.name,
+        language=language,
+        project_type=project_type,
+        framework=framework,
+        has_tests=profile.has_tests,
+        has_linter=profile.has_linter,
+        has_ci=profile.has_ci,
+    )
+    return profile

--- a/factory/obsidian/notes.py
+++ b/factory/obsidian/notes.py
@@ -8,7 +8,11 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
+import structlog
+
 from factory.models import CompositeScore, ExperimentRecord
+
+log = structlog.get_logger()
 
 _DEFAULT_VAULT = Path.home() / "obsidian-vaults" / "factory"
 
@@ -187,6 +191,7 @@ def obsidian_search_vault(
 def init_vault(vault_path: Path | None = None) -> Path:
     """Create the full factory vault structure. Returns the vault path."""
     vault = vault_path if vault_path is not None else _get_vault_path()
+    log.info("init_vault", vault=str(vault))
 
     # .obsidian/
     _ensure_dir(vault / ".obsidian")
@@ -239,6 +244,7 @@ def init_vault(vault_path: Path | None = None) -> Path:
             "## Projects\n\n(none yet)\n"
         )
 
+    log.debug("init_vault_complete", vault=str(vault))
     return vault
 
 
@@ -246,6 +252,7 @@ def _auto_init_vault() -> Path:
     """Get vault path and auto-create structure if needed."""
     vault = _get_vault_path()
     if not (vault / ".obsidian").exists():
+        log.info("auto_init_vault_triggered", vault=str(vault))
         init_vault(vault)
     return vault
 
@@ -257,6 +264,7 @@ def write_experiment_note(
     score_after: CompositeScore | None = None,
 ) -> Path:
     """Create an Obsidian note for a completed experiment."""
+    log.debug("write_experiment_note", project=project_name, exp_id=record.id, verdict=record.verdict)
     vault = _auto_init_vault()
     experiments_dir = vault / _PROJECTS_DIR / project_name / "Experiments"
     _ensure_dir(experiments_dir)
@@ -327,6 +335,7 @@ def write_experiment_note(
     # Try obsidian-cli first, fall back to direct write
     note_name = f"{_PROJECTS_DIR}/{project_name}/Experiments/{project_name}-{record.id:03d}"
     if not _obsidian_create(note_name, content):
+        log.debug("write_experiment_note_fallback_to_file", path=str(note_path))
         note_path.write_text(content)
 
     return note_path
@@ -340,6 +349,12 @@ def write_project_dashboard(
     eval_dimensions: list[dict] | None = None,
 ) -> Path:
     """Create or update the project dashboard note."""
+    log.debug(
+        "write_project_dashboard",
+        project=project_name,
+        state=state,
+        record_count=len(records),
+    )
     vault = _auto_init_vault()
     projects_dir = vault / _PROJECTS_DIR / project_name
     _ensure_dir(projects_dir)
@@ -396,6 +411,7 @@ def write_project_dashboard(
     # Try obsidian-cli first, fall back to direct write
     note_name = f"{_PROJECTS_DIR}/{project_name}/{project_name}"
     if not _obsidian_create(note_name, content):
+        log.debug("write_project_dashboard_fallback_to_file", path=str(note_path))
         note_path.write_text(content)
 
     return note_path
@@ -406,6 +422,7 @@ def write_strategy_note(
     strategy_content: str,
 ) -> Path:
     """Write a strategy snapshot to Obsidian."""
+    log.debug("write_strategy_note", project=project_name)
     vault = _auto_init_vault()
     strategies_dir = vault / _PROJECTS_DIR / project_name / "Strategies"
     _ensure_dir(strategies_dir)
@@ -434,6 +451,7 @@ def write_strategy_note(
     # Try obsidian-cli first, fall back to direct write
     note_name = f"{_PROJECTS_DIR}/{project_name}/Strategies/{project_name}-{date_str}"
     if not _obsidian_create(note_name, content):
+        log.debug("write_strategy_note_fallback_to_file", path=str(note_path))
         note_path.write_text(content)
 
     return note_path
@@ -446,6 +464,7 @@ def update_memory_index(projects: list[dict] | None = None) -> Path:
     reads each dashboard note for the latest score.
     """
     vault = _get_vault_path()
+    log.debug("update_memory_index", vault=str(vault))
 
     if projects is None:
         projects = []
@@ -496,6 +515,8 @@ def update_memory_index(projects: list[dict] | None = None) -> Path:
 
     # Try obsidian-cli first, fall back to direct write
     if not _obsidian_create("MEMORY", content):
+        log.debug("update_memory_index_fallback_to_file", path=str(memory_path))
         memory_path.write_text(content)
 
+    log.info("update_memory_index_complete", project_count=len(projects))
     return memory_path

--- a/factory/state.py
+++ b/factory/state.py
@@ -3,7 +3,11 @@
 import subprocess
 from pathlib import Path
 
+import structlog
+
 from factory.models import ProjectState
+
+log = structlog.get_logger()
 
 
 def _has_open_plan_issues(project_path: Path) -> bool:
@@ -18,8 +22,10 @@ def _has_open_plan_issues(project_path: Path) -> bool:
                 timeout=15,
             )
             if result.returncode == 0 and result.stdout.strip() not in ("", "[]"):
+                log.debug("open_plan_issues_found", label=label)
                 return True
         except (subprocess.TimeoutExpired, FileNotFoundError):
+            log.debug("open_plan_issues_check_failed", label=label)
             return False
     return False
 
@@ -39,8 +45,11 @@ def _has_pending_eval_review(project_path: Path) -> bool:
 
     try:
         data = json.loads(profile_path.read_text())
-        return data.get("human_reviewed", False) is False
+        pending = data.get("human_reviewed", False) is False
+        log.debug("pending_eval_review_check", human_reviewed=data.get("human_reviewed"), pending=pending)
+        return pending
     except (json.JSONDecodeError, KeyError):
+        log.debug("pending_eval_review_parse_error", path=str(profile_path))
         return False
 
 
@@ -54,19 +63,26 @@ def detect_state(project_path: Path) -> ProjectState:
       4. Has .git, open plan/implementation GitHub issues -> REPO_INCOMPLETE
       5. Has .git, no open issues -> NO_FACTORY
     """
+    log.debug("detect_state_start", project=str(project_path))
+
     if not project_path.exists() or not (project_path / ".git").exists():
+        log.info("detect_state_result", state=ProjectState.NO_REPO.value)
         return ProjectState.NO_REPO
 
     # Check for pending eval review BEFORE checking for full factory.
     # This handles the discover → review → init flow where eval_profile.json
     # exists but config.json does not yet.
     if _has_pending_eval_review(project_path):
+        log.info("detect_state_result", state=ProjectState.EVALS_PENDING_REVIEW.value)
         return ProjectState.EVALS_PENDING_REVIEW
 
     if (project_path / ".factory" / "config.json").exists():
+        log.info("detect_state_result", state=ProjectState.HAS_FACTORY.value)
         return ProjectState.HAS_FACTORY
 
     if _has_open_plan_issues(project_path):
+        log.info("detect_state_result", state=ProjectState.REPO_INCOMPLETE.value)
         return ProjectState.REPO_INCOMPLETE
 
+    log.info("detect_state_result", state=ProjectState.NO_FACTORY.value)
     return ProjectState.NO_FACTORY

--- a/factory/store.py
+++ b/factory/store.py
@@ -8,7 +8,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
+import structlog
+
 from factory.models import CompositeScore, EvalProfile, ExperimentRecord, FactoryConfig
+
+log = structlog.get_logger()
 
 
 TSV_COLUMNS = [
@@ -27,6 +31,7 @@ class ExperimentStore:
 
     async def init(self, config: FactoryConfig) -> None:
         """Create .factory/ structure with config.json, results.tsv, experiments/, strategy/."""
+        log.info("store_init", project=str(self.project_path), goal=config.goal)
         self.factory_dir.mkdir(exist_ok=True)
         (self.factory_dir / "experiments").mkdir(exist_ok=True)
         (self.factory_dir / "strategy").mkdir(exist_ok=True)
@@ -42,9 +47,11 @@ class ExperimentStore:
             writer = csv.writer(buf, dialect="excel-tab")
             writer.writerow(TSV_COLUMNS)
             tsv_path.write_text(buf.getvalue())
+        log.debug("store_init_complete", factory_dir=str(self.factory_dir))
 
     async def reparse_config(self) -> FactoryConfig:
         """Re-read factory.md from project root, regenerate config.json."""
+        log.debug("reparse_config_start", project=str(self.project_path))
         factory_md = self.project_path / "factory.md"
         text = factory_md.read_text()
 
@@ -114,19 +121,23 @@ class ExperimentStore:
         (self.factory_dir / "config.json").write_text(
             json.dumps(config.model_dump(), indent=2) + "\n"
         )
+        log.info("reparse_config_complete", goal=config.goal, scope_count=len(config.scope))
         return config
 
     async def next_id(self) -> int:
         """Return max existing experiment ID + 1, or 1 if none exist."""
         experiments_dir = self.factory_dir / "experiments"
         if not experiments_dir.exists():
+            log.debug("next_id_no_experiments_dir")
             return 1
         ids = [
             int(d.name)
             for d in experiments_dir.iterdir()
             if d.is_dir() and d.name.isdigit()
         ]
-        return max(ids) + 1 if ids else 1
+        next_val = max(ids) + 1 if ids else 1
+        log.debug("next_id_computed", next_id=next_val, existing_count=len(ids))
+        return next_val
 
     async def begin(self, hypothesis: str) -> int:
         """Create experiments/NNN/hypothesis.md, return the experiment ID.
@@ -135,6 +146,7 @@ class ExperimentStore:
         previous interrupted run), return its ID without crashing.
         """
         exp_id = await self.next_id()
+        log.info("experiment_begin", exp_id=exp_id, hypothesis=hypothesis[:80])
         exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
         exp_dir.mkdir(parents=True, exist_ok=True)
         hyp_path = exp_dir / "hypothesis.md"
@@ -149,6 +161,7 @@ class ExperimentStore:
         score: CompositeScore,
     ) -> None:
         """Write eval_before.json or eval_after.json into the experiment dir."""
+        log.debug("save_eval", exp_id=exp_id, phase=phase, score=score.total)
         exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
         filename = f"eval_{phase}.json"
         (exp_dir / filename).write_text(
@@ -157,6 +170,7 @@ class ExperimentStore:
 
     async def save_diff(self, exp_id: int) -> None:
         """Capture git diff HEAD~1 into changes.diff."""
+        log.debug("save_diff", exp_id=exp_id)
         exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
         result = subprocess.run(
             ["git", "diff", "HEAD~1"],
@@ -172,6 +186,12 @@ class ExperimentStore:
 
         Creates the experiment directory if it is missing (e.g. after git clean).
         """
+        log.info(
+            "experiment_finalize",
+            exp_id=exp_id,
+            verdict=record.verdict,
+            delta=record.delta,
+        )
         exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
         exp_dir.mkdir(parents=True, exist_ok=True)
         (exp_dir / "verdict.json").write_text(
@@ -200,6 +220,7 @@ class ExperimentStore:
         """Parse results.tsv into a list of ExperimentRecords."""
         tsv_path = self.factory_dir / "results.tsv"
         if not tsv_path.exists():
+            log.debug("load_history_no_tsv", path=str(tsv_path))
             return []
 
         records: list[ExperimentRecord] = []
@@ -220,16 +241,23 @@ class ExperimentStore:
                     cost_usd=float(row["cost_usd"]) if row["cost_usd"] else None,
                     notes=row["notes"],
                 ))
+        log.debug("load_history_complete", record_count=len(records))
         return records
 
     async def read_config(self) -> FactoryConfig:
         """Read .factory/config.json and return a FactoryConfig."""
+        log.debug("read_config", path=str(self.factory_dir / "config.json"))
         config_path = self.factory_dir / "config.json"
         data = json.loads(config_path.read_text())
         return FactoryConfig(**data)
 
     async def save_eval_profile(self, profile: EvalProfile) -> None:
         """Write .factory/eval_profile.json."""
+        log.info(
+            "save_eval_profile",
+            dimension_count=len(profile.dimensions),
+            human_reviewed=profile.human_reviewed,
+        )
         (self.factory_dir / "eval_profile.json").write_text(
             json.dumps(profile.model_dump(), indent=2) + "\n"
         )
@@ -238,19 +266,24 @@ class ExperimentStore:
         """Read .factory/eval_profile.json, return None if missing."""
         profile_path = self.factory_dir / "eval_profile.json"
         if not profile_path.exists():
+            log.debug("read_eval_profile_not_found", path=str(profile_path))
             return None
         data = json.loads(profile_path.read_text())
+        log.debug("read_eval_profile_loaded", dimension_count=len(data.get("dimensions", [])))
         return EvalProfile(**data)
 
     async def read_strategy(self) -> str | None:
         """Read strategy/current.md, return None if missing."""
         strategy_path = self.factory_dir / "strategy" / "current.md"
         if not strategy_path.exists():
+            log.debug("read_strategy_not_found")
             return None
+        log.debug("read_strategy_loaded", path=str(strategy_path))
         return strategy_path.read_text()
 
     async def write_strategy(self, content: str) -> None:
         """Write strategy/current.md."""
+        log.info("write_strategy", content_length=len(content))
         strategy_path = self.factory_dir / "strategy" / "current.md"
         strategy_path.parent.mkdir(parents=True, exist_ok=True)
         strategy_path.write_text(content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "remote-factory"
 version = "0.1.0"
 description = "Domain-agnostic multi-agent software evolution loop"
 requires-python = ">=3.11"
-dependencies = ["pydantic>=2.0"]
+dependencies = ["pydantic>=2.0", "structlog>=24.0"]
 
 [project.scripts]
 factory = "factory.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -462,6 +462,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "structlog" },
 ]
 
 [package.dev-dependencies]
@@ -474,7 +475,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.0" }]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "structlog", specifier = ">=24.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -508,6 +512,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
     { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
     { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `structlog` structured logging to `factory/store.py`, `factory/digest.py`, `factory/state.py`, `factory/discovery/introspect.py`, and `factory/obsidian/notes.py`
- Configure structlog globally in `factory/__init__.py` to output to stderr (prevents interference with JSON stdout output)
- Add `structlog>=24.0` as a project dependency

## Details
Closes #36. Factory experiment #27.

Logging is **additive only** — no existing function signatures or behavior changed. Log levels follow the convention:
- **debug**: routine operations (file reads, ID computation, fallback-to-file writes)
- **info**: decisions and state transitions (experiment begin/finalize, state detection results, introspection results, vault scan summaries)

All 316 tests pass. mypy and ruff report zero errors.

## Test plan
- [x] `uv run pytest -v` — 316 passed
- [x] `uv run mypy factory/ --no-error-summary` — 0 errors
- [x] `uv run ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)