### PR TITLE
feat: add factory checkpoint and resume commands

### DIFF
--- a/factory/checkpoint.py
+++ b/factory/checkpoint.py
@@ -1,0 +1,75 @@
+"""Checkpoint/resume system for crash-resilient CEO orchestration."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+
+log = structlog.get_logger()
+
+_CHECKPOINT_FILE = "checkpoint.json"
+
+
+class CheckpointState(BaseModel):
+    """Serializable snapshot of a CEO cycle's progress."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    mode: str
+    active_experiment_id: int | None
+    completed_agents: list[str]
+    pending_agents: list[str]
+    last_eval_scores: dict[str, float]
+    current_hypothesis: str | None
+    timestamp: str
+
+
+def save_checkpoint(project_path: Path, state: CheckpointState) -> None:
+    """Serialize checkpoint state to .factory/checkpoint.json."""
+    factory_dir = project_path / ".factory"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = factory_dir / _CHECKPOINT_FILE
+    checkpoint_path.write_text(state.model_dump_json(indent=2))
+    log.info("checkpoint.saved", path=str(checkpoint_path))
+
+
+def load_checkpoint(project_path: Path) -> CheckpointState | None:
+    """Load checkpoint from .factory/checkpoint.json, or None if absent."""
+    checkpoint_path = project_path / ".factory" / _CHECKPOINT_FILE
+    if not checkpoint_path.exists():
+        log.debug("checkpoint.not_found", path=str(checkpoint_path))
+        return None
+    data = json.loads(checkpoint_path.read_text())
+    state = CheckpointState.model_validate(data)
+    log.info("checkpoint.loaded", path=str(checkpoint_path))
+    return state
+
+
+def clear_checkpoint(project_path: Path) -> None:
+    """Remove checkpoint file after a successful cycle."""
+    checkpoint_path = project_path / ".factory" / _CHECKPOINT_FILE
+    if checkpoint_path.exists():
+        checkpoint_path.unlink()
+        log.info("checkpoint.cleared", path=str(checkpoint_path))
+    else:
+        log.debug("checkpoint.clear_noop", path=str(checkpoint_path))
+
+
+def format_checkpoint(state: CheckpointState) -> str:
+    """Format a checkpoint as a human-readable string."""
+    lines = [
+        f"Mode:          {state.mode}",
+        f"Experiment:    {state.active_experiment_id or 'none'}",
+        f"Hypothesis:    {state.current_hypothesis or 'none'}",
+        f"Completed:     {', '.join(state.completed_agents) or 'none'}",
+        f"Pending:       {', '.join(state.pending_agents) or 'none'}",
+    ]
+    if state.last_eval_scores:
+        scores = ", ".join(f"{k}={v:.3f}" for k, v in state.last_eval_scores.items())
+        lines.append(f"Eval scores:   {scores}")
+    lines.append(f"Timestamp:     {state.timestamp}")
+    return "\n".join(lines)

