### PR TITLE
feat: research citation tracking for experiments

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -676,6 +676,39 @@ def cmd_resume(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_research(args: argparse.Namespace) -> int:
+    """Print citation index table and coverage summary."""
+    from factory.research_index import build_citation_index, citation_coverage
+    from factory.store import ExperimentStore
+
+    project_path = Path(args.path).resolve()
+    store = ExperimentStore(project_path)
+    records = _run(store.load_history())
+
+    if not records:
+        print("No experiments recorded.")
+        return 0
+
+    index = build_citation_index(project_path)
+    coverage = citation_coverage(project_path)
+
+    # Print table
+    header = f"{'ID':>4}  {'Hypothesis':<52}  Citations"
+    print(header)
+    print("-" * len(header))
+    for r in records:
+        hyp = r.hypothesis[:50]
+        cites = index.get(r.id, [])
+        cite_str = ", ".join(cites) if cites else "-"
+        print(f"{r.id:>4}  {hyp:<52}  {cite_str}")
+
+    # Summary
+    cited_count = sum(1 for r in records if r.research_citations)
+    print()
+    print(f"{len(records)} experiments, {cited_count} cited, coverage {coverage:.0%}")
+    return 0
+
+
 def cmd_diff(args: argparse.Namespace) -> int:
     """Compare two experiments side-by-side."""
     from factory.analysis import compare_experiments, format_comparison
@@ -1433,6 +1466,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("status", help="Print project status summary")
     p.add_argument("path", help="Path to the project")
 
+    # research
+    p = sub.add_parser("research", help="Print research citation index for experiments")
+    p.add_argument("path", help="Path to the project")
+
     # diff
     p = sub.add_parser("diff", help="Compare two experiments side-by-side")
     p.add_argument("path", help="Path to the project")
@@ -1628,6 +1665,7 @@ def main(argv: list[str] | None = None) -> int:
         "notify": cmd_notify,
         "study": cmd_study,
         "status": cmd_status,
+        "research": cmd_research,
         "diff": cmd_diff,
         "explain": cmd_explain,
         "export": cmd_export,

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -238,16 +238,24 @@ def eval_research_grounding(project_path: Path) -> dict:
         exp_total = len(list(factory_exp_dir.iterdir())) if factory_exp_dir.exists() else 0
         doc_ratio = min(1.0, exp_notes / max(exp_total, 1))
 
+        # Sub-score E: Citation ratio — fraction of recent experiments with citations
+        from factory.research_index import citation_coverage
+
+        citation_ratio = citation_coverage(project_path)
+
+        # Rebalance weights to include citation_ratio at 0.20
         score = (
-            0.25 * knowledge_score
-            + 0.35 * utilization
-            + 0.15 * has_research
-            + 0.25 * doc_ratio
+            0.20 * knowledge_score
+            + 0.28 * utilization
+            + 0.12 * has_research
+            + 0.20 * doc_ratio
+            + 0.20 * citation_ratio
         )
         details = (
             f"sources={source_count}, utilization={utilization:.2f}, "
             f"research_report={'yes' if has_research else 'no'}, "
-            f"doc_ratio={doc_ratio:.2f} ({exp_notes}/{max(exp_total, 1)})"
+            f"doc_ratio={doc_ratio:.2f} ({exp_notes}/{max(exp_total, 1)}), "
+            f"citation_ratio={citation_ratio:.2f}"
         )
 
         return {

--- a/factory/models.py
+++ b/factory/models.py
@@ -143,6 +143,7 @@ class ExperimentRecord(BaseModel):
     verdict: Literal["keep", "revert", "error"]
     cost_usd: float | None
     notes: str
+    research_citations: list[str] = []
 
 
 # ── cross-project insights ───────────────────────────────────────

--- a/factory/research_index.py
+++ b/factory/research_index.py
@@ -1,0 +1,68 @@
+"""Research citation index — tracks which experiments cite research sources."""
+
+import csv
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def _load_citations_from_tsv(project_path: Path) -> list[tuple[int, list[str]]]:
+    """Parse results.tsv and return list of (experiment_id, citations) tuples."""
+    tsv_path = project_path / ".factory" / "results.tsv"
+    if not tsv_path.exists():
+        return []
+
+    results: list[tuple[int, list[str]]] = []
+    with open(tsv_path, newline="") as f:
+        reader = csv.DictReader(f, dialect="excel-tab")
+        for row in reader:
+            exp_id = int(row["id"])
+            raw = row.get("research_citations", "")
+            citations = [c.strip() for c in raw.split("|") if c.strip()] if raw else []
+            results.append((exp_id, citations))
+    return results
+
+
+def build_citation_index(project_path: Path) -> dict[int, list[str]]:
+    """Load experiment history and return mapping of experiment_id to list of citations."""
+    all_rows = _load_citations_from_tsv(project_path)
+    index: dict[int, list[str]] = {}
+    for exp_id, citations in all_rows:
+        if citations:
+            index[exp_id] = citations
+    log.debug(
+        "citation_index_built",
+        total_experiments=len(all_rows),
+        cited_experiments=len(index),
+    )
+    return index
+
+
+def citation_coverage(project_path: Path) -> float:
+    """Return fraction of recent experiments (last 10) with at least one citation."""
+    all_rows = _load_citations_from_tsv(project_path)
+    if not all_rows:
+        return 0.0
+    recent = all_rows[-10:]
+    cited = sum(1 for _, citations in recent if citations)
+    coverage = cited / len(recent)
+    log.debug(
+        "citation_coverage_computed",
+        recent_count=len(recent),
+        cited_count=cited,
+        coverage=coverage,
+    )
+    return coverage
+
+
+def uncited_experiments(project_path: Path) -> list[int]:
+    """Return experiment IDs without citations from recent history (last 10)."""
+    all_rows = _load_citations_from_tsv(project_path)
+    if not all_rows:
+        return []
+    recent = all_rows[-10:]
+    uncited = [exp_id for exp_id, citations in recent if not citations]
+    log.debug("uncited_experiments_found", count=len(uncited))
+    return uncited

--- a/factory/store.py
+++ b/factory/store.py
@@ -18,7 +18,7 @@ log = structlog.get_logger()
 TSV_COLUMNS = [
     "id", "timestamp", "hypothesis", "change_summary", "issue_number",
     "pr_number", "score_before", "score_after", "delta", "verdict",
-    "cost_usd", "notes",
+    "cost_usd", "notes", "research_citations",
 ]
 
 
@@ -215,6 +215,7 @@ class ExperimentStore:
                 record.verdict,
                 record.cost_usd if record.cost_usd is not None else "",
                 record.notes,
+                "|".join(record.research_citations) if record.research_citations else "",
             ])
 
     async def load_history(self) -> list[ExperimentRecord]:
