### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.2.0 (2026-04-29)
+
+### Features
+
+- **Bob Shell runner** — Alternative CLI backend via `--runner bob` or `FACTORY_RUNNER=bob`. Protocol-based runner abstraction (`factory/runners/`) with dry-run mode (`FACTORY_BOB_DRY_RUN=1`), per-cycle and per-day invocation ceilings, auth persistence for nested subagents, and streaming output with role-prefixed lines
+- **CEO completion guard** — Auto-resumes when the CEO exits before all planned work is complete. Cycle state persists in `.factory/state/cycle.json` across respawns, with cross-cycle scoping (timestamps in `results.tsv`) to prevent stale experiment contamination. Configurable max respawns via `FACTORY_CEO_MAX_RESPAWNS`, 24-hour staleness threshold, and budget-aware re-spawn gating
+- **Interactive ideation mode** — `factory ceo "idea" --mode interactive` launches a research → brainstorm → refine loop before any code is written. The new Distiller agent synthesizes research and user feedback into a structured project spec (`idea.md`). Up to 5 refinement iterations with targeted follow-up research
+- **Focused mode** — `--focus "target"` pins a single backlog item and scopes the entire pipeline: one item, one hypothesis, one experiment, done. Requires improve mode, mutually exclusive with `--loop`
+- **Unified backlog** — Replaces the old deferred-items system with `.factory/strategy/backlog.md`. The Strategist clears backlog items each cycle with convergence tracking — new items are capped, backlog must shrink not grow. CLI: `factory backlog-list`, `factory backlog-add`, `factory backlog-remove`
+- **Session summaries** — End-of-cycle reports via `factory summary`: what was built (kept experiments with score deltas), what was deferred, what needs human input. Written to `.factory/reviews/session-summary.md`
+- **Experiment checkpoint/resume** — Per-experiment CEO state saved via `factory checkpoint` for crash-resilient recovery. Includes completed agents, pending agents, hypothesis state, and completed experiment IDs
+- **Auto-discovery** — Managed projects auto-detected from projects directory. `factory study` scans sibling projects for cross-project insights
+- **Citation backfill** — Research grounding scores now extract and backfill citations from experiment history for more accurate `research_grounding` dimension scoring
+- **Model override** — `--model` flag and `FACTORY_MODEL` env var for controlling which model agent subprocesses use
+
+### Fixes
+
+- **CEO no longer auto-merges PRs** — Leaves merge for human review, matching the no-merge policy (#125)
+- **Guard check ignores auto-generated lock files** — `uv.lock`, `package-lock.json`, etc. no longer trigger scope violations
+- **Interactive mode path resolution** — Idea strings are no longer treated as file paths (#125)
+- **Reviewer prompt** — Corrected from "merge" to "approve PR" to match the no-merge policy
+- **Discover auto-chains** — Discovery mode proceeds directly to improve mode instead of stopping
+- **Deferred item persistence** — Deferred items survive strategy rewrites across cycles
+- **Calendar-time estimate stripping** — CEO gate rejects agent outputs containing time estimates like "8-10 weeks"
+
+### Quality
+
+- **1144 tests** — Up from 878 at v0.1.0 (30% increase)
+- **Codecov** — Coverage reporting integrated into CI
+
 ## v0.1.1 (2026-04-24)
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Runner: Claude Code](https://img.shields.io/badge/runner-Claude_Code-7c3aed)](https://docs.anthropic.com/en/docs/claude-code)
-[![Runner: Bob Shell](https://img.shields.io/badge/runner-Bob_Shell-f59e0b)](https://bobshell.ai)
+[![Runner: Bob Shell](https://img.shields.io/badge/runner-Bob_Shell-f59e0b)](https://bob.ibm.com)
 
 **Describe what you want. The Factory builds it, tests it, and keeps improving it — autonomously.** You give it a spec file, a rough idea, or an existing codebase. The Factory researches best practices, scaffolds the project, sets up evaluation, and runs a continuous improvement loop — measuring every change and keeping only what makes things better. The agents that do this work learn from every experiment and get sharper over time.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![codecov](https://codecov.io/gh/akashgit/remote-factory/graph/badge.svg)](https://codecov.io/gh/akashgit/remote-factory)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Runner: Claude Code](https://img.shields.io/badge/runner-Claude_Code-7c3aed)](https://docs.anthropic.com/en/docs/claude-code)
+[![Runner: Bob Shell](https://img.shields.io/badge/runner-Bob_Shell-f59e0b)](https://bobshell.ai)
 
 **Describe what you want. The Factory builds it, tests it, and keeps improving it — autonomously.** You give it a spec file, a rough idea, or an existing codebase. The Factory researches best practices, scaffolds the project, sets up evaluation, and runs a continuous improvement loop — measuring every change and keeping only what makes things better. The agents that do this work learn from every experiment and get sharper over time.
 
@@ -24,6 +26,21 @@ factory ceo ~/my-project --focus "add WebSocket support"
 The CEO runs as a foreground Claude Code session — you can talk to it at any time, just like you would with Claude Code. Ask it what it's doing, steer it if something looks off, provide missing credentials, or redirect its focus mid-cycle. It's autonomous by default, collaborative when you want it to be.
 
 Under the hood, the CEO orchestrates seven specialists — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Distiller — each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. Every change is a hypothesis: scored before and after, kept only if it improves the score, archived as institutional memory. Failed experiments aren't wasted — they teach the agents what to avoid next time.
+
+## What's New in v0.2.0
+
+- **Bob Shell runner** — Alternative CLI backend via `--runner bob`. Includes dry-run mode, per-cycle/daily usage ceilings, and auth persistence for nested subagents
+- **Interactive ideation** — `--mode interactive` launches a research → brainstorm → refine loop with the new Distiller agent before any code is written
+- **Focused mode** — `--focus "add auth"` pins a single backlog item: one hypothesis, one experiment, done
+- **CEO completion guard** — Auto-resumes when the CEO exits prematurely. Cycle state persists across respawns with cross-cycle scoping to prevent stale experiment contamination
+- **Unified backlog** — Replaces the old deferred-items system. The Strategist clears backlog items each cycle with convergence tracking
+- **Session summaries** — End-of-cycle reports: what was built, what was deferred, what needs human input
+- **Experiment checkpoint/resume** — CEO saves progress per-experiment for crash-resilient recovery
+- **Auto-discovery** — Managed projects are auto-detected from the projects directory
+- **Citation backfill** — Research grounding scores now extract and backfill citations from experiment history
+- **1144 tests** — Up from 878 at initial release
+
+See the [full changelog](CHANGELOG.md) for details.
 
 ## How It Works
 
@@ -351,7 +368,7 @@ See `factory --help` for the complete list.
 
 ```bash
 uv sync --all-groups              # Install all deps including dev
-uv run pytest -v                  # 954 tests
+uv run pytest -v                  # 1144 tests
 uv run ruff check .               # Lint
 uv run mypy factory/              # Type check
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "remote-factory"
-version = "0.1.2"
+version = "0.2.0"
 description = "A harness for agentic software evolution — detect, delegate, evaluate, archive"
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -1293,7 +1293,7 @@ wheels = [
 
 [[package]]
 name = "remote-factory"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Add runner badges (Claude Code + Bob Shell) to README header
- Add "What's New in v0.2.0" section to README highlighting all major features since v0.1.1
- Full v0.2.0 changelog entry covering 84 commits: Bob Shell runner, CEO completion guard, interactive ideation, focused mode, unified backlog, session summaries, checkpoint/resume, auto-discovery, citation backfill
- Bump version to 0.2.0 in pyproject.toml + uv.lock
- Update test count from 954 to 1144

## Test plan

- [ ] Verify shields.io badge URLs render correctly on GitHub
- [ ] Verify changelog links and formatting render correctly
- [ ] `uv run pytest --co -q` confirms 1144 tests
- [ ] `uv run ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)