--- a/factory/checkpoint.py
+++ b/factory/checkpoint.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
 from pathlib import Path
 
 import structlog

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -561,6 +561,58 @@ def cmd_archive(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_checkpoint(args: argparse.Namespace) -> int:
+    """Show or save a checkpoint for crash-resilient resume."""
+    from factory.checkpoint import (
+        CheckpointState,
+        format_checkpoint,
+        load_checkpoint,
+        save_checkpoint,
+    )
+
+    project_path = Path(args.path).resolve()
+
+    if args.save:
+        state = CheckpointState(
+            mode=args.mode or "improve",
+            active_experiment_id=args.experiment,
+            completed_agents=[a.strip() for a in args.completed.split(",")] if args.completed else [],
+            pending_agents=[a.strip() for a in args.pending.split(",")] if args.pending else [],
+            last_eval_scores=json.loads(args.scores) if args.scores else {},
+            current_hypothesis=args.hypothesis,
+            timestamp=datetime.now().isoformat(),
+        )
+        save_checkpoint(project_path, state)
+        print(f"Checkpoint saved to {project_path / '.factory' / 'checkpoint.json'}")
+        return 0
+
+    # Show current checkpoint
+    state = load_checkpoint(project_path)
+    if state is None:
+        print("No checkpoint found.")
+        return 0
+    print(format_checkpoint(state))
+    return 0
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    """Load checkpoint and display resume context for the CEO."""
+    from factory.checkpoint import format_checkpoint, load_checkpoint
+
+    project_path = Path(args.path).resolve()
+    state = load_checkpoint(project_path)
+    if state is None:
+        print("No checkpoint found. Nothing to resume.")
+        return 1
+
+    print("=== Resume Context ===")
+    print(format_checkpoint(state))
+    print()
+    print("The CEO should resume from this state, skipping completed agents")
+    print(f"and continuing with: {', '.join(state.pending_agents) or 'none'}")
+    return 0
+
+
 def cmd_vault_init(args: argparse.Namespace) -> int:
     from factory.obsidian.notes import init_vault
 
@@ -1283,6 +1335,24 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("archive", help="Write experiment notes to Obsidian vault")
     p.add_argument("path", help="Path to the project")
 
+    # checkpoint
+    p = sub.add_parser("checkpoint", help="Show or save a CEO checkpoint for crash-resilient resume")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--save", action="store_true", default=False, help="Save a checkpoint")
+    p.add_argument("--mode", default=None, help="CEO mode (e.g. improve, build)")
+    p.add_argument("--experiment", type=int, default=None, help="Active experiment ID")
+    p.add_argument("--completed", default=None,
+                    help="Comma-separated list of completed agent roles")
+    p.add_argument("--pending", default=None,
+                    help="Comma-separated list of pending agent roles")
+    p.add_argument("--scores", default=None,
+                    help="JSON dict of eval scores (e.g. '{\"tests\": 0.9}')")
+    p.add_argument("--hypothesis", default=None, help="Current hypothesis text")
+
+    # resume
+    p = sub.add_parser("resume", help="Load checkpoint and display resume context")
+    p.add_argument("path", help="Path to the project")
+
     # vault-init
     p = sub.add_parser("vault-init", help="Create the factory Obsidian vault")
 
@@ -1415,6 +1485,8 @@ def main(argv: list[str] | None = None) -> int:
         "ace": cmd_ace,
         "digest": cmd_digest,
         "archive": cmd_archive,
+        "checkpoint": cmd_checkpoint,
+        "resume": cmd_resume,
         "vault-init": cmd_vault_init,
         "install": cmd_install,
         "dashboard": cmd_dashboard,

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -587,11 +587,11 @@ def cmd_checkpoint(args: argparse.Namespace) -> int:
         return 0
 
     # Show current checkpoint
-    state = load_checkpoint(project_path)
-    if state is None:
+    loaded = load_checkpoint(project_path)
+    if loaded is None:
         print("No checkpoint found.")
         return 0
-    print(format_checkpoint(state))
+    print(format_checkpoint(loaded))
     return 0
 
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,218 @@
+"""Tests for factory.checkpoint — save/load/clear/format + CLI commands."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from factory.checkpoint import (
+    CheckpointState,
+    clear_checkpoint,
+    format_checkpoint,
+    load_checkpoint,
+    save_checkpoint,
+)
+
+
+@pytest.fixture
+def checkpoint_project(tmp_path: Path) -> Path:
+    """Create a minimal project directory with .factory/."""
+    project = tmp_path / "ckpt-project"
+    project.mkdir()
+    (project / ".factory").mkdir()
+    return project
+
+
+@pytest.fixture
+def sample_state() -> CheckpointState:
+    """Return a sample CheckpointState for testing."""
+    return CheckpointState(
+        mode="improve",
+        active_experiment_id=38,
+        completed_agents=["researcher", "strategist"],
+        pending_agents=["builder", "reviewer", "evaluator"],
+        last_eval_scores={"tests": 0.95, "lint": 1.0},
+        current_hypothesis="Add checkpoint serialization",
+        timestamp="2026-04-20T12:00:00",
+    )
+
+
+# ── model tests ──────────────────────────────────────────────────
+
+
+def test_checkpoint_state_strict() -> None:
+    """CheckpointState rejects extra fields."""
+    with pytest.raises(Exception):
+        CheckpointState(
+            mode="improve",
+            active_experiment_id=None,
+            completed_agents=[],
+            pending_agents=[],
+            last_eval_scores={},
+            current_hypothesis=None,
+            timestamp="2026-01-01T00:00:00",
+            extra_field="bad",
+        )
+
+
+def test_checkpoint_state_nullable_fields() -> None:
+    """CheckpointState allows None for optional fields."""
+    state = CheckpointState(
+        mode="build",
+        active_experiment_id=None,
+        completed_agents=[],
+        pending_agents=["researcher"],
+        last_eval_scores={},
+        current_hypothesis=None,
+        timestamp="2026-01-01T00:00:00",
+    )
+    assert state.active_experiment_id is None
+    assert state.current_hypothesis is None
+
+
+# ── save / load / clear ──────────────────────────────────────────
+
+
+def test_save_and_load(checkpoint_project: Path, sample_state: CheckpointState) -> None:
+    """save_checkpoint writes JSON, load_checkpoint round-trips it."""
+    save_checkpoint(checkpoint_project, sample_state)
+
+    checkpoint_path = checkpoint_project / ".factory" / "checkpoint.json"
+    assert checkpoint_path.exists()
+
+    loaded = load_checkpoint(checkpoint_project)
+    assert loaded is not None
+    assert loaded == sample_state
+    assert loaded.mode == "improve"
+    assert loaded.active_experiment_id == 38
+    assert loaded.completed_agents == ["researcher", "strategist"]
+    assert loaded.pending_agents == ["builder", "reviewer", "evaluator"]
+    assert loaded.last_eval_scores == {"tests": 0.95, "lint": 1.0}
+    assert loaded.current_hypothesis == "Add checkpoint serialization"
+
+
+def test_load_missing(checkpoint_project: Path) -> None:
+    """load_checkpoint returns None when no checkpoint exists."""
+    assert load_checkpoint(checkpoint_project) is None
+
+
+def test_clear(checkpoint_project: Path, sample_state: CheckpointState) -> None:
+    """clear_checkpoint removes the file."""
+    save_checkpoint(checkpoint_project, sample_state)
+    checkpoint_path = checkpoint_project / ".factory" / "checkpoint.json"
+    assert checkpoint_path.exists()
+
+    clear_checkpoint(checkpoint_project)
+    assert not checkpoint_path.exists()
+
+
+def test_clear_noop(checkpoint_project: Path) -> None:
+    """clear_checkpoint does not raise when no checkpoint exists."""
+    clear_checkpoint(checkpoint_project)  # should not raise
+
+
+def test_save_creates_factory_dir(tmp_path: Path, sample_state: CheckpointState) -> None:
+    """save_checkpoint creates .factory/ if it doesn't exist."""
+    project = tmp_path / "bare-project"
+    project.mkdir()
+    save_checkpoint(project, sample_state)
+    assert (project / ".factory" / "checkpoint.json").exists()
+
+
+# ── format ───────────────────────────────────────────────────────
+
+
+def test_format_full(sample_state: CheckpointState) -> None:
+    """format_checkpoint includes all fields."""
+    output = format_checkpoint(sample_state)
+    assert "improve" in output
+    assert "38" in output
+    assert "researcher" in output
+    assert "builder" in output
+    assert "Add checkpoint serialization" in output
+    assert "tests=0.950" in output
+    assert "lint=1.000" in output
+    assert "2026-04-20T12:00:00" in output
+
+
+def test_format_empty_scores() -> None:
+    """format_checkpoint omits eval scores line when empty."""
+    state = CheckpointState(
+        mode="discover",
+        active_experiment_id=None,
+        completed_agents=[],
+        pending_agents=[],
+        last_eval_scores={},
+        current_hypothesis=None,
+        timestamp="2026-01-01T00:00:00",
+    )
+    output = format_checkpoint(state)
+    assert "Eval scores" not in output
+    assert "discover" in output
+
+
+# ── CLI integration ──────────────────────────────────────────────
+
+
+def test_cli_checkpoint_show_none(checkpoint_project: Path) -> None:
+    """factory checkpoint <path> shows 'No checkpoint' when empty."""
+    from factory.cli import main
+
+    code = main(["checkpoint", str(checkpoint_project)])
+    assert code == 0
+
+
+def test_cli_checkpoint_save_and_show(checkpoint_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """factory checkpoint --save persists state, then show reads it."""
+    from factory.cli import main
+
+    # Save
+    code = main([
+        "checkpoint", str(checkpoint_project),
+        "--save",
+        "--mode", "improve",
+        "--experiment", "38",
+        "--completed", "researcher,strategist",
+        "--pending", "builder,reviewer",
+        "--hypothesis", "Test hypothesis",
+        "--scores", '{"tests": 0.9}',
+    ])
+    assert code == 0
+    capsys.readouterr()  # clear output
+
+    # Show
+    code = main(["checkpoint", str(checkpoint_project)])
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "improve" in output
+    assert "38" in output
+    assert "researcher" in output
+    assert "builder" in output
+
+
+def test_cli_resume_no_checkpoint(checkpoint_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """factory resume <path> returns 1 when no checkpoint."""
+    from factory.cli import main
+
+    code = main(["resume", str(checkpoint_project)])
+    assert code == 1
+    output = capsys.readouterr().out
+    assert "No checkpoint" in output
+
+
+def test_cli_resume_with_checkpoint(checkpoint_project: Path, sample_state: CheckpointState, capsys: pytest.CaptureFixture[str]) -> None:
+    """factory resume <path> displays resume context."""
+    save_checkpoint(checkpoint_project, sample_state)
+
+    from factory.cli import main
+
+    code = main(["resume", str(checkpoint_project)])
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "Resume Context" in output
+    assert "improve" in output
+    assert "builder" in output
+    assert "reviewer" in output

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-from datetime import datetime
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Summary
- Adds `factory/checkpoint.py` with `CheckpointState` Pydantic model and `save_checkpoint`, `load_checkpoint`, `clear_checkpoint`, `format_checkpoint` functions
- Adds `factory checkpoint <path>` CLI command to show or save checkpoint state (with `--save` and associated flags)
- Adds `factory resume <path>` CLI command to load and display resume context for the CEO agent
- 13 tests covering model validation, persistence round-trip, formatting, and CLI integration

Closes #57

## Test plan
- [x] `pytest tests/test_checkpoint.py -v` — 13/13 pass
- [x] `pytest -v` — full suite 674/674 pass
- [ ] Manual: `factory checkpoint /path --save --mode improve --experiment 38` saves checkpoint
- [ ] Manual: `factory checkpoint /path` shows saved state
- [ ] Manual: `factory resume /path` prints formatted resume context

🤖 Generated with [Claude Code](https://claude.com/claude-code)