### PR TITLE
refactor: remove vault idea fuzzy matching, use file paths instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Initial public release.
 - **CEO Agent** — dedicated orchestrator with 5-state machine (no_repo, incomplete, no_factory, evals_pending_review, has_factory), automatic mode routing, and mandatory archival
 - **7 Specialist Agents** — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, each running as independent Claude Code subprocesses
 - **Experiment Loop** — every change is a hypothesis: measured before/after, kept or reverted based on composite eval score
-- **Universal Input** — accepts directories, GitHub URLs, Obsidian vault ideas, or raw text prompts
+- **Universal Input** — accepts directories, GitHub URLs, idea file paths, or raw text prompts
 
 ### Eval System
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-**Describe what you want. The Factory builds it, tests it, and keeps improving it — autonomously.** You can hand it a one-line prompt, a detailed spec, an idea note from your Obsidian vault, or an existing codebase. The Factory researches best practices, scaffolds the project, sets up evaluation, and then runs a continuous improvement loop — measuring every change and keeping only what makes things better. The agents that do this work learn from every experiment and get sharper over time.
+**Describe what you want. The Factory builds it, tests it, and keeps improving it — autonomously.** You can hand it a one-line prompt, a detailed spec, a path to an idea file, or an existing codebase. The Factory researches best practices, scaffolds the project, sets up evaluation, and then runs a continuous improvement loop — measuring every change and keeping only what makes things better. The agents that do this work learn from every experiment and get sharper over time.
 
 ```bash
 # Got an idea? Describe it.
 factory ceo --prompt "Build a CLI that converts CSV to JSON with streaming support"
 
-# Have ideas in your Obsidian vault? Just name one.
-factory ceo "weather dashboard"  # fuzzy-matches your vault notes, reads the full spec, builds it
+# Have an idea written up in a file? Pass the path.
+factory ceo ~/ideas/weather-dashboard.md  # reads the file as the build spec
 
 # Already have a repo? Point the factory at it.
 factory ceo ~/my-project
@@ -88,7 +88,7 @@ factory ceo --prompt "Build a REST API for bookmark management with tags and sea
 
 **Prerequisites:** Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated). See the [full setup guide](docs/setup.md).
 
-**Why Obsidian?** The vault is the factory's long-term memory. Experiment history, cross-project insights, research notes, and agent learnings all live there. If you use Claude to brainstorm ideas and save them as vault notes, the factory can build directly from those notes — just reference them by name. Without a vault, the factory still works but starts fresh every time. See [Obsidian setup](docs/setup.md#optional-obsidian-vault).
+**Why Obsidian?** The vault is the factory's long-term memory. Experiment history, cross-project insights, research notes, and agent learnings all live there. Without a vault, the factory still works but starts fresh every time. See [Obsidian setup](docs/setup.md#optional-obsidian-vault).
 
 ## What Can It Do?
 
@@ -97,7 +97,7 @@ factory ceo --prompt "Build a REST API for bookmark management with tags and sea
 | Input | What happens |
 |-------|-------------|
 | `factory ceo --prompt "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
-| `factory ceo "my idea name"` | Fuzzy-matches an idea note in your Obsidian vault, reads the full spec, and builds it end-to-end |
+| `factory ceo ~/ideas/my-idea.md` | Reads the file as the build spec and builds the project end-to-end |
 | `factory ceo https://github.com/user/repo` | Clones the repo, discovers what it does, sets up evaluation, then starts improving |
 
 **Improve what exists** — point it at any codebase:

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,14 +7,14 @@ hide:
 
 **Describe what you want. The Factory builds it, tests it, and keeps improving it — autonomously.**
 
