### PR TITLE
fix: research_grounding doc_ratio checks both vault layouts

### DIFF
--- a/factory/agents/prompts/archivist.md
+++ b/factory/agents/prompts/archivist.md
@@ -40,6 +40,13 @@ You have access to these Obsidian skills:
 
 ### 1. Archive Experiment Results
 
+**IMPORTANT:** Experiment notes MUST be written to the `Experiments/` subdirectory:
+`10-Projects/{project}/Experiments/{project}-{NNN}.md`
+
+Do NOT write experiment notes as flat files at the project level (e.g. `Exp-001.md`).
+The eval `doc_ratio` sub-score checks the `Experiments/` subdirectory first. Using the
+canonical path ensures scores are counted correctly.
+
 For each completed experiment, create a note:
 
 ```bash

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -227,8 +227,13 @@ def eval_research_grounding(project_path: Path) -> dict:
 
         # Sub-score D: Experiment notes documented in vault
         project_name = project_path.name
-        exp_dir = vault / "10-Projects" / project_name / "Experiments"
-        exp_notes = len(list(exp_dir.glob("*.md"))) if exp_dir.exists() else 0
+        project_vault = vault / "10-Projects" / project_name
+        # Check Experiments/ subdirectory (canonical location)
+        exp_dir = project_vault / "Experiments"
+        exp_dir_count = len(list(exp_dir.glob("*.md"))) if exp_dir.exists() else 0
+        # Fallback: check flat Exp-*.md files at project level
+        flat_count = len(list(project_vault.glob("Exp-*.md"))) if project_vault.exists() else 0
+        exp_notes = max(exp_dir_count, flat_count)
         factory_exp_dir = project_path / ".factory" / "experiments"
         exp_total = len(list(factory_exp_dir.iterdir())) if factory_exp_dir.exists() else 0
         doc_ratio = min(1.0, exp_notes / max(exp_total, 1))

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -226,7 +226,7 @@ def eval_research_grounding(project_path: Path) -> dict:
         has_research = 1.0 if research_md.exists() else 0.0
 
         # Sub-score D: Experiment notes documented in vault
-        project_name = project_path.name
+        project_name = project_path.resolve().name
         project_vault = vault / "10-Projects" / project_name
         # Check Experiments/ subdirectory (canonical location)
         exp_dir = project_vault / "Experiments"

--- a/factory/obsidian/templates.py
+++ b/factory/obsidian/templates.py
@@ -59,6 +59,15 @@ def decision_tags(project_name: str) -> list[str]:
     return [FACTORY_TAG, DECISION_TAG, project_name]
 
 
+def experiment_note_path(project_name: str, experiment_id: int) -> str:
+    """Return the canonical vault path for an experiment note.
+
+    Experiment notes live in ``10-Projects/<project>/Experiments/`` so that
+    the eval ``doc_ratio`` sub-score finds them reliably.
+    """
+    return f"10-Projects/{project_name}/Experiments/{project_name}-{experiment_id:03d}"
+
+
 def wikilink(title: str) -> str:
     """Return an Obsidian wikilink."""
     return f"[[{title}]]"

--- a/tests/test_eval_growth.py
+++ b/tests/test_eval_growth.py
@@ -290,6 +290,60 @@ class TestResearchGrounding:
             result = eval_research_grounding(tmp_path)
             assert result["score"] >= 0.2
 
+    def test_doc_ratio_with_experiments_subdirectory(self, tmp_path):
+        """doc_ratio counts notes in Experiments/ subdirectory."""
+        vault = tmp_path / "obsidian-vaults" / "factory"
+        exp_dir = vault / "10-Projects" / tmp_path.name / "Experiments"
+        exp_dir.mkdir(parents=True)
+        for i in range(4):
+            (exp_dir / f"{tmp_path.name}-{i:03d}.md").write_text("note")
+        # Create 4 factory experiments so ratio = 4/4 = 1.0
+        factory_exp = tmp_path / ".factory" / "experiments"
+        for i in range(4):
+            (factory_exp / f"{i:03d}").mkdir(parents=True)
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = eval_research_grounding(tmp_path)
+            assert "doc_ratio=" in result["details"]
+            assert "4/4" in result["details"]
+
+    def test_doc_ratio_with_flat_exp_files(self, tmp_path):
+        """doc_ratio falls back to flat Exp-*.md files at project level."""
+        vault = tmp_path / "obsidian-vaults" / "factory"
+        project_vault = vault / "10-Projects" / tmp_path.name
+        project_vault.mkdir(parents=True)
+        # Write flat Exp-*.md files (legacy layout)
+        for i in range(6):
+            (project_vault / f"Exp-{i:03d}.md").write_text("note")
+        # Create 6 factory experiments
+        factory_exp = tmp_path / ".factory" / "experiments"
+        for i in range(6):
+            (factory_exp / f"{i:03d}").mkdir(parents=True)
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = eval_research_grounding(tmp_path)
+            assert "doc_ratio=" in result["details"]
+            assert "6/6" in result["details"]
+
+    def test_doc_ratio_prefers_max_of_both_layouts(self, tmp_path):
+        """doc_ratio uses max(subdirectory count, flat count)."""
+        vault = tmp_path / "obsidian-vaults" / "factory"
+        project_vault = vault / "10-Projects" / tmp_path.name
+        # Subdirectory has 2 notes
+        exp_dir = project_vault / "Experiments"
+        exp_dir.mkdir(parents=True)
+        for i in range(2):
+            (exp_dir / f"{tmp_path.name}-{i:03d}.md").write_text("note")
+        # Flat files have 5 notes
+        for i in range(5):
+            (project_vault / f"Exp-{i:03d}.md").write_text("note")
+        # 5 factory experiments
+        factory_exp = tmp_path / ".factory" / "experiments"
+        for i in range(5):
+            (factory_exp / f"{i:03d}").mkdir(parents=True)
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = eval_research_grounding(tmp_path)
+            # Should use max(2, 5) = 5
+            assert "5/5" in result["details"]
+
     def test_no_generic_tag_matching(self, tmp_path):
         vault = tmp_path / "obsidian-vaults" / "factory"
         sources = vault / "20-Knowledge" / "Sources"


### PR DESCRIPTION
## Summary
- **`factory/eval/growth.py`**: `eval_research_grounding()` now checks both `Experiments/*.md` subdirectory and flat `Exp-*.md` files at the project level, using `max(exp_dir_count, flat_count)` for doc_ratio. Previously only checked the subdirectory, causing doc_ratio=0.00 despite 6+ notes existing as flat files.
- **`factory/obsidian/templates.py`**: Added `experiment_note_path()` helper that returns the canonical `Experiments/` subdirectory path for new experiment notes.
- **`factory/agents/prompts/archivist.md`**: Added explicit guidance to write experiment notes to the `Experiments/` subdirectory (not as flat files).
- **`tests/test_eval_growth.py`**: Added 3 tests covering subdirectory layout, flat file layout, and max-of-both behavior.

## Test plan
- [x] `pytest tests/test_eval_growth.py -v` — all 36 tests pass (3 new)
- [x] `pytest -v` — all 661 tests pass
- [x] `factory eval .` — composite score 0.801 (no regression)
- [x] Verified actual vault at `~/obsidian-vaults/factory/10-Projects/remote-factory/` has 6 flat `Exp-*.md` files and no `Experiments/` dir

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)