### PR TITLE
feat: add session summary report at end of factory cycles

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1039,6 +1039,21 @@ factory checkpoint "$PROJECT_PATH" --clear
 
 **Wait for this to complete before proceeding.** Do NOT commit until archival is confirmed.
 
+### Step 3b: Session Summary
+
+Generate the end-of-cycle session summary:
+
+```bash
+uv run python -m factory summary "$PROJECT_PATH"
+```
+
+This writes `.factory/reviews/session-summary.md` with:
+1. **What was built** — kept experiments with score deltas and PR numbers
+2. **What was deferred** — remaining backlog items for future cycles
+3. **What needs human input** — failed experiments, guard violations, marginal reverts
+
+Review the summary output. If it reveals critical issues you missed, address them before proceeding.
+
 ### Step 4: Notify
 
 ```bash

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -407,6 +407,24 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_summary(args: argparse.Namespace) -> int:
+    """Generate an end-of-session summary report."""
+    from factory.summary import format_summary, generate_summary, save_summary
+
+    project_path = Path(args.path).resolve()
+    _emit_cli_event(project_path, "summary.started", {})
+    summary = _run(generate_summary(project_path))
+    output = format_summary(summary)
+    _run(save_summary(project_path, summary))
+    _emit_cli_event(project_path, "summary.completed", {
+        "kept": len(summary.experiments_kept),
+        "reverted": len(summary.experiments_reverted),
+        "errored": len(summary.experiments_errored),
+        "backlog": len(summary.backlog_remaining),
+    })
+    print(output)
+    return 0
+
 
 def cmd_export(args: argparse.Namespace) -> int:
     """Export a complete project snapshot as JSON to stdout."""
@@ -1877,6 +1895,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("status", help="Print project status summary")
     p.add_argument("path", help="Path to the project")
 
+    # summary
+    p = sub.add_parser("summary", help="Generate end-of-session summary report")
+    p.add_argument("path", help="Path to the project")
+
     # research
     p = sub.add_parser("research", help="Print research citation index for experiments")
     p.add_argument("path", help="Path to the project")
@@ -2150,6 +2172,7 @@ def main(argv: list[str] | None = None) -> int:
         "deferred-list": cmd_backlog_list,
         "backlog-add": cmd_backlog_add,
         "status": cmd_status,
+        "summary": cmd_summary,
         "research": cmd_research,
         "diff": cmd_diff,
         "explain": cmd_explain,

--- a/factory/models.py
+++ b/factory/models.py
@@ -263,6 +263,28 @@ class CostBudget(BaseModel):
     current_month_spent: float = 0.0
 
 
+# ── session summary ──────────────────────────────────────────
+
+
+class SessionSummary(BaseModel):
+    """End-of-cycle summary: what was built, deferred, and needs human input."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    project_name: str
+    generated_at: datetime
+    mode: str
+    experiments_kept: list[ExperimentRecord]
+    experiments_reverted: list[ExperimentRecord]
+    experiments_errored: list[ExperimentRecord]
+    backlog_remaining: list[str]
+    guard_violations: list[str]
+    needs_human_input: list[str]
+    score_start: float | None
+    score_end: float | None
+    total_cost_usd: float | None
+
+
 # ── protocols ─────────────────────────────────────────────────────
 
 

--- a/factory/summary.py
+++ b/factory/summary.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import structlog
 
+from factory.events import load_events
 from factory.models import CompositeScore, SessionSummary
 from factory.store import ExperimentStore
 from factory.strategy import categorize_hypothesis
@@ -18,9 +19,20 @@ _MARGINAL_DELTA_THRESHOLD = 0.01
 
 
 async def generate_summary(project_path: Path) -> SessionSummary:
-    """Build a SessionSummary from the project's .factory/ state."""
+    """Build a SessionSummary from the project's .factory/ state.
+
+    Scopes to the current session by filtering experiments to those recorded
+    after the most recent ``cycle.started`` event.  Falls back to all
+    experiments when no cycle event exists (e.g. manual invocation).
+    """
     store = ExperimentStore(project_path)
-    records = await store.load_history()
+    all_records = await store.load_history()
+    cycle_start = _latest_cycle_start(project_path)
+    records = (
+        [r for r in all_records if r.timestamp >= cycle_start]
+        if cycle_start
+        else all_records
+    )
 
     kept = [r for r in records if r.verdict == "keep"]
     reverted = [r for r in records if r.verdict == "revert"]
@@ -46,7 +58,8 @@ async def generate_summary(project_path: Path) -> SessionSummary:
         score_start = records[0].score_before
         score_end = records[-1].score_after
 
-    total_cost = sum(r.cost_usd for r in records if r.cost_usd is not None) or None
+    costs = [r.cost_usd for r in records if r.cost_usd is not None]
+    total_cost = sum(costs) if costs else None
 
     mode = _detect_mode(project_path)
 
@@ -158,7 +171,7 @@ def _read_backlog(project_path: Path) -> list[str]:
     try:
         from factory.study import _parse_backlog_items
         return _parse_backlog_items(project_path)
-    except (ImportError, Exception):
+    except (ImportError, OSError):
         log.debug("summary.backlog_read_failed")
         return []
 
@@ -182,9 +195,21 @@ def _collect_guard_violations(
             for v in score.guard_violations:
                 if v not in violations:
                     violations.append(v)
-        except (json.JSONDecodeError, Exception):
+        except (json.JSONDecodeError, OSError, ValueError, KeyError):
             continue
     return violations
+
+
+def _latest_cycle_start(project_path: Path) -> datetime | None:
+    """Return the timestamp of the most recent ``cycle.started`` event, or None."""
+    events = load_events(project_path)
+    for ev in reversed(events):
+        if ev.get("type") == "cycle.started":
+            try:
+                return datetime.fromisoformat(ev["timestamp"])
+            except (ValueError, KeyError):
+                return None
+    return None
 
 
 def _detect_mode(project_path: Path) -> str:
@@ -194,17 +219,12 @@ def _detect_mode(project_path: Path) -> str:
         try:
             data = json.loads(ckpt_path.read_text())
             return data.get("mode", "unknown")
-        except (json.JSONDecodeError, Exception):
+        except (json.JSONDecodeError, OSError):
             pass
-    events_path = project_path / ".factory" / "events.jsonl"
-    if events_path.exists():
-        try:
-            for line in reversed(events_path.read_text().splitlines()):
-                ev = json.loads(line)
-                if ev.get("type") == "cycle.started" and "mode" in ev.get("data", {}):
-                    return ev["data"]["mode"]
-        except (json.JSONDecodeError, Exception):
-            pass
+    events = load_events(project_path)
+    for ev in reversed(events):
+        if ev.get("type") == "cycle.started" and "mode" in ev.get("data", {}):
+            return ev["data"]["mode"]
     return "unknown"
 
 

--- a/factory/summary.py
+++ b/factory/summary.py
@@ -1,0 +1,214 @@
+"""Session summary — generate an end-of-cycle report for a factory run."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import structlog
+
+from factory.models import CompositeScore, SessionSummary
+from factory.store import ExperimentStore
+from factory.strategy import categorize_hypothesis
+
+log = structlog.get_logger()
+
+_MARGINAL_DELTA_THRESHOLD = 0.01
+
+
+async def generate_summary(project_path: Path) -> SessionSummary:
+    """Build a SessionSummary from the project's .factory/ state."""
+    store = ExperimentStore(project_path)
+    records = await store.load_history()
+
+    kept = [r for r in records if r.verdict == "keep"]
+    reverted = [r for r in records if r.verdict == "revert"]
+    errored = [r for r in records if r.verdict == "error"]
+
+    backlog = _read_backlog(project_path)
+    violations = _collect_guard_violations(project_path, [r.id for r in records])
+
+    needs_input: list[str] = []
+    for r in errored:
+        needs_input.append(f"Experiment #{r.id} [ERROR]: {r.hypothesis}")
+    for v in violations:
+        needs_input.append(f"Guard violation: {v}")
+    for r in reverted:
+        if r.delta is not None and abs(r.delta) < _MARGINAL_DELTA_THRESHOLD:
+            needs_input.append(
+                f"Experiment #{r.id} [MARGINAL REVERT, delta={r.delta:+.4f}]: {r.hypothesis}"
+            )
+
+    score_start: float | None = None
+    score_end: float | None = None
+    if records:
+        score_start = records[0].score_before
+        score_end = records[-1].score_after
+
+    total_cost = sum(r.cost_usd for r in records if r.cost_usd is not None) or None
+
+    mode = _detect_mode(project_path)
+
+    return SessionSummary(
+        project_name=project_path.resolve().name,
+        generated_at=datetime.now(timezone.utc),
+        mode=mode,
+        experiments_kept=kept,
+        experiments_reverted=reverted,
+        experiments_errored=errored,
+        backlog_remaining=backlog,
+        guard_violations=violations,
+        needs_human_input=needs_input,
+        score_start=score_start,
+        score_end=score_end,
+        total_cost_usd=total_cost,
+    )
+
+
+def format_summary(summary: SessionSummary) -> str:
+    """Render a SessionSummary as human-readable markdown."""
+    total = (
+        len(summary.experiments_kept)
+        + len(summary.experiments_reverted)
+        + len(summary.experiments_errored)
+    )
+    net_delta = _net_delta(summary)
+    lines: list[str] = [
+        f"# Session Summary — {summary.project_name}",
+        "",
+        f"_Generated: {summary.generated_at.strftime('%Y-%m-%d %H:%M UTC')}_",
+        "",
+        "## Overview",
+        "",
+        f"- **Mode:** {summary.mode}",
+        f"- **Experiments:** {total} total "
+        f"({len(summary.experiments_kept)} kept, "
+        f"{len(summary.experiments_reverted)} reverted, "
+        f"{len(summary.experiments_errored)} errors)",
+    ]
+
+    if summary.score_start is not None and summary.score_end is not None:
+        lines.append(
+            f"- **Score:** {summary.score_start:.4f} → {summary.score_end:.4f}"
+            f" (net: {net_delta:+.4f})"
+        )
+    if summary.total_cost_usd is not None:
+        lines.append(f"- **Cost:** ${summary.total_cost_usd:.2f}")
+
+    lines.append("")
+
+    # What Was Built
+    lines.append("## What Was Built")
+    lines.append("")
+    if summary.experiments_kept:
+        lines.append("| # | Hypothesis | Category | Delta | PR |")
+        lines.append("|---|------------|----------|-------|----|")
+        for r in summary.experiments_kept:
+            cat = categorize_hypothesis(r.hypothesis).name
+            delta_str = f"{r.delta:+.4f}" if r.delta is not None else "—"
+            pr_str = f"#{r.pr_number}" if r.pr_number else "—"
+            lines.append(f"| {r.id} | {r.hypothesis[:60]} | {cat} | {delta_str} | {pr_str} |")
+    else:
+        lines.append("No experiments were kept this session.")
+    lines.append("")
+
+    # What Was Deferred
+    lines.append("## What Was Deferred")
+    lines.append("")
+    if summary.backlog_remaining:
+        for item in summary.backlog_remaining:
+            lines.append(f"- {item}")
+    else:
+        lines.append("No items in backlog.")
+    lines.append("")
+
+    # Needs Your Input
+    lines.append("## Needs Your Input")
+    lines.append("")
+    if summary.needs_human_input:
+        for item in summary.needs_human_input:
+            lines.append(f"- {item}")
+    else:
+        lines.append("Nothing requires your attention.")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+async def save_summary(project_path: Path, summary: SessionSummary) -> Path:
+    """Persist the summary as markdown and JSON under .factory/reviews/."""
+    reviews_dir = project_path / ".factory" / "reviews"
+    reviews_dir.mkdir(parents=True, exist_ok=True)
+
+    md_path = reviews_dir / "session-summary.md"
+    md_path.write_text(format_summary(summary))
+
+    json_path = reviews_dir / "session-summary.json"
+    json_path.write_text(
+        json.dumps(summary.model_dump(), indent=2, default=str) + "\n"
+    )
+
+    log.info("summary.saved", md=str(md_path), json=str(json_path))
+    return md_path
+
+
+def _read_backlog(project_path: Path) -> list[str]:
+    """Read backlog items, delegating to study module's parser."""
+    try:
+        from factory.study import _parse_backlog_items
+        return _parse_backlog_items(project_path)
+    except (ImportError, Exception):
+        log.debug("summary.backlog_read_failed")
+        return []
+
+
+def _collect_guard_violations(
+    project_path: Path,
+    experiment_ids: list[int],
+) -> list[str]:
+    """Collect unique guard violations from eval_after.json files."""
+    violations: list[str] = []
+    for exp_id in experiment_ids:
+        eval_path = (
+            project_path / ".factory" / "experiments"
+            / f"{exp_id:03d}" / "eval_after.json"
+        )
+        if not eval_path.exists():
+            continue
+        try:
+            data = json.loads(eval_path.read_text())
+            score = CompositeScore(**data)
+            for v in score.guard_violations:
+                if v not in violations:
+                    violations.append(v)
+        except (json.JSONDecodeError, Exception):
+            continue
+    return violations
+
+
+def _detect_mode(project_path: Path) -> str:
+    """Best-effort mode detection from checkpoint or events."""
+    ckpt_path = project_path / ".factory" / "checkpoint.json"
+    if ckpt_path.exists():
+        try:
+            data = json.loads(ckpt_path.read_text())
+            return data.get("mode", "unknown")
+        except (json.JSONDecodeError, Exception):
+            pass
+    events_path = project_path / ".factory" / "events.jsonl"
+    if events_path.exists():
+        try:
+            for line in reversed(events_path.read_text().splitlines()):
+                ev = json.loads(line)
+                if ev.get("type") == "cycle.started" and "mode" in ev.get("data", {}):
+                    return ev["data"]["mode"]
+        except (json.JSONDecodeError, Exception):
+            pass
+    return "unknown"
+
+
+def _net_delta(summary: SessionSummary) -> float:
+    if summary.score_start is not None and summary.score_end is not None:
+        return summary.score_end - summary.score_start
+    return 0.0

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,376 @@
+"""Tests for factory.summary — session summary generation, formatting, and persistence."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from factory.models import ExperimentRecord, SessionSummary
+from factory.summary import (
+    format_summary,
+    generate_summary,
+    save_summary,
+)
+
+
+# ── fixtures ─────────────────────────────────────────────────
+
+
+def _make_record(
+    *,
+    id: int = 1,
+    verdict: str = "keep",
+    hypothesis: str = "Add structured logging",
+    delta: float | None = 0.045,
+    score_before: float | None = 0.70,
+    score_after: float | None = 0.745,
+    pr_number: int | None = 42,
+    cost_usd: float | None = 1.50,
+) -> ExperimentRecord:
+    return ExperimentRecord(
+        id=id,
+        timestamp=datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc),
+        hypothesis=hypothesis,
+        change_summary="Added logging",
+        issue_number=None,
+        pr_number=pr_number,
+        score_before=score_before,
+        score_after=score_after,
+        delta=delta,
+        verdict=verdict,
+        cost_usd=cost_usd,
+        notes="",
+    )
+
+
+@pytest.fixture
+def summary_project(tmp_path: Path) -> Path:
+    """Create a project with .factory/ structure and populated results."""
+    project = tmp_path / "summary-project"
+    project.mkdir()
+    factory = project / ".factory"
+    factory.mkdir()
+    (factory / "experiments").mkdir()
+    (factory / "strategy").mkdir()
+    (factory / "reviews").mkdir()
+
+    # Write results.tsv with mixed verdicts
+    import csv
+    import io
+
+    from factory.store import TSV_COLUMNS
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, dialect="excel-tab")
+    writer.writerow(TSV_COLUMNS)
+    for row in [
+        [1, "2026-04-26T10:00:00+00:00", "Add logging", "Added logging", "", "42",
+         "0.700", "0.745", "0.045", "keep", "1.50", "", ""],
+        [2, "2026-04-26T11:00:00+00:00", "Fix imports", "Fixed imports", "", "43",
+         "0.745", "0.760", "0.015", "keep", "0.80", "", ""],
+        [3, "2026-04-26T12:00:00+00:00", "Add caching", "Added caching", "", "",
+         "0.760", "0.755", "-0.005", "revert", "2.00", "", ""],
+        [4, "2026-04-26T13:00:00+00:00", "Broken refactor", "Refactored", "", "",
+         "0.760", "", "", "error", "0.50", "", ""],
+    ]:
+        writer.writerow(row)
+    (factory / "results.tsv").write_text(buf.getvalue())
+
+    # Write backlog
+    (factory / "strategy" / "backlog.md").write_text(
+        "- Add rate limiting\n"
+        "- Improve test coverage\n"
+        "- Write API docs\n"
+    )
+
+    # Write eval_after with guard violations for experiment 3
+    exp3 = factory / "experiments" / "003"
+    exp3.mkdir()
+    (exp3 / "eval_after.json").write_text(json.dumps({
+        "total": 0.755,
+        "results": [],
+        "guard_violations": ["scope_check: modified files outside scope"],
+        "passed": False,
+    }))
+
+    # Write events.jsonl with mode info
+    (factory / "events.jsonl").write_text(
+        json.dumps({"type": "cycle.started", "timestamp": "2026-04-26T09:00:00Z",
+                     "project": "summary-project", "agent": None,
+                     "data": {"cycle": 1, "mode": "improve"}}) + "\n"
+    )
+
+    return project
+
+
+# ── generate_summary tests ───────────────────────────────────
+
+
+async def test_generate_empty_history(tmp_path: Path) -> None:
+    """Empty project yields empty summary lists."""
+    project = tmp_path / "empty-project"
+    project.mkdir()
+    factory = project / ".factory"
+    factory.mkdir()
+    (factory / "experiments").mkdir()
+    (factory / "strategy").mkdir()
+    (factory / "reviews").mkdir()
+
+    # Empty results.tsv (header only)
+    import csv
+    import io
+
+    from factory.store import TSV_COLUMNS
+
+    buf = io.StringIO()
+    csv.writer(buf, dialect="excel-tab").writerow(TSV_COLUMNS)
+    (factory / "results.tsv").write_text(buf.getvalue())
+
+    summary = await generate_summary(project)
+    assert summary.experiments_kept == []
+    assert summary.experiments_reverted == []
+    assert summary.experiments_errored == []
+    assert summary.score_start is None
+    assert summary.score_end is None
+    assert summary.total_cost_usd is None
+
+
+async def test_generate_mixed_verdicts(summary_project: Path) -> None:
+    """Experiments are correctly bucketed by verdict."""
+    summary = await generate_summary(summary_project)
+    assert len(summary.experiments_kept) == 2
+    assert len(summary.experiments_reverted) == 1
+    assert len(summary.experiments_errored) == 1
+    assert summary.experiments_kept[0].id == 1
+    assert summary.experiments_kept[1].id == 2
+    assert summary.experiments_reverted[0].id == 3
+    assert summary.experiments_errored[0].id == 4
+
+
+async def test_backlog_included(summary_project: Path) -> None:
+    """Backlog items from backlog.md appear in summary."""
+    summary = await generate_summary(summary_project)
+    assert "Add rate limiting" in summary.backlog_remaining
+    assert "Improve test coverage" in summary.backlog_remaining
+    assert "Write API docs" in summary.backlog_remaining
+
+
+async def test_guard_violations_collected(summary_project: Path) -> None:
+    """Guard violations from eval_after.json are collected."""
+    summary = await generate_summary(summary_project)
+    assert len(summary.guard_violations) == 1
+    assert "scope_check" in summary.guard_violations[0]
+
+
+async def test_score_trajectory(summary_project: Path) -> None:
+    """score_start and score_end come from first/last experiments."""
+    summary = await generate_summary(summary_project)
+    assert summary.score_start == 0.70
+    # Last experiment (error) has no score_after
+    assert summary.score_end is None
+
+
+async def test_total_cost(summary_project: Path) -> None:
+    """total_cost_usd sums across all experiments."""
+    summary = await generate_summary(summary_project)
+    assert summary.total_cost_usd == pytest.approx(4.80)
+
+
+async def test_needs_human_input(summary_project: Path) -> None:
+    """Errored experiments, guard violations, and marginal reverts appear."""
+    summary = await generate_summary(summary_project)
+    error_items = [i for i in summary.needs_human_input if "ERROR" in i]
+    assert len(error_items) == 1
+    assert "#4" in error_items[0]
+
+    guard_items = [i for i in summary.needs_human_input if "Guard violation" in i]
+    assert len(guard_items) == 1
+
+    marginal_items = [i for i in summary.needs_human_input if "MARGINAL" in i]
+    assert len(marginal_items) == 1
+    assert "#3" in marginal_items[0]
+
+
+async def test_mode_from_events(summary_project: Path) -> None:
+    """Mode is detected from events.jsonl."""
+    summary = await generate_summary(summary_project)
+    assert summary.mode == "improve"
+
+
+# ── format_summary tests ────────────────────────────────────
+
+
+def test_format_output() -> None:
+    """All sections present in formatted markdown."""
+    summary = SessionSummary(
+        project_name="test-project",
+        generated_at=datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc),
+        mode="improve",
+        experiments_kept=[_make_record(id=1, verdict="keep")],
+        experiments_reverted=[_make_record(id=2, verdict="revert", delta=-0.005)],
+        experiments_errored=[],
+        backlog_remaining=["Add caching", "Write docs"],
+        guard_violations=[],
+        needs_human_input=["Experiment #2 [MARGINAL REVERT]: test"],
+        score_start=0.70,
+        score_end=0.745,
+        total_cost_usd=2.30,
+    )
+    output = format_summary(summary)
+    assert "# Session Summary" in output
+    assert "## Overview" in output
+    assert "## What Was Built" in output
+    assert "## What Was Deferred" in output
+    assert "## Needs Your Input" in output
+    assert "test-project" in output
+    assert "improve" in output
+    assert "0.7000" in output
+    assert "0.7450" in output
+    assert "$2.30" in output
+    assert "Add caching" in output
+    assert "#42" in output
+
+
+def test_format_empty_kept() -> None:
+    """No-keeps shows appropriate message."""
+    summary = SessionSummary(
+        project_name="test",
+        generated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
+        mode="improve",
+        experiments_kept=[],
+        experiments_reverted=[],
+        experiments_errored=[],
+        backlog_remaining=[],
+        guard_violations=[],
+        needs_human_input=[],
+        score_start=None,
+        score_end=None,
+        total_cost_usd=None,
+    )
+    output = format_summary(summary)
+    assert "No experiments were kept" in output
+    assert "No items in backlog" in output
+    assert "Nothing requires your attention" in output
+
+
+def test_format_no_scores() -> None:
+    """Score line omitted when scores are None."""
+    summary = SessionSummary(
+        project_name="test",
+        generated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
+        mode="build",
+        experiments_kept=[],
+        experiments_reverted=[],
+        experiments_errored=[],
+        backlog_remaining=[],
+        guard_violations=[],
+        needs_human_input=[],
+        score_start=None,
+        score_end=None,
+        total_cost_usd=None,
+    )
+    output = format_summary(summary)
+    assert "Score:" not in output
+
+
+# ── save_summary tests ──────────────────────────────────────
+
+
+async def test_save_creates_files(tmp_path: Path) -> None:
+    """save_summary writes both .md and .json files."""
+    project = tmp_path / "save-project"
+    project.mkdir()
+
+    summary = SessionSummary(
+        project_name="save-project",
+        generated_at=datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc),
+        mode="improve",
+        experiments_kept=[_make_record()],
+        experiments_reverted=[],
+        experiments_errored=[],
+        backlog_remaining=["Item A"],
+        guard_violations=[],
+        needs_human_input=[],
+        score_start=0.70,
+        score_end=0.745,
+        total_cost_usd=1.50,
+    )
+
+    md_path = await save_summary(project, summary)
+    assert md_path.exists()
+    assert md_path.name == "session-summary.md"
+    assert "Session Summary" in md_path.read_text()
+
+    json_path = project / ".factory" / "reviews" / "session-summary.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text())
+    assert data["project_name"] == "save-project"
+    assert len(data["experiments_kept"]) == 1
+
+
+async def test_save_creates_reviews_dir(tmp_path: Path) -> None:
+    """save_summary creates .factory/reviews/ if missing."""
+    project = tmp_path / "no-reviews"
+    project.mkdir()
+
+    summary = SessionSummary(
+        project_name="no-reviews",
+        generated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
+        mode="build",
+        experiments_kept=[],
+        experiments_reverted=[],
+        experiments_errored=[],
+        backlog_remaining=[],
+        guard_violations=[],
+        needs_human_input=[],
+        score_start=None,
+        score_end=None,
+        total_cost_usd=None,
+    )
+
+    md_path = await save_summary(project, summary)
+    assert md_path.exists()
+
+
+# ── CLI integration ──────────────────────────────────────────
+
+
+def test_cli_summary(summary_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """factory summary <path> prints output and returns 0."""
+    from factory.cli import main
+
+    code = main(["summary", str(summary_project)])
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "Session Summary" in output
+    assert "What Was Built" in output
+    assert "What Was Deferred" in output
+    assert "Needs Your Input" in output
+    assert (summary_project / ".factory" / "reviews" / "session-summary.md").exists()
+    assert (summary_project / ".factory" / "reviews" / "session-summary.json").exists()
+
+
+# ── model tests ──────────────────────────────────────────────
+
+
+def test_session_summary_strict() -> None:
+    """SessionSummary rejects extra fields."""
+    with pytest.raises(Exception):
+        SessionSummary(
+            project_name="test",
+            generated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
+            mode="improve",
+            experiments_kept=[],
+            experiments_reverted=[],
+            experiments_errored=[],
+            backlog_remaining=[],
+            guard_violations=[],
+            needs_human_input=[],
+            score_start=None,
+            score_end=None,
+            total_cost_usd=None,
+            extra_field="bad",
+        )

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -200,6 +200,57 @@ async def test_mode_from_events(summary_project: Path) -> None:
     assert summary.mode == "improve"
 
 
+async def test_session_scoping(summary_project: Path) -> None:
+    """Only experiments after the latest cycle.started event are included."""
+    # The fixture has cycle.started at 09:00 and experiments at 10:00-13:00.
+    # Add a second cycle.started at 11:30 — only experiments 3 and 4 should appear.
+    events_path = summary_project / ".factory" / "events.jsonl"
+    with open(events_path, "a") as f:
+        f.write(json.dumps({
+            "type": "cycle.started",
+            "timestamp": "2026-04-26T11:30:00+00:00",
+            "project": "summary-project",
+            "agent": None,
+            "data": {"cycle": 2, "mode": "improve"},
+        }) + "\n")
+
+    summary = await generate_summary(summary_project)
+    all_ids = (
+        [r.id for r in summary.experiments_kept]
+        + [r.id for r in summary.experiments_reverted]
+        + [r.id for r in summary.experiments_errored]
+    )
+    assert 1 not in all_ids
+    assert 2 not in all_ids
+    assert 3 in all_ids
+    assert 4 in all_ids
+
+
+async def test_zero_cost_not_dropped(tmp_path: Path) -> None:
+    """Zero total cost is reported as 0.0, not None."""
+    import csv
+    import io
+
+    from factory.store import TSV_COLUMNS
+
+    project = tmp_path / "zero-cost"
+    project.mkdir()
+    factory = project / ".factory"
+    factory.mkdir()
+    (factory / "experiments").mkdir()
+    (factory / "strategy").mkdir()
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, dialect="excel-tab")
+    writer.writerow(TSV_COLUMNS)
+    writer.writerow([1, "2026-04-26T10:00:00+00:00", "Free fix", "Fixed",
+                     "", "", "0.7", "0.8", "0.1", "keep", "0.0", "", ""])
+    (factory / "results.tsv").write_text(buf.getvalue())
+
+    summary = await generate_summary(project)
+    assert summary.total_cost_usd == 0.0
+
+
 # ── format_summary tests ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Adds a **session summary** feature that generates a structured end-of-cycle report at the end of every factory session
- Captures three key outputs: **what was built** (kept experiments with score deltas and PR numbers), **what was deferred** (remaining backlog items), and **what needs human input** (errors, guard violations, marginal reverts)
- Persisted to `.factory/reviews/session-summary.{md,json}` and printed to stdout

## Changes

| File | Change |
|------|--------|
| `factory/models.py` | New `SessionSummary` Pydantic model |
| `factory/summary.py` | Core module: `generate_summary`, `format_summary`, `save_summary` |
| `factory/cli.py` | New `factory summary <path>` CLI command |
| `factory/agents/prompts/ceo.md` | New Step 3b between Final Archive and Notify |
| `tests/test_summary.py` | 15 tests covering generation, formatting, persistence, CLI |

## Test plan

- [x] `ruff check` passes on new files
- [x] `mypy` passes on `factory/summary.py`
- [x] 15 new tests pass (`pytest tests/test_summary.py -v`)
- [x] Full suite passes (1021 tests, 0 regressions)
- [ ] Manual: `factory summary /path/to/project` prints formatted report
- [ ] Manual: `.factory/reviews/session-summary.md` created with correct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)