-You can hand it a one-line prompt, a detailed spec, an idea note from your Obsidian vault, or an existing codebase. The Factory researches best practices, scaffolds the project, sets up evaluation, and then runs a continuous improvement loop — measuring every change and keeping only what makes things better. The agents that do this work learn from every experiment and get sharper over time.
+You can hand it a one-line prompt, a detailed spec, a path to an idea file, or an existing codebase. The Factory researches best practices, scaffolds the project, sets up evaluation, and then runs a continuous improvement loop — measuring every change and keeping only what makes things better. The agents that do this work learn from every experiment and get sharper over time.
 
 ```bash
 # Got an idea? Describe it.
 factory ceo --prompt "Build a CLI that converts CSV to JSON with streaming support"
 
-# Have ideas in your Obsidian vault? Just name one.
-factory ceo "weather dashboard"  # fuzzy-matches your vault notes, reads the full spec, builds it
+# Have an idea written up in a file? Pass the path.
+factory ceo ~/ideas/weather-dashboard.md  # reads the file as the build spec
 
 # Already have a repo? Point the factory at it.
 factory ceo ~/my-project
@@ -48,7 +48,7 @@ A CEO agent orchestrates six specialists — each running as an independent [Cla
 | Input | What happens |
 |-------|-------------|
 | `factory ceo --prompt "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
-| `factory ceo "my idea name"` | Fuzzy-matches an idea note in your Obsidian vault, reads the full spec, and builds it end-to-end |
+| `factory ceo ~/ideas/my-idea.md` | Reads the file as the build spec and builds the project end-to-end |
 | `factory ceo https://github.com/user/repo` | Clones the repo, discovers what it does, sets up evaluation, then starts improving |
 
 **Improve what exists** — point it at any codebase:
@@ -101,7 +101,7 @@ Each agent accumulates behavioral rules — DOs and DON'Ts — with evidence cou
 factory ceo ~/my-project --mode meta
 ```
 
-See [ACE Self-Improvement](ace.md) for details.
+See [Self-Improvement Loop](self-improvement.md) for the full picture — how the CEO tracks agents, how cross-project learning works, and how the CEO improves itself. See [ACE Self-Improvement](ace.md) for the playbook evolution mechanics.
 
 ## Architecture
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Each agent accumulates behavioral rules — DOs and DON'Ts — with evidence cou
 factory ceo ~/my-project --mode meta
 ```
 
-See [Self-Improvement Loop](self-improvement.md) for the full picture — how the CEO tracks agents, how cross-project learning works, and how the CEO improves itself. See [ACE Self-Improvement](ace.md) for the playbook evolution mechanics.
+See [ACE Self-Improvement](ace.md) for details.
 
 ## Architecture
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -853,9 +853,9 @@ def cmd_vault_init(args: argparse.Namespace) -> int:
     vault_result = init_vault()
     if vault_result is None:
         default = Path.home() / "obsidian-vaults" / "factory"
-        print(f"No vault path configured. Set FACTORY_VAULT_PATH or run:")
+        print("No vault path configured. Set FACTORY_VAULT_PATH or run:")
         print(f"  export FACTORY_VAULT_PATH={default}")
-        print(f"  factory vault-init")
+        print("  factory vault-init")
         return 1
     print(f"Factory vault initialized at {vault_result}")
     return 0

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1054,33 +1054,21 @@ def _is_github_url(path: str) -> bool:
 
 _PROJECTS_DIR = Path(os.environ.get("FACTORY_PROJECTS_DIR", str(Path.home() / "cursor-projects")))
 
-def _get_ideas_dirs() -> list[Path]:
-    """Return idea directories from the ``FACTORY_IDEAS_DIRS`` env var.
-
-    The env var is a colon-separated list of directory paths.  When unset,
-    returns an empty list so that vault lookup is skipped gracefully.
-    """
-    raw = os.environ.get("FACTORY_IDEAS_DIRS", "")
-    if not raw.strip():
-        return []
-    return [Path(p.strip()).expanduser() for p in raw.split(":") if p.strip()]
-
-
 def _resolve_input(raw: str) -> tuple[Path, str | None]:
     """Resolve any user input to (project_path, optional_context).
 
     Handles four input types in priority order:
     1. Existing directory → use directly
-    2. GitHub URL → clone
-    3. Vault idea name → fuzzy match, create repo, return idea as context
-    4. Raw prompt → create repo, return prompt as context
+    2. Existing file → read as spec, create repo
+    3. GitHub URL → clone
+    4. Raw prompt → create repo, use prompt as spec
     """
     # 1. Existing directory
     expanded = Path(raw).expanduser()
     if expanded.is_dir():
         return expanded.resolve(), None
 
