### PR TITLE
fix: remove all hardcoded user-specific paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ factory run /path/to/project                    # Same as factory ceo
 factory run /path/to/project --loop --interval 1800  # Continuous heartbeat
 factory tmux /path/to/project --loop            # In detached tmux session
 factory agent researcher --task "..." --project /path  # Invoke a specialist directly
-factory dashboard --projects-dir ~/cursor-projects    # Live web dashboard on :8420
+factory dashboard --projects-dir ~/factory-projects    # Live web dashboard on :8420
 factory export /path/to/project                 # Dump full project snapshot as JSON
 factory checkpoint /path/to/project             # Save CEO state for crash recovery
 factory resume /path/to/project                 # Resume from saved checkpoint

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd remote-factory && uv sync && uv tool install -e .
 factory install
 
 # Set up the Obsidian vault (highly recommended — gives the factory persistent memory)
-export FACTORY_VAULT_PATH=~/obsidian-vaults/factory
+export FACTORY_VAULT_PATH=~/factory-vault
 factory vault-init
 
 # Build something

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,9 @@ Generated at runtime by the factory. Add to `.gitignore` — do not edit manuall
 
 The Factory spawns Claude Code as subprocesses — it does not call the Claude API directly. Configure Claude Code authentication however you normally would (API key, Vertex AI, etc.).
 
-| Variable | Purpose | Required |
-|----------|---------|----------|
-| `FACTORY_VAULT_PATH` | Custom Obsidian vault path | Optional |
-| `FACTORY_PROJECTS_DIR` | Override default projects directory | Optional |
+| Variable | Purpose | Default | Required |
+|----------|---------|---------|----------|
+| `FACTORY_VAULT_PATH` | Obsidian vault for persistent cross-project memory | *(none — vault features disabled)* | Optional |
+| `FACTORY_PROJECTS_DIR` | Parent directory for prompt-created projects | `~/factory-projects` | Optional |
+| `FACTORY_PLAYBOOKS_DIR` | Directory for ACE-evolved agent playbooks | `~/.factory/playbooks` | Optional |
+| `FACTORY_MODEL` | Model override for agent subprocesses | *(Claude Code default)* | Optional |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ factory ceo "Build a CLI that converts CSV to JSON with streaming support"
 
 This will:
 
-1. Create a project directory at `~/cursor-projects/build-a-cli-that-converts-csv-to-json-with-streami/`
+1. Create a project directory at `~/factory-projects/build-a-cli-that-converts-csv-to-json-with-streami/`
 2. Initialize a git repo
 3. Save your prompt as the build spec (`.factory/strategy/current.md`)
 4. Launch the CEO agent in interactive mode

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ cd remote-factory && uv sync && uv tool install -e .
 factory install
 
 # Set up the Obsidian vault (highly recommended)
-export FACTORY_VAULT_PATH=~/obsidian-vaults/factory
+export FACTORY_VAULT_PATH=~/factory-vault
 factory vault-init
 ```
 

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -66,7 +66,7 @@ Activate Mode 3 when ANY of these are true:
 
 1. **Run cross-project insights first**:
    ```bash
