### PR TITLE
Dashboard: sparklines + radar chart for dimensions

### DIFF
--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -49,7 +49,21 @@ def create_app(projects_dir: Path) -> FastAPI:
         path = projects_dir / name
         if not (path / ".factory" / "results.tsv").exists():
             return []
-        return _load_tsv(path / ".factory" / "results.tsv")
+        rows = _load_tsv(path / ".factory" / "results.tsv")
+        for row in rows:
+            row["dimensions"] = _load_experiment_dimensions(path, row.get("id", ""))
+        return rows
+
+    @app.get("/api/projects/{name}/dimensions")
+    async def project_dimensions(name: str) -> dict[str, Any]:
+        log.info(
+            "dashboard_request",
+            endpoint="/api/projects/{name}/dimensions",
+            project=name,
+        )
+        path = projects_dir / name
+        dims = _load_latest_dimensions(path)
+        return {"dimensions": dims}
 
     @app.get("/api/projects/{name}/events")
     async def project_events(name: str, limit: int = 100) -> list[dict[str, Any]]:
@@ -148,6 +162,7 @@ def _project_summary(path: Path) -> dict[str, Any]:
         info["revert_count"] = sum(1 for r in rows if r.get("verdict") == "revert")
 
         scores = [float(r["score_after"]) for r in rows if r.get("score_after")]
+        info["scores"] = scores
         if scores:
             info["latest_score"] = scores[-1]
 
@@ -191,3 +206,60 @@ def _load_tsv(path: Path) -> list[dict[str, str]]:
         rows = list(reader)
     log.debug("load_tsv_complete", path=str(path), row_count=len(rows))
     return rows
+
+
+def _load_experiment_dimensions(
+    project_path: Path, exp_id: str
+) -> list[dict[str, Any]]:
+    """Load dimension scores from an experiment's eval_after.json."""
+    if not exp_id:
+        return []
+    exp_dir = project_path / ".factory" / "experiments" / str(exp_id).zfill(3)
+    eval_file = exp_dir / "eval_after.json"
+    if not eval_file.exists():
+        return []
+    try:
+        data = json.loads(eval_file.read_text())
+        results = data.get("results", [])
+        return [
+            {
+                "name": r.get("name", ""),
+                "score": r.get("score", 0.0),
+                "weight": r.get("weight", 0.0),
+                "passed": r.get("passed", False),
+            }
+            for r in results
+        ]
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def _load_latest_dimensions(project_path: Path) -> list[dict[str, Any]]:
+    """Load dimensions from the most recent experiment's eval_after.json."""
+    exp_base = project_path / ".factory" / "experiments"
+    if not exp_base.exists():
+        return []
+    # Sort experiment dirs descending to find the latest
+    exp_dirs = sorted(
+        (d for d in exp_base.iterdir() if d.is_dir()),
+        key=lambda d: d.name,
+        reverse=True,
+    )
+    for exp_dir in exp_dirs:
+        eval_file = exp_dir / "eval_after.json"
+        if eval_file.exists():
+            try:
+                data = json.loads(eval_file.read_text())
+                results = data.get("results", [])
+                return [
+                    {
+                        "name": r.get("name", ""),
+                        "score": r.get("score", 0.0),
+                        "weight": r.get("weight", 0.0),
+                        "passed": r.get("passed", False),
+                    }
+                    for r in results
+                ]
+            except (json.JSONDecodeError, OSError):
+                continue
+    return []