-    # 1b. Existing file (e.g. path to a vault idea .md file)
+    # 2. Existing file (e.g. path to an idea/spec .md file)
     if expanded.is_file():
         idea_content = expanded.read_text()
         slug = _slugify(expanded.stem.split("—")[0].strip())
@@ -1091,25 +1079,12 @@ def _resolve_input(raw: str) -> tuple[Path, str | None]:
         print(f"Project directory: {project_path}")
         return project_path, idea_content
 
-    # 2. GitHub URL
+    # 3. GitHub URL
     if _is_github_url(raw):
         tmp_dir = tempfile.mkdtemp(prefix="factory-")
         subprocess.run(["git", "clone", raw, tmp_dir], check=True)
         print(f"Cloned {raw} → {tmp_dir}")
         return Path(tmp_dir).resolve(), None
-
-    # 3. Vault idea (fuzzy match)
-    match = _match_vault_idea(raw)
-    if match:
-        idea_content = match.read_text()
-        # Derive project name from idea title (before the em dash)
-        slug = _slugify(match.stem.split("\u2014")[0].strip())
-        project_path = _PROJECTS_DIR / slug
-        _ensure_repo(project_path)
-        _persist_spec(project_path, idea_content)
-        print(f"Matched vault idea: {match.stem}")
-        print(f"Project directory: {project_path}")
-        return project_path, idea_content
 
     # 4. Raw prompt
     slug = _slugify(raw[:50])
@@ -1119,40 +1094,6 @@ def _resolve_input(raw: str) -> tuple[Path, str | None]:
     print(f"New project from prompt: {project_path}")
     return project_path, raw
 
-
-def _match_vault_idea(query: str) -> Path | None:
-    """Fuzzy-match a query against vault idea filenames."""
-    q = query.lower().strip()
-    candidates: list[tuple[int, Path]] = []
-
-    for ideas_dir in _get_ideas_dirs():
-        if not ideas_dir.is_dir():
-            continue
-        for f in ideas_dir.glob("*.md"):
-            if f.name == "Ideas.md":
-                continue
-            stem = f.stem.lower()
-            short = stem.split("\u2014")[0].strip()  # part before em dash
-
-            # Exact match on full stem or short name
-            if q == stem or q == short:
-                return f
-
-            # Substring match
-            if q in stem:
-                # Score: shorter match = better (more specific)
-                candidates.append((len(stem), f))
-
-            # Word-level match: all query words appear in stem
-            q_words = q.split()
-            if len(q_words) > 1 and all(w in stem for w in q_words):
-                candidates.append((len(stem), f))
-
-    if not candidates:
-        return None
-    # Best match = shortest stem (most specific)
-    candidates.sort(key=lambda x: x[0])
-    return candidates[0][1]
 
 
 def _slugify(text: str) -> str:
@@ -1377,8 +1318,8 @@ def cmd_tmux_stop(args: argparse.Namespace) -> int:
 def _auto_detect_mode(project_path: Path, has_prompt: bool = False) -> str:
     """Detect the right mode based on project state.
 
-    When --prompt is provided, no_factory routes to build (not discover)
-    because the user is giving us a build spec for a new project.
+    When a build spec is available (--prompt, idea file, or raw prompt),
+    no_factory routes to build (not discover).
     """
     from factory.state import detect_state
     from factory.models import ProjectState
@@ -1840,7 +1781,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # ceo — launch the Factory CEO agent directly
     p = sub.add_parser("ceo", help="Launch the Factory CEO agent (interactive by default)")