-   uv run python -m factory insights "$PROJECT_PATH" --projects-dir ~/cursor-projects
+   uv run python -m factory insights "$PROJECT_PATH" --projects-dir "${FACTORY_PROJECTS_DIR:-~/factory-projects}"
    ```
    This generates `.factory/strategy/insights.md` with category success rates and patterns across all managed projects.
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -894,9 +894,8 @@ def cmd_vault_init(args: argparse.Namespace) -> int:
 
     vault_result = init_vault()
     if vault_result is None:
-        default = Path.home() / "obsidian-vaults" / "factory"
         print("No vault path configured. Set FACTORY_VAULT_PATH or run:")
-        print(f"  export FACTORY_VAULT_PATH={default}")
+        print("  export FACTORY_VAULT_PATH=~/factory-vault")
         print("  factory vault-init")
         return 1
     print(f"Factory vault initialized at {vault_result}")
@@ -1114,7 +1113,7 @@ def _resolve_model(args: argparse.Namespace) -> str | None:
     return env or None
 
 
-_PROJECTS_DIR = Path(os.environ.get("FACTORY_PROJECTS_DIR", str(Path.home() / "cursor-projects")))
+_PROJECTS_DIR = Path(os.environ.get("FACTORY_PROJECTS_DIR", str(Path.home() / "factory-projects")))
 
 def _resolve_input(raw: str) -> tuple[Path, str | None]:
     """Resolve any user input to (project_path, optional_context).
@@ -1776,16 +1775,16 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("insights", help="Cross-project analysis of experiment histories")
     p.add_argument("path", help="Path to the project (insights.md written here)")
     p.add_argument(
-        "--projects-dir", default="~/cursor-projects",
-        help="Directory containing factory-managed projects (default: ~/cursor-projects)",
+        "--projects-dir", default="~/factory-projects",
+        help="Directory containing factory-managed projects (default: ~/factory-projects)",
     )
 
     # ace
     p = sub.add_parser("ace", help="Run ACE self-improvement on agent playbooks")
     p.add_argument("path", help="Path to the project")
     p.add_argument(
-        "--projects-dir", default="~/cursor-projects",
-        help="Directory containing factory-managed projects (default: ~/cursor-projects)",
+        "--projects-dir", default="~/factory-projects",
+        help="Directory containing factory-managed projects (default: ~/factory-projects)",
     )
     p.add_argument(
         "--dry-run", action="store_true", default=False,
@@ -1867,8 +1866,8 @@ def build_parser() -> argparse.ArgumentParser:
     # dashboard — live web dashboard
     p = sub.add_parser("dashboard", help="Launch the live Factory dashboard")
     p.add_argument(
-        "--projects-dir", default="~/cursor-projects",
-        help="Directory containing factory-managed projects (default: ~/cursor-projects)",
+        "--projects-dir", default="~/factory-projects",
+        help="Directory containing factory-managed projects (default: ~/factory-projects)",
     )
     p.add_argument("--port", type=int, default=8420, help="Server port (default: 8420)")
     p.add_argument("--host", default="0.0.0.0", help="Server host (default: 0.0.0.0)")

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -9,6 +9,7 @@ All functions take a project_path and return an EvalResult-compatible dict.
 
 import ast
 import csv
+import os
 import re
 from collections import Counter
 from pathlib import Path
@@ -331,7 +332,7 @@ def eval_factory_effectiveness(project_path: Path) -> dict:
             delta_score = 0.5
 
         # Sub-score C: Multi-project management
-        projects_dir = Path.home() / "cursor-projects"
+        projects_dir = Path(os.environ.get("FACTORY_PROJECTS_DIR", str(Path.home() / "factory-projects")))
         managed = 0
         if projects_dir.exists():
             for child in projects_dir.iterdir():

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -367,7 +367,7 @@ class TestDashboardCLI:
         args = parser.parse_args(["dashboard"])
         assert args.port == 8420
         assert args.host == "0.0.0.0"
-        assert args.projects_dir == "~/cursor-projects"
+        assert args.projects_dir == "~/factory-projects"
 
     def test_dashboard_parser_custom(self):
         from factory.cli import build_parser

--- a/tests/test_eval_growth.py
+++ b/tests/test_eval_growth.py
@@ -401,8 +401,9 @@ class TestFactoryEffectiveness:
         result = eval_factory_effectiveness(tmp_path)
         assert result["score"] < 0.3
 
-    def test_multi_project_detection(self, tmp_path):
-        projects = tmp_path / "cursor-projects"
+    def test_multi_project_detection(self, tmp_path, monkeypatch):
+        projects = tmp_path / "factory-projects"
+        monkeypatch.setenv("FACTORY_PROJECTS_DIR", str(projects))
         for name in ["proj-a", "proj-b", "proj-c"]:
             (projects / name / ".factory").mkdir(parents=True)
             _write_tsv(projects / name / ".factory" / "results.tsv", [
@@ -413,6 +414,5 @@ class TestFactoryEffectiveness:
             for i in range(8)
         ]
         _write_tsv(tmp_path / ".factory" / "results.tsv", main_tsv_rows)
-        with patch("pathlib.Path.home", return_value=tmp_path):
-            result = eval_factory_effectiveness(tmp_path)
-            assert "managed_projects=3" in result["details"]
+        result = eval_factory_effectiveness(tmp_path)
+        assert "managed_projects=3" in result["details"]

--- a/tests/test_playbook_hygiene.py
+++ b/tests/test_playbook_hygiene.py
@@ -1,19 +1,21 @@
-"""Guard test: shipped playbooks must stay clean of user-specific data.
+"""Guard tests: shipped code must stay clean of user-specific data.
 
-If this test fails, it means someone (or ACE) wrote personal project
-data into the factory default playbooks. Evolved playbooks belong in
+If a test fails, it means someone (or ACE) wrote personal project
+data into the source tree. Evolved playbooks belong in
 ~/.factory/playbooks/, not in the source tree.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
 
-PLAYBOOKS_DIR = Path(__file__).parent.parent / "factory" / "agents" / "playbooks"
+REPO_ROOT = Path(__file__).parent.parent
+PLAYBOOKS_DIR = REPO_ROOT / "factory" / "agents" / "playbooks"
 
-FORBIDDEN_PATTERNS = [
+FORBIDDEN_PLAYBOOK_PATTERNS = [
     "erica-agent",
     "cp-agent",
     "backyard-chronicle",
@@ -34,6 +36,45 @@ FORBIDDEN_PATTERNS = [
     "96/96",
 ]
 
+# Regex patterns that catch ANY user's absolute home paths, not just one developer's.
+# /Users/<name>/ is macOS, /home/<name>/ is Linux. Both indicate a leaked local path.
+# We allow "~/" and env-var-based paths ($HOME, $FACTORY_*) since those are portable.
+ABSOLUTE_HOME_RE = re.compile(r"/(Users|home)/[a-zA-Z0-9._-]+/")
+
+# Literal substrings that should never appear in shipped source.
+FORBIDDEN_SOURCE_PATTERNS = [
+    "cursor-projects",
+    "obsidian-vaults/factory",
+]
+
+SOURCE_EXTENSIONS = {"*.py", "*.md"}
+
+SOURCE_DIRS = [
+    REPO_ROOT / "factory",
+    REPO_ROOT / "docs",
+]
+
+# Files allowed to contain patterns (test file, changelog history, illustrative examples).
+ALLOWLIST_ABSOLUTE = {
+    Path("tests/test_playbook_hygiene.py"),
+    Path("factory/study.py"),  # docstring example: "e.g. /home/dev/projects/my-app"
+}
+ALLOWLIST_SUBSTRINGS = {
+    Path("tests/test_playbook_hygiene.py"),
+    Path("CHANGELOG.md"),  # historical entries documenting past fixes
+}
+
+
+def _collect_source_files() -> list[Path]:
+    files: list[Path] = []
+    for src_dir in SOURCE_DIRS:
+        for ext in SOURCE_EXTENSIONS:
+            files.extend(src_dir.rglob(ext))
+    # Also check top-level shipped files
+    for ext in SOURCE_EXTENSIONS:
+        files.extend(REPO_ROOT.glob(ext))
+    return sorted(set(files))
+
 
 @pytest.fixture
 def playbook_files():
@@ -48,7 +89,7 @@ class TestPlaybookHygiene:
         """Shipped playbooks must not contain user-specific project references."""
         for path in playbook_files:
             content = path.read_text()
-            for pattern in FORBIDDEN_PATTERNS:
+            for pattern in FORBIDDEN_PLAYBOOK_PATTERNS:
                 assert pattern not in content, (
                     f"{path.name} contains personal data: '{pattern}'. "
                     f"Evolved playbooks belong in ~/.factory/playbooks/, "
@@ -92,3 +133,52 @@ class TestPlaybookHygiene:
         expected = {"archivist", "builder", "ceo", "evaluator", "reviewer", "strategist"}
         actual = {p.stem for p in PLAYBOOKS_DIR.glob("*.md")}
         assert expected == actual
+
+
+class TestNoHardcodedPaths:
+    """Source tree must not contain hardcoded user-specific paths.
+
+    This catches ANY developer's paths — /Users/<anyone>/ or /home/<anyone>/ —
+    plus known bad substrings. If your code needs a user-local path, use an
+    env var (FACTORY_PROJECTS_DIR, FACTORY_VAULT_PATH, etc.) or ~/relative.
+    """
+
+    def test_no_absolute_home_paths(self):
+        """No absolute /Users/<name>/ or /home/<name>/ paths in shipped code."""
+        violations: list[str] = []
+        for path in _collect_source_files():
+            rel = path.relative_to(REPO_ROOT)
+            if rel in ALLOWLIST_ABSOLUTE:
+                continue
+            try:
+                content = path.read_text()
+            except UnicodeDecodeError:
+                continue
+            for i, line in enumerate(content.splitlines(), 1):
+                if ABSOLUTE_HOME_RE.search(line):
+                    violations.append(f"{rel}:{i}: {line.strip()[:100]}")
+        assert not violations, (
+            "Absolute home-directory paths found in source tree.\n"
+            "Use env vars or ~/ instead:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+
+    def test_no_forbidden_substrings(self):
+        """Known bad substrings must not appear in shipped source."""
+        violations: list[str] = []
+        for path in _collect_source_files():
+            rel = path.relative_to(REPO_ROOT)
+            if rel in ALLOWLIST_SUBSTRINGS:
+                continue
+            try:
+                content = path.read_text()
+            except UnicodeDecodeError:
+                continue
+            for pattern in FORBIDDEN_SOURCE_PATTERNS:
+                if pattern in content:
+                    violations.append(f"{rel}: contains '{pattern}'")
+        assert not violations, (
+            "Hardcoded user-specific paths found in source tree.\n"
+            "Use env vars (FACTORY_PROJECTS_DIR, FACTORY_VAULT_PATH) instead:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )


### PR DESCRIPTION
## Summary

- Replace `~/cursor-projects` default with `~/factory-projects` across CLI, eval, agent prompts, and docs (all configurable via `FACTORY_PROJECTS_DIR`)
- Remove absolute `/Users/akash/` path from slides builder script (now uses `Path(__file__)` relative resolution)
- Replace `~/obsidian-vaults/factory` with `~/factory-vault` in README/docs examples
- Use `$FACTORY_VAULT_PATH` env var references in agent prompts instead of hardcoded paths
- Document all env vars (`FACTORY_PROJECTS_DIR`, `FACTORY_VAULT_PATH`, `FACTORY_PLAYBOOKS_DIR`, `FACTORY_MODEL`) with defaults in configuration docs
- Add robust CI guard tests that catch **any** developer's absolute home paths (`/Users/<anyone>/` or `/home/<anyone>/`) via regex, plus known bad substrings — prevents future leaks regardless of who contributes

Closes #92

## Test plan

- [x] All 928 tests pass
- [x] Ruff lint clean
- [x] Mypy clean (pre-existing mcp stub issue only)
- [x] Guard tests catch absolute paths from any OS/user, not just one developer
- [x] `grep -r "cursor-projects"` returns zero hits outside test guard definitions
- [x] `grep -r "/Users/"` returns zero hits outside test guard definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)