### PR TITLE
fix: interactive mode treats idea string as file path

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1116,11 +1116,17 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                   "backlog items.", file=sys.stderr)
             return 1
 
-    project_path, context = _resolve_input(raw_path)
     interactive_idea: str | None = None
     if mode == "interactive":
-        interactive_idea = context or "(ask the user to describe their idea)"
-        context = None  # idea is embedded in the Phase 0 block, not as Project Specification
+        # In interactive mode the positional arg is always an idea string, not a path.
+        # Skip _resolve_input to avoid misinterpreting the idea as a file/directory.
+        interactive_idea = raw_path
+        slug = _slugify(raw_path[:50])
+        project_path = _PROJECTS_DIR / slug
+        _ensure_repo(project_path)
+        context = None
+    else:
+        project_path, context = _resolve_input(raw_path)
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
     if mode == "auto":


### PR DESCRIPTION
## Summary
- When using `factory ceo "some idea" --mode interactive`, the idea string was passed through `_resolve_input()` which checks if it matches an existing file or directory. If it did, the idea got misinterpreted as a file/dir path instead of a raw idea.
- Fix: skip `_resolve_input` entirely in interactive mode — create the project directory directly from the slugified idea string.

## Test plan
- [x] All 228 existing CLI/CEO tests pass
- [ ] Manual: `factory ceo "distributed eval runner" --mode interactive` no longer errors about file not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)