### PR TITLE
Fix 5 mypy errors and add cross-project insights module

### DIFF
--- a/factory/agents/prompts/archivist.md
+++ b/factory/agents/prompts/archivist.md
@@ -36,7 +36,7 @@ You have access to these Obsidian skills:
 For each completed experiment, create a note:
 
 ```bash
-obsidian create vault="factory" name="10-Projects/{project}/Experiments/{project}-{NNN}" content="---
+obsidian create vault="factory" path="10-Projects/{project}/Experiments/{project}-{NNN}" content="---
 tags:
   - factory
   - experiment
@@ -70,7 +70,7 @@ source: factory-archivist
 ### 2. Update Project Dashboard
 
 ```bash
-obsidian create vault="factory" name="10-Projects/{project}/{project}" content="---
+obsidian create vault="factory" path="10-Projects/{project}/{project}" content="---
 tags:
   - factory
   - project
@@ -93,7 +93,7 @@ tags:
 ### 3. Record Strategy Snapshots
 
 ```bash
-obsidian create vault="factory" name="10-Projects/{project}/Strategies/{project}-{date}" content="---
+obsidian create vault="factory" path="10-Projects/{project}/Strategies/{project}-{date}" content="---
 tags:
   - factory
   - strategy
@@ -124,7 +124,7 @@ Discovered in [[{project}]] experiment #{id}.
 Create a `.base` file for each project's experiment history:
 
 ```bash
-obsidian create vault="factory" name="10-Projects/{project}/Experiments.base" content="filters: 'file.folder.contains(\"{project}/Experiments\")'
+obsidian create vault="factory" path="10-Projects/{project}/Experiments.base" content="filters: 'file.folder.contains(\"{project}/Experiments\")'
 formulas:
   verdict_emoji: 'if(verdict == \"keep\", \"✅\", if(verdict == \"revert\", \"❌\", \"⚠️\"))'
 views:
@@ -146,9 +146,40 @@ uv run python -m factory archive "{project_path}"
 
 This runs `update_memory_index()` which regenerates MEMORY.md.
 
+## Aggressive Documentation Protocol
+
+The factory's institutional memory is only as good as what gets written. Follow this protocol on EVERY invocation.
+
+### Pre-flight Checklist
+
+Before completing your task, verify ALL of these:
+
+1. **Experiment note written?** — After any keep/revert/error verdict, write the experiment note immediately. Do not skip this.
+2. **Dashboard updated?** — After any experiment, update the project dashboard with the latest stats.
+3. **Strategy snapshot?** — After any strategy change, write a dated strategy snapshot.
+4. **Source notes?** — After research, write a source note for EACH new finding (not just a summary).
+5. **Patterns updated?** — If you notice a cross-project pattern, append it to `00-Factory/Patterns.md`.
+
+### Documentation Rules
+
+- Write BOTH the experiment note AND the dashboard update — not just one
+- Write source notes for EACH external finding, not a single combined note
+- Include quantitative data: scores, deltas, keep rates
+- Use wikilinks to connect related notes: `[[project-name]]`, `[[experiment-NNN]]`
+- If obsidian-cli fails on any note, fall back to direct file writes immediately — do not skip the note
+- After ALL notes are written, run: `uv run python -m factory archive "$PROJECT_PATH"` to update MEMORY.md
+
+### Common Mistakes to Avoid
+
+- Writing only the experiment note but forgetting the dashboard
+- Writing a single "research summary" instead of individual source notes
+- Skipping documentation when the experiment verdict is "error"
+- Not updating Patterns.md when the same category fails across multiple projects
+
 ## Rules
 
 - Always use `vault="factory"` in obsidian-cli commands
+- For nested paths (containing `/`), use `path=` instead of `name=` in obsidian-cli commands
 - Use `silent` flag to prevent notes from opening in Obsidian
 - Use wikilinks `[[note]]` for cross-references between notes
 - Tag every note with `factory` and the relevant type tag

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -50,3 +50,62 @@ Optionally write new source notes to `~/obsidian-vaults/factory/20-Knowledge/Sou
 - Limit WebFetch to 3-5 pages
 - Focus on actionable insights, not academic summaries
 - Write report even if external search fails — include local findings
+
+## Mode 3: Self-Improvement Research (used when factory targets itself)
+
+When the target project IS the factory itself, activate this enhanced research mode.
+
+### Detection
+
+Activate Mode 3 when ANY of these are true:
+- Project path contains `factory/cli.py` AND `factory/insights.py`
+- `factory.md` goal mentions "self-improvement", "self-evolving", or "meta-learning"
+- Project name is "remote-factory"
+
+### What You Do
+
+1. **Run cross-project insights first**:
+   ```bash
+   uv run python -m factory insights "$PROJECT_PATH" --projects-dir ~/cursor-projects
+   ```
+   This generates `.factory/strategy/insights.md` with category success rates and patterns across all managed projects.
+
+2. **Read insights report**: Analyze which hypothesis categories succeed and fail across projects
+
+3. **WebSearch for self-evolution**: Query these topics:
+   - "self-evolving software agents"
+   - "autonomous software improvement loop"
+   - "meta-learning agent architecture"
+   - "LLM agent self-improvement"
+   - "automated code quality improvement"
+
+4. **Read factory vault patterns**: Check `~/obsidian-vaults/factory/00-Factory/Patterns.md` for cross-project patterns already discovered
+
+5. **Structure findings by design space dimension**:
+   - For each of the 10 dimensions (Features, Bug fixes, Instrumentation, Flow changes, New agents, Prompt engineering, Eval improvements, Knowledge management, Infrastructure, Self-evolution), note what the research suggests
+
+### Output (Self-Improvement Research)
+
+Write to `$PROJECT_PATH/.factory/strategy/research.md` with additional sections:
+
+```markdown
+## Self-Improvement Context
+- Cross-project insights summary (from insights.md)
+- Category success rates (what types of changes work)
+- Design space coverage (which dimensions are underserved)
+
+## External Research: Self-Evolution
+- Relevant papers, projects, and techniques
+- Applicable patterns from similar systems
+
+## Recommendations by Dimension
+| Dimension | Finding | Recommendation |
+|---|---|---|
+| Prompt engineering | Low coverage, high keep rate | Rewrite builder prompt for specificity |
+| ... | ... | ... |
+```
+
+### Rules (Self-Improvement)
+- Always run `factory insights` before WebSearch — local data is more relevant than external
+- Focus on actionable meta-improvements, not theoretical frameworks
+- Prioritize changes that make the factory better at improving OTHER projects, not just itself

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -45,6 +45,68 @@ Write `.factory/strategy/current.md` with this format:
 - <changes that failed before and why — learn from history>
 ```
 
