### PR TITLE
feat: add Bob Shell runner support as alternative CLI backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,8 @@ The factory supports multiple CLI backends via the runner abstraction (`factory/
 
 **Bob Shell specifics:**
 - Requires `BOBSHELL_API_KEY` environment variable to be set
-- Uses custom modes (`.bob/custom_modes.yaml`) to inject agent role definitions
-- Model selection is handled via `--chat-mode` instead of `--model`
+- Uses 'code' mode; agent role definitions are injected via the prompt
+- Model selection is not configurable (Bob Shell uses its default model)
 
 **Dry-run mode:** Set `FACTORY_BOB_DRY_RUN=1` to test Bob Shell integration without spending tokens. The factory returns stub responses and logs usage. This is automatically set in tests via `tests/conftest.py`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ The factory supports multiple CLI backends via the runner abstraction (`factory/
 - All invocations are logged to `.factory/bob_usage.jsonl`
 - Ceiling violations emit events to `.factory/events.jsonl` and abort with an actionable error message
 
+**Important:** Target projects should add `.factory/` to their `.gitignore`. The factory writes experiment data, usage logs, and potentially sensitive auth files (`.factory/.bob_auth`) to this directory. These are project-local artifacts that should not be committed to version control.
+
 ## Running the factory
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,25 @@ All domain models live in `factory/models.py` as strict Pydantic v2 models. Key 
 
 Requires Claude Code installed and authenticated. The factory spawns `claude` subprocesses — it does not call the API directly. Any Claude Code authentication method works (API key, Vertex AI, etc.).
 
+## Runners
+
+The factory supports multiple CLI backends via the runner abstraction (`factory/runners/`). By default, it uses Claude Code (`claude` CLI), but Bob Shell (`bob` CLI) is also supported as a switchable alternative.
+
+**Runner selection:** Set `FACTORY_RUNNER=bob` to use Bob Shell, or pass `--runner bob` to individual commands. Default is `claude`.
+
+**Bob Shell specifics:**
+- Requires `BOBSHELL_API_KEY` environment variable to be set
+- Uses custom modes (`.bob/custom_modes.yaml`) to inject agent role definitions
+- Model selection is handled via `--chat-mode` instead of `--model`
+
+**Dry-run mode:** Set `FACTORY_BOB_DRY_RUN=1` to test Bob Shell integration without spending tokens. The factory returns stub responses and logs usage. This is automatically set in tests via `tests/conftest.py`.
+
+**Token guardrails:** Bob Shell has no token telemetry, so the factory self-enforces invocation ceilings:
+- `FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE` (default: 3)
+- `FACTORY_BOB_MAX_INVOCATIONS_PER_DAY` (default: 20)
+- All invocations are logged to `.factory/bob_usage.jsonl`
+- Ceiling violations emit events to `.factory/events.jsonl` and abort with an actionable error message
+
 ## Running the factory
 
 ```bash
@@ -129,7 +148,7 @@ factory precheck /path --score-before 0.7 --score-after 0.85  # Hard precheck ga
 factory review --verdict KEEP --pr 42           # Post structured review on GitHub PR
 ```
 
-`factory run` / `factory ceo` spawn the CEO agent as a `claude -p` subprocess. The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all agent roles. `--focus` activates targeted mode: builds exactly one backlog item (e.g. `--focus "eval reliability"`), generating a single hypothesis and exiting after that experiment. Requires improve mode; mutually exclusive with `--loop`. `--mode interactive` enters ideation mode: pass a raw idea as the positional argument (e.g. `factory ceo "distributed eval runner" --mode interactive`). The CEO researches the space via the Researcher, then iteratively refines the idea with the Distiller agent through user feedback, producing an idea.md spec before building. Incompatible with `--headless` and `--focus`.
+`factory run` / `factory ceo` spawn the CEO agent as a subprocess using the selected runner (`claude` by default, or `bob` with `--runner bob`). The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all agent roles. `--focus` activates targeted mode: builds exactly one backlog item (e.g. `--focus "eval reliability"`), generating a single hypothesis and exiting after that experiment. Requires improve mode; mutually exclusive with `--loop`. `--mode interactive` enters ideation mode: pass a raw idea as the positional argument (e.g. `factory ceo "distributed eval runner" --mode interactive`). The CEO researches the space via the Researcher, then iteratively refines the idea with the Distiller agent through user feedback, producing an idea.md spec before building. Incompatible with `--headless` and `--focus`.
 
 ## Observability
 

--- a/factory/agents/playbooks/ceo.md
+++ b/factory/agents/playbooks/ceo.md
@@ -1,7 +1,7 @@
 ---
 role: ceo
-updated: 2026-04-25
-item_count: 6
+updated: 2026-04-26
+item_count: 9
 ---
 
 ## Behavioral Playbook — Ceo
@@ -15,3 +15,6 @@ item_count: 6
 - [ceo-00006] helpful=0 harmful=0 :: At the end of Build mode (before transitioning to Discover/Improve), extract all deferred items from the build plan into .factory/strategy/deferred.md via `factory deferred-list`. The Strategist's $DEFERRED_DIRECTIVE checks for this file.
 
 ### DON'T
+- [ceo-00007] helpful=0 harmful=0 :: NEVER exit Build mode between phases with a self-judged "stopping point" rationale. Phrases like "This is a good stopping point" or "Phase 1 is complete and documented" are FORBIDDEN exit reasons. A scaffold without implementation is not a deliverable — complete ALL planned phases before exiting.
+- [ceo-00008] helpful=0 harmful=0 :: NEVER exit Improve mode after Strategy approval but before executing hypotheses. Phrases like "this is beyond the scope of a single session" or "strategy is ready for execution" are FORBIDDEN exit reasons. Strategy approval is NOT completion — you MUST spawn Builder for EVERY approved hypothesis and get verdicts before exiting.
+- [ceo-00009] helpful=0 harmful=0 :: NEVER spawn subagents in the background. Do not run `factory agent <role>` with `&`, `run_in_background`, or any background process mode. Do not `tail -f` any log file waiting for subagent output — no such file exists. The runner captures all output to `.factory/reviews/<role>-latest.md` synchronously. Background spawning causes double-spend when the CEO "recovers" by re-invoking synchronously.

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -18,6 +18,29 @@ You DO:
 - Ensure archival happens at every checkpoint (MANDATORY)
 - Run self-improvement cycles (ACE) to evolve agent playbooks
 
+## Cycle Completion — CRITICAL (ALL MODES)
+
+**You MUST complete ALL planned work before exiting.** This applies to every mode:
+
+- **Build mode:** All phases (B0–B6) must be attempted
+- **Improve mode:** Every approved hypothesis must have a Builder keep/revert verdict
+- **Discover mode:** The eval profile must be generated
+- **Meta mode:** Same as Improve, plus ACE playbook evolution
+
+**Self-judged early exits are FORBIDDEN.** Do not exit because:
+- "This is a good stopping point" — there are no stopping points, only completion
+- "This is beyond the scope of a single session" — the scope is the planned work
+- "The scaffold is complete" — scaffolds are not deliverables
+
+**Valid exit conditions are:**
+1. All planned work has been completed (verdicts for all hypotheses / phases attempted)
+2. An unrecoverable failure occurred (emit `cycle.aborted` event via CLI, then exit)
+3. The user explicitly interrupted the session (Ctrl+C)
+
+**After each step/phase:** Check your plan at `.factory/strategy/current.md`. If planned work remains, proceed to the next item. If all planned work is complete, proceed to final archival.
+
+The factory will auto-resume incomplete cycles, but this wastes context and money. Complete your work in one session.
+
 ## Your Agents
 
 Spawn specialists via the CLI. Each agent gets a fresh context window with its resolved prompt + any evolved playbook auto-injected.
@@ -25,6 +48,37 @@ Spawn specialists via the CLI. Each agent gets a fresh context window with its r
 ```bash
 factory agent <role> --task "<task description>" --project /path/to/project [--timeout 600]
 ```
+
+### Subagent Invocation — CRITICAL (SYNCHRONOUS ONLY)
+
+**All subagent invocations MUST be synchronous.** This is an inviolable constraint.
+
+- **Do NOT** run `factory agent <role>` in the background (no `&`, no `run_in_background`, no background process mode)
+- **Do NOT** `tail -f` any log file waiting for subagent output — there is no such file
+- **Do NOT** poll for subagent completion via any mechanism — the call is blocking
+
+**Why:** The factory's `invoke_agent` function is synchronous by design. It:
+1. Runs the subagent as a blocking subprocess
+2. Captures stdout/stderr to `.factory/reviews/<role>-latest.md`
+3. Emits `agent.started`/`agent.completed` events to `.factory/events.jsonl`
+4. Returns only when the subagent finishes
+
+**Correct pattern:**
+```bash
+factory agent researcher --task "..." --project "$PROJECT_PATH" --timeout 300
+# Command blocks until Researcher completes
+cat "$PROJECT_PATH/.factory/reviews/researcher-latest.md"  # Read the output
+```
+
+**Forbidden pattern (causes double-spend):**
+```bash
+# WRONG — do not do this
+factory agent researcher --task "..." &   # Background spawn
+tail -f some-log-file                      # Polling (doesn't work)
+# CEO sees empty output, "recovers" by re-spawning synchronously → 2x cost
+```
+
+Spawning subagents in the background and polling for output is not supported and doubles token/coin spend on every retry. Trust the runner — it captures everything.
 
 | Role       | Purpose                                                        |
 |------------|----------------------------------------------------------------|
@@ -325,6 +379,25 @@ When the user approves the spec:
 ## Mode: Build (`no_repo` / `incomplete`)
 
 The project doesn't exist or is incomplete. **You MUST still follow the full agent pipeline.** Do NOT jump straight to the Builder.
+
+### BUILD PIPELINE COMPLETION — CRITICAL (NON-OVERRIDABLE)
+
+**You MUST complete ALL planned phases (B0 through B6) before exiting Build mode.**
+
+This is an **inviolable constraint**. There is NO valid reason to exit between phases. Specifically:
+
+1. **Phase completions are CHECKPOINTS, not stopping points.** Checkpointing is for crash recovery and progress tracking, NOT for deciding when to stop. Completing Phase 1 means you proceed to Phase 2, not that you exit.
+
+2. **"Good stopping point" is NOT a valid exit condition.** The phrase "this is a good stopping point" or any equivalent self-judged rationale for early exit is FORBIDDEN. A scaffold without implementation is not a deliverable.
+
+3. **Valid exit conditions are:**
+   - All planned phases (B0 through B6) have been attempted
+   - An unrecoverable agent failure occurred (must be reported as ABORT with `--verdict error`, not as a normal completion)
+   - The user explicitly interrupted the session
+
+4. **After each phase completes:** Check the plan at `.factory/strategy/current.md`. If there are more phases, proceed to the next phase. If this was the final phase, proceed to B5 (E2E verification) then B6 (re-detect).
+
+Violating this constraint means the factory produced no usable output. A project with only scaffolds and no implementation is a failure, regardless of how clean the scaffolds are.
 
 ### B0: Research (Researcher Agent)
 

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -97,6 +97,7 @@ async def invoke_agent(
     dangerously_skip_permissions: bool = True,
     model: str | None = None,
     runner_name: str | None = None,
+    _track_failures: bool = True,
 ) -> tuple[str, int]:
     """Invoke a Claude Code agent with the resolved prompt + task.
 
@@ -108,11 +109,14 @@ async def invoke_agent(
         dangerously_skip_permissions: If True, skip permission prompts.
         model: Optional model override.
         runner_name: CLI backend to use ("claude" or "bob"). Defaults to FACTORY_RUNNER env var.
+        _track_failures: If True (default), track consecutive failures globally.
+            Set to False when called from invoke_agents_parallel to avoid race conditions.
 
     Returns (stdout, return_code).
 
     Raises:
-        ConsecutiveAgentFailureError: If too many consecutive agent spawns fail.
+        ConsecutiveAgentFailureError: If too many consecutive agent spawns fail
+            (only when _track_failures=True).
     """
     global _consecutive_failures
 
@@ -137,8 +141,9 @@ async def invoke_agent(
     except Exception as e:
         logger.error("%s agent failed: %s", role, e)
         _emit_safe(project_path, "agent.failed", agent=role, data={"error": str(e)[:200]})
-        _consecutive_failures += 1
-        _check_failure_threshold(project_path, role)
+        if _track_failures:
+            _consecutive_failures += 1
+            _check_failure_threshold(project_path, role)
         return f"Error: {e}", 1
 
     if return_code != 0:
@@ -147,15 +152,17 @@ async def invoke_agent(
             project_path, "agent.failed", agent=role,
             data={"return_code": return_code, "stderr": stdout[:200] if stdout else ""},
         )
-        _consecutive_failures += 1
-        _check_failure_threshold(project_path, role)
+        if _track_failures:
+            _consecutive_failures += 1
+            _check_failure_threshold(project_path, role)
     else:
         _emit_safe(
             project_path, "agent.completed", agent=role,
             data={"return_code": 0},
         )
-        # Reset counter on success
-        _consecutive_failures = 0
+        if _track_failures:
+            # Reset counter on success
+            _consecutive_failures = 0
 
     _save_review(project_path, role, stdout, return_code)
 
@@ -219,7 +226,12 @@ async def invoke_agents_parallel(
     model: str | None = None,
     runner_name: str | None = None,
 ) -> list[tuple[str, int]]:
-    """Invoke multiple agents concurrently. Returns list of (output, return_code)."""
+    """Invoke multiple agents concurrently. Returns list of (output, return_code).
+
+    Raises:
+        ConsecutiveAgentFailureError: If all agents in the batch fail, indicating
+            infrastructure problems (e.g., API key not propagating to subprocesses).
+    """
     coros = [
         invoke_agent(
             role,
@@ -229,7 +241,25 @@ async def invoke_agents_parallel(
             dangerously_skip_permissions=dangerously_skip_permissions,
             model=model,
             runner_name=runner_name,
+            _track_failures=False,  # Avoid race condition; track locally below
         )
         for role, task in tasks
     ]
-    return list(await asyncio.gather(*coros))
+    results = list(await asyncio.gather(*coros))
+
+    # Track failures locally to avoid race condition with global counter
+    failure_count = sum(1 for _, code in results if code != 0)
+    if failure_count >= _FAILURE_ABORT_THRESHOLD and failure_count == len(results):
+        # All agents failed — likely infrastructure issue
+        _emit_safe(
+            project_path,
+            "cycle.aborted",
+            data={
+                "reason": "consecutive_agent_failures",
+                "failure_count": failure_count,
+                "last_agent": "parallel_batch",
+            },
+        )
+        raise ConsecutiveAgentFailureError(failure_count, "parallel_batch")
+
+    return results

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -4,15 +4,43 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from pathlib import Path
 from typing import Literal
 
 from factory.ace.injector import inject_playbook, load_playbook
+from factory.runners import get_runner
 
 logger = logging.getLogger(__name__)
 
 AgentRole = Literal["researcher", "strategist", "builder", "reviewer", "evaluator", "archivist", "distiller", "ceo"]
+
+# Consecutive failure tracking
+_consecutive_failures: int = 0
+_FAILURE_ABORT_THRESHOLD: int = 2
+
+
+class ConsecutiveAgentFailureError(Exception):
+    """Raised when too many consecutive agent spawns fail.
+
+    This prevents the CEO from falling back to doing work itself when subagent
+    infrastructure is broken. Instead, the cycle should abort with a clear error.
+    """
+
+    def __init__(self, failure_count: int, last_agent: str) -> None:
+        self.failure_count = failure_count
+        self.last_agent = last_agent
+        super().__init__(
+            f"Aborting after {failure_count} consecutive agent spawn failures. "
+            f"Last failed agent: {last_agent}. "
+            "Check .factory/events.jsonl for details. "
+            "This usually means BOBSHELL_API_KEY is not being propagated to subprocesses."
+        )
+
+
+def reset_failure_counter() -> None:
+    """Reset the consecutive failure counter. Call at start of a cycle."""
+    global _consecutive_failures
+    _consecutive_failures = 0
 
 # Directory containing base agent prompts (shipped with the factory)
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
@@ -68,72 +96,88 @@ async def invoke_agent(
     timeout: float = 600.0,
     dangerously_skip_permissions: bool = True,
     model: str | None = None,
+    runner_name: str | None = None,
 ) -> tuple[str, int]:
     """Invoke a Claude Code agent with the resolved prompt + task.
 
-    Returns (stdout, return_code).
-    """
-    prompt = resolve_prompt(role, project_path)
-    full_prompt = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
+    Args:
+        role: The agent role to invoke.
+        task: The task description.
+        project_path: Path to the project.
+        timeout: Maximum execution time in seconds.
+        dangerously_skip_permissions: If True, skip permission prompts.
+        model: Optional model override.
+        runner_name: CLI backend to use ("claude" or "bob"). Defaults to FACTORY_RUNNER env var.
 
-    cmd = ["claude", "-p", full_prompt]
-    if dangerously_skip_permissions:
-        cmd.append("--dangerously-skip-permissions")
-    if model:
-        cmd.extend(["--model", model])
+    Returns (stdout, return_code).
+
+    Raises:
+        ConsecutiveAgentFailureError: If too many consecutive agent spawns fail.
+    """
+    global _consecutive_failures
+
+    prompt = resolve_prompt(role, project_path)
 
     logger.info("Invoking %s agent for %s", role, project_path.name)
 
-    # Emit agent started event
     _emit_safe(project_path, "agent.started", agent=role, data={"task": task[:200]})
 
-    # Clean environment: remove VIRTUAL_ENV so the target project's own
-    # venv is used (prevents mypy/pytest from checking wrong packages).
-    env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-    if model:
-        env["FACTORY_MODEL"] = model
+    runner = get_runner(runner_name)
 
     try:
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        stdout, return_code = await runner.headless(
+            prompt=prompt,
+            task=task,
             cwd=project_path,
-            env=env,
+            timeout=timeout,
+            model=model,
+            dangerously_skip_permissions=dangerously_skip_permissions,
+            role=role,
         )
-        stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=timeout
-        )
-    except asyncio.TimeoutError:
-        proc.kill()  # type: ignore[union-attr]
-        await proc.wait()  # type: ignore[union-attr]
-        logger.error("%s agent timed out after %ss", role, timeout)
-        _emit_safe(project_path, "agent.timeout", agent=role, data={"timeout": timeout})
-        return f"Agent timed out after {timeout}s", 1
-    except FileNotFoundError:
-        logger.error("'claude' CLI not found on PATH")
-        _emit_safe(project_path, "agent.failed", agent=role, data={"error": "claude CLI not found"})
-        return "Error: 'claude' CLI not found on PATH", 1
+    except Exception as e:
+        logger.error("%s agent failed: %s", role, e)
+        _emit_safe(project_path, "agent.failed", agent=role, data={"error": str(e)[:200]})
+        _consecutive_failures += 1
+        _check_failure_threshold(project_path, role)
+        return f"Error: {e}", 1
 
-    stdout = stdout_bytes.decode()
-    stderr = stderr_bytes.decode()
-
-    if proc.returncode != 0:
-        logger.warning("%s agent exited with code %d: %s", role, proc.returncode, stderr[:200])
+    if return_code != 0:
+        logger.warning("%s agent exited with code %d", role, return_code)
         _emit_safe(
             project_path, "agent.failed", agent=role,
-            data={"return_code": proc.returncode, "stderr": stderr[:200]},
+            data={"return_code": return_code, "stderr": stdout[:200] if stdout else ""},
         )
+        _consecutive_failures += 1
+        _check_failure_threshold(project_path, role)
     else:
         _emit_safe(
             project_path, "agent.completed", agent=role,
             data={"return_code": 0},
         )
+        # Reset counter on success
+        _consecutive_failures = 0
 
-    # Save output to .factory/reviews/ so the CEO can review it
-    _save_review(project_path, role, stdout, proc.returncode or 0)
+    _save_review(project_path, role, stdout, return_code)
 
-    return stdout, proc.returncode or 0
+    return stdout, return_code
+
+
+def _check_failure_threshold(project_path: Path, last_agent: str) -> None:
+    """Check if consecutive failures have exceeded the threshold and abort if so."""
+    global _consecutive_failures
+
+    if _consecutive_failures >= _FAILURE_ABORT_THRESHOLD:
+        # Emit cycle.aborted event before raising
+        _emit_safe(
+            project_path,
+            "cycle.aborted",
+            data={
+                "reason": "consecutive_agent_failures",
+                "failure_count": _consecutive_failures,
+                "last_agent": last_agent,
+            },
+        )
+        raise ConsecutiveAgentFailureError(_consecutive_failures, last_agent)
 
 
 def _emit_safe(project_path: Path, event_type: str, **kwargs: object) -> None:

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -217,6 +217,7 @@ async def invoke_agents_parallel(
     timeout: float = 600.0,
     dangerously_skip_permissions: bool = True,
     model: str | None = None,
+    runner_name: str | None = None,
 ) -> list[tuple[str, int]]:
     """Invoke multiple agents concurrently. Returns list of (output, return_code)."""
     coros = [
@@ -227,6 +228,7 @@ async def invoke_agents_parallel(
             timeout=timeout,
             dangerously_skip_permissions=dangerously_skip_permissions,
             model=model,
+            runner_name=runner_name,
         )
         for role, task in tasks
     ]

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -132,8 +132,47 @@ def _count_hypotheses(project_path: Path) -> int:
     return len(matches)
 
 
-def _count_verdicts(project_path: Path) -> int:
-    """Count verdict.json files in .factory/experiments/*/."""
+def _count_verdicts(project_path: Path, since_ts: datetime | None = None) -> int:
+    """Count experiments with verdicts, optionally filtered by timestamp.
+
+    If since_ts is provided, only counts experiments created after that time.
+    This prevents counting stale experiments from previous cycles.
+
+    Reads from results.tsv for timestamp-aware counting. Falls back to counting
+    verdict.json files if results.tsv doesn't exist (backward compatibility).
+    """
+    import csv
+
+    tsv_path = project_path / ".factory" / "results.tsv"
+
+    # If results.tsv exists, use it for timestamp-aware counting
+    if tsv_path.exists():
+        count = 0
+        with open(tsv_path, newline="") as f:
+            reader = csv.DictReader(f, dialect="excel-tab")
+            for row in reader:
+                verdict = row.get("verdict", "").strip().lower()
+                if verdict not in ("keep", "revert", "error"):
+                    continue
+
+                if since_ts is not None:
+                    try:
+                        row_ts = datetime.fromisoformat(row["timestamp"])
+                        if row_ts.tzinfo is None:
+                            row_ts = row_ts.replace(tzinfo=timezone.utc)
+                        since_ts_tz = since_ts
+                        if since_ts_tz.tzinfo is None:
+                            since_ts_tz = since_ts_tz.replace(tzinfo=timezone.utc)
+                        if row_ts < since_ts_tz:
+                            continue
+                    except (KeyError, ValueError):
+                        continue
+
+                count += 1
+        return count
+
+    # Fallback: count verdict.json files (no timestamp filtering possible)
+    # This path is used when results.tsv doesn't exist yet (e.g., fresh projects, tests)
     experiments_dir = project_path / ".factory" / "experiments"
     if not experiments_dir.exists():
         return 0
@@ -165,14 +204,22 @@ def _has_aborted(project_path: Path, since_ts: str | None = None) -> bool:
     return False
 
 
-def _detect_incomplete(project_path: Path, mode: str) -> IncompleteGap | None:
+def _detect_incomplete(
+    project_path: Path, mode: str, cycle_started_at: datetime | None = None
+) -> IncompleteGap | None:
     """Detect if the cycle is incomplete for the given mode.
 
     Returns IncompleteGap if work is incomplete, None if complete.
+
+    Args:
+        project_path: Path to the project.
+        mode: CEO mode (improve, build, discover, meta).
+        cycle_started_at: If provided, only counts experiments created after this time.
+            This prevents counting stale experiments from previous cycles.
     """
     if mode in ("improve", "meta"):
         planned = _count_hypotheses(project_path)
-        completed = _count_verdicts(project_path)
+        completed = _count_verdicts(project_path, since_ts=cycle_started_at)
 
         if planned == 0:
             # No strategy yet — not an incomplete improve cycle, probably discover mode
@@ -205,7 +252,7 @@ def _detect_incomplete(project_path: Path, mode: str) -> IncompleteGap | None:
         # For build mode, check if Builder completed at least one hypothesis
         # In build mode, the strategy file should have phases marked as hypotheses
         planned = _count_hypotheses(project_path)
-        completed = _count_verdicts(project_path)
+        completed = _count_verdicts(project_path, since_ts=cycle_started_at)
 
         if planned == 0:
             # No strategy means we're in scaffold phase — check for eval profile
@@ -404,13 +451,14 @@ async def run_ceo_with_completion_guard(
             return result, code
 
         # Explicit ABORT — respect it and clean up cycle state
-        if _has_aborted(project_path):
+        # Pass cycle start time to filter out stale abort events from previous cycles
+        if _has_aborted(project_path, since_ts=cycle_state.started_at.isoformat()):
             log.info("ceo_aborted", reason="cycle.aborted event found")
             delete_cycle_state(project_path)
             return result, code
 
-        # Check for incomplete work
-        gap = _detect_incomplete(project_path, mode)
+        # Check for incomplete work — pass cycle start time to filter stale experiments
+        gap = _detect_incomplete(project_path, mode, cycle_started_at=cycle_state.started_at)
         if gap is None:
             log.info("ceo_complete", attempt=attempt)
             # Cycle complete — delete cycle state so next invocation starts fresh

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -95,7 +95,9 @@ def delete_cycle_state(project_path: Path) -> bool:
     return False
 
 
-def create_cycle_state(mode: str, initial_prompt: str = "") -> CycleState:
+def create_cycle_state(
+    mode: str, initial_prompt: str = "", runner_name: str | None = None
+) -> CycleState:
     """Create a new CycleState for a fresh cycle."""
     return CycleState(
         cycle_id=str(uuid.uuid4())[:8],
@@ -103,6 +105,7 @@ def create_cycle_state(mode: str, initial_prompt: str = "") -> CycleState:
         mode=mode,  # type: ignore[arg-type]
         initial_prompt=initial_prompt[:1000],  # Truncate to avoid bloat
         respawns=0,
+        runner_name=runner_name,
     )
 
 
@@ -365,7 +368,7 @@ async def run_ceo_with_completion_guard(
     # Check for existing in-flight cycle (respawn scenario)
     cycle_state = read_cycle_state(project_path)
     if cycle_state:
-        # Continuing an existing cycle — use its mode, not the passed-in one
+        # Continuing an existing cycle — use its mode and runner, not the passed-in ones
         log.info(
             "cycle_state_found",
             cycle_id=cycle_state.cycle_id,
@@ -373,9 +376,12 @@ async def run_ceo_with_completion_guard(
             passed_mode=mode,
         )
         mode = cycle_state.mode
+        # Restore runner_name from persisted state (if set)
+        if cycle_state.runner_name:
+            runner_name = cycle_state.runner_name
     else:
         # Fresh cycle — create new state
-        cycle_state = create_cycle_state(mode, initial_task)
+        cycle_state = create_cycle_state(mode, initial_task, runner_name)
         write_cycle_state(project_path, cycle_state)
         log.info("cycle_state_created", cycle_id=cycle_state.cycle_id, mode=mode)
 

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -7,19 +7,103 @@ to "wrap up" early.
 
 from __future__ import annotations
 
+import json
 import os
 import re
+import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 import structlog
 
 from factory.events import emit_event, load_events
+from factory.models import CycleState
 
 log = structlog.get_logger()
 
+# Staleness threshold for cycle.json (24 hours)
+CYCLE_STALENESS_HOURS = 24
+
 # Hard cap on re-spawns per cycle (env-overridable)
 DEFAULT_MAX_RESPAWNS = 5
+
+
+# ── cycle state persistence ──────────────────────────────────────
+
+
+def _cycle_state_path(project_path: Path) -> Path:
+    """Return the path to .factory/state/cycle.json."""
+    return project_path / ".factory" / "state" / "cycle.json"
+
+
+def read_cycle_state(project_path: Path) -> CycleState | None:
+    """Read in-flight cycle state if it exists and is non-stale.
+
+    Returns None if:
+    - cycle.json doesn't exist
+    - cycle.json is malformed
+    - cycle.json is stale (older than CYCLE_STALENESS_HOURS)
+    """
+    path = _cycle_state_path(project_path)
+    if not path.exists():
+        return None
+
+    try:
+        data = json.loads(path.read_text())
+
+        # Parse datetime from ISO string (model_dump(mode="json") serializes as ISO)
+        if "started_at" in data and isinstance(data["started_at"], str):
+            data["started_at"] = datetime.fromisoformat(data["started_at"].replace("Z", "+00:00"))
+
+        state = CycleState.model_validate(data)
+
+        # Check staleness
+        now = datetime.now(timezone.utc)
+        started = state.started_at
+        if started.tzinfo is None:
+            started = started.replace(tzinfo=timezone.utc)
+        age_hours = (now - started).total_seconds() / 3600
+
+        if age_hours > CYCLE_STALENESS_HOURS:
+            log.info("cycle_state_stale", age_hours=age_hours, cycle_id=state.cycle_id)
+            return None
+
+        return state
+    except (json.JSONDecodeError, ValueError) as e:
+        log.warning("cycle_state_parse_error", error=str(e))
+        return None
+
+
+def write_cycle_state(project_path: Path, state: CycleState) -> None:
+    """Write cycle state to .factory/state/cycle.json."""
+    path = _cycle_state_path(project_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Use model_dump with mode="json" for proper datetime serialization
+    data = state.model_dump(mode="json")
+    path.write_text(json.dumps(data, indent=2))
+    log.info("cycle_state_written", cycle_id=state.cycle_id, mode=state.mode, respawns=state.respawns)
+
+
+def delete_cycle_state(project_path: Path) -> bool:
+    """Delete cycle.json on cycle completion. Returns True if deleted."""
+    path = _cycle_state_path(project_path)
+    if path.exists():
+        path.unlink()
+        log.info("cycle_state_deleted", path=str(path))
+        return True
+    return False
+
+
+def create_cycle_state(mode: str, initial_prompt: str = "") -> CycleState:
+    """Create a new CycleState for a fresh cycle."""
+    return CycleState(
+        cycle_id=str(uuid.uuid4())[:8],
+        started_at=datetime.now(timezone.utc),
+        mode=mode,  # type: ignore[arg-type]
+        initial_prompt=initial_prompt[:1000],  # Truncate to avoid bloat
+        respawns=0,
+    )
 
 
 @dataclass
@@ -148,10 +232,27 @@ def _detect_incomplete(project_path: Path, mode: str) -> IncompleteGap | None:
     return None
 
 
-def _build_continuation_task(gap: IncompleteGap) -> str:
-    """Build the continuation task string for re-spawning the CEO."""
+def _build_continuation_task(gap: IncompleteGap, cycle_state: CycleState | None = None) -> str:
+    """Build the continuation task string for re-spawning the CEO.
+
+    Includes explicit mode directive to prevent mode flipping on respawn.
+    """
+    # Mode directive header — prevents mode flip on respawn
+    mode_directive = (
+        f"## CRITICAL: Mode Override\n\n"
+        f"This is a CONTINUATION of an in-flight {gap.mode.upper()} cycle. "
+        f"Do NOT re-detect mode. Do NOT switch to a different mode. "
+        f"The cycle mode is **{gap.mode}** — execute {gap.mode.upper()} mode only.\n\n"
+    )
+
+    if cycle_state:
+        mode_directive += (
+            f"Cycle ID: {cycle_state.cycle_id}\n"
+            f"Respawn count: {cycle_state.respawns}\n\n"
+        )
+
     if gap.mode in ("improve", "meta"):
-        return (
+        body = (
             f"Resume execution from hypothesis {gap.next_item}. "
             f"Strategy is already approved at .factory/strategy/current.md — "
             f"do not re-plan, do not re-run Researcher or Strategist. "
@@ -159,18 +260,21 @@ def _build_continuation_task(gap: IncompleteGap) -> str:
             f"Progress so far: {gap.completed}/{gap.planned} hypotheses have verdicts."
         )
     elif gap.mode == "build":
-        return (
+        body = (
             f"Resume Build pipeline from {gap.next_item}. "
             f"Plan is already approved at .factory/strategy/current.md. "
             f"Progress so far: {gap.completed}/{gap.planned} phases complete. "
             f"Continue with the next phase immediately."
         )
     elif gap.mode == "discover":
-        return (
+        body = (
             "Resume Discovery. The eval profile has not been generated yet. "
             "Complete the Discover mode workflow to produce .factory/eval_profile.json."
         )
-    return f"Resume from {gap.next_item}."
+    else:
+        body = f"Resume from {gap.next_item}."
+
+    return mode_directive + body
 
 
 def _budget_allows_respawn(runner_name: str | None, project_path: Path) -> bool:
@@ -230,6 +334,9 @@ async def run_ceo_with_completion_guard(
 ) -> tuple[str, int]:
     """Spawn CEO; if it exits with planned work undone, re-spawn until done or cap hit.
 
+    Mode is persisted in .factory/state/cycle.json to prevent mode flipping across
+    respawns. The cycle state is created on first spawn and deleted on completion.
+
     Args:
         project_path: Path to the project.
         initial_task: Initial task string for the CEO.
@@ -255,12 +362,29 @@ async def run_ceo_with_completion_guard(
     if max_respawns is None:
         max_respawns = int(os.environ.get("FACTORY_CEO_MAX_RESPAWNS", DEFAULT_MAX_RESPAWNS))
 
+    # Check for existing in-flight cycle (respawn scenario)
+    cycle_state = read_cycle_state(project_path)
+    if cycle_state:
+        # Continuing an existing cycle — use its mode, not the passed-in one
+        log.info(
+            "cycle_state_found",
+            cycle_id=cycle_state.cycle_id,
+            original_mode=cycle_state.mode,
+            passed_mode=mode,
+        )
+        mode = cycle_state.mode
+    else:
+        # Fresh cycle — create new state
+        cycle_state = create_cycle_state(mode, initial_task)
+        write_cycle_state(project_path, cycle_state)
+        log.info("cycle_state_created", cycle_id=cycle_state.cycle_id, mode=mode)
+
     task = initial_task
     final_output = ""
     gap: IncompleteGap | None = None
 
     for attempt in range(max_respawns + 1):
-        log.info("ceo_spawn", attempt=attempt, task_preview=task[:100])
+        log.info("ceo_spawn", attempt=attempt, task_preview=task[:100], mode=mode)
 
         result, code = await invoke_agent(
             "ceo", task, project_path,
@@ -268,20 +392,23 @@ async def run_ceo_with_completion_guard(
         )
         final_output = result
 
-        # User interrupt — respect it
+        # User interrupt — respect it (but don't delete cycle state for later resume)
         if code in (130, 143) or code > 128:
             log.info("ceo_user_interrupt", code=code)
             return result, code
 
-        # Explicit ABORT — respect it
+        # Explicit ABORT — respect it and clean up cycle state
         if _has_aborted(project_path):
             log.info("ceo_aborted", reason="cycle.aborted event found")
+            delete_cycle_state(project_path)
             return result, code
 
         # Check for incomplete work
         gap = _detect_incomplete(project_path, mode)
         if gap is None:
             log.info("ceo_complete", attempt=attempt)
+            # Cycle complete — delete cycle state so next invocation starts fresh
+            delete_cycle_state(project_path)
             return result, code
 
         # Check budget before re-spawning
@@ -290,13 +417,19 @@ async def run_ceo_with_completion_guard(
             _write_cycle_incomplete(project_path, gap, "budget_exceeded")
             return result, 1
 
-        # Emit respawn event
+        # Update cycle state with incremented respawn count
+        cycle_state.respawns += 1
+        write_cycle_state(project_path, cycle_state)
+
+        # Emit respawn event with cycle_id
         emit_event(
             project_path,
             "ceo.respawn",
             agent="ceo",
             data={
                 "attempt": attempt + 1,
+                "cycle_id": cycle_state.cycle_id,
+                "mode": mode,
                 "reason": gap.reason,
                 "planned": gap.planned,
                 "completed": gap.completed,
@@ -304,11 +437,11 @@ async def run_ceo_with_completion_guard(
             },
         )
 
-        # Build continuation task
-        task = _build_continuation_task(gap)
-        log.info("ceo_respawn", attempt=attempt + 1, next_item=gap.next_item)
+        # Build continuation task with explicit mode directive
+        task = _build_continuation_task(gap, cycle_state)
+        log.info("ceo_respawn", attempt=attempt + 1, next_item=gap.next_item, mode=mode)
 
-    # Cap hit
+    # Cap hit — don't delete cycle state to allow manual resume
     if gap:
         log.warning("ceo_respawn_cap_hit", attempts=max_respawns + 1, gap=gap)
         _write_cycle_incomplete(project_path, gap, "respawn_cap_hit")

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -1,0 +1,316 @@
+"""CEO completion guard — auto-resume on premature exit.
+
+Detects when the CEO exits before all planned work is complete and re-spawns
+with a continuation task. This is a structural fix for model-side decisions
+to "wrap up" early.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import structlog
+
+from factory.events import emit_event, load_events
+
+log = structlog.get_logger()
+
+# Hard cap on re-spawns per cycle (env-overridable)
+DEFAULT_MAX_RESPAWNS = 5
+
+
+@dataclass
+class IncompleteGap:
+    """Describes what work is incomplete."""
+
+    mode: str
+    planned: int
+    completed: int
+    next_item: str
+    reason: str
+
+
+def _count_hypotheses(project_path: Path) -> int:
+    """Count hypotheses in .factory/strategy/current.md."""
+    strategy_file = project_path / ".factory" / "strategy" / "current.md"
+    if not strategy_file.exists():
+        return 0
+
+    content = strategy_file.read_text()
+    # Match headings like "#### H1:" or "### H2:" etc.
+    matches = re.findall(r"^#{2,4}\s+H(\d+):", content, re.MULTILINE)
+    return len(matches)
+
+
+def _count_verdicts(project_path: Path) -> int:
+    """Count verdict.json files in .factory/experiments/*/."""
+    experiments_dir = project_path / ".factory" / "experiments"
+    if not experiments_dir.exists():
+        return 0
+
+    count = 0
+    for exp_dir in experiments_dir.iterdir():
+        if exp_dir.is_dir() and (exp_dir / "verdict.json").exists():
+            count += 1
+    return count
+
+
+def _has_eval_profile(project_path: Path) -> bool:
+    """Check if .factory/eval_profile.json exists and is non-empty."""
+    profile = project_path / ".factory" / "eval_profile.json"
+    if not profile.exists():
+        return False
+    return profile.stat().st_size > 10  # More than just "{}"
+
+
+def _has_aborted(project_path: Path, since_ts: str | None = None) -> bool:
+    """Check if cycle.aborted event exists in events.jsonl."""
+    events = load_events(project_path)
+    for event in reversed(events):
+        if event.get("type") == "cycle.aborted":
+            if since_ts is None:
+                return True
+            if event.get("timestamp", "") >= since_ts:
+                return True
+    return False
+
+
+def _detect_incomplete(project_path: Path, mode: str) -> IncompleteGap | None:
+    """Detect if the cycle is incomplete for the given mode.
+
+    Returns IncompleteGap if work is incomplete, None if complete.
+    """
+    if mode in ("improve", "meta"):
+        planned = _count_hypotheses(project_path)
+        completed = _count_verdicts(project_path)
+
+        if planned == 0:
+            # No strategy yet — not an incomplete improve cycle, probably discover mode
+            return None
+
+        if completed >= planned:
+            return None
+
+        next_h = completed + 1
+        return IncompleteGap(
+            mode=mode,
+            planned=planned,
+            completed=completed,
+            next_item=f"H{next_h}",
+            reason=f"improve.incomplete: {completed}/{planned} hypotheses have verdicts",
+        )
+
+    elif mode == "discover":
+        if _has_eval_profile(project_path):
+            return None
+        return IncompleteGap(
+            mode=mode,
+            planned=1,
+            completed=0,
+            next_item="eval_profile",
+            reason="discover.incomplete: no eval_profile.json",
+        )
+
+    elif mode == "build":
+        # For build mode, check if Builder completed at least one hypothesis
+        # In build mode, the strategy file should have phases marked as hypotheses
+        planned = _count_hypotheses(project_path)
+        completed = _count_verdicts(project_path)
+
+        if planned == 0:
+            # No strategy means we're in scaffold phase — check for eval profile
+            if not _has_eval_profile(project_path):
+                return IncompleteGap(
+                    mode=mode,
+                    planned=1,
+                    completed=0,
+                    next_item="discovery",
+                    reason="build.incomplete: no eval profile yet",
+                )
+            return None
+
+        if completed >= planned:
+            return None
+
+        next_h = completed + 1
+        return IncompleteGap(
+            mode=mode,
+            planned=planned,
+            completed=completed,
+            next_item=f"Phase{next_h}",
+            reason=f"build.incomplete: {completed}/{planned} phases have verdicts",
+        )
+
+    # Unknown mode — assume complete
+    return None
+
+
+def _build_continuation_task(gap: IncompleteGap) -> str:
+    """Build the continuation task string for re-spawning the CEO."""
+    if gap.mode in ("improve", "meta"):
+        return (
+            f"Resume execution from hypothesis {gap.next_item}. "
+            f"Strategy is already approved at .factory/strategy/current.md — "
+            f"do not re-plan, do not re-run Researcher or Strategist. "
+            f"Spawn Builder for {gap.next_item} immediately. "
+            f"Progress so far: {gap.completed}/{gap.planned} hypotheses have verdicts."
+        )
+    elif gap.mode == "build":
+        return (
+            f"Resume Build pipeline from {gap.next_item}. "
+            f"Plan is already approved at .factory/strategy/current.md. "
+            f"Progress so far: {gap.completed}/{gap.planned} phases complete. "
+            f"Continue with the next phase immediately."
+        )
+    elif gap.mode == "discover":
+        return (
+            "Resume Discovery. The eval profile has not been generated yet. "
+            "Complete the Discover mode workflow to produce .factory/eval_profile.json."
+        )
+    return f"Resume from {gap.next_item}."
+
+
+def _budget_allows_respawn(runner_name: str | None, project_path: Path) -> bool:
+    """Check if budget/ceiling allows another spawn."""
+    if runner_name == "bob":
+        from factory.runners.usage import check_ceilings, CeilingExceededError
+        from datetime import datetime, timezone
+
+        try:
+            check_ceilings(project_path, datetime.now(timezone.utc))
+            return True
+        except CeilingExceededError:
+            return False
+
+    # Claude runner has no ceiling
+    return True
+
+
+def _write_cycle_incomplete(project_path: Path, gap: IncompleteGap, reason: str) -> None:
+    """Write .factory/strategy/cycle-incomplete.md describing what wasn't finished."""
+    strategy_dir = project_path / ".factory" / "strategy"
+    strategy_dir.mkdir(parents=True, exist_ok=True)
+
+    incomplete_file = strategy_dir / "cycle-incomplete.md"
+    content = f"""# Cycle Incomplete
+
+**Mode:** {gap.mode}
+**Reason:** {reason}
+**Planned:** {gap.planned}
+**Completed:** {gap.completed}
+**Next item that wasn't started:** {gap.next_item}
+
+## Details
+
+{gap.reason}
+
+This file is written when the CEO completion guard gives up after hitting
+the respawn cap or budget limit. The cycle can be resumed manually with:
+
+```bash
+factory ceo /path/to/project --headless
+```
+"""
+    incomplete_file.write_text(content)
+    log.warning("cycle_incomplete", reason=reason, gap=gap)
+
+
+async def run_ceo_with_completion_guard(
+    project_path: Path,
+    initial_task: str,
+    *,
+    mode: str,
+    runner_name: str | None = None,
+    model: str | None = None,
+    timeout: float = 3600.0,
+    max_respawns: int | None = None,
+) -> tuple[str, int]:
+    """Spawn CEO; if it exits with planned work undone, re-spawn until done or cap hit.
+
+    Args:
+        project_path: Path to the project.
+        initial_task: Initial task string for the CEO.
+        mode: CEO mode (improve, build, discover, meta).
+        runner_name: Runner to use (claude or bob).
+        model: Optional model override.
+        timeout: Timeout per CEO spawn in seconds.
+        max_respawns: Max re-spawns (default from env or 5).
+
+    Returns:
+        (final_output, exit_code)
+    """
+    from factory.agents.runner import invoke_agent
+
+    # Check escape hatch
+    if os.environ.get("FACTORY_CEO_RESPAWN_DISABLED") == "1":
+        log.info("ceo_respawn_disabled", reason="FACTORY_CEO_RESPAWN_DISABLED=1")
+        return await invoke_agent(
+            "ceo", initial_task, project_path,
+            timeout=timeout, model=model, runner_name=runner_name,
+        )
+
+    if max_respawns is None:
+        max_respawns = int(os.environ.get("FACTORY_CEO_MAX_RESPAWNS", DEFAULT_MAX_RESPAWNS))
+
+    task = initial_task
+    final_output = ""
+    gap: IncompleteGap | None = None
+
+    for attempt in range(max_respawns + 1):
+        log.info("ceo_spawn", attempt=attempt, task_preview=task[:100])
+
+        result, code = await invoke_agent(
+            "ceo", task, project_path,
+            timeout=timeout, model=model, runner_name=runner_name,
+        )
+        final_output = result
+
+        # User interrupt — respect it
+        if code in (130, 143) or code > 128:
+            log.info("ceo_user_interrupt", code=code)
+            return result, code
+
+        # Explicit ABORT — respect it
+        if _has_aborted(project_path):
+            log.info("ceo_aborted", reason="cycle.aborted event found")
+            return result, code
+
+        # Check for incomplete work
+        gap = _detect_incomplete(project_path, mode)
+        if gap is None:
+            log.info("ceo_complete", attempt=attempt)
+            return result, code
+
+        # Check budget before re-spawning
+        if not _budget_allows_respawn(runner_name, project_path):
+            log.warning("ceo_budget_exceeded", gap=gap)
+            _write_cycle_incomplete(project_path, gap, "budget_exceeded")
+            return result, 1
+
+        # Emit respawn event
+        emit_event(
+            project_path,
+            "ceo.respawn",
+            agent="ceo",
+            data={
+                "attempt": attempt + 1,
+                "reason": gap.reason,
+                "planned": gap.planned,
+                "completed": gap.completed,
+                "next": gap.next_item,
+            },
+        )
+
+        # Build continuation task
+        task = _build_continuation_task(gap)
+        log.info("ceo_respawn", attempt=attempt + 1, next_item=gap.next_item)
+
+    # Cap hit
+    if gap:
+        log.warning("ceo_respawn_cap_hit", attempts=max_respawns + 1, gap=gap)
+        _write_cycle_incomplete(project_path, gap, "respawn_cap_hit")
+
+    return final_output, 1

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1199,7 +1199,10 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     # Interactive foreground mode: use runner's interactive_exec
     prompt = resolve_prompt("ceo", project_path)
     runner = get_runner(runner_name)
-    runner.interactive_exec(prompt, task, project_path, model=model, role="ceo")
+    runner.interactive_exec(
+        prompt, task, project_path,
+        model=model, role="ceo", dangerously_skip_permissions=True
+    )
 
 
 def _is_github_url(path: str) -> bool:

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1039,6 +1039,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
     project_path = Path(args.project).resolve()
     timeout = getattr(args, "timeout", 600.0)
     model = _resolve_model(args)
+    runner = _resolve_runner(args)
 
     result, code = _run(invoke_agent(
         role,
@@ -1047,6 +1048,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
         timeout=timeout,
         dangerously_skip_permissions=True,
         model=model,
+        runner_name=runner,
     ))
     print(result)
     return code
@@ -1088,6 +1090,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     With --mode interactive: brainstorm an idea via research + Distiller before building.
     """
     from factory.agents.runner import resolve_prompt
+    from factory.runners import get_runner
 
     raw_path = getattr(args, "path", None)
     mode = getattr(args, "mode", "auto")
@@ -1136,6 +1139,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)
     model = _resolve_model(args)
+    runner_name = _resolve_runner(args)
 
     if focus and prompt_file:
         print("Error: --focus (targeted mode) and --prompt are mutually exclusive. "
@@ -1168,15 +1172,16 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     if headless:
         # Non-interactive pipe mode (for scripting, cron, tmux)
-        from factory.agents.runner import invoke_agent
+        # Uses completion guard to auto-resume on premature exit
+        from factory.ceo_completion import run_ceo_with_completion_guard
 
-        result, code = _run(invoke_agent(
-            "ceo",
-            task,
+        result, code = _run(run_ceo_with_completion_guard(
             project_path,
-            timeout=3600.0,
-            dangerously_skip_permissions=True,
+            task,
+            mode=mode,
+            runner_name=runner_name,
             model=model,
+            timeout=3600.0,
         ))
         print(result)
         if code == 0:
@@ -1190,22 +1195,10 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             model=model,
         )
 
-    # Interactive foreground mode: launch claude with CEO prompt as system context
+    # Interactive foreground mode: use runner's interactive_exec
     prompt = resolve_prompt("ceo", project_path)
-
-    cmd = [
-        "claude",
-        "--append-system-prompt", prompt,
-        "--dangerously-skip-permissions",
-        task,  # initial user message
-    ]
-    if model:
-        cmd.extend(["--model", model])
-        os.environ["FACTORY_MODEL"] = model
-
-    # Replace this process with the interactive claude session
-    os.chdir(project_path)
-    os.execvp("claude", cmd)
+    runner = get_runner(runner_name)
+    runner.interactive_exec(prompt, task, project_path, model=model, role="ceo")
 
 
 def _is_github_url(path: str) -> bool:
@@ -1223,6 +1216,17 @@ def _resolve_model(args: argparse.Namespace) -> str | None:
         return flag
     env = (os.environ.get("FACTORY_MODEL") or "").strip()
     return env or None
+
+
+def _resolve_runner(args: argparse.Namespace) -> str | None:
+    """Resolve runner: CLI flag > FACTORY_RUNNER env var > None (default to 'claude').
+
+    Returns None to let get_runner() handle the default.
+    """
+    flag = (getattr(args, "runner", None) or "").strip()
+    if flag:
+        return flag
+    return None
 
 
 _PROJECTS_DIR = Path(os.environ.get("FACTORY_PROJECTS_DIR", str(Path.home() / "factory-projects")))
@@ -2061,6 +2065,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Timeout in seconds (default: 600)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocess (default: FACTORY_MODEL env var, or claude CLI default)")
+    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+                    help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
 
     # ceo — launch the Factory CEO agent directly
     p = sub.add_parser("ceo", help="Launch the Factory CEO agent (interactive by default)")
@@ -2099,6 +2105,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Target branch for PRs (default: from factory.md, fallback: main)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
+    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+                    help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
 
     # run
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
@@ -2142,6 +2150,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Target branch for PRs (default: from factory.md, fallback: main)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
+    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+                    help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
 
     # tmux — launch factory run in a detached tmux session
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")
@@ -2160,6 +2170,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Attach to session after creating")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
+    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+                    help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
 
     # tmux-ls — list factory tmux sessions
     sub.add_parser("tmux-ls", help="List running factory tmux sessions")

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1132,8 +1132,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         project_path, context = _resolve_input(raw_path)
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
-    if mode == "auto":
-        mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))
+    force_fresh = mode == "auto-fresh"
+    if mode in ("auto", "auto-fresh"):
+        mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context), force_fresh=force_fresh)
     discover_only = getattr(args, "discover_only", False)
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
@@ -1494,14 +1495,34 @@ def cmd_tmux_stop(args: argparse.Namespace) -> int:
 
 
 
-def _auto_detect_mode(project_path: Path, has_prompt: bool = False) -> str:
+def _auto_detect_mode(project_path: Path, has_prompt: bool = False, force_fresh: bool = False) -> str:
     """Detect the right mode based on project state.
+
+    Checks for an in-flight cycle first — if one exists, returns its mode
+    regardless of current project state (prevents mode flip on respawn).
+
+    Args:
+        project_path: Path to the project.
+        has_prompt: True if a build spec is available.
+        force_fresh: If True, ignores in-flight cycle and detects from scratch.
 
     When a build spec is available (--prompt, idea file, or raw prompt),
     no_factory routes to build (not discover).
     """
-    from factory.state import detect_state
+    from factory.ceo_completion import read_cycle_state
     from factory.models import ProjectState
+    from factory.state import detect_state
+
+    # Layer 2: Check for in-flight cycle (unless forced fresh)
+    if not force_fresh:
+        cycle_state = read_cycle_state(project_path)
+        if cycle_state:
+            print(
+                f"  In-flight cycle: {cycle_state.cycle_id} → mode: {cycle_state.mode} "
+                f"(respawns: {cycle_state.respawns})",
+                file=sys.stderr,
+            )
+            return cycle_state.mode
 
     state = detect_state(project_path)
     mode_map = {
@@ -1710,8 +1731,9 @@ def cmd_run(args: argparse.Namespace) -> int:
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
     mode = getattr(args, "mode", "auto")
-    if mode == "auto":
-        mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))
+    force_fresh = mode == "auto-fresh"
+    if mode in ("auto", "auto-fresh"):
+        mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context), force_fresh=force_fresh)
     loop = getattr(args, "loop", False)
     focus = getattr(args, "focus", None)
     discover_only = getattr(args, "discover_only", False)
@@ -2080,10 +2102,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "build", "discover", "improve", "meta", "interactive"],
+        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "interactive"],
         default="auto",
-        help="Run mode: auto (default, detects from project state), build, discover, "
-             "improve, meta, or interactive (research + brainstorm → spec → build)",
+        help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
+             "build, discover, improve, meta, or interactive (research + brainstorm → spec → build)",
     )
     p.add_argument(
         "--focus", default=None,
@@ -2118,9 +2140,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "build", "discover", "improve", "meta"],
+        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta"],
         default="auto",
-        help="Run mode: auto (default, detects from project state), build, discover, improve, or meta",
+        help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
+             "build, discover, improve, or meta",
     )
     p.add_argument(
         "--focus", default=None,
@@ -2159,9 +2182,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--session", default=None, help="Custom tmux session name")
     p.add_argument(
         "--mode",
-        choices=["auto", "build", "discover", "improve", "meta"],
+        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta"],
         default="auto",
-        help="Run mode (default: auto)",
+        help="Run mode (default: auto, respects in-flight cycle)",
     )
     p.add_argument("--loop", action="store_true", default=False, help="Enable loop mode")
     p.add_argument("--interval", type=int, default=1800, help="Loop interval in seconds")

--- a/factory/models.py
+++ b/factory/models.py
@@ -285,6 +285,24 @@ class SessionSummary(BaseModel):
     total_cost_usd: float | None
 
 
+# ── cycle state ──────────────────────────────────────────────────
+
+
+class CycleState(BaseModel):
+    """In-flight cycle state persisted at .factory/state/cycle.json.
+
+    Ensures mode is preserved across CEO respawns within a single cycle.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    cycle_id: str
+    started_at: datetime
+    mode: Literal["build", "discover", "improve", "meta"]
+    initial_prompt: str = ""
+    respawns: int = 0
+
+
 # ── protocols ─────────────────────────────────────────────────────
 
 

--- a/factory/models.py
+++ b/factory/models.py
@@ -301,6 +301,7 @@ class CycleState(BaseModel):
     mode: Literal["build", "discover", "improve", "meta"]
     initial_prompt: str = ""
     respawns: int = 0
+    runner_name: str | None = None
 
 
 # ── protocols ─────────────────────────────────────────────────────

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -1,0 +1,55 @@
+"""Runner abstraction layer for CLI backends (claude, bob, etc.)."""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+from factory.runners._stream import should_stream, stream_subprocess
+from factory.runners.bob import BobRunner, is_dry_run
+from factory.runners.claude import ClaudeRunner
+from factory.runners.protocol import Runner
+
+__all__ = [
+    "Runner",
+    "ClaudeRunner",
+    "BobRunner",
+    "get_runner",
+    "RunnerName",
+    "is_dry_run",
+    "should_stream",
+    "stream_subprocess",
+]
+
+RunnerName = Literal["claude", "bob"]
+
+_RUNNERS: dict[str, type[Runner]] = {
+    "claude": ClaudeRunner,  # type: ignore[dict-item]
+    "bob": BobRunner,  # type: ignore[dict-item]
+}
+
+
+def get_runner(name: str | None = None) -> Runner:
+    """Get a runner by name.
+
+    Resolution order:
+    1. Explicit name argument
+    2. FACTORY_RUNNER environment variable
+    3. Default to "claude"
+
+    Raises:
+        ValueError: If the runner name is not recognized.
+    """
+    resolved = name or os.environ.get("FACTORY_RUNNER", "claude")
+    resolved = resolved.lower().strip()
+
+    if resolved not in _RUNNERS:
+        available = ", ".join(_RUNNERS.keys())
+        raise ValueError(f"Unknown runner '{resolved}'. Available: {available}")
+
+    return _RUNNERS[resolved]()
+
+
+def register_runner(name: str, runner_class: type[Runner]) -> None:
+    """Register a runner implementation (used by bob module on import)."""
+    _RUNNERS[name] = runner_class

--- a/factory/runners/_stream.py
+++ b/factory/runners/_stream.py
@@ -1,0 +1,97 @@
+"""Shared streaming helper for subprocess output."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import BinaryIO
+
+
+def should_stream() -> bool:
+    """Determine if we should stream subprocess output to the terminal.
+
+    Returns True unless:
+    - FACTORY_RUNNER_QUIET=1 is set
+    - stdout is not a TTY (e.g., piped to file)
+    """
+    if os.environ.get("FACTORY_RUNNER_QUIET", "").lower() in ("1", "true", "yes"):
+        return False
+    if not sys.stdout.isatty():
+        return False
+    return True
+
+
+async def tee_stream(
+    src: asyncio.StreamReader,
+    dest: BinaryIO,
+    buffer: list[bytes],
+    *,
+    stream: bool = True,
+    prefix: bytes | None = None,
+) -> None:
+    """Read from an async stream, optionally tee to a destination, and collect in buffer.
+
+    Args:
+        src: Async stream reader (e.g., proc.stdout).
+        dest: Destination file-like object (e.g., sys.stdout.buffer).
+        buffer: List to collect all bytes read.
+        stream: If True, write to dest as data arrives. If False, only buffer.
+        prefix: Optional prefix to prepend to each line (e.g., b"[bob:researcher] ").
+    """
+    while True:
+        line = await src.readline()
+        if not line:
+            break
+        buffer.append(line)
+        if stream:
+            if prefix:
+                dest.write(prefix)
+            dest.write(line)
+            dest.flush()
+
+
+async def stream_subprocess(
+    proc: asyncio.subprocess.Process,
+    *,
+    stream: bool = True,
+    prefix: str | None = None,
+) -> tuple[bytes, bytes]:
+    """Stream subprocess stdout/stderr to the terminal while collecting output.
+
+    Args:
+        proc: The subprocess with PIPE for stdout and stderr.
+        stream: If True, stream to sys.stdout/stderr. If False, only collect.
+        prefix: Optional prefix for each line (e.g., "[bob:researcher]").
+
+    Returns:
+        (stdout_bytes, stderr_bytes) tuple with all collected output.
+    """
+    stdout_buf: list[bytes] = []
+    stderr_buf: list[bytes] = []
+
+    prefix_bytes = f"{prefix} ".encode() if prefix else None
+
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+
+    await asyncio.gather(
+        tee_stream(
+            proc.stdout,
+            sys.stdout.buffer,
+            stdout_buf,
+            stream=stream,
+            prefix=prefix_bytes,
+        ),
+        tee_stream(
+            proc.stderr,
+            sys.stderr.buffer,
+            stderr_buf,
+            stream=stream,
+            prefix=prefix_bytes,
+        ),
+    )
+
+    await proc.wait()
+
+    return b"".join(stdout_buf), b"".join(stderr_buf)

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -11,6 +11,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 
+import shutil
+
 import yaml
 
 from factory.runners._stream import should_stream, stream_subprocess
@@ -79,12 +81,12 @@ def _persist_key(project_path: Path) -> None:
         logger.warning("Failed to persist API key: %s", e)
 
 
-def _check_auth() -> None:
+def _check_auth(start_path: Path | None = None) -> None:
     """Check that BOBSHELL_API_KEY is set (once per process).
 
     Resolution order:
     1. Environment variable BOBSHELL_API_KEY
-    2. File .factory/.bob_auth (searched from cwd upward)
+    2. File .factory/.bob_auth (searched from start_path upward, or cwd if None)
 
     If found in file, injects into os.environ for subprocess inheritance.
     """
@@ -98,7 +100,8 @@ def _check_auth() -> None:
         return
 
     # Fall back to file-based persistence
-    auth_file = _find_auth_file(Path.cwd())
+    search_from = start_path if start_path is not None else Path.cwd()
+    auth_file = _find_auth_file(search_from)
     if auth_file:
         try:
             key = auth_file.read_text().strip()
@@ -116,6 +119,35 @@ def _check_auth() -> None:
 def is_dry_run() -> bool:
     """Return True if dry-run mode is enabled."""
     return os.environ.get("FACTORY_BOB_DRY_RUN", "").lower() in ("1", "true", "yes")
+
+
+def _get_bob_bin_dir() -> str | None:
+    """Find the directory containing the bob binary.
+
+    Used to prepend to PATH so that the correct Node version is found
+    when bob's shebang resolves `#!/usr/bin/env node`.
+    """
+    bob_path = shutil.which("bob")
+    if bob_path:
+        return str(Path(bob_path).parent)
+    return None
+
+
+def _make_env_with_bob_path() -> dict[str, str]:
+    """Create environment dict with bob's bin directory prepended to PATH.
+
+    Bob Shell's shebang is `#!/usr/bin/env node`. If multiple Node version
+    managers (nvm, fnm, volta) are installed, the wrong Node may be found.
+    Prepending bob's bin directory ensures its companion node is used.
+    """
+    env = dict(os.environ)
+    bob_bin_dir = _get_bob_bin_dir()
+    if bob_bin_dir:
+        current_path = env.get("PATH", "")
+        if not current_path.startswith(bob_bin_dir):
+            env["PATH"] = f"{bob_bin_dir}:{current_path}"
+            logger.debug("Prepended bob bin dir to PATH: %s", bob_bin_dir)
+    return env
 
 
 def _prompt_hash(prompt: str) -> str:
@@ -180,10 +212,14 @@ def _ensure_custom_modes(project_path: Path, role: str, prompt: str) -> None:
 def _get_chat_mode(role: str, model: str | None) -> str:
     """Determine the chat mode to use.
 
-    Always returns the role-based mode (factory-<role>).
-    The model parameter is accepted for API compatibility but not used.
+    Bob Shell only supports built-in modes: plan, code, advanced, ask.
+    Custom modes are not supported (unlike Claude Code).
+    We use 'code' mode as the most appropriate for agent work.
+
+    The role and model parameters are accepted for API compatibility
+    but not used — the agent role is injected via the prompt instead.
     """
-    return f"factory-{role}"
+    return "code"
 
 
 class BobRunner:
@@ -224,7 +260,7 @@ class BobRunner:
         if is_dry_run():
             return self._dry_run_response(role, cwd, task)
 
-        _check_auth()
+        _check_auth(cwd)
 
         try:
             check_ceilings(project_path, self.cycle_start)
@@ -232,7 +268,8 @@ class BobRunner:
             self._emit_ceiling_event(project_path, e)
             return str(e), 1
 
-        _ensure_custom_modes(project_path, role, prompt)
+        # NOTE: Custom modes are not supported in Bob Shell (unlike Claude Code).
+        # The agent role definition is injected via the prompt instead.
 
         chat_mode = _get_chat_mode(role, model)
         full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
@@ -243,7 +280,7 @@ class BobRunner:
 
         logger.info("BobRunner headless: cwd=%s, role=%s, chat_mode=%s", cwd, role, chat_mode)
 
-        env = dict(os.environ)
+        env = _make_env_with_bob_path()
         start_time = time.monotonic()
 
         stream = should_stream()
@@ -307,7 +344,7 @@ class BobRunner:
             print(f"[DRY-RUN] Task: {task[:200]}...")
             raise SystemExit(0)
 
-        _check_auth()
+        _check_auth(cwd)
 
         try:
             check_ceilings(project_path, self.cycle_start)
@@ -315,19 +352,26 @@ class BobRunner:
             print(f"ERROR: {e}")
             raise SystemExit(1) from e
 
-        _ensure_custom_modes(project_path, role, prompt)
+        # NOTE: Custom modes are not supported in Bob Shell (unlike Claude Code).
+        # The agent role definition is injected via the prompt instead.
 
         chat_mode = _get_chat_mode(role, model)
+        full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
 
         cmd = [
             "bob",
             f"--chat-mode={chat_mode}",
-            "-i", task,
+            "-i", full_task,
         ]
         if dangerously_skip_permissions:
             cmd.append("--yolo")
 
         logger.info("BobRunner interactive_exec: cwd=%s, chat_mode=%s", cwd, chat_mode)
+
+        # Ensure bob's bin directory is first in PATH so the correct Node is found
+        bob_bin_dir = _get_bob_bin_dir()
+        if bob_bin_dir and not os.environ.get("PATH", "").startswith(bob_bin_dir):
+            os.environ["PATH"] = f"{bob_bin_dir}:{os.environ.get('PATH', '')}"
 
         os.chdir(cwd)
         os.execvp("bob", cmd)

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -151,17 +151,9 @@ def _make_env_with_bob_path() -> dict[str, str]:
     return env
 
 
-def _get_chat_mode(role: str, model: str | None) -> str:
-    """Determine the chat mode to use.
-
-    Bob Shell only supports built-in modes: plan, code, advanced, ask.
-    Custom modes are not supported (unlike Claude Code).
-    We use 'code' mode as the most appropriate for agent work.
-
-    The role and model parameters are accepted for API compatibility
-    but not used — the agent role is injected via the prompt instead.
-    """
-    return "code"
+# Bob Shell only supports built-in modes: plan, code, advanced, ask.
+# We use 'code' mode for agent work; the role is injected via the prompt.
+_BOB_CHAT_MODE = "code"
 
 
 class BobRunner:
@@ -218,7 +210,7 @@ class BobRunner:
         # NOTE: Custom modes are not supported in Bob Shell (unlike Claude Code).
         # The agent role definition is injected via the prompt instead.
 
-        chat_mode = _get_chat_mode(role, model)
+        chat_mode = _BOB_CHAT_MODE
         full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
 
         cmd = ["bob", "-p", full_task, f"--chat-mode={chat_mode}"]
@@ -302,7 +294,7 @@ class BobRunner:
         # NOTE: Custom modes are not supported in Bob Shell (unlike Claude Code).
         # The agent role definition is injected via the prompt instead.
 
-        chat_mode = _get_chat_mode(role, model)
+        chat_mode = _BOB_CHAT_MODE
         full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
 
         cmd = [

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -1,0 +1,385 @@
+"""BobRunner — Bob Shell CLI backend implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn
+
+import yaml
+
+from factory.runners._stream import should_stream, stream_subprocess
+from factory.runners.usage import (
+    CeilingExceededError,
+    check_ceilings,
+    log_usage,
+)
+
+logger = logging.getLogger(__name__)
+
+_auth_checked = False
+
+# File where we persist the API key for nested subagent spawns
+_AUTH_FILE_NAME = ".bob_auth"
+
+
+class BobAuthError(Exception):
+    """Raised when BOBSHELL_API_KEY is not set."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "BOBSHELL_API_KEY environment variable is not set. "
+            "See bob-runner-package/bob-shell-docs/README.md for setup instructions."
+        )
+
+
+def _find_auth_file(start_path: Path) -> Path | None:
+    """Search for the auth file starting from start_path and walking up.
+
+    Returns the path to the auth file if found, or None.
+    """
+    path = start_path.resolve()
+    while path != path.parent:
+        auth_file = path / ".factory" / _AUTH_FILE_NAME
+        if auth_file.is_file():
+            return auth_file
+        path = path.parent
+    return None
+
+
+def _persist_key(project_path: Path) -> None:
+    """Persist BOBSHELL_API_KEY to a file for nested subagent spawns.
+
+    Only writes if:
+    - BOBSHELL_API_KEY is set in the environment
+    - The .factory directory exists
+    - The file doesn't already exist (or we're updating it)
+
+    The file is created with chmod 600 for security.
+    """
+    key = os.environ.get("BOBSHELL_API_KEY")
+    if not key:
+        return
+
+    factory_dir = project_path / ".factory"
+    if not factory_dir.is_dir():
+        return
+
+    auth_file = factory_dir / _AUTH_FILE_NAME
+    try:
+        auth_file.write_text(key)
+        auth_file.chmod(0o600)
+        logger.debug("Persisted BOBSHELL_API_KEY to %s", auth_file)
+    except OSError as e:
+        logger.warning("Failed to persist API key: %s", e)
+
+
+def _check_auth() -> None:
+    """Check that BOBSHELL_API_KEY is set (once per process).
+
+    Resolution order:
+    1. Environment variable BOBSHELL_API_KEY
+    2. File .factory/.bob_auth (searched from cwd upward)
+
+    If found in file, injects into os.environ for subprocess inheritance.
+    """
+    global _auth_checked
+    if _auth_checked:
+        return
+
+    # First check environment variable
+    if os.environ.get("BOBSHELL_API_KEY"):
+        _auth_checked = True
+        return
+
+    # Fall back to file-based persistence
+    auth_file = _find_auth_file(Path.cwd())
+    if auth_file:
+        try:
+            key = auth_file.read_text().strip()
+            if key:
+                os.environ["BOBSHELL_API_KEY"] = key
+                logger.info("Loaded BOBSHELL_API_KEY from %s", auth_file)
+                _auth_checked = True
+                return
+        except OSError as e:
+            logger.warning("Failed to read auth file %s: %s", auth_file, e)
+
+    raise BobAuthError()
+
+
+def is_dry_run() -> bool:
+    """Return True if dry-run mode is enabled."""
+    return os.environ.get("FACTORY_BOB_DRY_RUN", "").lower() in ("1", "true", "yes")
+
+
+def _prompt_hash(prompt: str) -> str:
+    """Compute a short hash of the prompt for cache invalidation."""
+    return hashlib.sha256(prompt.encode()).hexdigest()[:16]
+
+
+def _ensure_custom_modes(cwd: Path, role: str, prompt: str) -> None:
+    """Ensure the factory custom mode exists in .bob/custom_modes.yaml.
+
+    Creates the mode for the given role if it doesn't exist.
+    Updates the mode if the prompt has changed (detected via hash).
+    """
+    bob_dir = cwd / ".bob"
+    bob_dir.mkdir(parents=True, exist_ok=True)
+
+    modes_file = bob_dir / "custom_modes.yaml"
+
+    existing_modes: dict = {}
+    if modes_file.exists():
+        try:
+            existing_modes = yaml.safe_load(modes_file.read_text()) or {}
+        except yaml.YAMLError:
+            existing_modes = {}
+
+    custom_modes = existing_modes.get("customModes", [])
+
+    mode_slug = f"factory-{role}"
+    current_hash = _prompt_hash(prompt)
+
+    # Find existing mode if any
+    existing_mode_idx = None
+    for idx, m in enumerate(custom_modes):
+        if m.get("slug") == mode_slug:
+            existing_mode_idx = idx
+            break
+
+    if existing_mode_idx is not None:
+        existing_hash = custom_modes[existing_mode_idx].get("_promptHash")
+        if existing_hash == current_hash:
+            return  # Cache hit — prompt unchanged
+        # Cache miss — prompt changed, update the mode
+        logger.info("Prompt changed for %s (hash %s → %s), updating mode", role, existing_hash, current_hash)
+        custom_modes.pop(existing_mode_idx)
+
+    new_mode = {
+        "slug": mode_slug,
+        "name": f"Factory {role.title()}",
+        "roleDefinition": prompt[:2000],
+        "whenToUse": f"Factory agent role: {role}",
+        "groups": ["read", "command", "edit"],
+        "_promptHash": current_hash,
+    }
+    custom_modes.append(new_mode)
+    existing_modes["customModes"] = custom_modes
+
+    modes_file.write_text(yaml.dump(existing_modes, default_flow_style=False, allow_unicode=True))
+    logger.info("Wrote bob custom mode: %s (hash %s) to %s", mode_slug, current_hash, modes_file)
+
+
+MODEL_TO_CHAT_MODE: dict[str, str] = {
+    "opus": "factory-ceo",
+    "sonnet": "factory-builder",
+    "haiku": "factory-researcher",
+}
+
+
+def _get_chat_mode(role: str, model: str | None) -> str:
+    """Determine the chat mode to use.
+
+    Priority:
+    1. Model-based mapping (if model is specified and matches)
+    2. Role-based mode (factory-<role>)
+    """
+    if model and model.lower() in MODEL_TO_CHAT_MODE:
+        return MODEL_TO_CHAT_MODE[model.lower()]
+    return f"factory-{role}"
+
+
+class BobRunner:
+    """Runner implementation for Bob Shell CLI."""
+
+    name: str = "bob"
+
+    def __init__(self, cycle_start: datetime | None = None) -> None:
+        """Initialize BobRunner.
+
+        Args:
+            cycle_start: Start time of the current factory cycle (for ceiling tracking).
+        """
+        self.cycle_start = cycle_start or datetime.now(timezone.utc)
+        self._role: str = "unknown"
+
+    async def headless(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        timeout: float = 600.0,
+        model: str | None = None,
+        dangerously_skip_permissions: bool = True,
+        role: str = "unknown",
+    ) -> tuple[str, int]:
+        """Run a headless Bob Shell invocation.
+
+        Returns (stdout, return_code).
+        """
+        self._role = role
+        project_path = self._find_project_path(cwd)
+
+        # Persist key for nested subagent spawns (before dry-run check so file exists)
+        _persist_key(project_path)
+
+        if is_dry_run():
+            return self._dry_run_response(role, cwd, task)
+
+        _check_auth()
+
+        try:
+            check_ceilings(project_path, self.cycle_start)
+        except CeilingExceededError as e:
+            self._emit_ceiling_event(project_path, e)
+            return str(e), 1
+
+        _ensure_custom_modes(cwd, role, prompt)
+
+        chat_mode = _get_chat_mode(role, model)
+        full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
+
+        cmd = ["bob", "-p", full_task, "--yolo", f"--chat-mode={chat_mode}"]
+
+        logger.info("BobRunner headless: cwd=%s, role=%s, chat_mode=%s", cwd, role, chat_mode)
+
+        env = dict(os.environ)
+        start_time = time.monotonic()
+
+        stream = should_stream()
+        prefix = f"[bob:{role}]" if stream else None
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                stream_subprocess(proc, stream=stream, prefix=prefix),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()  # type: ignore[union-attr]
+            await proc.wait()  # type: ignore[union-attr]
+            duration = time.monotonic() - start_time
+            log_usage(project_path, role, cwd, duration, 1, dry_run=False)
+            logger.error("BobRunner timed out after %ss", timeout)
+            return f"Agent timed out after {timeout}s", 1
+        except FileNotFoundError:
+            logger.error("'bob' CLI not found on PATH")
+            return "Error: 'bob' CLI not found on PATH", 1
+
+        duration = time.monotonic() - start_time
+        return_code = proc.returncode or 0
+
+        log_usage(project_path, role, cwd, duration, return_code, dry_run=False)
+
+        stdout = stdout_bytes.decode()
+        stderr = stderr_bytes.decode()
+
+        if return_code != 0:
+            logger.warning("BobRunner exited with code %d: %s", return_code, stderr[:200])
+
+        return stdout, return_code
+
+    def interactive_exec(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        model: str | None = None,
+        role: str = "ceo",
+    ) -> NoReturn:
+        """Replace process with interactive Bob Shell session."""
+        project_path = self._find_project_path(cwd)
+
+        # Persist key for nested subagent spawns (before dry-run check so file exists)
+        _persist_key(project_path)
+
+        if is_dry_run():
+            print(f"[DRY-RUN] Would exec: bob --chat-mode=factory-{role} --yolo")
+            print(f"[DRY-RUN] Task: {task[:200]}...")
+            raise SystemExit(0)
+
+        _check_auth()
+
+        project_path = self._find_project_path(cwd)
+
+        try:
+            check_ceilings(project_path, self.cycle_start)
+        except CeilingExceededError as e:
+            print(f"ERROR: {e}")
+            raise SystemExit(1) from e
+
+        _ensure_custom_modes(cwd, role, prompt)
+
+        chat_mode = _get_chat_mode(role, model)
+
+        cmd = [
+            "bob",
+            f"--chat-mode={chat_mode}",
+            "--yolo",
+            "-i", task,
+        ]
+
+        logger.info("BobRunner interactive_exec: cwd=%s, chat_mode=%s", cwd, chat_mode)
+
+        os.chdir(cwd)
+        os.execvp("bob", cmd)
+
+    def _find_project_path(self, cwd: Path) -> Path:
+        """Find the project root (directory containing .factory/)."""
+        path = cwd.resolve()
+        while path != path.parent:
+            if (path / ".factory").is_dir():
+                return path
+            path = path.parent
+        return cwd.resolve()
+
+    def _dry_run_response(self, role: str, cwd: Path, task: str) -> tuple[str, int]:
+        """Return a stub response for dry-run mode."""
+        project_path = self._find_project_path(cwd)
+
+        log_usage(project_path, role, cwd, 0.0, 0, dry_run=True)
+
+        response = (
+            f"[DRY-RUN] BobRunner would have executed:\n"
+            f"  role: {role}\n"
+            f"  cwd: {cwd}\n"
+            f"  task: {task[:100]}...\n"
+            f"\n"
+            f"Dry-run stub response: Task acknowledged."
+        )
+        logger.info("BobRunner dry-run: role=%s, cwd=%s", role, cwd)
+        return response, 0
+
+    def _emit_ceiling_event(self, project_path: Path, error: CeilingExceededError) -> None:
+        """Emit a structured event when a ceiling is hit."""
+        try:
+            from factory.events import emit_event
+
+            emit_event(
+                project_path,
+                "bob.ceiling_exceeded",
+                data={
+                    "ceiling": error.ceiling_name,
+                    "current": error.current,
+                    "limit": error.limit,
+                    "env_var": error.env_var,
+                },
+            )
+        except Exception:
+            logger.debug("Failed to emit ceiling event", exc_info=True)
+
+

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -123,13 +123,14 @@ def _prompt_hash(prompt: str) -> str:
     return hashlib.sha256(prompt.encode()).hexdigest()[:16]
 
 
-def _ensure_custom_modes(cwd: Path, role: str, prompt: str) -> None:
-    """Ensure the factory custom mode exists in .bob/custom_modes.yaml.
+def _ensure_custom_modes(project_path: Path, role: str, prompt: str) -> None:
+    """Ensure the factory custom mode exists in .factory/.bob/custom_modes.yaml.
 
     Creates the mode for the given role if it doesn't exist.
     Updates the mode if the prompt has changed (detected via hash).
     """
-    bob_dir = cwd / ".bob"
+    # NOTE: Bob Shell limits roleDefinition to 2000 chars; large prompts are truncated
+    bob_dir = project_path / ".factory" / ".bob"
     bob_dir.mkdir(parents=True, exist_ok=True)
 
     modes_file = bob_dir / "custom_modes.yaml"
@@ -176,22 +177,12 @@ def _ensure_custom_modes(cwd: Path, role: str, prompt: str) -> None:
     logger.info("Wrote bob custom mode: %s (hash %s) to %s", mode_slug, current_hash, modes_file)
 
 
-MODEL_TO_CHAT_MODE: dict[str, str] = {
-    "opus": "factory-ceo",
-    "sonnet": "factory-builder",
-    "haiku": "factory-researcher",
-}
-
-
 def _get_chat_mode(role: str, model: str | None) -> str:
     """Determine the chat mode to use.
 
-    Priority:
-    1. Model-based mapping (if model is specified and matches)
-    2. Role-based mode (factory-<role>)
+    Always returns the role-based mode (factory-<role>).
+    The model parameter is accepted for API compatibility but not used.
     """
-    if model and model.lower() in MODEL_TO_CHAT_MODE:
-        return MODEL_TO_CHAT_MODE[model.lower()]
     return f"factory-{role}"
 
 
@@ -241,12 +232,14 @@ class BobRunner:
             self._emit_ceiling_event(project_path, e)
             return str(e), 1
 
-        _ensure_custom_modes(cwd, role, prompt)
+        _ensure_custom_modes(project_path, role, prompt)
 
         chat_mode = _get_chat_mode(role, model)
         full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
 
-        cmd = ["bob", "-p", full_task, "--yolo", f"--chat-mode={chat_mode}"]
+        cmd = ["bob", "-p", full_task, f"--chat-mode={chat_mode}"]
+        if dangerously_skip_permissions:
+            cmd.append("--yolo")
 
         logger.info("BobRunner headless: cwd=%s, role=%s, chat_mode=%s", cwd, role, chat_mode)
 
@@ -300,6 +293,7 @@ class BobRunner:
         *,
         model: str | None = None,
         role: str = "ceo",
+        dangerously_skip_permissions: bool = False,
     ) -> NoReturn:
         """Replace process with interactive Bob Shell session."""
         project_path = self._find_project_path(cwd)
@@ -308,13 +302,12 @@ class BobRunner:
         _persist_key(project_path)
 
         if is_dry_run():
-            print(f"[DRY-RUN] Would exec: bob --chat-mode=factory-{role} --yolo")
+            yolo_flag = " --yolo" if dangerously_skip_permissions else ""
+            print(f"[DRY-RUN] Would exec: bob --chat-mode=factory-{role}{yolo_flag}")
             print(f"[DRY-RUN] Task: {task[:200]}...")
             raise SystemExit(0)
 
         _check_auth()
-
-        project_path = self._find_project_path(cwd)
 
         try:
             check_ceilings(project_path, self.cycle_start)
@@ -322,16 +315,17 @@ class BobRunner:
             print(f"ERROR: {e}")
             raise SystemExit(1) from e
 
-        _ensure_custom_modes(cwd, role, prompt)
+        _ensure_custom_modes(project_path, role, prompt)
 
         chat_mode = _get_chat_mode(role, model)
 
         cmd = [
             "bob",
             f"--chat-mode={chat_mode}",
-            "--yolo",
             "-i", task,
         ]
+        if dangerously_skip_permissions:
+            cmd.append("--yolo")
 
         logger.info("BobRunner interactive_exec: cwd=%s, chat_mode=%s", cwd, chat_mode)
 

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import logging
 import os
+import shutil
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
-
-import shutil
-
-import yaml
 
 from factory.runners._stream import should_stream, stream_subprocess
 from factory.runners.usage import (
@@ -89,6 +85,11 @@ def _check_auth(start_path: Path | None = None) -> None:
     2. File .factory/.bob_auth (searched from start_path upward, or cwd if None)
 
     If found in file, injects into os.environ for subprocess inheritance.
+
+    Limitation: _auth_checked is a module-level flag, so the check only runs once
+    per Python process. If the key changes or expires mid-session, the cached
+    result won't reflect that. For long-running processes, consider restarting
+    the factory rather than relying on key rotation.
     """
     global _auth_checked
     if _auth_checked:
@@ -150,65 +151,6 @@ def _make_env_with_bob_path() -> dict[str, str]:
     return env
 
 
-def _prompt_hash(prompt: str) -> str:
-    """Compute a short hash of the prompt for cache invalidation."""
-    return hashlib.sha256(prompt.encode()).hexdigest()[:16]
-
-
-def _ensure_custom_modes(project_path: Path, role: str, prompt: str) -> None:
-    """Ensure the factory custom mode exists in .factory/.bob/custom_modes.yaml.
-
-    Creates the mode for the given role if it doesn't exist.
-    Updates the mode if the prompt has changed (detected via hash).
-    """
-    # NOTE: Bob Shell limits roleDefinition to 2000 chars; large prompts are truncated
-    bob_dir = project_path / ".factory" / ".bob"
-    bob_dir.mkdir(parents=True, exist_ok=True)
-
-    modes_file = bob_dir / "custom_modes.yaml"
-
-    existing_modes: dict = {}
-    if modes_file.exists():
-        try:
-            existing_modes = yaml.safe_load(modes_file.read_text()) or {}
-        except yaml.YAMLError:
-            existing_modes = {}
-
-    custom_modes = existing_modes.get("customModes", [])
-
-    mode_slug = f"factory-{role}"
-    current_hash = _prompt_hash(prompt)
-
-    # Find existing mode if any
-    existing_mode_idx = None
-    for idx, m in enumerate(custom_modes):
-        if m.get("slug") == mode_slug:
-            existing_mode_idx = idx
-            break
-
-    if existing_mode_idx is not None:
-        existing_hash = custom_modes[existing_mode_idx].get("_promptHash")
-        if existing_hash == current_hash:
-            return  # Cache hit — prompt unchanged
-        # Cache miss — prompt changed, update the mode
-        logger.info("Prompt changed for %s (hash %s → %s), updating mode", role, existing_hash, current_hash)
-        custom_modes.pop(existing_mode_idx)
-
-    new_mode = {
-        "slug": mode_slug,
-        "name": f"Factory {role.title()}",
-        "roleDefinition": prompt[:2000],
-        "whenToUse": f"Factory agent role: {role}",
-        "groups": ["read", "command", "edit"],
-        "_promptHash": current_hash,
-    }
-    custom_modes.append(new_mode)
-    existing_modes["customModes"] = custom_modes
-
-    modes_file.write_text(yaml.dump(existing_modes, default_flow_style=False, allow_unicode=True))
-    logger.info("Wrote bob custom mode: %s (hash %s) to %s", mode_slug, current_hash, modes_file)
-
-
 def _get_chat_mode(role: str, model: str | None) -> str:
     """Determine the chat mode to use.
 
@@ -250,6 +192,11 @@ class BobRunner:
         """Run a headless Bob Shell invocation.
 
         Returns (stdout, return_code).
+
+        Note: The prompt+task are passed as a CLI argument via `-p`. Very large prompts
+        may hit the OS ARG_MAX limit (typically 128-256KB on Linux). If you encounter
+        "Argument list too long" errors, consider reducing prompt size or using a
+        file-based approach for prompt injection.
         """
         self._role = role
         project_path = self._find_project_path(cwd)

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -1,0 +1,123 @@
+"""ClaudeRunner — Claude Code CLI backend implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import NoReturn
+
+from factory.runners._stream import should_stream, stream_subprocess
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeRunner:
+    """Runner implementation for Claude Code CLI."""
+
+    name: str = "claude"
+
+    async def headless(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        timeout: float = 600.0,
+        model: str | None = None,
+        dangerously_skip_permissions: bool = True,
+        role: str = "unknown",
+    ) -> tuple[str, int]:
+        """Run a headless Claude Code invocation.
+
+        Args:
+            prompt: The system prompt / agent role definition.
+            task: The task to execute.
+            cwd: Working directory for the subprocess.
+            timeout: Maximum execution time in seconds.
+            model: Optional model override.
+            dangerously_skip_permissions: If True, skip permission prompts.
+            role: Agent role (used for streaming prefix).
+
+        Returns (stdout, return_code).
+        """
+        full_prompt = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
+
+        cmd = ["claude", "-p", full_prompt]
+        if dangerously_skip_permissions:
+            cmd.append("--dangerously-skip-permissions")
+        if model:
+            cmd.extend(["--model", model])
+
+        logger.info("ClaudeRunner headless: cwd=%s, model=%s", cwd, model)
+
+        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        if model:
+            env["FACTORY_MODEL"] = model
+
+        stream = should_stream()
+        prefix = f"[claude:{role}]" if stream else None
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                stream_subprocess(proc, stream=stream, prefix=prefix),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()  # type: ignore[union-attr]
+            await proc.wait()  # type: ignore[union-attr]
+            logger.error("ClaudeRunner timed out after %ss", timeout)
+            return f"Agent timed out after {timeout}s", 1
+        except FileNotFoundError:
+            logger.error("'claude' CLI not found on PATH")
+            return "Error: 'claude' CLI not found on PATH", 1
+
+        stdout = stdout_bytes.decode()
+        stderr = stderr_bytes.decode()
+
+        if proc.returncode != 0:
+            logger.warning("ClaudeRunner exited with code %d: %s", proc.returncode, stderr[:200])
+
+        return stdout, proc.returncode or 0
+
+    def interactive_exec(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        model: str | None = None,
+        role: str = "ceo",
+    ) -> NoReturn:
+        """Replace process with interactive Claude Code session.
+
+        Args:
+            prompt: The system prompt to append.
+            task: The initial user message.
+            cwd: Working directory (os.chdir is called before exec).
+            model: Optional model override.
+            role: Agent role (unused by claude, but kept for API compatibility).
+        """
+        _ = role  # unused by claude runner
+        cmd = [
+            "claude",
+            "--append-system-prompt", prompt,
+            "--dangerously-skip-permissions",
+            task,
+        ]
+        if model:
+            cmd.extend(["--model", model])
+            os.environ["FACTORY_MODEL"] = model
+
+        logger.info("ClaudeRunner interactive_exec: cwd=%s", cwd)
+
+        os.chdir(cwd)
+        os.execvp("claude", cmd)

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -96,6 +96,7 @@ class ClaudeRunner:
         *,
         model: str | None = None,
         role: str = "ceo",
+        dangerously_skip_permissions: bool = False,
     ) -> NoReturn:
         """Replace process with interactive Claude Code session.
 
@@ -105,14 +106,16 @@ class ClaudeRunner:
             cwd: Working directory (os.chdir is called before exec).
             model: Optional model override.
             role: Agent role (unused by claude, but kept for API compatibility).
+            dangerously_skip_permissions: If True, skip permission prompts.
         """
         _ = role  # unused by claude runner
         cmd = [
             "claude",
             "--append-system-prompt", prompt,
-            "--dangerously-skip-permissions",
-            task,
         ]
+        if dangerously_skip_permissions:
+            cmd.append("--dangerously-skip-permissions")
+        cmd.append(task)
         if model:
             cmd.extend(["--model", model])
             os.environ["FACTORY_MODEL"] = model

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -46,6 +46,7 @@ class Runner(Protocol):
         *,
         model: str | None = None,
         role: str = "ceo",
+        dangerously_skip_permissions: bool = False,
     ) -> NoReturn:
         """Replace the current process with an interactive CLI session.
 
@@ -57,5 +58,6 @@ class Runner(Protocol):
             cwd: Working directory (os.chdir is called before exec).
             model: Optional model override.
             role: Agent role name (used by bob for custom mode selection).
+            dangerously_skip_permissions: If True, skip permission prompts (--yolo for bob).
         """
         ...

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -31,7 +31,7 @@ class Runner(Protocol):
             timeout: Maximum execution time in seconds.
             model: Optional model override.
             dangerously_skip_permissions: If True, skip permission prompts.
-            role: Agent role name (used by bob for custom mode selection).
+            role: Agent role name (used for logging and output prefixing).
 
         Returns:
             (stdout, return_code) tuple.
@@ -57,7 +57,7 @@ class Runner(Protocol):
             task: The initial user message.
             cwd: Working directory (os.chdir is called before exec).
             model: Optional model override.
-            role: Agent role name (used by bob for custom mode selection).
+            role: Agent role name (used for logging and output prefixing).
             dangerously_skip_permissions: If True, skip permission prompts (--yolo for bob).
         """
         ...

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -1,0 +1,61 @@
+"""Runner protocol — interface for CLI backend implementations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NoReturn, Protocol
+
+
+class Runner(Protocol):
+    """Protocol for CLI backend implementations (claude, bob, etc.)."""
+
+    name: str
+
+    async def headless(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        timeout: float = 600.0,
+        model: str | None = None,
+        dangerously_skip_permissions: bool = True,
+        role: str = "unknown",
+    ) -> tuple[str, int]:
+        """Run a headless (non-interactive) agent invocation.
+
+        Args:
+            prompt: The system prompt / agent role definition.
+            task: The task to execute.
+            cwd: Working directory for the subprocess.
+            timeout: Maximum execution time in seconds.
+            model: Optional model override.
+            dangerously_skip_permissions: If True, skip permission prompts.
+            role: Agent role name (used by bob for custom mode selection).
+
+        Returns:
+            (stdout, return_code) tuple.
+        """
+        ...
+
+    def interactive_exec(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        model: str | None = None,
+        role: str = "ceo",
+    ) -> NoReturn:
+        """Replace the current process with an interactive CLI session.
+
+        This function does not return — it calls os.execvp to replace the process.
+
+        Args:
+            prompt: The system prompt to append.
+            task: The initial user message.
+            cwd: Working directory (os.chdir is called before exec).
+            model: Optional model override.
+            role: Agent role name (used by bob for custom mode selection).
+        """
+        ...

--- a/factory/runners/usage.py
+++ b/factory/runners/usage.py
@@ -1,0 +1,155 @@
+"""Bob usage tracking — log and ceiling enforcement."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TypedDict
+
+USAGE_LOG_NAME = "bob_usage.jsonl"
+
+
+class UsageEntry(TypedDict):
+    timestamp: str
+    role: str
+    cwd: str
+    duration_seconds: float
+    exit_code: int
+    dry_run: bool
+
+
+def get_usage_log_path(project_path: Path) -> Path:
+    """Return the path to the bob usage log for a project."""
+    return project_path / ".factory" / USAGE_LOG_NAME
+
+
+def log_usage(
+    project_path: Path,
+    role: str,
+    cwd: Path,
+    duration_seconds: float,
+    exit_code: int,
+    dry_run: bool = False,
+) -> None:
+    """Append a usage entry to the project's bob_usage.jsonl."""
+    log_path = get_usage_log_path(project_path)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    entry: UsageEntry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "role": role,
+        "cwd": str(cwd),
+        "duration_seconds": duration_seconds,
+        "exit_code": exit_code,
+        "dry_run": dry_run,
+    }
+
+    with open(log_path, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def count_today_invocations(project_path: Path, *, include_dry_run: bool = False) -> int:
+    """Count non-dry-run bob invocations from today."""
+    log_path = get_usage_log_path(project_path)
+    if not log_path.exists():
+        return 0
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    count = 0
+
+    with open(log_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                if entry.get("timestamp", "").startswith(today):
+                    if include_dry_run or not entry.get("dry_run", False):
+                        count += 1
+            except json.JSONDecodeError:
+                continue
+
+    return count
+
+
+def count_cycle_invocations(project_path: Path, cycle_start: datetime | None = None) -> int:
+    """Count non-dry-run bob invocations in the current cycle.
+
+    If cycle_start is None, counts all invocations from today (approximation).
+    """
+    if cycle_start is None:
+        return count_today_invocations(project_path)
+
+    log_path = get_usage_log_path(project_path)
+    if not log_path.exists():
+        return 0
+
+    count = 0
+    cycle_start_iso = cycle_start.isoformat()
+
+    with open(log_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                ts = entry.get("timestamp", "")
+                if ts >= cycle_start_iso and not entry.get("dry_run", False):
+                    count += 1
+            except json.JSONDecodeError:
+                continue
+
+    return count
+
+
+def get_cycle_ceiling() -> int:
+    """Get the per-cycle invocation ceiling from env var."""
+    return int(os.environ.get("FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", "3"))
+
+
+def get_daily_ceiling() -> int:
+    """Get the per-day invocation ceiling from env var."""
+    return int(os.environ.get("FACTORY_BOB_MAX_INVOCATIONS_PER_DAY", "20"))
+
+
+class CeilingExceededError(Exception):
+    """Raised when a bob invocation ceiling is exceeded."""
+
+    def __init__(self, ceiling_name: str, current: int, limit: int, env_var: str) -> None:
+        self.ceiling_name = ceiling_name
+        self.current = current
+        self.limit = limit
+        self.env_var = env_var
+        super().__init__(
+            f"Bob {ceiling_name} ceiling exceeded: {current}/{limit}. "
+            f"To increase, set {env_var}={limit + 5}"
+        )
+
+
+def check_ceilings(
+    project_path: Path,
+    cycle_start: datetime | None = None,
+) -> None:
+    """Check all ceilings before a bob invocation.
+
+    Raises CeilingExceededError if any ceiling is exceeded.
+    """
+    # Check per-day ceiling
+    daily_count = count_today_invocations(project_path)
+    daily_limit = get_daily_ceiling()
+    if daily_count >= daily_limit:
+        raise CeilingExceededError(
+            "daily", daily_count, daily_limit, "FACTORY_BOB_MAX_INVOCATIONS_PER_DAY"
+        )
+
+    # Check per-cycle ceiling
+    cycle_count = count_cycle_invocations(project_path, cycle_start)
+    cycle_limit = get_cycle_ceiling()
+    if cycle_count >= cycle_limit:
+        raise CeilingExceededError(
+            "per-cycle", cycle_count, cycle_limit, "FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE"
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.34",
     "mcp>=1.27.0",
+    "pyyaml>=6.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -44,5 +45,5 @@ line-length = 100
 extend-exclude = ["mkdocs.yml"]
 
 [dependency-groups]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.8", "mypy>=1.10", "pytest-cov>=5.0", "httpx>=0.27"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.8", "mypy>=1.10", "pytest-cov>=5.0", "httpx>=0.27", "types-pyyaml>=6.0"]
 docs = ["mkdocs-material>=9.5"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,19 @@
 """Shared pytest fixtures for remote-factory tests."""
 
+import os
 from pathlib import Path
 
 import pytest
 
 from factory.models import FactoryConfig
+
+# CRITICAL: Set FACTORY_BOB_DRY_RUN=1 before any tests run.
+# This ensures BobRunner never invokes real bob during tests.
+os.environ["FACTORY_BOB_DRY_RUN"] = "1"
+
+# Disable CEO completion guard by default in tests.
+# Tests that need to exercise the guard can unset this or test with mocked invoke_agent.
+os.environ["FACTORY_CEO_RESPAWN_DISABLED"] = "1"
 
 
 @pytest.fixture

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -100,7 +100,7 @@ class TestInvokeAgentsParallel:
 
         call_count = 0
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True):
             nonlocal call_count
             call_count += 1
             return (f"output-{role}", 0)
@@ -120,7 +120,7 @@ class TestInvokeAgentsParallel:
         """invoke_agents_parallel returns results from all agents."""
         from factory.agents.runner import invoke_agents_parallel
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True):
             return (f"output-{role}", 0)
 
         monkeypatch.setattr("factory.agents.runner.invoke_agent", mock_invoke)
@@ -141,7 +141,7 @@ class TestInvokeAgentsParallel:
 
         captured_models: list[str | None] = []
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True):
             captured_models.append(model)
             return (f"output-{role}", 0)
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -100,7 +100,7 @@ class TestInvokeAgentsParallel:
 
         call_count = 0
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None):
             nonlocal call_count
             call_count += 1
             return (f"output-{role}", 0)
@@ -120,7 +120,7 @@ class TestInvokeAgentsParallel:
         """invoke_agents_parallel returns results from all agents."""
         from factory.agents.runner import invoke_agents_parallel
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None):
             return (f"output-{role}", 0)
 
         monkeypatch.setattr("factory.agents.runner.invoke_agent", mock_invoke)
