### PR TITLE
docs: fix --prompt usage across README and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Requires Claude Code installed and authenticated. The factory spawns `claude` su
 
 ```bash
 factory ceo /path/to/project                    # Launch CEO agent (single cycle)
-factory ceo --interactive "distributed eval runner"  # Brainstorm + research → build from idea
+factory ceo "distributed eval runner" --mode interactive  # Brainstorm + research → build from idea
 factory ceo /path/to/project --mode meta        # Improve + ACE playbook evolution
 factory ceo /path/to/project --focus "dashboard UI"  # Targeted mode: build exactly one item
 factory ceo --prompt "Build a weather CLI"      # Build from a raw prompt
@@ -114,7 +114,7 @@ factory precheck /path --score-before 0.7 --score-after 0.85  # Hard precheck ga
 factory review --verdict KEEP --pr 42           # Post structured review on GitHub PR
 ```
 
-`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all 7 agent roles. `--focus` activates targeted mode: builds exactly one backlog item (e.g. `--focus "eval reliability"`), generating a single hypothesis and exiting after that experiment. Requires improve mode; mutually exclusive with `--loop` and `--prompt`. `--prompt` builds a new project from a raw text description. `--interactive "idea"` enters ideation mode: the CEO researches the space via the Researcher, then iteratively refines the idea with the Distiller agent through user feedback, producing an idea.md spec before building. Incompatible with `--headless`, `--prompt`, and `--focus`.
+`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all 7 agent roles. `--focus` activates targeted mode: builds exactly one backlog item (e.g. `--focus "eval reliability"`), generating a single hypothesis and exiting after that experiment. Requires improve mode; mutually exclusive with `--loop` and `--prompt`. `--prompt` builds a new project from a raw text description. `--mode interactive` enters ideation mode: pass a raw idea as the positional argument (e.g. `factory ceo "distributed eval runner" --mode interactive`). The CEO researches the space via the Researcher, then iteratively refines the idea with the Distiller agent through user feedback, producing an idea.md spec before building. Incompatible with `--headless`, `--prompt`, and `--focus`.
 
 ## Observability
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ A dedicated Claude Code agent that owns the full factory workflow. Spawned via `
 
 ### Layer 3: Specialist Agents (`factory/agents/`)
 
-Seven specialist Claude Code subprocesses spawned by the CEO via `factory agent <role>`. Agent prompts are resolved via `factory/agents/runner.py` with a two-tier lookup: project-specific override (`.factory/agents/<role>.md`) then factory default (`factory/agents/prompts/<role>.md`). Evolved playbooks from `~/.factory/playbooks/<role>.md` (user-local, ACE-generated) are auto-injected, falling back to factory defaults in `factory/agents/playbooks/<role>.md`.
+Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent <role>`. Agent prompts are resolved via `factory/agents/runner.py` with a two-tier lookup: project-specific override (`.factory/agents/<role>.md`) then factory default (`factory/agents/prompts/<role>.md`). Evolved playbooks from `~/.factory/playbooks/<role>.md` (user-local, ACE-generated) are auto-injected, falling back to factory defaults in `factory/agents/playbooks/<role>.md`.
 
 **Roles:** Researcher (observe), Strategist (hypothesize), Builder (implement), Reviewer (guard), Evaluator (measure), Archivist (record), Distiller (refine ideas), CEO (orchestrate).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ factory ceo /path/to/project                    # Launch CEO agent (single cycle
 factory ceo "distributed eval runner" --mode interactive  # Brainstorm + research → build from idea
 factory ceo /path/to/project --mode meta        # Improve + ACE playbook evolution
 factory ceo /path/to/project --focus "dashboard UI"  # Targeted mode: build exactly one item
-factory ceo --prompt "Build a weather CLI"      # Build from a raw prompt
+factory ceo "Build a weather CLI"               # Build from a raw prompt
 factory run /path/to/project                    # Same as factory ceo
 factory run /path/to/project --loop --interval 1800  # Continuous heartbeat
 factory tmux /path/to/project --loop            # In detached tmux session
@@ -114,7 +114,7 @@ factory precheck /path --score-before 0.7 --score-after 0.85  # Hard precheck ga
 factory review --verdict KEEP --pr 42           # Post structured review on GitHub PR
 ```
 
-`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all 7 agent roles. `--focus` activates targeted mode: builds exactly one backlog item (e.g. `--focus "eval reliability"`), generating a single hypothesis and exiting after that experiment. Requires improve mode; mutually exclusive with `--loop` and `--prompt`. `--prompt` builds a new project from a raw text description. `--mode interactive` enters ideation mode: pass a raw idea as the positional argument (e.g. `factory ceo "distributed eval runner" --mode interactive`). The CEO researches the space via the Researcher, then iteratively refines the idea with the Distiller agent through user feedback, producing an idea.md spec before building. Incompatible with `--headless`, `--prompt`, and `--focus`.
+`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all 7 agent roles. `--focus` activates targeted mode: builds exactly one backlog item (e.g. `--focus "eval reliability"`), generating a single hypothesis and exiting after that experiment. Requires improve mode; mutually exclusive with `--loop` and `--prompt`. `--prompt` loads a spec file as the build plan (e.g. `--prompt spec.md`). To build from a raw string, pass it as the positional argument (e.g. `factory ceo "Build a weather CLI"`). `--mode interactive` enters ideation mode: pass a raw idea as the positional argument (e.g. `factory ceo "distributed eval runner" --mode interactive`). The CEO researches the space via the Researcher, then iteratively refines the idea with the Distiller agent through user feedback, producing an idea.md spec before building. Incompatible with `--headless`, `--prompt`, and `--focus`.
 
 ## Observability
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ A dedicated Claude Code agent that owns the full factory workflow. Spawned via `
 
 Seven specialist Claude Code subprocesses spawned by the CEO via `factory agent <role>`. Agent prompts are resolved via `factory/agents/runner.py` with a two-tier lookup: project-specific override (`.factory/agents/<role>.md`) then factory default (`factory/agents/prompts/<role>.md`). Evolved playbooks from `~/.factory/playbooks/<role>.md` (user-local, ACE-generated) are auto-injected, falling back to factory defaults in `factory/agents/playbooks/<role>.md`.
 
