### PR TITLE
fix: parse bold-text deferred headings + standardize Build mode output

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -216,6 +216,16 @@ Generate a phased build plan as GitHub issues:
 - Phase 1: Project scaffold + eval harness (always first)
 - Phase 2-N: Feature implementation in dependency order
 Each issue should be one PR's worth of work.
+
+At the end of the plan, add a section for items not included in MVP:
+
+## Deferred
+
+- <item 1>
+- <item 2>
+
+This section MUST use a markdown heading (## Deferred) — not bold text or other formatting. Items listed here will be automatically prioritized when the project enters Improve mode.
+
 Write the plan to .factory/strategy/current.md." --project "$PROJECT_PATH" --timeout 300
 ```
 
@@ -230,9 +240,16 @@ This is a **hard gate**. The Builder MUST NOT start until you approve the plan.
    - Is Phase 1 always scaffold + eval harness?
    - Is the total scope achievable or is it over-ambitious?
    - Are there any phases that should be split, merged, or reordered?
+   - **Does the plan have a `## Deferred` section?** If items were excluded from MVP scope, they MUST be listed under a `## Deferred` heading (not bold text, not inline mentions). REDIRECT if deferred items exist but aren't in a proper `## Deferred` section.
 3. Write verdict to `.factory/reviews/ceo-verdict-strategist.md`
 4. If REDIRECT: re-invoke the Strategist with specific corrections (e.g., "Phase 3 is too large — split into 3a and 3b", "Missing error handling phase")
-5. If PROCEED: write `PLAN APPROVED` in your verdict file, then continue to B2
+5. If PROCEED: write `PLAN APPROVED` in your verdict file, then persist deferred items:
+
+```bash
+uv run python -m factory deferred-list "$PROJECT_PATH"
+```
+
+If deferred items were parsed, they are now in `.factory/strategy/deferred.md` and will survive future strategy rewrites. Continue to B2.
 
 ### B2: MANDATORY Archivist — record approved plan (DO NOT SKIP)
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -337,13 +337,14 @@ def cmd_deferred_remove(args: argparse.Namespace) -> int:
 
 
 def cmd_deferred_list(args: argparse.Namespace) -> int:
-    from factory.study import _parse_deferred_items
+    from factory.study import _parse_deferred_items, _persist_deferred_items
 
     project_path = Path(args.path)
     items = _parse_deferred_items(project_path)
     if not items:
         print("No deferred items.")
         return 0
+    _persist_deferred_items(project_path, items)
     for item in items:
         print(f"- {item}")
     return 0

--- a/factory/study.py
+++ b/factory/study.py
@@ -290,10 +290,6 @@ def _analyze_observability(project_path: Path, language: str = "python") -> dict
     }
 
 
-_DEFERRED_KEYWORDS_RE = re.compile(
-    r"(deferred|post[-\s]mvp|future\s+work|backlog)",
-    re.IGNORECASE,
-)
 _DEFERRED_HEADING_RE = re.compile(
     r"^(?:#{1,4}\s+|\*\*).*(deferred|post[-\s]mvp|future\s+work|backlog).*$",
     re.IGNORECASE,

--- a/factory/study.py
+++ b/factory/study.py
@@ -290,11 +290,15 @@ def _analyze_observability(project_path: Path, language: str = "python") -> dict
     }
 
 
-_DEFERRED_HEADING_RE = re.compile(
-    r"^#{1,4}\s+.*(deferred|post[-\s]mvp|future\s+work|backlog).*$",
+_DEFERRED_KEYWORDS_RE = re.compile(
+    r"(deferred|post[-\s]mvp|future\s+work|backlog)",
     re.IGNORECASE,
 )
-_ANY_HEADING_RE = re.compile(r"^#{1,4}\s+")
+_DEFERRED_HEADING_RE = re.compile(
+    r"^(?:#{1,4}\s+|\*\*).*(deferred|post[-\s]mvp|future\s+work|backlog).*$",
+    re.IGNORECASE,
+)
+_ANY_HEADING_RE = re.compile(r"^(?:#{1,4}\s+|\*\*[A-Z])")
 _BULLET_PREFIX_RE = re.compile(r"^[-*•]\s+")
 
 

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -987,6 +987,27 @@ class TestExtractDeferredBullets:
         content = "## Deferred\nSome paragraph text.\n- Actual item\n\nMore text.\n"
         assert _extract_deferred_bullets(content) == ["Actual item"]
 
+    def test_bold_text_heading(self):
+        content = (
+            "**Total estimated phases:** 5\n\n"
+            "**What is deferred (post-MVP):**\n"
+            "- Docker-Wyze-Bridge\n- RSS feed\n- Deployment\n\n"
+        )
+        assert _extract_deferred_bullets(content) == [
+            "Docker-Wyze-Bridge", "RSS feed", "Deployment",
+        ]
+
+    def test_bold_heading_stops_at_next_bold_heading(self):
+        content = (
+            "**Deferred:**\n- Item one\n- Item two\n"
+            "**Other section:**\n- Not deferred\n"
+        )
+        assert _extract_deferred_bullets(content) == ["Item one", "Item two"]
+
+    def test_bold_heading_stops_at_markdown_heading(self):
+        content = "**Backlog:**\n- Backlog item\n## Next Phase\n- Phase item\n"
+        assert _extract_deferred_bullets(content) == ["Backlog item"]
+
 
 class TestParseDeferredItems:
     def test_returns_empty_when_no_factory_dir(self, tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #84/#85 — discovered during real testing on backyard-chronicle that the deferred-item parser missed all 10 items because Build mode's Strategist wrote `**What is deferred (post-MVP):**` (bold text) instead of `## Deferred` (markdown heading).

Three fixes:
- **Parser regex** now matches both `## Deferred` and `**Deferred:**` style headings
- **Build mode Strategist task** explicitly requires `## Deferred` heading format
- **Build mode CEO review gate** checks deferred section format and runs `factory deferred-list` to persist items to `deferred.md` after plan approval
- **`deferred-list` command** now auto-persists items it finds, ensuring `deferred.md` stays in sync

Verified against backyard-chronicle's actual `current.md` — all 10 deferred items now parsed correctly.

## Test plan

- [x] 903 tests pass (3 new bold-heading tests)
- [x] ruff clean
- [x] Verified `_extract_deferred_bullets()` against live backyard-chronicle file — returns all 10 items
- [x] `test_bold_text_heading` — the exact format from backyard-chronicle
- [x] `test_bold_heading_stops_at_next_bold_heading` — section boundary handling
- [x] `test_bold_heading_stops_at_markdown_heading` — mixed heading styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)