### PR TITLE
fix: strip calendar-time estimates from agent pipeline

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -639,7 +639,7 @@ factory agent builder --task "Implement GitHub issue #$ISSUE_NUM in <owner>/<rep
 1. Read the issue: gh issue view $ISSUE_NUM
 2. cd $PROJECT_PATH, read CLAUDE.md and factory.md
 3. Read the CEO-approved strategy at .factory/reviews/ceo-verdict-strategist.md
-4. git checkout -b experiment/$EXP_ID
+4. git checkout -b experiment/$EXP_ID-$SHORT_DESCRIPTION (e.g. experiment/3-add-retry-logic)
 5. Implement exactly what the issue describes
 6. Run tests and evals
 7. Commit and open PR targeting main

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -87,8 +87,8 @@ You are NOT a passive pipeline. After EVERY agent completes, you MUST review its
 
 | Role       | Check for                                                                |
 |------------|--------------------------------------------------------------------------|
-| Researcher | Covered the right topics? Enough depth? Web research included? Gaps?     |
-| Strategist | Plan aligns with goals? Phases are right-sized? **At least one growth hypothesis?** |
+| Researcher | Covered the right topics? Enough depth? Web research included? Gaps? **No calendar-time estimates** (e.g., "8-10 weeks") — REDIRECT if present. |
+| Strategist | Plan aligns with goals? Phases are right-sized? **At least one growth hypothesis?** **No calendar-time estimates** — REDIRECT if present. |
 | Builder    | PR matches the plan? No scope creep? Tests included? CLAUDE.md followed? |
 | Reviewer   | Review is substantive? Violations caught? Not rubber-stamped?            |
 | Evaluator  | Scores are valid JSON? All dimensions present? Before/after compared?    |
@@ -639,7 +639,7 @@ factory agent builder --task "Implement GitHub issue #$ISSUE_NUM in <owner>/<rep
 1. Read the issue: gh issue view $ISSUE_NUM
 2. cd $PROJECT_PATH, read CLAUDE.md and factory.md
 3. Read the CEO-approved strategy at .factory/reviews/ceo-verdict-strategist.md
-4. git checkout -b experiment/$EXP_ID-$SHORT_DESCRIPTION (e.g. experiment/3-add-retry-logic)
+4. git checkout -b experiment/$EXP_ID
 5. Implement exactly what the issue describes
 6. Run tests and evals
 7. Commit and open PR targeting main

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -50,6 +50,7 @@ Optionally write new source notes to `$FACTORY_VAULT_PATH/20-Knowledge/Sources/`
 - Limit WebFetch to 3-5 pages
 - Focus on actionable insights, not academic summaries
 - Write report even if external search fails — include local findings
+- Do not include calendar-time estimates (e.g., "8-10 weeks", "6 months"). The factory uses AI agents, not human teams — duration estimates are meaningless and misleading in this context. Scope findings by complexity and dependency count, not time.
 
 ## Mode 3: Self-Improvement Research (used when factory targets itself)
 

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -116,3 +116,4 @@ Write to `$PROJECT_PATH/.factory/strategy/research.md` with additional sections:
 - Always run `factory insights` before WebSearch — local data is more relevant than external
 - Focus on actionable meta-improvements, not theoretical frameworks
 - Prioritize changes that make the factory better at improving OTHER projects, not just itself
+- Do not include calendar-time estimates — same rule as Mode 2

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -251,6 +251,7 @@ When the project has user-defined eval dimensions (configured in `factory.md` `#
 
 ## Rules
 
+- Never include or propagate calendar-time estimates (e.g., "8-10 weeks", "MVP in 3 months"). The factory uses AI agents — human-timeline estimates are meaningless. Scope hypotheses by complexity (files touched, dependency depth), not duration. If research input contains time estimates, strip them.
 - Each hypothesis must be scoped to one PR's worth of work
 - Never propose changes that violate the project's guards
 - Learn from failed experiments — don't repeat the same mistake


### PR DESCRIPTION
## Summary

- **Researcher** prompt: added rule to never include calendar-time estimates (e.g., "8-10 weeks"). Scope by complexity/dependency count instead.
- **Strategist** prompt: added rule to strip time estimates from research input and never propagate them into hypotheses.
- **CEO** review gates: Researcher and Strategist review criteria now flag time estimates as a REDIRECT trigger.

**Why:** AI agents don't operate on human timelines. When the Researcher generates "MVP in 8-10 weeks", the CEO passes it through, and the Strategist echoes it into the build plan — producing a meaningless artifact that looks authoritative. This adds gates at all three points in the chain.

Reported by @Maxusmusti

## Test plan
- [ ] Run factory on a new project spec and verify research output contains no time estimates
- [ ] Verify CEO REDIRECT triggers if time estimates leak through

🤖 Generated with [Claude Code](https://claude.com/claude-code)