@@ -249,6 +250,14 @@ class ExperimentStore:
                 if verdict_raw not in valid_verdicts:
                     verdict_raw = "error"
 
+                # Parse research_citations (backward compat: column may be absent)
+                citations_raw = row.get("research_citations", "")
+                citations = (
+                    [c.strip() for c in citations_raw.split("|") if c.strip()]
+                    if citations_raw
+                    else []
+                )
+
                 records.append(ExperimentRecord(
                     id=int(row["id"]),
                     timestamp=datetime.fromisoformat(row["timestamp"]),
@@ -262,6 +271,7 @@ class ExperimentStore:
                     verdict=verdict_raw,  # type: ignore[arg-type]
                     cost_usd=_safe_float(row["cost_usd"]),
                     notes=row["notes"],
+                    research_citations=citations,
                 ))
         log.debug("load_history_complete", record_count=len(records))
         return records

--- a/tests/test_research_index.py
+++ b/tests/test_research_index.py
@@ -1,0 +1,200 @@
+"""Tests for factory.research_index — citation tracking for experiments."""
+
+import csv
+from io import StringIO
+from pathlib import Path
+
+from factory.cli import cmd_research
+from factory.research_index import (
+    build_citation_index,
+    citation_coverage,
+    uncited_experiments,
+)
+
+
+def _write_results_tsv(project_path: Path, rows: list[dict]) -> None:
+    """Write a results.tsv with the full column set including research_citations."""
+    factory_dir = project_path / ".factory"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    tsv_path = factory_dir / "results.tsv"
+
+    fieldnames = [
+        "id", "timestamp", "hypothesis", "change_summary", "issue_number",
+        "pr_number", "score_before", "score_after", "delta", "verdict",
+        "cost_usd", "notes", "research_citations",
+    ]
+    buf = StringIO()
+    writer = csv.DictWriter(buf, fieldnames=fieldnames, dialect="excel-tab")
+    writer.writeheader()
+    for row in rows:
+        full_row = {k: row.get(k, "") for k in fieldnames}
+        writer.writerow(full_row)
+    tsv_path.write_text(buf.getvalue())
+
+
+def _make_row(
+    exp_id: int,
+    hypothesis: str = "Test hypothesis",
+    citations: str = "",
+) -> dict:
+    """Create a minimal experiment row dict."""
+    return {
+        "id": str(exp_id),
+        "timestamp": "2025-01-01T00:00:00",
+        "hypothesis": hypothesis,
+        "change_summary": "Changes",
+        "verdict": "keep",
+        "notes": "",
+        "research_citations": citations,
+    }
+
+
+class TestBuildCitationIndex:
+    def test_empty_project(self, tmp_path: Path) -> None:
+        """No .factory dir returns empty index."""
+        index = build_citation_index(tmp_path)
+        assert index == {}
+
+    def test_no_citations(self, tmp_path: Path) -> None:
+        """Experiments without citations produce empty index."""
+        _write_results_tsv(tmp_path, [
+            _make_row(1),
+            _make_row(2),
+        ])
+        index = build_citation_index(tmp_path)
+        assert index == {}
+
+    def test_with_citations(self, tmp_path: Path) -> None:
+        """Experiments with citations appear in the index."""
+        _write_results_tsv(tmp_path, [
+            _make_row(1, citations="https://arxiv.org/abs/1234|#42"),
+            _make_row(2),
+            _make_row(3, citations="Ideas/Research.md"),
+        ])
+        index = build_citation_index(tmp_path)
+        assert 1 in index
+        assert index[1] == ["https://arxiv.org/abs/1234", "#42"]
+        assert 2 not in index
+        assert 3 in index
+        assert index[3] == ["Ideas/Research.md"]
+
+    def test_single_citation(self, tmp_path: Path) -> None:
+        """Single citation (no pipe separator) works correctly."""
+        _write_results_tsv(tmp_path, [
+            _make_row(1, citations="https://example.com"),
+        ])
+        index = build_citation_index(tmp_path)
+        assert index[1] == ["https://example.com"]
+
+
+class TestCitationCoverage:
+    def test_empty_project(self, tmp_path: Path) -> None:
+        """No experiments returns 0.0 coverage."""
+        coverage = citation_coverage(tmp_path)
+        assert coverage == 0.0
+
+    def test_no_citations(self, tmp_path: Path) -> None:
+        """All uncited experiments return 0.0 coverage."""
+        _write_results_tsv(tmp_path, [_make_row(i) for i in range(1, 6)])
+        coverage = citation_coverage(tmp_path)
+        assert coverage == 0.0
+
+    def test_partial_coverage(self, tmp_path: Path) -> None:
+        """Some cited experiments return correct fraction."""
+        _write_results_tsv(tmp_path, [
+            _make_row(1, citations="https://example.com"),
+            _make_row(2),
+            _make_row(3, citations="#55"),
+            _make_row(4),
+            _make_row(5),
+        ])
+        coverage = citation_coverage(tmp_path)
+        assert coverage == 2 / 5
+
+    def test_full_coverage(self, tmp_path: Path) -> None:
+        """All cited experiments return 1.0 coverage."""
+        _write_results_tsv(tmp_path, [
+            _make_row(i, citations=f"ref-{i}") for i in range(1, 4)
+        ])
+        coverage = citation_coverage(tmp_path)
+        assert coverage == 1.0
+
+    def test_uses_last_10(self, tmp_path: Path) -> None:
+        """Coverage only considers the last 10 experiments."""
+        rows = [_make_row(i) for i in range(1, 13)]  # 12 uncited
+        rows[-1]["research_citations"] = "ref-12"  # only last is cited
+        _write_results_tsv(tmp_path, rows)
+        coverage = citation_coverage(tmp_path)
+        assert coverage == 1 / 10  # 1 cited in last 10
+
+
+class TestUncitedExperiments:
+    def test_empty_project(self, tmp_path: Path) -> None:
+        uncited = uncited_experiments(tmp_path)
+        assert uncited == []
+
+    def test_all_cited(self, tmp_path: Path) -> None:
+        _write_results_tsv(tmp_path, [
+            _make_row(1, citations="ref-1"),
+            _make_row(2, citations="ref-2"),
+        ])
+        uncited = uncited_experiments(tmp_path)
+        assert uncited == []
+
+    def test_some_uncited(self, tmp_path: Path) -> None:
+        _write_results_tsv(tmp_path, [
+            _make_row(1, citations="ref-1"),
+            _make_row(2),
+            _make_row(3, citations="ref-3"),
+            _make_row(4),
+        ])
+        uncited = uncited_experiments(tmp_path)
+        assert uncited == [2, 4]
+
+    def test_uses_last_10(self, tmp_path: Path) -> None:
+        """Only last 10 experiments are considered."""
+        rows = [_make_row(i, citations=f"ref-{i}") for i in range(1, 13)]  # 12 cited
+        rows[-1]["research_citations"] = ""  # last one uncited
+        _write_results_tsv(tmp_path, rows)
+        uncited = uncited_experiments(tmp_path)
+        assert uncited == [12]
+
+
+class TestCmdResearch:
+    def test_no_experiments(self, tmp_path: Path, capsys) -> None:
+        import argparse
+
+        args = argparse.Namespace(path=str(tmp_path))
+        ret = cmd_research(args)
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "No experiments recorded" in captured.out
+
+    def test_output_format(self, tmp_path: Path, capsys) -> None:
+        import argparse
+
+        _write_results_tsv(tmp_path, [
+            _make_row(1, hypothesis="Add structured logging", citations="https://example.com|#42"),
+            _make_row(2, hypothesis="Fix crash in parser"),
+        ])
+        args = argparse.Namespace(path=str(tmp_path))
+        ret = cmd_research(args)
+        assert ret == 0
+        captured = capsys.readouterr()
+        output = captured.out
+
+        # Check header
+        assert "ID" in output
+        assert "Hypothesis" in output
+        assert "Citations" in output
+
+        # Check rows
+        assert "Add structured logging" in output
+        assert "https://example.com" in output
+        assert "#42" in output
+        assert "Fix crash in parser" in output
+
+        # Check summary
+        assert "2 experiments" in output
+        assert "1 cited" in output
+        assert "50%" in output


### PR DESCRIPTION
## Summary

- Added `research_citations: list[str] = []` field to `ExperimentRecord` with backward-compatible TSV serialization (pipe-delimited, graceful handling of missing column in old TSV files)
- Created `factory/research_index.py` module with `build_citation_index()`, `citation_coverage()`, and `uncited_experiments()` functions
- Added `citation_ratio` sub-score (weight 0.20) to `eval_research_grounding()` in growth dimensions, rebalancing existing sub-score weights
- Added `factory research <path>` CLI command that prints a formatted citation table and coverage summary

## Test plan

- [x] 15 new tests in `tests/test_research_index.py` covering all functions and CLI output
- [x] Full test suite passes (773 tests, 0 failures)
- [x] `ruff check .` clean
- [x] `mypy factory/ --ignore-missing-imports` — 2 pre-existing errors only (in unrelated files)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)