-**Roles:** Researcher (observe), Strategist (hypothesize), Builder (implement), Reviewer (guard), Evaluator (measure), Archivist (record), CEO (orchestrate).
+**Roles:** Researcher (observe), Strategist (hypothesize), Builder (implement), Reviewer (guard), Evaluator (measure), Archivist (record), Distiller (refine ideas), CEO (orchestrate).
 
 ### Key data flow
 
@@ -93,6 +93,7 @@ Requires Claude Code installed and authenticated. The factory spawns `claude` su
 
 ```bash
 factory ceo /path/to/project                    # Launch CEO agent (single cycle)
+factory ceo --interactive "distributed eval runner"  # Brainstorm + research → build from idea
 factory ceo /path/to/project --mode meta        # Improve + ACE playbook evolution
 factory ceo /path/to/project --focus "dashboard UI"  # Targeted mode: build exactly one item
 factory ceo --prompt "Build a weather CLI"      # Build from a raw prompt
@@ -113,7 +114,7 @@ factory precheck /path --score-before 0.7 --score-after 0.85  # Hard precheck ga
 factory review --verdict KEEP --pr 42           # Post structured review on GitHub PR
 ```
 
-`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all 7 agent roles. `--focus` activates targeted mode: builds exactly one backlog item (e.g. `--focus "eval reliability"`), generating a single hypothesis and exiting after that experiment. Requires improve mode; mutually exclusive with `--loop` and `--prompt`. `--prompt` builds a new project from a raw text description.
+`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all 7 agent roles. `--focus` activates targeted mode: builds exactly one backlog item (e.g. `--focus "eval reliability"`), generating a single hypothesis and exiting after that experiment. Requires improve mode; mutually exclusive with `--loop` and `--prompt`. `--prompt` builds a new project from a raw text description. `--interactive "idea"` enters ideation mode: the CEO researches the space via the Researcher, then iteratively refines the idea with the Distiller agent through user feedback, producing an idea.md spec before building. Incompatible with `--headless`, `--prompt`, and `--focus`.
 
 ## Observability
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 ```bash
 # Got an idea? Describe it.
-factory ceo --prompt "Build a CLI that converts CSV to JSON with streaming support"
+factory ceo "Build a CLI that converts CSV to JSON with streaming support"
 
 # Have an idea written up in a file? Pass the path.
-factory ceo ~/ideas/weather-dashboard.md  # reads the file as the build spec
+factory ceo ~/ideas/weather-dashboard.md
 
 # Already have a repo? Point the factory at it.
 factory ceo ~/my-project
@@ -92,7 +92,7 @@ export FACTORY_VAULT_PATH=~/factory-vault
 factory vault-init
 
 # Build something
-factory ceo --prompt "Build a REST API for bookmark management with tags and search"
+factory ceo "Build a REST API for bookmark management with tags and search"
 ```
 
 **Prerequisites:** Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated). See the [full setup guide](docs/setup.md).
@@ -105,7 +105,7 @@ factory ceo --prompt "Build a REST API for bookmark management with tags and sea
 
 | Input | What happens |
 |-------|-------------|
-| `factory ceo --prompt "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
+| `factory ceo "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
 | `factory ceo ~/ideas/my-idea.md` | Reads the file as the build spec and builds the project end-to-end |
 | `factory ceo https://github.com/user/repo` | Clones the repo, discovers what it does, sets up evaluation, then starts improving |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,10 @@ You can hand it a one-line prompt, a detailed spec, a path to an idea file, or a
 
 ```bash
 # Got an idea? Describe it.
-factory ceo --prompt "Build a CLI that converts CSV to JSON with streaming support"
+factory ceo "Build a CLI that converts CSV to JSON with streaming support"
 
 # Have an idea written up in a file? Pass the path.
-factory ceo ~/ideas/weather-dashboard.md  # reads the file as the build spec
+factory ceo ~/ideas/weather-dashboard.md
 
 # Already have a repo? Point the factory at it.
 factory ceo ~/my-project
@@ -47,7 +47,7 @@ A CEO agent orchestrates six specialists — each running as an independent [Cla
 
 | Input | What happens |
 |-------|-------------|
-| `factory ceo --prompt "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
+| `factory ceo "Build a weather CLI"` | Researches best practices, scaffolds the project, sets up tests and eval, then improves it |
 | `factory ceo ~/ideas/my-idea.md` | Reads the file as the build spec and builds the project end-to-end |
 | `factory ceo https://github.com/user/repo` | Clones the repo, discovers what it does, sets up evaluation, then starts improving |
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -173,6 +173,152 @@ uv run python -m factory detect "$PROJECT_PATH"
 - `evals_pending_review` → **Review mode**
 - `has_factory` → **Improve mode**
 
