### PR TITLE
fix: drop OBSIDIAN_VAULT_PATH fallback to prevent personal vault writes

### DIFF
--- a/factory/agents/prompts/archivist.md
+++ b/factory/agents/prompts/archivist.md
@@ -20,7 +20,7 @@ You are invoked **asynchronously** (fire-and-forget) by the CEO/orchestrator at 
 
 ## Vault
 
-The factory vault location is controlled by the `FACTORY_VAULT_PATH` environment variable. If the vault path is not configured (`FACTORY_VAULT_PATH` unset and `OBSIDIAN_VAULT_PATH` unset), write archive notes to `.factory/archive/` inside the project directory instead. This ensures archival works on any machine without requiring an Obsidian vault.
+The factory vault location is controlled by the `FACTORY_VAULT_PATH` environment variable. If it is unset, write archive notes to `.factory/archive/` inside the project directory instead. This ensures archival works on any machine without requiring an Obsidian vault.
 
 **When vault IS configured:**
 - Use the obsidian-cli to interact with it (or direct file writes as fallback)

--- a/factory/obsidian/notes.py
+++ b/factory/obsidian/notes.py
@@ -115,12 +115,11 @@ tags:
 def vault_path() -> Path | None:
     """Return the configured vault path, or ``None`` when unconfigured.
 
-    Reads from ``FACTORY_VAULT_PATH`` first (new canonical name), then falls
-    back to ``OBSIDIAN_VAULT_PATH`` for backwards-compatibility.  When neither
-    env var is set the vault is considered *unavailable* and callers should
-    skip vault operations gracefully.
+    Reads from ``FACTORY_VAULT_PATH`` only.  When the env var is unset the
+    vault is considered *unavailable* and callers should skip vault operations
+    gracefully (writes fall back to ``.factory/archive/``).
     """
-    raw = os.environ.get("FACTORY_VAULT_PATH") or os.environ.get("OBSIDIAN_VAULT_PATH")
+    raw = os.environ.get("FACTORY_VAULT_PATH")
     if raw:
         return Path(raw)
     return None

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -267,8 +267,7 @@ class TestFormatDigest:
 
 class TestCmdDigest:
     def test_digest_default(self, populated_vault: Path, monkeypatch, capsys):
-        monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(populated_vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(populated_vault))
         result = main(["digest"])
         assert result == 0
         out = capsys.readouterr().out
@@ -276,8 +275,7 @@ class TestCmdDigest:
         assert "project-a" in out
 
     def test_digest_specific_date(self, populated_vault: Path, monkeypatch, capsys):
-        monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(populated_vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(populated_vault))
         today = date.today().isoformat()
         result = main(["digest", "--date", today])
         assert result == 0
@@ -286,8 +284,7 @@ class TestCmdDigest:
         assert "Add auth module" in out
 
     def test_digest_no_vault(self, tmp_path: Path, monkeypatch, capsys):
-        monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "nonexistent"))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(tmp_path / "nonexistent"))
         result = main(["digest"])
         assert result == 0
         out = capsys.readouterr().out

--- a/tests/test_obsidian.py
+++ b/tests/test_obsidian.py
@@ -21,7 +21,7 @@ from factory.obsidian.notes import (
 def set_vault_path(obsidian_vault, monkeypatch):
     """Set OBSIDIAN_VAULT_PATH to temp dir and disable obsidian-cli for all tests."""
     monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
-    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(obsidian_vault))
+    monkeypatch.setenv("FACTORY_VAULT_PATH", str(obsidian_vault))
     # Disable obsidian-cli so write functions always fall back to direct file I/O.
     # Individual tests in TestObsidianCli override this as needed.
     monkeypatch.setattr(
@@ -222,7 +222,7 @@ class TestAutoInit:
     def test_auto_creates_vault_on_write(self, tmp_path, monkeypatch):
         """Writing a note to nonexistent vault creates the vault structure."""
         vault = tmp_path / "new-vault"
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(vault))
         assert not vault.exists()
 
         record = ExperimentRecord(

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -329,7 +329,7 @@ class TestStudyProjectLocal:
     def test_includes_obsidian_notes(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.delenv("FACTORY_VAULT_PATH", raising=False)
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "vault"))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(tmp_path / "vault"))
 
         project_path = tmp_path / "myapp"
         project_path.mkdir()