-    p.add_argument("path", help="Project path, GitHub URL, vault idea name, or prompt")
+    p.add_argument("path", help="Project path, GitHub URL, idea file path, or prompt")
     p.add_argument(
         "--prompt", default=None,
         help="Path to a prompt/spec file (absolute or relative to project). "
@@ -1871,7 +1812,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # run
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
-    p.add_argument("path", help="Project path, GitHub URL, vault idea name, or prompt")
+    p.add_argument("path", help="Project path, GitHub URL, idea file path, or prompt")
     p.add_argument(
         "--prompt", default=None,
         help="Path to a prompt/spec file (absolute or relative to project). "

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1071,7 +1071,7 @@ def _resolve_input(raw: str) -> tuple[Path, str | None]:
     # 2. Existing file (e.g. path to an idea/spec .md file)
     if expanded.is_file():
         idea_content = expanded.read_text()
-        slug = _slugify(expanded.stem.split("—")[0].strip())
+        slug = _slugify(expanded.stem.split("\u2014")[0].strip())
         project_path = _PROJECTS_DIR / slug
         _ensure_repo(project_path)
         _persist_spec(project_path, idea_content)
@@ -1093,7 +1093,6 @@ def _resolve_input(raw: str) -> tuple[Path, str | None]:
     _persist_spec(project_path, raw)
     print(f"New project from prompt: {project_path}")
     return project_path, raw
-
 
 
 def _slugify(text: str) -> str:

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -995,7 +995,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         context = _read_prompt_file(project_path, prompt_file)
     mode = getattr(args, "mode", "auto")
     if mode == "auto":
-        mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file))
+        mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))
     headless = getattr(args, "headless", False)
     focus = getattr(args, "focus", None)
     min_growth = getattr(args, "min_growth", None)
@@ -1079,6 +1079,17 @@ def _resolve_input(raw: str) -> tuple[Path, str | None]:
     expanded = Path(raw).expanduser()
     if expanded.is_dir():
         return expanded.resolve(), None
+
+    # 1b. Existing file (e.g. path to a vault idea .md file)
+    if expanded.is_file():
+        idea_content = expanded.read_text()
+        slug = _slugify(expanded.stem.split("—")[0].strip())
+        project_path = _PROJECTS_DIR / slug
+        _ensure_repo(project_path)
+        _persist_spec(project_path, idea_content)
+        print(f"Idea file: {expanded.name}")
+        print(f"Project directory: {project_path}")
+        return project_path, idea_content
 
     # 2. GitHub URL
     if _is_github_url(raw):
@@ -1531,7 +1542,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         context = _read_prompt_file(project_path, prompt_file)
     mode = getattr(args, "mode", "auto")
     if mode == "auto":
-        mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file))
+        mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))
     loop = getattr(args, "loop", False)
     focus = getattr(args, "focus", None)
     min_growth = getattr(args, "min_growth", None)
@@ -1582,7 +1593,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             _emit_cli_event(project_path, "cycle.completed", {"cycle": cycle, "mode": mode})
 
             # Re-detect mode for next cycle (state may have advanced)
-            mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file))
+            mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))
 
             if shutdown_requested:
                 break

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,8 @@ import signal
 from datetime import datetime
 from unittest.mock import patch, AsyncMock
 
+import pytest
+
 from factory.cli import main, build_parser, _is_github_url, _slugify, _resolve_input, _persist_spec
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
@@ -769,21 +771,40 @@ class TestResolveInput:
         idea_file = tmp_path / "My Project \u2014 Something Cool.md"
         idea_file.write_text("# Build something cool")
 
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
-             patch("factory.cli.subprocess.run"):
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
             project_path, context = _resolve_input(str(idea_file))
 
         assert project_path.name == "my-project"
+        assert (project_path / ".git").is_dir()
         assert context is not None
         assert "Build something cool" in context
 
     def test_raw_prompt(self, tmp_path):
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
-             patch("factory.cli.subprocess.run"):
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
             project_path, context = _resolve_input("Build a todo app with FastAPI")
 
         assert project_path.parent == tmp_path / "projects"
+        assert (project_path / ".git").is_dir()
         assert context == "Build a todo app with FastAPI"
+
+    def test_non_md_file(self, tmp_path):
+        py_file = tmp_path / "script.py"
+        py_file.write_text("print('hello')")
+
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+            project_path, context = _resolve_input(str(py_file))
+
+        assert project_path.name == "script"
+        assert (project_path / ".git").is_dir()
+        assert context == "print('hello')"
+
+    def test_binary_file_raises(self, tmp_path):
+        bin_file = tmp_path / "data.bin"
+        bin_file.write_bytes(b"\x00\x01\x02\xff")
+
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
+             pytest.raises(UnicodeDecodeError):
+            _resolve_input(str(bin_file))
 
     def test_ceo_receives_context(self, tmp_path):
         """When an idea file is given, its content reaches the CEO task."""