+**Exception:** If your task includes `## Interactive Ideation Mode (Phase 0)`, enter Phase 0 first regardless of project state. After Phase 0 completes, proceed to Build mode.
+
+---
+
+## Phase 0: Ideation (Interactive Mode)
+
+This phase activates when your task includes a `## Interactive Ideation Mode (Phase 0)` section. You are running in foreground interactive mode — the user can see your output and respond.
+
+### Purpose
+
+Transform a vague idea into a research-grounded, buildable project specification (idea.md) through iterative refinement with the user.
+
+### I0: Research the Space (Researcher Agent)
+
+Tell the user you're researching the space, then spawn the Researcher:
+
+```bash
+factory agent researcher --task "Mode 2 research for a new project idea.
+
+The user wants to build: <RAW_IDEA>
+
+Research:
+1. Search the web for similar projects, existing solutions, and prior art
+2. Identify the best technology stack for this type of project
+3. Find architecture patterns and best practices
+4. Identify potential pitfalls and common mistakes
+5. Read the factory vault at $FACTORY_VAULT_PATH for prior knowledge on similar builds (skip if unset)
+
+Write a thorough research report to .factory/strategy/research.md covering:
+- Similar projects found (with links)
+- Recommended tech stack with rationale
+- Architecture patterns that fit
+- Potential pitfalls to avoid
+- MVP scope recommendation
+" --project "$PROJECT_PATH" --timeout 300
+```
+
+### I0r: CEO Review — Research
+
+Apply the standard CEO Review Gate:
+1. Read `.factory/reviews/researcher-latest.md` and `.factory/strategy/research.md`
+2. Is the research relevant to the user's idea? Does it cover the technology landscape adequately?
+3. Write verdict to `.factory/reviews/ceo-verdict-researcher.md`
+4. If REDIRECT: re-invoke the Researcher with specific gaps
+5. If PROCEED: continue to I1
+
+### I1: Distill (Distiller Agent)
+
+Spawn the Distiller to synthesize the research into a structured spec:
+
+```bash
+factory agent distiller --task "Distill a project specification from research and a raw idea.
+
+Raw idea: <RAW_IDEA>
+
+Read the research report at .factory/strategy/research.md for domain context, technology recommendations, and prior art.
+
+Produce a complete idea.md specification." --project "$PROJECT_PATH" --timeout 300
+```
+
+### I1r: CEO Review — Draft Spec
+
+Read `.factory/reviews/distiller-latest.md` and assess the draft:
+- Does it capture the user's intent?
+- Are the technology choices well-justified by research?
+- Is the scope achievable?
+- Are features specific enough for a Builder agent?
+
+Write your review to `.factory/reviews/ceo-verdict-distiller.md`.
+
+### I2: Present to User
+
+**This is where you interact with the user.** Present the Distiller's output clearly. Highlight the key choices the Distiller made and any open questions. Then ask the user for their feedback:
+
+- They can approve (e.g. "looks good", "let's build", "approved")
+- They can give specific feedback (e.g. "add WebSocket support", "use Go instead", "drop the admin dashboard for v1")
+- They can ask you to research a specific sub-topic before revising
+
+**One topic at a time.** If the spec has open questions, surface the most important one first. Do not dump all questions at once.
+
+### I3: Iterate on Feedback
+
+If the user provides feedback (anything other than approval):
+
+**Optional: Targeted follow-up research.** If the user's feedback introduces a new domain or technology not covered by the initial research, spawn the Researcher again with a narrow scope:
+
+```bash
+factory agent researcher --task "Targeted follow-up research for project ideation.
+
+The user wants to modify the project spec. Their feedback: <USER_FEEDBACK>
+
+Research specifically:
+- <targeted topic from feedback>
+
+Append findings to .factory/strategy/research.md (do not overwrite the existing report)." --project "$PROJECT_PATH" --timeout 180
+```
+
+**Re-spawn the Distiller with feedback:**
+
+```bash
+factory agent distiller --task "Refine the project specification based on user feedback.
+
+Raw idea: <RAW_IDEA>
+
+## Prior Draft
+
+<paste the previous draft>
+
+## User Feedback
+
+<paste the user's feedback>
+
+## Follow-Up Research
+
+<paste any new research findings, or 'None — original research still applies'>
+
+Read the full research report at .factory/strategy/research.md for context.
+
+Produce a complete updated specification." --project "$PROJECT_PATH" --timeout 300
+```
+
+Read the Distiller's output and return to **I2** (present the updated draft to the user).
+
+### I4: Finalize and Transition
+
+When the user approves the spec:
+
+1. **Persist the spec**: Write the final idea.md content to `.factory/strategy/current.md` (prepend `## Project Specification\n\n` before the content)
+2. **Spawn Archivist** to record the ideation process:
+   ```bash
+   factory agent archivist --task "Record the ideation process for $PROJECT_PATH.
+   Read .factory/strategy/current.md (the approved spec).
+   Read .factory/strategy/research.md (the research).
+   Write project inception notes to the vault." --project "$PROJECT_PATH"
+   ```
+3. **Transition to Build mode**: The spec is now persisted. Continue with **Mode: Build** starting from step B0 (Research). The Build-mode Researcher will do a more focused, implementation-oriented research pass using the approved spec as context.
+
+**Important:** Do not skip Build mode's Research and Strategy steps just because Phase 0 did research. Phase 0 research is broad and exploratory (what should we build?). Build mode research is implementation-focused (how do we build it?).
+
+### Ideation Rules
+
+- **Maximum 5 iterations.** If the user has not approved after 5 rounds of feedback, summarize the current state and ask them to either approve the latest draft or provide a final definitive direction.
+- **Do not build anything during Phase 0.** No code, no scaffolding, no repos beyond the project directory. Phase 0 produces only a spec document.
+- **Research is optional on refinement.** Only re-spawn the Researcher if the user's feedback introduces genuinely new territory. Minor scope adjustments (add/remove features, change priorities) do not need new research.
+- **Be concise when presenting.** After the first full presentation, highlight what changed rather than re-presenting the entire spec. But always show the full spec so the user can read it in context.
+
 ---
 
 ## Mode: Build (`no_repo` / `incomplete`)

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -12,7 +12,7 @@ You are a **decision-maker and delegator**. You do NOT:
 
 You DO:
 - Read reports from specialist agents and make decisions citing specific data
-- Delegate ALL execution to the 7 specialist agents via `factory agent <role>`
+- Delegate ALL execution to the 8 specialist agents via `factory agent <role>`
 - Manage the experiment lifecycle (begin, finalize, keep/revert)
 - Handle administrative bookkeeping (git commits, GitHub issues/PRs, notifications)
 - Ensure archival happens at every checkpoint (MANDATORY)
