### PR TITLE
feat: add --no-github flag to disable GitHub operations

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1238,6 +1238,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     if mode in ("auto", "auto-fresh"):
         mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context), force_fresh=force_fresh)
     discover_only = getattr(args, "discover_only", False)
+    no_github = getattr(args, "no_github", False)
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)
@@ -1271,7 +1272,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     task = _build_ceo_task(
         project_path, ceo_mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
-        discover_only=discover_only,
+        discover_only=discover_only, no_github=no_github,
         interactive_idea=interactive_idea,
         research_ideation=research_ideation,
     )
@@ -1303,7 +1304,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             project_path, focus=focus,
             min_growth=min_growth, max_new=max_new, branch=branch,
             already_improved=mode in ("improve", "meta") or discover_only,
-            model=model,
+            model=model, no_github=no_github,
         )
 
     # Interactive foreground mode: use runner's interactive_exec
@@ -1503,6 +1504,8 @@ def cmd_tmux(args: argparse.Namespace) -> int:
         run_args += f" --max-cycles {args.max_cycles}"
     if model:
         run_args += f" --model {shlex.quote(model)}"
+    if getattr(args, "no_github", False):
+        run_args += " --no-github"
 
     run_cmd_parts.append(run_args)
     shell_cmd = " && ".join(run_cmd_parts)
@@ -1674,6 +1677,7 @@ def _build_ceo_task(
     max_new: int | None = None,
     branch: str | None = None,
     discover_only: bool = False,
+    no_github: bool = False,
     interactive_idea: str | None = None,
     research_ideation: str | None = None,
 ) -> str:
@@ -1788,6 +1792,18 @@ def _build_ceo_task(
             "make a keep/revert decision. Respect research_constraints and cost_budget."
         )
 
+    if no_github:
+        task += (
+            "\n\n## GitHub Operations Disabled\n\n"
+            "The user has passed --no-github. Do NOT:\n"
+            "- Create issues on GitHub\n"
+            "- Create or post pull requests\n"
+            "- Push to remote repositories\n"
+            "- Clone from GitHub URLs\n\n"
+            "Work locally only. When a GitHub operation would normally occur, "
+            "skip it and note what was skipped in the experiment log."
+        )
+
     return task
 
 
