### PR TITLE
feat: ground truth leakage guards for research mode

### DIFF
--- a/factory/agents/prompts/builder.md
+++ b/factory/agents/prompts/builder.md
@@ -57,6 +57,8 @@ gh pr create --base $TARGET_BRANCH \
 - Implement ONLY what the issue asks for — no extras, no refactoring, no "while I'm here" changes
 - Do NOT modify files outside the declared scope in factory.md
 - Do NOT modify eval/score.py or .factory/ contents
+- Do NOT read or access `fixed_surfaces` files (ground truth, test data, expected outputs). These files contain answers — reading them and using that knowledge in your implementation is ground truth leakage, even if you don't modify the files themselves. Derive your solution from the problem description and mutable surfaces only.
+- Do NOT reverse-engineer expected answers from test data, eval infrastructure, or any file listed in `fixed_surfaces`. If you need to understand what the system should do, read the issue description and the code in `mutable_surfaces`.
 - Do NOT ask for input — if stuck, comment on the issue and exit
 - Always run tests before opening the PR
 - Keep commits focused and atomic

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1288,7 +1288,13 @@ Establish the starting point by running the system and recording the baseline me
    - `fixed_surfaces`: files the Builder MUST NOT modify (eval infrastructure, test data, ground truth)
    - `research_constraints`: additional free-text constraints
 
-3. **Execute the baseline run.** The Evaluator agent runs the shell command directly and manages artifacts:
+3. **Pre-flight validation (MANDATORY).** Before spawning any agents, validate the research config:
+   ```bash
+   uv run python -m factory validate-research "$PROJECT_PATH"
+   ```
+   If validation fails (non-empty error list), STOP. Fix the config issues before proceeding. Common errors: empty `fixed_surfaces` (no leakage guards), `mutable_surfaces`/`fixed_surfaces` overlap (ambiguous constraints), patterns matching no files (stale config).
+
+4. **Execute the baseline run.** The Evaluator agent runs the shell command directly and manages artifacts:
 
    ```bash
    factory agent evaluator --task "Run research baseline for $PROJECT_PATH.
@@ -1462,12 +1468,17 @@ This is a **hard gate**. The Builder MUST NOT start until you approve.
 2. **Surface constraint check (MANDATORY):** For each hypothesis, verify:
    - All target files are in `mutable_surfaces` — if ANY file is in `fixed_surfaces`, **REDIRECT immediately**
    - No hypothesis proposes changes to eval infrastructure, test data, or ground truth
-3. Verify hypotheses target the dominant failure modes from the Failure Analyst's report
-4. Verify expected impact is realistic given the failure distribution
-5. **Hypothesis count check:** Research mode should have 1-3 hypotheses. More than 3 → REDIRECT.
-6. Write verdict to `.factory/reviews/ceo-verdict-strategist.md`
-7. If REDIRECT: re-invoke with corrections (e.g., "H2 targets a fixed surface", "No hypothesis addresses the dominant failure mode")
-8. If PROCEED: write `PLAN APPROVED`
+3. **Ground truth leakage scan (MANDATORY):** For each hypothesis, run the leakage scanner:
+   ```bash
+   uv run python -m factory leakage-check "$PROJECT_PATH" --text "<hypothesis text>"
+   ```
+   If risk level is `medium` or `high` → **REDIRECT immediately**. The hypothesis encodes ground truth (via negation hints, specific values, or token overlap with fixed surfaces). Tell the Strategist which hypothesis failed and why — it must be rephrased to describe capability improvements, not answers.
+4. Verify hypotheses target the dominant failure modes from the Failure Analyst's report
+5. Verify expected impact is realistic given the failure distribution
+6. **Hypothesis count check:** Research mode should have 1-3 hypotheses. More than 3 → REDIRECT.
+7. Write verdict to `.factory/reviews/ceo-verdict-strategist.md`
+8. If REDIRECT: re-invoke with corrections (e.g., "H2 targets a fixed surface", "H1 leaks ground truth via negation hint", "No hypothesis addresses the dominant failure mode")
+9. If PROCEED: write `PLAN APPROVED`
 
 **MANDATORY Archivist — record strategy (DO NOT SKIP):**
 
@@ -1554,8 +1565,14 @@ Apply the standard CEO Review Gate (same as Improve mode 2d-review), with one ad
    ```
    - If ANY modified file is in `fixed_surfaces` → **ABORT immediately**, close PR, revert
    - If ANY modified file is NOT in `mutable_surfaces` → **REDIRECT** the Builder to remove those changes