@@ -141,7 +141,7 @@ class TestInvokeAgentsParallel:
 
         captured_models: list[str | None] = []
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None):
             captured_models.append(model)
             return (f"output-{role}", 0)
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,10 +1,17 @@
 """Tests for factory.agents — prompt loading and resolution."""
 
+import json
 from pathlib import Path
 
 import pytest
 
-from factory.agents.runner import resolve_prompt, AgentRole, _PROMPTS_DIR
+from factory.agents.runner import (
+    resolve_prompt,
+    AgentRole,
+    _PROMPTS_DIR,
+    ConsecutiveAgentFailureError,
+    reset_failure_counter,
+)
 
 
 # Path to the project root (parent of factory/)
@@ -149,51 +156,54 @@ class TestInvokeAgentModel:
     @pytest.mark.asyncio
     async def test_model_flag_in_subprocess_cmd(self, tmp_path, monkeypatch):
         """invoke_agent includes --model in subprocess command when model is set."""
+        from unittest.mock import AsyncMock, patch
+
         from factory.agents.runner import invoke_agent
 
         captured_cmd: list[str] = []
 
         async def mock_exec(*args, **kwargs):
             captured_cmd.extend(args)
-            proc = type("P", (), {
-                "communicate": lambda self: (b"ok", b""),
-                "returncode": 0,
-                "kill": lambda self: None,
-                "wait": lambda self: None,
-            })()
-
-            async def communicate():
-                return (b"ok", b"")
-            proc.communicate = communicate
+            proc = AsyncMock()
+            proc.returncode = 0
             return proc
 
