### PR TITLE
feat: add research mode models, config parsing, and CLI wiring

### DIFF
--- a/factory/agents/prompts/failure_analyst.md
+++ b/factory/agents/prompts/failure_analyst.md
@@ -1,0 +1,99 @@
+# Failure Analyst Agent
+
+You are the Failure Analyst agent for the Software Factory's Research mode. Your job is to read run artifacts from a research experiment, classify failures by stage and root cause, and produce a structured analysis that the Strategist uses to form targeted hypotheses.
+
+## What You Do
+
+1. **Read run artifacts**: Load structured outputs (JSON results, logs, transcripts) from `.factory/research/runs/<cycle>/`
+2. **Classify per-instance failures**: For each instance in the problem set, identify the failure stage and root cause
+3. **Identify cross-instance patterns**: Aggregate failures into categories and compute distribution
+4. **Compare with prior cycles**: If previous runs exist, report what improved and what regressed
+5. **Suggest targeted interventions**: For each dominant failure mode, suggest specific system changes
+
+## Input
+
+You will be given:
+- The run directory path (`.factory/research/runs/<cycle>/`)
+- The research target config (objective, metric, target value)
+- The result summary (resolved/total, metric value)
+- Prior run summaries for comparison (if available)
+- The list of mutable surfaces (files the system is allowed to change)
+
+## Analysis Framework
+
+### Per-Instance Classification
+
+For each instance in the results, produce:
+
+```
+Instance <id>:
+  Status: PASS | FAIL | ERROR | TIMEOUT
+  Stage: <which pipeline stage failed — e.g., localization, planning, execution, validation>
+  Failure: <what specifically went wrong>
+  Root cause: <why it went wrong — be specific>
+  Category: <failure category — use UPPERCASE_SNAKE_CASE, e.g., LOCALIZATION_MISS, PATCH_INVALID>
+  Suggested fix: <targeted intervention within mutable surfaces>
+```
+
+### Aggregated Failure Distribution
+
+```
+Failure Distribution:
+  CATEGORY_A: N instances (X%)
+  CATEGORY_B: M instances (Y%)
+  ...
+
+Dominant failure mode: CATEGORY_A (X%)
+```
+
+### Cross-Cycle Comparison (if prior runs exist)
+
+```
+Cycle Comparison (<previous> → <current>):
+  Resolved: N → M (delta: +/- K)
+  CATEGORY_A: N → M (trend: improving | regressing | stable)
+  CATEGORY_B: N → M (trend: ...)
+  
+  Improvements: <what got better and likely why>
+  Regressions: <what got worse and likely why>
+  New failures: <failure modes not seen in prior cycle>
+```
+
+## Output
+
+Write your analysis to `.factory/research/runs/<cycle>/failure_analysis.md` with the following structure:
+
+```markdown
+# Failure Analysis — Cycle <N>
+
+## Summary
+- Instances: <resolved>/<total> (<metric_value>)
+- Dominant failure mode: <category> (<percentage>%)
+- Comparison with prior cycle: <improving | regressing | new baseline>
+
+## Per-Instance Results
+<per-instance classification for each instance>
+
+## Failure Distribution
+<aggregated failure categories with counts and percentages>
+
+## Cross-Cycle Comparison
+<comparison with prior run, or "First run — no prior data" for baseline>
+
+## Recommended Interventions
+<ranked list of suggested changes, most impactful first>
+<each intervention should name specific files within mutable surfaces>
+
+## Failure Taxonomy Update
+<any new failure categories discovered this cycle>
+```
+
+## Rules
+
+- **Be specific.** "The agent failed" is not a classification. "The Cartographer ranked the correct file #7 out of 12 because it followed import chains only 2 levels deep" is a classification.
+- **Use structured data.** Parse JSON, JSONL, and log files programmatically. Don't skim — extract.
+- **Respect mutable surfaces.** Suggested fixes must only reference files within the declared mutable surfaces. Never suggest changes to fixed surfaces (eval infrastructure, test data, ground truth).
+- **Pipeline outputs are authoritative.** Don't second-guess results. If the test says FAIL, it's FAIL. Your job is to explain WHY, not to dispute the outcome.
+- **Prioritize by frequency.** The dominant failure mode gets the most attention. Fixing 60% of failures in one category is better than fixing 5% across six categories.
+- **Track the failure taxonomy.** If you discover a new failure category not seen in prior cycles, name it clearly and add it to the taxonomy. Use consistent naming across cycles.
+- **Compare fairly.** When comparing cycles, account for any changes in the problem set. If new instances were added, don't attribute their failures to regression.

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -12,7 +12,10 @@ from factory.runners import get_runner
 
 logger = logging.getLogger(__name__)
 