-2. Standard review: does the PR match the hypothesis? Scope creep? Tests included?
-3. Write verdict to `.factory/reviews/ceo-verdict-builder.md`
+2. **Ground truth leakage scan on PR diff (MANDATORY):** The Builder may have read fixed surface files (no file modification = Layer 1 doesn't fire) and embedded ground-truth-derived logic in code. Scan the diff:
+   ```bash
+   DIFF_TEXT=$(gh pr diff $PR_NUM)
+   uv run python -m factory leakage-check "$PROJECT_PATH" --text "$DIFF_TEXT"
+   ```
+   If risk level is `medium` or `high` → **REDIRECT** the Builder: "PR diff contains tokens/values that match ground truth files. Remove ground-truth-derived logic and re-implement from first principles using only the problem description."
+3. Standard review: does the PR match the hypothesis? Scope creep? Tests included?
+4. Write verdict to `.factory/reviews/ceo-verdict-builder.md`
 
 **MANDATORY Archivist — record build (DO NOT SKIP):**
 
@@ -1618,7 +1635,7 @@ The research target metric must satisfy the **monotonic improvement policy:**
 
 #### R5c. Precheck Gate
 
-Run the standard precheck (same as Improve mode):
+Run the standard precheck with surface guard enabled:
 
 ```bash
 BASELINE_SHA=$(cd "$PROJECT_PATH" && git log --format=%H -1 $TARGET_BRANCH)
@@ -1628,6 +1645,8 @@ uv run python -m factory precheck "$PROJECT_PATH" \
     --hypothesis "$HYPOTHESIS" \
     --baseline $BASELINE_SHA
 ```
+
+The precheck automatically runs fixed surface guards and ground truth leakage detection when `fixed_surfaces` is configured in factory.md. These are hard, non-overridable gates — if the precheck reports a `fixed_surfaces` or `ground_truth_leakage` failure, it is a mandatory revert. No CEO override allowed.
 
 If precheck fails → mandatory revert.
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1565,10 +1565,11 @@ Apply the standard CEO Review Gate (same as Improve mode 2d-review), with one ad
    ```
    - If ANY modified file is in `fixed_surfaces` → **ABORT immediately**, close PR, revert
    - If ANY modified file is NOT in `mutable_surfaces` → **REDIRECT** the Builder to remove those changes
-2. **Ground truth leakage scan on PR diff (MANDATORY):** The Builder may have read fixed surface files (no file modification = Layer 1 doesn't fire) and embedded ground-truth-derived logic in code. Scan the diff:
+2. **Ground truth leakage scan on PR diff (MANDATORY):** The Builder may have read fixed surface files (no file modification = Layer 1 doesn't fire) and embedded ground-truth-derived logic in code. Scan the diff using a temp file (do NOT use shell variable expansion — diffs contain special chars that break `"$DIFF_TEXT"`):
    ```bash
-   DIFF_TEXT=$(gh pr diff $PR_NUM)
-   uv run python -m factory leakage-check "$PROJECT_PATH" --text "$DIFF_TEXT"
+   gh pr diff $PR_NUM > /tmp/factory-pr-diff-$PR_NUM.txt
+   uv run python -m factory leakage-check "$PROJECT_PATH" --text-file /tmp/factory-pr-diff-$PR_NUM.txt
+   rm -f /tmp/factory-pr-diff-$PR_NUM.txt
    ```
    If risk level is `medium` or `high` → **REDIRECT** the Builder: "PR diff contains tokens/values that match ground truth files. Remove ground-truth-derived logic and re-implement from first principles using only the problem description."
 3. Standard review: does the PR match the hypothesis? Scope creep? Tests included?

--- a/factory/agents/prompts/failure_analyst.md
+++ b/factory/agents/prompts/failure_analyst.md
@@ -95,6 +95,7 @@ Structure of `failure_analysis.md`:
 - **Be specific.** "The agent failed" is not a classification. "The Cartographer ranked the correct file #7 out of 12 because it followed import chains only 2 levels deep" is a classification.
 - **Use structured data.** Parse JSON, JSONL, and log files programmatically. Don't skim — extract.
 - **Respect mutable surfaces.** Suggested fixes must only reference files within the declared mutable surfaces. Never suggest changes to fixed surfaces (eval infrastructure, test data, ground truth).
+- **Describe behavior, not answers.** Your analysis must describe WHAT the system did wrong (behavioral), not what the correct answer IS (content). Say "the agent failed to localize the correct file because it only searched top-level directories" — NOT "the agent should have edited utils.py line 42". Encoding expected outputs in your analysis is ground truth leakage.
 - **Pipeline outputs are authoritative.** Don't second-guess results. If the test says FAIL, it's FAIL. Your job is to explain WHY, not to dispute the outcome.
 - **Prioritize by frequency.** The dominant failure mode gets the most attention. Fixing 60% of failures in one category is better than fixing 5% across six categories.
 - **Track the failure taxonomy.** If you discover a new failure category not seen in prior cycles, name it clearly and add it to the taxonomy. Use consistent naming across cycles.

--- a/factory/agents/prompts/reviewer.md
+++ b/factory/agents/prompts/reviewer.md
@@ -77,10 +77,23 @@ uv run python -m factory review \
 
 If `--pr` is provided, the review is posted on the PR automatically. Use `--dry-run` to preview without posting.
 
+## Surface Constraints (Research Mode)
+
+When reviewing PRs for research mode projects (those with `fixed_surfaces` in factory.md):
+
+1. **Check changed files against fixed surfaces**: Run `gh pr diff --name-only` and cross-reference every changed file against `fixed_surfaces` from the factory config. Any modification to a fixed surface file is a **non-negotiable REVERT** — no exceptions, no "the change is harmless" arguments.
+
+2. **Check for ground truth leakage in code**: If the PR diff contains specific values, identifiers, or logic patterns that appear to be derived from ground truth files, flag it as a leakage risk. The Builder should not have read fixed surface files to inform its implementation.
+
+3. **Run the surface guard**: `uv run python -m factory guard $PROJECT_PATH --baseline $BASELINE_SHA --check-surfaces`
+
+Fixed surface modification is a **Sacred Rule violation** — treat it the same as deleting tests or modifying eval/score.py.
+
 ## Rules
 
 - Guard violations are non-negotiable — always revert
 - Score regression is non-negotiable — always revert
+- Fixed surface modification is non-negotiable — always revert (research mode)
 - Be strict but fair — don't block good changes for style nitpicks
 - Document your reasoning clearly for the Strategist to learn from
 - Always post reviews on PRs when a PR number is available

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -366,6 +366,16 @@ Research mode projects declare `mutable_surfaces` and `fixed_surfaces` in `facto
 
 Before writing any hypothesis, verify that every file you plan to change appears in `mutable_surfaces`. If a fix requires changing a fixed surface, note it as a constraint in your observations but do NOT generate a hypothesis for it.
 
+### Ground Truth Isolation
+
+Ground truth files (`fixed_surfaces`) contain the correct answers. Your hypotheses must NEVER leak ground truth — directly or indirectly:
+
+- **Never read fixed surface content** to inform your hypotheses. Base your reasoning on the Failure Analyst's behavioral analysis and the Researcher's findings — not on what the answers are.
+- **Never encode expected outputs** in hypothesis text. "Ensure the agent uses subtraction" leaks the answer. "Improve the agent's arithmetic operator selection" does not.
+- **Never use negation to hint at answers.** "Do NOT use addition" is equivalent to saying "use subtraction" — it leaks the correct operation by elimination. Frame hypotheses as capability improvements: "improve operator selection accuracy" not "avoid addition".
+- **Never include specific values from ground truth.** If the expected accuracy is 0.847, do not write "target accuracy near 0.85" — that hints at the answer. Write "improve metric score" instead.
+- **Frame hypotheses as capability improvements**, not answer targeting. Good: "Improve file localization by expanding search depth." Bad: "Ensure the agent finds and edits utils.py."
+
 ### Explicit Rules Over Subtle Suggestions
 
 When a hypothesis involves modifying agent prompts (a common mutable surface), prefer explicit rules over subtle suggestions. From prior factory experiments, we've learned:

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -799,7 +799,18 @@ def cmd_leakage_check(args: argparse.Namespace) -> int:
         print("SKIP: no fixed surface files found to fingerprint")
         return 0
 
-    report = scan_for_leakage(args.text, fingerprints, args.sensitivity)
+    text = args.text
+    if args.text_file:
+        text = Path(args.text_file).read_text()
+    elif args.text is None:
+        import sys
+        if not sys.stdin.isatty():
+            text = sys.stdin.read()
+        else:
+            print("ERROR: provide --text, --text-file, or pipe to stdin")
+            return 1
+
+    report = scan_for_leakage(text, fingerprints, args.sensitivity)
 
     output = {
         "flagged": report.flagged,
@@ -2038,7 +2049,8 @@ def build_parser() -> argparse.ArgumentParser:
     # leakage-check
     p = sub.add_parser("leakage-check", help="Scan text for ground truth leakage against fixed surfaces")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--text", required=True, help="Text to scan for leakage (hypothesis, strategy, etc.)")
+    p.add_argument("--text", default=None, help="Text to scan for leakage (hypothesis, strategy, etc.)")
+    p.add_argument("--text-file", default=None, help="Path to file containing text to scan (safer for large diffs)")
     p.add_argument("--sensitivity", choices=["low", "medium", "high"], default="medium",
                     help="Sensitivity level (default: medium)")
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -801,7 +801,11 @@ def cmd_leakage_check(args: argparse.Namespace) -> int:
 
     text = args.text
     if args.text_file:
-        text = Path(args.text_file).read_text()
+        text_path = Path(args.text_file)
+        if not text_path.is_file():
+            print(f"ERROR: text file not found: {args.text_file}")
+            return 1
+        text = text_path.read_text()
     elif args.text is None:
         import sys
         if not sys.stdin.isatty():

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -206,15 +206,21 @@ def cmd_guard(args: argparse.Namespace) -> int:
 
     project_path = Path(args.path)
 
-    # Optionally load scope from factory config
+    # Optionally load scope and fixed surfaces from factory config
     scope = None
-    if args.check_scope:
+    fixed_surfaces = None
+    if args.check_scope or args.check_surfaces:
         from factory.store import ExperimentStore
         store = ExperimentStore(project_path)
         config = _run(store.read_config())
-        scope = config.scope
+        if args.check_scope:
+            scope = config.scope
+        if args.check_surfaces:
+            fixed_surfaces = config.fixed_surfaces
 
-    violations = check_all(project_path, args.baseline, allowed_scope=scope)
+    violations = check_all(
+        project_path, args.baseline, allowed_scope=scope, fixed_surfaces=fixed_surfaces,
+    )
     _emit_cli_event(project_path, "guard.completed", {
         "violations": len(violations),
         "clean": len(violations) == 0,
@@ -753,6 +759,7 @@ def cmd_precheck(args: argparse.Namespace) -> int:
         allowed_scope=config.scope if args.baseline else None,
         smoke_test_command=config.smoke_test,
         similarity_threshold=args.similarity_threshold,
+        fixed_surfaces=config.fixed_surfaces if config.fixed_surfaces else None,
     )
 
     # Output as JSON for machine consumption
@@ -772,6 +779,63 @@ def cmd_precheck(args: argparse.Namespace) -> int:
     })
 
     return 0 if result.passed else 1
+
+
+def cmd_leakage_check(args: argparse.Namespace) -> int:
+    """Check text for ground truth leakage against fixed surface fingerprints."""
+    from factory.research.leakage import fingerprint_fixed_surfaces, scan_for_leakage
+    from factory.store import ExperimentStore
+
+    project_path = Path(args.path).resolve()
+    store = ExperimentStore(project_path)
+    config = _run(store.read_config())
+
+    if not config.fixed_surfaces:
+        print("SKIP: no fixed_surfaces configured in factory.md")
+        return 0
+
+    fingerprints = fingerprint_fixed_surfaces(project_path, config.fixed_surfaces)
+    if not fingerprints:
+        print("SKIP: no fixed surface files found to fingerprint")
+        return 0
+
+    report = scan_for_leakage(args.text, fingerprints, args.sensitivity)
+
+    output = {
+        "flagged": report.flagged,
+        "risk_level": report.risk_level,
+        "findings": [
+            {
+                "source_file": f.source_file,
+                "leaked_token": f.leaked_token,
+                "context": f.context,
+                "leak_type": f.leak_type,
+            }
+            for f in report.findings
+        ],
+    }
+    print(json.dumps(output, indent=2))
+    return 1 if report.risk_level in ("medium", "high") else 0
+
+
+def cmd_validate_research(args: argparse.Namespace) -> int:
+    """Validate research mode configuration for ground truth isolation."""
+    from factory.research.leakage import validate_research_config
+    from factory.store import ExperimentStore
+
+    project_path = Path(args.path).resolve()
+    store = ExperimentStore(project_path)
+    config = _run(store.read_config())
+
+    errors = validate_research_config(config, project_path)
+
+    if not errors:
+        print("VALID: research config passes all ground truth isolation checks")
+        return 0
+
+    for error in errors:
+        print(f"ERROR: {error}")
+    return 1
 
 
 def cmd_review(args: argparse.Namespace) -> int:
@@ -1906,6 +1970,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("path", help="Path to the project")
     p.add_argument("--baseline", required=True, help="Baseline commit SHA")
     p.add_argument("--check-scope", action="store_true", help="Also check file scope")
+    p.add_argument("--check-surfaces", action="store_true",
+                    help="Also check fixed surface constraints (research mode)")
 
     # begin
     p = sub.add_parser("begin", help="Start experiment, print ID")
@@ -1967,6 +2033,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     # summary
     p = sub.add_parser("summary", help="Generate end-of-session summary report")
+    p.add_argument("path", help="Path to the project")
+
+    # leakage-check
+    p = sub.add_parser("leakage-check", help="Scan text for ground truth leakage against fixed surfaces")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--text", required=True, help="Text to scan for leakage (hypothesis, strategy, etc.)")
+    p.add_argument("--sensitivity", choices=["low", "medium", "high"], default="medium",
+                    help="Sensitivity level (default: medium)")
+
+    # validate-research
+    p = sub.add_parser("validate-research", help="Validate research mode configuration for ground truth isolation")
     p.add_argument("path", help="Path to the project")
 
     # backfill-citations
@@ -2269,6 +2346,8 @@ def main(argv: list[str] | None = None) -> int:
         "digest": cmd_digest,
         "archive": cmd_archive,
         "precheck": cmd_precheck,
+        "leakage-check": cmd_leakage_check,
+        "validate-research": cmd_validate_research,
         "review": cmd_review,
         "checkpoint": cmd_checkpoint,
         "resume": cmd_resume,

--- a/factory/eval/guards.py
+++ b/factory/eval/guards.py
@@ -139,6 +139,38 @@ def check_scope(project_path: Path, baseline_sha: str, allowed_scope: list[str])
     return None
 
 
+def check_fixed_surfaces(
+    project_path: Path, baseline_sha: str, fixed_surfaces: list[str]
+) -> str | None:
+    """Guard: changed files must not be in the fixed_surfaces list.
+
+    Fixed surfaces are files that must never be modified (e.g. ground truth,
+    test data, eval infrastructure). Uses the same glob matching as check_scope.
+    Returns a violation string if fixed surfaces were modified, None otherwise.
+    """
+    try:
+        diff_output = _run_git(["diff", "--name-only", f"{baseline_sha}..HEAD"], project_path)
+    except subprocess.CalledProcessError:
+        return "Cannot determine changed files"
+
+    if not diff_output.strip():
+        return None
+
+    changed_files = diff_output.strip().splitlines()
+    violated: list[str] = []
+
+    for changed_file in changed_files:
+        basename = changed_file.split("/")[-1]
+        if basename in _AUTO_GENERATED_FILES:
+            continue
+        if any(_glob_match(changed_file, pattern) for pattern in fixed_surfaces):
+            violated.append(changed_file)
+
+    if violated:
+        return f"Fixed surface modified: {', '.join(violated)}"
+    return None
+
+
 def snapshot_eval_tree(project_path: Path) -> str:
     """Take a snapshot of eval/ tree for later comparison."""
     try:
@@ -152,6 +184,7 @@ def check_all(
     baseline_sha: str,
     eval_tree_before: str | None = None,
     allowed_scope: list[str] | None = None,
+    fixed_surfaces: list[str] | None = None,
 ) -> list[str]:
     """Run all guards, return list of violation strings (empty = pass)."""
     violations: list[str] = []
@@ -171,6 +204,11 @@ def check_all(
 
     if allowed_scope is not None:
         v = check_scope(project_path, baseline_sha, allowed_scope)
+        if v:
+            violations.append(v)
+
+    if fixed_surfaces:
+        v = check_fixed_surfaces(project_path, baseline_sha, fixed_surfaces)
         if v:
             violations.append(v)
 

--- a/factory/precheck.py
+++ b/factory/precheck.py
@@ -144,7 +144,6 @@ def check_anti_pattern(
 def check_surfaces(
     project_path: Path,
     baseline_sha: str,
-    fixed_surfaces: list[str],
 ) -> CheckResult:
     """Run factory guard --check-surfaces and report pass/fail.
 
@@ -323,7 +322,7 @@ def run_precheck(
 
     # 3. Fixed surface guard (only if baseline + fixed_surfaces provided)
     if baseline_sha and fixed_surfaces:
-        checks.append(check_surfaces(project_path, baseline_sha, fixed_surfaces))
+        checks.append(check_surfaces(project_path, baseline_sha))
 
     # 4. Ground truth leakage check (only if fixed_surfaces provided)
     if fixed_surfaces:

--- a/factory/precheck.py
+++ b/factory/precheck.py
@@ -141,6 +141,107 @@ def check_anti_pattern(
     )
 
 
+def check_surfaces(
+    project_path: Path,
+    baseline_sha: str,
+    fixed_surfaces: list[str],
+) -> CheckResult:
+    """Run factory guard --check-surfaces and report pass/fail.
+
+    This is a hard gate — the CEO cannot override a failed surface check.
+    Any modification to a fixed surface file is a mandatory revert.
+    """
+    cmd = [
+        "uv", "run", "python", "-m", "factory", "guard",
+        str(project_path), "--baseline", baseline_sha, "--check-surfaces",
+    ]
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=project_path,
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult(name="fixed_surfaces", passed=False, detail="Surface guard check timed out")
+    except FileNotFoundError:
+        return CheckResult(name="fixed_surfaces", passed=False, detail="Guard command not found")
+
+    if result.returncode == 0:
+        return CheckResult(name="fixed_surfaces", passed=True, detail="No fixed surfaces modified")
+
+    violations = [
+        line.replace("VIOLATION: ", "").strip()
+        for line in result.stdout.splitlines()
+        if line.startswith("VIOLATION:")
+    ]
+    return CheckResult(
+        name="fixed_surfaces",
+        passed=False,
+        detail=f"Fixed surface violations: {'; '.join(violations) or result.stdout.strip()[:200]}",
+    )
+
+
+def check_leakage(
+    hypothesis: str,
+    project_path: Path,
+    fixed_surfaces: list[str],
+    baseline_sha: str | None = None,
+    sensitivity: str = "medium",
+) -> CheckResult:
+    """Check for ground truth content leaking into hypothesis or code diff.
+
+    Scans:
+    1. The hypothesis text against fingerprints of fixed surface files
+    2. The PR diff (if baseline_sha provided) against the same fingerprints
+
+    This catches both direct references ("the answer is 42") and indirect
+    hints ("do NOT use subtraction").
+    """
+    from factory.research.leakage import (
+        fingerprint_fixed_surfaces,
+        get_diff_text,
+        scan_diff_for_leakage,
+        scan_for_leakage,
+    )
+
+    fingerprints = fingerprint_fixed_surfaces(project_path, fixed_surfaces)
+    if not fingerprints:
+        return CheckResult(
+            name="ground_truth_leakage",
+            passed=True,
+            detail="No fixed surface files found to fingerprint (skipped)",
+        )
+
+    # Scan hypothesis text
+    report = scan_for_leakage(hypothesis, fingerprints, sensitivity)
+
+    # Also scan PR diff if baseline is available
+    if baseline_sha and not report.flagged:
+        diff_text = get_diff_text(project_path, baseline_sha)
+        if diff_text:
+            report = scan_diff_for_leakage(diff_text, fingerprints, sensitivity)
+
+    if not report.flagged:
+        return CheckResult(
+            name="ground_truth_leakage",
+            passed=True,
+            detail="No ground truth leakage detected",
+        )
+
+    finding_details = "; ".join(
+        f"{f.leak_type}: '{f.leaked_token}' from {f.source_file}"
+        for f in report.findings[:3]
+    )
+    return CheckResult(
+        name="ground_truth_leakage",
+        passed=report.risk_level not in ("medium", "high"),
+        detail=f"Leakage risk={report.risk_level}: {finding_details}",
+    )
+
+
 def check_smoke_test(
     smoke_test_command: str,
     project_path: Path,
@@ -205,6 +306,7 @@ def run_precheck(
     allowed_scope: list[str] | None = None,
     smoke_test_command: str = "",
     similarity_threshold: float = 0.6,
+    fixed_surfaces: list[str] | None = None,
 ) -> PreCheckResult:
     """Run all prechecks and return aggregate result.
 
@@ -219,10 +321,18 @@ def run_precheck(
     if baseline_sha:
         checks.append(check_scope(project_path, baseline_sha, allowed_scope))
 
-    # 3. Anti-pattern detection
+    # 3. Fixed surface guard (only if baseline + fixed_surfaces provided)
+    if baseline_sha and fixed_surfaces:
+        checks.append(check_surfaces(project_path, baseline_sha, fixed_surfaces))
+
+    # 4. Ground truth leakage check (only if fixed_surfaces provided)
+    if fixed_surfaces:
+        checks.append(check_leakage(hypothesis, project_path, fixed_surfaces, baseline_sha))
+
+    # 5. Anti-pattern detection
     checks.append(check_anti_pattern(hypothesis, history, similarity_threshold))
 
-    # 4. Smoke test
+    # 6. Smoke test
     checks.append(check_smoke_test(smoke_test_command, project_path))
 
     # Aggregate

--- a/factory/research/leakage.py
+++ b/factory/research/leakage.py
@@ -1,0 +1,408 @@
+"""Ground truth leakage detection for research mode.
+
+Provides programmatic guards against ground truth content leaking into
+hypotheses, strategies, or code changes — either directly (file access)
+or indirectly (content hints like "do NOT use subtraction").
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from factory.models import FactoryConfig
+
+import structlog
+
+log = structlog.get_logger()
+
+# Tokens that appear in almost every codebase — not distinctive enough to flag
+_STOPWORDS: frozenset[str] = frozenset({
+    # Python keywords / builtins
+    "def", "class", "return", "import", "from", "if", "else", "elif",
+    "for", "while", "try", "except", "with", "as", "in", "not", "and",
+    "or", "is", "none", "true", "false", "self", "cls", "pass", "break",
+    "continue", "raise", "yield", "lambda", "assert", "global", "nonlocal",
+    "finally", "del", "async", "await",
+    # JS/TS keywords
+    "var", "let", "const", "function", "new", "this", "typeof", "instanceof",
+    "null", "undefined", "void", "throw", "catch", "export", "default",
+    # Common programming terms
+    "test", "tests", "error", "errors", "data", "result", "results",
+    "value", "values", "name", "type", "types", "path", "file", "files",
+    "list", "dict", "set", "map", "get", "put", "post", "delete",
+    "init", "main", "run", "start", "stop", "open", "close", "read",
+    "write", "print", "log", "debug", "info", "warn", "config",
+    "input", "output", "args", "kwargs", "key", "item", "items",
+    "index", "count", "size", "length", "string", "number", "int",
+    "float", "bool", "byte", "bytes", "char", "array", "object",
+    "node", "text", "content", "body", "header", "status", "code",
+    "message", "response", "request", "url", "port", "host",
+    "the", "and", "for", "with", "that", "this", "from", "have",
+    "are", "was", "were", "been", "has", "had", "will", "would",
+    "should", "could", "can", "may", "must", "shall", "might",
+    "use", "using", "used", "make", "made", "add", "added",
+    "fix", "fixed", "update", "updated", "change", "changed",
+    "create", "created", "remove", "removed", "check", "checked",
+})
+
+# Minimum token length to consider
+_MIN_TOKEN_LEN = 3
+
+# Regex for negation patterns: "do NOT <word>", "avoid <word>", etc.
+_NEGATION_PATTERNS = [
+    re.compile(r"\bdo\s+not\s+(\w+)", re.IGNORECASE),
+    re.compile(r"\bshould\s+not\s+(\w+)", re.IGNORECASE),
+    re.compile(r"\bmust\s+not\s+(\w+)", re.IGNORECASE),
+    re.compile(r"\bavoid\s+(\w+)", re.IGNORECASE),
+    re.compile(r"\bnever\s+(\w+)", re.IGNORECASE),
+    re.compile(r"\bdon'?t\s+(\w+)", re.IGNORECASE),
+]
+
+# Regex to extract numeric literals (integers and decimals)
+_NUMERIC_RE = re.compile(r"\b(\d+\.\d+|\d{2,})\b")
+
+# Regex to extract quoted strings
+_QUOTED_RE = re.compile(r"""(?:"([^"]{3,}?)"|'([^']{3,}?)')""")
+
+# Regex to split camelCase and snake_case identifiers
+_IDENT_SPLIT_RE = re.compile(r"[A-Z][a-z]+|[a-z]+|[A-Z]+(?=[A-Z]|$)|\d+")
+
+# Sensitivity thresholds for token overlap (Jaccard)
+_OVERLAP_THRESHOLDS = {
+    "low": 0.25,
+    "medium": 0.15,
+    "high": 0.08,
+}
+
+
+@dataclass
+class LeakageFinding:
+    """A single instance of potential ground truth leakage."""
+
+    source_file: str
+    leaked_token: str
+    context: str
+    leak_type: str  # "token_overlap" | "negation_hint" | "specific_value"
+
+
+@dataclass
+class LeakageReport:
+    """Result of a content leakage check."""
+
+    flagged: bool
+    risk_level: str  # "none" | "low" | "medium" | "high"
+    findings: list[LeakageFinding] = field(default_factory=list)
+
+
+def _tokenize_text(text: str) -> set[str]:
+    """Extract tokens from text, splitting identifiers and filtering stopwords."""
+    raw_words = re.findall(r"[A-Za-z_]\w*", text)
+    tokens: set[str] = set()
+    for word in raw_words:
+        # Split camelCase/PascalCase
+        parts = _IDENT_SPLIT_RE.findall(word)
+        for part in parts:
+            lower = part.lower()
+            if len(lower) >= _MIN_TOKEN_LEN and lower not in _STOPWORDS:
+                tokens.add(lower)
+        # Also keep the full word if long enough
+        lower_word = word.lower()
+        if len(lower_word) >= _MIN_TOKEN_LEN and lower_word not in _STOPWORDS:
+            tokens.add(lower_word)
+    return tokens
+
+
+def _extract_specific_values(text: str) -> set[str]:
+    """Extract numeric literals and quoted strings from text."""
+    values: set[str] = set()
+    for m in _NUMERIC_RE.finditer(text):
+        val = m.group(1)
+        # Skip very common numbers
+        if val not in ("0", "1", "2", "10", "100", "0.0", "1.0", "0.5"):
+            values.add(val)
+    for m in _QUOTED_RE.finditer(text):
+        val = m.group(1) or m.group(2)
+        if val:
+            values.add(val)
+    return values
+
+
+def fingerprint_fixed_surfaces(
+    project_path: Path, fixed_surfaces: list[str]
+) -> dict[str, set[str]]:
+    """Build a fingerprint (set of distinctive tokens) for each fixed surface file.
+
+    Glob-expands patterns, reads file content, extracts identifiers and
+    specific values. Common stopwords are filtered out.
+    """
+    fingerprints: dict[str, set[str]] = {}
+    if not fixed_surfaces:
+        return fingerprints
+
+    for pattern in fixed_surfaces:
+        # Glob-expand the pattern relative to project_path
+        matched_files = list(project_path.glob(pattern))
+        if not matched_files:
+            # Try as a direct path
+            direct = project_path / pattern
+            if direct.is_file():
+                matched_files = [direct]
+
+        for filepath in matched_files:
+            if not filepath.is_file():
+                continue
+            try:
+                content = filepath.read_text(errors="replace")
+            except (OSError, PermissionError):
+                continue
+
+            rel_path = str(filepath.relative_to(project_path))
+            tokens = _tokenize_text(content)
+            values = _extract_specific_values(content)
+            tokens |= values
+
+            if tokens:
+                fingerprints[rel_path] = tokens
+
+    log.debug(
+        "fingerprinted_fixed_surfaces",
+        file_count=len(fingerprints),
+        total_tokens=sum(len(t) for t in fingerprints.values()),
+    )
+    return fingerprints
+
+
+def _check_token_overlap(
+    text_tokens: set[str],
+    fingerprints: dict[str, set[str]],
+    threshold: float,
+) -> list[LeakageFinding]:
+    """Check Jaccard-like overlap between text tokens and fingerprint sets."""
+    findings: list[LeakageFinding] = []
+    for source_file, fp_tokens in fingerprints.items():
+        if not fp_tokens or not text_tokens:
+            continue
+        overlap = text_tokens & fp_tokens
+        jaccard = len(overlap) / len(text_tokens | fp_tokens)
+        if jaccard >= threshold:
+            top_tokens = sorted(overlap)[:5]
+            findings.append(LeakageFinding(
+                source_file=source_file,
+                leaked_token=", ".join(top_tokens),
+                context=f"Jaccard overlap={jaccard:.2f} ({len(overlap)} shared tokens)",
+                leak_type="token_overlap",
+            ))
+    return findings
+
+
+def _check_negation_hints(
+    text: str,
+    fingerprints: dict[str, set[str]],
+) -> list[LeakageFinding]:
+    """Check for negation patterns that encode ground truth by exclusion."""
+    all_fp_tokens: set[str] = set()
+    token_sources: dict[str, str] = {}
+    for source_file, tokens in fingerprints.items():
+        for t in tokens:
+            all_fp_tokens.add(t)
+            token_sources[t] = source_file
+
+    findings: list[LeakageFinding] = []
+    for pattern in _NEGATION_PATTERNS:
+        for match in pattern.finditer(text):
+            negated_word = match.group(1).lower()
+            if negated_word in all_fp_tokens:
+                source = token_sources[negated_word]
+                start = max(0, match.start() - 20)
+                end = min(len(text), match.end() + 20)
+                findings.append(LeakageFinding(
+                    source_file=source,
+                    leaked_token=negated_word,
+                    context=text[start:end].strip(),
+                    leak_type="negation_hint",
+                ))
+    return findings
+
+
+def _check_specific_values(
+    text: str,
+    fingerprints: dict[str, set[str]],
+) -> list[LeakageFinding]:
+    """Check for specific numeric/string values from ground truth appearing in text."""
+    text_values = _extract_specific_values(text)
+    if not text_values:
+        return []
+
+    findings: list[LeakageFinding] = []
+    for source_file, fp_tokens in fingerprints.items():
+        fp_values = {t for t in fp_tokens if re.match(r"^\d", t) or len(t) > 5}
+        overlap = text_values & fp_values
+        for val in overlap:
+            idx = text.find(val)
+            start = max(0, idx - 20)
+            end = min(len(text), idx + len(val) + 20)
+            findings.append(LeakageFinding(
+                source_file=source_file,
+                leaked_token=val,
+                context=text[start:end].strip() if idx >= 0 else val,
+                leak_type="specific_value",
+            ))
+    return findings
+
+
+def scan_for_leakage(
+    text: str,
+    fingerprints: dict[str, set[str]],
+    sensitivity: str = "medium",
+) -> LeakageReport:
+    """Scan text for potential ground truth leakage against fixed surface fingerprints.
+
+    Three sub-checks:
+    1. Token overlap: Jaccard similarity between text and fingerprint tokens
+    2. Negation hints: "do NOT <token>", "avoid <token>" where token is from ground truth
+    3. Specific values: numeric/string literals from ground truth appearing in text
+
+    Args:
+        text: The text to scan (hypothesis, strategy, diff, etc.)
+        fingerprints: Output of fingerprint_fixed_surfaces()
+        sensitivity: "low", "medium", or "high" (lower threshold = more sensitive)
+
+    Returns:
+        LeakageReport with flagged status, risk level, and findings.
+    """
+    if not text or not fingerprints:
+        return LeakageReport(flagged=False, risk_level="none")
+
+    threshold = _OVERLAP_THRESHOLDS.get(sensitivity, _OVERLAP_THRESHOLDS["medium"])
+    text_tokens = _tokenize_text(text)
+
+    all_findings: list[LeakageFinding] = []
+
+    # Sub-check 1: token overlap
+    all_findings.extend(_check_token_overlap(text_tokens, fingerprints, threshold))
+
+    # Sub-check 2: negation hints (always run regardless of sensitivity)
+    all_findings.extend(_check_negation_hints(text, fingerprints))
+
+    # Sub-check 3: specific values
+    all_findings.extend(_check_specific_values(text, fingerprints))
+
+    if not all_findings:
+        return LeakageReport(flagged=False, risk_level="none")
+
+    # Determine risk level from findings
+    has_negation = any(f.leak_type == "negation_hint" for f in all_findings)
+    has_value = any(f.leak_type == "specific_value" for f in all_findings)
+    has_overlap = any(f.leak_type == "token_overlap" for f in all_findings)
+
+    if has_negation or (has_value and has_overlap):
+        risk_level = "high"
+    elif has_value or has_overlap:
+        risk_level = "medium"
+    else:
+        risk_level = "low"
+
+    log.info(
+        "leakage_scan_complete",
+        flagged=True,
+        risk_level=risk_level,
+        finding_count=len(all_findings),
+    )
+    return LeakageReport(flagged=True, risk_level=risk_level, findings=all_findings)
+
+
+def scan_diff_for_leakage(
+    diff_text: str,
+    fingerprints: dict[str, set[str]],
+    sensitivity: str = "medium",
+) -> LeakageReport:
+    """Scan a PR diff for ground truth leakage.
+
+    Extracts only added lines (+ prefix) from the diff to avoid false positives
+    from unchanged context lines, then runs the standard leakage scanner.
+    """
+    if not diff_text or not fingerprints:
+        return LeakageReport(flagged=False, risk_level="none")
+
+    # Extract only added lines (strip the + prefix)
+    added_lines: list[str] = []
+    for line in diff_text.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            added_lines.append(line[1:])
+
+    if not added_lines:
+        return LeakageReport(flagged=False, risk_level="none")
+
+    added_text = "\n".join(added_lines)
+    return scan_for_leakage(added_text, fingerprints, sensitivity)
+
+
+def validate_research_config(
+    config: FactoryConfig,
+    project_path: Path,
+) -> list[str]:
+    """Validate research mode configuration for ground truth isolation.
+
+    Returns list of error strings (empty = valid).
+    """
+    from factory.eval.guards import _glob_match
+
+    errors: list[str] = []
+
+    if config.research_target is None:
+        errors.append("research_target is not configured — research mode requires a target")
+
+    if not config.fixed_surfaces:
+        errors.append(
+            "fixed_surfaces is empty — ground truth files must be listed to enable "
+            "leakage guards. Without this, all leakage checks are vacuous."
+        )
+
+    if not config.mutable_surfaces:
+        errors.append(
+            "mutable_surfaces is empty — the Builder needs at least one file it can modify"
+        )
+
+    # Check that fixed_surfaces patterns match at least one existing file
+    for pattern in config.fixed_surfaces:
+        matched = list(project_path.glob(pattern))
+        direct = project_path / pattern
+        if not matched and not direct.exists():
+            errors.append(
+                f"fixed_surfaces pattern '{pattern}' matches no files — "
+                f"verify the pattern is correct"
+            )
+
+    # Check for overlap between mutable and fixed surfaces
+    for mutable_pattern in config.mutable_surfaces:
+        mutable_files = list(project_path.glob(mutable_pattern))
+        for mf in mutable_files:
+            rel_path = str(mf.relative_to(project_path))
+            for fixed_pattern in config.fixed_surfaces:
+                if _glob_match(rel_path, fixed_pattern):
+                    errors.append(
+                        f"overlap: '{rel_path}' matches both mutable_surfaces "
+                        f"('{mutable_pattern}') and fixed_surfaces ('{fixed_pattern}')"
+                    )
+
+    return errors
+
+
+def get_diff_text(project_path: Path, baseline_sha: str) -> str:
+    """Get the diff between baseline and HEAD."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", f"{baseline_sha}..HEAD"],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.stdout
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return ""

--- a/factory/research/leakage.py
+++ b/factory/research/leakage.py
@@ -123,7 +123,7 @@ def _extract_specific_values(text: str) -> set[str]:
     for m in _NUMERIC_RE.finditer(text):
         val = m.group(1)
         # Skip very common numbers
-        if val not in ("0", "1", "2", "10", "100", "0.0", "1.0", "0.5"):
+        if val not in ("10", "100", "0.0", "1.0", "0.5"):
             values.add(val)
     for m in _QUOTED_RE.finditer(text):
         val = m.group(1) or m.group(2)

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -1157,3 +1157,12 @@ class TestCeoPromptResearchMode:
         state_machine_idx = ceo_prompt.index("## State Machine")
         completion_section = ceo_prompt[completion_idx:state_machine_idx]
         assert "Research mode" in completion_section
+
+    def test_leakage_guards_in_research_mode(self, ceo_prompt: str) -> None:
+        """Research mode includes ground truth leakage guards."""
+        research_idx = ceo_prompt.index("## Mode: Research")
+        meta_idx = ceo_prompt.index("## Mode: Meta")
+        research_section = ceo_prompt[research_idx:meta_idx]
+        assert "validate-research" in research_section
+        assert "leakage-check" in research_section
+        assert "text-file" in research_section

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -9,6 +9,7 @@ from factory.eval.guards import (
     _glob_match,
     check_eval_immutable,
     check_experiment_branch,
+    check_fixed_surfaces,
     check_git_clean,
     check_scope,
     snapshot_eval_tree,
@@ -153,6 +154,54 @@ class TestGlobMatch:
         assert _glob_match(filepath, pattern) is expected
 
 
+class TestCheckFixedSurfaces:
+    def test_no_violation_safe_files(self, git_project):
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "src" / "new.py").write_text("new\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "safe change"], git_project)
+        result = check_fixed_surfaces(git_project, baseline, ["data/**", "ground_truth.json"])
+        assert result is None
+
+    def test_violation_fixed_surface_modified(self, git_project):
+        (git_project / "ground_truth.json").write_text("{}\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "add truth"], git_project)
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "ground_truth.json").write_text('{"answer": 42}\n')
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "modify truth"], git_project)
+        result = check_fixed_surfaces(git_project, baseline, ["ground_truth.json"])
+        assert result is not None
+        assert "ground_truth.json" in result
+
+    def test_lock_files_ignored(self, git_project):
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "uv.lock").write_text("lock content\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "lock change"], git_project)
+        result = check_fixed_surfaces(git_project, baseline, ["**"])
+        assert result is None
+
+    def test_glob_patterns(self, git_project):
+        (git_project / "data").mkdir()
+        (git_project / "data" / "expected.json").write_text("{}\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "add data"], git_project)
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "data" / "expected.json").write_text('{"changed": true}\n')
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "modify data"], git_project)
+        result = check_fixed_surfaces(git_project, baseline, ["data/**/*.json"])
+        assert result is not None
+        assert "expected.json" in result
+
+    def test_no_changes(self, git_project):
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        result = check_fixed_surfaces(git_project, baseline, ["data/**"])
+        assert result is None
+
+
 class TestCheckAll:
     def test_clean_passes(self, git_project):
         baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
@@ -162,3 +211,17 @@ class TestCheckAll:
         _git(["commit", "-m", "change"], git_project)
         violations = check_all(git_project, baseline, eval_tree_before=tree)
         assert violations == []
+
+    def test_fixed_surfaces_wired(self, git_project):
+        (git_project / "truth.json").write_text("{}\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "add truth"], git_project)
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "truth.json").write_text('{"modified": true}\n')
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "modify truth"], git_project)
+        violations = check_all(
+            git_project, baseline,
+            fixed_surfaces=["truth.json"],
+        )
+        assert any("Fixed surface" in v for v in violations)

--- a/tests/test_leakage.py
+++ b/tests/test_leakage.py
@@ -1,0 +1,449 @@
+"""Tests for factory.research.leakage — ground truth leakage detection."""
+
+from __future__ import annotations
+
+from factory.research.leakage import (
+    _check_negation_hints,
+    _check_specific_values,
+    _check_token_overlap,
+    _extract_specific_values,
+    _tokenize_text,
+    fingerprint_fixed_surfaces,
+    scan_diff_for_leakage,
+    scan_for_leakage,
+    validate_research_config,
+)
+
+
+# ── _tokenize_text ───────────────────────────────────────────
+
+
+class TestTokenizeText:
+    def test_basic_identifiers(self):
+        tokens = _tokenize_text("calculate_accuracy parse_findings")
+        assert "calculate" in tokens
+        assert "accuracy" in tokens
+        assert "parse" in tokens
+        assert "findings" in tokens
+
+    def test_camel_case_split(self):
+        tokens = _tokenize_text("calculateAccuracy parseResults")
+        assert "calculate" in tokens
+        assert "accuracy" in tokens
+
+    def test_stopwords_filtered(self):
+        tokens = _tokenize_text("def return import class self")
+        assert "def" not in tokens
+        assert "return" not in tokens
+        assert "import" not in tokens
+
+    def test_short_tokens_filtered(self):
+        tokens = _tokenize_text("ab cd x calculateAccuracy")
+        assert "ab" not in tokens
+        assert "cd" not in tokens
+        assert "calculate" in tokens
+
+    def test_empty_text(self):
+        assert _tokenize_text("") == set()
+
+    def test_full_words_kept(self):
+        tokens = _tokenize_text("calculateAccuracy")
+        assert "calculateaccuracy" in tokens
+
+
+# ── _extract_specific_values ─────────────────────────────────
+
+
+class TestExtractSpecificValues:
+    def test_numeric_literals(self):
+        values = _extract_specific_values("accuracy = 0.847 and count = 42")
+        assert "0.847" in values
+        assert "42" in values
+
+    def test_common_numbers_filtered(self):
+        values = _extract_specific_values("x = 0 y = 1 z = 100 w = 0.5")
+        assert "0" not in values
+        assert "1" not in values
+        assert "100" not in values
+        assert "0.5" not in values
+
+    def test_quoted_strings(self):
+        values = _extract_specific_values('label = "expected_output" and key = \'secret_value\'')
+        assert "expected_output" in values
+        assert "secret_value" in values
+
+    def test_short_quoted_strings_filtered(self):
+        values = _extract_specific_values('"ab" "ok"')
+        assert "ab" not in values
+        assert "ok" not in values
+
+    def test_empty_text(self):
+        assert _extract_specific_values("") == set()
+
+
+# ── fingerprint_fixed_surfaces ───────────────────────────────
+
+
+class TestFingerprintFixedSurfaces:
+    def test_extracts_tokens_from_files(self, tmp_path):
+        (tmp_path / "ground_truth.py").write_text(
+            "def calculate_subtraction(a, b):\n"
+            "    return a - b\n"
+            "EXPECTED_ACCURACY = 0.847\n"
+        )
+        fps = fingerprint_fixed_surfaces(tmp_path, ["ground_truth.py"])
+        assert "ground_truth.py" in fps
+        tokens = fps["ground_truth.py"]
+        assert "calculate" in tokens
+        assert "subtraction" in tokens
+        assert "0.847" in tokens
+
+    def test_empty_fixed_surfaces(self, tmp_path):
+        assert fingerprint_fixed_surfaces(tmp_path, []) == {}
+
+    def test_missing_file(self, tmp_path):
+        fps = fingerprint_fixed_surfaces(tmp_path, ["nonexistent.py"])
+        assert fps == {}
+
+    def test_glob_pattern(self, tmp_path):
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "expected.json").write_text(
+            '{"answer": "subtraction", "score": 0.95}\n'
+        )
+        fps = fingerprint_fixed_surfaces(tmp_path, ["data/*.json"])
+        assert len(fps) == 1
+        key = next(iter(fps))
+        assert "expected.json" in key
+
+    def test_directory_ignored(self, tmp_path):
+        (tmp_path / "somedir").mkdir()
+        fps = fingerprint_fixed_surfaces(tmp_path, ["somedir"])
+        assert fps == {}
+
+
+# ── _check_token_overlap ─────────────────────────────────────
+
+
+class TestCheckTokenOverlap:
+    def test_high_overlap(self):
+        text_tokens = {"calculate", "subtraction", "accuracy", "expected"}
+        fingerprints = {
+            "truth.py": {"calculate", "subtraction", "accuracy", "expected", "result"},
+        }
+        findings = _check_token_overlap(text_tokens, fingerprints, threshold=0.15)
+        assert len(findings) == 1
+        assert findings[0].leak_type == "token_overlap"
+        assert findings[0].source_file == "truth.py"
+
+    def test_no_overlap(self):
+        text_tokens = {"logging", "agent", "builder"}
+        fingerprints = {"truth.py": {"calculate", "subtraction", "accuracy"}}
+        findings = _check_token_overlap(text_tokens, fingerprints, threshold=0.15)
+        assert findings == []
+
+    def test_empty_tokens(self):
+        findings = _check_token_overlap(set(), {"truth.py": {"calculate"}}, threshold=0.15)
+        assert findings == []
+
+
+# ── _check_negation_hints ────────────────────────────────────
+
+
+class TestCheckNegationHints:
+    def test_do_not_pattern(self):
+        fingerprints = {"truth.py": {"subtract", "division", "multiply"}}
+        findings = _check_negation_hints("do not subtract from the result", fingerprints)
+        assert len(findings) == 1
+        assert findings[0].leak_type == "negation_hint"
+        assert findings[0].leaked_token == "subtract"
+
+    def test_should_not_pattern(self):
+        fingerprints = {"truth.py": {"multiply"}}
+        findings = _check_negation_hints("should not multiply the values", fingerprints)
+        assert len(findings) == 1
+
+    def test_avoid_pattern(self):
+        fingerprints = {"truth.py": {"division"}}
+        findings = _check_negation_hints("avoid division here", fingerprints)
+        assert len(findings) == 1
+
+    def test_never_pattern(self):
+        fingerprints = {"truth.py": {"recursion"}}
+        findings = _check_negation_hints("never recursion in this function", fingerprints)
+        assert len(findings) == 1
+
+    def test_dont_pattern(self):
+        fingerprints = {"truth.py": {"subtract"}}
+        findings = _check_negation_hints("don't subtract anything", fingerprints)
+        assert len(findings) == 1
+
+    def test_no_match(self):
+        fingerprints = {"truth.py": {"subtract"}}
+        findings = _check_negation_hints("add the values together", fingerprints)
+        assert findings == []
+
+    def test_negated_word_not_in_fingerprint(self):
+        fingerprints = {"truth.py": {"subtract"}}
+        findings = _check_negation_hints("do not multiply the values", fingerprints)
+        assert findings == []
+
+
+# ── _check_specific_values ───────────────────────────────────
+
+
+class TestCheckSpecificValues:
+    def test_numeric_value_leaked(self):
+        fingerprints = {"truth.py": {"0.847", "calculate"}}
+        findings = _check_specific_values("the expected accuracy is 0.847", fingerprints)
+        assert len(findings) == 1
+        assert findings[0].leaked_token == "0.847"
+        assert findings[0].leak_type == "specific_value"
+
+    def test_no_value_match(self):
+        fingerprints = {"truth.py": {"0.847"}}
+        findings = _check_specific_values("improve the accuracy score", fingerprints)
+        assert findings == []
+
+    def test_empty_text(self):
+        fingerprints = {"truth.py": {"0.847"}}
+        findings = _check_specific_values("", fingerprints)
+        assert findings == []
+
+
+# ── scan_for_leakage ─────────────────────────────────────────
+
+
+class TestScanForLeakage:
+    def test_no_leakage(self):
+        fingerprints = {"truth.py": {"subtract", "division", "accuracy"}}
+        report = scan_for_leakage("improve logging in the agent", fingerprints)
+        assert not report.flagged
+        assert report.risk_level == "none"
+
+    def test_negation_hint_high_risk(self):
+        fingerprints = {"truth.py": {"subtract"}}
+        report = scan_for_leakage("do not subtract from the value", fingerprints)
+        assert report.flagged
+        assert report.risk_level == "high"
+
+    def test_specific_value_medium_risk(self):
+        fingerprints = {"truth.py": {"0.847"}}
+        report = scan_for_leakage("target accuracy of 0.847", fingerprints)
+        assert report.flagged
+        assert report.risk_level in ("medium", "high")
+
+    def test_empty_text(self):
+        fingerprints = {"truth.py": {"subtract"}}
+        report = scan_for_leakage("", fingerprints)
+        assert not report.flagged
+
+    def test_empty_fingerprints(self):
+        report = scan_for_leakage("do not subtract", {})
+        assert not report.flagged
+
+    def test_sensitivity_levels(self):
+        fingerprints = {"truth.py": {"calculate", "accuracy", "expected", "subtract"}}
+        text = "calculate the accuracy"
+
+        report_low = scan_for_leakage(text, fingerprints, sensitivity="low")
+        report_high = scan_for_leakage(text, fingerprints, sensitivity="high")
+        # High sensitivity should be more likely to flag than low
+        if report_low.flagged:
+            assert report_high.flagged
+
+
+# ── scan_diff_for_leakage ────────────────────────────────────
+
+
+class TestScanDiffForLeakage:
+    def test_added_lines_scanned(self):
+        fingerprints = {"truth.py": {"0.847"}}
+        diff = (
+            "diff --git a/src/main.py b/src/main.py\n"
+            "--- a/src/main.py\n"
+            "+++ b/src/main.py\n"
+            "@@ -1,3 +1,4 @@\n"
+            " existing code\n"
+            "+EXPECTED_VALUE = 0.847\n"
+            " more code\n"
+        )
+        report = scan_diff_for_leakage(diff, fingerprints)
+        assert report.flagged
+
+    def test_context_lines_ignored(self):
+        fingerprints = {"truth.py": {"0.847"}}
+        diff = (
+            "diff --git a/src/main.py b/src/main.py\n"
+            "--- a/src/main.py\n"
+            "+++ b/src/main.py\n"
+            "@@ -1,3 +1,3 @@\n"
+            " EXISTING_VALUE = 0.847\n"
+            "-old line\n"
+            "+new line\n"
+        )
+        report = scan_diff_for_leakage(diff, fingerprints)
+        assert not report.flagged
+
+    def test_empty_diff(self):
+        fingerprints = {"truth.py": {"0.847"}}
+        report = scan_diff_for_leakage("", fingerprints)
+        assert not report.flagged
+
+    def test_no_added_lines(self):
+        fingerprints = {"truth.py": {"subtract"}}
+        diff = (
+            "diff --git a/src/main.py b/src/main.py\n"
+            "--- a/src/main.py\n"
+            "+++ b/src/main.py\n"
+            "@@ -1,3 +1,2 @@\n"
+            " existing\n"
+            "-removed line with subtract\n"
+        )
+        report = scan_diff_for_leakage(diff, fingerprints)
+        assert not report.flagged
+
+
+# ── validate_research_config ─────────────────────────────────
+
+
+class TestValidateResearchConfig:
+    def test_valid_config(self, tmp_path):
+        from factory.models import FactoryConfig, ResearchTarget
+
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "truth.json").write_text("{}")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "solver.py").write_text("")
+
+        config = FactoryConfig(
+            goal="test",
+            scope=["src/**"],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            research_target=ResearchTarget(
+                objective="test",
+                metric="accuracy",
+                target=0.9,
+                run_command="echo ok",
+                result_path="results.json",
+            ),
+            fixed_surfaces=["data/*.json"],
+            mutable_surfaces=["src/**/*.py"],
+        )
+        errors = validate_research_config(config, tmp_path)
+        assert errors == []
+
+    def test_missing_research_target(self, tmp_path):
+        from factory.models import FactoryConfig
+
+        config = FactoryConfig(
+            goal="test",
+            scope=["src/**"],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            fixed_surfaces=["data/*.json"],
+            mutable_surfaces=["src/**/*.py"],
+        )
+        errors = validate_research_config(config, tmp_path)
+        assert any("research_target" in e for e in errors)
+
+    def test_empty_fixed_surfaces(self, tmp_path):
+        from factory.models import FactoryConfig, ResearchTarget
+
+        config = FactoryConfig(
+            goal="test",
+            scope=["src/**"],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            research_target=ResearchTarget(
+                objective="test",
+                metric="accuracy",
+                target=0.9,
+                run_command="echo ok",
+                result_path="results.json",
+            ),
+            fixed_surfaces=[],
+            mutable_surfaces=["src/**/*.py"],
+        )
+        errors = validate_research_config(config, tmp_path)
+        assert any("fixed_surfaces" in e for e in errors)
+
+    def test_empty_mutable_surfaces(self, tmp_path):
+        from factory.models import FactoryConfig, ResearchTarget
+
+        (tmp_path / "truth.py").write_text("data")
+
+        config = FactoryConfig(
+            goal="test",
+            scope=["src/**"],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            research_target=ResearchTarget(
+                objective="test",
+                metric="accuracy",
+                target=0.9,
+                run_command="echo ok",
+                result_path="results.json",
+            ),
+            fixed_surfaces=["truth.py"],
+            mutable_surfaces=[],
+        )
+        errors = validate_research_config(config, tmp_path)
+        assert any("mutable_surfaces" in e for e in errors)
+
+    def test_fixed_pattern_matches_no_files(self, tmp_path):
+        from factory.models import FactoryConfig, ResearchTarget
+
+        config = FactoryConfig(
+            goal="test",
+            scope=["src/**"],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            research_target=ResearchTarget(
+                objective="test",
+                metric="accuracy",
+                target=0.9,
+                run_command="echo ok",
+                result_path="results.json",
+            ),
+            fixed_surfaces=["nonexistent/*.json"],
+            mutable_surfaces=["src/**/*.py"],
+        )
+        errors = validate_research_config(config, tmp_path)
+        assert any("matches no files" in e for e in errors)
+
+    def test_mutable_fixed_overlap(self, tmp_path):
+        from factory.models import FactoryConfig, ResearchTarget
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "solver.py").write_text("")
+
+        config = FactoryConfig(
+            goal="test",
+            scope=["src/**"],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            research_target=ResearchTarget(
+                objective="test",
+                metric="accuracy",
+                target=0.9,
+                run_command="echo ok",
+                result_path="results.json",
+            ),
+            fixed_surfaces=["src/**/*.py"],
+            mutable_surfaces=["src/**/*.py"],
+        )
+        errors = validate_research_config(config, tmp_path)
+        assert any("overlap" in e for e in errors)

--- a/tests/test_precheck.py
+++ b/tests/test_precheck.py
@@ -13,9 +13,11 @@ from factory.strategy import (
 )
 from factory.precheck import (
     check_anti_pattern,
+    check_leakage,
     check_score_direction,
     check_scope,
     check_smoke_test,
+    check_surfaces,
     run_precheck,
 )
 from factory.review import (
@@ -234,6 +236,81 @@ class TestCheckSmokeTest:
         assert "timed out" in r.detail.lower()
 
 
+# ── precheck: check_surfaces ─────────────────────────────────
+
+
+class TestCheckSurfaces:
+    @patch("factory.precheck.subprocess.run")
+    def test_clean(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="clean\n", stderr="")
+        r = check_surfaces(Path("/tmp/test"), "abc123", ["data/**"])
+        assert r.passed
+        assert r.name == "fixed_surfaces"
+
+    @patch("factory.precheck.subprocess.run")
+    def test_violations(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="VIOLATION: Fixed surface modified: data/truth.json",
+            stderr="",
+        )
+        r = check_surfaces(Path("/tmp/test"), "abc123", ["data/**"])
+        assert not r.passed
+        assert "truth.json" in r.detail
+
+    @patch("factory.precheck.subprocess.run")
+    def test_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="guard", timeout=60)
+        r = check_surfaces(Path("/tmp/test"), "abc123", ["data/**"])
+        assert not r.passed
+        assert "timed out" in r.detail.lower()
+
+    @patch("factory.precheck.subprocess.run")
+    def test_command_not_found(self, mock_run):
+        mock_run.side_effect = FileNotFoundError()
+        r = check_surfaces(Path("/tmp/test"), "abc123", ["data/**"])
+        assert not r.passed
+        assert "not found" in r.detail.lower()
+
+
+# ── precheck: check_leakage ──────────────────────────────────
+
+
+class TestCheckLeakage:
+    def test_no_leakage(self, tmp_path):
+        (tmp_path / "truth.py").write_text("def subtract(a, b): return a - b\n")
+        r = check_leakage(
+            "improve logging in the builder agent",
+            tmp_path,
+            ["truth.py"],
+        )
+        assert r.passed
+        assert r.name == "ground_truth_leakage"
+
+    def test_negation_hint_detected(self, tmp_path):
+        (tmp_path / "truth.py").write_text("def subtract(a, b): return a - b\n")
+        r = check_leakage(
+            "do not subtract from the values",
+            tmp_path,
+            ["truth.py"],
+        )
+        assert not r.passed
+        assert "leakage" in r.detail.lower() or "risk" in r.detail.lower()
+
+    def test_no_fixed_surface_files(self, tmp_path):
+        r = check_leakage(
+            "do not subtract",
+            tmp_path,
+            ["nonexistent.py"],
+        )
+        assert r.passed
+        assert "skipped" in r.detail.lower()
+
+    def test_empty_fixed_surfaces(self, tmp_path):
+        r = check_leakage("anything", tmp_path, [])
+        assert r.passed
+
+
 # ── precheck: run_precheck ────────────────────────────────────
 
 
@@ -293,6 +370,21 @@ class TestRunPrecheck:
         assert not result.passed
         assert "score_direction" in result.blocking_failures
         assert "anti_pattern" in result.blocking_failures
+
+    def test_fixed_surfaces_included(self, tmp_path):
+        (tmp_path / "truth.py").write_text("def subtract(a, b): return a - b\n")
+        result = run_precheck(
+            score_before=0.7,
+            score_after=0.85,
+            threshold=0.8,
+            hypothesis="do not subtract from the values",
+            history=[],
+            project_path=tmp_path,
+            baseline_sha="abc123",
+            fixed_surfaces=["truth.py"],
+        )
+        check_names = [c.name for c in result.checks]
+        assert "ground_truth_leakage" in check_names
 
     def test_summary_output(self):
         result = run_precheck(

--- a/tests/test_precheck.py
+++ b/tests/test_precheck.py
@@ -243,7 +243,7 @@ class TestCheckSurfaces:
     @patch("factory.precheck.subprocess.run")
     def test_clean(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="clean\n", stderr="")
-        r = check_surfaces(Path("/tmp/test"), "abc123", ["data/**"])
+        r = check_surfaces(Path("/tmp/test"), "abc123")
         assert r.passed
         assert r.name == "fixed_surfaces"
 
@@ -254,21 +254,21 @@ class TestCheckSurfaces:
             stdout="VIOLATION: Fixed surface modified: data/truth.json",
             stderr="",
         )
-        r = check_surfaces(Path("/tmp/test"), "abc123", ["data/**"])
+        r = check_surfaces(Path("/tmp/test"), "abc123")
         assert not r.passed
         assert "truth.json" in r.detail
 
     @patch("factory.precheck.subprocess.run")
     def test_timeout(self, mock_run):
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="guard", timeout=60)
-        r = check_surfaces(Path("/tmp/test"), "abc123", ["data/**"])
+        r = check_surfaces(Path("/tmp/test"), "abc123")
         assert not r.passed
         assert "timed out" in r.detail.lower()
 
     @patch("factory.precheck.subprocess.run")
     def test_command_not_found(self, mock_run):
         mock_run.side_effect = FileNotFoundError()
-        r = check_surfaces(Path("/tmp/test"), "abc123", ["data/**"])
+        r = check_surfaces(Path("/tmp/test"), "abc123")
         assert not r.passed
         assert "not found" in r.detail.lower()
 


### PR DESCRIPTION
## Summary

Adds comprehensive ground truth leakage prevention for research mode — 6 layers of defense ensuring that ground truth content (correct patches, expected test outputs, solutions) cannot leak into hypotheses, strategies, or code changes, either directly or indirectly.

**The problem:** Research mode experiments (e.g. SWE-bench) have ground truth files. Today the factory only has prompt-level surface constraints — agents are *told* not to touch fixed files. There's no programmatic enforcement, and no detection of *content-level* leakage like a hypothesis that says "do NOT use subtraction" (which leaks the correct operation by elimination).

### Layers

| Layer | What | Where |
|-------|------|-------|
| 1. Programmatic fixed-surface guard | Blocks PRs that modify fixed_surfaces files | `factory/eval/guards.py` |
| 2. Precheck surface gate | Hard, non-overridable precheck for surface violations | `factory/precheck.py` |
| 3. Content-level leakage detection | Token fingerprinting, negation hint detection, specific value matching, PR diff scanning | `factory/research/leakage.py` (new) |
| 4. Pre-cycle validation | Validates research config before any agents spawn | CLI `validate-research` |
| 5. Prompt hardening | Ground truth isolation rules in all 5 agent prompts + CEO | Agent prompts |
| 6. Tests | 46 new test cases across 3 test files | `tests/` |

### Leakage vectors covered

- Builder modifies fixed_surfaces → Layer 1 + 2
- Builder reads fixed_surfaces and embeds answer in code → Layer 3 (diff scanning)
- Hypothesis encodes ground truth ("do NOT subtract") → Layer 3 (negation hints)
- Hypothesis contains specific expected values ("0.847") → Layer 3 (specific values)
- Hypothesis has high token overlap with ground truth → Layer 3 (Jaccard overlap)
- User forgets to list ground truth in fixed_surfaces → Layer 4 (validation)
- Mutable/fixed surfaces overlap → Layer 4 (cross-check)

### New CLI commands

- `factory leakage-check <path> --text "..." [--sensitivity medium]` — scan text for leakage
- `factory validate-research <path>` — validate research mode config

## Test plan

- [x] All 1290 tests pass (`uv run pytest -v`)
- [x] Lint clean (`uv run ruff check .`)
- [x] Type check clean (`uv run mypy factory/`)
- [ ] Manual review of all 6 layers
- [ ] Verify negation hint detection catches "do NOT subtract" pattern
- [ ] Verify PR diff scanning catches embedded ground truth values

🤖 Generated with [Claude Code](https://claude.com/claude-code)