-        monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+        with patch(
+            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"ok", b"")
 
-        await invoke_agent("researcher", "test task", tmp_path, model="claude-opus-4-6")
-        assert "--model" in captured_cmd
-        model_idx = captured_cmd.index("--model")
-        assert captured_cmd[model_idx + 1] == "claude-opus-4-6"
+            monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+
+            await invoke_agent("researcher", "test task", tmp_path, model="claude-opus-4-6")
+            assert "--model" in captured_cmd
+            model_idx = captured_cmd.index("--model")
+            assert captured_cmd[model_idx + 1] == "claude-opus-4-6"
 
     @pytest.mark.asyncio
     async def test_no_model_flag_when_none(self, tmp_path, monkeypatch):
         """invoke_agent omits --model when model is None."""
+        from unittest.mock import AsyncMock, patch
+
         from factory.agents.runner import invoke_agent
 
         captured_cmd: list[str] = []
 
         async def mock_exec(*args, **kwargs):
             captured_cmd.extend(args)
-            proc = type("P", (), {"returncode": 0})()
-
-            async def communicate():
-                return (b"ok", b"")
-            proc.communicate = communicate
+            proc = AsyncMock()
+            proc.returncode = 0
             return proc
 
-        monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+        with patch(
+            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"ok", b"")
 