@@ -34,6 +34,7 @@ factory agent <role> --task "<task description>" --project /path/to/project [--t
 | Reviewer   | Guard: enforce sacred rules, scope constraints, code quality on PR        |
 | Evaluator  | Measure: run evals before/after changes, report composite + breakdown     |
 | Archivist  | Record: write learnings to Obsidian vault (MANDATORY at checkpoints)      |
+| Distiller  | Refine: synthesize research + raw idea into buildable spec (Phase 0)     |
 
 ### Archivist Protocol — CRITICAL (HARD ENFORCEMENT)
 

--- a/factory/agents/prompts/distiller.md
+++ b/factory/agents/prompts/distiller.md
@@ -1,0 +1,76 @@
+# Distiller Agent
+
+You are the Distiller agent for the Software Factory. Your job is to transform a vague idea and research findings into a precise, buildable project specification (idea.md).
+
+## What You Do
+
+1. **Read the raw idea**: Understand the user's intent, even if underspecified
+2. **Read the research**: Study the Researcher's findings at `.factory/strategy/research.md` for domain context, prior art, technology recommendations, and pitfalls
+3. **Synthesize**: Combine the user's intent with research-grounded recommendations into a structured specification
+4. **Be opinionated**: Make concrete technology and architecture decisions based on research. Do not list alternatives — pick the best one and justify it
+5. **Write the spec**: Produce a complete idea.md in the format below
+
+## Input
+
+You will be given:
+- The user's raw idea (a short phrase or sentence)
+- Research findings (from the Researcher agent)
+- Optionally: a previous draft and user feedback for refinement
+
+## Output
+
+Write the idea.md content to stdout using this exact structure:
+
+```markdown
+# <Project Name>
+
+## Vision
+<1-2 sentences: what this project does and why it matters>
+
+## Core Features
+<Bulleted list of concrete, buildable features. Each feature should be
+specific enough that a Builder agent can implement it in one PR.>
+
+- **<Feature Name>**: <What it does, how it works>
+- ...
+
+## Architecture
+- **Language/Runtime**: <choice + one-line rationale>
+- **Framework**: <choice + one-line rationale>
+- **Data Storage**: <choice + one-line rationale, if applicable>
+- **Key Libraries**: <list with rationale>
+
+## User Interface
+<How users interact with this: CLI commands, API endpoints, web UI
+pages, etc. Be specific about the primary user flow.>
+
+## Non-Goals (v1)
+<What this project explicitly does NOT do in the first version.
+Important for scoping.>
+
+## Open Questions
+<Anything that genuinely requires user input: API keys needed,
+deployment target, specific business logic choices. Keep this short —
+most decisions should be made by the Distiller based on research.>
+```
+
+## Refinement Mode
+
+When your task includes a `## Prior Draft` and `## User Feedback` section, you are refining a previous draft:
+
+1. Read the prior draft carefully
+2. Read the user's feedback — they may want changes to scope, architecture, features, or direction
+3. If the task includes `## Follow-Up Research`, incorporate the new research findings
+4. Produce a complete updated draft (not a diff — the full spec)
+5. Briefly note what changed and why at the very end under `## Changes from Prior Draft`
+
+## Rules
+
+- Be specific and concrete — avoid weasel words like "flexible", "scalable", "robust" unless you define what you mean
+- Every feature must be implementable by an AI coding agent without human intervention (except items in Open Questions)
+- Prefer proven, well-documented technologies over cutting-edge ones
+- Architecture decisions must be grounded in the research findings — cite the reasoning
+- The spec must be complete enough to build from without further clarification (except Open Questions)
+- Do not include timelines or effort estimates — the factory uses AI agents
+- Do not include deployment or CI/CD setup — the factory handles that separately
+- If the user's idea is too broad for a single project, narrow it to an achievable MVP and note what was deferred in Non-Goals

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -12,7 +12,7 @@ from factory.ace.injector import inject_playbook, load_playbook
 
 logger = logging.getLogger(__name__)
 
-AgentRole = Literal["researcher", "strategist", "builder", "reviewer", "evaluator", "archivist", "ceo"]
+AgentRole = Literal["researcher", "strategist", "builder", "reviewer", "evaluator", "archivist", "distiller", "ceo"]
 
 # Directory containing base agent prompts (shipped with the factory)
 _PROMPTS_DIR = Path(__file__).parent / "prompts"

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1053,18 +1053,48 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     Default: interactive foreground session (user can see and interact).
     With --headless: pipe mode via claude -p (for scripting, cron, etc.).
+    With --interactive: brainstorm an idea via research + Distiller before building.
     """
     from factory.agents.runner import resolve_prompt
 
-    project_path, context = _resolve_input(args.path)
+    interactive_idea = getattr(args, "interactive", None)
+    raw_path = getattr(args, "path", None)
+
+    if not raw_path and not interactive_idea:
+        print("Error: provide a project path/prompt, or use --interactive 'idea'",
+              file=sys.stderr)
+        return 1
+
+    headless = getattr(args, "headless", False)
     prompt_file = getattr(args, "prompt", None)
+    focus = getattr(args, "focus", None)
+
+    if interactive_idea:
+        if headless:
+            print("Error: --interactive requires foreground mode "
+                  "(incompatible with --headless)", file=sys.stderr)
+            return 1
+        if prompt_file:
+            print("Error: --interactive and --prompt are mutually exclusive. "
+                  "--interactive generates the spec; --prompt provides one.",
+                  file=sys.stderr)
+            return 1
+        if focus:
+            print("Error: --interactive and --focus are mutually exclusive. "
+                  "--interactive is for new ideas; --focus targets existing "
+                  "backlog items.", file=sys.stderr)
+            return 1
+
+    resolve_target = raw_path or interactive_idea
+    assert resolve_target is not None  # validated above
+    project_path, context = _resolve_input(resolve_target)
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
     mode = getattr(args, "mode", "auto")
-    if mode == "auto":
+    if interactive_idea:
+        mode = "build"
+    elif mode == "auto":
         mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))
-    headless = getattr(args, "headless", False)
-    focus = getattr(args, "focus", None)
     discover_only = getattr(args, "discover_only", False)
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
@@ -1080,7 +1110,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
               "The project must already be built before targeting specific items.", file=sys.stderr)
         return 1
 
-    _print_banner(mode)
+    _print_banner("ideation" if interactive_idea else mode)
     _ensure_dashboard(project_path)
 
     if focus:
@@ -1091,6 +1121,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         project_path, mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
         discover_only=discover_only,
+        interactive_idea=interactive_idea,
     )
 
     from factory.checkpoint import clear_checkpoint, format_checkpoint, load_checkpoint
@@ -1454,9 +1485,22 @@ def _build_ceo_task(
     max_new: int | None = None,
     branch: str | None = None,
     discover_only: bool = False,
+    interactive_idea: str | None = None,
 ) -> str:
     """Build the CEO agent task string from mode and optional context."""
     task = f"Project: {project_path}\nMode: {mode}"
+
+    if interactive_idea:
+        task += (
+            f"\n\n## Interactive Ideation Mode (Phase 0)\n\n"
+            f"**Raw idea from user:** {interactive_idea}\n\n"
+            f"You are in interactive ideation mode. Before building anything, "
+            f"you must refine this idea into a complete spec through research "
+            f"and iterative user feedback. Follow the Phase 0: Ideation protocol "
+            f"in your system prompt.\n\n"
+            f"After the user approves the final spec, persist it to "
+            f".factory/strategy/current.md and proceed to Build mode.\n"
+        )
 
     if prompt_file:
         task += (
@@ -1962,7 +2006,7 @@ def build_parser() -> argparse.ArgumentParser:
     # agent — invoke a specialist agent directly
     p = sub.add_parser("agent", help="Invoke a specialist agent with a task")
     p.add_argument("role", choices=["researcher", "strategist", "builder", "reviewer",
-                                     "evaluator", "archivist", "ceo"],
+                                     "evaluator", "archivist", "distiller", "ceo"],
                     help="Agent role to invoke")
     p.add_argument("--task", required=True, help="Task description for the agent")
     p.add_argument("--project", required=True, help="Path to the project")
@@ -1973,7 +2017,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     # ceo — launch the Factory CEO agent directly
     p = sub.add_parser("ceo", help="Launch the Factory CEO agent (interactive by default)")
-    p.add_argument("path", help="Project path, GitHub URL, idea file path, or prompt")
+    p.add_argument("path", nargs="?", default=None,
+                    help="Project path, GitHub URL, idea file path, or prompt")
+    p.add_argument(
+        "--interactive", default=None, metavar="IDEA",
+        help="Enter interactive ideation mode: research the space, brainstorm with "
+             "the Distiller agent, refine the idea with user feedback, then build. "
+             "Takes a raw idea string (e.g. --interactive 'distributed eval runner')",
+    )
     p.add_argument(
         "--prompt", default=None,
         help="Path to a prompt/spec file (absolute or relative to project). "

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1088,10 +1088,15 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     resolve_target = raw_path or interactive_idea
     assert resolve_target is not None  # validated above
     project_path, context = _resolve_input(resolve_target)
+    if interactive_idea:
+        context = None  # idea is embedded in the Phase 0 block, not as Project Specification
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
     mode = getattr(args, "mode", "auto")
     if interactive_idea:
+        if mode not in ("auto", "build"):
+            print(f"Warning: --interactive always uses build mode, ignoring --mode '{mode}'",
+                  file=sys.stderr)
         mode = "build"
     elif mode == "auto":
         mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1053,52 +1053,45 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     Default: interactive foreground session (user can see and interact).
     With --headless: pipe mode via claude -p (for scripting, cron, etc.).
-    With --interactive: brainstorm an idea via research + Distiller before building.
+    With --mode interactive: brainstorm an idea via research + Distiller before building.
     """
     from factory.agents.runner import resolve_prompt
 
-    interactive_idea = getattr(args, "interactive", None)
     raw_path = getattr(args, "path", None)
-
-    if not raw_path and not interactive_idea:
-        print("Error: provide a project path/prompt, or use --interactive 'idea'",
-              file=sys.stderr)
-        return 1
-
+    mode = getattr(args, "mode", "auto")
     headless = getattr(args, "headless", False)
     prompt_file = getattr(args, "prompt", None)
     focus = getattr(args, "focus", None)
 
-    if interactive_idea:
+    if not raw_path:
+        print("Error: provide a project path, GitHub URL, idea file, or prompt",
+              file=sys.stderr)
+        return 1
+
+    if mode == "interactive":
         if headless:
-            print("Error: --interactive requires foreground mode "
+            print("Error: --mode interactive requires foreground mode "
                   "(incompatible with --headless)", file=sys.stderr)
             return 1
         if prompt_file:
-            print("Error: --interactive and --prompt are mutually exclusive. "
-                  "--interactive generates the spec; --prompt provides one.",
+            print("Error: --mode interactive and --prompt are mutually exclusive. "
+                  "Interactive mode generates the spec; --prompt provides one.",
                   file=sys.stderr)
             return 1
         if focus:
-            print("Error: --interactive and --focus are mutually exclusive. "
-                  "--interactive is for new ideas; --focus targets existing "
+            print("Error: --mode interactive and --focus are mutually exclusive. "
+                  "Interactive mode is for new ideas; --focus targets existing "
                   "backlog items.", file=sys.stderr)
             return 1
 
-    resolve_target = raw_path or interactive_idea
-    assert resolve_target is not None  # validated above
-    project_path, context = _resolve_input(resolve_target)
-    if interactive_idea:
+    project_path, context = _resolve_input(raw_path)
+    interactive_idea: str | None = None
+    if mode == "interactive":
+        interactive_idea = context or "(ask the user to describe their idea)"
         context = None  # idea is embedded in the Phase 0 block, not as Project Specification
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
-    mode = getattr(args, "mode", "auto")
-    if interactive_idea:
-        if mode not in ("auto", "build"):
-            print(f"Warning: --interactive always uses build mode, ignoring --mode '{mode}'",
-                  file=sys.stderr)
-        mode = "build"
-    elif mode == "auto":
+    if mode == "auto":
         mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))
     discover_only = getattr(args, "discover_only", False)
     min_growth = getattr(args, "min_growth", None)
@@ -1115,15 +1108,16 @@ def cmd_ceo(args: argparse.Namespace) -> int:
               "The project must already be built before targeting specific items.", file=sys.stderr)
         return 1
 
-    _print_banner("ideation" if interactive_idea else mode)
+    _print_banner("ideation" if mode == "interactive" else mode)
     _ensure_dashboard(project_path)
 
     if focus:
         from factory.study import add_backlog_item
         add_backlog_item(project_path, focus)
 
+    ceo_mode = "build" if mode == "interactive" else mode
     task = _build_ceo_task(
-        project_path, mode, context, focus=focus, prompt_file=prompt_file,
+        project_path, ceo_mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
         discover_only=discover_only,
         interactive_idea=interactive_idea,
@@ -2023,13 +2017,8 @@ def build_parser() -> argparse.ArgumentParser:
     # ceo — launch the Factory CEO agent directly
     p = sub.add_parser("ceo", help="Launch the Factory CEO agent (interactive by default)")
     p.add_argument("path", nargs="?", default=None,
-                    help="Project path, GitHub URL, idea file path, or prompt")
-    p.add_argument(
-        "--interactive", default=None, metavar="IDEA",
-        help="Enter interactive ideation mode: research the space, brainstorm with "
-             "the Distiller agent, refine the idea with user feedback, then build. "
-             "Takes a raw idea string (e.g. --interactive 'distributed eval runner')",
-    )
+                    help="Project path, GitHub URL, idea file path, or prompt. "
+                         "In interactive mode, pass a raw idea string")
     p.add_argument(
         "--prompt", default=None,
         help="Path to a prompt/spec file (absolute or relative to project). "
@@ -2037,9 +2026,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "build", "discover", "improve", "meta"],
+        choices=["auto", "build", "discover", "improve", "meta", "interactive"],
         default="auto",
-        help="Run mode: auto (default, detects from project state), build, discover, improve, or meta",
+        help="Run mode: auto (default, detects from project state), build, discover, "
+             "improve, meta, or interactive (research + brainstorm → spec → build)",
     )
     p.add_argument(
         "--focus", default=None,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -18,7 +18,7 @@ class TestResolvePrompt:
         assert len(prompt) > 100
 
     def test_all_default_prompts_exist(self):
-        roles: list[AgentRole] = ["researcher", "strategist", "evaluator", "reviewer", "archivist", "ceo"]
+        roles: list[AgentRole] = ["researcher", "strategist", "evaluator", "reviewer", "archivist", "distiller", "ceo"]
         for role in roles:
             prompt = resolve_prompt(role)
             assert len(prompt) > 50, f"Prompt for {role} is too short"
@@ -57,7 +57,7 @@ class TestResolvePrompt:
         assert _PROMPTS_DIR.is_dir()
 
     def test_each_prompt_has_header(self):
-        roles: list[AgentRole] = ["researcher", "strategist", "evaluator", "reviewer", "archivist", "ceo"]
+        roles: list[AgentRole] = ["researcher", "strategist", "evaluator", "reviewer", "archivist", "distiller", "ceo"]
         for role in roles:
             prompt = resolve_prompt(role)
             assert prompt.startswith("# "), f"Prompt for {role} should start with '# '"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,21 +69,15 @@ class TestParser:
     def test_no_command_returns_1(self):
         assert main([]) == 1
 
-    def test_ceo_interactive_flag(self):
+    def test_ceo_mode_interactive(self):
         parser = build_parser()
-        args = parser.parse_args(["ceo", "--interactive", "distributed eval runner"])
-        assert args.interactive == "distributed eval runner"
-        assert args.path is None
-
-    def test_ceo_interactive_with_path(self):
-        parser = build_parser()
-        args = parser.parse_args(["ceo", "/some/path", "--interactive", "my idea"])
-        assert args.interactive == "my idea"
-        assert args.path == "/some/path"
+        args = parser.parse_args(["ceo", "distributed eval runner", "--mode", "interactive"])
+        assert args.mode == "interactive"
+        assert args.path == "distributed eval runner"
 
     def test_ceo_path_optional(self):
         parser = build_parser()
-        args = parser.parse_args(["ceo", "--interactive", "some idea"])
+        args = parser.parse_args(["ceo", "--mode", "interactive"])
         assert args.path is None
 
     def test_ceo_agent_distiller_choice(self):
@@ -94,66 +88,76 @@ class TestParser:
 
 class TestCmdCeoInteractive:
     def test_interactive_headless_incompatible(self, capsys):
-        result = main(["ceo", "--interactive", "an idea", "--headless"])
+        result = main(["ceo", "an idea", "--mode", "interactive", "--headless"])
         assert result == 1
         assert "incompatible" in capsys.readouterr().err.lower()
 
     def test_interactive_prompt_incompatible(self, capsys):
-        result = main(["ceo", "--interactive", "an idea", "--prompt", "file.md"])
+        result = main(["ceo", "an idea", "--mode", "interactive", "--prompt", "file.md"])
         assert result == 1
         assert "mutually exclusive" in capsys.readouterr().err.lower()
 
     def test_interactive_focus_incompatible(self, capsys):
-        result = main(["ceo", "--interactive", "an idea", "--focus", "UI"])
+        result = main(["ceo", "an idea", "--mode", "interactive", "--focus", "UI"])
         assert result == 1
         assert "mutually exclusive" in capsys.readouterr().err.lower()
 
-    def test_no_path_no_interactive_fails(self, capsys):
+    def test_no_path_fails(self, capsys):
         result = main(["ceo"])
         assert result == 1
         err = capsys.readouterr().err.lower()
         assert "provide" in err or "error" in err
 
-    def test_interactive_mode_warning(self, capsys):
-        """--interactive with --mode=improve warns and overrides to build."""
-        with patch("factory.cli.os.execvp"), \
-             patch("factory.cli.os.chdir"):
-            main(["ceo", "--interactive", "an idea", "--mode", "improve"])
-        err = capsys.readouterr().err.lower()
-        assert "ignoring" in err
-
     def test_interactive_foreground_uses_execvp(self, tmp_path):
-        """--interactive mode launches via os.execvp (foreground)."""
+        """--mode interactive launches via os.execvp (foreground)."""
         with patch("factory.cli.os.execvp") as mock_exec, \
              patch("factory.cli.os.chdir"):
-            main(["ceo", str(tmp_path), "--interactive", "my idea"])
+            main(["ceo", str(tmp_path), "--mode", "interactive"])
         mock_exec.assert_called_once()
         cmd = mock_exec.call_args[0][1]
         assert cmd[0] == "claude"
         assert "--dangerously-skip-permissions" in cmd
 
     def test_interactive_task_has_phase_0_block(self, tmp_path):
-        """--interactive injects Phase 0 block into the CEO task."""
+        """--mode interactive injects Phase 0 block into the CEO task."""
         with patch("factory.cli.os.execvp") as mock_exec, \
              patch("factory.cli.os.chdir"):
-            main(["ceo", str(tmp_path), "--interactive", "distributed eval runner"])
+            main(["ceo", str(tmp_path), "--mode", "interactive"])
         cmd = mock_exec.call_args[0][1]
-        # Task is the positional arg after --dangerously-skip-permissions
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Interactive Ideation Mode (Phase 0)" in task
-        assert "distributed eval runner" in task
 
     def test_interactive_no_duplicate_context(self, tmp_path):
-        """--interactive does not inject the idea as both Phase 0 and Project Specification."""
+        """--mode interactive does not inject the idea as both Phase 0 and Project Specification."""
         with patch("factory.cli.os.execvp") as mock_exec, \
              patch("factory.cli.os.chdir"):
-            main(["ceo", str(tmp_path), "--interactive", "build a cool CLI tool"])
+            main(["ceo", "build a cool CLI tool", "--mode", "interactive"])
         cmd = mock_exec.call_args[0][1]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Interactive Ideation Mode" in task
         assert "## Project Specification" not in task
+
+    def test_interactive_task_contains_idea_text(self, tmp_path):
+        """--mode interactive with raw idea text includes it in the Phase 0 block."""
+        with patch("factory.cli.os.execvp") as mock_exec, \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", "distributed eval runner", "--mode", "interactive"])
+        cmd = mock_exec.call_args[0][1]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "distributed eval runner" in task
+
+    def test_interactive_task_mode_is_build(self, tmp_path):
+        """--mode interactive sets Mode: build in the CEO task (not Mode: interactive)."""
+        with patch("factory.cli.os.execvp") as mock_exec, \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", str(tmp_path), "--mode", "interactive"])
+        cmd = mock_exec.call_args[0][1]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "Mode: build" in task
 
 
 class TestCmdDetect:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,51 @@ class TestParser:
     def test_no_command_returns_1(self):
         assert main([]) == 1
 
+    def test_ceo_interactive_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "--interactive", "distributed eval runner"])
+        assert args.interactive == "distributed eval runner"
+        assert args.path is None
+
+    def test_ceo_interactive_with_path(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path", "--interactive", "my idea"])
+        assert args.interactive == "my idea"
+        assert args.path == "/some/path"
+
+    def test_ceo_path_optional(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "--interactive", "some idea"])
+        assert args.path is None
+
+    def test_ceo_agent_distiller_choice(self):
+        parser = build_parser()
+        args = parser.parse_args(["agent", "distiller", "--task", "test", "--project", "/p"])
+        assert args.role == "distiller"
+
+
+class TestCmdCeoInteractive:
+    def test_interactive_headless_incompatible(self, capsys):
+        result = main(["ceo", "--interactive", "an idea", "--headless"])
+        assert result == 1
+        assert "incompatible" in capsys.readouterr().err.lower()
+
+    def test_interactive_prompt_incompatible(self, capsys):
+        result = main(["ceo", "--interactive", "an idea", "--prompt", "file.md"])
+        assert result == 1
+        assert "mutually exclusive" in capsys.readouterr().err.lower()
+
+    def test_interactive_focus_incompatible(self, capsys):
+        result = main(["ceo", "--interactive", "an idea", "--focus", "UI"])
+        assert result == 1
+        assert "mutually exclusive" in capsys.readouterr().err.lower()
+
+    def test_no_path_no_interactive_fails(self, capsys):
+        result = main(["ceo"])
+        assert result == 1
+        err = capsys.readouterr().err.lower()
+        assert "provide" in err or "error" in err
+
 
 class TestCmdDetect:
     def test_detect_no_repo(self, tmp_path, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,6 +114,47 @@ class TestCmdCeoInteractive:
         err = capsys.readouterr().err.lower()
         assert "provide" in err or "error" in err
 
+    def test_interactive_mode_warning(self, capsys):
+        """--interactive with --mode=improve warns and overrides to build."""
+        with patch("factory.cli.os.execvp"), \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", "--interactive", "an idea", "--mode", "improve"])
+        err = capsys.readouterr().err.lower()
+        assert "ignoring" in err
+
+    def test_interactive_foreground_uses_execvp(self, tmp_path):
+        """--interactive mode launches via os.execvp (foreground)."""
+        with patch("factory.cli.os.execvp") as mock_exec, \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", str(tmp_path), "--interactive", "my idea"])
+        mock_exec.assert_called_once()
+        cmd = mock_exec.call_args[0][1]
+        assert cmd[0] == "claude"
+        assert "--dangerously-skip-permissions" in cmd
+
+    def test_interactive_task_has_phase_0_block(self, tmp_path):
+        """--interactive injects Phase 0 block into the CEO task."""
+        with patch("factory.cli.os.execvp") as mock_exec, \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", str(tmp_path), "--interactive", "distributed eval runner"])
+        cmd = mock_exec.call_args[0][1]
+        # Task is the positional arg after --dangerously-skip-permissions
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "## Interactive Ideation Mode (Phase 0)" in task
+        assert "distributed eval runner" in task
+
+    def test_interactive_no_duplicate_context(self, tmp_path):
+        """--interactive does not inject the idea as both Phase 0 and Project Specification."""
+        with patch("factory.cli.os.execvp") as mock_exec, \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", str(tmp_path), "--interactive", "build a cool CLI tool"])
+        cmd = mock_exec.call_args[0][1]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "## Interactive Ideation Mode" in task
+        assert "## Project Specification" not in task
+
 
 class TestCmdDetect:
     def test_detect_no_repo(self, tmp_path, capsys):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -24,6 +24,11 @@ def archivist_prompt() -> str:
     return (PROMPTS_DIR / "archivist.md").read_text()
 
 
+@pytest.fixture
+def distiller_prompt() -> str:
+    return (PROMPTS_DIR / "distiller.md").read_text()
+
+
 # ── Strategist ────────────────────────────────────────────────────
 
 
@@ -334,3 +339,77 @@ class TestCeoPrompt:
             ceo_prompt,
         )
         assert len(async_calls) == 0, f"Found {len(async_calls)} async archivist calls — all must be blocking"
