### PR TITLE
feat: add factory deferred-remove/deferred-list CLI commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ factory checkpoint /path/to/project             # Save CEO state for crash recov
 factory resume /path/to/project                 # Resume from saved checkpoint
 factory diff /path --exp1 N --exp2 M            # Compare two experiments
 factory explain /path --exp N                   # Explain experiment with FEEC analysis
+factory deferred-list /path                     # List pending deferred items
+factory deferred-remove /path "item text"       # Remove a completed deferred item
 factory precheck /path --score-before 0.7 --score-after 0.85  # Hard precheck gate
 factory review --verdict KEEP --pr 42           # Post structured review on GitHub PR
 ```

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -716,8 +716,8 @@ uv run python -m factory finalize "$PROJECT_PATH" \
     --notes "ceo:keep score_delta=+X.XXXX precheck=passed agents_spawned=R,S,B,R,E"
 
 # If this experiment addressed a deferred item, remove it from deferred.md
-# Check the hypothesis for a **Deferred item:** tag — if present, remove that
-# line from .factory/strategy/deferred.md so it's not re-prioritized next cycle.
+# Check the hypothesis for a **Deferred item:** tag — if present, run:
+uv run python -m factory deferred-remove "$PROJECT_PATH" "<exact deferred item text>"
 ```
 
 **If precheck FAILS → Mandatory Revert:**

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -324,6 +324,31 @@ def cmd_study(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_deferred_remove(args: argparse.Namespace) -> int:
+    from factory.study import remove_deferred_item
+
+    project_path = Path(args.path)
+    item_text = args.item
+    if remove_deferred_item(project_path, item_text):
+        print(f"Removed deferred item: {item_text}")
+        return 0
+    print(f"Deferred item not found: {item_text}", file=sys.stderr)
+    return 1
+
+
+def cmd_deferred_list(args: argparse.Namespace) -> int:
+    from factory.study import _parse_deferred_items
+
+    project_path = Path(args.path)
+    items = _parse_deferred_items(project_path)
+    if not items:
+        print("No deferred items.")
+        return 0
+    for item in items:
+        print(f"- {item}")
+    return 0
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     from factory.state import detect_state
     from factory.store import ExperimentStore
@@ -1671,6 +1696,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory containing factory-managed projects for cross-project insights",
     )
 
+    # deferred-remove
+    p = sub.add_parser("deferred-remove", help="Remove a completed deferred item")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("item", help="Exact text of the deferred item to remove")
+
+    # deferred-list
+    p = sub.add_parser("deferred-list", help="List pending deferred items")
+    p.add_argument("path", help="Path to the project")
+
     # status
     p = sub.add_parser("status", help="Print project status summary")
     p.add_argument("path", help="Path to the project")
@@ -1930,6 +1964,8 @@ def main(argv: list[str] | None = None) -> int:
         "history": cmd_history,
         "notify": cmd_notify,
         "study": cmd_study,
+        "deferred-remove": cmd_deferred_remove,
+        "deferred-list": cmd_deferred_list,
         "status": cmd_status,
         "research": cmd_research,
         "diff": cmd_diff,

--- a/factory/study.py
+++ b/factory/study.py
@@ -372,6 +372,41 @@ def _persist_deferred_items(project_path: Path, items: list[str]) -> None:
     deferred_path.write_text("\n".join(lines) + "\n")
 
 