-        await invoke_agent("researcher", "test task", tmp_path, model=None)
-        assert "--model" not in captured_cmd
+            monkeypatch.setattr("asyncio.create_subprocess_exec", mock_exec)
+
+            await invoke_agent("researcher", "test task", tmp_path, model=None)
+            assert "--model" not in captured_cmd
 
 
 class TestResolveModel:
@@ -251,4 +261,217 @@ class TestResolveModel:
         args = argparse.Namespace()
         assert _resolve_model(args) is None
 
+
+class TestConsecutiveFailureAbort:
+    """Tests for consecutive agent failure tracking and abort."""
+
+    def setup_method(self):
+        """Reset the failure counter before each test."""
+        reset_failure_counter()
+
+    def teardown_method(self):
+        """Reset the failure counter after each test."""
+        reset_failure_counter()
+
+    @pytest.mark.asyncio
+    async def test_success_resets_counter(self, tmp_path, monkeypatch):
+        """Successful agent invocation resets the failure counter."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        (tmp_path / ".factory").mkdir()
+
+        # Mock the runner at the point where it's imported in runner.py
+        class MockRunner:
+            name = "claude"
+            async def headless(self, *args, **kwargs):
+                return ("success", 0)
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda _: MockRunner())
+
+        # Set a non-zero failure count
+        runner_module._consecutive_failures = 1
+
+        await invoke_agent("researcher", "test", tmp_path)
+
+        # Should be reset to 0 after success
+        assert runner_module._consecutive_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_failure_increments_counter(self, tmp_path, monkeypatch):
+        """Failed agent invocation increments the failure counter."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        (tmp_path / ".factory").mkdir()
+
+        class MockRunner:
+            name = "claude"
+            async def headless(self, *args, **kwargs):
+                return ("error output", 1)  # non-zero exit code
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda _: MockRunner())
+
+        # Start at 0
+        assert runner_module._consecutive_failures == 0
+
+        await invoke_agent("researcher", "test", tmp_path)
+
+        # Should be incremented to 1
+        assert runner_module._consecutive_failures == 1
+
+    @pytest.mark.asyncio
+    async def test_abort_after_threshold(self, tmp_path, monkeypatch):
+        """Abort with error after 2 consecutive failures."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        (tmp_path / ".factory").mkdir()
+
+        class MockRunner:
+            name = "claude"
+            async def headless(self, *args, **kwargs):
+                return ("error", 1)
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda _: MockRunner())
+
+        # First failure - should not raise
+        await invoke_agent("researcher", "test", tmp_path)
+        assert runner_module._consecutive_failures == 1
+
+        # Second failure - should raise ConsecutiveAgentFailureError
+        with pytest.raises(ConsecutiveAgentFailureError) as exc_info:
+            await invoke_agent("strategist", "test", tmp_path)
+
+        assert exc_info.value.failure_count == 2
+        assert exc_info.value.last_agent == "strategist"
+        assert "consecutive agent spawn failures" in str(exc_info.value)
+        assert "events.jsonl" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_abort_emits_event(self, tmp_path, monkeypatch):
+        """Abort emits cycle.aborted event."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        (tmp_path / ".factory").mkdir()
+
+        class MockRunner:
+            name = "claude"
+            async def headless(self, *args, **kwargs):
+                return ("error", 1)
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda _: MockRunner())
+
+        # First failure
+        await invoke_agent("researcher", "test", tmp_path)
+
+        # Second failure - triggers abort
+        with pytest.raises(ConsecutiveAgentFailureError):
+            await invoke_agent("strategist", "test", tmp_path)
+
+        # Check event was emitted
+        events_file = tmp_path / ".factory" / "events.jsonl"
+        assert events_file.exists()
+
+        events = [json.loads(line) for line in events_file.read_text().splitlines()]
+        abort_events = [e for e in events if e["type"] == "cycle.aborted"]
+        assert len(abort_events) == 1
+
+        abort_event = abort_events[0]
+        assert abort_event["data"]["reason"] == "consecutive_agent_failures"
+        assert abort_event["data"]["failure_count"] == 2
+        assert abort_event["data"]["last_agent"] == "strategist"
+
+    @pytest.mark.asyncio
+    async def test_exception_also_increments_counter(self, tmp_path, monkeypatch):
+        """Exception during agent invocation also increments the failure counter."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        (tmp_path / ".factory").mkdir()
+
+        class MockRunner:
+            name = "claude"
+            async def headless(self, *args, **kwargs):
+                raise RuntimeError("Connection failed")
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda _: MockRunner())
+
+        # First failure via exception
+        stdout, code = await invoke_agent("researcher", "test", tmp_path)
+        assert code == 1
+        assert "Error:" in stdout
+        assert runner_module._consecutive_failures == 1
+
+    def test_reset_failure_counter(self):
+        """reset_failure_counter resets the counter to 0."""
+        import factory.agents.runner as runner_module
+
+        runner_module._consecutive_failures = 5
+        reset_failure_counter()
+        assert runner_module._consecutive_failures == 0
+
+    def test_error_message_is_actionable(self):
+        """Error message provides actionable guidance."""
+        error = ConsecutiveAgentFailureError(2, "researcher")
+        msg = str(error)
+
+        assert "2 consecutive" in msg
+        assert "researcher" in msg
+        assert "events.jsonl" in msg
+        assert "BOBSHELL_API_KEY" in msg  # hint about the common cause
+
+
+class TestCeoPromptNoBackgroundSpawning:
+    """Regression tests: CEO prompt must not suggest background subagent spawning.
+
+    The CEO historically invented a broken pattern: spawning `factory agent`
+    in the background and polling via `tail -f` for output. This doesn't work
+    and causes double-spend. These tests ensure the prompt forbids this pattern.
+    """
+
+    def test_no_background_ampersand_after_factory_agent(self):
+        """CEO prompt must not show `factory agent ... &` pattern."""
+        prompt = resolve_prompt("ceo")
+        # Look for patterns like: factory agent ... &
+        # We want to ensure no code block shows backgrounding via &
+        import re
+        # Match lines that start factory agent and end with &
+        pattern = r"factory\s+agent\s+[^`\n]+\s+&\s*$"
+        matches = re.findall(pattern, prompt, re.MULTILINE)
+        # The only & should be in the "Forbidden pattern" example showing what NOT to do
+        # That example has a comment after it: "# Background spawn"
+        for match in matches:
+            assert "WRONG" in prompt[prompt.find(match) - 50:prompt.find(match)], \
+                f"Found `factory agent ... &` without 'WRONG' context: {match}"
+
+    def test_no_tail_f_for_agent_output(self):
+        """CEO prompt must not suggest `tail -f` for agent log output."""
+        prompt = resolve_prompt("ceo")
+        import re
+        # Find all tail -f occurrences
+        pattern = r"tail\s+-[fF]\s+\S+"
+        matches = re.findall(pattern, prompt)
+        # All matches should be in a "Forbidden" or "WRONG" context
+        for match in matches:
+            context_start = max(0, prompt.find(match) - 100)
+            context = prompt[context_start:prompt.find(match) + len(match)]
+            assert any(marker in context for marker in ["WRONG", "Forbidden", "do not"]), \
+                f"Found `tail -f` without forbidden context: {match}"
+
+    def test_has_synchronous_only_rule(self):
+        """CEO prompt must explicitly state subagent calls are synchronous."""
+        prompt = resolve_prompt("ceo")
+        assert "SYNCHRONOUS" in prompt or "synchronous" in prompt
+        assert "blocking" in prompt.lower()
+
+    def test_playbook_forbids_background_spawning(self):
+        """CEO playbook must have a DON'T rule against background spawning."""
+        playbook_path = _PROJECT_ROOT / "factory" / "agents" / "playbooks" / "ceo.md"
+        playbook = playbook_path.read_text()
+        assert "background" in playbook.lower()
+        assert "DON'T" in playbook or "Don't" in playbook
+        # Should mention the consequence: double-spend
+        assert "double" in playbook.lower()
 

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -228,6 +228,226 @@ class TestDetectIncomplete:
         assert "no eval_profile.json" in gap.reason
 
 
