### PR TITLE
Add FEEC priority heuristic for strategist

### DIFF
--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -35,6 +35,7 @@ Write `.factory/strategy/current.md` with this format:
 ### Hypotheses
 
 #### H1: <short title>
+- **Category:** FIX/EXPLOIT/EXPLORE/COMBINE
 - **What:** <specific, scoped change — one PR's worth>
 - **Why:** <reasoning tied to observations>
 - **Expected impact:** <which eval dimensions improve and by how much>
@@ -68,6 +69,40 @@ The study includes an **Observability Coverage** section. This is critical infra
 - **Uninstrumented files** — source files with zero logging (target: none)
 
 **When observability is already good (>0.7):** Note it in observations, don't waste a hypothesis on it.
+
+## Priority Framework — FEEC
+
+Every hypothesis must be tagged with one of four categories, listed in strict
+priority order:
+
+| Priority | Category | When to use |
+|----------|----------|-------------|
+| 1 | **FIX** | A test is failing, a crash is observed, a mypy/lint error exists, or a recent experiment caused a regression. Fix these **first** — nothing else matters until the build is green. |
+| 2 | **EXPLOIT** | A recent experiment improved a score. Build on that momentum — deepen, extend, or optimize the same dimension. |
+| 3 | **EXPLORE** | Try something genuinely new that is not tied to a recent success or failure. Use when the current approach has plateaued. |
+| 4 | **COMBINE** | Merge two or more previously successful approaches into one. This is the rarest category — only propose it when distinct experiments each showed gains and their combination is plausible. |
+
+When generating hypotheses, always evaluate and tag them:
+
+```markdown
+#### H1: <title>
+- **Category:** FIX
+- **What:** …
+```
+
+**Ordering rule:** Present FIX hypotheses before EXPLOIT, EXPLOIT before EXPLORE,
+and EXPLORE before COMBINE.
+
+## Stuck Protocol
+
+If **3 or more consecutive hypotheses in the same category are reverted**,
+the factory is stuck. When this happens:
+
+1. Acknowledge the pattern in the Observations section.
+2. **Shift to the next category** — e.g. if three FIX attempts were reverted,
+   move to EXPLOIT or EXPLORE.
+3. Explain *why* the category shift is warranted.
+4. Do NOT keep retrying the same category with minor variations.
 
 ## Persona Heuristics
 