-AgentRole = Literal["researcher", "strategist", "builder", "reviewer", "evaluator", "archivist", "distiller", "ceo"]
+AgentRole = Literal[
+    "researcher", "strategist", "builder", "reviewer", "evaluator",
+    "archivist", "distiller", "ceo", "failure_analyst",
+]
 
 # Consecutive failure tracking
 _consecutive_failures: int = 0

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1536,6 +1536,16 @@ def _auto_detect_mode(project_path: Path, has_prompt: bool = False, force_fresh:
         ProjectState.HAS_FACTORY: "improve",
     }
     mode = mode_map[state]
+
+    if state == ProjectState.HAS_FACTORY:
+        try:
+            from factory.store import ExperimentStore
+            config = _run(ExperimentStore(project_path).read_config())
+            if config.research_target is not None:
+                mode = "research"
+        except Exception:
+            pass
+
     print(f"  State: {state.value} → mode: {mode}", file=sys.stderr)
     return mode
 
@@ -1634,6 +1644,15 @@ def _build_ceo_task(
             "\n\nRun Meta mode: full self-improvement. First, run the complete Improve loop "
             "on this project (experiments, keep/revert decisions). Then run ACE playbook "
             "evolution for all agent roles using cross-project experiment data."
+        )
+    elif mode == "research":
+        task += (
+            "\n\nRun Research mode: the project has a research target defined in factory.md. "
+            "Read the research_target from config.json to understand the objective, metric, "
+            "target value, and run command. Each cycle: form a hypothesis to improve the "
+            "metric, implement the change within mutable_surfaces only (leave fixed_surfaces "
+            "untouched), run the research command, compare results against the target, and "
+            "make a keep/revert decision. Respect research_constraints and cost_budget."
         )
 
     return task
@@ -2105,10 +2124,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "interactive"],
+        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "interactive", "research"],
         default="auto",
         help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
-             "build, discover, improve, meta, or interactive (research + brainstorm → spec → build)",
+             "build, discover, improve, meta, interactive (research + brainstorm → spec → build), "
+             "or research (autonomous research optimization)",
     )
     p.add_argument(
         "--focus", default=None,
@@ -2143,10 +2163,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta"],
+        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "research"],
         default="auto",
         help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
-             "build, discover, improve, or meta",
+             "build, discover, improve, meta, or research",
     )
     p.add_argument(
         "--focus", default=None,
@@ -2185,7 +2205,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--session", default=None, help="Custom tmux session name")
     p.add_argument(
         "--mode",
-        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta"],
+        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "research"],
         default="auto",
         help="Run mode (default: auto, respects in-flight cycle)",
     )

--- a/factory/models.py
+++ b/factory/models.py
@@ -57,6 +57,29 @@ class EvalWeights(BaseModel):
     project: float = 0.0
 
 
+class ResearchTarget(BaseModel):
+    """Research mode target — defines the objective, metric, and how to measure it."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    objective: str
+    metric: str
+    target: float
+    run_command: str
+    result_path: str
+    result_parser: str = "json"
+    timeout: int = 3600
+
+
+class CostBudgetConfig(BaseModel):
+    """Per-project cost budget limits for research mode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    max_per_cycle: float | None = None
+    max_total: float | None = None
+
+
 class FactoryConfig(BaseModel):
     """Machine-readable config stored at .factory/config.json."""
 
@@ -73,6 +96,11 @@ class FactoryConfig(BaseModel):
     smoke_test: str = ""
     project_eval: list[ProjectEvalDimension] = []
     eval_weights: EvalWeights = EvalWeights()
+    research_target: ResearchTarget | None = None
+    mutable_surfaces: list[str] = []
+    fixed_surfaces: list[str] = []
+    research_constraints: list[str] = []
+    cost_budget: CostBudgetConfig | None = None
 
 
 # ── eval ──────────────────────────────────────────────────────────
@@ -298,7 +326,7 @@ class CycleState(BaseModel):
 
     cycle_id: str
     started_at: datetime
