### PR TITLE
ci: run CI on push to main for Codecov baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Add `push: branches: [main]` trigger to CI workflow
- Codecov requires a coverage upload from main to establish the baseline — without it the dashboard stays empty

## Test plan
- [ ] After merge, CI runs on main and Codecov dashboard populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)