### PR TITLE
Add one-liner installer and factory self-update command

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -708,6 +708,47 @@ def cmd_vault_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_self_update(args: argparse.Namespace) -> int:
+    """Self-update the factory CLI via uv tool upgrade."""
+    from importlib.metadata import version as pkg_version
+
+    try:
+        version_before = pkg_version("remote-factory")
+    except Exception:
+        version_before = "unknown"
+
+    print(f"Current version: {version_before}")
+    print("Upgrading remote-factory...")
+
+    result = subprocess.run(
+        ["uv", "tool", "upgrade", "remote-factory"],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+
+    if result.returncode != 0:
+        print("Upgrade failed.", file=sys.stderr)
+        return 1
+
+    # Re-check version (may not reflect in this process, but show what uv reported)
+    try:
+        version_after = pkg_version("remote-factory")
+    except Exception:
+        version_after = "unknown"
+
+    print(f"Version after upgrade: {version_after}")
+    if version_before == version_after:
+        print("Already up to date.")
+    else:
+        print(f"Updated: {version_before} -> {version_after}")
+    return 0
+
+
 def cmd_install(args: argparse.Namespace) -> int:
     """Install the Factory CEO as a Claude Code agent."""
     from factory.agents.runner import resolve_prompt
@@ -1460,6 +1501,9 @@ def build_parser() -> argparse.ArgumentParser:
     # vault-init
     p = sub.add_parser("vault-init", help="Create the factory Obsidian vault")
 
+    # self-update
+    sub.add_parser("self-update", help="Upgrade the factory CLI to the latest version")
+
     # install — install Factory CEO as a Claude Code agent
     sub.add_parser("install", help="Install Factory CEO as a Claude Code agent (~/.claude/agents/)")
 
@@ -1595,6 +1639,7 @@ def main(argv: list[str] | None = None) -> int:
         "checkpoint": cmd_checkpoint,
         "resume": cmd_resume,
         "vault-init": cmd_vault_init,
+        "self-update": cmd_self_update,
         "install": cmd_install,
         "dashboard": cmd_dashboard,
         "agent": cmd_agent,

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Remote Factory Installer ─────────────────────────────────────
+# Usage: curl -sSf https://raw.githubusercontent.com/akashgit/remote-factory/main/install.sh | bash
+
+REPO_URL="https://github.com/akashgit/remote-factory.git"
+MIN_PYTHON="3.11"
+
+# ── banner ────────────────────────────────────────────────────────
+
+echo ""
+echo "  ┏━╸┏━┓┏━╸╺┳╸┏━┓┏━┓╻ ╻"
+echo "  ┣╸ ┣━┫┃   ┃ ┃ ┃┣┳┛┗┳┛"
+echo "  ╹  ╹ ╹┗━╸ ╹ ┗━┛╹┗╸ ╹ "
+echo "  Multi-Agent Software Evolution"
+echo ""
+echo "  Installing Remote Factory..."
+echo ""
+
+# ── detect OS and arch ────────────────────────────────────────────
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+echo "  OS:   ${OS}"
+echo "  Arch: ${ARCH}"
+echo ""
+
+# ── check Python 3.11+ ───────────────────────────────────────────
+
+check_python_version() {
+    local py_cmd="$1"
+    if ! command -v "$py_cmd" &>/dev/null; then
+        return 1
+    fi
+    local version
+    version="$("$py_cmd" --version 2>&1 | awk '{print $2}')"
+    local major minor
+    major="$(echo "$version" | cut -d. -f1)"
+    minor="$(echo "$version" | cut -d. -f2)"
+    if [[ "$major" -ge 3 ]] && [[ "$minor" -ge 11 ]]; then
+        echo "  Python: $version ($py_cmd)"
+        return 0
+    fi
+    return 1
+}
+
+PYTHON_OK=false
+for cmd in python3 python; do
+    if check_python_version "$cmd"; then
+        PYTHON_OK=true
+        break
+    fi
+done
+
+if [[ "$PYTHON_OK" != "true" ]]; then
+    echo "  ERROR: Python ${MIN_PYTHON}+ is required but not found."
+    echo "  Install Python ${MIN_PYTHON}+ and try again."
+    exit 1
+fi
+
+echo ""
+
+# ── check/install uv ─────────────────────────────────────────────
+
+if command -v uv &>/dev/null; then
+    echo "  uv: $(uv --version) (already installed)"
+else
+    echo "  uv: not found, installing..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # Source the env so uv is on PATH for this session
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+    if command -v uv &>/dev/null; then
+        echo "  uv: $(uv --version) (installed)"
+    else
+        echo "  ERROR: Failed to install uv."
+        exit 1
+    fi
+fi
+
+echo ""
+
+# ── install remote-factory ───────────────────────────────────────
+
+echo "  Installing remote-factory..."
+uv tool install "remote-factory @ git+${REPO_URL}"
+echo ""
+
+# ── register CEO agent ───────────────────────────────────────────
+
+if command -v factory &>/dev/null; then
+    echo "  Registering Factory CEO agent..."
+    factory install || true
+    echo ""
+fi
+
+# ── verify ────────────────────────────────────────────────────────
+
+if command -v factory &>/dev/null; then
+    echo "  Verification: factory CLI is available"
+    factory --help >/dev/null 2>&1 && echo "  factory --help: OK" || echo "  factory --help: FAILED"
+else
+    echo "  WARNING: 'factory' not found on PATH."
+    echo "  You may need to add ~/.local/bin to your PATH:"
+    echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+fi
+
+echo ""
+
+# ── success ───────────────────────────────────────────────────────
+
+echo "  ============================================"
+echo "  Remote Factory installed successfully!"
+echo "  ============================================"
+echo ""
+echo "  Next steps:"
+echo ""
+echo "    1. Set up Vertex AI credentials:"
+echo "       export CLAUDE_CODE_USE_VERTEX=1"
+echo "       export CLOUD_ML_REGION=us-east5"
+echo "       export ANTHROPIC_VERTEX_PROJECT_ID=<your-project-id>"
+echo ""
+echo "    2. Run the factory on a project:"
+echo "       factory ceo /path/to/your/project"
+echo ""
+echo "    3. Or build from a prompt:"
+echo "       factory ceo --prompt \"Build a weather CLI\""
+echo ""
+echo "    4. Update later with:"
+echo "       factory self-update"
+echo ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,21 @@ version = "0.1.0"
 description = "Domain-agnostic multi-agent software evolution loop"
 requires-python = ">=3.11"
 dependencies = ["pydantic>=2.0", "structlog>=24.0", "fastapi>=0.115", "uvicorn[standard]>=0.34"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Testing",
+    "Intended Audience :: Developers",
+]
+
+[project.urls]
+Homepage = "https://github.com/akashgit/remote-factory"
+Repository = "https://github.com/akashgit/remote-factory"
+Issues = "https://github.com/akashgit/remote-factory/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,76 @@
+"""Tests for the installer script and self-update CLI command."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from factory.cli import cmd_self_update
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+
+# ── install.sh tests ─────────────────────────────────────────────
+
+
+def test_install_sh_is_valid_bash():
+    """install.sh passes bash -n syntax check."""
+    result = subprocess.run(
+        ["bash", "-n", str(INSTALL_SH)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"bash -n failed: {result.stderr}"
+
+
+def test_install_sh_is_executable():
+    """install.sh has the executable permission bit set."""
+    assert os.access(INSTALL_SH, os.X_OK), "install.sh is not executable"
+
+
+def test_install_sh_has_shebang():
+    """install.sh starts with a proper shebang line."""
+    first_line = INSTALL_SH.read_text().splitlines()[0]
+    assert first_line == "#!/usr/bin/env bash"
+
+
+def test_install_sh_has_set_euo_pipefail():
+    """install.sh uses strict error handling."""
+    content = INSTALL_SH.read_text()
+    assert "set -euo pipefail" in content
+
+
+# ── self-update CLI tests ────────────────────────────────────────
+
+
+def test_cmd_self_update_success():
+    """cmd_self_update returns 0 when uv tool upgrade succeeds."""
+    import argparse
+
+    mock_result = subprocess.CompletedProcess(
+        args=["uv", "tool", "upgrade", "remote-factory"],
+        returncode=0,
+        stdout="Nothing to upgrade\n",
+        stderr="",
+    )
+    with patch("factory.cli.subprocess.run", return_value=mock_result):
+        code = cmd_self_update(argparse.Namespace())
+    assert code == 0
+
+
+def test_cmd_self_update_failure():
+    """cmd_self_update returns 1 when uv tool upgrade fails."""
+    import argparse
+
+    mock_result = subprocess.CompletedProcess(
+        args=["uv", "tool", "upgrade", "remote-factory"],
+        returncode=1,
+        stdout="",
+        stderr="error: remote-factory is not installed\n",
+    )
+    with patch("factory.cli.subprocess.run", return_value=mock_result):
+        code = cmd_self_update(argparse.Namespace())
+    assert code == 1


### PR DESCRIPTION
## Summary

- **`install.sh`**: Curl-pipe-sh compatible installer that detects OS/arch, checks Python 3.11+, installs `uv` if missing, installs `remote-factory` via `uv tool install`, registers the CEO agent, and prints next steps
- **`factory self-update`**: New CLI subcommand that runs `uv tool upgrade remote-factory` with before/after version reporting
- **`pyproject.toml`**: Added PyPI classifiers (Beta, Python 3.11-3.13, MIT) and project URLs (Homepage, Repository, Issues)
- **`tests/test_installer.py`**: 6 tests covering bash syntax validation, executable bit, shebang, strict mode, and mocked self-update success/failure

## Test plan

- [x] `pytest tests/test_installer.py -v` — 6/6 passed
- [x] `pytest tests/ -v` — 758/758 passed
- [x] `ruff check .` — all checks passed
- [x] `mypy factory/cli.py --ignore-missing-imports` — no issues
- [x] `bash -n install.sh` — valid syntax

Closes #64. Factory experiment #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)