### PR TITLE
fix: add CODECOV_TOKEN to coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary
- Add `token: ${{ secrets.CODECOV_TOKEN }}` to the Codecov upload step — required even for public repos
- Secret already set via `gh secret set`

## Test plan
- [ ] CI passes and coverage uploads successfully to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)