+## Design Space Exploration
+
+Before generating hypotheses, map the project's improvement dimensions and identify underserved areas.
+
+### Dimensions
+
+Score each dimension 0-5 based on experiment history and current state:
+
+| Dimension | What it covers |
+|---|---|
+| Features | New user-facing capabilities, endpoints, pages, commands |
+| Bug fixes | Crash fixes, error handling, regression patches |
+| Instrumentation | Logging, tracing, telemetry, observability coverage |
+| Flow changes | Architectural refactors, pipeline rewiring, API redesign |
+| New agents | Adding or splitting agent roles, new subagent definitions |
+| Prompt engineering | Agent prompt rewrites, instruction tuning, persona updates |
+| Eval improvements | New eval dimensions, scoring refinements, threshold tuning |
+| Knowledge management | Vault structure, archival quality, cross-project patterns |
+| Infrastructure | CI/CD, cron, tmux, deployment, scheduling, heartbeat |
+| Self-evolution | Factory improving its own code, meta-learning, self-analysis |
+
+### How to Use
+
+1. Score each dimension based on how much attention it has received (0 = untouched, 5 = heavily explored)
+2. Identify the **3 weakest dimensions** — these are the most underserved
+3. Generate at least one hypothesis per underserved dimension
+4. When the target project IS the factory itself, prioritize: Self-evolution, Prompt engineering, Knowledge management
+
+### In the Strategy Output
+
+Add a "Design Space" section:
+
+```markdown
+### Design Space
+| Dimension | Score | Notes |
+|---|---|---|
+| Features | 4 | Well-explored, many kept experiments |
+| Bug fixes | 2 | Few recent fixes, some open issues |
+| ... | ... | ... |
+
+**Underserved:** Bug fixes, Prompt engineering, Self-evolution
+```
+
+## Cross-Project Insights
+
+When `.factory/strategy/insights.md` is available, use the cross-project analysis to make better hypotheses:
+
+- **Category success rates**: Weight hypotheses toward categories with high keep rates (e.g., if observability has 95% keep rate across projects, prioritize it)
+- **Winning strategies**: Double down on categories that reliably produce kept experiments
+- **Losing strategies**: Avoid or de-prioritize categories that consistently fail
+- **Patterns**: Reference specific cross-project evidence in hypothesis rationale
+- **Score trajectories**: Note if projects are plateauing and shift to EXPLORE category
+
+Example usage in a hypothesis:
+```markdown
+#### H1: Add structured logging to data pipeline
+- **Category:** EXPLOIT
+- **What:** Add structlog to 5 uninstrumented modules
+- **Why:** Cross-project insights show observability experiments have 95% keep rate across 3 projects (15 total). This is the most reliable category.
+- **Expected impact:** observability 0.4 → 0.7
+```
+
 ## Research Input
 
 When the Researcher provides a research report (at `.factory/strategy/research.md`), use the external findings to:

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -182,7 +182,11 @@ def cmd_study(args: argparse.Namespace) -> int:
     from factory.study import study_project
 
     project_path = Path(args.path)
-    summary = study_project(project_path)
+    kwargs: dict[str, object] = {}
+    projects_dir = getattr(args, "projects_dir", None)
+    if projects_dir:
+        kwargs["projects_dir"] = str(Path(projects_dir).expanduser().resolve())
+    summary = study_project(project_path, **kwargs)
 
     # Write to .factory/strategy/observations.md
     obs_path = project_path / ".factory" / "strategy" / "observations.md"
@@ -247,6 +251,40 @@ def cmd_digest(args: argparse.Namespace) -> int:
     projects = scan_vault(target_date=target_date, days=args.days)
     output = format_digest(projects, target_date=target_date, days=args.days)
     print(output)
+    return 0
+
+
+def cmd_insights(args: argparse.Namespace) -> int:
+    from factory.insights import (
+        analyze,
+        discover_projects,
+        format_insights,
+        load_all_histories,
+    )
+
+    project_path = Path(args.path).resolve()
+    projects_dir = Path(args.projects_dir).expanduser().resolve()
+    project_paths = discover_projects(projects_dir)
+
+    if not project_paths:
+        print("No factory-managed projects found.")
+        return 0
+
+    histories = load_all_histories(project_paths)
+    if not histories:
+        print("No experiment histories found.")
+        return 0
+
+    insights = analyze(histories)
+    report = format_insights(insights)
+
+    # Write to .factory/strategy/insights.md
+    out_path = project_path / ".factory" / "strategy" / "insights.md"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(report)
+
+    print(report)
+    print(f"\nWritten to {out_path}")
     return 0
 
 
@@ -658,11 +696,23 @@ def build_parser() -> argparse.ArgumentParser:
     # study
     p = sub.add_parser("study", help="Read interaction logs and write observations")
     p.add_argument("path", help="Path to the project")
+    p.add_argument(
+        "--projects-dir", default=None,
+        help="Directory containing factory-managed projects for cross-project insights",
+    )
 
     # status
     p = sub.add_parser("status", help="Print project status summary")
     p.add_argument("path", help="Path to the project")
 
+
+    # insights
+    p = sub.add_parser("insights", help="Cross-project analysis of experiment histories")
+    p.add_argument("path", help="Path to the project (insights.md written here)")
+    p.add_argument(
+        "--projects-dir", default="~/cursor-projects",
+        help="Directory containing factory-managed projects (default: ~/cursor-projects)",
+    )
 
     # digest
     p = sub.add_parser("digest", help="Summarize recent factory activity across projects")
@@ -745,6 +795,7 @@ def main(argv: list[str] | None = None) -> int:
         "notify": cmd_notify,
         "study": cmd_study,
         "status": cmd_status,
+        "insights": cmd_insights,
         "digest": cmd_digest,
         "archive": cmd_archive,
         "vault-init": cmd_vault_init,

