### PR TITLE
feat: add factory diff and factory explain commands

### DIFF
--- a/factory/analysis.py
+++ b/factory/analysis.py
@@ -1,0 +1,244 @@
+"""Cross-experiment comparison and single-experiment impact analysis."""
+
+from __future__ import annotations
+
+import json
+
+import structlog
+
+from factory.models import ExperimentRecord
+from factory.store import ExperimentStore
+from factory.strategy import categorize_hypothesis
+
+log = structlog.get_logger()
+
+
+# ── helpers ─────────────────────────────────────────────────────
+
+
+def _load_experiment_record(store: ExperimentStore, exp_id: int) -> ExperimentRecord | None:
+    """Find an experiment record by ID from results.tsv history."""
+    import asyncio
+
+    records = asyncio.run(store.load_history())
+    for r in records:
+        if r.id == exp_id:
+            return r
+    return None
+
+
+def _load_eval_json(store: ExperimentStore, exp_id: int, phase: str) -> dict | None:
+    """Load eval_before.json or eval_after.json for an experiment, or None if missing."""
+    eval_path = store.factory_dir / "experiments" / f"{exp_id:03d}" / f"eval_{phase}.json"
+    if not eval_path.exists():
+        log.debug("eval_json_not_found", exp_id=exp_id, phase=phase, path=str(eval_path))
+        return None
+    return json.loads(eval_path.read_text())
+
+
+def _load_hypothesis_text(store: ExperimentStore, exp_id: int) -> str | None:
+    """Load the hypothesis.md text for an experiment."""
+    hyp_path = store.factory_dir / "experiments" / f"{exp_id:03d}" / "hypothesis.md"
+    if not hyp_path.exists():
+        return None
+    return hyp_path.read_text()
+
+
+# ── public API ──────────────────────────────────────────────────
+
+
+def dimension_diff(eval_before: dict, eval_after: dict) -> list[dict]:
+    """Compare two eval result dicts and return per-dimension score changes.
+
+    Each eval dict is expected to have a ``results`` key containing a list
+    of ``{"name": ..., "score": ..., ...}`` entries (the ``EvalResult`` shape).
+
+    Returns a list of dicts with keys: name, before, after, delta.
+    """
+    before_map: dict[str, float] = {}
+    for r in eval_before.get("results", []):
+        before_map[r["name"]] = r["score"]
+
+    after_map: dict[str, float] = {}
+    for r in eval_after.get("results", []):
+        after_map[r["name"]] = r["score"]
+
+    all_dims = sorted(set(before_map) | set(after_map))
+    diffs: list[dict] = []
+    for name in all_dims:
+        b = before_map.get(name, 0.0)
+        a = after_map.get(name, 0.0)
+        diffs.append({
+            "name": name,
+            "before": b,
+            "after": a,
+            "delta": round(a - b, 6),
+        })
+
+    log.debug("dimension_diff", dimensions=len(diffs))
+    return diffs
+
+
+def compare_experiments(
+    store: ExperimentStore,
+    id_a: int,
+    id_b: int,
+) -> dict:
+    """Compare two experiments side-by-side.
+
+    Returns a dict with keys: experiment_a, experiment_b, dimension_diffs.
+    Each experiment entry contains: id, hypothesis, verdict, score_before,
+    score_after, delta, feec_category.
+    """
+    log.info("compare_experiments", id_a=id_a, id_b=id_b)
+
+    record_a = _load_experiment_record(store, id_a)
+    record_b = _load_experiment_record(store, id_b)
+
+    if record_a is None:
+        raise ValueError(f"Experiment {id_a} not found in results.tsv")
+    if record_b is None:
+        raise ValueError(f"Experiment {id_b} not found in results.tsv")
+
+    def _experiment_summary(record: ExperimentRecord) -> dict:
+        cat = categorize_hypothesis(record.hypothesis)
+        return {
+            "id": record.id,
+            "hypothesis": record.hypothesis,
+            "verdict": record.verdict,
+            "score_before": record.score_before,
+            "score_after": record.score_after,
+            "delta": record.delta,
+            "feec_category": cat.name,
+        }
+
+    result: dict = {
+        "experiment_a": _experiment_summary(record_a),
+        "experiment_b": _experiment_summary(record_b),
+        "dimension_diffs": None,
+    }
+
+    # Try to compute dimension-level diffs between the two experiments'
+    # eval_after results (most useful comparison)
+    eval_a = _load_eval_json(store, id_a, "after")
+    eval_b = _load_eval_json(store, id_b, "after")
+
+    if eval_a and eval_b:
+        result["dimension_diffs"] = dimension_diff(eval_a, eval_b)
+
+    return result
+
+
+def explain_experiment(
+    store: ExperimentStore,
+    exp_id: int,
+) -> dict:
+    """Structured analysis of a single experiment.
+
+    Returns a dict with keys: id, hypothesis, hypothesis_full, verdict,
+    score_before, score_after, delta, feec_category, dimension_breakdown.
+    """
+    log.info("explain_experiment", exp_id=exp_id)
+
+    record = _load_experiment_record(store, exp_id)
+    if record is None:
+        raise ValueError(f"Experiment {exp_id} not found in results.tsv")
+
+    cat = categorize_hypothesis(record.hypothesis)
+    full_text = _load_hypothesis_text(store, exp_id)
+
+    result: dict = {
+        "id": record.id,
+        "hypothesis": record.hypothesis,
+        "hypothesis_full": full_text,
+        "verdict": record.verdict,
+        "score_before": record.score_before,
+        "score_after": record.score_after,
+        "delta": record.delta,
+        "feec_category": cat.name,
+        "dimension_breakdown": None,
+    }
+
+    # If both before/after evals exist, compute dimension breakdown
+    eval_before = _load_eval_json(store, exp_id, "before")
+    eval_after = _load_eval_json(store, exp_id, "after")
+
+    if eval_before and eval_after:
+        result["dimension_breakdown"] = dimension_diff(eval_before, eval_after)
+
+    return result
+
+
+# ── formatters ──────────────────────────────────────────────────
+
+
+def format_comparison(comparison: dict) -> str:
+    """Format a comparison dict as a human-readable string."""
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append("Experiment Comparison")
+    lines.append("=" * 60)
+
+    for label, key in [("A", "experiment_a"), ("B", "experiment_b")]:
+        exp = comparison[key]
+        lines.append("")
+        lines.append(f"  [{label}] Experiment #{exp['id']}")
+        lines.append(f"      Hypothesis: {exp['hypothesis']}")
+        lines.append(f"      FEEC:       {exp['feec_category']}")
+        lines.append(f"      Verdict:    {exp['verdict']}")
+        if exp["score_before"] is not None:
+            lines.append(f"      Score:      {exp['score_before']:.4f} → {exp['score_after']:.4f} (Δ {exp['delta']:+.4f})")
+        else:
+            lines.append("      Score:      n/a")
+
+    diffs = comparison.get("dimension_diffs")
+    if diffs:
+        lines.append("")
+        lines.append("  Dimension Diffs (A eval_after → B eval_after):")
+        lines.append(f"    {'Dimension':<30} {'A':>8} {'B':>8} {'Δ':>8}")
+        lines.append(f"    {'-' * 54}")
+        for d in diffs:
+            delta_str = f"{d['delta']:+.4f}" if d["delta"] != 0 else "  0.0000"
+            lines.append(f"    {d['name']:<30} {d['before']:>8.4f} {d['after']:>8.4f} {delta_str:>8}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_explanation(explanation: dict) -> str:
+    """Format an explanation dict as a human-readable string."""
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append(f"Experiment #{explanation['id']} — Explanation")
+    lines.append("=" * 60)
+    lines.append("")
+    lines.append(f"  Hypothesis:     {explanation['hypothesis']}")
+    lines.append(f"  FEEC Category:  {explanation['feec_category']}")
+    lines.append(f"  Verdict:        {explanation['verdict']}")
+
+    if explanation["score_before"] is not None:
+        lines.append(
+            f"  Score:          {explanation['score_before']:.4f} → "
+            f"{explanation['score_after']:.4f} (Δ {explanation['delta']:+.4f})"
+        )
+    else:
+        lines.append("  Score:          n/a")
+
+    if explanation["hypothesis_full"] and explanation["hypothesis_full"] != explanation["hypothesis"]:
+        lines.append("")
+        lines.append("  Full Hypothesis:")
+        for line in explanation["hypothesis_full"].splitlines():
+            lines.append(f"    {line}")
+
+    breakdown = explanation.get("dimension_breakdown")
+    if breakdown:
+        lines.append("")
+        lines.append("  Dimension Breakdown:")
+        lines.append(f"    {'Dimension':<30} {'Before':>8} {'After':>8} {'Δ':>8}")
+        lines.append(f"    {'-' * 54}")
+        for d in breakdown:
+            delta_str = f"{d['delta']:+.4f}" if d["delta"] != 0 else "  0.0000"
+            lines.append(f"    {d['name']:<30} {d['before']:>8.4f} {d['after']:>8.4f} {delta_str:>8}")
+
+    lines.append("")
+    return "\n".join(lines)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -613,6 +613,30 @@ def cmd_resume(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_diff(args: argparse.Namespace) -> int:
+    """Compare two experiments side-by-side."""
+    from factory.analysis import compare_experiments, format_comparison
+    from factory.store import ExperimentStore
+
+    project_path = Path(args.path).resolve()
+    store = ExperimentStore(project_path)
+    comparison = compare_experiments(store, args.id_a, args.id_b)
+    print(format_comparison(comparison))
+    return 0
+
+
+def cmd_explain(args: argparse.Namespace) -> int:
+    """Explain a single experiment with FEEC category and dimension breakdown."""
+    from factory.analysis import explain_experiment, format_explanation
+    from factory.store import ExperimentStore
+
+    project_path = Path(args.path).resolve()
+    store = ExperimentStore(project_path)
+    explanation = explain_experiment(store, args.id)
+    print(format_explanation(explanation))
+    return 0
+
+
 def cmd_vault_init(args: argparse.Namespace) -> int:
     from factory.obsidian.notes import init_vault
 
@@ -1301,6 +1325,16 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("status", help="Print project status summary")
     p.add_argument("path", help="Path to the project")
 
+    # diff
+    p = sub.add_parser("diff", help="Compare two experiments side-by-side")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("id_a", type=int, help="First experiment ID")
+    p.add_argument("id_b", type=int, help="Second experiment ID")
+
+    # explain
+    p = sub.add_parser("explain", help="Explain a single experiment with FEEC analysis")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("id", type=int, help="Experiment ID")
 
     # export
     p = sub.add_parser("export", help="Export complete project snapshot as JSON to stdout")
@@ -1480,6 +1514,8 @@ def main(argv: list[str] | None = None) -> int:
         "notify": cmd_notify,
         "study": cmd_study,
         "status": cmd_status,
+        "diff": cmd_diff,
+        "explain": cmd_explain,
         "export": cmd_export,
         "insights": cmd_insights,
         "ace": cmd_ace,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,398 @@
+"""Tests for factory.analysis — experiment comparison and explanation."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from factory.analysis import (
+    compare_experiments,
+    dimension_diff,
+    explain_experiment,
+    format_comparison,
+    format_explanation,
+)
+from factory.models import CompositeScore, EvalResult, ExperimentRecord
+from factory.store import ExperimentStore
+
+
+@pytest.fixture
+def analysis_store(tmp_path: Path) -> ExperimentStore:
+    """Create a store with two finalized experiments and eval data."""
+    import asyncio
+
+    project = tmp_path / "project"
+    project.mkdir()
+    store = ExperimentStore(project)
+
+    from factory.models import FactoryConfig
+
+    config = FactoryConfig(
+        goal="Test project",
+        scope=["src/**/*.py"],
+        guards=["Do not delete tests"],
+        eval_command="python eval/score.py",
+        eval_threshold=0.8,
+        constraints=[],
+    )
+    asyncio.run(store.init(config))
+
+    # Experiment 1: a "fix" hypothesis that was kept
+    exp1 = asyncio.run(store.begin("Fix broken test suite"))
+    score_before_1 = CompositeScore(
+        total=0.6,
+        results=[
+            EvalResult(name="tests", score=0.5, weight=1.0, passed=False, details="3/6 pass"),
+            EvalResult(name="lint", score=0.7, weight=0.5, passed=True, details="clean"),
+        ],
+        guard_violations=[],
+        passed=False,
+    )
+    score_after_1 = CompositeScore(
+        total=0.85,
+        results=[
+            EvalResult(name="tests", score=0.9, weight=1.0, passed=True, details="5/6 pass"),
+            EvalResult(name="lint", score=0.8, weight=0.5, passed=True, details="clean"),
+        ],
+        guard_violations=[],
+        passed=True,
+    )
+    asyncio.run(store.save_eval(exp1, "before", score_before_1))
+    asyncio.run(store.save_eval(exp1, "after", score_after_1))
+    record1 = ExperimentRecord(
+        id=exp1,
+        timestamp=datetime(2026, 1, 10, 12, 0, 0),
+        hypothesis="Fix broken test suite",
+        change_summary="Fixed 2 failing tests",
+        issue_number=10,
+        pr_number=11,
+        score_before=0.6,
+        score_after=0.85,
+        delta=0.25,
+        verdict="keep",
+        cost_usd=0.50,
+        notes="",
+    )
+    asyncio.run(store.finalize(exp1, record1))
+
+    # Experiment 2: an "explore" hypothesis that was reverted
+    exp2 = asyncio.run(store.begin("Add new dashboard page"))
+    score_before_2 = CompositeScore(
+        total=0.85,
+        results=[
+            EvalResult(name="tests", score=0.9, weight=1.0, passed=True, details="5/6 pass"),
+            EvalResult(name="lint", score=0.8, weight=0.5, passed=True, details="clean"),
+        ],
+        guard_violations=[],
+        passed=True,
+    )
+    score_after_2 = CompositeScore(
+        total=0.75,
+        results=[
+            EvalResult(name="tests", score=0.7, weight=1.0, passed=True, details="4/6 pass"),
+            EvalResult(name="lint", score=0.8, weight=0.5, passed=True, details="clean"),
+        ],
+        guard_violations=[],
+        passed=False,
+    )
+    asyncio.run(store.save_eval(exp2, "before", score_before_2))
+    asyncio.run(store.save_eval(exp2, "after", score_after_2))
+    record2 = ExperimentRecord(
+        id=exp2,
+        timestamp=datetime(2026, 1, 11, 14, 0, 0),
+        hypothesis="Add new dashboard page",
+        change_summary="Added dashboard page with charts",
+        issue_number=12,
+        pr_number=13,
+        score_before=0.85,
+        score_after=0.75,
+        delta=-0.10,
+        verdict="revert",
+        cost_usd=1.20,
+        notes="Regression in tests",
+    )
+    asyncio.run(store.finalize(exp2, record2))
+
+    return store
+
+
+@pytest.fixture
+def store_no_evals(tmp_path: Path) -> ExperimentStore:
+    """Create a store with experiments but no eval JSON files."""
+    import asyncio
+
+    project = tmp_path / "project"
+    project.mkdir()
+    store = ExperimentStore(project)
+
+    from factory.models import FactoryConfig
+
+    config = FactoryConfig(
+        goal="Test",
+        scope=[],
+        guards=[],
+        eval_command="echo ok",
+        eval_threshold=0.5,
+        constraints=[],
+    )
+    asyncio.run(store.init(config))
+
+    exp1 = asyncio.run(store.begin("Improve logging"))
+    record1 = ExperimentRecord(
+        id=exp1,
+        timestamp=datetime(2026, 2, 1, 10, 0, 0),
+        hypothesis="Improve logging",
+        change_summary="Added structlog",
+        issue_number=None,
+        pr_number=None,
+        score_before=None,
+        score_after=None,
+        delta=None,
+        verdict="keep",
+        cost_usd=None,
+        notes="",
+    )
+    asyncio.run(store.finalize(exp1, record1))
+    return store
+
+
+# ── dimension_diff ──────────────────────────────────────────────
+
+
+class TestDimensionDiff:
+    def test_basic_diff(self):
+        before = {
+            "results": [
+                {"name": "tests", "score": 0.5},
+                {"name": "lint", "score": 0.7},
+            ],
+        }
+        after = {
+            "results": [
+                {"name": "tests", "score": 0.9},
+                {"name": "lint", "score": 0.8},
+            ],
+        }
+        diffs = dimension_diff(before, after)
+        assert len(diffs) == 2
+
+        tests_diff = next(d for d in diffs if d["name"] == "tests")
+        assert tests_diff["before"] == 0.5
+        assert tests_diff["after"] == 0.9
+        assert tests_diff["delta"] == pytest.approx(0.4)
+
+        lint_diff = next(d for d in diffs if d["name"] == "lint")
+        assert lint_diff["delta"] == pytest.approx(0.1)
+
+    def test_new_dimension_in_after(self):
+        before = {"results": [{"name": "tests", "score": 0.5}]}
+        after = {
+            "results": [
+                {"name": "tests", "score": 0.9},
+                {"name": "coverage", "score": 0.8},
+            ],
+        }
+        diffs = dimension_diff(before, after)
+        assert len(diffs) == 2
+        coverage = next(d for d in diffs if d["name"] == "coverage")
+        assert coverage["before"] == 0.0
+        assert coverage["after"] == 0.8
+
+    def test_dimension_removed_in_after(self):
+        before = {
+            "results": [
+                {"name": "tests", "score": 0.5},
+                {"name": "old_metric", "score": 0.3},
+            ],
+        }
+        after = {"results": [{"name": "tests", "score": 0.9}]}
+        diffs = dimension_diff(before, after)
+        assert len(diffs) == 2
+        old = next(d for d in diffs if d["name"] == "old_metric")
+        assert old["after"] == 0.0
+        assert old["delta"] == pytest.approx(-0.3)
+
+    def test_empty_results(self):
+        diffs = dimension_diff({"results": []}, {"results": []})
+        assert diffs == []
+
+    def test_missing_results_key(self):
+        diffs = dimension_diff({}, {})
+        assert diffs == []
+
+
+# ── compare_experiments ─────────────────────────────────────────
+
+
+class TestCompareExperiments:
+    def test_basic_comparison(self, analysis_store: ExperimentStore):
+        result = compare_experiments(analysis_store, 1, 2)
+
+        assert result["experiment_a"]["id"] == 1
+        assert result["experiment_b"]["id"] == 2
+        assert result["experiment_a"]["verdict"] == "keep"
+        assert result["experiment_b"]["verdict"] == "revert"
+        assert result["experiment_a"]["feec_category"] == "FIX"
+        assert result["experiment_b"]["feec_category"] == "EXPLORE"
+
+    def test_comparison_has_scores(self, analysis_store: ExperimentStore):
+        result = compare_experiments(analysis_store, 1, 2)
+        assert result["experiment_a"]["score_before"] == 0.6
+        assert result["experiment_a"]["score_after"] == 0.85
+        assert result["experiment_a"]["delta"] == 0.25
+
+    def test_comparison_dimension_diffs(self, analysis_store: ExperimentStore):
+        result = compare_experiments(analysis_store, 1, 2)
+        diffs = result["dimension_diffs"]
+        assert diffs is not None
+        assert len(diffs) == 2
+        # Compares eval_after of exp1 vs eval_after of exp2
+        tests_diff = next(d for d in diffs if d["name"] == "tests")
+        assert tests_diff["before"] == 0.9  # exp1 after
+        assert tests_diff["after"] == 0.7   # exp2 after
+
+    def test_comparison_no_evals(self, store_no_evals: ExperimentStore):
+        result = compare_experiments(store_no_evals, 1, 1)
+        assert result["dimension_diffs"] is None
+
+    def test_missing_experiment_raises(self, analysis_store: ExperimentStore):
+        with pytest.raises(ValueError, match="Experiment 99 not found"):
+            compare_experiments(analysis_store, 1, 99)
+
+    def test_missing_first_experiment_raises(self, analysis_store: ExperimentStore):
+        with pytest.raises(ValueError, match="Experiment 99 not found"):
+            compare_experiments(analysis_store, 99, 1)
+
+
+# ── explain_experiment ──────────────────────────────────────────
+
+
+class TestExplainExperiment:
+    def test_basic_explanation(self, analysis_store: ExperimentStore):
+        result = explain_experiment(analysis_store, 1)
+        assert result["id"] == 1
+        assert result["hypothesis"] == "Fix broken test suite"
+        assert result["feec_category"] == "FIX"
+        assert result["verdict"] == "keep"
+
+    def test_explanation_scores(self, analysis_store: ExperimentStore):
+        result = explain_experiment(analysis_store, 1)
+        assert result["score_before"] == 0.6
+        assert result["score_after"] == 0.85
+        assert result["delta"] == 0.25
+
+    def test_explanation_dimension_breakdown(self, analysis_store: ExperimentStore):
+        result = explain_experiment(analysis_store, 1)
+        breakdown = result["dimension_breakdown"]
+        assert breakdown is not None
+        assert len(breakdown) == 2
+        tests = next(d for d in breakdown if d["name"] == "tests")
+        assert tests["before"] == 0.5
+        assert tests["after"] == 0.9
+        assert tests["delta"] == pytest.approx(0.4)
+
+    def test_explanation_full_hypothesis(self, analysis_store: ExperimentStore):
+        result = explain_experiment(analysis_store, 1)
+        assert result["hypothesis_full"] is not None
+        assert "Fix broken test suite" in result["hypothesis_full"]
+
+    def test_explanation_no_evals(self, store_no_evals: ExperimentStore):
+        result = explain_experiment(store_no_evals, 1)
+        assert result["dimension_breakdown"] is None
+        assert result["score_before"] is None
+
+    def test_missing_experiment_raises(self, analysis_store: ExperimentStore):
+        with pytest.raises(ValueError, match="Experiment 99 not found"):
+            explain_experiment(analysis_store, 99)
+
+
+# ── format functions ────────────────────────────────────────────
+
+
+class TestFormatComparison:
+    def test_format_includes_both_experiments(self, analysis_store: ExperimentStore):
+        comparison = compare_experiments(analysis_store, 1, 2)
+        output = format_comparison(comparison)
+        assert "Experiment #1" in output
+        assert "Experiment #2" in output
+        assert "FIX" in output
+        assert "EXPLORE" in output
+        assert "keep" in output
+        assert "revert" in output
+
+    def test_format_includes_dimension_diffs(self, analysis_store: ExperimentStore):
+        comparison = compare_experiments(analysis_store, 1, 2)
+        output = format_comparison(comparison)
+        assert "tests" in output
+        assert "lint" in output
+        assert "Dimension Diffs" in output
+
+    def test_format_no_evals(self, store_no_evals: ExperimentStore):
+        comparison = compare_experiments(store_no_evals, 1, 1)
+        output = format_comparison(comparison)
+        assert "Experiment #1" in output
+        assert "n/a" in output
+        # Should not include dimension section
+        assert "Dimension Diffs" not in output
+
+
+class TestFormatExplanation:
+    def test_format_includes_key_fields(self, analysis_store: ExperimentStore):
+        explanation = explain_experiment(analysis_store, 1)
+        output = format_explanation(explanation)
+        assert "Experiment #1" in output
+        assert "Fix broken test suite" in output
+        assert "FIX" in output
+        assert "keep" in output
+
+    def test_format_includes_breakdown(self, analysis_store: ExperimentStore):
+        explanation = explain_experiment(analysis_store, 1)
+        output = format_explanation(explanation)
+        assert "Dimension Breakdown" in output
+        assert "tests" in output
+        assert "lint" in output
+
+    def test_format_no_evals(self, store_no_evals: ExperimentStore):
+        explanation = explain_experiment(store_no_evals, 1)
+        output = format_explanation(explanation)
+        assert "n/a" in output
+        assert "Dimension Breakdown" not in output
+
+
+# ── CLI integration ─────────────────────────────────────────────
+
+
+class TestCLIIntegration:
+    def test_diff_command_registered(self):
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        # Should not raise
+        args = parser.parse_args(["diff", "/tmp/proj", "1", "2"])
+        assert args.command == "diff"
+        assert args.id_a == 1
+        assert args.id_b == 2
+
+    def test_explain_command_registered(self):
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["explain", "/tmp/proj", "3"])
+        assert args.command == "explain"
+        assert args.id == 3
+
+    def test_diff_handler_in_handlers(self):
+        from factory.cli import build_parser
+
+        # Verify the commands are in the handler dict by checking
+        # that parsing succeeds and command name is correct
+        parser = build_parser()
+        args = parser.parse_args(["diff", "/tmp/p", "1", "2"])
+        assert args.command == "diff"
+
+    def test_explain_handler_in_handlers(self):
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["explain", "/tmp/p", "5"])
+        assert args.command == "explain"


### PR DESCRIPTION
## Summary

- Adds `factory/analysis.py` with `compare_experiments`, `explain_experiment`, `dimension_diff`, `format_comparison`, and `format_explanation` functions
- Adds `factory diff <path> <id_a> <id_b>` and `factory explain <path> <id>` CLI commands registered in the handler dict and argparse parser
- Adds `tests/test_analysis.py` with 27 tests covering all public functions, format outputs, edge cases (missing evals, missing experiments), and CLI integration

Closes #59

## Test plan

- [x] `pytest tests/test_analysis.py -v` — 27/27 pass
- [x] `pytest -v` — 701/701 pass (no regressions)
- [x] `ruff check factory/analysis.py factory/cli.py tests/test_analysis.py` — clean
- [x] `mypy factory/analysis.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)