### PR TITLE
fix(docs): keep diagrams readable in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,14 @@
+/* Diagrams render correctly in dark mode.
+ *
+ * D2-generated SVGs bake in light fills and dark navy text. In Material's
+ * slate scheme the page filter (brightness/contrast) muddies the colored
+ * shape backgrounds and washes out the text inside them. Wrap the SVGs in a
+ * white surface and disable any inherited image filter so the diagrams
+ * display with their intended contrast on dark pages.
+ */
+[data-md-color-scheme="slate"] .md-typeset img[src$=".svg"] {
+  background-color: #ffffff;
+  border-radius: 6px;
+  padding: 0.75rem;
+  filter: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,9 @@ theme:
   icon:
     repo: fontawesome/brands/github
 
+extra_css:
+  - stylesheets/extra.css
+
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
## Summary
- Fixes #76 — D2-generated SVG diagrams render with washed-out, low-contrast text on Material's slate (dark) scheme.
- Adds a tiny stylesheet (`docs/stylesheets/extra.css`) that, **only in slate**, gives diagram SVGs a white surface and clears any inherited image filter so the baked-in light fills + near-black text display with their intended contrast.
- Wires it in via `extra_css:` in `mkdocs.yml`.

## Why this approach
- Zero changes to the `.d2` sources or generated SVGs — diagrams stay single-file and don't need a light/dark variant pipeline.
- Light mode is untouched (selector is gated on `[data-md-color-scheme="slate"]`).
- Scoped to `.md-typeset img[src$=".svg"]`, so it doesn't affect badges or other inline SVG usages in the chrome.

## Test plan
- [x] `mkdocs build --strict` succeeds.
- [x] `extra.css` is emitted to `site/stylesheets/extra.css` and linked from rendered pages.
- [x] Confirmed the rendered `architecture/` page emits standard `<img src=".../diagrams/*.svg">` tags inside `.md-typeset`, so the selector matches.
- [ ] Reviewer toggles dark mode on the deployed Pages site and confirms the five diagrams (`architecture`, `data-flow`, `eval-system`, `experiment-lifecycle`, `state-machine`) are legible.