+def remove_deferred_item(project_path: Path, item_text: str) -> bool:
+    """Remove a completed deferred item from deferred.md by exact match.
+
+    Returns True if the item was found and removed, False otherwise.
+    """
+    deferred_path = project_path / ".factory" / "strategy" / "deferred.md"
+    if not deferred_path.exists():
+        return False
+
+    try:
+        content = deferred_path.read_text()
+    except OSError:
+        return False
+
+    remaining: list[str] = []
+    found = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        m = _BULLET_PREFIX_RE.match(stripped)
+        if m and stripped[m.end():].strip() == item_text:
+            found = True
+            continue
+        if stripped:
+            remaining.append(line)
+
+    if not found:
+        return False
+
+    if remaining:
+        deferred_path.write_text("\n".join(remaining) + "\n")
+    else:
+        deferred_path.unlink()
+    return True
+
+
 def _path_to_slug(project_path: Path) -> str:
     """Convert a project path to Claude's directory slug format.
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -21,6 +21,7 @@ from factory.study import (
     _persist_deferred_items,
     _read_obsidian_notes,
     _search_similar_projects,
+    remove_deferred_item,
     study_project,
     study_project_local,
 )
@@ -1110,3 +1111,105 @@ class TestStudyDeferredIntegration:
             result = study_project_local(project_path)
         assert "Deferred Items" not in result
         assert "Deferred slots" not in result
+
+
+class TestRemoveDeferredItem:
+    def test_removes_exact_match(self, tmp_path):
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "deferred.md").write_text(
+            "- Camera feed\n- OAuth login\n- Genre expansion\n"
+        )
+        assert remove_deferred_item(tmp_path, "OAuth login") is True
+        content = (strategy_dir / "deferred.md").read_text()
+        assert "OAuth login" not in content
+        assert "Camera feed" in content
+        assert "Genre expansion" in content
+
+    def test_returns_false_when_not_found(self, tmp_path):
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "deferred.md").write_text("- Camera feed\n")
+        assert remove_deferred_item(tmp_path, "Nonexistent item") is False
+
+    def test_returns_false_when_no_file(self, tmp_path):
+        assert remove_deferred_item(tmp_path, "Anything") is False
+
+    def test_deletes_file_when_last_item_removed(self, tmp_path):
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "deferred.md").write_text("- Only item\n")
+        assert remove_deferred_item(tmp_path, "Only item") is True
+        assert not (strategy_dir / "deferred.md").exists()
+
+    def test_no_partial_match(self, tmp_path):
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "deferred.md").write_text("- Camera feed integration\n")
+        assert remove_deferred_item(tmp_path, "Camera feed") is False
+        assert (strategy_dir / "deferred.md").exists()
+
+    def test_handles_different_bullet_styles(self, tmp_path):
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "deferred.md").write_text("* Camera feed\n")
+        assert remove_deferred_item(tmp_path, "Camera feed") is True
+        assert not (strategy_dir / "deferred.md").exists()
+
+
+class TestCmdDeferredRemove:
+    def test_cli_subcommand_exists(self):
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["deferred-remove", "/some/path", "some item"])
+        assert args.command == "deferred-remove"
+        assert args.path == "/some/path"
+        assert args.item == "some item"
+
+    def test_removes_item_via_cli(self, tmp_path):
+        from factory.cli import main
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "deferred.md").write_text("- Camera feed\n- OAuth\n")
+        result = main(["deferred-remove", str(tmp_path), "Camera feed"])
+        assert result == 0
+        assert "Camera feed" not in (strategy_dir / "deferred.md").read_text()
+
+    def test_returns_error_when_not_found(self, tmp_path):
+        from factory.cli import main
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "deferred.md").write_text("- Camera feed\n")
+        result = main(["deferred-remove", str(tmp_path), "Nonexistent"])
+        assert result == 1
+
+
+class TestCmdDeferredList:
+    def test_cli_subcommand_exists(self):
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["deferred-list", "/some/path"])
+        assert args.command == "deferred-list"
+
+    def test_lists_items(self, tmp_path, capsys):
+        from factory.cli import main
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "deferred.md").write_text("- Camera feed\n- OAuth login\n")
+        result = main(["deferred-list", str(tmp_path)])
+        assert result == 0
+        output = capsys.readouterr().out
+        assert "Camera feed" in output
+        assert "OAuth login" in output
+
+    def test_empty_list(self, tmp_path, capsys):
+        from factory.cli import main
+
+        result = main(["deferred-list", str(tmp_path)])
+        assert result == 0
+        assert "No deferred items" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Follow-up to #84 — replaces the CEO's natural-language text editing of `deferred.md` with exact-match CLI commands, eliminating the risk of misidentifying or partially matching deferred items.

- `factory deferred-remove <path> "<item>"` — exact-match removal from `deferred.md`; deletes the file when the last item is removed
- `factory deferred-list <path>` — lists pending deferred items
- `remove_deferred_item()` in study.py uses regex-based bullet parsing for consistent handling
- CEO prompt updated to use `factory deferred-remove` in the keep flow
- 12 new tests: exact match, partial match rejection, file cleanup on last item, CLI integration

## Test plan

- [x] All 900 tests pass (888 existing + 12 new)
- [x] ruff clean
- [x] `test_no_partial_match` — verifies "Camera feed" does NOT match "Camera feed integration"
- [x] `test_deletes_file_when_last_item_removed` — verifies cleanup
- [x] `test_removes_item_via_cli` — end-to-end CLI test

🤖 Generated with [Claude Code](https://claude.com/claude-code)