### PR TITLE
Fix research_grounding cold-start — citation backfill + extraction

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -909,6 +909,18 @@ def cmd_research(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_backfill_citations(args: argparse.Namespace) -> int:
+    """Backfill citations from experiment text into .factory/citations.json."""
+    from factory.research_index import backfill_citations
+
+    project_path = Path(args.path).resolve()
+    index = backfill_citations(project_path)
+    print(f"Backfilled citations for {len(index)} experiments")
+    for exp_id, cites in sorted(index.items(), key=lambda x: int(x[0])):
+        print(f"  #{exp_id}: {', '.join(cites[:5])}")
+    return 0
+
+
 def cmd_diff(args: argparse.Namespace) -> int:
     """Compare two experiments side-by-side."""
     from factory.analysis import compare_experiments, format_comparison
@@ -1903,6 +1915,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("summary", help="Generate end-of-session summary report")
     p.add_argument("path", help="Path to the project")
 
+    # backfill-citations
+    p = sub.add_parser("backfill-citations", help="Extract citations from experiment text into citations.json")
+    p.add_argument("path", help="Path to the project")
+
     # research
     p = sub.add_parser("research", help="Print research citation index for experiments")
     p.add_argument("path", help="Path to the project")
@@ -2178,6 +2194,7 @@ def main(argv: list[str] | None = None) -> int:
         "status": cmd_status,
         "summary": cmd_summary,
         "research": cmd_research,
+        "backfill-citations": cmd_backfill_citations,
         "diff": cmd_diff,
         "explain": cmd_explain,
         "export": cmd_export,

--- a/factory/research_index.py
+++ b/factory/research_index.py
@@ -1,11 +1,73 @@
 """Research citation index — tracks which experiments cite research sources."""
 
 import csv
+import json
+import re
 from pathlib import Path
 
 import structlog
 
 log = structlog.get_logger()
+
+_URL_RE = re.compile(r"https?://[^\s),]+")
+_ISSUE_RE = re.compile(r"#(\d+)")
+_ARXIV_RE = re.compile(r"arxiv[:/](\d{4}\.\d{4,5})", re.IGNORECASE)
+
+
+def extract_citations(text: str) -> list[str]:
+    """Extract URLs, GitHub issue refs, and arxiv IDs from text."""
+    citations: list[str] = []
+    citations.extend(_URL_RE.findall(text))
+    for m in _ISSUE_RE.finditer(text):
+        citations.append(f"#{m.group(1)}")
+    for m in _ARXIV_RE.finditer(text):
+        citations.append(f"arxiv:{m.group(1)}")
+    return sorted(set(citations))
+
+
+def _load_backfill(project_path: Path) -> dict[str, list[str]]:
+    """Load backfilled citations from .factory/citations.json."""
+    path = project_path / ".factory" / "citations.json"
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        return {str(k): v for k, v in data.items()}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def backfill_citations(project_path: Path) -> dict[str, list[str]]:
+    """Scan experiments and extract citations from hypothesis/notes text.
+
+    Writes results to .factory/citations.json and returns the index.
+    """
+    tsv_path = project_path / ".factory" / "results.tsv"
+    if not tsv_path.exists():
+        return {}
+
+    index: dict[str, list[str]] = {}
+    with open(tsv_path, newline="") as f:
+        reader = csv.DictReader(f, dialect="excel-tab")
+        for row in reader:
+            exp_id = row["id"]
+            text = " ".join([
+                row.get("hypothesis", ""),
+                row.get("change_summary", ""),
+                row.get("notes", ""),
+            ])
+            citations = extract_citations(text)
+            if citations:
+                index[exp_id] = citations
+
+    out_path = project_path / ".factory" / "citations.json"
+    out_path.write_text(json.dumps(index, indent=2) + "\n")
+    log.info(
+        "citations_backfilled",
+        total_experiments=len(index),
+        output=str(out_path),
+    )
+    return index
 
 
 def _load_citations_from_tsv(project_path: Path) -> list[tuple[int, list[str]]]:
@@ -14,6 +76,8 @@ def _load_citations_from_tsv(project_path: Path) -> list[tuple[int, list[str]]]:
     if not tsv_path.exists():
         return []
 
+    backfill = _load_backfill(project_path)
+
     results: list[tuple[int, list[str]]] = []
     with open(tsv_path, newline="") as f:
         reader = csv.DictReader(f, dialect="excel-tab")
@@ -21,6 +85,8 @@ def _load_citations_from_tsv(project_path: Path) -> list[tuple[int, list[str]]]:
             exp_id = int(row["id"])
             raw = row.get("research_citations", "")
             citations = [c.strip() for c in raw.split("|") if c.strip()] if raw else []
+            if not citations:
+                citations = backfill.get(str(exp_id), [])
             results.append((exp_id, citations))
     return results
 

--- a/tests/test_research_index.py
+++ b/tests/test_research_index.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 from factory.cli import cmd_research
 from factory.research_index import (
+    backfill_citations,
     build_citation_index,
     citation_coverage,
+    extract_citations,
     uncited_experiments,
 )
 
@@ -47,6 +49,71 @@ def _make_row(
         "notes": "",
         "research_citations": citations,
     }
+
+
+class TestExtractCitations:
+    def test_extracts_urls(self) -> None:
+        text = "Based on https://arxiv.org/abs/2405.12345 and https://github.com/user/repo"
+        cites = extract_citations(text)
+        assert "https://arxiv.org/abs/2405.12345" in cites
+        assert "https://github.com/user/repo" in cites
+
+    def test_extracts_issue_refs(self) -> None:
+        text = "Closes #115 and related to #42"
+        cites = extract_citations(text)
+        assert "#115" in cites
+        assert "#42" in cites
+
+    def test_extracts_arxiv_ids(self) -> None:
+        text = "Informed by arxiv:2405.12345 and arxiv/2301.0001"
+        cites = extract_citations(text)
+        assert "arxiv:2405.12345" in cites
+        assert "arxiv:2301.0001" in cites
+
+    def test_empty_text(self) -> None:
+        assert extract_citations("") == []
+
+    def test_deduplicates(self) -> None:
+        text = "#42 and #42 again"
+        cites = extract_citations(text)
+        assert cites.count("#42") == 1
+
+
+class TestBackfillCitations:
+    def test_empty_project(self, tmp_path: Path) -> None:
+        index = backfill_citations(tmp_path)
+        assert index == {}
+
+    def test_extracts_from_hypothesis(self, tmp_path: Path) -> None:
+        _write_results_tsv(tmp_path, [
+            _make_row(1, hypothesis="Fix issue #115 based on https://example.com"),
+            _make_row(2, hypothesis="Just a plain hypothesis"),
+        ])
+        index = backfill_citations(tmp_path)
+        assert "1" in index
+        assert "#115" in index["1"]
+        assert "https://example.com" in index["1"]
+        assert "2" not in index
+
+    def test_writes_citations_json(self, tmp_path: Path) -> None:
+        _write_results_tsv(tmp_path, [
+            _make_row(1, hypothesis="See #42"),
+        ])
+        backfill_citations(tmp_path)
+        citations_file = tmp_path / ".factory" / "citations.json"
+        assert citations_file.exists()
+
+    def test_coverage_uses_backfill(self, tmp_path: Path) -> None:
+        """citation_coverage should read from backfilled citations.json."""
+        _write_results_tsv(tmp_path, [
+            _make_row(1, hypothesis="Fix issue #115"),
+            _make_row(2, hypothesis="Fix issue #42"),
+            _make_row(3, hypothesis="Plain hypothesis"),
+        ])
+        assert citation_coverage(tmp_path) == 0.0
+        backfill_citations(tmp_path)
+        coverage = citation_coverage(tmp_path)
+        assert coverage > 0.0
 
 
 class TestBuildCitationIndex:


### PR DESCRIPTION
## Summary
- Add `extract_citations()` for pulling URLs, issue refs, and arxiv IDs from experiment text
- Add `backfill_citations()` + `factory backfill-citations` CLI command that writes `.factory/citations.json`
- Update `citation_coverage()` to read from both TSV column and backfilled index, fixing the cold-start penalty
- 9 new tests for extraction, backfill, and coverage integration

Factory experiment 46. Closes #119.

## Test plan
- [x] `extract_citations()` correctly parses URLs, `#N` refs, and `arxiv:` IDs
- [x] `backfill_citations()` writes `citations.json` and populates from hypothesis/notes text
- [x] `citation_coverage()` reads backfilled data when TSV column is empty
- [x] All 24 research index tests pass
- [x] Lint and type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)