@@ -791,7 +812,6 @@ class TestResolveInput:
         idea_file.write_text("# Test Idea\nBuild X that does Y")
 
         with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
-             patch("factory.cli.subprocess.run"), \
              patch("factory.cli._chain_modes", return_value=0), \
              patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
             main(["ceo", str(idea_file), "--headless"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ import signal
 from datetime import datetime
 from unittest.mock import patch, AsyncMock
 
-from factory.cli import main, build_parser, _is_github_url, _match_vault_idea, _slugify, _resolve_input, _persist_spec
+from factory.cli import main, build_parser, _is_github_url, _slugify, _resolve_input, _persist_spec
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -323,7 +323,8 @@ class TestCmdVaultInit:
         assert args.command == "vault-init"
 
     def test_vault_init_calls_init_vault(self, tmp_path, capsys, monkeypatch):
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "vault"))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(tmp_path / "vault"))
+        monkeypatch.delenv("OBSIDIAN_VAULT_PATH", raising=False)
         result = main(["vault-init"])
         assert result == 0
         out = capsys.readouterr().out
@@ -737,63 +738,6 @@ class TestSlugify:
         assert _slugify("!!!") == "factory-project"
 
 
-class TestMatchVaultIdea:
-    def test_exact_match(self, tmp_path):
-        ideas_dir = tmp_path / "Ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "Locals Know — Restaurant Discovery.md").write_text("# Locals Know")
-        (ideas_dir / "Ideas.md").write_text("# MOC")
-
-        with patch("factory.cli._get_ideas_dirs", return_value=[ideas_dir]):
-            match = _match_vault_idea("Locals Know")
-        assert match is not None
-        assert "Locals Know" in match.stem
-
-    def test_short_name_match(self, tmp_path):
-        ideas_dir = tmp_path / "Ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "Betty Terminal \u2014 AI-Native Terminal.md").write_text("# Betty")
-
-        with patch("factory.cli._get_ideas_dirs", return_value=[ideas_dir]):
-            match = _match_vault_idea("Betty Terminal")
-        assert match is not None
-
-    def test_substring_match(self, tmp_path):
-        ideas_dir = tmp_path / "Ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "Kalshi Bot \u2014 High-Probability Trader.md").write_text("# Kalshi")
-
-        with patch("factory.cli._get_ideas_dirs", return_value=[ideas_dir]):
-            match = _match_vault_idea("kalshi")
-        assert match is not None
-        assert "Kalshi" in match.stem
-
-    def test_no_match(self, tmp_path):
-        ideas_dir = tmp_path / "Ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "Some Idea.md").write_text("# Idea")
-
-        with patch("factory.cli._get_ideas_dirs", return_value=[ideas_dir]):
-            match = _match_vault_idea("nonexistent thing")
-        assert match is None
-
-    def test_skips_moc(self, tmp_path):
-        ideas_dir = tmp_path / "Ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "Ideas.md").write_text("# Ideas MOC")
-
-        with patch("factory.cli._get_ideas_dirs", return_value=[ideas_dir]):
-            match = _match_vault_idea("Ideas")
-        assert match is None
-
-    def test_multi_word_match(self, tmp_path):
-        ideas_dir = tmp_path / "Ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "Voice to Vault \u2014 Speak and Save.md").write_text("# V2V")
-
-        with patch("factory.cli._get_ideas_dirs", return_value=[ideas_dir]):
-            match = _match_vault_idea("voice vault")
-        assert match is not None
 
 
 class TestPersistSpec:
@@ -821,23 +765,20 @@ class TestResolveInput:
         assert project_path == tmp_path
         assert context is None
 
-    def test_vault_idea(self, tmp_path):
-        ideas_dir = tmp_path / "Ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "My Project \u2014 Something Cool.md").write_text("# Build something cool")
+    def test_idea_file(self, tmp_path):
+        idea_file = tmp_path / "My Project \u2014 Something Cool.md"
+        idea_file.write_text("# Build something cool")
 