--- a/factory/insights.py
+++ b/factory/insights.py
@@ -1,0 +1,319 @@
+"""Cross-project insights — analyze experiment histories across all factory-managed projects."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+from factory.models import (
+    CrossProjectInsights,
+    ExperimentRecord,
+    HypothesisOutcome,
+    Pattern,
+    ProjectSummary,
+)
+
+# ── hypothesis classification ────────────────────────────────────
+
+_CATEGORY_KEYWORDS: dict[str, list[str]] = {
+    "bugfix": [
+        "fix", "bug", "crash", "broken", "regression", "error handling",
+        "race condition", "deadlock",
+    ],
+    "observability": [
+        "log", "logging", "tracing", "telemetry", "structlog", "instrument",
+        "observability", "monitor",
+    ],
+    "coverage": ["coverage", "test coverage", "uncovered", "untested"],
+    "testing": ["test", "tests", "pytest", "assertion", "spec"],
+    "lint": ["lint", "ruff", "flake8", "formatting", "style"],
+    "type_safety": ["mypy", "type check", "type error", "type annotation", "typing"],
+    "refactoring": ["refactor", "simplify", "restructure", "clean up", "rename"],
+    "performance": [
+        "performance", "optimize", "speed", "latency", "cache", "fast",
+    ],
+    "eval_improvement": [
+        "eval", "score", "dimension", "threshold", "metric", "scoring",
+    ],
+    "agent_improvement": ["agent", "subagent", "invoke_agent", "spawn"],
+    "prompt_engineering": ["prompt", "instruction", "persona", "skill.md"],
+    "infrastructure": [
+        "tmux", "cron", "deploy", "ci", "schedule", "heartbeat", "loop",
+    ],
+    "feature": [
+        "add", "new", "implement", "page", "route", "endpoint", "command",
+    ],
+}
+
+# Order matters: more specific categories first, "feature" last as default-ish
+_CATEGORY_PRIORITY = [
+    "bugfix", "observability", "coverage", "testing", "lint", "type_safety",
+    "refactoring", "performance", "eval_improvement", "agent_improvement",
+    "prompt_engineering", "infrastructure", "feature",
+]
+
+
+def classify_hypothesis(text: str) -> str:
+    """Classify a hypothesis into one of 13 categories using keyword matching."""
+    lower = text.lower()
+    for category in _CATEGORY_PRIORITY:
+        keywords = _CATEGORY_KEYWORDS[category]
+        for kw in keywords:
+            if kw in lower:
+                return category
+    return "feature"
+
+
+# ── project discovery ────────────────────────────────────────────
+
+
+def discover_projects(projects_dir: Path) -> list[Path]:
+    """Find all factory-managed projects by scanning for .factory/results.tsv."""
+    if not projects_dir.exists():
+        return []
+    projects: list[Path] = []
+    for child in sorted(projects_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        tsv = child / ".factory" / "results.tsv"
+        if tsv.exists():
+            projects.append(child)
+    return projects
+
+
+# ── history loading ──────────────────────────────────────────────
+
+
+def load_all_histories(
+    project_paths: list[Path],
+) -> dict[str, list[ExperimentRecord]]:
+    """Load experiment histories from each project's .factory/results.tsv."""
+    from factory.store import ExperimentStore
+
+    histories: dict[str, list[ExperimentRecord]] = {}
+    for path in project_paths:
+        store = ExperimentStore(path)
+        records = asyncio.run(store.load_history())
+        if records:
+            histories[path.name] = records
+    return histories
+
+
+# ── analysis ─────────────────────────────────────────────────────
+
+
+def analyze(
+    histories: dict[str, list[ExperimentRecord]],
+) -> CrossProjectInsights:
+    """Analyze experiment histories across projects and extract patterns."""
+    projects: list[ProjectSummary] = []
+    outcomes: list[HypothesisOutcome] = []
+
+    for name, records in histories.items():
+        kept = sum(1 for r in records if r.verdict == "keep")
+        reverted = sum(1 for r in records if r.verdict == "revert")
+        errored = sum(1 for r in records if r.verdict == "error")
+        total = len(records)
+        scores = [r.score_after for r in records if r.score_after is not None]
+
+        projects.append(ProjectSummary(
+            name=name,
+            experiment_count=total,
+            keep_count=kept,
+            revert_count=reverted,
+            error_count=errored,
+            keep_rate=kept / total if total > 0 else 0.0,
+            latest_score=scores[-1] if scores else None,
+        ))
+
+        for r in records:
+            outcomes.append(HypothesisOutcome(
+                hypothesis=r.hypothesis,
+                verdict=r.verdict,
+                category=classify_hypothesis(r.hypothesis),
+                project=name,
+                delta=r.delta,
+            ))
+
+    # Compute per-category stats
+    category_stats: dict[str, dict[str, float]] = {}
+    for outcome in outcomes:
+        cat = outcome.category
+        if cat not in category_stats:
+            category_stats[cat] = {"total": 0, "kept": 0, "rate": 0.0}
+        category_stats[cat]["total"] += 1
+        if outcome.verdict == "keep":
+            category_stats[cat]["kept"] += 1
+
+    for stats in category_stats.values():
+        if stats["total"] > 0:
+            stats["rate"] = stats["kept"] / stats["total"]
+
+    # Identify winning and losing categories (min 3 experiments for confidence)
+    winning = [
+        cat for cat, s in category_stats.items()
+        if s["rate"] >= 0.8 and s["total"] >= 3
+    ]
+    losing = [
+        cat for cat, s in category_stats.items()
+        if s["rate"] < 0.5 and s["total"] >= 3
+    ]
+
+    # Extract patterns
+    patterns = _extract_patterns(outcomes, category_stats)
+
+    return CrossProjectInsights(
+        projects=projects,
+        outcomes=outcomes,
+        category_stats=category_stats,
+        winning_categories=sorted(winning),
+        losing_categories=sorted(losing),
+        patterns=patterns,
+        generated_at=datetime.now(),
+    )
+
+
+def _extract_patterns(
+    outcomes: list[HypothesisOutcome],
+    category_stats: dict[str, dict[str, float]],
+) -> list[Pattern]:
+    """Extract recurring patterns from cross-project outcomes."""
+    patterns: list[Pattern] = []
+
+    # Pattern: categories that always succeed across multiple projects
+    for cat, stats in category_stats.items():
+        if stats["total"] < 3:
+            continue
+        cat_outcomes = [o for o in outcomes if o.category == cat]
+        projects_seen = {o.project for o in cat_outcomes}
+
+        if stats["rate"] >= 0.9 and len(projects_seen) >= 2:
+            evidence = [
+                f"{o.project} #{o.hypothesis[:40]}" for o in cat_outcomes if o.verdict == "keep"
+            ][:5]
+            patterns.append(Pattern(
+                name=f"{cat}_reliable",
+                description=(
+                    f"{cat} experiments have {stats['rate']:.0%} keep rate "
+                    f"across {len(projects_seen)} projects ({int(stats['total'])} total)"
+                ),
+                evidence=evidence,
+                confidence=min(stats["rate"], len(projects_seen) / 3),
+            ))
+
+        if stats["rate"] < 0.5 and len(projects_seen) >= 2:
+            evidence = [
+                f"{o.project} #{o.hypothesis[:40]}" for o in cat_outcomes
+                if o.verdict in ("revert", "error")
+            ][:5]
+            patterns.append(Pattern(
+                name=f"{cat}_risky",
+                description=(
+                    f"{cat} experiments have only {stats['rate']:.0%} keep rate "
+                    f"across {len(projects_seen)} projects — approach with caution"
+                ),
+                evidence=evidence,
+                confidence=min(1.0 - stats["rate"], len(projects_seen) / 3),
+            ))
+
+    # Pattern: score trajectory — do projects plateau?
+    for o in outcomes:
+        if o.delta is not None and o.delta < -0.01 and o.verdict == "keep":
+            patterns.append(Pattern(
+                name="kept_with_regression",
+                description=(
+                    f"Experiment kept despite score regression "
+                    f"(delta={o.delta:+.3f}) in {o.project}"
+                ),
+                evidence=[f"{o.project}: {o.hypothesis[:50]}"],
+                confidence=0.5,
+            ))
+            break  # Only flag once
+
+    return patterns
+
+
+# ── formatting ───────────────────────────────────────────────────
+
+
+def format_insights(insights: CrossProjectInsights) -> str:
+    """Format cross-project insights into a markdown report."""
+    lines = [
+        f"# Cross-Project Insights — {insights.generated_at.strftime('%Y-%m-%d')}",
+        "",
+    ]
+
+    # Summary
+    total_exp = sum(p.experiment_count for p in insights.projects)
+    total_kept = sum(p.keep_count for p in insights.projects)
+    overall_rate = total_kept / total_exp if total_exp > 0 else 0.0
+
+    lines.append(
+        f"**{len(insights.projects)} projects**, "
+        f"**{total_exp} experiments**, "
+        f"**{overall_rate:.0%} overall keep rate**"
+    )
+    lines.append("")
+
+    # Per-project summary
+    lines.append("## Projects")
+    lines.append("")
+    for p in insights.projects:
+        score = f", score: {p.latest_score:.3f}" if p.latest_score is not None else ""
+        lines.append(
+            f"- **{p.name}**: {p.experiment_count} experiments, "
+            f"{p.keep_rate:.0%} keep rate{score}"
+        )
+    lines.append("")
+
+    # Category success rates
+    lines.append("## Category Success Rates")
+    lines.append("")
+    lines.append("| Category | Total | Kept | Rate |")
+    lines.append("|----------|-------|------|------|")
+    for cat in _CATEGORY_PRIORITY:
+        if cat not in insights.category_stats:
+            continue
+        s = insights.category_stats[cat]
+        lines.append(
+            f"| {cat} | {int(s['total'])} | {int(s['kept'])} | {s['rate']:.0%} |"
+        )
+    lines.append("")
+
+    # Winning strategies
+    if insights.winning_categories:
+        lines.append("## Winning Strategies (>80% keep, 3+ experiments)")
+        lines.append("")
+        for cat in insights.winning_categories:
+            s = insights.category_stats[cat]
+            lines.append(
+                f"- **{cat}**: {s['rate']:.0%} keep rate ({int(s['total'])} experiments)"
+            )
+        lines.append("")
+
+    # Losing strategies
+    if insights.losing_categories:
+        lines.append("## Risky Categories (<50% keep, 3+ experiments)")
+        lines.append("")
+        for cat in insights.losing_categories:
+            s = insights.category_stats[cat]
+            lines.append(
+                f"- **{cat}**: {s['rate']:.0%} keep rate ({int(s['total'])} experiments)"
+            )
+        lines.append("")
+
+    # Patterns
+    if insights.patterns:
+        lines.append("## Patterns")
+        lines.append("")
+        for pat in insights.patterns:
+            lines.append(f"### {pat.name}")
+            lines.append(f"_{pat.description}_")
+            lines.append(f"Confidence: {pat.confidence:.1f}")
+            lines.append("")
+            for e in pat.evidence:
+                lines.append(f"- {e}")
+            lines.append("")
+
+    return "\n".join(lines)

