### PR TITLE
fix: use descriptive experiment branch names

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -614,7 +614,7 @@ factory agent builder --task "Implement GitHub issue #$ISSUE_NUM in <owner>/<rep
 1. Read the issue: gh issue view $ISSUE_NUM
 2. cd $PROJECT_PATH, read CLAUDE.md and factory.md
 3. Read the CEO-approved strategy at .factory/reviews/ceo-verdict-strategist.md
-4. git checkout -b experiment/$EXP_ID
+4. git checkout -b experiment/$EXP_ID-$SHORT_DESCRIPTION (e.g. experiment/3-add-retry-logic)
 5. Implement exactly what the issue describes
 6. Run tests and evals
 7. Commit and open PR targeting main


### PR DESCRIPTION
## Problem

The CEO prompt instructs the Builder to create experiment branches using only the experiment ID:

```
git checkout -b experiment/$EXP_ID
```

This produces generic branch names like `experiment/1`, `experiment/2` that give no indication of what the experiment is about. When running multiple experiments or reviewing git history, these are hard to distinguish.

## Fix

Updated the CEO prompt to include a short description slug:

```
git checkout -b experiment/$EXP_ID-$SHORT_DESCRIPTION (e.g. experiment/3-add-retry-logic)
```

The Builder agent already uses descriptive naming (`feature/$FEATURE_NAME`) in its own prompt — this change aligns the CEO's instructions to the Builder with that pattern.

## Scope

One line changed in `factory/agents/prompts/ceo.md`. No code changes — this is purely a prompt improvement.

## Test plan
- [x] All existing tests pass (44 CEO/agent tests verified)
- [ ] Next factory run should produce branches like `experiment/3-add-retry-logic` instead of `experiment/3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)