### PR TITLE
Dashboard: score history line chart with hygiene/growth breakdown

### DIFF
--- a/factory/dashboard/static/index.html
+++ b/factory/dashboard/static/index.html
@@ -367,6 +367,34 @@
     width: 100%; max-width: 420px; margin: 0 auto;
   }
 
+  /* View toggle */
+  .view-toggle {
+    float: right;
+    display: inline-flex;
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .toggle-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-dim);
+    padding: 2px 10px;
+    font-size: 10px;
+    font-family: var(--font);
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+  }
+  .toggle-btn.active {
+    background: var(--accent);
+    color: var(--bg);
+  }
+  .toggle-btn:hover:not(.active) {
+    background: var(--surface);
+  }
+
   /* Responsive */
   @media (max-width: 800px) {
     main {
@@ -412,9 +440,18 @@
   </div>
 
   <div class="panel experiments-panel">
-    <div class="panel-header">Experiments <span id="exp-project-name"></span></div>
+    <div class="panel-header">
+      Experiments <span id="exp-project-name"></span>
+      <div class="view-toggle" id="view-toggle">
+        <button class="toggle-btn active" data-view="table">Table</button>
+        <button class="toggle-btn" data-view="chart">Chart</button>
+      </div>
+    </div>
     <div class="panel-body" id="experiments-list">
       <div class="empty-state">Select a project to view experiments</div>
+    </div>
+    <div class="panel-body" id="chart-container" style="display:none;height:300px">
+      <canvas id="score-chart"></canvas>
     </div>
   </div>
 </main>
@@ -483,6 +520,9 @@ async function loadExperiments(name) {
     const res = await fetch(`/api/projects/${name}/history`);
     const rows = await res.json();
     renderExperiments(rows);
+    if (isChartViewActive()) {
+      renderScoreChart(rows);
+    }
   } catch (e) {
     document.getElementById('experiments-list').innerHTML =
       '<div class="empty-state">Failed to load experiments</div>';
@@ -779,6 +819,145 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') closeModal();
 });
 
+// ── Score History Chart ──
+let scoreChartInstance = null;
+
+function renderScoreChart(rows) {
+  if (scoreChartInstance) {
+    scoreChartInstance.destroy();
+    scoreChartInstance = null;
+  }
+
+  if (rows.length === 0) return;
+
+  const hygieneNames = ['tests', 'lint', 'type_check', 'coverage', 'guard_patterns', 'config_parser'];
+
+  const labels = rows.map(r => `#${r.id}`);
+  const composites = rows.map(r => r.score_after ? parseFloat(r.score_after) : null);
+
+  const hygieneAvgs = rows.map(r => {
+    const dims = r.dimensions || [];
+    const hyg = dims.filter(d => hygieneNames.includes(d.name));
+    return hyg.length > 0 ? hyg.reduce((sum, d) => sum + d.score, 0) / hyg.length : null;
+  });
+
+  const growthAvgs = rows.map(r => {
+    const dims = r.dimensions || [];
+    const growth = dims.filter(d => !hygieneNames.includes(d.name));
+    return growth.length > 0 ? growth.reduce((sum, d) => sum + d.score, 0) / growth.length : null;
+  });
+
+  const pointColors = rows.map(r => {
+    if (r.verdict === 'keep') return '#3fb950';
+    if (r.verdict === 'revert') return '#f85149';
+    return '#d29922';
+  });
+
+  const ctx = document.getElementById('score-chart').getContext('2d');
+  scoreChartInstance = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Composite',
+          data: composites,
+          borderColor: 'rgba(88,166,255,1)',
+          backgroundColor: 'rgba(88,166,255,0.1)',
+          borderWidth: 2.5,
+          pointBackgroundColor: pointColors,
+          pointRadius: 5,
+          pointHoverRadius: 7,
+          fill: false,
+          tension: 0.2,
+        },
+        {
+          label: 'Hygiene Avg',
+          data: hygieneAvgs,
+          borderColor: 'rgba(88,166,255,0.4)',
+          borderWidth: 1.5,
+          borderDash: [4, 2],
+          pointRadius: 0,
+          fill: false,
+          tension: 0.2,
+        },
+        {
+          label: 'Growth Avg',
+          data: growthAvgs,
+          borderColor: 'rgba(63,185,80,0.4)',
+          borderWidth: 1.5,
+          borderDash: [4, 2],
+          pointRadius: 0,
+          fill: false,
+          tension: 0.2,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        y: {
+          min: 0, max: 1,
+          ticks: { color: 'rgba(125,133,144,0.6)', stepSize: 0.2 },
+          grid: { color: 'rgba(48,54,61,0.6)' },
+        },
+        x: {
+          ticks: { color: 'rgba(125,133,144,0.6)', font: { size: 10 } },
+          grid: { display: false },
+        },
+      },
+      plugins: {
+        legend: {
+          labels: { color: '#e6edf3', font: { size: 11 } },
+        },
+        tooltip: {
+          callbacks: {
+            afterLabel: function(ctx) {
+              const row = rows[ctx.dataIndex];
+              const parts = [];
+              if (row.hypothesis) parts.push(row.hypothesis.substring(0, 40));
+              if (row.delta) parts.push('delta: ' + row.delta);
+              if (row.verdict) parts.push('verdict: ' + row.verdict);
+              return parts.join('\n');
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+function initToggle() {
+  document.querySelectorAll('.toggle-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.toggle-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const view = btn.dataset.view;
+      document.getElementById('experiments-list').style.display = view === 'table' ? '' : 'none';
+      document.getElementById('chart-container').style.display = view === 'chart' ? '' : 'none';
+      if (view === 'chart' && selectedProject) {
+        loadChartData(selectedProject);
+      }
+    });
+  });
+}
+
+async function loadChartData(name) {
+  try {
+    const res = await fetch(`/api/projects/${name}/history`);
+    const rows = await res.json();
+    renderScoreChart(rows);
+  } catch (e) {
+    console.error('Failed to load chart data:', e);
+  }
+}
+
+function isChartViewActive() {
+  const active = document.querySelector('.toggle-btn.active');
+  return active && active.dataset.view === 'chart';
+}
+
 // ── KPI Summary ──
 async function loadSummary() {
   try {
@@ -829,6 +1008,7 @@ function renderKPIs(data) {
 loadProjects();
 loadSummary();
 connectSSE();
+initToggle();
 // Refresh projects every 10s
 setInterval(() => {
   loadProjects();

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -274,6 +274,16 @@ class TestDimensionsAPI:
         assert resp.status_code == 200
         assert resp.json() == {"dimensions": []}
 
+    def test_history_includes_score_fields(self, client: TestClient):
+        resp = client.get("/api/projects/proj-a/history")
+        rows = resp.json()
+        assert len(rows) == 2
+        # Both score_before and score_after should be present
+        assert rows[0]["score_before"] == "0.500"
+        assert rows[0]["score_after"] == "0.600"
+        assert rows[1]["score_before"] == "0.600"
+        assert rows[1]["score_after"] == "0.550"
+
     def test_history_includes_dimensions(self, client: TestClient):
         resp = client.get("/api/projects/proj-a/history")
         rows = resp.json()


### PR DESCRIPTION
## Summary
- Add Table/Chart toggle buttons in the experiments panel header to switch between the existing table view and a new score history line chart
- Chart renders three lines: composite score (thick accent), hygiene average (dashed blue), and growth average (dashed green) over experiment history
- Keep/revert verdicts shown as green/red point markers on the composite line; hover tooltips display hypothesis, delta, and verdict
- Add test verifying the history endpoint returns `score_before` and `score_after` fields

Closes #53

## Test plan
- [x] `pytest tests/test_dashboard.py -v` — 31 tests pass (including new `test_history_includes_score_fields`)
- [x] `ruff check factory/dashboard/` — clean
- [ ] Manual: load dashboard, select a project, toggle to Chart view, verify chart renders with correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)