### PR TITLE
docs: add meta mode cadence guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Each agent accumulates behavioral rules — DOs and DON'Ts — with evidence cou
 factory ceo ~/my-project --mode meta
 ```
 
-Meta mode is the factory's recursive self-improvement: improve the project, then improve the agents that improved the project. Over time, agents get sharper at the specific kinds of changes that work for *your* codebase. For active projects, run meta mode on a regular cadence — weekly is a good default, nightly if the factory is running many experiments per day. Don't run it right after initial build or after every improve cycle; ACE needs enough experiment data (at least 5-10 across projects) to produce meaningful playbook updates. See [ACE Self-Improvement](docs/ace.md) for details.
+Meta mode is the factory's recursive self-improvement: improve the project, then improve the agents that improved the project. Over time, agents get sharper at the specific kinds of changes that work for *your* codebase. For active projects, run meta mode on a regular cadence — weekly is a good default, nightly if the factory is running many experiments per day.
+
+Don't run it right after initial build or after every improve cycle; ACE needs enough experiment data (at least 5 across projects) to produce meaningful playbook updates. See [ACE Self-Improvement](docs/ace.md) for details.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Each agent accumulates behavioral rules — DOs and DON'Ts — with evidence cou
 factory ceo ~/my-project --mode meta
 ```
 
-Meta mode is the factory's recursive self-improvement: improve the project, then improve the agents that improved the project. Over time, agents get sharper at the specific kinds of changes that work for *your* codebase. See [ACE Self-Improvement](docs/ace.md) for details.
+Meta mode is the factory's recursive self-improvement: improve the project, then improve the agents that improved the project. Over time, agents get sharper at the specific kinds of changes that work for *your* codebase. For active projects, run meta mode on a regular cadence — weekly is a good default, nightly if the factory is running many experiments per day. Don't run it right after initial build or after every improve cycle; ACE needs enough experiment data (at least 5-10 across projects) to produce meaningful playbook updates. See [ACE Self-Improvement](docs/ace.md) for details.
 
 ## Quick Start
 

--- a/docs/ace.md
+++ b/docs/ace.md
@@ -74,7 +74,7 @@ Meta mode runs the full improvement loop, then reflects on the outcomes to evolv
 
 ACE produces meaningful playbook updates only when there is enough experiment data to analyze. Running it too frequently churns rules on small samples; ignoring it means agents never learn from their mistakes.
 
