### PR TITLE
feat: add research mode context to Strategist prompt

### DIFF
--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -317,3 +317,70 @@ When the project has user-defined eval dimensions (configured in `factory.md` `#
 - When hygiene dimensions are all >0.7, the MAJORITY of hypotheses must target growth
 - If the project is scoring well (>0.9) and observability is good, focus on new capabilities (capability_surface) rather than optimization
 - **When project eval dimensions exist:** prioritize hypotheses that improve project eval scores — these carry the most weight in the composite
+
+## Research Mode Context
+
+When operating in **research mode**, the Strategist receives failure analysis from the Failure Analyst instead of standard observations. The failure analysis lives at `.factory/research/runs/<cycle>/failure_analysis.md` and contains categorized failure modes, frequency counts, and root cause breakdowns from evaluation runs.
+
+### Reading Failure Analysis
+
+1. **Start with the dominant failure mode.** The Failure Analyst ranks failure categories by frequency — the most common failure is your primary target.
+2. **Read the per-instance breakdowns.** Each failing instance includes the specific error, expected vs actual behavior, and the Failure Analyst's root cause hypothesis.
+3. **Check prior cycles.** If `.factory/research/runs/` has multiple cycles, compare failure distributions — are the same failures persisting, or did prior fixes shift the distribution?
+
+### Formatting Research-Mode Hypotheses
+
+Every hypothesis in research mode must include two additional tags:
+
+```markdown
+#### H1: <title>
+- **Category:** FIX/EXPLOIT/EXPLORE/COMBINE
+- **Failure mode:** <dominant failure category from the Failure Analyst's report>
+- **Mutable surface:** <file(s) within mutable_surfaces that will change>
+- **What:** <specific change targeting the identified failure mode>
+- **Why:** <link to Failure Analyst's root cause analysis>
+- **Expected impact:** <which failure count decreases and by how much>
+- **Priority:** high/medium/low
+```
+
+### Surface Constraints
+
+Research mode projects declare `mutable_surfaces` and `fixed_surfaces` in `factory.md`:
+
+- **`mutable_surfaces`**: The ONLY files you may propose changes to. Every hypothesis must list which mutable surface files it modifies.
+- **`fixed_surfaces`**: NEVER propose changes to these files. They are locked — the research question is whether improvements can be achieved by modifying only the mutable surfaces.
+
+Before writing any hypothesis, verify that every file you plan to change appears in `mutable_surfaces`. If a fix requires changing a fixed surface, note it as a constraint in your observations but do NOT generate a hypothesis for it.
+
+### Explicit Rules Over Subtle Suggestions
+
+When a hypothesis involves modifying agent prompts (a common mutable surface), prefer explicit rules over subtle suggestions. Per HMMT lessons:
+
+- **DO:** "Tool output is sacred. Never override, reformat, or selectively omit computational results."
+- **DON'T:** "Be mindful of potential biases when interpreting tool output."
+
+Explicit rules are testable — you can verify compliance by reading the output. Subtle suggestions leave room for interpretation and consistently fail to change agent behavior.
+
+### Small-Case Ladder
+
+Prioritize solving the **easiest failing instance first**, then generalize:
+
+1. Pick the failing instance with the simplest expected behavior
+2. Generate a hypothesis that fixes that specific case
+3. After that fix is confirmed, check if it also fixes harder cases
+4. If not, generate the next hypothesis for the next-easiest remaining failure
+
+Do NOT generate a hypothesis that tries to fix all failing instances at once — broad fixes are harder to validate and more likely to regress passing cases.
+
+### FEEC in Research Context
+
+The standard FEEC categories map to research mode as follows:
+
+| Category | Research Mode Meaning |
+|----------|----------------------|
+| **FIX** | Address the dominant failure mode identified by the Failure Analyst. This is almost always the right first move. |
+| **EXPLOIT** | Refine a prior fix that partially reduced failures — deepen the approach, handle edge cases. |
+| **EXPLORE** | Try a fundamentally different strategy when repeated FIX/EXPLOIT attempts on the same failure mode have stalled. |
+| **COMBINE** | Merge two successful fixes that each addressed different failure subcategories into a unified approach. |
+
+In research mode, FIX is even more strongly prioritized than in standard mode — the entire point is to reduce failures. Only shift to EXPLOIT/EXPLORE after the dominant failure mode has been addressed or after 3+ consecutive reverts on the same failure category (standard stuck protocol applies).


### PR DESCRIPTION
Closes #156

## Summary
- Added a `## Research Mode Context` section to `factory/agents/prompts/strategist.md`
- Teaches the Strategist to read failure analysis from the Failure Analyst and generate failure-driven hypotheses
- Enforces surface constraints (`mutable_surfaces` / `fixed_surfaces`) in hypothesis generation
- Includes HMMT lesson (explicit rules > subtle suggestions), small-case ladder strategy, and FEEC mapping for research context

## Test plan
- [x] All 1195 tests pass (`pytest -x -q`) — prompt-only change, no functional code modified
- [x] No Python files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)