-        with patch("factory.cli._get_ideas_dirs", return_value=[ideas_dir]), \
-             patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
              patch("factory.cli.subprocess.run"):
-            project_path, context = _resolve_input("My Project")
+            project_path, context = _resolve_input(str(idea_file))
 
         assert project_path.name == "my-project"
         assert context is not None
         assert "Build something cool" in context
 
     def test_raw_prompt(self, tmp_path):
-        with patch("factory.cli._get_ideas_dirs", return_value=[tmp_path / "nope"]), \
-             patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
              patch("factory.cli.subprocess.run"):
             project_path, context = _resolve_input("Build a todo app with FastAPI")
 
@@ -845,17 +786,15 @@ class TestResolveInput:
         assert context == "Build a todo app with FastAPI"
 
     def test_ceo_receives_context(self, tmp_path):
-        """When a vault idea is matched, its content reaches the CEO task."""
-        ideas_dir = tmp_path / "Ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "Test Idea \u2014 Details.md").write_text("# Test Idea\nBuild X that does Y")
+        """When an idea file is given, its content reaches the CEO task."""
+        idea_file = tmp_path / "Test Idea \u2014 Details.md"
+        idea_file.write_text("# Test Idea\nBuild X that does Y")
 
-        with patch("factory.cli._get_ideas_dirs", return_value=[ideas_dir]), \
-             patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
              patch("factory.cli.subprocess.run"), \
              patch("factory.cli._chain_modes", return_value=0), \
              patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            main(["ceo", "Test Idea", "--headless"])
+            main(["ceo", str(idea_file), "--headless"])
 
         task_arg = mock_agent.call_args[0][1]  # second positional = task
         assert "Build X that does Y" in task_arg

--- a/tests/test_vault_decouple.py
+++ b/tests/test_vault_decouple.py
@@ -1,4 +1,4 @@
-"""Tests for vault decoupling — FACTORY_VAULT_PATH / FACTORY_IDEAS_DIRS env vars."""
+"""Tests for vault decoupling — FACTORY_VAULT_PATH env var."""
 
 from __future__ import annotations
 
