### PR TITLE
fix: correct factory ceo examples to use positional prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Requires Claude Code installed and authenticated. The factory spawns `claude` su
 factory ceo /path/to/project                    # Launch CEO agent (single cycle)
 factory ceo /path/to/project --mode meta        # Improve + ACE playbook evolution
 factory ceo /path/to/project --focus "dashboard UI"  # Focus on a specific area
-factory ceo --prompt "Build a weather CLI"      # Build from a raw prompt
+factory ceo "Build a weather CLI"               # Build from a raw prompt
 factory run /path/to/project                    # Same as factory ceo
 factory run /path/to/project --loop --interval 1800  # Continuous heartbeat
 factory tmux /path/to/project --loop            # In detached tmux session
@@ -112,7 +112,7 @@ factory precheck /path --score-before 0.7 --score-after 0.85  # Hard precheck ga
 factory review --verdict KEEP --pr 42           # Post structured review on GitHub PR
 ```
 
-`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all 7 agent roles. `--focus` narrows improvement efforts to a specific area (e.g. `--focus "eval reliability"`), ensuring at least 2 of 3 hypotheses target that area. `--prompt` builds a new project from a raw text description.
+`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all 7 agent roles. `--focus` narrows improvement efforts to a specific area (e.g. `--focus "eval reliability"`), ensuring at least 2 of 3 hypotheses target that area. `--prompt` loads a spec file as the build context for an existing project. To build from a raw text description, pass the prompt as the positional `path` argument.
 
 ## Observability
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```bash
 # Got an idea? Describe it.
-factory ceo --prompt "Build a CLI that converts CSV to JSON with streaming support"
+factory ceo "Build a CLI that converts CSV to JSON with streaming support"
 
 # Have an idea written up in a file? Pass the path.
 factory ceo ~/ideas/weather-dashboard.md  # reads the file as the build spec
@@ -91,7 +91,7 @@ export FACTORY_VAULT_PATH=~/factory-vault
 factory vault-init
 
 # Build something
-factory ceo --prompt "Build a REST API for bookmark management with tags and search"
+factory ceo "Build a REST API for bookmark management with tags and search"
 ```
 
 **Prerequisites:** Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated). See the [full setup guide](docs/setup.md).
@@ -104,7 +104,7 @@ factory ceo --prompt "Build a REST API for bookmark management with tags and sea
 
 | Input | What happens |
 |-------|-------------|
-| `factory ceo --prompt "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
+| `factory ceo "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
 | `factory ceo ~/ideas/my-idea.md` | Reads the file as the build spec and builds the project end-to-end |
 | `factory ceo https://github.com/user/repo` | Clones the repo, discovers what it does, sets up evaluation, then starts improving |
 
@@ -279,7 +279,7 @@ See `factory --help` for the complete list.
 
 ```bash
 uv sync --all-groups              # Install all deps including dev
-uv run pytest -v                  # 924 tests
+uv run pytest -v                  # Full suite
 uv run ruff check .               # Lint
 uv run mypy factory/              # Type check
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ You can hand it a one-line prompt, a detailed spec, a path to an idea file, or a
 
 ```bash
 # Got an idea? Describe it.
-factory ceo --prompt "Build a CLI that converts CSV to JSON with streaming support"
+factory ceo "Build a CLI that converts CSV to JSON with streaming support"
 
 # Have an idea written up in a file? Pass the path.
 factory ceo ~/ideas/weather-dashboard.md  # reads the file as the build spec
@@ -47,7 +47,7 @@ A CEO agent orchestrates six specialists — each running as an independent [Cla
 
 | Input | What happens |
 |-------|-------------|
-| `factory ceo --prompt "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
+| `factory ceo "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
 | `factory ceo ~/ideas/my-idea.md` | Reads the file as the build spec and builds the project end-to-end |
 | `factory ceo https://github.com/user/repo` | Clones the repo, discovers what it does, sets up evaluation, then starts improving |
 


### PR DESCRIPTION
## Summary
- Remove `--prompt` flag from all inline-string examples in README, CLAUDE.md, and docs/index.md
- The `--prompt` flag expects a **file path**, not an inline string — passing a raw string causes a "file not found" error
- The positional `path` argument already handles raw text prompts via `_resolve_input()` (case 4: slug + git init + persist spec)
- Also corrects the `--prompt` description in CLAUDE.md and updates stale test count in README

Fixes #91

## Test plan
- [x] `uv run pytest tests/ -v` — 939 passed
- [x] `uv run ruff check .` — clean
- [x] Verified `factory ceo "Build a test app"` works (positional prompt → `_resolve_input` case 4)
- [x] Verified no remaining `factory ceo --prompt "inline"` patterns: `grep -rn 'factory ceo --prompt "' --include='*.md'` returns 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)