-    mode: Literal["build", "discover", "improve", "meta"]
+    mode: Literal["build", "discover", "improve", "meta", "research"]
     initial_prompt: str = ""
     respawns: int = 0
     runner_name: str | None = None

--- a/factory/store.py
+++ b/factory/store.py
@@ -12,12 +12,14 @@ import structlog
 
 from factory.models import (
     CompositeScore,
+    CostBudgetConfig,
     EvalProfile,
     EvalWeights,
     ExperimentRecord,
     FactoryConfig,
     HypothesisBudget,
     ProjectEvalDimension,
+    ResearchTarget,
 )
 
 log = structlog.get_logger()
@@ -79,6 +81,39 @@ def _parse_project_eval(items: str | list[str] | float) -> list[ProjectEvalDimen
             description=fields.get("description", ""),
         ))
     return dims
+
+
+def _parse_research_target(items: str | list[str] | float) -> ResearchTarget | None:
+    """Parse research target key-value block from factory.md."""
+    kv = _parse_kv_list(items, str)
+    if not kv:
+        return None
+    objective = str(kv.get("Objective", ""))
+    metric = str(kv.get("Metric", ""))
+    run_command = str(kv.get("Run Command", ""))
+    result_path = str(kv.get("Result Path", ""))
+    if not objective or not metric or not run_command or not result_path:
+        return None
+    return ResearchTarget(
+        objective=objective,
+        metric=metric,
+        target=float(str(kv.get("Target", "0.0"))),
+        run_command=run_command,
+        result_path=result_path,
+        result_parser=str(kv.get("Result Parser", "json")),
+        timeout=int(float(str(kv.get("Timeout", "3600")))),
+    )
+
+
+def _parse_cost_budget(items: str | list[str] | float) -> CostBudgetConfig | None:
+    """Parse cost budget key-value block from factory.md."""
+    kv = _parse_kv_list(items, float)
+    if not kv:
+        return None
+    return CostBudgetConfig(
+        max_per_cycle=float(str(kv["Max per cycle"])) if "Max per cycle" in kv else None,
+        max_total=float(str(kv["Max total"])) if "Max total" in kv else None,
+    )
 
 
 class ExperimentStore:
@@ -179,6 +214,16 @@ class ExperimentStore:
         smoke_test_raw = parsed.get("smoke_test", "")
         smoke_test = str(smoke_test_raw).strip() if smoke_test_raw else ""
 
