### PR TITLE
feat: add Researcher step (R1.5) to research mode cycle

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1316,7 +1316,7 @@ Establish the starting point by running the system and recording the baseline me
 Save crash-recovery checkpoint:
 ```bash
 factory checkpoint "$PROJECT_PATH" --save --mode research \
-  --completed "baseline" --pending "failure_analyst,strategist,builder,evaluator,archivist"
+  --completed "baseline" --pending "failure_analyst,researcher,strategist,builder,evaluator,archivist"
 ```
 
 ### Phase R1: ANALYZE (Failure Analyst Agent)
@@ -1362,12 +1362,64 @@ echo "- [x] archivist after failure analysis — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 Save crash-recovery checkpoint:
 ```bash
 factory checkpoint "$PROJECT_PATH" --save --mode research \
-  --completed "baseline,failure_analyst" --pending "strategist,builder,evaluator,archivist"
+  --completed "baseline,failure_analyst" --pending "researcher,strategist,builder,evaluator,archivist"
+```
+
+### Phase R1.5: RESEARCH (Researcher Agent)
+
+After the Failure Analyst classifies what failed and why, spawn the Researcher to search for solutions to those specific failure patterns. This step is optional — if the Researcher fails, the Strategist can still work from the failure analysis alone.
+
+```bash
+factory agent researcher --task "Mode 4 failure research for $PROJECT_PATH.
+
+Read the failure analysis at .factory/research/runs/$CYCLE_ID/failure_analysis.md.
+Read the research target config from .factory/config.json (objective: $OBJECTIVE, metric: $METRIC, target: $TARGET).
+
+The dominant failure mode is: $DOMINANT_FAILURE_MODE ($FAILURE_PERCENTAGE%)
+Current metric: $CURRENT_METRIC (target: $TARGET, previous best: $PREVIOUS_BEST)
+
+Mutable surfaces (files that CAN be changed):
+$MUTABLE_SURFACES
+
+Read the factory vault at $FACTORY_VAULT_PATH for prior knowledge on these failure patterns (skip if unset).
+
+Search the web for solutions, workarounds, and best practices for the dominant failure modes.
+Write research report to .factory/strategy/research.md" --project "$PROJECT_PATH" --timeout 300
+```
+
+If the Researcher fails, proceed — the Strategist can work from failure analysis alone.
+
+**R1.5-review: CEO Review — Research**
+
+Apply the **CEO Review Gate**:
+1. Read `.factory/reviews/researcher-latest.md` and `.factory/strategy/research.md`
+2. Check: Are findings specific to the failure patterns from R1? Did web research surface actionable fixes? Are suggested solutions within mutable surfaces?
+3. Write verdict to `.factory/reviews/ceo-verdict-researcher.md`
+4. If REDIRECT: re-invoke the Researcher with specific gaps (e.g., "Research focused on general domain, not the specific LOCALIZATION_MISS failure pattern")
+5. If PROCEED: continue to R2
+
+**MANDATORY Archivist — record research findings (DO NOT SKIP):**
+
+```bash
+factory agent archivist --task "Record the Researcher's failure-targeted findings for $PROJECT_PATH research cycle.
+Read .factory/strategy/research.md, .factory/research/runs/$CYCLE_ID/failure_analysis.md, and .factory/reviews/ceo-verdict-researcher.md.
+Write research notes to the vault." --project "$PROJECT_PATH"
+```
+
+Then write checkpoint:
+```bash
+echo "- [x] archivist after research — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PROJECT_PATH/.factory/reviews/archivist-checkpoints.md"
+```
+
+Save crash-recovery checkpoint:
+```bash
+factory checkpoint "$PROJECT_PATH" --save --mode research \
+  --completed "baseline,failure_analyst,researcher" --pending "strategist,builder,evaluator,archivist"
 ```
 
 ### Phase R2: HYPOTHESIZE (Strategist Agent)
 
-Spawn the Strategist with failure analysis context to generate targeted hypotheses.
+Spawn the Strategist with failure analysis context and research findings to generate targeted hypotheses.
 
 ```bash
 factory agent strategist --task "Generate research hypotheses for $PROJECT_PATH.
@@ -1375,6 +1427,7 @@ factory agent strategist --task "Generate research hypotheses for $PROJECT_PATH.
 Read the failure analysis at .factory/research/runs/$CYCLE_ID/failure_analysis.md.
 Read the research target config from .factory/config.json.
 Read the CEO's failure analysis review at .factory/reviews/ceo-verdict-failure_analyst.md.
+Read the CEO's research review at .factory/reviews/ceo-verdict-researcher.md (if it exists).
 
 The dominant failure mode is: $DOMINANT_FAILURE_MODE ($FAILURE_PERCENTAGE%)
 Current metric: $CURRENT_METRIC (target: $TARGET, previous best: $PREVIOUS_BEST)
@@ -1426,7 +1479,7 @@ echo "- [x] archivist after strategy — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PR
 Save crash-recovery checkpoint:
 ```bash
 factory checkpoint "$PROJECT_PATH" --save --mode research \
