### PR TITLE
feat: add --no-github flag to disable GitHub operations

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1505,6 +1505,8 @@ def cmd_tmux(args: argparse.Namespace) -> int:
         run_args += f" --max-cycles {args.max_cycles}"
     if model:
         run_args += f" --model {shlex.quote(model)}"
+    if getattr(args, "no_github", False):
+        run_args += " --no-github"
 
     run_cmd_parts.append(run_args)
     shell_cmd = " && ".join(run_cmd_parts)
@@ -2389,6 +2391,10 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
     p.add_argument("--runner", choices=["claude", "bob"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
+    p.add_argument(
+        "--no-github", action="store_true", default=False,
+        help="Disable GitHub operations (issue creation, PR creation). Use for local-only experimentation.",
+    )
 
     # tmux-ls — list factory tmux sessions
     sub.add_parser("tmux-ls", help="List running factory tmux sessions")

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1243,6 +1243,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     branch = getattr(args, "branch", None)
     model = _resolve_model(args)
     runner_name = _resolve_runner(args)
+    no_github = getattr(args, "no_github", False)
 
     if mode == "research" and not research_ideation and not _has_research_target(project_path):
         print("Error: --mode research requires research_target in factory.md. "
@@ -1274,6 +1275,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         discover_only=discover_only,
         interactive_idea=interactive_idea,
         research_ideation=research_ideation,
+        no_github=no_github,
     )
 
     from factory.checkpoint import clear_checkpoint, format_checkpoint, load_checkpoint
@@ -1303,7 +1305,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             project_path, focus=focus,
             min_growth=min_growth, max_new=max_new, branch=branch,
             already_improved=mode in ("improve", "meta") or discover_only,
-            model=model,
+            model=model, no_github=no_github,
         )
 
     # Interactive foreground mode: use runner's interactive_exec
@@ -1676,6 +1678,7 @@ def _build_ceo_task(
     discover_only: bool = False,
     interactive_idea: str | None = None,
     research_ideation: str | None = None,
+    no_github: bool = False,
 ) -> str:
     """Build the CEO agent task string from mode and optional context."""
     task = f"Project: {project_path}\nMode: {mode}"
@@ -1752,6 +1755,15 @@ def _build_ceo_task(
     if context:
         task += f"\n\n## Project Specification\n\n{context}"
 
+    if no_github:
+        task += (
+            "\n\n## GitHub Disabled (--no-github)\n\n"
+            "**CRITICAL:** Do NOT create GitHub issues or PRs. This run is local-only.\n"
+            "- Skip step 2c (Create GitHub Issue) entirely\n"
+            "- Skip PR creation in the Builder agent task\n"
+            "- Experiments still work — just no GitHub tracking\n"
+        )
+
     if mode == "build":
         task += (
             "\n\nRun Build mode: the project is new or incomplete. Follow the Build mode "
@@ -1800,6 +1812,7 @@ def _chain_modes(
     already_improved: bool = False,
     max_chains: int = 3,
     model: str | None = None,
+    no_github: bool = False,
 ) -> int:
     """After a cycle completes, re-detect state and chain into the next mode.
 
@@ -1826,7 +1839,7 @@ def _chain_modes(
         code = _run_single_cycle(
             project_path, next_mode, focus=focus,
             min_growth=min_growth, max_new=max_new, branch=branch,
-            model=model,
+            model=model, no_github=no_github,
         )
         if code != 0:
             return code
@@ -1844,6 +1857,7 @@ def _run_single_cycle(
     branch: str | None = None,
     discover_only: bool = False,
     model: str | None = None,
+    no_github: bool = False,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
     from factory.agents.runner import invoke_agent
@@ -1856,7 +1870,7 @@ def _run_single_cycle(
     task = _build_ceo_task(
         project_path, mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
-        discover_only=discover_only,
+        discover_only=discover_only, no_github=no_github,
     )
 
     checkpoint = load_checkpoint(project_path)
@@ -1896,6 +1910,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)
     model = _resolve_model(args)
+    no_github = getattr(args, "no_github", False)
 
     if focus and loop:
         print("Error: --focus (targeted mode) and --loop are mutually exclusive. "
@@ -1913,7 +1928,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     _print_banner(mode)
     _ensure_dashboard(project_path)
 
-    budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch)
+    budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch, no_github=no_github)
     skip_improve = mode in ("improve", "meta") or discover_only
 
     if not loop:
@@ -1926,7 +1941,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         return _chain_modes(
             project_path, focus=focus, already_improved=skip_improve,
             min_growth=min_growth, max_new=max_new, branch=branch,
-            model=model,
+            model=model, no_github=no_github,
         )
 
     # Heartbeat loop mode
@@ -1958,7 +1973,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             _chain_modes(
                 project_path, focus=focus, already_improved=skip_improve,
                 min_growth=min_growth, max_new=max_new, branch=branch,
-                model=model,
+                model=model, no_github=no_github,
             )
             _emit_cli_event(project_path, "cycle.completed", {"cycle": cycle, "mode": mode})
 
@@ -2300,6 +2315,10 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
     p.add_argument("--runner", choices=["claude", "bob"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
+    p.add_argument(
+        "--no-github", action="store_true", default=False,
+        help="Disable GitHub operations (issue creation, PR creation). Use for local-only experimentation.",
+    )
 
     # run
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
@@ -2346,6 +2365,10 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
     p.add_argument("--runner", choices=["claude", "bob"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
+    p.add_argument(
+        "--no-github", action="store_true", default=False,
+        help="Disable GitHub operations (issue creation, PR creation). Use for local-only experimentation.",
+    )
 
     # tmux — launch factory run in a detached tmux session
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1928,13 +1928,13 @@ def cmd_run(args: argparse.Namespace) -> int:
     _print_banner(mode)
     _ensure_dashboard(project_path)
 
-    budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch, no_github=no_github)
+    budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch)
     skip_improve = mode in ("improve", "meta") or discover_only
 
     if not loop:
         code = _run_single_cycle(
             project_path, mode, context, focus=focus, prompt_file=prompt_file,
-            discover_only=discover_only, model=model, **budget_kwargs,
+            discover_only=discover_only, model=model, no_github=no_github, **budget_kwargs,
         )
         if code != 0:
             return code
@@ -1968,7 +1968,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
             _run_single_cycle(
                 project_path, mode, context, focus=focus, prompt_file=prompt_file,
-                discover_only=discover_only, model=model, **budget_kwargs,
+                discover_only=discover_only, model=model, no_github=no_github, **budget_kwargs,
             )
             _chain_modes(
                 project_path, focus=focus, already_improved=skip_improve,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1001,6 +1001,28 @@ class TestCmdCeo:
         args = parser.parse_args(["ceo", "/some/path"])
         assert args.headless is False
 
+    def test_ceo_headless_no_github_includes_directive(self, tmp_path):
+        """cmd_ceo --headless --no-github includes GitHub Disabled directive in task."""
+        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
+             patch("factory.cli._chain_modes", return_value=0):
+            result = main(["ceo", str(tmp_path), "--headless", "--no-github"])
+        assert result == 0
+        task = mock_agent.call_args[0][1]
+        assert "## GitHub Disabled (--no-github)" in task
+        assert "Do NOT create GitHub issues or PRs" in task
+
+    def test_ceo_foreground_no_github_includes_directive(self, tmp_path):
+        """cmd_ceo --no-github (foreground) includes GitHub Disabled directive."""
+        with patch("factory.cli.os.execvp") as mock_exec, \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", str(tmp_path), "--no-github"])
+        cmd = mock_exec.call_args[0][1]
+        # Find the task argument (after --dangerously-skip-permissions)
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "## GitHub Disabled (--no-github)" in task
+        assert "Do NOT create GitHub issues or PRs" in task
+
 
 class TestSlugify:
     def test_basic_slug(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1024,6 +1024,62 @@ class TestCmdCeo:
         assert "Do NOT create GitHub issues or PRs" in task
 
 
+class TestCmdTmuxNoGithub:
+    def test_tmux_parser_has_no_github_flag(self):
+        """Parser accepts --no-github flag on tmux command."""
+        parser = build_parser()
+        args = parser.parse_args(["tmux", "/some/path", "--no-github"])
+        assert args.no_github is True
+
+    def test_tmux_parser_default_no_github_false(self):
+        """Parser defaults --no-github to False on tmux command."""
+        parser = build_parser()
+        args = parser.parse_args(["tmux", "/some/path"])
+        assert args.no_github is False
+
+    def test_tmux_forwards_no_github_flag(self, tmp_path):
+        """cmd_tmux --no-github includes the flag in the shell command."""
+        def mock_subprocess_run(args, **kwargs):
+            result = type("Result", (), {"returncode": 1 if "has-session" in args else 0})()
+            return result
+
+        with patch("factory.cli.subprocess.run", side_effect=mock_subprocess_run) as mock_run, \
+             patch("factory.cli._tmux_available", return_value=True):
+            main(["tmux", str(tmp_path), "--no-github"])
+
+        # Find the new-session call (second call after has-session check fails)
+        new_session_call = None
+        for call in mock_run.call_args_list:
+            if "new-session" in call[0][0]:
+                new_session_call = call
+                break
+
+        assert new_session_call is not None, "new-session call not found"
+        shell_cmd = new_session_call[0][0][-1]  # Last arg is the shell command
+        assert "--no-github" in shell_cmd
+
+    def test_tmux_without_no_github_flag(self, tmp_path):
+        """cmd_tmux without --no-github does not include the flag."""
+        def mock_subprocess_run(args, **kwargs):
+            result = type("Result", (), {"returncode": 1 if "has-session" in args else 0})()
+            return result
+
+        with patch("factory.cli.subprocess.run", side_effect=mock_subprocess_run) as mock_run, \
+             patch("factory.cli._tmux_available", return_value=True):
+            main(["tmux", str(tmp_path)])
+
+        # Find the new-session call
+        new_session_call = None
+        for call in mock_run.call_args_list:
+            if "new-session" in call[0][0]:
+                new_session_call = call
+                break
+
+        assert new_session_call is not None, "new-session call not found"
+        shell_cmd = new_session_call[0][0][-1]
+        assert "--no-github" not in shell_cmd
+
+
 class TestSlugify:
     def test_basic_slug(self):
         assert _slugify("Locals Know") == "locals-know"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -828,6 +828,19 @@ class TestHeartbeatLoop:
         out = capsys.readouterr().out
         assert "[factory] Cycle 1 completed. Sleeping for 60s..." in out
 
+    def test_loop_passes_no_github_flag(self, tmp_path):
+        """--no-github flag is propagated through the loop path."""
+        with patch("factory.cli._run_single_cycle", return_value=0) as mock_cycle, \
+             patch("factory.cli._chain_modes", return_value=0) as mock_chain:
+            result = main([
+                "run", str(tmp_path), "--loop", "--max-cycles", "1", "--no-github",
+            ])
+        assert result == 0
+        mock_cycle.assert_called_once()
+        assert mock_cycle.call_args.kwargs.get("no_github") is True
+        mock_chain.assert_called_once()
+        assert mock_chain.call_args.kwargs.get("no_github") is True
+
 
 # ── Factory v2: agent and ceo commands ────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds `--no-github` CLI flag to both `factory ceo` and `factory run` commands
- When enabled, injects a directive into the CEO task to skip GitHub issue/PR creation
- Propagates the flag through `_build_ceo_task()`, `_run_single_cycle()`, and `_chain_modes()` call chain

## Test plan
- [x] All 102 CLI tests pass (`pytest tests/test_cli.py -v`)
- [x] Parser correctly recognizes `--no-github` flag on both commands
- [x] Directive text is correctly injected when flag is set
- [x] No directive when flag is not set (default behavior unchanged)

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)