### PR TITLE
ci: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,14 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync --all-groups
-      - name: Run tests
-        run: uv run pytest -v --tb=short
+      - name: Run tests with coverage
+        run: uv run pytest -v --tb=short --cov=factory --cov-report=xml
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
 
   lint:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The Factory: From Idea to Evolving Software
 
 [![CI](https://github.com/akashgit/remote-factory/actions/workflows/ci.yml/badge.svg)](https://github.com/akashgit/remote-factory/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/akashgit/remote-factory/graph/badge.svg)](https://codecov.io/gh/akashgit/remote-factory)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary
- Add `--cov=factory --cov-report=xml` to pytest in CI and upload results via `codecov/codecov-action@v5` (Python 3.12 matrix only)
- Add Codecov badge to README

## Test plan
- [ ] CI passes with coverage upload
- [ ] Codecov badge renders on README after first upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)