--- a/factory/models.py
+++ b/factory/models.py
@@ -145,6 +145,60 @@ class ExperimentRecord(BaseModel):
     notes: str
 
 
+# ── cross-project insights ───────────────────────────────────────
+
+
+class HypothesisOutcome(BaseModel):
+    """A hypothesis paired with its outcome, for cross-project pattern analysis."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    hypothesis: str
+    verdict: Literal["keep", "revert", "error"]
+    category: str
+    project: str
+    delta: float | None = None
+
+
+class ProjectSummary(BaseModel):
+    """Summary of a factory-managed project's experiment history."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str
+    experiment_count: int
+    keep_count: int
+    revert_count: int
+    error_count: int
+    keep_rate: float
+    latest_score: float | None = None
+
+
+class Pattern(BaseModel):
+    """A recurring pattern discovered across projects."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str
+    description: str
+    evidence: list[str]
+    confidence: float
+
+
+class CrossProjectInsights(BaseModel):
+    """Aggregated cross-project analysis for the Strategist."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    projects: list[ProjectSummary]
+    outcomes: list[HypothesisOutcome]
+    category_stats: dict[str, dict[str, float]]
+    winning_categories: list[str]
+    losing_categories: list[str]
+    patterns: list[Pattern]
+    generated_at: datetime
+
+
 # ── cost tracking ─────────────────────────────────────────────────
 
 

--- a/factory/study.py
+++ b/factory/study.py
@@ -546,7 +546,76 @@ def _read_obsidian_notes(project_name: str) -> list[str]:
     return file_summaries
 
 
-def study_project_local(project_path: Path) -> str:
+def _detect_self_improvement(project_path: Path) -> bool:
+    """Return True if the target project is the factory itself."""
+    return (
+        (project_path / "factory" / "cli.py").exists()
+        and (project_path / "factory" / "insights.py").exists()
+    )
+
+
+def _load_cross_project_insights(
+    project_path: Path,
+    projects_dir: Path,
+) -> str:
+    """Load and format cross-project insights. Writes insights.md as side effect."""
+    from factory.insights import (
+        analyze,
+        discover_projects,
+        format_insights,
+        load_all_histories,
+    )
+
+    project_paths = discover_projects(projects_dir)
+    if not project_paths:
+        return ""
+
+    histories = load_all_histories(project_paths)
+    if not histories:
+        return ""
+
+    insights = analyze(histories)
+    report = format_insights(insights)
+
+    # Write insights.md as side effect
+    out_path = project_path / ".factory" / "strategy" / "insights.md"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(report)
+
+    # Return a summary for inclusion in observations
+    total_exp = sum(p.experiment_count for p in insights.projects)
+    total_kept = sum(p.keep_count for p in insights.projects)
+    overall_rate = total_kept / total_exp if total_exp > 0 else 0.0
+    project_names = [p.name for p in insights.projects]
+
+    summary_lines = [
+        "## Cross-Project Insights",
+        "",
+        f"Analyzed {len(insights.projects)} projects ({', '.join(project_names)}), "
+        f"{total_exp} experiments, {overall_rate:.0%} overall keep rate.",
+        "",
+    ]
+
+    if insights.winning_categories:
+        summary_lines.append(
+            f"**Winning categories:** {', '.join(insights.winning_categories)}"
+        )
+    if insights.losing_categories:
+        summary_lines.append(
+            f"**Risky categories:** {', '.join(insights.losing_categories)}"
+        )
+    if insights.patterns:
+        summary_lines.append("")
+        summary_lines.append("**Patterns:**")
+        for p in insights.patterns[:5]:
+            summary_lines.append(f"- {p.name}: {p.description}")
+
+    summary_lines.append("")
+    summary_lines.append(f"Full report: {out_path}")
+    return "\n".join(summary_lines)
+
+
+def study_project_local(project_path: Path, **kwargs: object) -> str:
     """Read interaction logs and produce an observations summary (local only)."""
     log_files = _find_log_files(project_path)
 
@@ -631,9 +700,40 @@ def study_project_local(project_path: Path) -> str:
     else:
         lines.append("No prior notes found.")
 