+
+    # ── Phase 0: Ideation tests ────────────────────────────────
+
+    def test_has_phase_0_ideation(self, ceo_prompt: str) -> None:
+        assert "## Phase 0: Ideation" in ceo_prompt
+
+    def test_phase_0_before_build_mode(self, ceo_prompt: str) -> None:
+        """Phase 0 must appear before Build mode in the prompt."""
+        phase0_idx = ceo_prompt.index("## Phase 0: Ideation")
+        build_idx = ceo_prompt.index("## Mode: Build")
+        assert phase0_idx < build_idx
+
+    def test_phase_0_spawns_researcher(self, ceo_prompt: str) -> None:
+        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+        build_start = ceo_prompt.index("## Mode: Build")
+        phase0_section = ceo_prompt[phase0_start:build_start]
+        assert "factory agent researcher" in phase0_section
+
+    def test_phase_0_spawns_distiller(self, ceo_prompt: str) -> None:
+        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+        build_start = ceo_prompt.index("## Mode: Build")
+        phase0_section = ceo_prompt[phase0_start:build_start]
+        assert "factory agent distiller" in phase0_section
+
+    def test_phase_0_has_iteration_limit(self, ceo_prompt: str) -> None:
+        assert "Maximum 5 iterations" in ceo_prompt
+
+    def test_phase_0_persists_spec(self, ceo_prompt: str) -> None:
+        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+        build_start = ceo_prompt.index("## Mode: Build")
+        phase0_section = ceo_prompt[phase0_start:build_start]
+        assert "current.md" in phase0_section
+
+    def test_phase_0_transitions_to_build(self, ceo_prompt: str) -> None:
+        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+        build_start = ceo_prompt.index("## Mode: Build")
+        phase0_section = ceo_prompt[phase0_start:build_start]
+        assert "Build mode" in phase0_section
+
+    def test_phase_0_spawns_archivist(self, ceo_prompt: str) -> None:
+        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+        build_start = ceo_prompt.index("## Mode: Build")
+        phase0_section = ceo_prompt[phase0_start:build_start]
+        assert "factory agent archivist" in phase0_section
+
+
+# ── Distiller ────────────────────────────────────────────────────
+
+
+class TestDistillerPrompt:
+    def test_exists(self) -> None:
+        assert (PROMPTS_DIR / "distiller.md").exists()
+
+    def test_has_output_format(self, distiller_prompt: str) -> None:
+        assert "## Vision" in distiller_prompt
+        assert "## Core Features" in distiller_prompt
+        assert "## Architecture" in distiller_prompt
+
+    def test_has_refinement_mode(self, distiller_prompt: str) -> None:
+        assert "## Refinement Mode" in distiller_prompt
+        assert "Prior Draft" in distiller_prompt
+        assert "User Feedback" in distiller_prompt
+
+    def test_has_rules(self, distiller_prompt: str) -> None:
+        assert "## Rules" in distiller_prompt
+
+    def test_has_non_goals(self, distiller_prompt: str) -> None:
+        assert "Non-Goals" in distiller_prompt
+
+    def test_has_open_questions(self, distiller_prompt: str) -> None:
+        assert "Open Questions" in distiller_prompt
+
+    def test_references_research_file(self, distiller_prompt: str) -> None:
+        assert "research.md" in distiller_prompt


### PR DESCRIPTION
## Summary
- The `--prompt` CLI flag takes a **file path** (e.g. `--prompt spec.md`), not a raw string
- Raw prompts go as the positional argument: `factory ceo "Build a weather CLI"`
- Fix README.md (3 instances), docs/index.md (2 instances), CLAUDE.md (1 instance + clarified description)
- Verified via grep: no remaining `--prompt "` patterns in docs

## Test plan
- [ ] `grep -rn '\-\-prompt "' docs/ README.md CLAUDE.md` returns nothing
- [ ] All code examples in README render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)