@@ -45,7 +45,6 @@ def _clean_vault_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Remove all vault-related env vars so each test starts clean."""
     monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
     monkeypatch.delenv("OBSIDIAN_VAULT_PATH", raising=False)
-    monkeypatch.delenv("FACTORY_IDEAS_DIRS", raising=False)
     # Disable obsidian-cli so write functions fall back to direct file I/O
     monkeypatch.setattr(
         "factory.obsidian.notes._obsidian_create",
@@ -176,62 +175,12 @@ class TestVaultConfigured:
         assert path.exists()
 
 
-# ── _resolve_input / _get_ideas_dirs ─────────────────────────────
 
-
-class TestIdeasDirs:
-    def test_empty_when_unset(self) -> None:
-        from factory.cli import _get_ideas_dirs
-
-        assert _get_ideas_dirs() == []
-
-    def test_single_path(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        from factory.cli import _get_ideas_dirs
-
-        monkeypatch.setenv("FACTORY_IDEAS_DIRS", str(tmp_path / "ideas"))
-        result = _get_ideas_dirs()
-        assert len(result) == 1
-        assert result[0] == tmp_path / "ideas"
-
-    def test_multiple_paths(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        from factory.cli import _get_ideas_dirs
-
-        p1 = tmp_path / "ideas1"
-        p2 = tmp_path / "ideas2"
-        monkeypatch.setenv("FACTORY_IDEAS_DIRS", f"{p1}:{p2}")
-        result = _get_ideas_dirs()
-        assert len(result) == 2
-        assert result[0] == p1
-        assert result[1] == p2
-
-    def test_ignores_empty_segments(
-        self, monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        from factory.cli import _get_ideas_dirs
-
-        monkeypatch.setenv("FACTORY_IDEAS_DIRS", ":/foo::")
-        result = _get_ideas_dirs()
-        assert len(result) == 1
-        assert result[0] == Path("/foo")
-
-    def test_expands_tilde(
-        self, monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        from factory.cli import _get_ideas_dirs
-
-        monkeypatch.setenv("FACTORY_IDEAS_DIRS", "~/my-ideas")
-        result = _get_ideas_dirs()
-        assert len(result) == 1
-        assert "~" not in str(result[0])
-        assert str(result[0]).startswith("/")
+# ── _resolve_input ─────────────────────────────────────────────
 
 
 class TestResolveInputWithoutVault:
-    """_resolve_input works when FACTORY_IDEAS_DIRS is unset (no vault)."""
+    """_resolve_input works for directory and prompt inputs."""
 
     def test_existing_dir_works(self, tmp_path: Path) -> None:
         from factory.cli import _resolve_input
@@ -254,37 +203,17 @@ class TestResolveInputWithoutVault:
         assert path.exists()
         assert ctx == "build a weather dashboard"
 
-
-class TestMatchVaultIdea:
-    def test_returns_none_with_no_ideas_dirs(self) -> None:
-        from factory.cli import _match_vault_idea
-
-        assert _match_vault_idea("some idea") is None
-
-    def test_matches_idea_file(
+    def test_idea_file(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        from factory.cli import _match_vault_idea
+        import factory.cli as cli_mod
+        from factory.cli import _resolve_input
 
-        ideas_dir = tmp_path / "ideas"
-        ideas_dir.mkdir()
-        idea = ideas_dir / "Weather Dashboard — live forecast.md"
-        idea.write_text("# Weather Dashboard\nShow forecasts.")
-        monkeypatch.setenv("FACTORY_IDEAS_DIRS", str(ideas_dir))
+        monkeypatch.setattr(cli_mod, "_PROJECTS_DIR", tmp_path / "projects")
+        idea_file = tmp_path / "Weather Dashboard \u2014 live forecast.md"
+        idea_file.write_text("# Weather Dashboard\nShow forecasts.")
 
-        result = _match_vault_idea("weather dashboard")
-        assert result is not None
-        assert result == idea
-
-    def test_skips_ideas_md(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        from factory.cli import _match_vault_idea
-
-        ideas_dir = tmp_path / "ideas"
-        ideas_dir.mkdir()
-        (ideas_dir / "Ideas.md").write_text("# Ideas MOC")
-        monkeypatch.setenv("FACTORY_IDEAS_DIRS", str(ideas_dir))
-
-        result = _match_vault_idea("ideas")
-        assert result is None
+        path, ctx = _resolve_input(str(idea_file))
+        assert path.parent == tmp_path / "projects"
+        assert ctx is not None
+        assert "Weather Dashboard" in ctx


### PR DESCRIPTION
## Summary
- **Removes** the vault idea fuzzy matching system (`_match_vault_idea`, `_get_ideas_dirs`, `FACTORY_IDEAS_DIRS` env var). Users no longer pass an idea name that gets searched across Obsidian vault directories.
- **Replaces** with direct file path input: `factory ceo ~/ideas/my-idea.md` reads the file as the build spec. Simpler, explicit, no magic.
- **Fixes** auto-mode detection: context from file paths and raw prompts now correctly routes to `build` mode (was falling through to `discover`).
- **Fixes** vault-init test: uses `FACTORY_VAULT_PATH` (canonical) instead of `OBSIDIAN_VAULT_PATH` which was shadowed on machines with both set.
- **Updates** README, docs/index.md, CHANGELOG, and all tests.

The factory vault (`FACTORY_VAULT_PATH`) remains unchanged — it's the Archivist's write target, not an input source.

## Input resolution (after this PR)

| Priority | Input | Behavior |
|----------|-------|----------|
| 1 | Existing directory | Use as project path |
| 2 | Existing file | Read as spec, create project |
| 3 | GitHub URL | Clone repo |
| 4 | Raw prompt string | Create project from prompt |

## Test plan
- [x] All 104 tests pass (was 117 — removed 13 vault-idea-specific tests, fixed 1 pre-existing failure)
- [ ] Manual: `factory ceo ~/path/to/idea.md` → builds from file
- [ ] Manual: `factory ceo ~/existing-project` → discovers (no regression)
- [ ] Manual: `factory ceo "Build me X"` → builds from prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)