-  --completed "baseline,failure_analyst,strategist" --pending "builder,evaluator,archivist"
+  --completed "baseline,failure_analyst,researcher,strategist" --pending "builder,evaluator,archivist"
 ```
 
 ### Phase R3: IMPLEMENT (Builder Agent — per hypothesis)
@@ -1656,7 +1709,7 @@ echo "- [x] archivist after research experiment $EXP_ID ($VERDICT) — $(date -u
 Save crash-recovery checkpoint:
 ```bash
 factory checkpoint "$PROJECT_PATH" --save --mode research \
-  --completed "baseline,failure_analyst,strategist" --pending "builder,evaluator,archivist" \
+  --completed "baseline,failure_analyst,researcher,strategist" --pending "builder,evaluator,archivist" \
   --experiment $EXP_ID --completed-hypotheses "$COMPLETED_EXP_IDS"
 ```
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1344,7 +1344,7 @@ Produce failure_analysis.md in the run directory AND print a summary to stdout."
 2. Check: Are failures classified specifically (not vague)? Is the failure distribution computed? Are suggested interventions within mutable surfaces?
 3. Write verdict to `.factory/reviews/ceo-verdict-failure_analyst.md`
 4. If REDIRECT: re-invoke with specific gaps (e.g., "Missing per-instance classification", "Suggested fixes reference fixed surfaces")
-5. If PROCEED: continue to R2
+5. If PROCEED: continue to R1.5
 
 **MANDATORY Archivist — record failure analysis (DO NOT SKIP):**
 
@@ -1380,6 +1380,12 @@ Current metric: $CURRENT_METRIC (target: $TARGET, previous best: $PREVIOUS_BEST)
 
 Mutable surfaces (files that CAN be changed):
 $MUTABLE_SURFACES
+
+Fixed surfaces (files that MUST NOT be changed):
+$FIXED_SURFACES
+
+Research constraints:
+$RESEARCH_CONSTRAINTS
 
 Read the factory vault at $FACTORY_VAULT_PATH for prior knowledge on these failure patterns (skip if unset).
 

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -1,6 +1,6 @@
 # Researcher Agent
 
-You are the Researcher agent for the Software Factory. You have two modes of operation depending on how you are invoked.
+You are the Researcher agent for the Software Factory. You have four modes of operation depending on how you are invoked.
 
 ## Mode 1: Discovery (used in Discover mode)
 
@@ -139,7 +139,7 @@ Activate Mode 4 when the task mentions "Mode 4 failure research" or references a
 
 1. **Read the failure analysis**: Load `.factory/research/runs/<cycle>/failure_analysis.md` — this is your primary input
 2. **Extract dominant failure modes**: From the Failure Distribution section, identify the top 2-3 failure categories by frequency
-3. **Read research target config**: Understand the objective (e.g., "maximize SWE-bench resolve rate") and the mutable surfaces
+3. **Read research target config**: Understand the objective (e.g., "maximize SWE-bench resolve rate"), the mutable surfaces, and the fixed surfaces (files that MUST NOT be changed)
 4. **Check vault knowledge FIRST**: Read `$FACTORY_VAULT_PATH/20-Knowledge/Sources/` for prior knowledge on these failure categories (skip if unset). Only WebSearch for topics NOT already covered by vault sources.
 5. **Search for targeted solutions**: For each dominant failure mode, WebSearch for:
    - Known solutions, workarounds, and best practices
@@ -188,7 +188,7 @@ Write to `$PROJECT_PATH/.factory/strategy/research.md`:
 - Limit WebSearch to 5-8 queries, all focused on the specific failure patterns
 - Limit WebFetch to 3-5 pages
 - Do NOT do general domain research — Mode 2 handles that. Mode 4 is laser-focused on the failures
-- Map every finding to a mutable surface. Findings that require changing fixed surfaces should be noted as constraints, not recommendations
+- Map every finding to a mutable surface. Findings that require changing fixed surfaces (passed via the CEO's task or read from research target config) should be noted as constraints, not recommendations
 - Write report even if external search fails — include vault findings and failure analysis context
 - Do not include calendar-time estimates — same rule as Mode 2
 - Prioritize the dominant failure mode — spend 60%+ of your search budget on the #1 failure category

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -126,3 +126,69 @@ Write to `$PROJECT_PATH/.factory/strategy/research.md` with additional sections:
 - Focus on actionable meta-improvements, not theoretical frameworks
 - Prioritize changes that make the factory better at improving OTHER projects, not just itself
 - Do not include calendar-time estimates — same rule as Mode 2
+
+## Mode 4: Failure Research (used in Research mode)
+
+When invoked with "Mode 4" in the task, research solutions for specific failure patterns identified by the Failure Analyst.
+
+### Detection
+
+Activate Mode 4 when the task mentions "Mode 4 failure research" or references a `failure_analysis.md` file.
+
+### What You Do
+
+1. **Read the failure analysis**: Load `.factory/research/runs/<cycle>/failure_analysis.md` — this is your primary input
+2. **Extract dominant failure modes**: From the Failure Distribution section, identify the top 2-3 failure categories by frequency
+3. **Read research target config**: Understand the objective (e.g., "maximize SWE-bench resolve rate") and the mutable surfaces
+4. **Check vault knowledge FIRST**: Read `$FACTORY_VAULT_PATH/20-Knowledge/Sources/` for prior knowledge on these failure categories (skip if unset). Only WebSearch for topics NOT already covered by vault sources.
+5. **Search for targeted solutions**: For each dominant failure mode, WebSearch for:
+   - Known solutions, workarounds, and best practices
+   - Similar systems that solved the same class of problem
+   - Techniques specifically targeting the failure pattern (e.g., if LOCALIZATION_MISS is dominant, search for "code localization accuracy improvement techniques")
+6. **Read deeply**: Use WebFetch on the top 3-5 most promising results
+7. **Map solutions to mutable surfaces**: For each finding, note which mutable surface files would need to change
+8. **Synthesize**: Write structured research report focused on actionable fixes
+
+### Output (Failure Research)
+
+Write to `$PROJECT_PATH/.factory/strategy/research.md`:
+
+```markdown
+# Research — Failure-Targeted Solutions
+
+## Context
+- Research target: <objective>
+- Current metric: <value> (target: <target>)
+- Dominant failure modes: <top categories from failure analysis>
+
+## Prior Knowledge (Vault)
+- <relevant prior findings, or "No vault available">
+
+## Solution Research by Failure Mode
+
+### <FAILURE_CATEGORY_1> (<percentage>%)
+- **Root cause summary**: <from failure analysis>
+- **External findings**: <what web research revealed>
+- **Recommended approach**: <specific technique or pattern>
+- **Mutable surface**: <which files to modify>
+- **Confidence**: high/medium/low
+
+### <FAILURE_CATEGORY_2> (<percentage>%)
+- ...
+
+## Cross-Cutting Findings
+- <patterns that apply across multiple failure categories>
+
+## References
+- <URLs and sources consulted>
+```
+
+### Rules (Failure Research)
+- Always read the failure analysis FIRST — it defines your search scope
+- Limit WebSearch to 5-8 queries, all focused on the specific failure patterns
+- Limit WebFetch to 3-5 pages
+- Do NOT do general domain research — Mode 2 handles that. Mode 4 is laser-focused on the failures
+- Map every finding to a mutable surface. Findings that require changing fixed surfaces should be noted as constraints, not recommendations
+- Write report even if external search fails — include vault findings and failure analysis context
+- Do not include calendar-time estimates — same rule as Mode 2
+- Prioritize the dominant failure mode — spend 60%+ of your search budget on the #1 failure category

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -324,6 +324,12 @@ When operating in **research mode**, the following standard sections are **suspe
 
 The Strategist receives failure analysis from the Failure Analyst instead of standard observations. The failure analysis lives at `.factory/research/runs/<cycle>/failure_analysis.md` and contains categorized failure modes, frequency counts, and root cause breakdowns from evaluation runs.
 
+When a research report exists (at `.factory/strategy/research.md`), the Researcher has already searched for solutions to the specific failure patterns identified by the Failure Analyst. Use these findings to:
+- Prioritize hypotheses that align with researched solutions (higher confidence)
+- Reference specific techniques or patterns from the research in hypothesis rationale
+- Avoid proposing fixes that the research identified as ineffective or inappropriate for the mutable surfaces
+- If the CEO's research review (at `.factory/reviews/ceo-verdict-researcher.md`) highlights priorities, incorporate those into hypothesis ranking
+
 In research mode, the standard `Growth dimension`, `Type`, and `Backlog item`/`New` tags are **not required**. All hypotheses target the research metric — the growth minimum requirement is suspended.
 
 ### Reading Failure Analysis

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -307,7 +307,7 @@ def _build_continuation_task(gap: IncompleteGap, cycle_state: CycleState | None 
             f"Resume execution from hypothesis {gap.next_item}. "
             f"Strategy is already approved at .factory/strategy/current.md — "
             f"do not re-plan, do not re-run Researcher, Strategist, or Failure Analyst. "
-            f"The baseline run (R0) and failure analysis (R1) are already complete. "
+            f"The baseline run (R0), failure analysis (R1), and research (R1.5) are already complete. "
             f"Spawn Builder for {gap.next_item} immediately, then continue the "
             f"research cycle (R3–R5) for each remaining hypothesis. "
             f"Progress so far: {gap.completed}/{gap.planned} hypotheses have verdicts."

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -306,7 +306,7 @@ def _build_continuation_task(gap: IncompleteGap, cycle_state: CycleState | None 
         body = (
             f"Resume execution from hypothesis {gap.next_item}. "
             f"Strategy is already approved at .factory/strategy/current.md — "
-            f"do not re-plan, do not re-run Researcher, Strategist, or Failure Analyst. "
+            f"do not re-plan, do not re-run Failure Analyst, Researcher, or Strategist. "
             f"The baseline run (R0), failure analysis (R1), and research (R1.5) are already complete. "
             f"Spawn Builder for {gap.next_item} immediately, then continue the "
             f"research cycle (R3–R5) for each remaining hypothesis. "

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -570,6 +570,7 @@ class TestBuildContinuationTask:
         assert "RESEARCH" in task
         assert "do not re-plan" in task
         assert "1/3" in task
+        assert "R1.5" in task
 
     def test_continuation_includes_mode_directive(self) -> None:
         """Continuation task includes explicit mode directive to prevent flip."""
@@ -1087,14 +1088,31 @@ class TestCeoPromptResearchMode:
         """The CEO prompt contains a ## Mode: Research section."""
         assert "## Mode: Research" in ceo_prompt
 
-    def test_all_six_phases_present(self, ceo_prompt: str) -> None:
-        """All 6 research mode phases are documented."""
+    def test_all_seven_phases_present(self, ceo_prompt: str) -> None:
+        """All 7 research mode phases are documented."""
         assert "### Phase R0: BASELINE" in ceo_prompt
         assert "### Phase R1: ANALYZE" in ceo_prompt
+        assert "### Phase R1.5: RESEARCH" in ceo_prompt
         assert "### Phase R2: HYPOTHESIZE" in ceo_prompt
         assert "### Phase R3: IMPLEMENT" in ceo_prompt
         assert "### Phase R4: RUN" in ceo_prompt
         assert "### Phase R5: VERDICT" in ceo_prompt
+
+    def test_researcher_phase_in_research_mode(self, ceo_prompt: str) -> None:
+        """R1.5 (Researcher) exists between R1 (Analyze) and R2 (Hypothesize)."""
+        research_idx = ceo_prompt.index("## Mode: Research")
+        meta_idx = ceo_prompt.index("## Mode: Meta")
+        research_section = ceo_prompt[research_idx:meta_idx]
+
+        r1_idx = research_section.index("### Phase R1: ANALYZE")
+        r15_idx = research_section.index("### Phase R1.5: RESEARCH")
+        r2_idx = research_section.index("### Phase R2: HYPOTHESIZE")
+        assert r1_idx < r15_idx < r2_idx
+
+        r15_section = research_section[r15_idx:r2_idx]
+        assert "failure_analysis.md" in r15_section
+        assert "research.md" in r15_section
+        assert "archivist after research" in r15_section
 
     def test_references_research_infrastructure(self, ceo_prompt: str) -> None:
         """The prompt references ResearchTarget config, failure_analyst, and run_command."""


### PR DESCRIPTION
## Summary

- Research mode now spawns the Researcher agent between the Failure Analyst (R1) and the Strategist (R2)
- After failures are classified, the Researcher searches for solutions to the dominant failure patterns — web search, vault knowledge, and prior art — before hypotheses are generated
- This mirrors the Researcher→Strategist flow already used in Improve mode

## Changes

- **researcher.md**: Add Mode 4 (Failure Research) — reads failure_analysis.md, searches for targeted solutions, maps findings to mutable surfaces
- **ceo.md**: Insert Phase R1.5 with CEO review gate, mandatory Archivist, and crash-recovery checkpoint; update Strategist task to pass research review; update all checkpoint --completed/--pending lists
- **strategist.md**: Add paragraph for research-mode Strategist to use research.md when available
- **ceo_completion.py**: Update continuation task to mention R1.5
- **tests**: Add R1.5 phase presence/ordering test, update phase count test (6→7), add R1.5 mention to continuation test

## Test plan

- [ ] `uv run pytest tests/test_ceo_completion.py::TestCeoPromptResearchMode -v` — all 10 research mode tests pass
- [ ] `uv run pytest -v` — full suite (1230 tests) passes
- [ ] `uv run ruff check . && uv run mypy factory/` — lint and type clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)