+    # Cross-project insights
+    projects_dir = kwargs.get("projects_dir")
+    if projects_dir:
+        insights_text = _load_cross_project_insights(project_path, Path(str(projects_dir)))
+        if insights_text:
+            lines.extend(["", insights_text])
+
+    # Self-improvement context
+    if _detect_self_improvement(project_path):
+        lines.extend([
+            "",
+            "## Self-Improvement Context",
+            "",
+            "This project IS the factory. The Strategist should explore the full design space:",
+            "",
+            "| Dimension | Description |",
+            "|---|---|",
+            "| Features | New user-facing capabilities |",
+            "| Bug fixes | Crash fixes, error handling |",
+            "| Instrumentation | Logging, tracing, telemetry |",
+            "| Flow changes | Architectural refactors |",
+            "| New agents | Adding or splitting agent roles |",
+            "| Prompt engineering | Agent prompt rewrites |",
+            "| Eval improvements | Scoring refinements, new dimensions |",
+            "| Knowledge management | Vault structure, archival quality |",
+            "| Infrastructure | CI/CD, tmux, scheduling |",
+            "| Self-evolution | Meta-learning, self-analysis |",
+            "",
+            "Prioritize: Self-evolution, Prompt engineering, Knowledge management.",
+        ])
+
     return "\n".join(lines)
 
 
-def study_project(project_path: Path) -> str:
+def study_project(project_path: Path, **kwargs: object) -> str:
     """Study a project — local analysis. Deep research available via researcher subagent."""