-**Recommended cadence:** Weekly for most projects, nightly if you are running 5+ experiments per day. Wait until at least 5-10 experiments have been recorded across your managed projects before the first run.
+**Recommended cadence:** Weekly for most projects, nightly if you are running 5+ experiments per day. Wait until at least 5 experiments have been recorded across your managed projects before the first run (10+ preferred for stronger signal).
 
 **When to skip:** Right after initial project setup (no experiment data yet), or when fewer than 3 new experiments have completed since the last ACE run. See [When to Run Meta Mode](self-improvement.md#when-to-run-meta-mode) for the full decision framework.
 

--- a/docs/ace.md
+++ b/docs/ace.md
@@ -70,6 +70,14 @@ factory ceo ~/my-project --mode meta
 
 Meta mode runs the full improvement loop, then reflects on the outcomes to evolve all 7 agent playbooks. See [Self-Improvement Loop](self-improvement.md) for the full picture — including cross-project learning, CEO self-evaluation, and how the pieces fit together.
 
+## When to Run
+
+ACE produces meaningful playbook updates only when there is enough experiment data to analyze. Running it too frequently churns rules on small samples; ignoring it means agents never learn from their mistakes.
+
+**Recommended cadence:** Weekly for most projects, nightly if you are running 5+ experiments per day. Wait until at least 5-10 experiments have been recorded across your managed projects before the first run.
+
+**When to skip:** Right after initial project setup (no experiment data yet), or when fewer than 3 new experiments have completed since the last ACE run. See [When to Run Meta Mode](self-improvement.md#when-to-run-meta-mode) for the full decision framework.
+
 ## What Gets Evolved
 
 All 7 agent roles have playbooks:

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -270,10 +270,10 @@ Meta mode is the factory's most powerful self-improvement mechanism, but it has 
 |-------------|---------|-----------|
 | Light (1-2 experiments/day) | Weekly | One week accumulates enough new outcomes for ACE to find real patterns |
 | Heavy (5+ experiments/day) | Nightly | High experiment volume means new signal accumulates faster |
-| Occasional (a few experiments/week) | Biweekly or on-demand | Not enough data to justify frequent evolution |
+| Occasional (a few experiments/week) | Every two weeks or on-demand | Not enough data to justify frequent evolution |
 
 **Prerequisites — run meta mode only when:**
-- At least **5-10 experiments** have been recorded across your managed projects since the last meta run. ACE analyzes cross-project data; with fewer than 5 experiments, it lacks the sample size to distinguish signal from noise.
+- At least **5 experiments** have been recorded across your managed projects since the last meta run (10+ preferred for stronger signal). ACE analyzes cross-project data; with fewer than 5 experiments, it lacks the sample size to distinguish signal from noise.
 - The factory has been through at least one full Build-Discover-Improve cycle on at least one project. Running meta mode on a brand-new factory with no experiment history is a no-op.
 
 **Signs it's time to run meta mode:**
@@ -295,6 +295,7 @@ Meta mode is the factory's most powerful self-improvement mechanism, but it has 
 0 2 * * 0 cd ~/remote-factory && factory ceo ~/remote-factory --mode meta
 
 # Or use the factory's own tmux loop for nightly runs
+# Note: --mode is forwarded through tmux → run → ceo
 factory tmux ~/remote-factory --loop --interval 86400 --mode meta
 ```
 

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -260,6 +260,44 @@ factory ceo ~/remote-factory --mode meta
 factory ace ~/remote-factory
 ```
 
+### When to Run Meta Mode
+
+Meta mode is the factory's most powerful self-improvement mechanism, but it has diminishing returns if run too frequently or too early. ACE needs a critical mass of experiment data to generate meaningful playbook updates. Running it too early produces noisy rules from small samples; running it too often churns playbooks without enough new evidence between runs.
+
+**Recommended cadence:**
+
+| Usage level | Cadence | Rationale |
+|-------------|---------|-----------|
+| Light (1-2 experiments/day) | Weekly | One week accumulates enough new outcomes for ACE to find real patterns |
+| Heavy (5+ experiments/day) | Nightly | High experiment volume means new signal accumulates faster |
+| Occasional (a few experiments/week) | Biweekly or on-demand | Not enough data to justify frequent evolution |
+
+**Prerequisites — run meta mode only when:**
+- At least **5-10 experiments** have been recorded across your managed projects since the last meta run. ACE analyzes cross-project data; with fewer than 5 experiments, it lacks the sample size to distinguish signal from noise.
+- The factory has been through at least one full Build-Discover-Improve cycle on at least one project. Running meta mode on a brand-new factory with no experiment history is a no-op.
+
+**Signs it's time to run meta mode:**
+- **Stale playbooks**: Agents keep making the same mistakes that get reverted — the playbooks haven't learned to avoid those patterns yet.
+- **Consistent revert patterns**: You see 3+ reverts in the same category across projects, but the Strategist keeps proposing that category.
+- **New project types**: You started managing a project in a language or domain the factory hasn't seen before. Meta mode can generate domain-specific playbook rules from the new experiment data.
+- **Playbook counters are outdated**: Check `~/.factory/playbooks/*.md` — if the `helpful`/`harmful` counters are far behind the actual experiment count in `results.tsv`, ACE needs to catch up.
+
+**When NOT to run meta mode:**
+- **Right after initial build.** The factory just scaffolded a project and has zero or one experiment. ACE has nothing to learn from yet. Wait until the project has been through several improve cycles.
+- **After every improve loop.** This is the most common mistake. Each improve cycle produces 1-5 experiments — not enough new data to meaningfully change playbooks. The result is noisy churn: rules get added and removed in rapid succession without converging.
+- **When the last meta run was recent and few new experiments have run.** If you ran meta mode yesterday and only 2 new experiments have completed since, skip it.
+- **During a focused improvement sprint.** If you're using `--focus` to target a specific area, finish the focused work first. Meta mode's broad playbook evolution can dilute focus-specific learnings.
+
+**Automation:** For long-running factory deployments, schedule meta mode on a regular cadence:
+
+```bash
+# Weekly meta mode via cron, Sunday night
+0 2 * * 0 cd ~/remote-factory && factory ceo ~/remote-factory --mode meta
+
+# Or use the factory's own tmux loop for nightly runs
+factory tmux ~/remote-factory --loop --interval 86400 --mode meta
+```
+
 ## Hard Guardrails
 
 The loop is autonomous but not unconstrained. These guardrails cannot be overridden:

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -491,7 +491,7 @@ echo "- [x] archivist after research — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PR
 
 **0d. Evolve Agent Playbooks (ACE Self-Improvement)**
 
-Skip this step in Improve mode — ACE playbook evolution is handled by Meta mode (`--mode meta`), which runs the full Improve loop followed by ACE. Running ACE after every improve cycle adds noise: playbooks churn on small sample sizes and the factory wastes time re-evolving rules that haven't accumulated meaningful evidence. Meta mode should be run on a separate cadence — see **Meta Mode Cadence** below.
+Skip this step in Improve mode — ACE playbook evolution is handled by Meta mode (`--mode meta`), which runs the full Improve loop followed by ACE. Running ACE after every improve cycle adds noise: playbooks churn on small sample sizes and the factory wastes time re-evolving rules that haven't accumulated meaningful evidence. Meta mode should be run on a separate cadence — see [Meta Mode Cadence](#meta-mode-cadence) below.
 
 ### Step 1: Hypothesize (Strategist Agent)
 
@@ -910,7 +910,7 @@ Meta mode is powerful but has diminishing returns if run too frequently or too e
 - Mid-session as a "bonus step" — meta mode is a full cycle, not an addon
 
 **If a user asks about meta mode, advise:**
-1. "Have you run at least 5-10 experiments across your projects?" If no, it is premature.
+1. "Have you run at least 5 experiments across your projects?" If no, it is premature.
 2. "Are you seeing the same failure patterns repeating?" If yes, meta mode can help.
 3. "How often are you running it?" If more than weekly, suggest reducing frequency.
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -491,7 +491,7 @@ echo "- [x] archivist after research — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PR
 
 **0d. Evolve Agent Playbooks (ACE Self-Improvement)**
 
-Skip this step in Improve mode — ACE playbook evolution is handled by Meta mode (`--mode meta`), which runs the full Improve loop followed by ACE. Use Meta mode when you want the factory to improve itself.
+Skip this step in Improve mode — ACE playbook evolution is handled by Meta mode (`--mode meta`), which runs the full Improve loop followed by ACE. Running ACE after every improve cycle adds noise: playbooks churn on small sample sizes and the factory wastes time re-evolving rules that haven't accumulated meaningful evidence. Meta mode should be run on a separate cadence — see **Meta Mode Cadence** below.
 
 ### Step 1: Hypothesize (Strategist Agent)
 
@@ -892,6 +892,29 @@ factory agent archivist --task "Record ACE playbook evolution.
 ```
 
 Note: Evolved playbooks are stored in `~/.factory/playbooks/` (user-local), NOT in the factory source tree. They are never committed to the factory repo — they are personal to each user's experiment history.
+
+### Meta Mode Cadence
+
+Meta mode is powerful but has diminishing returns if run too frequently or too early. Follow these rules:
+
+**When to run meta mode:**
+- On a **regular cadence**: weekly for most projects, nightly if the factory runs 5+ experiments per day
+- When playbooks feel stale — agents keep making the same mistakes that get reverted
+- When you start managing a new type of project that existing playbooks may not cover
+- When the user explicitly asks for self-improvement
+
+**When NOT to run meta mode:**
+- Right after initial build — there is no experiment data yet for ACE to learn from
+- After every improve cycle — this churns playbooks on tiny samples and wastes time
+- When fewer than 5 experiments exist across all managed projects — not enough signal
+- Mid-session as a "bonus step" — meta mode is a full cycle, not an addon
+
+**If a user asks about meta mode, advise:**
+1. "Have you run at least 5-10 experiments across your projects?" If no, it is premature.
+2. "Are you seeing the same failure patterns repeating?" If yes, meta mode can help.
+3. "How often are you running it?" If more than weekly, suggest reducing frequency.
+
+**Do NOT auto-trigger meta mode.** Only run it when the user explicitly invokes `--mode meta` or when a scheduled cadence fires. Never append a meta cycle to the end of a normal improve run on your own initiative.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add clear guidance on **when and how often** to run `--mode meta` across README, CEO prompt, and docs
- Recommended cadence: weekly for most projects, nightly for heavy use
- Explicitly warn against running after every improve cycle or right after initial build
- Add prerequisites (5-10 experiments minimum) and automation examples

## Changes

| File | Change |
|------|--------|
| `README.md` | Expand meta mode paragraph with cadence recommendation (2 sentences) |
| `factory/agents/prompts/ceo.md` | Add reasoning to Step 0d + new "Meta Mode Cadence" subsection with actionable rules |
| `docs/self-improvement.md` | New "When to Run Meta Mode" section: cadence table, prerequisites, signals, anti-patterns, automation |
| `docs/ace.md` | New "When to Run" section with brief cadence note + cross-reference |

## Motivation

Meta mode is powerful but undocumented in terms of cadence. Users and the CEO agent itself had no guidance on frequency, leading to either overuse (after every cycle, adding noise) or neglect (never running it, missing optimization). This establishes clear best practices at every documentation layer.

## Test plan

- [x] `uv run pytest tests/test_prompts.py -v` — all 51 tests pass
- [ ] Verify cross-references resolve (README → ace.md, ace.md → self-improvement.md)
- [ ] Review rendered markdown for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)