--- a/factory/strategy.py
+++ b/factory/strategy.py
@@ -1,0 +1,126 @@
+"""FEEC priority heuristic — Fix, Exploit, Explore, Combine.
+
+Categorises and ranks hypotheses so the factory always addresses the
+highest-leverage category first:
+  1. FIX   — resolve a crash, error, or regression
+  2. EXPLOIT — build on a recent success
+  3. EXPLORE — try something new
+  4. COMBINE — merge prior successful approaches
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+import structlog
+
+log = structlog.get_logger()
+
+# ── keywords per category (lowercase) ───────────────────────────────
+
+_FIX_KEYWORDS: list[str] = [
+    "fix", "error", "bug", "crash", "fail", "regression", "broken", "repair",
+]
+_EXPLOIT_KEYWORDS: list[str] = [
+    "improve", "increase", "extend", "enhance", "build on", "optimize", "boost",
+]
+_COMBINE_KEYWORDS: list[str] = [
+    "combine", "merge", "integrate", "unify", "consolidate",
+]
+
+
+class FEECCategory(IntEnum):
+    """FEEC priority categories — lower value = higher priority."""
+
+    FIX = 0
+    EXPLOIT = 1
+    EXPLORE = 2
+    COMBINE = 3
+
+
+def categorize_hypothesis(
+    text: str,
+    history: list[dict] | None = None,
+) -> FEECCategory:
+    """Classify *text* into a FEEC category using keyword matching.
+
+    Checks FIX first, then EXPLOIT, then COMBINE.  If no keywords match the
+    text is classified as EXPLORE (the default / catch-all category).
+
+    ``history`` is accepted for forward-compatibility but not used by the
+    keyword heuristic today.
+    """
+    lower = text.lower()
+
+    if any(kw in lower for kw in _FIX_KEYWORDS):
+        log.debug("categorize_hypothesis", category="FIX", text=text[:80])
+        return FEECCategory.FIX
+
+    if any(kw in lower for kw in _EXPLOIT_KEYWORDS):
+        log.debug("categorize_hypothesis", category="EXPLOIT", text=text[:80])
+        return FEECCategory.EXPLOIT
+
+    if any(kw in lower for kw in _COMBINE_KEYWORDS):
+        log.debug("categorize_hypothesis", category="COMBINE", text=text[:80])
+        return FEECCategory.COMBINE
+
+    log.debug("categorize_hypothesis", category="EXPLORE", text=text[:80])
+    return FEECCategory.EXPLORE
+
+
+def rank_hypotheses(hypotheses: list[dict]) -> list[dict]:
+    """Sort *hypotheses* by FEEC priority (Fix > Exploit > Explore > Combine).
+
+    Each dict must contain a ``"description"`` key whose value is used for
+    categorization.  A ``"category"`` key is injected (or overwritten) with
+    the resolved :class:`FEECCategory` name.
+
+    The sort is **stable**: hypotheses in the same category keep their
+    original relative order.
+    """
+    for h in hypotheses:
+        cat = categorize_hypothesis(h.get("description", ""))
+        h["category"] = cat.name
+    ranked = sorted(hypotheses, key=lambda h: FEECCategory[h["category"]].value)
+    log.info(
+        "rank_hypotheses",
+        count=len(ranked),
+        order=[h["category"] for h in ranked],
+    )
+    return ranked
+
+
+def detect_stuck(
+    history: list[dict],
+    threshold: int = 3,
+) -> bool:
+    """Return ``True`` when the last *threshold* consecutive reverts share a category.
+
+    Each entry in *history* must have ``"verdict"`` and ``"hypothesis"`` keys.
+    Only entries whose verdict is ``"revert"`` are considered consecutive; a
+    ``"keep"`` verdict resets the streak.
+    """
+    if len(history) < threshold:
+        return False
+
+    # Walk backwards through history collecting consecutive reverts
+    consecutive_reverts: list[FEECCategory] = []
+    for entry in reversed(history):
+        if entry.get("verdict") != "revert":
+            break
+        cat = categorize_hypothesis(entry.get("hypothesis", ""))
+        consecutive_reverts.append(cat)
+
+    if len(consecutive_reverts) < threshold:
+        return False
+
+    # Check if the last `threshold` reverts are all in the same category
+    tail = consecutive_reverts[:threshold]
+    stuck = len(set(tail)) == 1
+    if stuck:
+        log.warning(
+            "stuck_detected",
+            category=tail[0].name,
+            consecutive=len(tail),
+        )
+    return stuck

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,216 @@
+"""Tests for factory.strategy — FEEC priority heuristic."""
+
+from factory.strategy import FEECCategory, categorize_hypothesis, detect_stuck, rank_hypotheses
+
+
+# ── categorize_hypothesis ────────────────────────────────────────────
+
+
+class TestCategorizeHypothesis:
+    def test_fix_keyword_error(self):
+        assert categorize_hypothesis("Fix the import error in cli.py") == FEECCategory.FIX
+
+    def test_fix_keyword_bug(self):
+        assert categorize_hypothesis("There is a bug in the parser") == FEECCategory.FIX
+
+    def test_fix_keyword_crash(self):
+        assert categorize_hypothesis("The server crashes on startup") == FEECCategory.FIX
+
+    def test_fix_keyword_fail(self):
+        assert categorize_hypothesis("Tests fail after refactor") == FEECCategory.FIX
+
+    def test_fix_keyword_regression(self):
+        assert categorize_hypothesis("Regression in score after last change") == FEECCategory.FIX
+
+    def test_fix_keyword_broken(self):
+        assert categorize_hypothesis("Broken endpoint returns 500") == FEECCategory.FIX
+
+    def test_fix_keyword_repair(self):
+        assert categorize_hypothesis("Repair the database migration") == FEECCategory.FIX
+
+    def test_exploit_keyword_improve(self):
+        assert categorize_hypothesis("Improve test coverage") == FEECCategory.EXPLOIT
+
+    def test_exploit_keyword_increase(self):
+        assert categorize_hypothesis("Increase cache hit rate") == FEECCategory.EXPLOIT
+
+    def test_exploit_keyword_extend(self):
+        assert categorize_hypothesis("Extend the logging module") == FEECCategory.EXPLOIT
+
+    def test_exploit_keyword_enhance(self):
+        assert categorize_hypothesis("Enhance the CLI output") == FEECCategory.EXPLOIT
+
+    def test_exploit_keyword_build_on(self):
+        assert categorize_hypothesis("Build on the recent auth success") == FEECCategory.EXPLOIT
+
+    def test_exploit_keyword_optimize(self):
+        assert categorize_hypothesis("Optimize database queries") == FEECCategory.EXPLOIT
+
+    def test_exploit_keyword_boost(self):
+        assert categorize_hypothesis("Boost response time") == FEECCategory.EXPLOIT
+
+    def test_combine_keyword_combine(self):
+        assert categorize_hypothesis("Combine caching and batching") == FEECCategory.COMBINE
+
+    def test_combine_keyword_merge(self):
+        assert categorize_hypothesis("Merge auth and rbac modules") == FEECCategory.COMBINE
+
+    def test_combine_keyword_integrate(self):
+        assert categorize_hypothesis("Integrate logging with tracing") == FEECCategory.COMBINE
+
+    def test_combine_keyword_unify(self):
+        assert categorize_hypothesis("Unify the config parsers") == FEECCategory.COMBINE
+
+    def test_combine_keyword_consolidate(self):
+        assert categorize_hypothesis("Consolidate duplicate handlers") == FEECCategory.COMBINE
+
+    def test_explore_default(self):
+        assert categorize_hypothesis("Add a new REST endpoint") == FEECCategory.EXPLORE
+
+    def test_explore_no_keywords(self):
+        assert categorize_hypothesis("Rewrite the scheduler") == FEECCategory.EXPLORE
+
+    def test_empty_text_defaults_to_explore(self):
+        assert categorize_hypothesis("") == FEECCategory.EXPLORE
+
+    def test_case_insensitive(self):
+        assert categorize_hypothesis("FIX the CRASH now") == FEECCategory.FIX
+
+    def test_fix_takes_priority_over_exploit(self):
+        """When both FIX and EXPLOIT keywords appear, FIX wins."""
+        assert categorize_hypothesis("Fix and improve the parser") == FEECCategory.FIX
+
+    def test_exploit_takes_priority_over_combine(self):
+        """When both EXPLOIT and COMBINE keywords appear, EXPLOIT wins."""
+        assert categorize_hypothesis("Improve by combining modules") == FEECCategory.EXPLOIT
+
+    def test_history_param_accepted(self):
+        """history parameter is accepted (forward-compat) without error."""
+        result = categorize_hypothesis("Fix a bug", history=[{"verdict": "revert"}])
+        assert result == FEECCategory.FIX
+
+
+# ── rank_hypotheses ──────────────────────────────────────────────────
+
+
+class TestRankHypotheses:
+    def test_sorts_by_feec_priority(self):
+        hypotheses = [
+            {"description": "Add a new endpoint"},
+            {"description": "Fix the crash"},
+            {"description": "Combine auth modules"},
+            {"description": "Improve test coverage"},
+        ]
+        ranked = rank_hypotheses(hypotheses)
+        categories = [h["category"] for h in ranked]
+        assert categories == ["FIX", "EXPLOIT", "EXPLORE", "COMBINE"]
+
+    def test_stable_sort_within_category(self):
+        hypotheses = [
+            {"description": "Fix the crash in login"},
+            {"description": "Fix the error in signup"},
+        ]
+        ranked = rank_hypotheses(hypotheses)
+        assert ranked[0]["description"] == "Fix the crash in login"
+        assert ranked[1]["description"] == "Fix the error in signup"
+
+    def test_empty_list(self):
+        assert rank_hypotheses([]) == []
+
+    def test_single_hypothesis(self):
+        ranked = rank_hypotheses([{"description": "Add feature"}])
+        assert len(ranked) == 1
+        assert ranked[0]["category"] == "EXPLORE"
+
+    def test_injects_category_key(self):
+        ranked = rank_hypotheses([{"description": "Fix a bug"}])
+        assert "category" in ranked[0]
+        assert ranked[0]["category"] == "FIX"
+
+    def test_all_same_category(self):
+        hypotheses = [
+            {"description": "Fix error A"},
+            {"description": "Fix bug B"},
+            {"description": "Fix crash C"},
+        ]
+        ranked = rank_hypotheses(hypotheses)
+        assert all(h["category"] == "FIX" for h in ranked)
+        # Order preserved
+        assert ranked[0]["description"] == "Fix error A"
+        assert ranked[2]["description"] == "Fix crash C"
+
+
+# ── detect_stuck ─────────────────────────────────────────────────────
+
+
+class TestDetectStuck:
+    def test_stuck_three_consecutive_same_category(self):
+        history = [
+            {"hypothesis": "Fix error 1", "verdict": "revert"},
+            {"hypothesis": "Fix crash 2", "verdict": "revert"},
+            {"hypothesis": "Fix bug 3", "verdict": "revert"},
+        ]
+        assert detect_stuck(history) is True
+
+    def test_not_stuck_different_categories(self):
+        history = [
+            {"hypothesis": "Fix error 1", "verdict": "revert"},
+            {"hypothesis": "Improve coverage", "verdict": "revert"},
+            {"hypothesis": "Fix crash 3", "verdict": "revert"},
+        ]
+        assert detect_stuck(history) is False
+
+    def test_not_stuck_below_threshold(self):
+        history = [
+            {"hypothesis": "Fix error 1", "verdict": "revert"},
+            {"hypothesis": "Fix crash 2", "verdict": "revert"},
+        ]
+        assert detect_stuck(history) is False
+
+    def test_not_stuck_keep_breaks_streak(self):
+        history = [
+            {"hypothesis": "Fix error 1", "verdict": "revert"},
+            {"hypothesis": "Fix crash 2", "verdict": "keep"},
+            {"hypothesis": "Fix bug 3", "verdict": "revert"},
+        ]
+        assert detect_stuck(history) is False
+
+    def test_empty_history(self):
+        assert detect_stuck([]) is False
+
+    def test_custom_threshold(self):
+        history = [
+            {"hypothesis": "Fix a", "verdict": "revert"},
+            {"hypothesis": "Fix b", "verdict": "revert"},
+        ]
+        assert detect_stuck(history, threshold=2) is True
+
+    def test_stuck_only_considers_tail(self):
+        """Only the most recent consecutive reverts matter."""
+        history = [
+            {"hypothesis": "Add endpoint", "verdict": "keep"},
+            {"hypothesis": "Fix error 1", "verdict": "revert"},
+            {"hypothesis": "Fix crash 2", "verdict": "revert"},
+            {"hypothesis": "Fix bug 3", "verdict": "revert"},
+        ]
+        assert detect_stuck(history) is True
+
+    def test_not_stuck_when_mixed_verdicts_in_tail(self):
+        history = [
+            {"hypothesis": "Fix a", "verdict": "revert"},
+            {"hypothesis": "Add feature", "verdict": "keep"},
+            {"hypothesis": "Fix b", "verdict": "revert"},
+            {"hypothesis": "Fix c", "verdict": "revert"},
+        ]
+        # Only last 2 are consecutive reverts
+        assert detect_stuck(history) is False
+
+    def test_missing_hypothesis_key(self):
+        """Entries without hypothesis key default to EXPLORE."""
+        history = [
+            {"verdict": "revert"},
+            {"verdict": "revert"},
+            {"verdict": "revert"},
+        ]
+        # All default to EXPLORE -> stuck
+        assert detect_stuck(history) is True


### PR DESCRIPTION
## Summary
- Add `factory/strategy.py` with `FEECCategory` enum, `categorize_hypothesis()`, `rank_hypotheses()`, and `detect_stuck()` functions implementing the Fix->Exploit->Explore->Combine priority heuristic
- Update `factory/agents/prompts/strategist.md` with FEEC priority framework section, stuck protocol section, and category tags in hypothesis template
- Add `tests/test_strategy.py` with 41 tests covering all FEEC categories, ranking, stuck detection, and edge cases

## Test plan
- [x] `uv run pytest tests/test_strategy.py -v` -- 41/41 passed
- [x] `uv run pytest -v` -- 357/357 passed (full suite)
- [x] `uv run mypy factory/ --no-error-summary` -- 0 errors
- [x] `uv run ruff check .` -- all checks passed

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)