### PR TITLE
Dashboard: KPI summary strip with aggregate metrics

### DIFF
--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -74,6 +74,41 @@ def create_app(projects_dir: Path) -> FastAPI:
         events = load_events(path)
         return events[-limit:]
 
+    @app.get("/api/summary")
+    async def summary() -> dict[str, Any]:
+        log.info("dashboard_request", endpoint="/api/summary")
+        from factory.events import discover_factory_projects
+
+        total_projects = 0
+        active_projects = 0
+        total_experiments = 0
+        keep_count = 0
+        revert_count = 0
+        score_sum = 0.0
+        score_count = 0
+
+        for path in discover_factory_projects(projects_dir):
+            info = _project_summary(path)
+            total_projects += 1
+            if info.get("active"):
+                active_projects += 1
+            total_experiments += info.get("experiment_count", 0)
+            keep_count += info.get("keep_count", 0)
+            revert_count += info.get("revert_count", 0)
+            if info.get("latest_score") is not None:
+                score_sum += info["latest_score"]
+                score_count += 1
+
+        return {
+            "total_projects": total_projects,
+            "active_projects": active_projects,
+            "avg_score": score_sum / score_count if score_count > 0 else None,
+            "total_experiments": total_experiments,
+            "keep_count": keep_count,
+            "revert_count": revert_count,
+            "keep_rate": keep_count / total_experiments if total_experiments > 0 else 0,
+        }
+
     @app.get("/api/events/stream")
     async def event_stream(request: Request) -> StreamingResponse:
         log.info("dashboard_request", endpoint="/api/events/stream")

--- a/factory/dashboard/static/index.html
+++ b/factory/dashboard/static/index.html
@@ -78,7 +78,7 @@
   main {
     display: grid;
     grid-template-columns: 280px 1fr;
-    grid-template-rows: 1fr 1fr;
+    grid-template-rows: 80px 1fr 1fr;
     gap: 0;
     height: calc(100vh - 80px);
   }
@@ -108,21 +108,21 @@
     flex: 1;
   }
 
-  /* Projects panel — spans both rows */
+  /* Projects panel — spans both content rows (below KPI strip) */
   .projects-panel {
-    grid-row: 1 / 3;
+    grid-row: 2 / 4;
   }
 
   /* Events panel — top right */
   .events-panel {
     grid-column: 2;
-    grid-row: 1;
+    grid-row: 2;
   }
 
   /* Experiments panel — bottom right */
   .experiments-panel {
     grid-column: 2;
-    grid-row: 2;
+    grid-row: 3;
     border-bottom: none;
   }
 
@@ -296,6 +296,43 @@
   .score-clickable { cursor: pointer; }
   .score-clickable:hover { text-decoration: underline; }
 