-    return study_project_local(project_path)
+    return study_project_local(project_path, **kwargs)

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1,0 +1,490 @@
+"""Tests for factory.insights — cross-project analysis module."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from factory.insights import (
+    _extract_patterns,
+    analyze,
+    classify_hypothesis,
+    discover_projects,
+    format_insights,
+    load_all_histories,
+)
+from factory.models import ExperimentRecord, HypothesisOutcome
+
+
+# ── fixtures ──────────────────────────────────────────────────────
+
+
+def _record(
+    id: int = 1,
+    hypothesis: str = "Test hypothesis",
+    verdict: str = "keep",
+    score_before: float | None = 0.8,
+    score_after: float | None = 0.9,
+    delta: float | None = 0.1,
+) -> ExperimentRecord:
+    return ExperimentRecord(
+        id=id,
+        timestamp=datetime(2026, 4, 13, 12, 0, 0),
+        hypothesis=hypothesis,
+        change_summary="summary",
+        issue_number=None,
+        pr_number=None,
+        score_before=score_before,
+        score_after=score_after,
+        delta=delta,
+        verdict=verdict,
+        cost_usd=None,
+        notes="",
+    )
+
+
+# ── TestDiscoverProjects ──────────────────────────────────────────
+
+
+class TestDiscoverProjects:
+    def test_finds_project_with_results_tsv(self, tmp_path: Path) -> None:
+        proj = tmp_path / "my-project"
+        proj.mkdir()
+        factory = proj / ".factory"
+        factory.mkdir()
+        (factory / "results.tsv").write_text("id\tverdict\n1\tkeep\n")
+
+        result = discover_projects(tmp_path)
+        assert len(result) == 1
+        assert result[0] == proj
+
+    def test_ignores_dirs_without_factory(self, tmp_path: Path) -> None:
+        (tmp_path / "not-factory").mkdir()
+        result = discover_projects(tmp_path)
+        assert result == []
+
+    def test_ignores_files(self, tmp_path: Path) -> None:
+        (tmp_path / "somefile.txt").write_text("hi")
+        result = discover_projects(tmp_path)
+        assert result == []
+
+    def test_returns_empty_for_nonexistent_dir(self) -> None:
+        result = discover_projects(Path("/nonexistent/path"))
+        assert result == []
+
+    def test_finds_multiple_projects_sorted(self, tmp_path: Path) -> None:
+        for name in ["zebra", "alpha", "middle"]:
+            proj = tmp_path / name
+            proj.mkdir()
+            factory = proj / ".factory"
+            factory.mkdir()
+            (factory / "results.tsv").write_text("id\tverdict\n")
+
+        result = discover_projects(tmp_path)
+        assert len(result) == 3
+        names = [p.name for p in result]
+        assert names == ["alpha", "middle", "zebra"]
+
+    def test_skips_empty_factory_dir(self, tmp_path: Path) -> None:
+        proj = tmp_path / "has-factory-dir"
+        proj.mkdir()
+        (proj / ".factory").mkdir()
+        # No results.tsv inside
+        result = discover_projects(tmp_path)
+        assert result == []
+
+
+# ── TestClassifyHypothesis ────────────────────────────────────────
+
+
+class TestClassifyHypothesis:
+    def test_bugfix(self) -> None:
+        assert classify_hypothesis("Fix crash in login handler") == "bugfix"
+
+    def test_observability(self) -> None:
+        assert classify_hypothesis("Add structlog to data pipeline") == "observability"
+
+    def test_coverage(self) -> None:
+        assert classify_hypothesis("Increase test coverage to 90%") == "coverage"
+
+    def test_testing(self) -> None:
+        assert classify_hypothesis("Add pytest tests for auth module") == "testing"
+
+    def test_lint(self) -> None:
+        assert classify_hypothesis("Run ruff lint check on cli.py") == "lint"
+
+    def test_type_safety(self) -> None:
+        assert classify_hypothesis("Resolve mypy type check warnings") == "type_safety"
+
+    def test_refactoring(self) -> None:
+        assert classify_hypothesis("Refactor database layer for clarity") == "refactoring"
+
+    def test_performance(self) -> None:
+        assert classify_hypothesis("Optimize query performance with cache") == "performance"
+
+    def test_eval_improvement(self) -> None:
+        assert classify_hypothesis("Add new eval dimension for security") == "eval_improvement"
+
+    def test_agent_improvement(self) -> None:
+        assert classify_hypothesis("Improve agent dispatch system") == "agent_improvement"
+
+    def test_prompt_engineering(self) -> None:
+        assert classify_hypothesis("Rewrite instruction prompt for builder") == "prompt_engineering"
+
+    def test_infrastructure(self) -> None:
+        assert classify_hypothesis("Add tmux integration for factory") == "infrastructure"
+
+    def test_feature(self) -> None:
+        assert classify_hypothesis("Add new page for user dashboard") == "feature"
+
+    def test_default_is_feature(self) -> None:
+        assert classify_hypothesis("Improve the overall quality") == "feature"
+
+    def test_case_insensitive(self) -> None:
+        assert classify_hypothesis("FIX A BUG IN THE SYSTEM") == "bugfix"
+
+    def test_priority_bugfix_over_testing(self) -> None:
+        # "fix" is higher priority than "test"
+        assert classify_hypothesis("Fix failing tests") == "bugfix"
+
+    def test_priority_observability_over_feature(self) -> None:
+        assert classify_hypothesis("Add logging to new endpoint") == "observability"
+
+
+# ── TestLoadAllHistories ──────────────────────────────────────────
+
+
+class TestLoadAllHistories:
+    def test_loads_from_multiple_projects(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Create two projects with TSV data
+        for name, count in [("proj-a", 3), ("proj-b", 2)]:
+            proj = tmp_path / name
+            proj.mkdir()
+            factory = proj / ".factory"
+            factory.mkdir()
+            lines = ["id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+                      "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes"]
+            for i in range(1, count + 1):
+                lines.append(
+                    f"{i}\t2026-04-13T12:00:00\tHypothesis {i}\tsummary\t\t\t\t\t\tkeep\t\t"
+                )
+            (factory / "results.tsv").write_text("\n".join(lines) + "\n")
+
+        paths = [tmp_path / "proj-a", tmp_path / "proj-b"]
+        histories = load_all_histories(paths)
+        assert "proj-a" in histories
+        assert "proj-b" in histories
+        assert len(histories["proj-a"]) == 3
+        assert len(histories["proj-b"]) == 2
+
+    def test_empty_tsv_excluded(self, tmp_path: Path) -> None:
+        proj = tmp_path / "empty"
+        proj.mkdir()
+        factory = proj / ".factory"
+        factory.mkdir()
+        (factory / "results.tsv").write_text(
+            "id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+            "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\n"
+        )
+        histories = load_all_histories([proj])
+        assert histories == {}
+
+    def test_missing_tsv_excluded(self, tmp_path: Path) -> None:
+        proj = tmp_path / "no-tsv"
+        proj.mkdir()
+        (proj / ".factory").mkdir()
+        histories = load_all_histories([proj])
+        assert histories == {}
+
+
+# ── TestAnalyze ───────────────────────────────────────────────────
+
+
+class TestAnalyze:
+    def test_basic_stats(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=1, hypothesis="Fix bug in auth", verdict="keep"),
+                _record(id=2, hypothesis="Fix crash handler", verdict="keep"),
+                _record(id=3, hypothesis="Fix error in parser", verdict="revert"),
+            ],
+        }
+        insights = analyze(histories)
+        assert len(insights.projects) == 1
+        assert insights.projects[0].name == "proj-a"
+        assert insights.projects[0].keep_count == 2
+        assert insights.projects[0].revert_count == 1
+        assert insights.projects[0].keep_rate == pytest.approx(2 / 3)
+
+    def test_multi_project(self) -> None:
+        histories = {
+            "proj-a": [_record(id=1, verdict="keep")],
+            "proj-b": [_record(id=1, verdict="revert")],
+        }
+        insights = analyze(histories)
+        assert len(insights.projects) == 2
+
+    def test_category_stats(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=1, hypothesis="Fix bug one", verdict="keep"),
+                _record(id=2, hypothesis="Fix bug two", verdict="keep"),
+                _record(id=3, hypothesis="Fix bug three", verdict="keep"),
+                _record(id=4, hypothesis="Add new page", verdict="revert"),
+                _record(id=5, hypothesis="Add new route", verdict="revert"),
+                _record(id=6, hypothesis="Add new command", verdict="revert"),
+            ],
+        }
+        insights = analyze(histories)
+        assert "bugfix" in insights.category_stats
+        assert insights.category_stats["bugfix"]["rate"] == pytest.approx(1.0)
+        assert "feature" in insights.category_stats
+        assert insights.category_stats["feature"]["rate"] == pytest.approx(0.0)
+
+    def test_winning_categories(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=i, hypothesis="Fix bug", verdict="keep")
+                for i in range(1, 5)
+            ],
+        }
+        insights = analyze(histories)
+        assert "bugfix" in insights.winning_categories
+
+    def test_losing_categories(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=1, hypothesis="Add page one", verdict="revert"),
+                _record(id=2, hypothesis="Add page two", verdict="error"),
+                _record(id=3, hypothesis="Add page three", verdict="revert"),
+            ],
+        }
+        insights = analyze(histories)
+        assert "feature" in insights.losing_categories
+
+    def test_needs_minimum_experiments(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=1, hypothesis="Fix a bug", verdict="keep"),
+                _record(id=2, hypothesis="Fix another bug", verdict="keep"),
+            ],
+        }
+        insights = analyze(histories)
+        # Only 2 experiments, threshold is 3
+        assert "bugfix" not in insights.winning_categories
+
+    def test_latest_score(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=1, score_after=0.8),
+                _record(id=2, score_after=0.95),
+            ],
+        }
+        insights = analyze(histories)
+        assert insights.projects[0].latest_score == pytest.approx(0.95)
+
+    def test_no_scores(self) -> None:
+        histories = {
+            "proj-a": [_record(id=1, score_after=None)],
+        }
+        insights = analyze(histories)
+        assert insights.projects[0].latest_score is None
+
+    def test_error_count(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=1, verdict="error"),
+                _record(id=2, verdict="error"),
+                _record(id=3, verdict="keep"),
+            ],
+        }
+        insights = analyze(histories)
+        assert insights.projects[0].error_count == 2
+
+    def test_empty_histories(self) -> None:
+        insights = analyze({})
+        assert insights.projects == []
+        assert insights.outcomes == []
+        assert insights.winning_categories == []
+        assert insights.losing_categories == []
+
+
+# ── TestExtractPatterns ───────────────────────────────────────────
+
+
+class TestExtractPatterns:
+    def test_reliable_pattern(self) -> None:
+        outcomes = [
+            HypothesisOutcome(
+                hypothesis=f"Fix bug {i}", verdict="keep",
+                category="bugfix", project=f"proj-{chr(97 + i % 2)}",
+            )
+            for i in range(5)
+        ]
+        stats = {"bugfix": {"total": 5, "kept": 5, "rate": 1.0}}
+        patterns = _extract_patterns(outcomes, stats)
+        reliable = [p for p in patterns if p.name == "bugfix_reliable"]
+        assert len(reliable) == 1
+        assert "100%" in reliable[0].description
+
+    def test_risky_pattern(self) -> None:
+        outcomes = [
+            HypothesisOutcome(
+                hypothesis=f"Add feature {i}", verdict="revert",
+                category="feature", project=f"proj-{chr(97 + i % 2)}",
+            )
+            for i in range(4)
+        ]
+        stats = {"feature": {"total": 4, "kept": 0, "rate": 0.0}}
+        patterns = _extract_patterns(outcomes, stats)
+        risky = [p for p in patterns if p.name == "feature_risky"]
+        assert len(risky) == 1
+
+    def test_kept_with_regression(self) -> None:
+        outcomes = [
+            HypothesisOutcome(
+                hypothesis="Risky change", verdict="keep",
+                category="feature", project="proj-a", delta=-0.05,
+            ),
+        ]
+        stats = {"feature": {"total": 1, "kept": 1, "rate": 1.0}}
+        patterns = _extract_patterns(outcomes, stats)
+        regression = [p for p in patterns if p.name == "kept_with_regression"]
+        assert len(regression) == 1
+
+    def test_no_pattern_for_small_sample(self) -> None:
+        outcomes = [
+            HypothesisOutcome(
+                hypothesis="Fix bug", verdict="keep",
+                category="bugfix", project="proj-a",
+            ),
+        ]
+        stats = {"bugfix": {"total": 1, "kept": 1, "rate": 1.0}}
+        patterns = _extract_patterns(outcomes, stats)
+        reliable = [p for p in patterns if "reliable" in p.name]
+        assert reliable == []
+
+    def test_no_pattern_single_project(self) -> None:
+        outcomes = [
+            HypothesisOutcome(
+                hypothesis=f"Fix bug {i}", verdict="keep",
+                category="bugfix", project="proj-a",
+            )
+            for i in range(5)
+        ]
+        stats = {"bugfix": {"total": 5, "kept": 5, "rate": 1.0}}
+        patterns = _extract_patterns(outcomes, stats)
+        # Need >= 2 projects for reliable pattern
+        reliable = [p for p in patterns if p.name == "bugfix_reliable"]
+        assert reliable == []
+
+
+# ── TestFormatInsights ────────────────────────────────────────────
+
+
+class TestFormatInsights:
+    def test_contains_header(self) -> None:
+        histories = {
+            "proj-a": [_record(id=1, hypothesis="Fix a bug", verdict="keep")],
+        }
+        insights = analyze(histories)
+        report = format_insights(insights)
+        assert "Cross-Project Insights" in report
+
+    def test_contains_project_summary(self) -> None:
+        histories = {
+            "proj-a": [_record(id=1, verdict="keep")],
+        }
+        insights = analyze(histories)
+        report = format_insights(insights)
+        assert "proj-a" in report
+        assert "100% keep rate" in report
+
+    def test_contains_category_table(self) -> None:
+        histories = {
+            "proj-a": [_record(id=1, hypothesis="Fix a bug", verdict="keep")],
+        }
+        insights = analyze(histories)
+        report = format_insights(insights)
+        assert "Category Success Rates" in report
+        assert "bugfix" in report
+
+    def test_empty_insights(self) -> None:
+        insights = analyze({})
+        report = format_insights(insights)
+        assert "0 projects" in report
+        assert "0 experiments" in report
+
+    def test_winning_section(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=i, hypothesis="Fix bug", verdict="keep")
+                for i in range(1, 5)
+            ],
+        }
+        insights = analyze(histories)
+        report = format_insights(insights)
+        assert "Winning Strategies" in report
+
+    def test_patterns_section(self) -> None:
+        histories = {
+            "proj-a": [
+                _record(id=1, hypothesis="Risky change", verdict="keep", delta=-0.05),
+            ],
+        }
+        insights = analyze(histories)
+        report = format_insights(insights)
+        assert "Patterns" in report
+        assert "kept_with_regression" in report
+
+
+# ── TestCmdInsights ───────────────────────────────────────────────
+
+
+class TestCmdInsights:
+    def test_writes_insights_file(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_insights
+
+        # Create a project with results.tsv
+        proj = tmp_path / "my-project"
+        proj.mkdir()
+        factory = proj / ".factory"
+        factory.mkdir()
+        lines = [
+            "id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+            "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes",
+            "1\t2026-04-13T12:00:00\tFix a bug\tsummary\t\t\t\t\t\tkeep\t\t",
+        ]
+        (factory / "results.tsv").write_text("\n".join(lines) + "\n")
+
+        # Create a target project for output
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / ".factory").mkdir()
+
+        args = type("Args", (), {
+            "path": str(target),
+            "projects_dir": str(tmp_path),
+        })()
+        ret = cmd_insights(args)
+        assert ret == 0
+
+        out_path = target / ".factory" / "strategy" / "insights.md"
+        assert out_path.exists()
+        content = out_path.read_text()
+        assert "Cross-Project Insights" in content
+
+    def test_no_projects_found(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_insights
+
+        target = tmp_path / "target"
+        target.mkdir()
+
+        args = type("Args", (), {
+            "path": str(target),
+            "projects_dir": str(tmp_path),
+        })()
+        ret = cmd_insights(args)
+        assert ret == 0

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,90 @@
+"""Tests for agent prompt content — verify critical sections exist."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PROMPTS_DIR = Path(__file__).parent.parent / "factory" / "agents" / "prompts"
+
+
+@pytest.fixture
+def strategist_prompt() -> str:
+    return (PROMPTS_DIR / "strategist.md").read_text()
+
+
+@pytest.fixture
+def researcher_prompt() -> str:
+    return (PROMPTS_DIR / "researcher.md").read_text()
+
+
+@pytest.fixture
+def archivist_prompt() -> str:
+    return (PROMPTS_DIR / "archivist.md").read_text()
+
+
+# ── Strategist ────────────────────────────────────────────────────
+
+
+class TestStrategistPrompt:
+    def test_has_design_space_section(self, strategist_prompt: str) -> None:
+        assert "## Design Space Exploration" in strategist_prompt
+
+    def test_lists_all_10_dimensions(self, strategist_prompt: str) -> None:
+        dimensions = [
+            "Features", "Bug fixes", "Instrumentation", "Flow changes",
+            "New agents", "Prompt engineering", "Eval improvements",
+            "Knowledge management", "Infrastructure", "Self-evolution",
+        ]
+        for dim in dimensions:
+            assert dim in strategist_prompt, f"Missing dimension: {dim}"
+
+    def test_has_cross_project_insights_section(self, strategist_prompt: str) -> None:
+        assert "## Cross-Project Insights" in strategist_prompt
+
+    def test_references_insights_md(self, strategist_prompt: str) -> None:
+        assert "insights.md" in strategist_prompt
+
+    def test_retains_feec_framework(self, strategist_prompt: str) -> None:
+        assert "## Priority Framework" in strategist_prompt or "FEEC" in strategist_prompt
+
+    def test_retains_stuck_protocol(self, strategist_prompt: str) -> None:
+        assert "## Stuck Protocol" in strategist_prompt
+
+    def test_retains_observability_priority(self, strategist_prompt: str) -> None:
+        assert "## Observability Priority" in strategist_prompt
+
+
+# ── Researcher ────────────────────────────────────────────────────
+
+
+class TestResearcherPrompt:
+    def test_has_mode_3(self, researcher_prompt: str) -> None:
+        assert "## Mode 3" in researcher_prompt
+
+    def test_mentions_factory_insights(self, researcher_prompt: str) -> None:
+        assert "factory insights" in researcher_prompt
+
+    def test_mentions_self_evolution_search(self, researcher_prompt: str) -> None:
+        assert "self-evolving" in researcher_prompt or "self-evolution" in researcher_prompt.lower()
+
+    def test_retains_mode_1_and_2(self, researcher_prompt: str) -> None:
+        assert "## Mode 1" in researcher_prompt
+        assert "## Mode 2" in researcher_prompt
+
+
+# ── Archivist ─────────────────────────────────────────────────────
+
+
+class TestArchivistPrompt:
+    def test_has_aggressive_documentation(self, archivist_prompt: str) -> None:
+        assert "## Aggressive Documentation Protocol" in archivist_prompt
+
+    def test_has_preflight_checklist(self, archivist_prompt: str) -> None:
+        assert "Pre-flight Checklist" in archivist_prompt
+
+    def test_uses_path_not_name_for_nested(self, archivist_prompt: str) -> None:
+        # All nested paths should use path= not name=
+        assert 'path="10-Projects' in archivist_prompt
+        assert 'name="10-Projects' not in archivist_prompt

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 from factory.study import (
+    _detect_self_improvement,
     _extract_keywords,
     _extract_messages,
     _find_log_files,
+    _load_cross_project_insights,
     _path_to_slug,
     _read_obsidian_notes,
     _search_similar_projects,
@@ -533,3 +535,191 @@ class TestReadObsidianNotes:
         summaries = _read_obsidian_notes("myapp")
         assert len(summaries) == 1
         assert "Caching patterns" in summaries[0]
+
+
+# ── TestDetectSelfImprovement ─────────────────────────────────────
+
+
+class TestDetectSelfImprovement:
+    def test_detects_factory_project(self, tmp_path):
+        factory_dir = tmp_path / "factory"
+        factory_dir.mkdir()
+        (factory_dir / "cli.py").write_text("# cli")
+        (factory_dir / "insights.py").write_text("# insights")
+        assert _detect_self_improvement(tmp_path) is True
+
+    def test_rejects_non_factory_project(self, tmp_path):
+        assert _detect_self_improvement(tmp_path) is False
+
+    def test_rejects_partial_factory(self, tmp_path):
+        factory_dir = tmp_path / "factory"
+        factory_dir.mkdir()
+        (factory_dir / "cli.py").write_text("# cli")
+        # Missing insights.py
+        assert _detect_self_improvement(tmp_path) is False
+
+
+# ── TestLoadCrossProjectInsights ──────────────────────────────────
+
+
+class TestLoadCrossProjectInsights:
+    def test_loads_from_multi_project_dir(self, tmp_path):
+        # Create two projects with TSV data
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
+        for name in ["alpha", "beta"]:
+            proj = projects_dir / name
+            proj.mkdir()
+            factory = proj / ".factory"
+            factory.mkdir()
+            lines = [
+                "id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+                "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes",
+                f"1\t2026-04-13T12:00:00\tFix a bug in {name}\tsummary\t\t\t\t\t\tkeep\t\t",
+            ]
+            (factory / "results.tsv").write_text("\n".join(lines) + "\n")
+
+        # Target project for output
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / ".factory").mkdir()
+
+        result = _load_cross_project_insights(target, projects_dir)
+        assert "Cross-Project Insights" in result
+        assert "alpha" in result
+        assert "beta" in result
+        # Check insights.md was written
+        insights_path = target / ".factory" / "strategy" / "insights.md"
+        assert insights_path.exists()
+
+    def test_returns_empty_for_no_projects(self, tmp_path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        target = tmp_path / "target"
+        target.mkdir()
+        result = _load_cross_project_insights(target, empty_dir)
+        assert result == ""
+
+    def test_returns_empty_for_no_histories(self, tmp_path):
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
+        proj = projects_dir / "empty-proj"
+        proj.mkdir()
+        factory = proj / ".factory"
+        factory.mkdir()
+        (factory / "results.tsv").write_text(
+            "id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+            "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\n"
+        )
+        target = tmp_path / "target"
+        target.mkdir()
+        result = _load_cross_project_insights(target, projects_dir)
+        assert result == ""
+
+
+# ── TestStudyWithInsights ─────────────────────────────────────────
+
+
+class TestStudyWithInsights:
+    def test_observations_include_cross_project(self, tmp_path, monkeypatch):
+        # Set up a minimal project so study_project doesn't crash
+        monkeypatch.setattr("factory.study._find_log_files", lambda _: [])
+        monkeypatch.setattr("factory.study._search_similar_projects", lambda _: [])
+        monkeypatch.setattr("factory.study._read_obsidian_notes", lambda _: [])
+        monkeypatch.setattr(
+            "factory.study._analyze_observability",
+            lambda _path, _lang: {
+                "observability_score": 0.5,
+                "function_coverage": 0.5,
+                "total_functions": 10,
+                "logged_functions": 5,
+                "total_log_statements": 20,
+                "has_structured_logging": True,
+                "has_request_tracing": False,
+                "logging_framework": "structlog",
+                "gaps": [],
+                "recommendations": [],
+            },
+        )
+        monkeypatch.setattr(
+            "factory.discovery.introspect._detect_language",
+            lambda _: "python",
+        )
+
+        # Create projects dir with data
+        projects_dir = tmp_path / "projects"
+        projects_dir.mkdir()
+        proj = projects_dir / "some-project"
+        proj.mkdir()
+        factory = proj / ".factory"
+        factory.mkdir()
+        lines = [
+            "id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+            "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes",
+            "1\t2026-04-13T12:00:00\tFix a bug\tsummary\t\t\t\t\t\tkeep\t\t",
+        ]
+        (factory / "results.tsv").write_text("\n".join(lines) + "\n")
+
+        # Target project
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / ".factory").mkdir()
+
+        summary = study_project(target, projects_dir=str(projects_dir))
+        assert "Cross-Project Insights" in summary
+
+    def test_self_improvement_context_added(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("factory.study._find_log_files", lambda _: [])
+        monkeypatch.setattr("factory.study._search_similar_projects", lambda _: [])
+        monkeypatch.setattr("factory.study._read_obsidian_notes", lambda _: [])
+        monkeypatch.setattr(
+            "factory.study._analyze_observability",
+            lambda _path, _lang: {
+                "observability_score": 0.5,
+                "function_coverage": 0.5,
+                "total_functions": 10,
+                "logged_functions": 5,
+                "total_log_statements": 20,
+                "has_structured_logging": True,
+                "has_request_tracing": False,
+                "logging_framework": "structlog",
+                "gaps": [],
+                "recommendations": [],
+            },
+        )
+        monkeypatch.setattr(
+            "factory.discovery.introspect._detect_language",
+            lambda _: "python",
+        )
+
+        # Make project look like the factory
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / ".factory").mkdir()
+        factory_dir = target / "factory"
+        factory_dir.mkdir()
+        (factory_dir / "cli.py").write_text("# cli")
+        (factory_dir / "insights.py").write_text("# insights")
+
+        summary = study_project(target)
+        assert "Self-Improvement Context" in summary
+        assert "Self-evolution" in summary
+
+
+# ── TestCmdStudyProjectsDir ───────────────────────────────────────
+
+
+class TestCmdStudyProjectsDir:
+    def test_parser_accepts_projects_dir(self):
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["study", "/some/path", "--projects-dir", "/other/path"])
+        assert args.projects_dir == "/other/path"
+
+    def test_parser_projects_dir_default_is_none(self):
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["study", "/some/path"])
+        assert args.projects_dir is None


### PR DESCRIPTION
## Context
Factory experiment #29. Hypothesis: Fix 5 mypy type errors in insights.py and study.py — variable shadowing and object type cast.

## Summary
- New `factory/insights.py`: cross-project pattern analysis (category stats, winning/losing strategies, pattern discovery)
- Updated `models.py` with `HypothesisOutcome`, `ProjectSummary`, `Pattern`, `CrossProjectInsights`, `CostBudget` models
- `study.py`: integrated cross-project insights via `--projects-dir` flag
- `cli.py`: added `insights` CLI command
- Fixed variable shadowing (`p` reused as `ProjectSummary` then `Pattern`) in insights.py
- Fixed `object`→`str` type cast for `projects_dir` in study.py
- Updated agent prompts (archivist, researcher, strategist) with improved instructions
- Added 190+ lines of tests for insights and prompts

## Eval
- **Before:** 0.9325 (type_check=0.75, 5 mypy errors)
- **After:** 0.955 (type_check=1.0, 0 errors)
- Guard: clean

## Test plan
- [x] 430 tests pass
- [x] mypy clean (0 errors)
- [x] ruff lint clean
- [x] Guard check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)