### PR TITLE
fix: repair 13 pre-existing test failures

### DIFF
--- a/tests/eval/test_runner.py
+++ b/tests/eval/test_runner.py
@@ -1,5 +1,7 @@
 """Tests for factory.eval.runner — mandatory dimensions + project eval execution."""
 
+import sys
+
 from factory.eval.runner import run_eval
 
 
@@ -33,7 +35,7 @@ class TestRunEval:
             '{"name": "api_health", "score": 1.0, "weight": 0.5, "passed": True, "details": "up"}'
             ']}, sys.stdout)\n'
         )
-        result = await run_eval(f"python {script}", tmp_path, threshold=0.0)
+        result = await run_eval(f"{sys.executable} {script}", tmp_path, threshold=0.0)
         names = {r.name for r in result.results}
         # 11 mandatory + 2 project additions
         assert "ui_renders" in names
@@ -49,7 +51,7 @@ class TestRunEval:
             '{"name": "tests", "score": 0.0, "weight": 1.0, "passed": false, "details": "fake override"}'
             ']}, sys.stdout)\n'
         )
-        result = await run_eval(f"python {script}", tmp_path, threshold=0.0)
+        result = await run_eval(f"{sys.executable} {script}", tmp_path, threshold=0.0)
         # The "tests" dimension should come from hygiene, not the project override
         test_results = [r for r in result.results if r.name == "tests"]
         assert len(test_results) == 1
@@ -74,7 +76,7 @@ class TestRunEval:
         """Project eval timeout doesn't prevent mandatory dimensions."""
         script = tmp_path / "hang.py"
         script.write_text("import time\ntime.sleep(60)\n")
-        result = await run_eval(f"python {script}", tmp_path, threshold=0.0, timeout=1.0)
+        result = await run_eval(f"{sys.executable} {script}", tmp_path, threshold=0.0, timeout=1.0)
         # Mandatory dimensions still computed
         names = {r.name for r in result.results}
         assert len(names) >= 11

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -267,6 +267,7 @@ class TestFormatDigest:
 
 class TestCmdDigest:
     def test_digest_default(self, populated_vault: Path, monkeypatch, capsys):
+        monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(populated_vault))
         result = main(["digest"])
         assert result == 0
@@ -275,6 +276,7 @@ class TestCmdDigest:
         assert "project-a" in out
 
     def test_digest_specific_date(self, populated_vault: Path, monkeypatch, capsys):
+        monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(populated_vault))
         today = date.today().isoformat()
         result = main(["digest", "--date", today])
@@ -284,6 +286,7 @@ class TestCmdDigest:
         assert "Add auth module" in out
 
     def test_digest_no_vault(self, tmp_path: Path, monkeypatch, capsys):
+        monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "nonexistent"))
         result = main(["digest"])
         assert result == 0

--- a/tests/test_obsidian.py
+++ b/tests/test_obsidian.py
@@ -20,6 +20,7 @@ from factory.obsidian.notes import (
 @pytest.fixture(autouse=True)
 def set_vault_path(obsidian_vault, monkeypatch):
     """Set OBSIDIAN_VAULT_PATH to temp dir and disable obsidian-cli for all tests."""
+    monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
     monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(obsidian_vault))
     # Disable obsidian-cli so write functions always fall back to direct file I/O.
     # Individual tests in TestObsidianCli override this as needed.

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -5,6 +5,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from factory.study import (
     _detect_self_improvement,
     _extract_keywords,
@@ -322,6 +324,7 @@ class TestStudyProjectLocal:
 
     def test_includes_obsidian_notes(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "vault"))
 
         project_path = tmp_path / "myapp"
@@ -642,6 +645,10 @@ class TestFetchOpenIssues:
 
 
 class TestReadObsidianNotes:
+    @pytest.fixture(autouse=True)
+    def _clear_factory_vault(self, monkeypatch):
+        monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
+
     def test_reads_notes(self, tmp_path, monkeypatch):
         vault = tmp_path / "vault"
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))


### PR DESCRIPTION
## Summary

- **test_runner.py**: `python` is a shell alias, not a binary — `asyncio.create_subprocess_exec` can't resolve it. Use `sys.executable` instead.
- **test_digest.py, test_obsidian.py, test_study.py**: Tests set `OBSIDIAN_VAULT_PATH` to a temp dir, but `FACTORY_VAULT_PATH` was already set in the real environment and takes precedence in `_get_vault_path()`. Added `monkeypatch.delenv("FACTORY_VAULT_PATH")` so the test fixtures take effect.

## Test plan

- [x] All 862 tests pass (was 849 passed / 13 failed)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)