+class TestCountVerdictsWithResultsTsv:
+    """Tests for _count_verdicts() using results.tsv with timestamp filtering.
+
+    These tests verify the primary code path (results.tsv) rather than the
+    fallback path (verdict.json files). The timestamp filtering is critical
+    for preventing cross-cycle contamination.
+    """
+
+    def _write_results_tsv(self, tmp_path: Path, rows: list[dict]) -> None:
+        """Helper to write a results.tsv with the given rows."""
+        import csv
+        from factory.store import TSV_COLUMNS
+
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir(parents=True, exist_ok=True)
+        tsv_path = factory_dir / "results.tsv"
+
+        with open(tsv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=TSV_COLUMNS, dialect="excel-tab")
+            writer.writeheader()
+            for row in rows:
+                # Fill in defaults for required columns
+                full_row = {col: "" for col in TSV_COLUMNS}
+                full_row.update(row)
+                writer.writerow(full_row)
+
+    def test_counts_all_verdicts_when_no_since_ts(self, tmp_path: Path) -> None:
+        """Without since_ts, all verdicts are counted."""
+        from factory.ceo_completion import _count_verdicts
+
+        self._write_results_tsv(tmp_path, [
+            {"id": "1", "timestamp": "2026-04-28T10:00:00+00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-28T11:00:00+00:00", "verdict": "revert"},
+            {"id": "3", "timestamp": "2026-04-28T12:00:00+00:00", "verdict": "keep"},
+        ])
+
+        count = _count_verdicts(tmp_path)
+        assert count == 3
+
+    def test_filters_by_since_ts(self, tmp_path: Path) -> None:
+        """With since_ts, only verdicts after that time are counted."""
+        from factory.ceo_completion import _count_verdicts
+
+        # Two old rows from a previous cycle, one new row from current cycle
+        self._write_results_tsv(tmp_path, [
+            {"id": "1", "timestamp": "2026-04-28T10:00:00+00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-28T11:00:00+00:00", "verdict": "revert"},
+            {"id": "3", "timestamp": "2026-04-29T14:00:00+00:00", "verdict": "keep"},
+        ])
+
+        # Filter to only count after noon on Apr 29
+        since = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        count = _count_verdicts(tmp_path, since_ts=since)
+        assert count == 1
+
+    def test_ignores_pending_verdicts(self, tmp_path: Path) -> None:
+        """Rows without keep/revert/error verdict are not counted."""
+        from factory.ceo_completion import _count_verdicts
+
+        self._write_results_tsv(tmp_path, [
+            {"id": "1", "timestamp": "2026-04-28T10:00:00+00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-28T11:00:00+00:00", "verdict": "pending"},
+            {"id": "3", "timestamp": "2026-04-28T12:00:00+00:00", "verdict": ""},
+        ])
+
+        count = _count_verdicts(tmp_path)
+        assert count == 1
+
+    def test_handles_error_verdict(self, tmp_path: Path) -> None:
+        """Error verdicts are counted (they are finalized experiments)."""
+        from factory.ceo_completion import _count_verdicts
+
+        self._write_results_tsv(tmp_path, [
+            {"id": "1", "timestamp": "2026-04-28T10:00:00+00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-28T11:00:00+00:00", "verdict": "error"},
+        ])
+
+        count = _count_verdicts(tmp_path)
+        assert count == 2
+
+    def test_handles_naive_timestamps(self, tmp_path: Path) -> None:
+        """Timestamps without timezone are treated as UTC."""
+        from factory.ceo_completion import _count_verdicts
+
+        self._write_results_tsv(tmp_path, [
+            {"id": "1", "timestamp": "2026-04-28T10:00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-29T14:00:00", "verdict": "keep"},
+        ])
+
+        since = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+        count = _count_verdicts(tmp_path, since_ts=since)
+        assert count == 1
+
+    def test_cross_cycle_scenario(self, tmp_path: Path) -> None:
+        """Realistic scenario: 3 experiments from old cycle, 2 from current cycle."""
+        from factory.ceo_completion import _count_verdicts
+
+        # Old cycle started at 2026-04-28T08:00:00
+        # Current cycle started at 2026-04-29T10:00:00
+        self._write_results_tsv(tmp_path, [
+            # Old cycle experiments
+            {"id": "1", "timestamp": "2026-04-28T09:00:00+00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-28T10:00:00+00:00", "verdict": "revert"},
+            {"id": "3", "timestamp": "2026-04-28T11:00:00+00:00", "verdict": "keep"},
+            # Current cycle experiments
+            {"id": "4", "timestamp": "2026-04-29T11:00:00+00:00", "verdict": "keep"},
+            {"id": "5", "timestamp": "2026-04-29T12:00:00+00:00", "verdict": "revert"},
+        ])
+
+        # Current cycle started at 10:00 on Apr 29
+        current_cycle_start = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
+        count = _count_verdicts(tmp_path, since_ts=current_cycle_start)
+        assert count == 2
+
+
+class TestDetectIncompleteWithTimestampFiltering:
+    """Tests for _detect_incomplete() with cycle_started_at parameter.
+
+    These tests verify that _detect_incomplete correctly scopes verdict counting
+    to the current cycle, preventing cross-cycle contamination.
+    """
+
+    def _write_results_tsv(self, tmp_path: Path, rows: list[dict]) -> None:
+        """Helper to write a results.tsv with the given rows."""
+        import csv
+        from factory.store import TSV_COLUMNS
+
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir(parents=True, exist_ok=True)
+        tsv_path = factory_dir / "results.tsv"
+
+        with open(tsv_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=TSV_COLUMNS, dialect="excel-tab")
+            writer.writeheader()
+            for row in rows:
+                full_row = {col: "" for col in TSV_COLUMNS}
+                full_row.update(row)
+                writer.writerow(full_row)
+
+    def test_improve_filters_by_cycle_start(self, tmp_path: Path) -> None:
+        """Improve mode only counts verdicts from the current cycle."""
+        from factory.ceo_completion import _detect_incomplete
+
+        # Setup: 2 hypotheses in current strategy
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "### Hypotheses\n\n#### H1: First\n\n#### H2: Second\n"
+        )
+
+        # 3 old verdicts from previous cycle, 1 from current cycle
+        self._write_results_tsv(tmp_path, [
+            {"id": "1", "timestamp": "2026-04-28T09:00:00+00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-28T10:00:00+00:00", "verdict": "keep"},
+            {"id": "3", "timestamp": "2026-04-28T11:00:00+00:00", "verdict": "keep"},
+            {"id": "4", "timestamp": "2026-04-29T11:00:00+00:00", "verdict": "keep"},
+        ])
+
+        # Current cycle started at 10:00 on Apr 29 — only 1 verdict should count
+        cycle_start = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
+        gap = _detect_incomplete(tmp_path, "improve", cycle_started_at=cycle_start)
+
+        # Should be incomplete: 2 hypotheses, only 1 current-cycle verdict
+        assert gap is not None
+        assert gap.planned == 2
+        assert gap.completed == 1
+        assert gap.next_item == "H2"
+
+    def test_improve_complete_with_cycle_filtering(self, tmp_path: Path) -> None:
+        """Improve mode is complete when current-cycle verdicts match hypotheses."""
+        from factory.ceo_completion import _detect_incomplete
+
+        # Setup: 2 hypotheses
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "### Hypotheses\n\n#### H1: First\n\n#### H2: Second\n"
+        )
+
+        # 1 old verdict, 2 current-cycle verdicts
+        self._write_results_tsv(tmp_path, [
+            {"id": "1", "timestamp": "2026-04-28T09:00:00+00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-29T11:00:00+00:00", "verdict": "keep"},
+            {"id": "3", "timestamp": "2026-04-29T12:00:00+00:00", "verdict": "revert"},
+        ])
+
+        cycle_start = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
+        gap = _detect_incomplete(tmp_path, "improve", cycle_started_at=cycle_start)
+
+        # Should be complete: 2 hypotheses, 2 current-cycle verdicts
+        assert gap is None
+
+    def test_build_filters_by_cycle_start(self, tmp_path: Path) -> None:
+        """Build mode only counts verdicts from the current cycle."""
+        from factory.ceo_completion import _detect_incomplete
+
+        # Setup: 3 phases in build plan
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "### Build Plan\n\n#### H1: Phase 1\n\n#### H2: Phase 2\n\n#### H3: Phase 3\n"
+        )
+
+        # 2 old verdicts, 1 current
+        self._write_results_tsv(tmp_path, [
+            {"id": "1", "timestamp": "2026-04-28T09:00:00+00:00", "verdict": "keep"},
+            {"id": "2", "timestamp": "2026-04-28T10:00:00+00:00", "verdict": "keep"},
+            {"id": "3", "timestamp": "2026-04-29T11:00:00+00:00", "verdict": "keep"},
+        ])
+
+        cycle_start = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
+        gap = _detect_incomplete(tmp_path, "build", cycle_started_at=cycle_start)
+
+        # Should be incomplete: 3 phases, only 1 current-cycle verdict
+        assert gap is not None
+        assert gap.planned == 3
+        assert gap.completed == 1
+        assert gap.next_item == "Phase2"
+
+
 class TestBuildContinuationTask:
     """Tests for _build_continuation_task()."""
 

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -1,0 +1,335 @@
+"""Tests for factory/ceo_completion.py — CEO completion guard."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestDetectIncomplete:
+    """Tests for _detect_incomplete()."""
+
+    def test_improve_complete_when_all_verdicts(self, tmp_path: Path) -> None:
+        """Improve mode is complete when verdict count >= hypothesis count."""
+        from factory.ceo_completion import _detect_incomplete
+
+        # Setup: 2 hypotheses in strategy
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "### Hypotheses\n\n#### H1: First\n\n#### H2: Second\n"
+        )
+
+        # Setup: 2 verdicts
+        for i in (1, 2):
+            exp_dir = tmp_path / ".factory" / "experiments" / f"00{i}"
+            exp_dir.mkdir(parents=True)
+            (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+
+        gap = _detect_incomplete(tmp_path, "improve")
+        assert gap is None
+
+    def test_improve_incomplete_when_missing_verdicts(self, tmp_path: Path) -> None:
+        """Improve mode is incomplete when verdict count < hypothesis count."""
+        from factory.ceo_completion import _detect_incomplete
+
+        # Setup: 3 hypotheses
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "### Hypotheses\n\n#### H1: First\n\n#### H2: Second\n\n#### H3: Third\n"
+        )
+
+        # Setup: only 1 verdict
+        exp_dir = tmp_path / ".factory" / "experiments" / "001"
+        exp_dir.mkdir(parents=True)
+        (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+
+        gap = _detect_incomplete(tmp_path, "improve")
+        assert gap is not None
+        assert gap.planned == 3
+        assert gap.completed == 1
+        assert gap.next_item == "H2"
+        assert "improve.incomplete" in gap.reason
+
+    def test_improve_no_strategy_returns_none(self, tmp_path: Path) -> None:
+        """No strategy file means nothing planned — not incomplete."""
+        from factory.ceo_completion import _detect_incomplete
+
+        (tmp_path / ".factory").mkdir()
+
+        gap = _detect_incomplete(tmp_path, "improve")
+        assert gap is None
+
+    def test_discover_complete_when_profile_exists(self, tmp_path: Path) -> None:
+        """Discover mode is complete when eval_profile.json exists."""
+        from factory.ceo_completion import _detect_incomplete
+
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "eval_profile.json").write_text('{"dimensions": []}')
+
+        gap = _detect_incomplete(tmp_path, "discover")
+        assert gap is None
+
+    def test_discover_incomplete_when_no_profile(self, tmp_path: Path) -> None:
+        """Discover mode is incomplete without eval_profile.json."""
+        from factory.ceo_completion import _detect_incomplete
+
+        (tmp_path / ".factory").mkdir()
+
+        gap = _detect_incomplete(tmp_path, "discover")
+        assert gap is not None
+        assert gap.mode == "discover"
+        assert "no eval_profile.json" in gap.reason
+
+
+class TestBuildContinuationTask:
+    """Tests for _build_continuation_task()."""
+
+    def test_improve_continuation(self) -> None:
+        """Improve mode continuation tells CEO to spawn Builder for next H."""
+        from factory.ceo_completion import _build_continuation_task, IncompleteGap
+
+        gap = IncompleteGap(
+            mode="improve",
+            planned=5,
+            completed=2,
+            next_item="H3",
+            reason="improve.incomplete",
+        )
+
+        task = _build_continuation_task(gap)
+        assert "Resume execution from hypothesis H3" in task
+        assert "do not re-plan" in task
+        assert "Spawn Builder for H3" in task
+        assert "2/5" in task
+
+    def test_build_continuation(self) -> None:
+        """Build mode continuation tells CEO to resume from next phase."""
+        from factory.ceo_completion import _build_continuation_task, IncompleteGap
+
+        gap = IncompleteGap(
+            mode="build",
+            planned=6,
+            completed=3,
+            next_item="Phase4",
+            reason="build.incomplete",
+        )
+
+        task = _build_continuation_task(gap)
+        assert "Resume Build pipeline" in task
+        assert "Phase4" in task
+
+
+class TestRunCeoWithCompletionGuard:
+    """Tests for run_ceo_with_completion_guard()."""
+
+    @pytest.fixture(autouse=True)
+    def enable_respawn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Enable respawn for all tests in this class (disabled globally in conftest)."""
+        monkeypatch.delenv("FACTORY_CEO_RESPAWN_DISABLED", raising=False)
+
+    async def test_complete_on_first_try_no_respawn(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If CEO completes all work in one spawn, no respawn occurs."""
+        from factory.ceo_completion import run_ceo_with_completion_guard
+
+        # Setup: 2 hypotheses, 2 verdicts (complete)
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n\n#### H2: B\n")
+
+        for i in (1, 2):
+            exp_dir = tmp_path / ".factory" / "experiments" / f"00{i}"
+            exp_dir.mkdir(parents=True)
+            (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+
+        mock_invoke = AsyncMock(return_value=("CEO output", 0))
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            result, code = await run_ceo_with_completion_guard(
+                tmp_path,
+                "Initial task",
+                mode="improve",
+                runner_name="claude",
+            )
+
+        assert code == 0
+        assert mock_invoke.call_count == 1
+
+    async def test_respawns_when_incomplete(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If CEO exits with work undone, it respawns with continuation task."""
+        from factory.ceo_completion import run_ceo_with_completion_guard
+
+        # Setup: 3 hypotheses
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n\n#### H2: B\n\n#### H3: C\n")
+        (tmp_path / ".factory" / "experiments").mkdir(parents=True)
+
+        call_count = 0
+
+        async def mock_invoke(role, task, path, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            # First call: create 1 verdict
+            if call_count == 1:
+                exp_dir = path / ".factory" / "experiments" / "001"
+                exp_dir.mkdir(parents=True, exist_ok=True)
+                (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+                return "First run", 0
+
+            # Second call: create 2nd verdict
+            if call_count == 2:
+                exp_dir = path / ".factory" / "experiments" / "002"
+                exp_dir.mkdir(parents=True, exist_ok=True)
+                (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+                return "Second run", 0
+
+            # Third call: create 3rd verdict (complete)
+            exp_dir = path / ".factory" / "experiments" / "003"
+            exp_dir.mkdir(parents=True, exist_ok=True)
+            (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+            return "Third run", 0
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            result, code = await run_ceo_with_completion_guard(
+                tmp_path,
+                "Initial task",
+                mode="improve",
+                runner_name="claude",
+            )
+
+        assert code == 0
+        assert call_count == 3
+
+        # Check respawn events were emitted
+        events_file = tmp_path / ".factory" / "events.jsonl"
+        assert events_file.exists()
+        events = [json.loads(line) for line in events_file.read_text().splitlines()]
+        respawn_events = [e for e in events if e["type"] == "ceo.respawn"]
+        assert len(respawn_events) == 2
+
+    async def test_respects_user_interrupt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exit code 130 (SIGINT) stops respawning."""
+        from factory.ceo_completion import run_ceo_with_completion_guard
+
+        # Setup incomplete
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n")
+        (tmp_path / ".factory" / "experiments").mkdir()
+
+        mock_invoke = AsyncMock(return_value=("Interrupted", 130))
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            result, code = await run_ceo_with_completion_guard(
+                tmp_path,
+                "Initial task",
+                mode="improve",
+                runner_name="claude",
+            )
+
+        assert code == 130
+        assert mock_invoke.call_count == 1
+
+    async def test_respects_abort_event(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cycle.aborted event stops respawning."""
+        from factory.ceo_completion import run_ceo_with_completion_guard
+        from factory.events import emit_event
+
+        # Setup incomplete
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n")
+        (tmp_path / ".factory" / "experiments").mkdir()
+
+        async def mock_invoke(role, task, path, **kwargs):
+            # CEO emits abort event
+            emit_event(path, "cycle.aborted", data={"reason": "unrecoverable"})
+            return "Aborted", 1
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            result, code = await run_ceo_with_completion_guard(
+                tmp_path,
+                "Initial task",
+                mode="improve",
+                runner_name="claude",
+            )
+
+        assert code == 1
+        # Only one call because abort was respected
+        events_file = tmp_path / ".factory" / "events.jsonl"
+        events = [json.loads(line) for line in events_file.read_text().splitlines()]
+        respawn_events = [e for e in events if e["type"] == "ceo.respawn"]
+        assert len(respawn_events) == 0
+
+    async def test_cap_hit_writes_incomplete_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After max respawns, writes cycle-incomplete.md and exits non-zero."""
+        from factory.ceo_completion import run_ceo_with_completion_guard
+
+        # Setup incomplete - will never complete
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n")
+        (tmp_path / ".factory" / "experiments").mkdir()
+
+        mock_invoke = AsyncMock(return_value=("Incomplete", 0))
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            result, code = await run_ceo_with_completion_guard(
+                tmp_path,
+                "Initial task",
+                mode="improve",
+                runner_name="claude",
+                max_respawns=2,  # Low cap for test
+            )
+
+        assert code == 1
+        # 1 initial + 2 respawns = 3 calls
+        assert mock_invoke.call_count == 3
+
+        # Check incomplete file was written
+        incomplete_file = strategy_dir / "cycle-incomplete.md"
+        assert incomplete_file.exists()
+        content = incomplete_file.read_text()
+        assert "respawn_cap_hit" in content
+
+    async def test_disabled_via_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FACTORY_CEO_RESPAWN_DISABLED=1 makes the guard a no-op."""
+        from factory.ceo_completion import run_ceo_with_completion_guard
+
+        monkeypatch.setenv("FACTORY_CEO_RESPAWN_DISABLED", "1")
+
+        # Setup incomplete
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n")
+        (tmp_path / ".factory" / "experiments").mkdir()
+
+        mock_invoke = AsyncMock(return_value=("Output", 0))
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            result, code = await run_ceo_with_completion_guard(
+                tmp_path,
+                "Initial task",
+                mode="improve",
+                runner_name="claude",
+            )
+
+        # Only one call — no respawn even though incomplete
+        assert mock_invoke.call_count == 1

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -1,10 +1,109 @@
 """Tests for factory/ceo_completion.py — CEO completion guard."""
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+
+class TestCycleState:
+    """Tests for cycle state persistence (read, write, delete, staleness)."""
+
+    def test_write_and_read_cycle_state(self, tmp_path: Path) -> None:
+        """Cycle state can be written and read back."""
+        from factory.ceo_completion import (
+            create_cycle_state,
+            read_cycle_state,
+            write_cycle_state,
+        )
+
+        state = create_cycle_state("build", "Build a CLI tool")
+        write_cycle_state(tmp_path, state)
+
+        loaded = read_cycle_state(tmp_path)
+        assert loaded is not None
+        assert loaded.cycle_id == state.cycle_id
+        assert loaded.mode == "build"
+        assert loaded.initial_prompt == "Build a CLI tool"
+        assert loaded.respawns == 0
+
+    def test_read_cycle_state_nonexistent(self, tmp_path: Path) -> None:
+        """read_cycle_state returns None if cycle.json doesn't exist."""
+        from factory.ceo_completion import read_cycle_state
+
+        assert read_cycle_state(tmp_path) is None
+
+    def test_delete_cycle_state(self, tmp_path: Path) -> None:
+        """delete_cycle_state removes the file and returns True."""
+        from factory.ceo_completion import (
+            create_cycle_state,
+            delete_cycle_state,
+            read_cycle_state,
+            write_cycle_state,
+        )
+
+        state = create_cycle_state("improve")
+        write_cycle_state(tmp_path, state)
+        assert read_cycle_state(tmp_path) is not None
+
+        deleted = delete_cycle_state(tmp_path)
+        assert deleted is True
+        assert read_cycle_state(tmp_path) is None
+
+    def test_delete_cycle_state_nonexistent(self, tmp_path: Path) -> None:
+        """delete_cycle_state returns False if file doesn't exist."""
+        from factory.ceo_completion import delete_cycle_state
+
+        assert delete_cycle_state(tmp_path) is False
+
+    def test_stale_cycle_state_ignored(self, tmp_path: Path) -> None:
+        """Cycle state older than 24 hours is treated as stale and ignored."""
+        from factory.ceo_completion import (
+            CYCLE_STALENESS_HOURS,
+            read_cycle_state,
+            _cycle_state_path,
+        )
+
+        # Write a cycle state with old timestamp
+        state_path = _cycle_state_path(tmp_path)
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        old_time = datetime.now(timezone.utc) - timedelta(hours=CYCLE_STALENESS_HOURS + 1)
+        state_data = {
+            "cycle_id": "old123",
+            "started_at": old_time.isoformat(),
+            "mode": "build",
+            "initial_prompt": "",
+            "respawns": 5,
+        }
+        state_path.write_text(json.dumps(state_data))
+
+        # Should return None due to staleness
+        loaded = read_cycle_state(tmp_path)
+        assert loaded is None
+
+    def test_malformed_cycle_state_ignored(self, tmp_path: Path) -> None:
+        """Malformed cycle.json returns None instead of crashing."""
+        from factory.ceo_completion import read_cycle_state, _cycle_state_path
+
+        state_path = _cycle_state_path(tmp_path)
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text("NOT VALID JSON {{{")
+
+        assert read_cycle_state(tmp_path) is None
+
+    def test_cycle_state_truncates_long_prompt(self, tmp_path: Path) -> None:
+        """Initial prompt is truncated to avoid bloat."""
+        from factory.ceo_completion import create_cycle_state, write_cycle_state, read_cycle_state
+
+        long_prompt = "x" * 5000
+        state = create_cycle_state("build", long_prompt)
+        write_cycle_state(tmp_path, state)
+
+        loaded = read_cycle_state(tmp_path)
+        assert loaded is not None
+        assert len(loaded.initial_prompt) <= 1000
 
 
 class TestDetectIncomplete:
@@ -121,6 +220,26 @@ class TestBuildContinuationTask:
         task = _build_continuation_task(gap)
         assert "Resume Build pipeline" in task
         assert "Phase4" in task
+
+    def test_continuation_includes_mode_directive(self) -> None:
+        """Continuation task includes explicit mode directive to prevent flip."""
+        from factory.ceo_completion import _build_continuation_task, IncompleteGap, create_cycle_state
+
+        gap = IncompleteGap(
+            mode="build",
+            planned=6,
+            completed=3,
+            next_item="Phase4",
+            reason="build.incomplete",
+        )
+        cycle_state = create_cycle_state("build", "Build a CLI")
+
+        task = _build_continuation_task(gap, cycle_state)
+        assert "## CRITICAL: Mode Override" in task
+        assert "CONTINUATION" in task
+        assert "BUILD" in task
+        assert "Do NOT re-detect mode" in task
+        assert cycle_state.cycle_id in task
 
 
 class TestRunCeoWithCompletionGuard:
@@ -333,3 +452,273 @@ class TestRunCeoWithCompletionGuard:
 
         # Only one call — no respawn even though incomplete
         assert mock_invoke.call_count == 1
+
+    async def test_creates_cycle_state_on_fresh_cycle(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fresh cycle creates cycle.json with the correct mode."""
+        from factory.ceo_completion import run_ceo_with_completion_guard, read_cycle_state
+
+        # Setup complete (so no respawns)
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n")
+        exp_dir = tmp_path / ".factory" / "experiments" / "001"
+        exp_dir.mkdir(parents=True)
+        (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+
+        mock_invoke = AsyncMock(return_value=("Done", 0))
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            # Invoke in build mode
+            await run_ceo_with_completion_guard(
+                tmp_path,
+                "Build task",
+                mode="build",
+                runner_name="claude",
+            )
+
+        # Cycle state should be deleted after completion
+        assert read_cycle_state(tmp_path) is None
+
+    async def test_deletes_cycle_state_on_completion(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cycle state is deleted when cycle completes successfully."""
+        from factory.ceo_completion import (
+            run_ceo_with_completion_guard,
+            read_cycle_state,
+            _cycle_state_path,
+        )
+
+        # Setup complete
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n")
+        exp_dir = tmp_path / ".factory" / "experiments" / "001"
+        exp_dir.mkdir(parents=True)
+        (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+
+        async def mock_invoke(role, task, path, **kwargs):
+            # Verify cycle state exists during invocation
+            assert read_cycle_state(path) is not None
+            return "Done", 0
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            await run_ceo_with_completion_guard(
+                tmp_path,
+                "Improve task",
+                mode="improve",
+                runner_name="claude",
+            )
+
+        # After completion, cycle state should be gone
+        assert not _cycle_state_path(tmp_path).exists()
+
+    async def test_mode_preserved_across_respawns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mode from initial cycle is preserved across all respawns."""
+        from factory.ceo_completion import run_ceo_with_completion_guard, read_cycle_state
+
+        # Setup: 2 hypotheses
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n\n#### H2: B\n")
+        (tmp_path / ".factory" / "experiments").mkdir(parents=True)
+
+        call_count = 0
+        observed_modes = []
+
+        async def mock_invoke(role, task, path, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            # Record mode from cycle state
+            state = read_cycle_state(path)
+            if state:
+                observed_modes.append(state.mode)
+
+            # First call: create 1 verdict
+            if call_count == 1:
+                exp_dir = path / ".factory" / "experiments" / "001"
+                exp_dir.mkdir(parents=True, exist_ok=True)
+                (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+                return "First run", 0
+
+            # Second call: create 2nd verdict (complete)
+            exp_dir = path / ".factory" / "experiments" / "002"
+            exp_dir.mkdir(parents=True, exist_ok=True)
+            (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+            return "Second run", 0
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            await run_ceo_with_completion_guard(
+                tmp_path,
+                "Build task",
+                mode="build",  # Start in build mode
+                runner_name="claude",
+            )
+
+        assert call_count == 2
+        # Both invocations should see the same mode
+        assert all(m == "build" for m in observed_modes)
+
+    async def test_respawn_increments_counter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each respawn increments the respawn counter in cycle state."""
+        from factory.ceo_completion import run_ceo_with_completion_guard, read_cycle_state
+
+        # Setup: 3 hypotheses
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n\n#### H2: B\n\n#### H3: C\n")
+        (tmp_path / ".factory" / "experiments").mkdir(parents=True)
+
+        call_count = 0
+        observed_respawns = []
+
+        async def mock_invoke(role, task, path, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            state = read_cycle_state(path)
+            if state:
+                observed_respawns.append(state.respawns)
+
+            # Each call creates one verdict
+            exp_dir = path / ".factory" / "experiments" / f"00{call_count}"
+            exp_dir.mkdir(parents=True, exist_ok=True)
+            (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+            return f"Run {call_count}", 0
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            await run_ceo_with_completion_guard(
+                tmp_path,
+                "Improve task",
+                mode="improve",
+                runner_name="claude",
+            )
+
+        assert call_count == 3
+        # Respawn counter: 0, 1, 2
+        assert observed_respawns == [0, 1, 2]
+
+    async def test_respawn_event_includes_cycle_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Respawn events include the cycle_id for correlation."""
+        from factory.ceo_completion import run_ceo_with_completion_guard
+
+        # Setup: 2 hypotheses
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text("#### H1: A\n\n#### H2: B\n")
+        (tmp_path / ".factory" / "experiments").mkdir(parents=True)
+
+        call_count = 0
+
+        async def mock_invoke(role, task, path, **kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            if call_count == 1:
+                exp_dir = path / ".factory" / "experiments" / "001"
+                exp_dir.mkdir(parents=True, exist_ok=True)
+                (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+                return "First", 0
+
+            exp_dir = path / ".factory" / "experiments" / "002"
+            exp_dir.mkdir(parents=True, exist_ok=True)
+            (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
+            return "Second", 0
+
+        with patch("factory.agents.runner.invoke_agent", mock_invoke):
+            await run_ceo_with_completion_guard(
+                tmp_path,
+                "Task",
+                mode="improve",
+                runner_name="claude",
+            )
+
+        # Check respawn event has cycle_id
+        events_file = tmp_path / ".factory" / "events.jsonl"
+        events = [json.loads(line) for line in events_file.read_text().splitlines()]
+        respawn_events = [e for e in events if e["type"] == "ceo.respawn"]
+        assert len(respawn_events) == 1
+        assert "cycle_id" in respawn_events[0]["data"]
+        assert "mode" in respawn_events[0]["data"]
+        assert respawn_events[0]["data"]["mode"] == "improve"
+
+
+class TestAutoDetectModeWithCycle:
+    """Tests for _auto_detect_mode respecting in-flight cycles."""
+
+    def test_returns_cycle_mode_when_inflight(self, tmp_path: Path) -> None:
+        """_auto_detect_mode returns cycle mode when cycle.json exists."""
+        from factory.cli import _auto_detect_mode
+        from factory.ceo_completion import create_cycle_state, write_cycle_state
+
+        # Create a git repo so state detection doesn't return NO_REPO
+        (tmp_path / ".git").mkdir()
+
+        # Write in-flight cycle state for build mode
+        state = create_cycle_state("build", "Initial task")
+        write_cycle_state(tmp_path, state)
+
+        # Even though project has no factory, should return build (from cycle)
+        mode = _auto_detect_mode(tmp_path, has_prompt=False)
+        assert mode == "build"
+
+    def test_ignores_cycle_when_force_fresh(self, tmp_path: Path) -> None:
+        """_auto_detect_mode ignores cycle.json when force_fresh=True."""
+        from factory.cli import _auto_detect_mode
+        from factory.ceo_completion import create_cycle_state, write_cycle_state
+
+        # Create a git repo
+        (tmp_path / ".git").mkdir()
+
+        # Write in-flight cycle state for build mode
+        state = create_cycle_state("build", "Initial task")
+        write_cycle_state(tmp_path, state)
+
+        # With force_fresh, should detect from state (no_factory → discover)
+        mode = _auto_detect_mode(tmp_path, has_prompt=False, force_fresh=True)
+        assert mode == "discover"
+
+    def test_detects_normally_when_no_cycle(self, tmp_path: Path) -> None:
+        """_auto_detect_mode detects from project state when no cycle.json."""
+        from factory.cli import _auto_detect_mode
+
+        # Create a git repo
+        (tmp_path / ".git").mkdir()
+
+        # No cycle state exists
+        mode = _auto_detect_mode(tmp_path, has_prompt=False)
+        assert mode == "discover"  # no_factory state
+
+    def test_detects_normally_when_cycle_stale(self, tmp_path: Path) -> None:
+        """_auto_detect_mode ignores stale cycle.json."""
+        from factory.cli import _auto_detect_mode
+        from factory.ceo_completion import CYCLE_STALENESS_HOURS, _cycle_state_path
+
+        # Create a git repo
+        (tmp_path / ".git").mkdir()
+
+        # Write stale cycle state
+        state_path = _cycle_state_path(tmp_path)
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        old_time = datetime.now(timezone.utc) - timedelta(hours=CYCLE_STALENESS_HOURS + 1)
+        state_data = {
+            "cycle_id": "old123",
+            "started_at": old_time.isoformat(),
+            "mode": "build",
+            "initial_prompt": "",
+            "respawns": 0,
+        }
+        state_path.write_text(json.dumps(state_data))
+
+        # Should ignore stale cycle and detect from state
+        mode = _auto_detect_mode(tmp_path, has_prompt=False)
+        assert mode == "discover"  # no_factory state

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -106,8 +106,52 @@ class TestCycleState:
         assert len(loaded.initial_prompt) <= 1000
 
 
+class TestBudgetAllowsRespawn:
+    """Tests for _budget_allows_respawn()."""
+
+    def test_returns_true_under_ceiling(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from factory.ceo_completion import _budget_allows_respawn
+
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_DAY", "10")
+        (tmp_path / ".factory").mkdir()
+
+        assert _budget_allows_respawn("bob", tmp_path) is True
+
+    def test_returns_false_over_ceiling(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from factory.ceo_completion import _budget_allows_respawn
+        from factory.runners.usage import log_usage
+
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_DAY", "1")
+        (tmp_path / ".factory").mkdir()
+        log_usage(tmp_path, "a", tmp_path, 1.0, 0, dry_run=False)
+
+        assert _budget_allows_respawn("bob", tmp_path) is False
+
+    def test_claude_always_allowed(self, tmp_path: Path) -> None:
+        from factory.ceo_completion import _budget_allows_respawn
+
+        assert _budget_allows_respawn("claude", tmp_path) is True
+        assert _budget_allows_respawn(None, tmp_path) is True
+
+
 class TestDetectIncomplete:
     """Tests for _detect_incomplete()."""
+
+    def test_build_incomplete_no_eval_profile(self, tmp_path: Path) -> None:
+        """Build mode without strategy needs eval profile."""
+        from factory.ceo_completion import _detect_incomplete
+
+        (tmp_path / ".factory").mkdir()
+
+        gap = _detect_incomplete(tmp_path, "build")
+        assert gap is not None
+        assert gap.mode == "build"
+        assert gap.next_item == "discovery"
+        assert "no eval profile" in gap.reason
 
     def test_improve_complete_when_all_verdicts(self, tmp_path: Path) -> None:
         """Improve mode is complete when verdict count >= hypothesis count."""
@@ -204,6 +248,21 @@ class TestBuildContinuationTask:
         assert "do not re-plan" in task
         assert "Spawn Builder for H3" in task
         assert "2/5" in task
+
+    def test_discover_continuation(self) -> None:
+        """Discover mode continuation tells CEO to resume discovery."""
+        from factory.ceo_completion import _build_continuation_task, IncompleteGap
+
+        gap = IncompleteGap(
+            mode="discover",
+            planned=1,
+            completed=0,
+            next_item="eval_profile",
+            reason="discover.incomplete",
+        )
+
+        task = _build_continuation_task(gap)
+        assert "Resume Discovery" in task or "discover" in task.lower()
 
     def test_build_continuation(self) -> None:
         """Build mode continuation tells CEO to resume from next phase."""

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -773,7 +773,7 @@ class TestBobPromptCacheInvalidation:
 
         _ensure_custom_modes(tmp_path, "ceo", "You are the CEO agent.")
 
-        modes_file = tmp_path / ".bob" / "custom_modes.yaml"
+        modes_file = tmp_path / ".factory" / ".bob" / "custom_modes.yaml"
         assert modes_file.exists()
 
         data = yaml.safe_load(modes_file.read_text())
@@ -791,7 +791,7 @@ class TestBobPromptCacheInvalidation:
         prompt = "You are the CEO agent."
         _ensure_custom_modes(tmp_path, "ceo", prompt)
 
-        modes_file = tmp_path / ".bob" / "custom_modes.yaml"
+        modes_file = tmp_path / ".factory" / ".bob" / "custom_modes.yaml"
         mtime_before = modes_file.stat().st_mtime
 
         # Small delay to ensure mtime would change if file was written
@@ -813,7 +813,7 @@ class TestBobPromptCacheInvalidation:
 
         _ensure_custom_modes(tmp_path, "ceo", old_prompt)
 
-        modes_file = tmp_path / ".bob" / "custom_modes.yaml"
+        modes_file = tmp_path / ".factory" / ".bob" / "custom_modes.yaml"
         data_before = yaml.safe_load(modes_file.read_text())
         hash_before = data_before["customModes"][0]["_promptHash"]
 
@@ -833,7 +833,7 @@ class TestBobPromptCacheInvalidation:
         _ensure_custom_modes(tmp_path, "ceo", "CEO prompt")
         _ensure_custom_modes(tmp_path, "builder", "Builder prompt")
 
-        modes_file = tmp_path / ".bob" / "custom_modes.yaml"
+        modes_file = tmp_path / ".factory" / ".bob" / "custom_modes.yaml"
         data = yaml.safe_load(modes_file.read_text())
         assert len(data["customModes"]) == 2
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -452,21 +452,17 @@ class TestKeyPersistence:
         auth_file.write_text("file-based-key")
 
         # Change to tmp_path so _find_auth_file can find it
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
+        monkeypatch.chdir(tmp_path)
 
-            from factory.runners.bob import _check_auth
+        from factory.runners.bob import _check_auth
 
-            _check_auth()
+        _check_auth()
 
-            # Verify the key was injected into os.environ
-            assert os.environ.get("BOBSHELL_API_KEY") == "file-based-key"
-        finally:
-            os.chdir(original_cwd)
-            # Clean up injected env var
-            monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
-            bob_module._auth_checked = False
+        # Verify the key was injected into os.environ
+        assert os.environ.get("BOBSHELL_API_KEY") == "file-based-key"
+        # Clean up injected env var
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+        bob_module._auth_checked = False
 
     def test_check_auth_prefers_env_var(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -482,19 +478,15 @@ class TestKeyPersistence:
         auth_file = tmp_path / ".factory" / ".bob_auth"
         auth_file.write_text("file-key")
 
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
+        monkeypatch.chdir(tmp_path)
 
-            from factory.runners.bob import _check_auth
+        from factory.runners.bob import _check_auth
 
-            _check_auth()
+        _check_auth()
 
-            # Env var should still be the original value
-            assert os.environ.get("BOBSHELL_API_KEY") == "env-key"
-        finally:
-            os.chdir(original_cwd)
-            bob_module._auth_checked = False
+        # Env var should still be the original value
+        assert os.environ.get("BOBSHELL_API_KEY") == "env-key"
+        bob_module._auth_checked = False
 
     def test_preflight_error_unchanged_when_no_key(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -506,19 +498,15 @@ class TestKeyPersistence:
         bob_module._auth_checked = False
 
         # No .factory directory, no auth file
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
+        monkeypatch.chdir(tmp_path)
 
-            from factory.runners.bob import _check_auth, BobAuthError
+        from factory.runners.bob import _check_auth, BobAuthError
 
-            with pytest.raises(BobAuthError) as exc_info:
-                _check_auth()
+        with pytest.raises(BobAuthError) as exc_info:
+            _check_auth()
 
-            assert "BOBSHELL_API_KEY environment variable is not set" in str(exc_info.value)
-        finally:
-            os.chdir(original_cwd)
-            bob_module._auth_checked = False
+        assert "BOBSHELL_API_KEY environment variable is not set" in str(exc_info.value)
+        bob_module._auth_checked = False
 
     async def test_headless_passes_key_to_subprocess(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -535,38 +523,35 @@ class TestKeyPersistence:
         auth_file = tmp_path / ".factory" / ".bob_auth"
         auth_file.write_text("subprocess-test-key")
 
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"output", b"")
 
             with patch(
-                "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
-            ) as mock_stream:
-                mock_stream.return_value = (b"output", b"")
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
 
-                with patch(
-                    "asyncio.create_subprocess_exec", new_callable=AsyncMock
-                ) as mock_exec:
-                    mock_proc = AsyncMock()
-                    mock_proc.returncode = 0
-                    mock_exec.return_value = mock_proc
+                runner = BobRunner()
+                await runner.headless(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    role="researcher",
+                )
 
-                    runner = BobRunner()
-                    await runner.headless(
-                        prompt="Test",
-                        task="Test",
-                        cwd=tmp_path,
-                        role="researcher",
-                    )
+                # Verify the subprocess was called with env containing the key
+                call_kwargs = mock_exec.call_args.kwargs
+                assert "env" in call_kwargs
+                assert call_kwargs["env"].get("BOBSHELL_API_KEY") == "subprocess-test-key"
 
-                    # Verify the subprocess was called with env containing the key
-                    call_kwargs = mock_exec.call_args.kwargs
-                    assert "env" in call_kwargs
-                    assert call_kwargs["env"].get("BOBSHELL_API_KEY") == "subprocess-test-key"
-        finally:
-            os.chdir(original_cwd)
-            monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
-            bob_module._auth_checked = False
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+        bob_module._auth_checked = False
 
 
 class TestStreamingOutput:
@@ -872,86 +857,3 @@ class TestStreamingOutput:
                 assert "Line 1" in content
                 assert "Line 2" in content
                 assert "Line 3" in content
-
-
-class TestBobPromptCacheInvalidation:
-    """Tests for bob custom_modes.yaml cache invalidation on prompt changes."""
-
-    def test_creates_mode_with_hash(self, tmp_path: Path) -> None:
-        """First call creates a mode with a _promptHash field."""
-        import yaml
-        from factory.runners.bob import _ensure_custom_modes
-
-        _ensure_custom_modes(tmp_path, "ceo", "You are the CEO agent.")
-
-        modes_file = tmp_path / ".factory" / ".bob" / "custom_modes.yaml"
-        assert modes_file.exists()
-
-        data = yaml.safe_load(modes_file.read_text())
-        modes = data["customModes"]
-        assert len(modes) == 1
-        assert modes[0]["slug"] == "factory-ceo"
-        assert "_promptHash" in modes[0]
-        assert len(modes[0]["_promptHash"]) == 16
-
-    def test_no_update_when_prompt_unchanged(self, tmp_path: Path) -> None:
-        """Second call with same prompt does not rewrite the file."""
-        from factory.runners.bob import _ensure_custom_modes
-
-        prompt = "You are the CEO agent."
-        _ensure_custom_modes(tmp_path, "ceo", prompt)
-
-        modes_file = tmp_path / ".factory" / ".bob" / "custom_modes.yaml"
-        mtime_before = modes_file.stat().st_mtime
-
-        # Small delay to ensure mtime would change if file was written
-        import time
-        time.sleep(0.01)
-
-        _ensure_custom_modes(tmp_path, "ceo", prompt)
-
-        mtime_after = modes_file.stat().st_mtime
-        assert mtime_after == mtime_before, "File should not be rewritten when prompt unchanged"
-
-    def test_updates_mode_when_prompt_changes(self, tmp_path: Path) -> None:
-        """Changed prompt triggers cache invalidation and mode update."""
-        import yaml
-        from factory.runners.bob import _ensure_custom_modes
-
-        old_prompt = "You are the CEO agent v1."
-        new_prompt = "You are the CEO agent v2 with new guardrails."
-
-        _ensure_custom_modes(tmp_path, "ceo", old_prompt)
-
-        modes_file = tmp_path / ".factory" / ".bob" / "custom_modes.yaml"
-        data_before = yaml.safe_load(modes_file.read_text())
-        hash_before = data_before["customModes"][0]["_promptHash"]
-
-        _ensure_custom_modes(tmp_path, "ceo", new_prompt)
-
-        data_after = yaml.safe_load(modes_file.read_text())
-        hash_after = data_after["customModes"][0]["_promptHash"]
-
-        assert hash_before != hash_after, "Hash should change when prompt changes"
-        assert "v2" in data_after["customModes"][0]["roleDefinition"]
-
-    def test_preserves_other_modes_when_updating(self, tmp_path: Path) -> None:
-        """Updating one mode does not remove other modes."""
-        import yaml
-        from factory.runners.bob import _ensure_custom_modes
-
-        _ensure_custom_modes(tmp_path, "ceo", "CEO prompt")
-        _ensure_custom_modes(tmp_path, "builder", "Builder prompt")
-
-        modes_file = tmp_path / ".factory" / ".bob" / "custom_modes.yaml"
-        data = yaml.safe_load(modes_file.read_text())
-        assert len(data["customModes"]) == 2
-
-        # Update CEO prompt
-        _ensure_custom_modes(tmp_path, "ceo", "CEO prompt UPDATED")
-
-        data_after = yaml.safe_load(modes_file.read_text())
-        assert len(data_after["customModes"]) == 2
-
-        slugs = {m["slug"] for m in data_after["customModes"]}
-        assert slugs == {"factory-ceo", "factory-builder"}

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -497,7 +497,6 @@ class TestStreamingOutput:
     async def test_tee_stream_collects_output(self) -> None:
         """tee_stream() collects all bytes in buffer."""
         from io import BytesIO
-        import asyncio
 
         from factory.runners._stream import tee_stream
 
@@ -785,7 +784,6 @@ class TestBobPromptCacheInvalidation:
 
     def test_no_update_when_prompt_unchanged(self, tmp_path: Path) -> None:
         """Second call with same prompt does not rewrite the file."""
-        import yaml
         from factory.runners.bob import _ensure_custom_modes
 
         prompt = "You are the CEO agent."

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1,0 +1,847 @@
+"""Tests for factory/runners/ — Runner protocol and implementations."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from factory.runners import ClaudeRunner, BobRunner, get_runner, is_dry_run
+from factory.runners.usage import (
+    CeilingExceededError,
+    check_ceilings,
+    count_today_invocations,
+    get_usage_log_path,
+    log_usage,
+)
+
+
+class TestGetRunner:
+    def test_default_is_claude(self) -> None:
+        runner = get_runner()
+        assert runner.name == "claude"
+
+    def test_explicit_claude(self) -> None:
+        runner = get_runner("claude")
+        assert runner.name == "claude"
+
+    def test_explicit_bob(self) -> None:
+        runner = get_runner("bob")
+        assert runner.name == "bob"
+
+    def test_from_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_RUNNER", "bob")
+        runner = get_runner()
+        assert runner.name == "bob"
+
+    def test_explicit_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_RUNNER", "bob")
+        runner = get_runner("claude")
+        assert runner.name == "claude"
+
+    def test_unknown_runner_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown runner 'unknown'"):
+            get_runner("unknown")
+
+
+class TestClaudeRunner:
+    async def test_headless_builds_correct_command(self, tmp_path: Path) -> None:
+        runner = ClaudeRunner()
+
+        with patch(
+            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"output", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                stdout, code = await runner.headless(
+                    prompt="You are a test agent.",
+                    task="Say hello",
+                    cwd=tmp_path,
+                    timeout=60.0,
+                    model="claude-opus-4-7",
+                )
+
+                assert code == 0
+                assert stdout == "output"
+
+                call_args = mock_exec.call_args
+                cmd = call_args[0]
+                assert cmd[0] == "claude"
+                assert "-p" in cmd
+                assert "--dangerously-skip-permissions" in cmd
+                assert "--model" in cmd
+                assert "claude-opus-4-7" in cmd
+
+
+class TestBobRunner:
+    def test_is_dry_run_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
+        assert is_dry_run() is True
+
+    def test_is_dry_run_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
+        assert is_dry_run() is False
+
+    async def test_dry_run_returns_stub(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
+
+        # Create .factory directory for usage log
+        (tmp_path / ".factory").mkdir()
+
+        runner = BobRunner()
+        stdout, code = await runner.headless(
+            prompt="You are a test agent.",
+            task="Say hello",
+            cwd=tmp_path,
+            role="researcher",
+        )
+
+        assert code == 0
+        assert "[DRY-RUN]" in stdout
+        assert "researcher" in stdout
+
+    async def test_dry_run_logs_usage(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
+
+        # Create .factory directory
+        (tmp_path / ".factory").mkdir()
+
+        runner = BobRunner()
+        await runner.headless(
+            prompt="Test prompt",
+            task="Test task",
+            cwd=tmp_path,
+            role="builder",
+        )
+
+        log_path = get_usage_log_path(tmp_path)
+        assert log_path.exists()
+
+        with open(log_path) as f:
+            entry = json.loads(f.readline())
+
+        assert entry["role"] == "builder"
+        assert entry["dry_run"] is True
+        assert entry["exit_code"] == 0
+
+
+class TestUsageTracking:
+    def test_log_usage_creates_file(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+
+        log_usage(tmp_path, "researcher", tmp_path, 1.5, 0, dry_run=False)
+
+        log_path = get_usage_log_path(tmp_path)
+        assert log_path.exists()
+
+        with open(log_path) as f:
+            entry = json.loads(f.readline())
+
+        assert entry["role"] == "researcher"
+        assert entry["duration_seconds"] == 1.5
+        assert entry["exit_code"] == 0
+        assert entry["dry_run"] is False
+
+    def test_count_today_invocations(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+
+        # Log some entries
+        log_usage(tmp_path, "a", tmp_path, 1.0, 0, dry_run=False)
+        log_usage(tmp_path, "b", tmp_path, 1.0, 0, dry_run=False)
+        log_usage(tmp_path, "c", tmp_path, 1.0, 0, dry_run=True)  # dry-run, shouldn't count
+
+        count = count_today_invocations(tmp_path)
+        assert count == 2  # dry-run excluded
+
+    def test_count_today_includes_dry_run(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+
+        log_usage(tmp_path, "a", tmp_path, 1.0, 0, dry_run=False)
+        log_usage(tmp_path, "b", tmp_path, 1.0, 0, dry_run=True)
+
+        count = count_today_invocations(tmp_path, include_dry_run=True)
+        assert count == 2
+
+
+class TestCeilings:
+    def test_check_ceilings_passes_when_under(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / ".factory").mkdir()
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_DAY", "10")
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", "5")
+
+        # Log a few entries (under ceiling)
+        log_usage(tmp_path, "a", tmp_path, 1.0, 0, dry_run=False)
+        log_usage(tmp_path, "b", tmp_path, 1.0, 0, dry_run=False)
+
+        # Should not raise
+        check_ceilings(tmp_path)
+
+    def test_check_ceilings_fails_on_daily(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / ".factory").mkdir()
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_DAY", "2")
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", "10")
+
+        log_usage(tmp_path, "a", tmp_path, 1.0, 0, dry_run=False)
+        log_usage(tmp_path, "b", tmp_path, 1.0, 0, dry_run=False)
+
+        with pytest.raises(CeilingExceededError) as exc_info:
+            check_ceilings(tmp_path)
+
+        assert exc_info.value.ceiling_name == "daily"
+        assert exc_info.value.env_var == "FACTORY_BOB_MAX_INVOCATIONS_PER_DAY"
+
+    def test_check_ceilings_fails_on_cycle(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / ".factory").mkdir()
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_DAY", "100")
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", "1")
+
+        log_usage(tmp_path, "a", tmp_path, 1.0, 0, dry_run=False)
+
+        with pytest.raises(CeilingExceededError) as exc_info:
+            check_ceilings(tmp_path)
+
+        assert exc_info.value.ceiling_name == "per-cycle"
+        assert exc_info.value.env_var == "FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE"
+
+    def test_ceiling_error_message_is_actionable(self) -> None:
+        error = CeilingExceededError("daily", 5, 5, "FACTORY_BOB_MAX_INVOCATIONS_PER_DAY")
+        msg = str(error)
+
+        assert "ceiling exceeded" in msg.lower()
+        assert "5/5" in msg
+        assert "FACTORY_BOB_MAX_INVOCATIONS_PER_DAY=10" in msg  # suggests bumping
+
+
+class TestBobAuthPreflight:
+    async def test_auth_check_fails_without_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+
+        # Reset the auth check state
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        (tmp_path / ".factory").mkdir()
+
+        runner = BobRunner()
+
+        from factory.runners.bob import BobAuthError
+
+        with pytest.raises(BobAuthError):
+            await runner.headless(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                role="researcher",
+            )
+
+    async def test_auth_check_passes_with_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
+        monkeypatch.setenv("BOBSHELL_API_KEY", "test-key")
+
+        # Reset the auth check state
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        (tmp_path / ".factory").mkdir()
+
+        # Mock the streaming subprocess to avoid actual bob invocation
+        with patch(
+            "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"output", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                runner = BobRunner()
+                stdout, code = await runner.headless(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    role="researcher",
+                )
+
+                assert code == 0
+
+
+class TestKeyPersistence:
+    """Tests for file-based API key persistence."""
+
+    def test_persist_key_creates_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify _persist_key writes the key to .factory/.bob_auth."""
+        monkeypatch.setenv("BOBSHELL_API_KEY", "test-secret-key")
+
+        (tmp_path / ".factory").mkdir()
+
+        from factory.runners.bob import _persist_key
+
+        _persist_key(tmp_path)
+
+        auth_file = tmp_path / ".factory" / ".bob_auth"
+        assert auth_file.exists()
+        assert auth_file.read_text() == "test-secret-key"
+
+        # Verify file permissions (chmod 600)
+        mode = auth_file.stat().st_mode
+        assert mode & 0o777 == 0o600
+
+    def test_persist_key_no_op_without_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify _persist_key does nothing if BOBSHELL_API_KEY is not set."""
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+
+        (tmp_path / ".factory").mkdir()
+
+        from factory.runners.bob import _persist_key
+
+        _persist_key(tmp_path)
+
+        auth_file = tmp_path / ".factory" / ".bob_auth"
+        assert not auth_file.exists()
+
+    def test_check_auth_reads_from_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify _check_auth falls back to reading from file when env var missing."""
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        # Create the auth file
+        (tmp_path / ".factory").mkdir()
+        auth_file = tmp_path / ".factory" / ".bob_auth"
+        auth_file.write_text("file-based-key")
+
+        # Change to tmp_path so _find_auth_file can find it
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+
+            from factory.runners.bob import _check_auth
+
+            _check_auth()
+
+            # Verify the key was injected into os.environ
+            assert os.environ.get("BOBSHELL_API_KEY") == "file-based-key"
+        finally:
+            os.chdir(original_cwd)
+            # Clean up injected env var
+            monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+            bob_module._auth_checked = False
+
+    def test_check_auth_prefers_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify env var takes precedence over file."""
+        monkeypatch.setenv("BOBSHELL_API_KEY", "env-key")
+
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        # Create the auth file with a different key
+        (tmp_path / ".factory").mkdir()
+        auth_file = tmp_path / ".factory" / ".bob_auth"
+        auth_file.write_text("file-key")
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+
+            from factory.runners.bob import _check_auth
+
+            _check_auth()
+
+            # Env var should still be the original value
+            assert os.environ.get("BOBSHELL_API_KEY") == "env-key"
+        finally:
+            os.chdir(original_cwd)
+            bob_module._auth_checked = False
+
+    def test_preflight_error_unchanged_when_no_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify BobAuthError is raised when key is missing from both env and file."""
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        # No .factory directory, no auth file
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+
+            from factory.runners.bob import _check_auth, BobAuthError
+
+            with pytest.raises(BobAuthError) as exc_info:
+                _check_auth()
+
+            assert "BOBSHELL_API_KEY environment variable is not set" in str(exc_info.value)
+        finally:
+            os.chdir(original_cwd)
+            bob_module._auth_checked = False
+
+    async def test_headless_passes_key_to_subprocess(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify the subprocess env dict contains BOBSHELL_API_KEY from file."""
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+        monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
+
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        # Create the auth file
+        (tmp_path / ".factory").mkdir()
+        auth_file = tmp_path / ".factory" / ".bob_auth"
+        auth_file.write_text("subprocess-test-key")
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+
+            with patch(
+                "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+            ) as mock_stream:
+                mock_stream.return_value = (b"output", b"")
+
+                with patch(
+                    "asyncio.create_subprocess_exec", new_callable=AsyncMock
+                ) as mock_exec:
+                    mock_proc = AsyncMock()
+                    mock_proc.returncode = 0
+                    mock_exec.return_value = mock_proc
+
+                    runner = BobRunner()
+                    await runner.headless(
+                        prompt="Test",
+                        task="Test",
+                        cwd=tmp_path,
+                        role="researcher",
+                    )
+
+                    # Verify the subprocess was called with env containing the key
+                    call_kwargs = mock_exec.call_args.kwargs
+                    assert "env" in call_kwargs
+                    assert call_kwargs["env"].get("BOBSHELL_API_KEY") == "subprocess-test-key"
+        finally:
+            os.chdir(original_cwd)
+            monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+            bob_module._auth_checked = False
+
+
+class TestStreamingOutput:
+    """Tests for streaming subprocess output to terminal."""
+
+    def test_should_stream_defaults_true_with_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """should_stream() returns True when stdout is a TTY and QUIET not set."""
+        monkeypatch.delenv("FACTORY_RUNNER_QUIET", raising=False)
+
+        from factory.runners._stream import should_stream
+
+        # When stdout is a TTY, should return True
+        with patch("sys.stdout.isatty", return_value=True):
+            assert should_stream() is True
+
+    def test_should_stream_false_when_quiet(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """should_stream() returns False when FACTORY_RUNNER_QUIET=1."""
+        monkeypatch.setenv("FACTORY_RUNNER_QUIET", "1")
+
+        from factory.runners._stream import should_stream
+
+        with patch("sys.stdout.isatty", return_value=True):
+            assert should_stream() is False
+
+    def test_should_stream_false_when_not_tty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """should_stream() returns False when stdout is not a TTY."""
+        monkeypatch.delenv("FACTORY_RUNNER_QUIET", raising=False)
+
+        from factory.runners._stream import should_stream
+
+        with patch("sys.stdout.isatty", return_value=False):
+            assert should_stream() is False
+
+    async def test_tee_stream_collects_output(self) -> None:
+        """tee_stream() collects all bytes in buffer."""
+        from io import BytesIO
+        import asyncio
+
+        from factory.runners._stream import tee_stream
+
+        # Create a mock stream reader
+        class MockReader:
+            def __init__(self, lines: list[bytes]) -> None:
+                self.lines = iter(lines)
+
+            async def readline(self) -> bytes:
+                try:
+                    return next(self.lines)
+                except StopIteration:
+                    return b""
+
+        reader = MockReader([b"line1\n", b"line2\n", b"line3\n"])
+        dest = BytesIO()
+        buffer: list[bytes] = []
+
+        await tee_stream(reader, dest, buffer, stream=False)  # type: ignore[arg-type]
+
+        assert buffer == [b"line1\n", b"line2\n", b"line3\n"]
+
+    async def test_tee_stream_writes_to_dest_when_streaming(self) -> None:
+        """tee_stream() writes to destination when stream=True."""
+        from io import BytesIO
+
+        from factory.runners._stream import tee_stream
+
+        class MockReader:
+            def __init__(self, lines: list[bytes]) -> None:
+                self.lines = iter(lines)
+
+            async def readline(self) -> bytes:
+                try:
+                    return next(self.lines)
+                except StopIteration:
+                    return b""
+
+        reader = MockReader([b"hello\n", b"world\n"])
+        dest = BytesIO()
+        buffer: list[bytes] = []
+
+        await tee_stream(reader, dest, buffer, stream=True)  # type: ignore[arg-type]
+
+        assert dest.getvalue() == b"hello\nworld\n"
+        assert buffer == [b"hello\n", b"world\n"]
+
+    async def test_tee_stream_adds_prefix(self) -> None:
+        """tee_stream() prepends prefix to each line when provided."""
+        from io import BytesIO
+
+        from factory.runners._stream import tee_stream
+
+        class MockReader:
+            def __init__(self, lines: list[bytes]) -> None:
+                self.lines = iter(lines)
+
+            async def readline(self) -> bytes:
+                try:
+                    return next(self.lines)
+                except StopIteration:
+                    return b""
+
+        reader = MockReader([b"line1\n", b"line2\n"])
+        dest = BytesIO()
+        buffer: list[bytes] = []
+
+        await tee_stream(
+            reader,  # type: ignore[arg-type]
+            dest,
+            buffer,
+            stream=True,
+            prefix=b"[test] ",
+        )
+
+        assert dest.getvalue() == b"[test] line1\n[test] line2\n"
+        # Buffer should NOT have prefix — only raw output
+        assert buffer == [b"line1\n", b"line2\n"]
+
+    async def test_stream_subprocess_collects_both_streams(self) -> None:
+        """stream_subprocess() collects from both stdout and stderr."""
+        from factory.runners._stream import stream_subprocess
+
+        # Create mock process with mock streams
+        class MockReader:
+            def __init__(self, lines: list[bytes]) -> None:
+                self.lines = iter(lines)
+
+            async def readline(self) -> bytes:
+                try:
+                    return next(self.lines)
+                except StopIteration:
+                    return b""
+
+        class MockProc:
+            def __init__(self) -> None:
+                self.stdout = MockReader([b"stdout line\n"])
+                self.stderr = MockReader([b"stderr line\n"])
+
+            async def wait(self) -> int:
+                return 0
+
+        proc = MockProc()
+
+        stdout, stderr = await stream_subprocess(proc, stream=False)  # type: ignore[arg-type]
+
+        assert stdout == b"stdout line\n"
+        assert stderr == b"stderr line\n"
+
+    async def test_claude_runner_uses_streaming(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ClaudeRunner.headless() streams output when should_stream() is True."""
+        monkeypatch.delenv("FACTORY_RUNNER_QUIET", raising=False)
+
+        runner = ClaudeRunner()
+
+        # Mock should_stream to return True
+        with patch("factory.runners.claude.should_stream", return_value=True):
+            with patch(
+                "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+            ) as mock_stream:
+                mock_stream.return_value = (b"output\n", b"")
+
+                with patch(
+                    "asyncio.create_subprocess_exec", new_callable=AsyncMock
+                ) as mock_exec:
+                    mock_proc = AsyncMock()
+                    mock_proc.returncode = 0
+                    mock_exec.return_value = mock_proc
+
+                    stdout, code = await runner.headless(
+                        prompt="Test",
+                        task="Test",
+                        cwd=tmp_path,
+                        role="researcher",
+                    )
+
+                    # Verify stream_subprocess was called with streaming enabled
+                    mock_stream.assert_called_once()
+                    call_kwargs = mock_stream.call_args.kwargs
+                    assert call_kwargs["stream"] is True
+                    assert call_kwargs["prefix"] == "[claude:researcher]"
+
+    async def test_bob_runner_uses_streaming(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """BobRunner.headless() streams output when should_stream() is True."""
+        monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
+        monkeypatch.delenv("FACTORY_RUNNER_QUIET", raising=False)
+
+        (tmp_path / ".factory").mkdir()
+
+        runner = BobRunner()
+
+        # For dry-run, streaming doesn't apply — test the non-dry-run path
+        monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
+        monkeypatch.setenv("BOBSHELL_API_KEY", "test-key")
+
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        with patch("factory.runners.bob.should_stream", return_value=True):
+            with patch(
+                "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+            ) as mock_stream:
+                mock_stream.return_value = (b"output\n", b"")
+
+                with patch(
+                    "asyncio.create_subprocess_exec", new_callable=AsyncMock
+                ) as mock_exec:
+                    mock_proc = AsyncMock()
+                    mock_proc.returncode = 0
+                    mock_exec.return_value = mock_proc
+
+                    stdout, code = await runner.headless(
+                        prompt="Test",
+                        task="Test",
+                        cwd=tmp_path,
+                        role="builder",
+                    )
+
+                    # Verify stream_subprocess was called with streaming enabled
+                    mock_stream.assert_called_once()
+                    call_kwargs = mock_stream.call_args.kwargs
+                    assert call_kwargs["stream"] is True
+                    assert call_kwargs["prefix"] == "[bob:builder]"
+
+        bob_module._auth_checked = False
+
+    async def test_quiet_mode_disables_streaming(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FACTORY_RUNNER_QUIET=1 disables streaming to terminal."""
+        monkeypatch.setenv("FACTORY_RUNNER_QUIET", "1")
+
+        runner = ClaudeRunner()
+
+        with patch(
+            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"output\n", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    role="researcher",
+                )
+
+                # Verify stream_subprocess was called with streaming disabled
+                mock_stream.assert_called_once()
+                call_kwargs = mock_stream.call_args.kwargs
+                assert call_kwargs["stream"] is False
+
+    async def test_output_saved_to_review_file_matches_buffer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The saved review file contains the same content as the buffer."""
+        monkeypatch.delenv("FACTORY_RUNNER_QUIET", raising=False)
+
+        (tmp_path / ".factory" / "reviews").mkdir(parents=True)
+
+        # Import invoke_agent which saves the review
+        from factory.agents.runner import invoke_agent
+
+        expected_output = "Line 1\nLine 2\nLine 3\n"
+
+        with patch(
+            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (expected_output.encode(), b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                stdout, code = await invoke_agent(
+                    "researcher",
+                    "Test task",
+                    tmp_path,
+                    runner_name="claude",
+                )
+
+                assert expected_output in stdout
+
+                # Check the saved review file
+                review_file = tmp_path / ".factory" / "reviews" / "researcher-latest.md"
+                assert review_file.exists()
+                content = review_file.read_text()
+                assert "Line 1" in content
+                assert "Line 2" in content
+                assert "Line 3" in content
+
+
+class TestBobPromptCacheInvalidation:
+    """Tests for bob custom_modes.yaml cache invalidation on prompt changes."""
+
+    def test_creates_mode_with_hash(self, tmp_path: Path) -> None:
+        """First call creates a mode with a _promptHash field."""
+        import yaml
+        from factory.runners.bob import _ensure_custom_modes
+
+        _ensure_custom_modes(tmp_path, "ceo", "You are the CEO agent.")
+
+        modes_file = tmp_path / ".bob" / "custom_modes.yaml"
+        assert modes_file.exists()
+
+        data = yaml.safe_load(modes_file.read_text())
+        modes = data["customModes"]
+        assert len(modes) == 1
+        assert modes[0]["slug"] == "factory-ceo"
+        assert "_promptHash" in modes[0]
+        assert len(modes[0]["_promptHash"]) == 16
+
+    def test_no_update_when_prompt_unchanged(self, tmp_path: Path) -> None:
+        """Second call with same prompt does not rewrite the file."""
+        import yaml
+        from factory.runners.bob import _ensure_custom_modes
+
+        prompt = "You are the CEO agent."
+        _ensure_custom_modes(tmp_path, "ceo", prompt)
+
+        modes_file = tmp_path / ".bob" / "custom_modes.yaml"
+        mtime_before = modes_file.stat().st_mtime
+
+        # Small delay to ensure mtime would change if file was written
+        import time
+        time.sleep(0.01)
+
+        _ensure_custom_modes(tmp_path, "ceo", prompt)
+
+        mtime_after = modes_file.stat().st_mtime
+        assert mtime_after == mtime_before, "File should not be rewritten when prompt unchanged"
+
+    def test_updates_mode_when_prompt_changes(self, tmp_path: Path) -> None:
+        """Changed prompt triggers cache invalidation and mode update."""
+        import yaml
+        from factory.runners.bob import _ensure_custom_modes
+
+        old_prompt = "You are the CEO agent v1."
+        new_prompt = "You are the CEO agent v2 with new guardrails."
+
+        _ensure_custom_modes(tmp_path, "ceo", old_prompt)
+
+        modes_file = tmp_path / ".bob" / "custom_modes.yaml"
+        data_before = yaml.safe_load(modes_file.read_text())
+        hash_before = data_before["customModes"][0]["_promptHash"]
+
+        _ensure_custom_modes(tmp_path, "ceo", new_prompt)
+
+        data_after = yaml.safe_load(modes_file.read_text())
+        hash_after = data_after["customModes"][0]["_promptHash"]
+
+        assert hash_before != hash_after, "Hash should change when prompt changes"
+        assert "v2" in data_after["customModes"][0]["roleDefinition"]
+
+    def test_preserves_other_modes_when_updating(self, tmp_path: Path) -> None:
+        """Updating one mode does not remove other modes."""
+        import yaml
+        from factory.runners.bob import _ensure_custom_modes
+
+        _ensure_custom_modes(tmp_path, "ceo", "CEO prompt")
+        _ensure_custom_modes(tmp_path, "builder", "Builder prompt")
+
+        modes_file = tmp_path / ".bob" / "custom_modes.yaml"
+        data = yaml.safe_load(modes_file.read_text())
+        assert len(data["customModes"]) == 2
+
+        # Update CEO prompt
+        _ensure_custom_modes(tmp_path, "ceo", "CEO prompt UPDATED")
+
+        data_after = yaml.safe_load(modes_file.read_text())
+        assert len(data_after["customModes"]) == 2
+
+        slugs = {m["slug"] for m in data_after["customModes"]}
+        assert slugs == {"factory-ceo", "factory-builder"}

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -90,6 +90,118 @@ class TestBobRunner:
         monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
         assert is_dry_run() is False
 
+    def test_interactive_exec_dry_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """interactive_exec prints dry-run message and exits."""
+        monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
+        (tmp_path / ".factory").mkdir()
+
+        runner = BobRunner()
+
+        with pytest.raises(SystemExit) as exc_info:
+            runner.interactive_exec(
+                prompt="Test prompt",
+                task="Test task",
+                cwd=tmp_path,
+                role="ceo",
+            )
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "[DRY-RUN]" in captured.out
+
+    async def test_headless_timeout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """BobRunner.headless() handles timeout gracefully."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        monkeypatch.setenv("BOBSHELL_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
+
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        (tmp_path / ".factory").mkdir()
+
+        with patch("factory.runners.bob.asyncio.wait_for", side_effect=asyncio.TimeoutError):
+            with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.kill = AsyncMock()
+                mock_proc.wait = AsyncMock()
+                mock_exec.return_value = mock_proc
+
+                runner = BobRunner()
+                stdout, code = await runner.headless(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    role="researcher",
+                    timeout=0.1,
+                )
+
+        assert code == 1
+        assert "timed out" in stdout.lower()
+        bob_module._auth_checked = False
+
+    def test_count_cycle_invocations_with_datetime(self, tmp_path: Path) -> None:
+        """count_cycle_invocations filters by cycle_start datetime."""
+        from datetime import datetime, timezone, timedelta
+        from factory.runners.usage import count_cycle_invocations, get_usage_log_path
+        import json
+
+        (tmp_path / ".factory").mkdir()
+
+        now = datetime.now(timezone.utc)
+        old_time = now - timedelta(hours=2)
+
+        log_path = get_usage_log_path(tmp_path)
+        entries = [
+            {"timestamp": old_time.isoformat(), "role": "a", "cwd": str(tmp_path),
+             "duration_seconds": 1.0, "exit_code": 0, "dry_run": False},
+            {"timestamp": now.isoformat(), "role": "b", "cwd": str(tmp_path),
+             "duration_seconds": 1.0, "exit_code": 0, "dry_run": False},
+            {"timestamp": now.isoformat(), "role": "c", "cwd": str(tmp_path),
+             "duration_seconds": 1.0, "exit_code": 0, "dry_run": True},
+        ]
+
+        with open(log_path, "w") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+        cycle_start = now - timedelta(hours=1)
+        count = count_cycle_invocations(tmp_path, cycle_start)
+        assert count == 1
+
+    async def test_headless_ceiling_exceeded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """BobRunner returns error when ceiling exceeded."""
+        monkeypatch.setenv("BOBSHELL_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
+        monkeypatch.setenv("FACTORY_BOB_MAX_INVOCATIONS_PER_DAY", "1")
+
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        (tmp_path / ".factory").mkdir()
+
+        log_usage(tmp_path, "a", tmp_path, 1.0, 0, dry_run=False)
+
+        runner = BobRunner()
+        stdout, code = await runner.headless(
+            prompt="Test",
+            task="Test",
+            cwd=tmp_path,
+            role="researcher",
+        )
+
+        assert code == 1
+        assert "ceiling" in stdout.lower() or "exceeded" in stdout.lower()
+        bob_module._auth_checked = False
+
     async def test_dry_run_returns_stub(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -1299,6 +1299,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "mcp" },
     { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1311,6 +1312,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 docs = [
     { name = "mkdocs-material" },
@@ -1321,6 +1323,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "mcp", specifier = ">=1.27.0" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
@@ -1333,6 +1336,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.8" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 docs = [{ name = "mkdocs-material", specifier = ">=9.5" }]
 
@@ -1580,6 +1584,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Runner abstraction layer**: Introduces a protocol-based runner system (`factory/runners/`) that allows switching between CLI backends (Claude Code or Bob Shell)
- **Bob Shell integration**: Full support for Bob Shell including custom mode injection (`.bob/custom_modes.yaml`), dry-run mode for testing, and self-enforced token guardrails
- **CEO mode persistence**: Fixes a bug where CEO mode would flip between sessions during re-spawns by persisting cycle state to `.factory/state/cycle.json`

## Key Changes

### New Runner Architecture (`factory/runners/`)
- `protocol.py` — Abstract `Runner` protocol defining the interface
- `claude.py` — Claude Code runner implementation (default)
- `bob.py` — Bob Shell runner with custom mode injection and usage tracking
- `usage.py` — Self-enforced invocation limits for Bob Shell (per-cycle and daily)
- `_stream.py` — Shared streaming utilities for subprocess output

### Bob Shell Specifics
- Uses `--chat-mode` for role injection (vs Claude's `--model`)
- Requires `BOBSHELL_API_KEY` environment variable
- Token guardrails: `FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE` (default: 3), `FACTORY_BOB_MAX_INVOCATIONS_PER_DAY` (default: 20)
- All invocations logged to `.factory/bob_usage.jsonl`
- Dry-run mode via `FACTORY_BOB_DRY_RUN=1` for testing

### CEO Completion Guard (`factory/ceo_completion.py`)
- New completion-guard wrapper for CEO agent execution
- Handles re-spawns, timeouts, and success detection
- Integrates with cycle state persistence for mode stability

### Bug Fix: Mode Flip Prevention
- Added `CycleState` model to persist mode across re-spawns
- Auto-detect respects in-flight cycles (< 24h old)
- New `--mode auto-fresh` option to force fresh detection

## Usage

```bash
# Default (Claude Code)
factory ceo /path/to/project

# Bob Shell
factory ceo /path/to/project --runner bob
# or
FACTORY_RUNNER=bob factory ceo /path/to/project

# Dry-run Bob Shell (for testing)
FACTORY_BOB_DRY_RUN=1 factory agent researcher --runner bob
```

## Test plan

- [x] All 1020 existing tests pass
- [x] New tests for runner abstraction (`tests/test_runners.py` — 847 lines)
- [x] New tests for CEO completion guard (`tests/test_ceo_completion.py` — 724 lines)
- [x] Extended agent tests with runner mocking (`tests/test_agents.py`)
- [x] Dry-run mode automatically set in test fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)