--- a/factory/dashboard/static/index.html
+++ b/factory/dashboard/static/index.html
@@ -634,7 +634,7 @@ function renderModal(projectName, compositeScore, dims) {
   overlay.id = 'dimension-modal';
   overlay.onclick = (e) => { if (e.target === overlay) closeModal(); };
 
-  const hygieneNames = ['tests_pass', 'lint_clean', 'type_check', 'coverage', 'build_ok', 'no_regressions'];
+  const hygieneNames = ['tests', 'lint', 'type_check', 'coverage', 'guard_patterns', 'config_parser'];
 
   overlay.innerHTML = `
     <div class="modal-content">

--- a/factory/dashboard/static/index.html
+++ b/factory/dashboard/static/index.html
@@ -288,6 +288,48 @@
     font-size: 12px;
   }
 
+  /* Score color helpers */
+  .score-green { color: var(--green); }
+  .score-yellow { color: var(--yellow); }
+  .score-red { color: var(--red); }
+
+  .score-clickable { cursor: pointer; }
+  .score-clickable:hover { text-decoration: underline; }
+
+  /* Modal overlay */
+  .modal-overlay {
+    position: fixed; inset: 0; z-index: 1000;
+    background: rgba(0,0,0,0.6); backdrop-filter: blur(4px);
+    display: flex; align-items: center; justify-content: center;
+  }
+
+  .modal-content {
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: 12px; padding: 24px; max-width: 500px; width: 90%;
+    position: relative;
+  }
+
+  .modal-close {
+    position: absolute; top: 12px; right: 16px;
+    background: none; border: none; color: var(--text-dim);
+    font-size: 20px; cursor: pointer; line-height: 1;
+  }
+
+  .modal-close:hover { color: var(--text); }
+
+  .modal-title {
+    font-size: 16px; font-weight: 700; margin-bottom: 4px;
+    color: var(--accent);
+  }
+
+  .modal-score {
+    font-size: 28px; font-weight: 800; margin-bottom: 16px;
+  }
+
+  .modal-chart-wrap {
+    width: 100%; max-width: 420px; margin: 0 auto;
+  }
+
   /* Responsive */
   @media (max-width: 800px) {
     main {
@@ -363,7 +405,13 @@ function renderProjects(projects) {
     return;
   }
 
-  el.innerHTML = projects.map(p => `
+  el.innerHTML = projects.map(p => {
+    const scores = p.scores || [];
+    const spark = sparkline(scores);
+    const scoreHtml = p.latest_score != null
+      ? `<div class="stat"><span class="stat-label">Score</span><span class="stat-value score-clickable ${scoreColorClass(p.latest_score)}" onclick="event.stopPropagation(); openDimensionModal('${p.name}', ${p.latest_score})">${p.latest_score.toFixed(3)}</span>${spark}</div>`
+      : '';
+    return `
     <div class="project-card ${p.name === selectedProject ? 'selected' : ''}"
          onclick="selectProject('${p.name}')">
       <div class="project-name">
@@ -372,13 +420,13 @@ function renderProjects(projects) {
       </div>
       ${p.goal ? `<div class="project-goal">${esc(p.goal)}</div>` : ''}
       <div class="project-stats">
-        ${p.latest_score != null ? `<div class="stat"><span class="stat-label">Score</span><span class="stat-value score">${p.latest_score.toFixed(3)}</span></div>` : ''}
+        ${scoreHtml}
         <div class="stat"><span class="stat-label">Exp</span><span class="stat-value">${p.experiment_count}</span></div>
         <div class="stat"><span class="stat-value keep">${p.keep_count}K</span></div>
         <div class="stat"><span class="stat-value revert">${p.revert_count}R</span></div>
       </div>
-    </div>
-  `).join('');
+    </div>`;
+  }).join('');
 }
 
 async function selectProject(name) {
@@ -536,6 +584,159 @@ function esc(str) {
   return d.innerHTML;
 }
 
+// ── Sparklines ──
+function sparkline(scores) {
+  if (scores.length < 2) return '';
+  const w = 60, h = 20;
+  const min = Math.min(...scores), max = Math.max(...scores);
+  const range = max - min || 1;
+  const points = scores.map((s, i) =>
+    `${(i / (scores.length - 1)) * w},${h - ((s - min) / range) * h}`
+  ).join(' ');
+  return `<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" style="vertical-align:middle;margin-left:8px"><polyline points="${points}" fill="none" stroke="var(--accent)" stroke-width="1.5" stroke-linecap="round"/></svg>`;
+}
+
+// ── Score color ──
+function scoreColorClass(score) {
+  if (score >= 0.8) return 'score-green';
+  if (score >= 0.6) return 'score-yellow';
+  return 'score-red';
+}
+
+function scoreColor(score) {
+  if (score >= 0.8) return 'var(--green)';
+  if (score >= 0.6) return 'var(--yellow)';
+  return 'var(--red)';
+}
+
+// ── Dimension radar modal ──
+let radarChartInstance = null;
+
+function openDimensionModal(projectName, compositeScore) {
+  // Remove existing modal if any
+  closeModal();
+
+  fetch(`/api/projects/${projectName}/dimensions`)
+    .then(res => res.json())
+    .then(data => {
+      const dims = data.dimensions || [];
+      if (dims.length === 0) {
+        return; // No data to show
+      }
+      renderModal(projectName, compositeScore, dims);
+    })
+    .catch(err => console.error('Failed to load dimensions:', err));
+}
+
+function renderModal(projectName, compositeScore, dims) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  overlay.id = 'dimension-modal';
+  overlay.onclick = (e) => { if (e.target === overlay) closeModal(); };
+
+  const hygieneNames = ['tests_pass', 'lint_clean', 'type_check', 'coverage', 'build_ok', 'no_regressions'];
+
+  overlay.innerHTML = `
+    <div class="modal-content">
+      <button class="modal-close" onclick="closeModal()">&times;</button>
+      <div class="modal-title">${esc(projectName)}</div>
+      <div class="modal-score" style="color: ${scoreColor(compositeScore)}">${compositeScore.toFixed(3)}</div>
+      <div class="modal-chart-wrap">
+        <canvas id="radar-chart"></canvas>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+
+  // Build radar chart
+  const labels = dims.map(d => d.name);
+  const scores = dims.map(d => d.score);
+  const bgColors = dims.map(d =>
+    hygieneNames.includes(d.name) ? 'rgba(88,166,255,0.15)' : 'rgba(63,185,80,0.15)'
+  );
+  const borderColors = dims.map(d =>
+    hygieneNames.includes(d.name) ? 'rgba(88,166,255,0.8)' : 'rgba(63,185,80,0.8)'
+  );
+
+  const ctx = document.getElementById('radar-chart').getContext('2d');
+  radarChartInstance = new Chart(ctx, {
+    type: 'radar',
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          label: 'Hygiene',
+          data: dims.map(d => hygieneNames.includes(d.name) ? d.score : null),
+          backgroundColor: 'rgba(88,166,255,0.15)',
+          borderColor: 'rgba(88,166,255,0.8)',
+          borderWidth: 2,
+          pointBackgroundColor: 'rgba(88,166,255,1)',
+          pointRadius: 3,
+          spanGaps: false,
+        },
+        {
+          label: 'Growth',
+          data: dims.map(d => !hygieneNames.includes(d.name) ? d.score : null),
+          backgroundColor: 'rgba(63,185,80,0.15)',
+          borderColor: 'rgba(63,185,80,0.8)',
+          borderWidth: 2,
+          pointBackgroundColor: 'rgba(63,185,80,1)',
+          pointRadius: 3,
+          spanGaps: false,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      scales: {
+        r: {
+          min: 0,
+          max: 1,
+          ticks: {
+            stepSize: 0.2,
+            color: 'rgba(125,133,144,0.6)',
+            backdropColor: 'transparent',
+          },
+          grid: {
+            color: 'rgba(48,54,61,0.6)',
+          },
+          angleLines: {
+            color: 'rgba(48,54,61,0.6)',
+          },
+          pointLabels: {
+            color: '#e6edf3',
+            font: { size: 10, family: 'var(--font)' },
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          labels: {
+            color: '#e6edf3',
+            font: { size: 11 },
+          },
+        },
+      },
+    },
+  });
+}
+
+function closeModal() {
+  const existing = document.getElementById('dimension-modal');
+  if (existing) {
+    if (radarChartInstance) {
+      radarChartInstance.destroy();
+      radarChartInstance = null;
+    }
+    existing.remove();
+  }
+}
+
+// Close modal on Escape key
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeModal();
+});
+
 // ── Init ──
 loadProjects();
 connectSSE();
@@ -545,5 +746,6 @@ setInterval(() => {
   if (selectedProject) loadExperiments(selectedProject);
 }, 10000);
 </script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </body>
 </html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -10,7 +10,13 @@ from pathlib import Path
 import pytest
 from starlette.testclient import TestClient
 
-from factory.dashboard.app import create_app, _project_summary, _load_tsv
+from factory.dashboard.app import (
+    create_app,
+    _load_experiment_dimensions,
+    _load_latest_dimensions,
+    _project_summary,
+    _load_tsv,
+)
 
 
 @pytest.fixture()
@@ -42,6 +48,39 @@ def projects_dir(tmp_path: Path) -> Path:
     writer.writerow(["2", "2026-04-17T10:00:00", "Fix linting", "Ran ruff",
                      "", "", "0.600", "0.550", "-0.050", "revert", "0.30", ""])
     (factory_a / "results.tsv").write_text(tsv.getvalue())
+
+    # Experiment directories with eval_after.json
+    exp_001 = factory_a / "experiments" / "001"
+    exp_001.mkdir(parents=True)
+    (exp_001 / "eval_after.json").write_text(json.dumps({
+        "total": 0.6,
+        "results": [
+            {"name": "tests_pass", "score": 0.8, "weight": 0.2, "passed": True,
+             "details": "ok"},
+            {"name": "lint_clean", "score": 0.5, "weight": 0.1, "passed": False,
+             "details": "3 warnings"},
+            {"name": "feature_completeness", "score": 0.7, "weight": 0.3,
+             "passed": True, "details": "ok"},
+        ],
+        "guard_violations": [],
+        "passed": True,
+    }))
+
+    exp_002 = factory_a / "experiments" / "002"
+    exp_002.mkdir(parents=True)
+    (exp_002 / "eval_after.json").write_text(json.dumps({
+        "total": 0.55,
+        "results": [
+            {"name": "tests_pass", "score": 0.9, "weight": 0.2, "passed": True,
+             "details": "ok"},
+            {"name": "lint_clean", "score": 0.4, "weight": 0.1, "passed": False,
+             "details": "5 warnings"},
+            {"name": "feature_completeness", "score": 0.6, "weight": 0.3,
+             "passed": True, "details": "ok"},
+        ],
+        "guard_violations": [],
+        "passed": True,
+    }))
 
     # Project B: empty factory
     proj_b = tmp_path / "proj-b"
@@ -146,6 +185,82 @@ class TestProjectSummary:
         assert last is not None
         assert last["id"] == "2"
         assert last["verdict"] == "revert"
+
+
+class TestDimensionsAPI:
+    def test_dimensions_endpoint(self, client: TestClient):
+        resp = client.get("/api/projects/proj-a/dimensions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "dimensions" in data
+        dims = data["dimensions"]
+        assert len(dims) == 3
+        # Should return the latest experiment (002)
+        names = [d["name"] for d in dims]
+        assert "tests_pass" in names
+        assert "lint_clean" in names
+        assert "feature_completeness" in names
+        # Check latest values (from exp 002)
+        tp = next(d for d in dims if d["name"] == "tests_pass")
+        assert tp["score"] == 0.9
+        assert tp["weight"] == 0.2
+        assert tp["passed"] is True
+
+    def test_dimensions_empty_project(self, client: TestClient):
+        resp = client.get("/api/projects/proj-b/dimensions")
+        assert resp.status_code == 200
+        assert resp.json() == {"dimensions": []}
+
+    def test_history_includes_dimensions(self, client: TestClient):
+        resp = client.get("/api/projects/proj-a/history")
+        rows = resp.json()
+        assert len(rows) == 2
+        # Experiment 1 should have dimensions from eval_after.json
+        assert "dimensions" in rows[0]
+        assert len(rows[0]["dimensions"]) == 3
+        # Experiment 2 as well
+        assert len(rows[1]["dimensions"]) == 3
+
+
+class TestProjectScores:
+    def test_scores_in_project_summary(self, client: TestClient):
+        resp = client.get("/api/projects")
+        proj_a = next(p for p in resp.json() if p["name"] == "proj-a")
+        assert "scores" in proj_a
+        assert proj_a["scores"] == [0.6, 0.55]
+
+    def test_scores_empty_project(self, client: TestClient):
+        resp = client.get("/api/projects")
+        proj_b = next(p for p in resp.json() if p["name"] == "proj-b")
+        # scores field should not be present or be empty for empty project
+        assert proj_b.get("scores") is None or proj_b.get("scores") == []
+
+
+class TestDimensionHelpers:
+    def test_load_experiment_dimensions(self, projects_dir: Path):
+        dims = _load_experiment_dimensions(projects_dir / "proj-a", "1")
+        assert len(dims) == 3
+        assert dims[0]["name"] == "tests_pass"
+        assert dims[0]["score"] == 0.8
+
+    def test_load_experiment_dimensions_missing(self, projects_dir: Path):
+        dims = _load_experiment_dimensions(projects_dir / "proj-a", "99")
+        assert dims == []
+
+    def test_load_experiment_dimensions_empty_id(self, projects_dir: Path):
+        dims = _load_experiment_dimensions(projects_dir / "proj-a", "")
+        assert dims == []
+
+    def test_load_latest_dimensions(self, projects_dir: Path):
+        dims = _load_latest_dimensions(projects_dir / "proj-a")
+        assert len(dims) == 3
+        # Latest is 002
+        tp = next(d for d in dims if d["name"] == "tests_pass")
+        assert tp["score"] == 0.9
+
+    def test_load_latest_dimensions_empty(self, projects_dir: Path):
+        dims = _load_latest_dimensions(projects_dir / "proj-b")
+        assert dims == []
 
 
 class TestLoadTsv:


### PR DESCRIPTION
## Summary
- Add inline SVG sparklines to project cards showing score_after trends from experiment history
- Add score color coding: green (>=0.8), yellow (>=0.6), red (<0.6)
- Add Chart.js radar chart modal triggered by clicking a project's score, showing all eval dimensions split into hygiene (blue) and growth (green) datasets
- New `/api/projects/{name}/dimensions` endpoint returning latest eval dimension breakdown
- Extended `/api/projects/{name}/history` to include per-experiment dimension scores from `eval_after.json`
- Added `scores` field to project summary for sparkline rendering without extra API calls

## Test plan
- [x] All 654 existing tests pass
- [x] 10 new tests for dimensions endpoint, history dimensions, scores field, and helper functions
- [x] `ruff check` passes clean

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)