+  /* KPI strip */
+  .kpi-strip {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 16px;
+    padding: 12px 24px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+  }
+  .kpi-card {
+    flex: 1;
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+  }
+  .kpi-value {
+    font-size: 24px;
+    font-weight: 800;
+    line-height: 1.2;
+  }
+  .kpi-label {
+    font-size: 11px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .kpi-bar {
+    display: flex;
+    height: 4px;
+    border-radius: 2px;
+    overflow: hidden;
+    margin-top: 4px;
+  }
+  .kpi-bar-keep { background: var(--green); }
+  .kpi-bar-revert { background: var(--red); }
+
   /* Modal overlay */
   .modal-overlay {
     position: fixed; inset: 0; z-index: 1000;
@@ -334,11 +371,13 @@
   @media (max-width: 800px) {
     main {
       grid-template-columns: 1fr;
-      grid-template-rows: auto auto auto;
+      grid-template-rows: auto auto auto auto;
     }
-    .projects-panel { grid-row: 1; max-height: 200px; }
-    .events-panel { grid-column: 1; grid-row: 2; }
-    .experiments-panel { grid-column: 1; grid-row: 3; }
+    .kpi-strip { flex-wrap: wrap; }
+    .kpi-card { min-width: calc(50% - 12px); }
+    .projects-panel { grid-row: 2; max-height: 200px; }
+    .events-panel { grid-column: 1; grid-row: 3; }
+    .experiments-panel { grid-column: 1; grid-row: 4; }
   }
 </style>
 </head>
@@ -356,6 +395,8 @@
 </header>
 
 <main>
+  <div class="kpi-strip" id="kpi-strip"></div>
+
   <div class="panel projects-panel">
     <div class="panel-header">Projects</div>
     <div class="panel-body" id="projects-list">
@@ -494,8 +535,9 @@ function connectSSE() {
     try {
       const event = JSON.parse(e.data);
       addEvent(event);
-      // Refresh projects on every event
+      // Refresh projects and summary on every event
       loadProjects();
+      loadSummary();
       // Refresh experiments if the event is for the selected project
       if (selectedProject && event.project === selectedProject) {
         loadExperiments(selectedProject);
@@ -737,12 +779,60 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') closeModal();
 });
 
+// ── KPI Summary ──
+async function loadSummary() {
+  try {
+    const res = await fetch('/api/summary');
+    const data = await res.json();
+    renderKPIs(data);
+  } catch (e) {
+    console.error('Failed to load summary:', e);
+  }
+}
+
+function renderKPIs(data) {
+  const el = document.getElementById('kpi-strip');
+  const keepPct = data.total_experiments > 0
+    ? ((data.keep_count / data.total_experiments) * 100).toFixed(0)
+    : '0';
+  const keepBarW = data.total_experiments > 0
+    ? (data.keep_count / data.total_experiments * 100)
+    : 0;
+
+  el.innerHTML = `
+    <div class="kpi-card">
+      <div class="kpi-label">Projects</div>
+      <div class="kpi-value">${data.total_projects}
+        <span style="font-size:12px;color:var(--green)">${data.active_projects} active</span>
+      </div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-label">Avg Score</div>
+      <div class="kpi-value" style="color:${scoreColor(data.avg_score)}">${data.avg_score != null ? data.avg_score.toFixed(3) : '\u2014'}</div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-label">Experiments</div>
+      <div class="kpi-value">${data.total_experiments}</div>
+      <div class="kpi-bar">
+        <div class="kpi-bar-keep" style="width:${keepBarW}%"></div>
+        <div class="kpi-bar-revert" style="width:${100 - keepBarW}%"></div>
+      </div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-label">Keep Rate</div>
+      <div class="kpi-value" style="color:${scoreColor(data.keep_rate)}">${keepPct}%</div>
+    </div>
+  `;
+}
+
 // ── Init ──
 loadProjects();
+loadSummary();
 connectSSE();
 // Refresh projects every 10s
 setInterval(() => {
   loadProjects();
+  loadSummary();
   if (selectedProject) loadExperiments(selectedProject);
 }, 10000);
 </script>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -163,6 +163,69 @@ class TestDashboardAPI:
         assert events[0]["type"] == "event.7"
 
 
+class TestSummaryAPI:
+    def test_summary_aggregation(self, client: TestClient):
+        resp = client.get("/api/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_projects"] == 2
+        assert data["active_projects"] == 0  # No recent events
+        assert data["total_experiments"] == 2
+        assert data["keep_count"] == 1
+        assert data["revert_count"] == 1
+        # avg_score: only proj-a has a score (0.55), proj-b has none
+        assert data["avg_score"] == pytest.approx(0.55)
+        # keep_rate: 1 / 2 = 0.5
+        assert data["keep_rate"] == pytest.approx(0.5)
+
+    def test_summary_empty_dir(self, tmp_path: Path):
+        app = create_app(tmp_path)
+        empty_client = TestClient(app)
+        resp = empty_client.get("/api/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_projects"] == 0
+        assert data["active_projects"] == 0
+        assert data["avg_score"] is None
+        assert data["total_experiments"] == 0
+        assert data["keep_count"] == 0
+        assert data["revert_count"] == 0
+        assert data["keep_rate"] == 0
+
+    def test_summary_keep_rate_calculation(self, projects_dir: Path):
+        """Test keep rate with additional project data."""
+        # Add another project with experiments
+        proj_c = projects_dir / "proj-c"
+        factory_c = proj_c / ".factory"
+        factory_c.mkdir(parents=True)
+
+        tsv = io.StringIO()
+        writer = csv.writer(tsv, dialect="excel-tab")
+        writer.writerow(["id", "timestamp", "hypothesis", "change_summary",
+                         "issue_number", "pr_number", "score_before", "score_after",
+                         "delta", "verdict", "cost_usd", "notes"])
+        writer.writerow(["1", "2026-04-16T10:00:00", "h1", "s1",
+                         "", "", "0.5", "0.7", "0.2", "keep", "0.1", ""])
+        writer.writerow(["2", "2026-04-16T11:00:00", "h2", "s2",
+                         "", "", "0.7", "0.8", "0.1", "keep", "0.1", ""])
+        writer.writerow(["3", "2026-04-16T12:00:00", "h3", "s3",
+                         "", "", "0.8", "0.75", "-0.05", "revert", "0.1", ""])
+        (factory_c / "results.tsv").write_text(tsv.getvalue())
+
+        app = create_app(projects_dir)
+        c = TestClient(app)
+        resp = c.get("/api/summary")
+        data = resp.json()
+        # proj-a: 2 exp (1 keep, 1 revert), proj-b: 0 exp, proj-c: 3 exp (2 keep, 1 revert)
+        assert data["total_projects"] == 3
+        assert data["total_experiments"] == 5
+        assert data["keep_count"] == 3
+        assert data["revert_count"] == 2
+        assert data["keep_rate"] == pytest.approx(0.6)
+        # avg_score: proj-a=0.55, proj-c=0.75 => (0.55+0.75)/2 = 0.65
+        assert data["avg_score"] == pytest.approx(0.65)
+
+
 class TestProjectSummary:
     def test_basic_summary(self, projects_dir: Path):
         info = _project_summary(projects_dir / "proj-a")


### PR DESCRIPTION
## Summary
- Add `/api/summary` endpoint that aggregates metrics across all discovered projects (total/active projects, avg score, total experiments, keep/revert counts, keep rate)
- Add a full-width KPI strip above the main dashboard grid with 4 cards: Projects, Avg Score, Experiments (with keep/revert proportional bar), and Keep Rate
- Color-coded scores, mobile responsive (2x2 grid on small screens), auto-refreshes on SSE events and 10s interval

## Test plan
- [x] `pytest tests/test_dashboard.py -v` — all 30 tests pass (3 new: aggregation, empty dir, keep rate calculation)
- [x] `ruff check factory/dashboard/` — clean
- [ ] Visual verification: `factory dashboard` and inspect the KPI strip renders above the grid

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)