@@ -655,7 +655,7 @@ class TestReadObsidianNotes:
 
     def test_reads_notes(self, tmp_path, monkeypatch):
         vault = tmp_path / "vault"
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(vault))
 
         experiments_dir = vault / "10-Projects" / "myapp" / "Experiments"
         experiments_dir.mkdir(parents=True)
@@ -669,7 +669,7 @@ class TestReadObsidianNotes:
 
     def test_multiple_subdirs(self, tmp_path, monkeypatch):
         vault = tmp_path / "vault"
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(vault))
 
         project_dir = vault / "10-Projects" / "myapp"
         for subdir in ["Experiments", "Strategies"]:
@@ -686,19 +686,19 @@ class TestReadObsidianNotes:
     def test_empty_vault(self, tmp_path, monkeypatch):
         vault = tmp_path / "vault"
         vault.mkdir()
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(vault))
 
         summaries = _read_obsidian_notes("myapp")
         assert summaries == []
 
     def test_no_vault(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "nonexistent"))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(tmp_path / "nonexistent"))
         summaries = _read_obsidian_notes("myapp")
         assert summaries == []
 
     def test_skips_frontmatter(self, tmp_path, monkeypatch):
         vault = tmp_path / "vault"
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(vault))
 
         project_dir = vault / "10-Projects" / "myapp"
         project_dir.mkdir(parents=True)
@@ -713,7 +713,7 @@ class TestReadObsidianNotes:
 
     def test_truncates_to_200_chars(self, tmp_path, monkeypatch):
         vault = tmp_path / "vault"
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(vault))
 
         project_dir = vault / "10-Projects" / "myapp"
         project_dir.mkdir(parents=True)
@@ -725,7 +725,7 @@ class TestReadObsidianNotes:
 
     def test_cross_project_knowledge(self, tmp_path, monkeypatch):
         vault = tmp_path / "vault"
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+        monkeypatch.setenv("FACTORY_VAULT_PATH", str(vault))
 
         concepts_dir = vault / "20-Knowledge" / "Concepts"
         concepts_dir.mkdir(parents=True)

--- a/tests/test_vault_decouple.py
+++ b/tests/test_vault_decouple.py
@@ -67,23 +67,12 @@ class TestVaultPath:
         assert result is not None
         assert result == tmp_path / "my-vault"
 
-    def test_returns_path_from_obsidian_vault_path(
+    def test_ignores_obsidian_vault_path(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
-        """Backwards-compat: OBSIDIAN_VAULT_PATH is still honoured."""
+        """OBSIDIAN_VAULT_PATH is no longer honoured — prevents personal vault writes."""
         monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "legacy"))
-        result = vault_path()
-        assert result is not None
-        assert result == tmp_path / "legacy"
-
-    def test_factory_vault_path_takes_precedence(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
-    ) -> None:
-        monkeypatch.setenv("FACTORY_VAULT_PATH", str(tmp_path / "new"))
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path / "old"))
-        result = vault_path()
-        assert result is not None
-        assert result == tmp_path / "new"
+        assert vault_path() is None
 
 
 # ── graceful skip when vault unavailable ─────────────────────────


### PR DESCRIPTION
## Summary
- Remove `OBSIDIAN_VAULT_PATH` fallback from `vault_path()` in `factory/obsidian/notes.py` — only `FACTORY_VAULT_PATH` is honored now
- When `FACTORY_VAULT_PATH` is unset, vault is unavailable and writes go to `.factory/archive/` (the safe default)
- Update archivist prompt to remove the fallback mention
- Fix all tests to use `FACTORY_VAULT_PATH`; replace backwards-compat test with an explicit "ignores OBSIDIAN_VAULT_PATH" test

**Root cause:** When `FACTORY_VAULT_PATH` wasn't set, the code fell back to `OBSIDIAN_VAULT_PATH` which pointed to the user's personal Obsidian vault, causing factory experiment notes to land there.

## Test plan
- [x] All 938 tests pass
- [x] Ruff lint passes
- [x] `test_ignores_obsidian_vault_path` confirms the old var is no longer honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)