### PR TITLE
Fix Live Events panel expanding without bounds

### DIFF
--- a/factory/dashboard/static/index.html
+++ b/factory/dashboard/static/index.html
@@ -88,6 +88,7 @@
     border-bottom: 1px solid var(--border);
     display: flex;
     flex-direction: column;
+    min-height: 0;
   }
 
   .panel-header {

--- a/factory/dashboard/static/index.html
+++ b/factory/dashboard/static/index.html
@@ -405,8 +405,8 @@
     .kpi-strip { flex-wrap: wrap; }
     .kpi-card { min-width: calc(50% - 12px); }
     .projects-panel { grid-row: 2; max-height: 200px; }
-    .events-panel { grid-column: 1; grid-row: 3; }
-    .experiments-panel { grid-column: 1; grid-row: 4; }
+    .events-panel { grid-column: 1; grid-row: 3; max-height: 50vh; }
+    .experiments-panel { grid-column: 1; grid-row: 4; max-height: 50vh; }
   }
 </style>
 </head>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -101,6 +101,7 @@ class TestDashboardAPI:
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
         assert "Factory" in resp.text
+        assert "min-height: 0" in resp.text
 
     def test_list_projects(self, client: TestClient):
         resp = client.get("/api/projects")


### PR DESCRIPTION
## Summary

- Add `min-height: 0` to `.panel` CSS class to fix unbounded vertical growth of the Live Events panel on desktop (grid `1fr` tracks)
- Add `max-height: 50vh` to `.events-panel` and `.experiments-panel` in the responsive breakpoint (`@media max-width: 800px`) to constrain panel height on narrow viewports where `auto` grid rows are used
- CSS grid items default to `min-height: auto`, which sizes them to fit content and prevents internal scrolling. The desktop fix overrides that default so `overflow-y: auto` on `.panel-body` engages correctly. The mobile fix uses explicit height constraints since `auto` tracks don't benefit from `min-height: 0`.
- Add regression test assertion for `min-height: 0` in `test_index_returns_html`

## Test plan

- [ ] Open dashboard with a project that generates many events
- [ ] Verify Live Events panel scrolls internally instead of pushing Experiments below the fold (desktop)
- [ ] Resize browser below 800px and verify Events and Experiments panels scroll internally (mobile)
- [ ] Verify Experiments table remains visible without page scroll
- [ ] Verify Projects sidebar scrolls correctly with many projects
- [ ] All 31 existing tests pass

Closes #168