+        research_target = _parse_research_target(parsed.get("research_target", []))
+        cost_budget = _parse_cost_budget(parsed.get("cost_budget", []))
+
+        mutable_raw = parsed.get("mutable_surfaces", [])
+        mutable_surfaces = list(mutable_raw) if isinstance(mutable_raw, list) else []
+        fixed_raw = parsed.get("fixed_surfaces", [])
+        fixed_surfaces = list(fixed_raw) if isinstance(fixed_raw, list) else []
+        rc_raw = parsed.get("research_constraints", [])
+        research_constraints = list(rc_raw) if isinstance(rc_raw, list) else []
+
         config = FactoryConfig(
             goal=str(parsed.get("goal", "")),
             scope=list(parsed.get("scope", [])),  # type: ignore[arg-type]
@@ -191,6 +236,11 @@ class ExperimentStore:
             smoke_test=smoke_test,
             project_eval=project_eval_dims,
             eval_weights=EvalWeights(**weights_kwargs) if weights_kwargs else EvalWeights(),  # type: ignore[arg-type]
+            research_target=research_target,
+            mutable_surfaces=mutable_surfaces,
+            fixed_surfaces=fixed_surfaces,
+            research_constraints=research_constraints,
+            cost_budget=cost_budget,
         )
 
         (self.factory_dir / "config.json").write_text(

--- a/factory/store.py
+++ b/factory/store.py
@@ -93,8 +93,9 @@ def _parse_research_target(items: str | list[str] | float) -> ResearchTarget | N
     run_command = str(kv.get("Run Command", ""))
     result_path = str(kv.get("Result Path", ""))
     if not objective or not metric or not run_command or not result_path:
+        log.debug("research_target_incomplete", keys=list(kv.keys()))
         return None
-    return ResearchTarget(
+    rt = ResearchTarget(
         objective=objective,
         metric=metric,
         target=float(str(kv.get("Target", "0.0"))),
@@ -103,6 +104,8 @@ def _parse_research_target(items: str | list[str] | float) -> ResearchTarget | N
         result_parser=str(kv.get("Result Parser", "json")),
         timeout=int(float(str(kv.get("Timeout", "3600")))),
     )
+    log.debug("research_target_parsed", metric=metric, target=rt.target)
+    return rt
 
 
 def _parse_cost_budget(items: str | list[str] | float) -> CostBudgetConfig | None:
@@ -110,10 +113,12 @@ def _parse_cost_budget(items: str | list[str] | float) -> CostBudgetConfig | Non
     kv = _parse_kv_list(items, float)
     if not kv:
         return None
-    return CostBudgetConfig(
+    budget = CostBudgetConfig(
         max_per_cycle=float(str(kv["Max per cycle"])) if "Max per cycle" in kv else None,
         max_total=float(str(kv["Max total"])) if "Max total" in kv else None,
     )
+    log.debug("cost_budget_parsed", max_per_cycle=budget.max_per_cycle, max_total=budget.max_total)
+    return budget
 
 
 class ExperimentStore:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -25,7 +25,10 @@ class TestResolvePrompt:
         assert len(prompt) > 100
 
     def test_all_default_prompts_exist(self):
-        roles: list[AgentRole] = ["researcher", "strategist", "evaluator", "reviewer", "archivist", "distiller", "ceo"]
+        roles: list[AgentRole] = [
+            "researcher", "strategist", "evaluator", "reviewer",
+            "archivist", "distiller", "ceo", "failure_analyst",
+        ]
         for role in roles:
             prompt = resolve_prompt(role)
             assert len(prompt) > 50, f"Prompt for {role} is too short"
@@ -64,10 +67,19 @@ class TestResolvePrompt:
         assert _PROMPTS_DIR.is_dir()
 
     def test_each_prompt_has_header(self):
-        roles: list[AgentRole] = ["researcher", "strategist", "evaluator", "reviewer", "archivist", "distiller", "ceo"]
+        roles: list[AgentRole] = [
+            "researcher", "strategist", "evaluator", "reviewer",
+            "archivist", "distiller", "ceo", "failure_analyst",
+        ]
         for role in roles:
             prompt = resolve_prompt(role)
             assert prompt.startswith("# "), f"Prompt for {role} should start with '# '"
+
+    def test_failure_analyst_prompt_content(self):
+        prompt = resolve_prompt("failure_analyst")
+        assert "Failure Analyst" in prompt
+        assert "failure_analysis.md" in prompt
+        assert "Per-Instance Classification" in prompt
 
 
 class TestResearcherPromptModes:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -919,3 +919,59 @@ class TestResolveInput:
         task_arg = mock_agent.call_args[0][1]  # second positional = task
         assert "Build X that does Y" in task_arg
         assert "Project Specification" in task_arg
+
+
+class TestResearchMode:
+    def test_ceo_parser_accepts_research_mode(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path", "--mode", "research"])
+        assert args.mode == "research"
+
+    def test_run_parser_accepts_research_mode(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--mode", "research"])
+        assert args.mode == "research"
+
+    def test_tmux_parser_accepts_research_mode(self):
+        parser = build_parser()
+        args = parser.parse_args(["tmux", "/some/path", "--mode", "research"])
+        assert args.mode == "research"
+
+    def test_research_mode_task_text(self, tmp_path):
+        """--mode research includes research-specific instructions in the CEO task."""
+        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
+             patch("factory.cli._chain_modes", return_value=0):
+            result = main(["ceo", str(tmp_path), "--mode", "research", "--headless"])
+        assert result == 0
+        task = mock_agent.call_args[0][1]
+        assert "Research mode" in task
+        assert "research_target" in task
+
+    def test_auto_detect_research_mode(self, tmp_project, sample_config):
+        """Auto-detection returns 'research' when config has research_target."""
+        from factory.models import ResearchTarget
+        from factory.store import ExperimentStore
+
+        rt = ResearchTarget(
+            objective="Minimize loss",
+            metric="val_loss",
+            target=0.01,
+            run_command="python train.py",
+            result_path="metrics.json",
+        )
+        config_with_research = sample_config.model_copy(update={"research_target": rt})
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(config_with_research))
+
+        from factory.cli import _auto_detect_mode
+        mode = _auto_detect_mode(tmp_project, force_fresh=True)
+        assert mode == "research"
+
+    def test_auto_detect_improve_without_research(self, tmp_project, sample_config):
+        """Auto-detection returns 'improve' when no research_target is set."""
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+
+        from factory.cli import _auto_detect_mode
+        mode = _auto_detect_mode(tmp_project, force_fresh=True)
+        assert mode == "improve"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,9 @@ from datetime import datetime
 
 from factory.models import (
     CostBudget,
+    CostBudgetConfig,
     CompositeScore,
+    CycleState,
     EvalDimension,
     EvalProfile,
     EvalResult,
@@ -14,6 +16,7 @@ from factory.models import (
     Hypothesis,
     ProjectProfile,
     ProjectState,
+    ResearchTarget,
 )
 
 
@@ -195,3 +198,123 @@ class TestCostBudget:
     def test_custom_budget(self):
         b = CostBudget(per_experiment_max=5.0, per_session_max=50.0)
         assert b.per_experiment_max == 5.0
+
+
+class TestResearchTarget:
+    def test_valid_target(self):
+        t = ResearchTarget(
+            objective="Minimize latency",
+            metric="p99_latency_ms",
+            target=50.0,
+            run_command="python benchmark.py",
+            result_path="results/benchmark.json",
+        )
+        assert t.objective == "Minimize latency"
+        assert t.result_parser == "json"
+        assert t.timeout == 3600
+
+    def test_custom_defaults(self):
+        t = ResearchTarget(
+            objective="Maximize accuracy",
+            metric="accuracy",
+            target=0.95,
+            run_command="python train.py",
+            result_path="results.json",
+            result_parser="exit_code",
+            timeout=7200,
+        )
+        assert t.result_parser == "exit_code"
+        assert t.timeout == 7200
+
+    def test_rejects_extra_fields(self):
+        with pytest.raises(Exception):
+            ResearchTarget(
+                objective="x", metric="y", target=1.0,
+                run_command="z", result_path="r", extra="bad",
+            )
+
+
+class TestCostBudgetConfig:
+    def test_defaults_none(self):
+        c = CostBudgetConfig()
+        assert c.max_per_cycle is None
+        assert c.max_total is None
+
+    def test_custom_values(self):
+        c = CostBudgetConfig(max_per_cycle=5.0, max_total=100.0)
+        assert c.max_per_cycle == 5.0
+        assert c.max_total == 100.0
+
+    def test_partial_values(self):
+        c = CostBudgetConfig(max_per_cycle=2.5)
+        assert c.max_per_cycle == 2.5
+        assert c.max_total is None
+
+    def test_rejects_extra_fields(self):
+        with pytest.raises(Exception):
+            CostBudgetConfig(max_per_cycle=1.0, extra="bad")
+
+
+class TestFactoryConfigResearchFields:
+    def test_defaults_preserve_backward_compat(self):
+        config = FactoryConfig(
+            goal="Test", scope=[], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[],
+        )
+        assert config.research_target is None
+        assert config.mutable_surfaces == []
+        assert config.fixed_surfaces == []
+        assert config.research_constraints == []
+        assert config.cost_budget is None
+
+    def test_with_research_target(self):
+        rt = ResearchTarget(
+            objective="Maximize F1",
+            metric="f1_score",
+            target=0.9,
+            run_command="python eval.py",
+            result_path="output.json",
+        )
+        config = FactoryConfig(
+            goal="Research", scope=[], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[], research_target=rt,
+            mutable_surfaces=["src/model.py"], fixed_surfaces=["data/"],
+            research_constraints=["No extra dependencies"],
+            cost_budget=CostBudgetConfig(max_per_cycle=3.0),
+        )
+        assert config.research_target is not None
+        assert config.research_target.objective == "Maximize F1"
+        assert config.mutable_surfaces == ["src/model.py"]
+        assert config.fixed_surfaces == ["data/"]
+        assert config.research_constraints == ["No extra dependencies"]
+        assert config.cost_budget is not None
+        assert config.cost_budget.max_per_cycle == 3.0
+
+    def test_roundtrip_json_with_research(self):
+        rt = ResearchTarget(
+            objective="Minimize loss",
+            metric="val_loss",
+            target=0.01,
+            run_command="python train.py",
+            result_path="metrics.json",
+        )
+        config = FactoryConfig(
+            goal="Research", scope=["src/"], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[], research_target=rt,
+            mutable_surfaces=["src/"], fixed_surfaces=["data/"],
+        )
+        data = config.model_dump()
+        restored = FactoryConfig(**data)
+        assert restored.research_target is not None
+        assert restored.research_target.objective == "Minimize loss"
+        assert restored == config
+
+
+class TestCycleStateResearchMode:
+    def test_research_mode_accepted(self):
+        cs = CycleState(
+            cycle_id="test-123",
+            started_at=datetime.now(),
+            mode="research",
+        )
+        assert cs.mode == "research"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -244,3 +244,111 @@ class TestStrategy:
     async def test_read_missing_strategy(self, store, sample_config):
         await store.init(sample_config)
         assert await store.read_strategy() is None
+
+
+class TestReparseResearchTarget:
+    """Tests for parsing research mode sections from factory.md."""
+
+    async def test_parse_research_target(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch project\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n- no deletes\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n- small changes\n\n"
+            "## Research Target\n"
+            "- Objective: Minimize latency\n"
+            "- Metric: p99_ms\n"
+            "- Target: 50.0\n"
+            "- Run Command: python benchmark.py\n"
+            "- Result Path: results/bench.json\n"
+            "- Result Parser: json\n"
+            "- Timeout: 1800\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.research_target is not None
+        assert config.research_target.objective == "Minimize latency"
+        assert config.research_target.metric == "p99_ms"
+        assert config.research_target.target == 50.0
+        assert config.research_target.run_command == "python benchmark.py"
+        assert config.research_target.result_path == "results/bench.json"
+        assert config.research_target.result_parser == "json"
+        assert config.research_target.timeout == 1800
+
+    async def test_parse_mutable_and_fixed_surfaces(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Mutable Surfaces\n"
+            "- src/model.py\n"
+            "- src/optimizer.py\n\n"
+            "## Fixed Surfaces\n"
+            "- data/\n"
+            "- configs/\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.mutable_surfaces == ["src/model.py", "src/optimizer.py"]
+        assert config.fixed_surfaces == ["data/", "configs/"]
+
+    async def test_parse_research_constraints(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Research Constraints\n"
+            "- No extra dependencies\n"
+            "- Must keep backward compat\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.research_constraints == ["No extra dependencies", "Must keep backward compat"]
+
+    async def test_parse_cost_budget(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Cost Budget\n"
+            "- Max per cycle: 5.0\n"
+            "- Max total: 50.0\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.cost_budget is not None
+        assert config.cost_budget.max_per_cycle == 5.0
+        assert config.cost_budget.max_total == 50.0
+
+    async def test_backward_compat_no_research_sections(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nNormal project\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n- no deletes\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n- small changes\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.research_target is None
+        assert config.mutable_surfaces == []
+        assert config.fixed_surfaces == []
+        assert config.research_constraints == []
+        assert config.cost_budget is None


### PR DESCRIPTION
## Summary
- Added `ResearchTarget` and `CostBudgetConfig` Pydantic models with strict validation
- Extended `FactoryConfig` with optional research fields (`research_target`, `mutable_surfaces`, `fixed_surfaces`, `research_constraints`, `cost_budget`) — all defaulted to preserve backward compatibility
- Added `"research"` to `CycleState.mode` Literal type
- Added factory.md section parsing for `## Research Target`, `## Mutable Surfaces`, `## Fixed Surfaces`, `## Research Constraints`, `## Cost Budget`
- Wired `"research"` mode into `ceo`, `run`, and `tmux` CLI subcommands
- Auto-detection returns `"research"` when config has a non-null `research_target`
- Added research-specific task text in `_build_ceo_task()`

Closes #152

## Test plan
- [x] ResearchTarget and CostBudgetConfig model validation (strict mode, extra="forbid")
- [x] FactoryConfig backward compatibility — no research fields doesn't break existing configs
- [x] FactoryConfig roundtrip JSON serialization with research fields
- [x] CycleState accepts "research" mode
- [x] factory.md parsing: Research Target, Mutable/Fixed Surfaces, Research Constraints, Cost Budget
- [x] CLI parser accepts --mode research for ceo, run, tmux
- [x] Research mode task text injected into CEO prompt
- [x] Auto-detection returns "research" when research_target is set
- [x] Auto-detection returns "improve" when no research_target
- [x] All 1159 tests pass, ruff clean, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)