@@ -1800,6 +1816,7 @@ def _chain_modes(
     already_improved: bool = False,
     max_chains: int = 3,
     model: str | None = None,
+    no_github: bool = False,
 ) -> int:
     """After a cycle completes, re-detect state and chain into the next mode.
 
@@ -1826,7 +1843,7 @@ def _chain_modes(
         code = _run_single_cycle(
             project_path, next_mode, focus=focus,
             min_growth=min_growth, max_new=max_new, branch=branch,
-            model=model,
+            no_github=no_github, model=model,
         )
         if code != 0:
             return code
@@ -1843,6 +1860,7 @@ def _run_single_cycle(
     max_new: int | None = None,
     branch: str | None = None,
     discover_only: bool = False,
+    no_github: bool = False,
     model: str | None = None,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
@@ -1856,7 +1874,7 @@ def _run_single_cycle(
     task = _build_ceo_task(
         project_path, mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
-        discover_only=discover_only,
+        discover_only=discover_only, no_github=no_github,
     )
 
     checkpoint = load_checkpoint(project_path)
@@ -1892,6 +1910,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     loop = getattr(args, "loop", False)
     focus = getattr(args, "focus", None)
     discover_only = getattr(args, "discover_only", False)
+    no_github = getattr(args, "no_github", False)
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)
@@ -1919,14 +1938,15 @@ def cmd_run(args: argparse.Namespace) -> int:
     if not loop:
         code = _run_single_cycle(
             project_path, mode, context, focus=focus, prompt_file=prompt_file,
-            discover_only=discover_only, model=model, **budget_kwargs,
+            discover_only=discover_only, no_github=no_github, model=model,
+            **budget_kwargs,
         )
         if code != 0:
             return code
         return _chain_modes(
             project_path, focus=focus, already_improved=skip_improve,
             min_growth=min_growth, max_new=max_new, branch=branch,
-            model=model,
+            model=model, no_github=no_github,
         )
 
     # Heartbeat loop mode
@@ -1953,12 +1973,13 @@ def cmd_run(args: argparse.Namespace) -> int:
 
             _run_single_cycle(
                 project_path, mode, context, focus=focus, prompt_file=prompt_file,
-                discover_only=discover_only, model=model, **budget_kwargs,
+                discover_only=discover_only, no_github=no_github, model=model,
+                **budget_kwargs,
             )
             _chain_modes(
                 project_path, focus=focus, already_improved=skip_improve,
                 min_growth=min_growth, max_new=max_new, branch=branch,
-                model=model,
+                model=model, no_github=no_github,
             )
             _emit_cli_event(project_path, "cycle.completed", {"cycle": cycle, "mode": mode})
 
@@ -2290,6 +2311,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--discover-only", action="store_true", default=False,
         help="Only run discovery and review — do not chain into improve",
     )
+    p.add_argument(
+        "--no-github", action="store_true", default=False,
+        help="Disable GitHub operations (issue creation, PR posting, cloning)",
+    )
     p.add_argument("--min-growth", type=int, default=None,
                     help="Minimum guaranteed growth hypotheses (default: 2)")
     p.add_argument("--max-new", type=int, default=None,
@@ -2323,6 +2348,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--discover-only", action="store_true", default=False,
         help="Only run discovery and review — do not chain into improve",
+    )
+    p.add_argument(
+        "--no-github", action="store_true", default=False,
+        help="Disable GitHub operations (issue creation, PR posting, cloning)",
     )
     p.add_argument(
         "--loop", action="store_true", default=False,
@@ -2362,6 +2391,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--max-cycles", type=int, default=None, help="Max cycles for loop mode")
     p.add_argument("--attach", action="store_true", default=False,
                     help="Attach to session after creating")
+    p.add_argument(
+        "--no-github", action="store_true", default=False,
+        help="Disable GitHub operations (issue creation, PR posting, cloning)",
+    )
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
     p.add_argument("--runner", choices=["claude", "bob"], default=None,


### PR DESCRIPTION
## Summary

- Adds `--no-github` CLI flag to `ceo`, `run`, and `tmux` subcommands
- When set, injects a directive into the CEO task to skip GitHub issue/PR creation, pushing, and cloning
- Threads the flag through the full call chain: `cmd_ceo`/`cmd_run` -> `_run_single_cycle` -> `_build_ceo_task` -> `_chain_modes`
- Includes `tmux` support (forwarded via shell command string), addressing the review feedback on the previous attempt (#124)

## Changes

Single file: `factory/cli.py`

1. **Argparse**: `--no-github` added to all three subcommand parsers (`ceo`, `run`, `tmux`)
2. **Extraction**: `getattr(args, "no_github", False)` in `cmd_ceo` and `cmd_run`
3. **Task injection**: `_build_ceo_task()` appends a "GitHub Operations Disabled" directive when flag is set
4. **Threading**: `_run_single_cycle()` and `_chain_modes()` accept and forward `no_github`
5. **tmux forwarding**: `cmd_tmux()` appends `--no-github` to the shell command passed to the tmux session

## Context

Supersedes #124, which was missing tmux subcommand support (flagged in review by @akashgit). This PR addresses that gap.

Fixes #122, closes #123

## Test plan

- [ ] `factory ceo --help` shows `--no-github`
- [ ] `factory run --help` shows `--no-github`
- [ ] `factory tmux --help` shows `--no-github`
- [ ] Flag injects directive into CEO task string
- [ ] No directive when flag is absent (default behavior unchanged)
- [ ] tmux forwards flag to underlying `factory run` command