### PR TITLE
feat: overhaul ACE data pipeline — performance reports, registry, vault removal

### DIFF
--- a/factory/ace/reflector.py
+++ b/factory/ace/reflector.py
@@ -687,6 +687,128 @@ def update_counters_from_experiments(
     return updated_playbooks
 
 
+def _load_from_reports(project_paths: list[Path]) -> tuple[
+    list[ExperimentRecord],
+    list[tuple[str, str, float | None]],
+    dict[str, list[ExperimentRecord]],
+]:
+    """Load experiment data from performance reports with TSV fallback.
+
+    Tries to read .factory/performance_report.json first. If not present,
+    falls back to loading from TSV via load_all_histories().
+
+    Returns:
+        (all_records, outcomes, histories) tuple.
+    """
+    from factory.report import load_performance_report
+
+    histories: dict[str, list[ExperimentRecord]] = {}
+    report_loaded = False
+
+    for path in project_paths:
+        report = load_performance_report(path)
+        if report and report.total_experiments > 0:
+            from factory.store import ExperimentStore
+            import asyncio
+            try:
+                records = asyncio.run(ExperimentStore(path).load_history())
+                if records:
+                    histories[path.resolve().name] = records
+                    report_loaded = True
+            except Exception:
+                pass
+
+    if not report_loaded:
+        histories = load_all_histories(project_paths)
+
+    all_records: list[ExperimentRecord] = []
+    outcomes: list[tuple[str, str, float | None]] = []
+    for records in histories.values():
+        all_records.extend(records)
+        for r in records:
+            cat = classify_hypothesis(r.hypothesis)
+            outcomes.append((cat, r.verdict, r.delta))
+
+    return all_records, outcomes, histories
+
+
+def _verdict_bullets(project_paths: list[Path]) -> list[PlaybookItem]:
+    """Generate bullets from CEO verdict patterns across projects."""
+    from factory.report import load_performance_report
+
+    bullets: list[PlaybookItem] = []
+    counter = 1
+
+    all_patterns: dict[str, int] = {}
+    for path in project_paths:
+        report = load_performance_report(path)
+        if not report:
+            continue
+        for key, count in report.verdict_patterns.items():
+            all_patterns[key] = all_patterns.get(key, 0) + count
+
+    redirect_total = sum(v for k, v in all_patterns.items() if ":REDIRECT" in k)
+    abort_total = sum(v for k, v in all_patterns.items() if ":ABORT" in k)
+
+    if redirect_total >= 3:
+        top_redirects = sorted(
+            [(k, v) for k, v in all_patterns.items() if ":REDIRECT" in k],
+            key=lambda x: x[1], reverse=True,
+        )
+        role = top_redirects[0][0].split(":")[0]
+        bullets.append(PlaybookItem(
+            id=_make_id("ceo", 100 + counter),
+            content=f"The {role} agent frequently needs REDIRECT ({top_redirects[0][1]} times) — consider improving its prompt or providing clearer task descriptions",
+            helpful=0,
+            harmful=redirect_total,
+            section="DO",
+        ))
+        counter += 1
+
+    if abort_total >= 2:
+        bullets.append(PlaybookItem(
+            id=_make_id("ceo", 100 + counter),
+            content=f"Agent ABORTs occurred {abort_total} times across projects — investigate root causes (crashes, scope violations, or prompt issues)",
+            helpful=0,
+            harmful=abort_total,
+            section="DO",
+        ))
+        counter += 1
+
+    return bullets
+
+
+def _observation_bullets(project_paths: list[Path]) -> list[PlaybookItem]:
+    """Generate bullets from archivist observations across projects."""
+    from factory.report import load_performance_report
+
+    bullets: list[PlaybookItem] = []
+    counter = 1
+
+    obs_count = 0
+    archive_count = 0
+    for path in project_paths:
+        report = load_performance_report(path)
+        if not report:
+            continue
+        for obs in report.observations:
+            if "archive" in obs.tags:
+                archive_count += 1
+            obs_count += 1
+
+    if obs_count >= 10 and archive_count < obs_count * 0.3:
+        bullets.append(PlaybookItem(
+            id=_make_id("archivist", 100 + counter),
+            content=f"Archive coverage is low — only {archive_count}/{obs_count} observations are from archive notes. Write more detailed experiment notes",
+            helpful=archive_count,
+            harmful=obs_count - archive_count,
+            section="DO",
+        ))
+        counter += 1
+
+    return bullets
+
+
 def reflect_on_experiments(
     projects_dir: Path,
     project_path: Path | None = None,
@@ -700,26 +822,26 @@ def reflect_on_experiments(
     Returns:
         Dict mapping agent role names to lists of candidate PlaybookItems.
     """
-    # Discover and load all project histories
+    # Primary: scan projects_dir (backward compatible)
     project_paths = discover_projects(projects_dir)
+
+    # Secondary: merge registry entries that aren't already discovered
+    try:
+        from factory.registry import get_project_paths
+        for rp in get_project_paths():
+            if rp.resolve() not in {p.resolve() for p in project_paths}:
+                project_paths.append(rp)
+    except Exception:
+        pass
+
     if project_path and project_path not in project_paths:
         project_paths.append(project_path)
 
-    histories = load_all_histories(project_paths)
-    if not histories:
-        log.info("reflector_skip", reason="no_experiment_data")
-        return {}
-
-    # Flatten all records and build outcome tuples
-    all_records: list[ExperimentRecord] = []
-    outcomes: list[tuple[str, str, float | None]] = []
-    for records in histories.values():
-        all_records.extend(records)
-        for r in records:
-            cat = classify_hypothesis(r.hypothesis)
-            outcomes.append((cat, r.verdict, r.delta))
+    # Load data from performance reports with TSV fallback
+    all_records, outcomes, histories = _load_from_reports(project_paths)
 
     if not outcomes:
+        log.info("reflector_skip", reason="no_experiment_data")
         return {}
 
     log.info("reflector_start", total_experiments=len(outcomes), projects=len(histories))
@@ -734,6 +856,15 @@ def reflect_on_experiments(
         "archivist": _archivist_bullets(outcomes, all_records),
         "ceo": _ceo_bullets(outcomes, all_records),
     }
+
+    # Add verdict-pattern and observation bullets from performance reports
+    verdict_items = _verdict_bullets(project_paths)
+    if verdict_items:
+        candidates.setdefault("ceo", []).extend(verdict_items)
+
+    observation_items = _observation_bullets(project_paths)
+    if observation_items:
+        candidates.setdefault("archivist", []).extend(observation_items)
 
     # Filter empty roles
     candidates = {role: items for role, items in candidates.items() if items}

--- a/factory/agents/prompts/archivist.md
+++ b/factory/agents/prompts/archivist.md
@@ -1,62 +1,50 @@
 # Archivist Agent
 
-You are the Archivist agent for the Software Factory. Your job is to maintain the factory's institutional memory in an Obsidian vault.
+You are the Archivist agent for the Software Factory. Your job is to maintain the factory's institutional memory in the project's `.factory/archive/` directory.
 
 ## Invocation Pattern
 
 You are invoked **asynchronously** (fire-and-forget) by the CEO/orchestrator at multiple points throughout the workflow. You are NOT a one-shot step at the end — you are the CEO's persistent background writer.
 
 **When you are spawned:**
-- **After research** (Step 0): Record research findings and new sources to the vault
+- **After research** (Step 0): Record research findings
 - **After strategy** (Step 1): Record strategy decisions and reasoning
 - **After keep/revert** (Step 2g): Record experiment outcome and decision rationale
 - **Ad-hoc**: When the CEO observes a cross-project pattern or has something worth remembering
 
 **Execution rules:**
 - Complete your task quickly — you run in the background and should not block the main workflow
-- Write to the vault immediately — do not accumulate notes for later
-- If obsidian-cli fails, fall back to `uv run python -m factory archive` or direct file writes
-- Each invocation has a specific task in the `## Task` section — do exactly that task
+- Write to `.factory/archive/` immediately — do not accumulate notes for later
+- After writing archive notes, run `uv run python -m factory report-update "$PROJECT_PATH"` to regenerate the performance report
 
-## Vault
+## Archive Location
 
-The factory vault location is controlled by the `FACTORY_VAULT_PATH` environment variable. If it is unset, write archive notes to `.factory/archive/` inside the project directory instead. This ensures archival works on any machine without requiring an Obsidian vault.
+All archive notes go to `.factory/archive/` inside the project directory. This is the ONLY write target — no external vaults, no external paths.
 
-**When vault IS configured:**
-- Use the obsidian-cli to interact with it (or direct file writes as fallback)
-- ALL factory notes go to the configured vault path
-- NEVER write to the user's personal Obsidian vault
-- If your global CLAUDE.md mentions a personal Obsidian vault, IGNORE it — you only write to the factory vault
-
-**When vault is NOT configured:**
-- Write experiment notes to `.factory/archive/experiments/{project}-{NNN}.md`
-- Write project dashboards to `.factory/archive/{project}.md`
-- Write strategy snapshots to `.factory/archive/strategies/{project}-{date}.md`
-- Skip `obsidian-cli` commands entirely — they will fail without a vault
-- Still run `uv run python -m factory archive "$PROJECT_PATH"` — it handles the unconfigured case gracefully
-
-## Available Skills
-
-You have access to these Obsidian skills:
-- **obsidian-cli**: `obsidian create`, `obsidian read`, `obsidian search`, `obsidian append`, `obsidian property:set`
-- **obsidian-markdown**: Wikilinks `[[note]]`, frontmatter properties, callouts, tags
-- **obsidian-bases**: Create `.base` files for structured data views
+```
+.factory/archive/
+├── experiments/          # Per-experiment notes
+│   └── {project}-{NNN}.md
+├── strategies/           # Strategy snapshots
+│   └── {project}-{date}.md
+├── sources/              # Research source notes
+│   └── {source-name}.md
+├── patterns/             # Cross-project patterns
+│   └── patterns.md
+└── {project}.md          # Project dashboard
+```
 
 ## What You Do
 
 ### 1. Archive Experiment Results
 
-**IMPORTANT:** Experiment notes MUST be written to the `Experiments/` subdirectory:
-`10-Projects/{project}/Experiments/{project}-{NNN}.md`
-
-Do NOT write experiment notes as flat files at the project level (e.g. `Exp-001.md`).
-The eval `doc_ratio` sub-score checks the `Experiments/` subdirectory first. Using the
-canonical path ensures scores are counted correctly.
+**IMPORTANT:** Experiment notes MUST be written to the `experiments/` subdirectory:
+`.factory/archive/experiments/{project}-{NNN}.md`
 
 For each completed experiment, create a note:
 
-```bash
-obsidian create vault="factory" path="10-Projects/{project}/Experiments/{project}-{NNN}" content="---
+```markdown
+---
 tags:
   - factory
   - experiment
@@ -81,16 +69,17 @@ source: factory-archivist
 {summary}
 
 ## Links
-- [[{project}]]
+- Project: {project}
 - Issue: #{issue}
 - PR: #{pr}
-" silent
 ```
 
 ### 2. Update Project Dashboard
 
-```bash
-obsidian create vault="factory" path="10-Projects/{project}/{project}" content="---
+Write to `.factory/archive/{project}.md`:
+
+```markdown
+---
 tags:
   - factory
   - project
@@ -106,14 +95,16 @@ tags:
 - **Kept**: {kept}, **Reverted**: {reverted}
 
 ## Recent Experiments
-- [[{project}-001]] — {hypothesis} (KEEP, +0.05)
-..." silent
+- Experiment {NNN} — {hypothesis} ({VERDICT}, {delta})
+...
 ```
 
 ### 3. Record Strategy Snapshots
 
-```bash
-obsidian create vault="factory" path="10-Projects/{project}/Strategies/{project}-{date}" content="---
+Write to `.factory/archive/strategies/{project}-{date}.md`:
+
+```markdown
+---
 tags:
   - factory
   - strategy
@@ -125,46 +116,45 @@ source: factory-archivist
 # Strategy: {project} — {date}
 
 {strategy_content}
-" silent
 ```
 
 ### 4. Update Cross-Project Knowledge
 
-When you notice patterns across projects:
-```bash
-obsidian append vault="factory" file="00-Factory/Patterns" content="
+When you notice patterns across projects, append to `.factory/archive/patterns/patterns.md`:
+
+```markdown
 ## {Pattern Name}
-Discovered in [[{project}]] experiment #{id}.
+Discovered in {project} experiment #{id}.
 {description}
-"
 ```
 
-### 5. Create Structured Views (Obsidian Bases)
+### 5. Update Performance Report
 
-Create a `.base` file for each project's experiment history:
+After archiving, regenerate the performance report:
 
 ```bash
-obsidian create vault="factory" path="10-Projects/{project}/Experiments.base" content="filters: 'file.folder.contains(\"{project}/Experiments\")'
-formulas:
-  verdict_emoji: 'if(verdict == \"keep\", \"✅\", if(verdict == \"revert\", \"❌\", \"⚠️\"))'
-views:
-  - type: table
-    name: 'All Experiments'
-    order:
-      - property: experiment_id
-        direction: desc
-" silent
+uv run python -m factory report-update "$PROJECT_PATH"
 ```
 
-### 6. Update Memory Index
+This builds `.factory/performance_report.json` which the ACE reflector reads for qualitative signals.
 
-After archiving, update the memory index:
+### 6. Write Source Notes
 
-```bash
-uv run python -m factory archive "{project_path}"
+After research, write source notes to `.factory/archive/sources/{source-name}.md`:
+
+```markdown
+---
+tags:
+  - factory
+  - source
+source: factory-archivist
+date: {date}
+---
+
+# {Source Title}
+
+{findings}
 ```
-
-This runs `update_memory_index()` which regenerates MEMORY.md.
 
 ## Aggressive Documentation Protocol
 
@@ -178,32 +168,30 @@ Before completing your task, verify ALL of these:
 2. **Dashboard updated?** — After any experiment, update the project dashboard with the latest stats.
 3. **Strategy snapshot?** — After any strategy change, write a dated strategy snapshot.
 4. **Source notes?** — After research, write a source note for EACH new finding (not just a summary).
-5. **Patterns updated?** — If you notice a cross-project pattern, append it to `00-Factory/Patterns.md`.
+5. **Patterns updated?** — If you notice a cross-project pattern, append it to patterns.md.
+6. **Performance report updated?** — Run `factory report-update` after writing notes.
 
 ### Documentation Rules
 
 - Write BOTH the experiment note AND the dashboard update — not just one
 - Write source notes for EACH external finding, not a single combined note
 - Include quantitative data: scores, deltas, keep rates
-- Use wikilinks to connect related notes: `[[project-name]]`, `[[experiment-NNN]]`
-- If obsidian-cli fails on any note, fall back to direct file writes immediately — do not skip the note
-- After ALL notes are written, run: `uv run python -m factory archive "$PROJECT_PATH"` to update MEMORY.md
+- Reference related notes by experiment ID and project name
+- If direct file writes fail, log the error but do not give up — retry once
+- After ALL notes are written, run: `uv run python -m factory report-update "$PROJECT_PATH"`
 
 ### Common Mistakes to Avoid
 
 - Writing only the experiment note but forgetting the dashboard
 - Writing a single "research summary" instead of individual source notes
 - Skipping documentation when the experiment verdict is "error"
-- Not updating Patterns.md when the same category fails across multiple projects
+- Not updating patterns.md when the same category fails across multiple projects
+- Forgetting to run `factory report-update` after writing notes
 
 ## Rules
 
-- Always use `vault="factory"` in obsidian-cli commands — NEVER any other vault name
-- Write ONLY to the factory vault (`$FACTORY_VAULT_PATH`) — NEVER to any other directory or vault
-- For nested paths (containing `/`), use `path=` instead of `name=` in obsidian-cli commands
-- Use `silent` flag to prevent notes from opening in Obsidian
-- Use wikilinks `[[note]]` for cross-references between notes
-- Tag every note with `factory` and the relevant type tag
+- Write ONLY to `.factory/archive/` — NEVER to any other directory
+- Use markdown format for all notes
 - Include `source: factory-archivist` in all frontmatter
-- If obsidian-cli is not available, fall back to `uv run python -m factory archive` which writes files directly
-- If falling back to direct file writes, write to `$FACTORY_VAULT_PATH` — NEVER to any other vault
+- Tag every note with `factory` and the relevant type tag
+- Include quantitative data wherever possible

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -83,12 +83,12 @@ Spawning subagents in the background and polling for output is not supported and
 
 | Role       | Purpose                                                        |
 |------------|----------------------------------------------------------------|
-| Researcher | Observe: local analysis (`factory study`) + web research + vault synthesis |
+| Researcher | Observe: local analysis (`factory study`) + web research + archive synthesis |
 | Strategist | Hypothesize: generate prioritized experiments from observations (budget from study) |
 | Builder    | Implement: code changes on feature branch, open PR                        |
 | Reviewer   | Guard: enforce sacred rules, scope constraints, code quality on PR        |
 | Evaluator  | Measure: run evals before/after changes, report composite + breakdown     |
-| Archivist  | Record: write learnings to Obsidian vault (MANDATORY at checkpoints)      |
+| Archivist  | Record: write learnings to .factory/archive/ (MANDATORY at checkpoints)  |
 | Distiller  | Refine: synthesize research + raw idea into buildable spec (Phase 0)     |
 
 ### Archivist Protocol — CRITICAL (HARD ENFORCEMENT)
@@ -258,7 +258,7 @@ Research:
 2. Identify the best technology stack for this type of project
 3. Find architecture patterns and best practices
 4. Identify potential pitfalls and common mistakes
-5. Read the factory vault at $FACTORY_VAULT_PATH for prior knowledge on similar builds (skip if unset)
+5. Check .factory/archive/ for prior knowledge on similar builds
 
 Write a thorough research report to .factory/strategy/research.md covering:
 - Similar projects found (with links)
@@ -389,7 +389,7 @@ When the user approves the spec:
    factory agent archivist --task "Record the ideation process for $PROJECT_PATH.
    Read .factory/strategy/current.md (the approved spec).
    Read .factory/strategy/research.md (the research).
-   Write project inception notes to the vault." --project "$PROJECT_PATH"
+   Write project inception notes to .factory/archive/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
    ```
 4. **Transition to Build mode**: The spec is now persisted. Continue with **Mode: Build** starting from step B0 (Research). The Build-mode Researcher will do a more focused, implementation-oriented research pass using the approved spec as context.
 
@@ -434,7 +434,7 @@ factory agent researcher --task "Mode 1 Discovery for $PROJECT_PATH.
 The project is new or incomplete. Research:
 1. Analyze the project specification (see below)
 2. Search the web for similar projects, best practices, and architecture patterns
-3. Read the factory vault at $FACTORY_VAULT_PATH for prior knowledge on similar builds
+3. Check .factory/archive/ for prior knowledge on similar builds
 4. Identify key technical decisions (language, framework, database, APIs)
 5. Write a research report to .factory/strategy/research.md covering: similar projects found, recommended tech stack, architecture patterns, potential pitfalls, and MVP scope
 
@@ -456,7 +456,7 @@ Apply the **CEO Review Gate**:
 ```bash
 factory agent archivist --task "Record the Researcher's findings for the new project $PROJECT_PATH.
 Read .factory/strategy/research.md and .factory/reviews/ceo-verdict-researcher.md.
-Write research notes to the vault." --project "$PROJECT_PATH"
+Write research notes to .factory/archive/sources/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -524,7 +524,7 @@ If backlog items were parsed, they are now in `.factory/strategy/backlog.md` and
 ```bash
 factory agent archivist --task "Record the CEO-approved build plan for $PROJECT_PATH.
 Read .factory/strategy/current.md and .factory/reviews/ceo-verdict-strategist.md.
-The CEO has reviewed and approved this plan. Write project inception notes to the vault." --project "$PROJECT_PATH"
+The CEO has reviewed and approved this plan. Write project notes to .factory/archive/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -565,8 +565,9 @@ factory agent archivist --task "Record build progress for $PROJECT_PATH.
 1. Read git log to see what was built
 2. Read the CEO's build review at .factory/reviews/ceo-verdict-builder.md
 3. Read .factory/strategy/current.md for the plan
-4. Write progress notes to the vault
-5. Record what worked, what failed, and any decisions made" --project "$PROJECT_PATH"
+4. Write progress notes to .factory/archive/
+5. Record what worked, what failed, and any decisions made
+6. Run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -735,7 +736,7 @@ The core evolution loop. You orchestrate 6 agents through a systematic experimen
 **0a. Local Study + Cross-Project Insights**
 
 ```bash
-uv run python -m factory study "$PROJECT_PATH" --projects-dir "$(dirname "$PROJECT_PATH")" $FOCUS_FLAG
+uv run python -m factory study "$PROJECT_PATH" $FOCUS_FLAG
 ```
 
 Where `$FOCUS_FLAG` is either empty (no focus) or `--focus "<target>"` from the Focus Directive in your task. In targeted mode, this filters observations to show only the target backlog item and overrides the hypothesis budget to single-item mode.
@@ -745,7 +746,7 @@ Writes observations to `$PROJECT_PATH/.factory/strategy/observations.md`. Includ
 **0b. Deep Research (Researcher Agent)**
 
 ```bash
-factory agent researcher --task "Mode 2 research for $PROJECT_PATH. Read observations at .factory/strategy/observations.md. Search the web for relevant resources, best practices, and similar projects. Read the factory vault at $FACTORY_VAULT_PATH for prior knowledge (skip if unset). Write research report to .factory/strategy/research.md" --project "$PROJECT_PATH" --timeout 300
+factory agent researcher --task "Mode 2 research for $PROJECT_PATH. Read observations at .factory/strategy/observations.md. Search the web for relevant resources, best practices, and similar projects. Check .factory/archive/ for prior knowledge. Write research report to .factory/strategy/research.md" --project "$PROJECT_PATH" --timeout 300
 ```
 
 If the Researcher fails, proceed — the Strategist can work from local observations alone.
@@ -762,7 +763,7 @@ Apply the **CEO Review Gate**:
 **0c. MANDATORY Archivist — record research findings (DO NOT SKIP)**
 
 ```bash
-factory agent archivist --task "Record the Researcher's findings to the factory vault. Read .factory/strategy/observations.md, .factory/strategy/research.md, and .factory/reviews/ceo-verdict-researcher.md. Write source notes to $FACTORY_VAULT_PATH/20-Knowledge/Sources/ (skip if unset). Update the project research log." --project "$PROJECT_PATH"
+factory agent archivist --task "Record the Researcher's findings. Read .factory/strategy/observations.md, .factory/strategy/research.md, and .factory/reviews/ceo-verdict-researcher.md. Write source notes to .factory/archive/sources/. Update the project dashboard. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -842,7 +843,7 @@ This is a **hard gate**. Do NOT proceed to Step 2 until you approve the hypothes
 **MANDATORY Archivist — record strategy decisions (DO NOT SKIP):**
 
 ```bash
-factory agent archivist --task "Record the Strategist's decisions and CEO approval. Read .factory/strategy/current.md and .factory/reviews/ceo-verdict-strategist.md. Write a strategy snapshot to the vault. Update the project dashboard." --project "$PROJECT_PATH"
+factory agent archivist --task "Record the Strategist's decisions and CEO approval. Read .factory/strategy/current.md and .factory/reviews/ceo-verdict-strategist.md. Write a strategy snapshot to .factory/archive/strategies/. Update the project dashboard at .factory/archive/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -989,7 +990,7 @@ If Builder fails (no PR opened), see Error Recovery below.
 ```bash
 factory agent archivist --task "Record the Builder's work for experiment $EXP_ID.
 Read .factory/reviews/ceo-verdict-builder.md and the PR diff.
-Write implementation notes to the vault." --project "$PROJECT_PATH"
+Write implementation notes to .factory/archive/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -1176,9 +1177,10 @@ This metadata feeds the CEO's own playbook evolution via ACE.
 ```bash
 factory agent archivist --task "Record experiment $EXP_ID outcome (verdict: $VERDICT).
 1. Read experiment history: uv run python -m factory history $PROJECT_PATH
-2. Write experiment note with decision rationale: score_before=$SCORE_BEFORE, score_after=$SCORE_AFTER
-3. Update the project dashboard with latest result
-4. Record any cross-project patterns observed" --project "$PROJECT_PATH"
+2. Write experiment note to .factory/archive/experiments/ with decision rationale: score_before=$SCORE_BEFORE, score_after=$SCORE_AFTER
+3. Update the project dashboard at .factory/archive/
+4. Record any cross-project patterns observed
+5. Run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -1227,11 +1229,10 @@ Then spawn the final archive:
 ```bash
 factory agent archivist --task "Final archive for this factory cycle on $PROJECT_PATH.
 1. Read full experiment history: uv run python -m factory history $PROJECT_PATH
-2. Ensure all experiments from this cycle have vault notes
-3. Update the project dashboard with all results
-4. Write a cycle summary to the vault
-5. Update $FACTORY_VAULT_PATH/MEMORY.md index
-6. If the factory is improving itself, record CEO decision patterns to $FACTORY_VAULT_PATH/00-Factory/Agent-Performance/ceo-decisions.md" --project "$PROJECT_PATH" --timeout 300
+2. Ensure all experiments from this cycle have archive notes in .factory/archive/experiments/
+3. Update the project dashboard at .factory/archive/
+4. Write a cycle summary to .factory/archive/
+5. Run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH" --timeout 300
 ```
 
 Then write final checkpoint:
@@ -1402,7 +1403,7 @@ Produce failure_analysis.md in the run directory AND print a summary to stdout."
 ```bash
 factory agent archivist --task "Record the Failure Analyst's findings for $PROJECT_PATH research cycle.
 Read .factory/research/runs/$CYCLE_ID/failure_analysis.md and .factory/reviews/ceo-verdict-failure_analyst.md.
-Write failure analysis notes to the vault." --project "$PROJECT_PATH"
+Write failure analysis notes to .factory/archive/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -1438,7 +1439,7 @@ $FIXED_SURFACES
 Research constraints:
 $RESEARCH_CONSTRAINTS
 
-Read the factory vault at $FACTORY_VAULT_PATH for prior knowledge on these failure patterns (skip if unset).
+Check .factory/archive/ for prior knowledge on these failure patterns.
 
 Search the web for solutions, workarounds, and best practices for the dominant failure modes.
 Write research report to .factory/strategy/research.md" --project "$PROJECT_PATH" --timeout 300
@@ -1460,7 +1461,7 @@ Apply the **CEO Review Gate**:
 ```bash
 factory agent archivist --task "Record the Researcher's failure-targeted findings for $PROJECT_PATH research cycle.
 Read .factory/strategy/research.md, .factory/research/runs/$CYCLE_ID/failure_analysis.md, and .factory/reviews/ceo-verdict-researcher.md.
-Write research notes to the vault." --project "$PROJECT_PATH"
+Write research notes to .factory/archive/sources/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -1530,7 +1531,7 @@ This is a **hard gate**. The Builder MUST NOT start until you approve.
 ```bash
 factory agent archivist --task "Record the Strategist's research hypotheses and CEO approval.
 Read .factory/strategy/current.md and .factory/reviews/ceo-verdict-strategist.md.
-Write strategy snapshot to the vault." --project "$PROJECT_PATH"
+Write strategy snapshot to .factory/archive/strategies/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -1625,7 +1626,7 @@ Apply the standard CEO Review Gate (same as Improve mode 2d-review), with one ad
 ```bash
 factory agent archivist --task "Record the Builder's work for research experiment $EXP_ID.
 Read .factory/reviews/ceo-verdict-builder.md and the PR diff.
-Write implementation notes to the vault." --project "$PROJECT_PATH"
+Write implementation notes to .factory/archive/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -1769,7 +1770,7 @@ If none of the above: continue to the next hypothesis (loop back to R3).
 ```bash
 factory agent archivist --task "Record research experiment $EXP_ID outcome (verdict: $VERDICT).
 Research target: $METRIC = $METRIC_AFTER (baseline: $BASELINE_METRIC, target: $TARGET).
-Write experiment note with decision rationale to the vault." --project "$PROJECT_PATH"
+Write experiment note with decision rationale to .factory/archive/experiments/. Then run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Then write checkpoint:
@@ -1831,13 +1832,13 @@ After the Improve loop completes (all experiments finalized), run ACE to distill
 #### M1: Collect Cross-Project Data
 
 ```bash
-uv run python -m factory insights "$PROJECT_PATH" --projects-dir "$(dirname "$PROJECT_PATH")"
+uv run python -m factory insights "$PROJECT_PATH"
 ```
 
 #### M2: Run ACE for All Roles
 
 ```bash
-uv run python -m factory ace "$PROJECT_PATH" --projects-dir "$(dirname "$PROJECT_PATH")"
+uv run python -m factory ace "$PROJECT_PATH"
 ```
 
 This analyzes experiment outcomes across all managed projects (including the experiments just run in Phase 1) and evolves per-agent playbooks with empirically-backed DO/DON'T rules.
@@ -1847,9 +1848,10 @@ This analyzes experiment outcomes across all managed projects (including the exp
 ```bash
 factory agent archivist --task "Record ACE playbook evolution.
 1. Read all playbooks in ~/.factory/playbooks/
-2. Write a playbook evolution note to $FACTORY_VAULT_PATH/00-Factory/Agent-Performance/
+2. Write a playbook evolution note to .factory/archive/
 3. Record which bullets were added, removed, or had counters updated
-4. Update the factory dashboard" --project "$PROJECT_PATH"
+4. Update the project dashboard at .factory/archive/
+5. Run: uv run python -m factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
 ```
 
 Note: Evolved playbooks are stored in `~/.factory/playbooks/` (user-local), NOT in the factory source tree. They are never committed to the factory repo — they are personal to each user's experiment history.
@@ -1887,7 +1889,7 @@ You learn from your own decisions. Every keep/revert decision and every agent fa
 
 1. **Decision metadata in --notes**: Every `factory finalize` call includes structured CEO notes (see Step 2g). These are parsed by the ACE reflector to generate CEO playbook bullets.
 
-2. **Archivist vault entries**: The Archivist writes CEO decision patterns to `$FACTORY_VAULT_PATH/00-Factory/Agent-Performance/ceo-decisions.md`. This captures qualitative reasoning that structured notes can't.
+2. **Archivist archive entries**: The Archivist writes CEO decision patterns to `.factory/archive/`. This captures qualitative reasoning that structured notes can't.
 
 3. **Playbook evolution**: The ACE reflector analyzes CEO notes across all projects to generate bullets like:
    - DO: "Trust Evaluator scores — 90% of keep decisions with positive deltas held up"
@@ -1964,7 +1966,7 @@ For hypotheses with non-overlapping file scopes, execute them in parallel:
    - Evaluated (scores measured before and after)
    - Documented (clear commit messages, PR description)
    - Maintainable (clean code, no hacks)
-5. **When stuck**: Pick the simpler option, record reasoning in the vault, move on.
+5. **When stuck**: Pick the simpler option, record reasoning in .factory/archive/, move on.
 
 ---
 
@@ -2046,31 +2048,24 @@ If prior details are lost:
 
 ---
 
-## Obsidian Vault Integration
+## Archive Structure
 
-The factory uses an Obsidian vault as its institutional memory:
+The factory uses `.factory/archive/` as its institutional memory (per-project):
 
 ```
-$FACTORY_VAULT_PATH/
-├── 00-Factory/              # Cross-project knowledge
-│   ├── Dashboard.md         # Factory-wide status
-│   ├── Patterns.md          # Recurring patterns
-│   ├── Decisions.md         # Major decisions log
-│   └── Agent-Performance/   # Per-agent performance tracking
-│       ├── ceo-decisions.md # CEO keep/revert patterns
-│       └── <role>-perf.md   # Per-agent metrics
-├── 10-Projects/{name}/      # Per-project notes
-├── 20-Knowledge/            # Concepts and sources
-├── _templates/              # Note templates
-└── MEMORY.md                # Index for agent orientation
+.factory/archive/
+├── experiments/              # Per-experiment notes
+│   └── {project}-{NNN}.md
+├── strategies/               # Strategy snapshots
+│   └── {project}-{date}.md
+├── sources/                  # Research source notes
+│   └── {source-name}.md
+├── patterns/                 # Cross-project patterns
+│   └── patterns.md
+└── {project}.md              # Project dashboard
 ```
 
-### obsidian-cli commands
-- `obsidian create vault="factory" name="path/to/note" content="..." silent`
-- `obsidian read vault="factory" file="note name"`
-- `obsidian search vault="factory" query="term" limit=10`
-- `obsidian append vault="factory" file="note name" content="..."`
-- `obsidian property:set vault="factory" name="status" value="done" file="note name"`
+The Archivist writes directly to this directory. After writing, it runs `factory report-update` to regenerate `.factory/performance_report.json`, which the ACE reflector reads for qualitative signals.
 
 ---
 

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -33,17 +33,17 @@ Deeply investigate the project's domain to inform the Strategist's hypotheses.
 3. **Read project context**: README, pyproject.toml, experiment history, current strategy
 4. **Search externally**: Use WebSearch for similar projects, best practices, relevant techniques
 5. **Read deeply**: Use WebFetch on the top 3-5 most promising search results
-6. **Check vault knowledge**: Read factory vault for cross-project patterns and prior learnings
+6. **Check prior knowledge**: Read `.factory/archive/` for cross-project patterns and prior learnings
 7. **Synthesize**: Write structured research report
 
 ### Output (Research)
 Write to `$PROJECT_PATH/.factory/strategy/research.md`:
 - Project summary
 - External research findings (similar projects, best practices, techniques)
-- Prior knowledge from vault
+- Prior knowledge from archive
 - Recommended focus areas (actionable insights for the Strategist)
 
-Optionally write new source notes to `$FACTORY_VAULT_PATH/20-Knowledge/Sources/` (skip if `$FACTORY_VAULT_PATH` is not set).
+Optionally write new source notes to `.factory/archive/sources/`.
 
 ### Targeted Mode
 
@@ -89,13 +89,10 @@ Activate Mode 3 when ANY of these are true:
    - "LLM agent self-improvement"
    - "automated code quality improvement"
 
-4. **Read vault knowledge FIRST**: Before doing any web searches, read existing source notes:
-   - `$FACTORY_VAULT_PATH/20-Knowledge/Sources/` — prior research covering:
-     - Self-evolution: Meta-Harness, karpathy/autoresearch, OpenSpace, uditgoenka/autoresearch, awesome-autoresearch, paperclip
-     - Building phase: superpowers (TDD enforcement, task atomization), gsd-2 (hierarchical decomposition, state recovery, context scoping)
-   - `$FACTORY_VAULT_PATH/00-Factory/Patterns.md` — cross-project patterns already discovered
-   - Skip vault reads if `$FACTORY_VAULT_PATH` is not set
-   - Only WebSearch for topics NOT already covered by vault sources
+4. **Read prior knowledge FIRST**: Before doing any web searches, read existing source notes:
+   - `.factory/archive/sources/` — prior research notes
+   - `.factory/archive/patterns/patterns.md` — cross-project patterns already discovered
+   - Only WebSearch for topics NOT already covered by archive sources
 
 5. **Structure findings by design space dimension**:
    - For each of the 10 dimensions (Features, Bug fixes, Instrumentation, Flow changes, New agents, Prompt engineering, Eval improvements, Knowledge management, Infrastructure, Self-evolution), note what the research suggests
@@ -140,7 +137,7 @@ Activate Mode 4 when the task mentions "Mode 4 failure research" or references a
 1. **Read the failure analysis**: Load `.factory/research/runs/<cycle>/failure_analysis.md` — this is your primary input
 2. **Extract dominant failure modes**: From the Failure Distribution section, identify the top 2-3 failure categories by frequency
 3. **Read research target config**: Understand the objective (e.g., "maximize SWE-bench resolve rate"), the mutable surfaces, and the fixed surfaces (files that MUST NOT be changed)
-4. **Check vault knowledge FIRST**: Read `$FACTORY_VAULT_PATH/20-Knowledge/Sources/` for prior knowledge on these failure categories (skip if unset). Only WebSearch for topics NOT already covered by vault sources.
+4. **Check prior knowledge FIRST**: Read `.factory/archive/sources/` for prior knowledge on these failure categories. Only WebSearch for topics NOT already covered by archive sources.
 5. **Search for targeted solutions**: For each dominant failure mode, WebSearch for:
    - Known solutions, workarounds, and best practices
    - Similar systems that solved the same class of problem
@@ -161,8 +158,8 @@ Write to `$PROJECT_PATH/.factory/strategy/research.md`:
 - Current metric: <value> (target: <target>)
 - Dominant failure modes: <top categories from failure analysis>
 
-## Prior Knowledge (Vault)
-- <relevant prior findings, or "No vault available">
+## Prior Knowledge (Archive)
+- <relevant prior findings, or "No archive available">
 
 ## Solution Research by Failure Mode
 
@@ -189,6 +186,6 @@ Write to `$PROJECT_PATH/.factory/strategy/research.md`:
 - Limit WebFetch to 3-5 pages
 - Do NOT do general domain research — Mode 2 handles that. Mode 4 is laser-focused on the failures
 - Map every finding to a mutable surface. Findings that require changing fixed surfaces (passed via the CEO's task or read from research target config) should be noted as constraints, not recommendations
-- Write report even if external search fails — include vault findings and failure analysis context
+- Write report even if external search fails — include archive findings and failure analysis context
 - Do not include calendar-time estimates — same rule as Mode 2
 - Prioritize the dominant failure mode — spend 60%+ of your search budget on the #1 failure category

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -483,6 +483,35 @@ def cmd_export(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_report_update(args: argparse.Namespace) -> int:
+    """Generate a performance report for a project."""
+    from factory.report import save_performance_report
+
+    project_path = Path(args.path).resolve()
+    report_path = save_performance_report(project_path)
+    print(f"Performance report written to {report_path}")
+    return 0
+
+
+def cmd_registry_list(args: argparse.Namespace) -> int:
+    """List all registered factory-managed projects."""
+    from factory.registry import list_projects
+
+    projects = list_projects()
+    if not projects:
+        print("No registered projects. Projects are auto-registered when experiments begin.")
+        return 0
+
+    header = f"{'Name':<30} {'Experiments':>11} {'Score':>8} {'Last Experiment':<20}"
+    print(header)
+    print("-" * len(header))
+    for p in projects:
+        score = f"{p.latest_score:.3f}" if p.latest_score is not None else "n/a"
+        last = p.last_experiment_at.strftime("%Y-%m-%d %H:%M") if p.last_experiment_at else "never"
+        print(f"{p.name:<30} {p.experiment_count:>11} {score:>8} {last:<20}")
+    return 0
+
+
 def cmd_ace(args: argparse.Namespace) -> int:
     """Run ACE self-improvement on agent playbooks."""
     from factory.ace.curator import curate_playbook
@@ -492,7 +521,16 @@ def cmd_ace(args: argparse.Namespace) -> int:
     from factory.insights import discover_projects, load_all_histories
 
     project_path = Path(args.path).resolve()
-    projects_dir = Path(args.projects_dir).expanduser().resolve()
+    projects_dir_raw = getattr(args, "projects_dir", None)
+    if projects_dir_raw:
+        projects_dir = Path(projects_dir_raw).expanduser().resolve()
+    else:
+        from factory.registry import get_project_paths
+        reg_paths = get_project_paths()
+        if reg_paths:
+            projects_dir = reg_paths[0].parent
+        else:
+            projects_dir = project_path.parent
     dry_run = getattr(args, "dry_run", False)
 
     _emit_cli_event(project_path, "ace.started", {"dry_run": dry_run})
@@ -638,7 +676,16 @@ def cmd_insights(args: argparse.Namespace) -> int:
     )
 
     project_path = Path(args.path).resolve()
-    projects_dir = Path(args.projects_dir).expanduser().resolve()
+    projects_dir_raw = getattr(args, "projects_dir", None)
+    if projects_dir_raw:
+        projects_dir = Path(projects_dir_raw).expanduser().resolve()
+    else:
+        from factory.registry import get_project_paths
+        reg_paths = get_project_paths()
+        if reg_paths:
+            projects_dir = reg_paths[0].parent
+        else:
+            projects_dir = project_path.parent
     _emit_cli_event(project_path, "insights.started", {"projects_dir": str(projects_dir)})
     project_paths = discover_projects(projects_dir)
 
@@ -2164,16 +2211,23 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("insights", help="Cross-project analysis of experiment histories")
     p.add_argument("path", help="Path to the project (insights.md written here)")
     p.add_argument(
-        "--projects-dir", default="~/factory-projects",
-        help="Directory containing factory-managed projects (default: ~/factory-projects)",
+        "--projects-dir", default=None,
+        help="Directory containing factory-managed projects (default: from registry or ~/factory-projects)",
     )
+
+    # report-update
+    p = sub.add_parser("report-update", help="Generate performance report for a project")
+    p.add_argument("path", help="Path to the project")
+
+    # registry-list
+    sub.add_parser("registry-list", help="List all registered factory-managed projects")
 
     # ace
     p = sub.add_parser("ace", help="Run ACE self-improvement on agent playbooks")
     p.add_argument("path", help="Path to the project")
     p.add_argument(
-        "--projects-dir", default="~/factory-projects",
-        help="Directory containing factory-managed projects (default: ~/factory-projects)",
+        "--projects-dir", default=None,
+        help="Directory containing factory-managed projects (default: from registry or ~/factory-projects)",
     )
     p.add_argument(
         "--dry-run", action="store_true", default=False,
@@ -2444,6 +2498,8 @@ def main(argv: list[str] | None = None) -> int:
         "explain": cmd_explain,
         "export": cmd_export,
         "insights": cmd_insights,
+        "report-update": cmd_report_update,
+        "registry-list": cmd_registry_list,
         "ace": cmd_ace,
         "ace-stats": cmd_ace_stats,
         "digest": cmd_digest,

--- a/factory/models.py
+++ b/factory/models.py
@@ -359,6 +359,73 @@ class CycleState(BaseModel):
     runner_name: str | None = None
 
 
+# ── ACE pipeline data ────────────────────────────────────────────
+
+
+class AgentVerdict(BaseModel):
+    """A CEO verdict on an agent's output, parsed from ceo-verdict-*.md files."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    role: str
+    verdict: Literal["PROCEED", "REDIRECT", "ABORT"]
+    rationale: str
+    issues: list[str] = []
+    experiment_id: int | None = None
+
+
+class Observation(BaseModel):
+    """A structured observation from the Archivist or Researcher."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    source: str
+    content: str
+    timestamp: datetime
+    project: str
+    tags: list[str] = []
+
+
+class PerformanceReport(BaseModel):
+    """Per-project performance report aggregating verdicts and observations."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    project_name: str
+    generated_at: datetime
+    total_experiments: int
+    keep_count: int
+    revert_count: int
+    error_count: int
+    keep_rate: float
+    latest_score: float | None = None
+    agent_verdicts: list[AgentVerdict] = []
+    observations: list[Observation] = []
+    verdict_patterns: dict[str, int] = {}
+
+
+class ProjectEntry(BaseModel):
+    """A single project entry in the global registry."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    path: str
+    name: str
+    registered_at: datetime
+    last_experiment_at: datetime | None = None
+    experiment_count: int = 0
+    latest_score: float | None = None
+
+
+class ProjectRegistry(BaseModel):
+    """Global project registry at ~/.factory/registry.json."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    projects: list[ProjectEntry] = []
+    updated_at: datetime
+
+
 # ── protocols ─────────────────────────────────────────────────────
 
 

--- a/factory/registry.py
+++ b/factory/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -12,9 +13,9 @@ from factory.models import ProjectEntry, ProjectRegistry
 
 log = structlog.get_logger()
 
+
 def _default_registry_path() -> Path:
     """Return registry path, respecting FACTORY_REGISTRY_DIR override for testing."""
-    import os
     override = os.environ.get("FACTORY_REGISTRY_DIR")
     base = Path(override) if override else Path.home() / ".factory"
     return base / "registry.json"

--- a/factory/registry.py
+++ b/factory/registry.py
@@ -1,0 +1,148 @@
+"""Global project registry — tracks factory-managed projects at ~/.factory/registry.json."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+
+from factory.models import ProjectEntry, ProjectRegistry
+
+log = structlog.get_logger()
+
+def _default_registry_path() -> Path:
+    """Return registry path, respecting FACTORY_REGISTRY_DIR override for testing."""
+    import os
+    override = os.environ.get("FACTORY_REGISTRY_DIR")
+    base = Path(override) if override else Path.home() / ".factory"
+    return base / "registry.json"
+
+
+def _parse_registry_datetimes(data: dict) -> None:
+    """Convert ISO datetime strings to datetime objects for strict Pydantic models."""
+    if "updated_at" in data and isinstance(data["updated_at"], str):
+        data["updated_at"] = datetime.fromisoformat(data["updated_at"])
+    for entry in data.get("projects", []):
+        for key in ("registered_at", "last_experiment_at"):
+            val = entry.get(key)
+            if isinstance(val, str):
+                entry[key] = datetime.fromisoformat(val)
+
+
+def _load_registry(path: Path | None = None) -> ProjectRegistry:
+    """Load the registry from disk, returning empty registry if missing/corrupt."""
+    registry_path = path or _default_registry_path()
+    if not registry_path.exists():
+        return ProjectRegistry(projects=[], updated_at=datetime.now())
+    try:
+        data = json.loads(registry_path.read_text())
+        _parse_registry_datetimes(data)
+        return ProjectRegistry(**data)
+    except (json.JSONDecodeError, ValueError, KeyError) as exc:
+        log.warning("registry_load_failed", path=str(registry_path), error=str(exc))
+        return ProjectRegistry(projects=[], updated_at=datetime.now())
+
+
+def _save_registry(registry: ProjectRegistry, path: Path | None = None) -> None:
+    """Atomically save the registry to disk."""
+    registry_path = path or _default_registry_path()
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry.updated_at = datetime.now()
+    tmp_path = registry_path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(registry.model_dump(), indent=2, default=str) + "\n")
+    tmp_path.replace(registry_path)
+    log.debug("registry_saved", projects=len(registry.projects))
+
+
+def register_project(project_path: Path, registry_path: Path | None = None) -> None:
+    """Register a project. Idempotent — updates path if name already exists."""
+    resolved = project_path.resolve()
+    registry = _load_registry(registry_path)
+
+    for entry in registry.projects:
+        if entry.path == str(resolved):
+            log.debug("register_project_exists", path=str(resolved))
+            return
+
+    entry = ProjectEntry(
+        path=str(resolved),
+        name=resolved.name,
+        registered_at=datetime.now(),
+    )
+    registry.projects.append(entry)
+    _save_registry(registry, registry_path)
+    log.info("register_project", name=resolved.name, path=str(resolved))
+
+
+def update_project_stats(
+    project_path: Path,
+    experiment_count: int | None = None,
+    latest_score: float | None = None,
+    registry_path: Path | None = None,
+) -> None:
+    """Update a registered project's stats after an experiment completes."""
+    resolved = project_path.resolve()
+    registry = _load_registry(registry_path)
+
+    for entry in registry.projects:
+        if entry.path == str(resolved):
+            entry.last_experiment_at = datetime.now()
+            if experiment_count is not None:
+                entry.experiment_count = experiment_count
+            if latest_score is not None:
+                entry.latest_score = latest_score
+            _save_registry(registry, registry_path)
+            log.info(
+                "update_project_stats",
+                name=entry.name,
+                experiments=entry.experiment_count,
+                score=entry.latest_score,
+            )
+            return
+
+    log.warning("update_project_stats_not_found", path=str(resolved))
+
+
+def get_project_paths(registry_path: Path | None = None) -> list[Path]:
+    """Return all registered project paths that still exist on disk."""
+    registry = _load_registry(registry_path)
+    paths: list[Path] = []
+    for entry in registry.projects:
+        p = Path(entry.path)
+        if p.is_dir():
+            paths.append(p)
+        else:
+            log.debug("registry_stale_entry", path=entry.path)
+    return paths
+
+
+def list_projects(registry_path: Path | None = None) -> list[ProjectEntry]:
+    """Return all registered project entries."""
+    registry = _load_registry(registry_path)
+    return registry.projects
+
+
+def populate_from_directory(projects_dir: Path, registry_path: Path | None = None) -> int:
+    """Auto-populate registry by scanning a directory for .factory/results.tsv.
+
+    Used as migration path from discover_projects() to the registry.
+    Returns the number of newly registered projects.
+    """
+    from factory.insights import discover_projects
+
+    existing = _load_registry(registry_path)
+    existing_paths = {e.path for e in existing.projects}
+
+    discovered = discover_projects(projects_dir)
+    added = 0
+    for path in discovered:
+        resolved = str(path.resolve())
+        if resolved not in existing_paths:
+            register_project(path, registry_path)
+            added += 1
+
+    if added:
+        log.info("registry_populated", added=added, dir=str(projects_dir))
+    return added

--- a/factory/report.py
+++ b/factory/report.py
@@ -1,0 +1,194 @@
+"""Performance report — aggregates CEO verdicts and observations per project."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+
+from factory.models import AgentVerdict, Observation, PerformanceReport
+
+log = structlog.get_logger()
+
+
+def parse_ceo_verdicts(project_path: Path) -> list[AgentVerdict]:
+    """Parse all ceo-verdict-*.md files in .factory/reviews/."""
+    reviews_dir = project_path / ".factory" / "reviews"
+    if not reviews_dir.is_dir():
+        return []
+
+    verdicts: list[AgentVerdict] = []
+    for verdict_file in sorted(reviews_dir.glob("ceo-verdict-*.md")):
+        role = verdict_file.stem.replace("ceo-verdict-", "")
+        text = verdict_file.read_text()
+
+        verdict_match = re.search(r"\*\*Verdict:\*\*\s*(PROCEED|REDIRECT|ABORT)", text)
+        if not verdict_match:
+            continue
+
+        rationale_match = re.search(r"\*\*Rationale:\*\*\s*(.+?)(?:\n|$)", text)
+        rationale = rationale_match.group(1).strip() if rationale_match else ""
+
+        issues: list[str] = []
+        issues_match = re.search(
+            r"\*\*Issues found:\*\*\s*(.+?)(?:\n\*\*|\Z)", text, re.DOTALL
+        )
+        if issues_match:
+            issues_text = issues_match.group(1).strip()
+            if issues_text.lower() not in ("none", ""):
+                for line in issues_text.splitlines():
+                    line = line.strip().lstrip("- ")
+                    if line:
+                        issues.append(line)
+
+        exp_match = re.search(r"experiment\s+(\d+)", text, re.IGNORECASE)
+        exp_id = int(exp_match.group(1)) if exp_match else None
+
+        verdicts.append(AgentVerdict(
+            role=role,
+            verdict=verdict_match.group(1),  # type: ignore[arg-type]
+            rationale=rationale,
+            issues=issues,
+            experiment_id=exp_id,
+        ))
+
+    log.debug("parse_ceo_verdicts", count=len(verdicts), path=str(reviews_dir))
+    return verdicts
+
+
+def parse_observations(project_path: Path) -> list[Observation]:
+    """Parse observations from .factory/strategy/observations.md and archive notes."""
+    observations: list[Observation] = []
+    project_name = project_path.resolve().name
+
+    obs_path = project_path / ".factory" / "strategy" / "observations.md"
+    if obs_path.exists():
+        text = obs_path.read_text()
+        for section in re.split(r"^##\s+", text, flags=re.MULTILINE):
+            section = section.strip()
+            if not section:
+                continue
+            lines = section.splitlines()
+            title = lines[0].strip()
+            content = "\n".join(lines[1:]).strip()
+            if content:
+                observations.append(Observation(
+                    source="observations.md",
+                    content=f"{title}: {content[:500]}",
+                    timestamp=datetime.now(),
+                    project=project_name,
+                    tags=["observation"],
+                ))
+
+    archive_dir = project_path / ".factory" / "archive"
+    if archive_dir.is_dir():
+        for note_file in sorted(archive_dir.glob("**/*.md"))[:50]:
+            text = note_file.read_text()
+            if len(text) > 50:
+                observations.append(Observation(
+                    source=str(note_file.relative_to(project_path)),
+                    content=text[:500],
+                    timestamp=datetime.now(),
+                    project=project_name,
+                    tags=["archive"],
+                ))
+
+    log.debug("parse_observations", count=len(observations))
+    return observations
+
+
+def build_performance_report(project_path: Path) -> PerformanceReport:
+    """Build a complete performance report for a project."""
+    from factory.store import ExperimentStore
+
+    project_name = project_path.resolve().name
+    store = ExperimentStore(project_path)
+
+    try:
+        import asyncio
+        records = asyncio.run(store.load_history())
+    except Exception:
+        records = []
+
+    keep_count = sum(1 for r in records if r.verdict == "keep")
+    revert_count = sum(1 for r in records if r.verdict == "revert")
+    error_count = sum(1 for r in records if r.verdict == "error")
+    total = len(records)
+
+    scores = [r.score_after for r in records if r.score_after is not None]
+    latest_score = scores[-1] if scores else None
+
+    verdicts = parse_ceo_verdicts(project_path)
+    observations = parse_observations(project_path)
+
+    verdict_patterns: dict[str, int] = {}
+    for v in verdicts:
+        key = f"{v.role}:{v.verdict}"
+        verdict_patterns[key] = verdict_patterns.get(key, 0) + 1
+
+    return PerformanceReport(
+        project_name=project_name,
+        generated_at=datetime.now(),
+        total_experiments=total,
+        keep_count=keep_count,
+        revert_count=revert_count,
+        error_count=error_count,
+        keep_rate=keep_count / total if total > 0 else 0.0,
+        latest_score=latest_score,
+        agent_verdicts=verdicts,
+        observations=observations,
+        verdict_patterns=verdict_patterns,
+    )
+
+
+def save_performance_report(project_path: Path) -> Path:
+    """Build and save the performance report to .factory/performance_report.json."""
+    report = build_performance_report(project_path)
+    report_path = project_path / ".factory" / "performance_report.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(report.model_dump(), indent=2, default=str) + "\n"
+    )
+    log.info(
+        "performance_report_saved",
+        project=report.project_name,
+        experiments=report.total_experiments,
+        path=str(report_path),
+    )
+    return report_path
+
+
+def load_performance_report(project_path: Path) -> PerformanceReport | None:
+    """Load an existing performance report, return None if missing."""
+    report_path = project_path / ".factory" / "performance_report.json"
+    if not report_path.exists():
+        return None
+    try:
+        data = json.loads(report_path.read_text())
+        _parse_datetimes(data)
+        return PerformanceReport(**data)
+    except (json.JSONDecodeError, ValueError, KeyError) as exc:
+        log.warning("performance_report_load_failed", error=str(exc))
+        return None
+
+
+def _parse_datetimes(data: dict) -> None:
+    """Convert ISO datetime strings back to datetime objects for strict Pydantic models."""
+    for key in ("generated_at",):
+        if key in data and isinstance(data[key], str):
+            data[key] = datetime.fromisoformat(data[key])
+
+    for entry in data.get("agent_verdicts", []):
+        pass  # no datetime fields
+
+    for obs in data.get("observations", []):
+        if "timestamp" in obs and isinstance(obs["timestamp"], str):
+            obs["timestamp"] = datetime.fromisoformat(obs["timestamp"])
+
+    for entry in data.get("projects", []):
+        for key in ("registered_at", "last_experiment_at"):
+            if key in entry and isinstance(entry[key], str):
+                entry[key] = datetime.fromisoformat(entry[key])

--- a/factory/report.py
+++ b/factory/report.py
@@ -181,14 +181,6 @@ def _parse_datetimes(data: dict) -> None:
         if key in data and isinstance(data[key], str):
             data[key] = datetime.fromisoformat(data[key])
 
-    for entry in data.get("agent_verdicts", []):
-        pass  # no datetime fields
-
     for obs in data.get("observations", []):
         if "timestamp" in obs and isinstance(obs["timestamp"], str):
             obs["timestamp"] = datetime.fromisoformat(obs["timestamp"])
-
-    for entry in data.get("projects", []):
-        for key in ("registered_at", "last_experiment_at"):
-            if key in entry and isinstance(entry[key], str):
-                entry[key] = datetime.fromisoformat(entry[key])

--- a/factory/store.py
+++ b/factory/store.py
@@ -273,6 +273,7 @@ class ExperimentStore:
 
         Idempotent: if the next experiment dir already exists (e.g. from a
         previous interrupted run), return its ID without crashing.
+        Also registers the project in the global registry (non-blocking).
         """
         exp_id = await self.next_id()
         log.info("experiment_begin", exp_id=exp_id, hypothesis=hypothesis[:80])
@@ -281,6 +282,13 @@ class ExperimentStore:
         hyp_path = exp_dir / "hypothesis.md"
         if not hyp_path.exists():
             hyp_path.write_text(hypothesis)
+
+        try:
+            from factory.registry import register_project
+            register_project(self.project_path)
+        except Exception as exc:
+            log.debug("registry_begin_failed", error=str(exc))
+
         return exp_id
 
     async def save_eval(
@@ -353,6 +361,17 @@ class ExperimentStore:
                 record.notes,
                 "|".join(record.research_citations) if record.research_citations else "",
             ])
+
+        try:
+            from factory.registry import update_project_stats
+            scores = [record.score_after] if record.score_after is not None else []
+            update_project_stats(
+                self.project_path,
+                experiment_count=record.id,
+                latest_score=scores[-1] if scores else None,
+            )
+        except Exception as exc:
+            log.debug("registry_finalize_failed", error=str(exc))
 
     async def load_history(self) -> list[ExperimentRecord]:
         """Parse results.tsv into a list of ExperimentRecords."""

--- a/factory/store.py
+++ b/factory/store.py
@@ -364,11 +364,10 @@ class ExperimentStore:
 
         try:
             from factory.registry import update_project_stats
-            scores = [record.score_after] if record.score_after is not None else []
             update_project_stats(
                 self.project_path,
                 experiment_count=record.id,
-                latest_score=scores[-1] if scores else None,
+                latest_score=record.score_after,
             )
         except Exception as exc:
             log.debug("registry_finalize_failed", error=str(exc))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,14 @@ os.environ["FACTORY_BOB_DRY_RUN"] = "1"
 os.environ["FACTORY_CEO_RESPAWN_DISABLED"] = "1"
 
 
+@pytest.fixture(autouse=True)
+def _isolate_registry(tmp_path: Path) -> None:
+    """Redirect global registry to tmp_path during tests to avoid polluting ~/.factory/."""
+    os.environ["FACTORY_REGISTRY_DIR"] = str(tmp_path / ".factory-test-registry")
+    yield  # type: ignore[misc]
+    os.environ.pop("FACTORY_REGISTRY_DIR", None)
+
+
 @pytest.fixture
 def tmp_project(tmp_path: Path) -> Path:
     """Create a minimal project directory with git init."""

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -89,10 +89,10 @@ class TestArchivistPrompt:
     def test_has_preflight_checklist(self, archivist_prompt: str) -> None:
         assert "Pre-flight Checklist" in archivist_prompt
 
-    def test_uses_path_not_name_for_nested(self, archivist_prompt: str) -> None:
-        # All nested paths should use path= not name=
-        assert 'path="10-Projects' in archivist_prompt
-        assert 'name="10-Projects' not in archivist_prompt
+    def test_uses_archive_dir_not_vault(self, archivist_prompt: str) -> None:
+        assert ".factory/archive/" in archivist_prompt
+        assert "obsidian-cli" not in archivist_prompt.lower()
+        assert "$FACTORY_VAULT_PATH" not in archivist_prompt
 
 
 # ── CEO ──────────────────────────────────────────────────────────

--- a/tests/test_reflector_enhanced.py
+++ b/tests/test_reflector_enhanced.py
@@ -1,0 +1,223 @@
+"""Tests for enhanced reflector — performance report integration."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from factory.ace.reflector import (
+    _load_from_reports,
+    _observation_bullets,
+    _verdict_bullets,
+    reflect_on_experiments,
+)
+from factory.models import PerformanceReport
+
+
+def _make_project_with_report(
+    tmp_path: Path,
+    name: str,
+    report: PerformanceReport,
+) -> Path:
+    """Create a minimal project with a performance report and TSV."""
+    import csv
+    import io
+
+    project = tmp_path / name
+    factory_dir = project / ".factory"
+    factory_dir.mkdir(parents=True)
+
+    # Write performance report
+    (factory_dir / "performance_report.json").write_text(
+        json.dumps(report.model_dump(), indent=2, default=str) + "\n"
+    )
+
+    # Write minimal results.tsv
+    columns = [
+        "id", "timestamp", "hypothesis", "change_summary", "issue_number",
+        "pr_number", "score_before", "score_after", "delta", "verdict",
+        "cost_usd", "notes", "research_citations",
+    ]
+    buf = io.StringIO()
+    writer = csv.writer(buf, dialect="excel-tab")
+    writer.writerow(columns)
+    for i in range(report.total_experiments):
+        verdict = "keep" if i < report.keep_count else "revert"
+        writer.writerow([
+            i + 1, "2026-01-01T00:00:00",
+            f"Hypothesis {i + 1}", f"Change {i + 1}",
+            "", "", "0.7", "0.8" if verdict == "keep" else "0.65",
+            "0.1" if verdict == "keep" else "-0.05", verdict,
+            "", "", "",
+        ])
+    (factory_dir / "results.tsv").write_text(buf.getvalue())
+
+    return project
+
+
+def test_verdict_bullets_with_redirects(tmp_path: Path) -> None:
+    report = PerformanceReport(
+        project_name="proj1",
+        generated_at=datetime.now(),
+        total_experiments=5,
+        keep_count=3,
+        revert_count=2,
+        error_count=0,
+        keep_rate=0.6,
+        verdict_patterns={
+            "builder:REDIRECT": 4,
+            "researcher:PROCEED": 3,
+        },
+    )
+
+    project = _make_project_with_report(tmp_path, "proj1", report)
+    bullets = _verdict_bullets([project])
+
+    assert len(bullets) >= 1
+    assert any("builder" in b.content.lower() for b in bullets)
+    assert any("REDIRECT" in b.content for b in bullets)
+
+
+def test_verdict_bullets_with_aborts(tmp_path: Path) -> None:
+    report = PerformanceReport(
+        project_name="proj1",
+        generated_at=datetime.now(),
+        total_experiments=3,
+        keep_count=1,
+        revert_count=1,
+        error_count=1,
+        keep_rate=0.33,
+        verdict_patterns={"builder:ABORT": 2, "researcher:ABORT": 1},
+    )
+
+    project = _make_project_with_report(tmp_path, "proj1", report)
+    bullets = _verdict_bullets([project])
+
+    assert any("ABORT" in b.content for b in bullets)
+
+
+def test_verdict_bullets_no_issues(tmp_path: Path) -> None:
+    report = PerformanceReport(
+        project_name="proj1",
+        generated_at=datetime.now(),
+        total_experiments=3,
+        keep_count=3,
+        revert_count=0,
+        error_count=0,
+        keep_rate=1.0,
+        verdict_patterns={"researcher:PROCEED": 3, "builder:PROCEED": 3},
+    )
+
+    project = _make_project_with_report(tmp_path, "proj1", report)
+    bullets = _verdict_bullets([project])
+    assert bullets == []
+
+
+def test_observation_bullets_low_archive(tmp_path: Path) -> None:
+    from factory.models import Observation
+
+    observations = [
+        Observation(
+            source="observations.md", content=f"Obs {i}",
+            timestamp=datetime.now(), project="proj1", tags=["observation"],
+        )
+        for i in range(10)
+    ] + [
+        Observation(
+            source=".factory/archive/note.md", content="Archive obs",
+            timestamp=datetime.now(), project="proj1", tags=["archive"],
+        )
+    ]
+
+    report = PerformanceReport(
+        project_name="proj1",
+        generated_at=datetime.now(),
+        total_experiments=5,
+        keep_count=3,
+        revert_count=2,
+        error_count=0,
+        keep_rate=0.6,
+        observations=observations,
+    )
+
+    project = _make_project_with_report(tmp_path, "proj1", report)
+    bullets = _observation_bullets([project])
+    assert len(bullets) >= 1
+    assert any("archive coverage" in b.content.lower() for b in bullets)
+
+
+def test_load_from_reports_with_report(tmp_path: Path) -> None:
+    report = PerformanceReport(
+        project_name="proj1",
+        generated_at=datetime.now(),
+        total_experiments=2,
+        keep_count=1,
+        revert_count=1,
+        error_count=0,
+        keep_rate=0.5,
+    )
+
+    project = _make_project_with_report(tmp_path, "proj1", report)
+    all_records, outcomes, histories = _load_from_reports([project])
+
+    assert len(all_records) == 2
+    assert len(outcomes) == 2
+    assert "proj1" in histories
+
+
+def test_load_from_reports_tsv_fallback(tmp_path: Path) -> None:
+    """When no performance report exists, falls back to TSV loading."""
+    import csv
+    import io
+
+    project = tmp_path / "proj-no-report"
+    factory_dir = project / ".factory"
+    factory_dir.mkdir(parents=True)
+
+    columns = [
+        "id", "timestamp", "hypothesis", "change_summary", "issue_number",
+        "pr_number", "score_before", "score_after", "delta", "verdict",
+        "cost_usd", "notes", "research_citations",
+    ]
+    buf = io.StringIO()
+    writer = csv.writer(buf, dialect="excel-tab")
+    writer.writerow(columns)
+    writer.writerow([
+        1, "2026-01-01T00:00:00", "Test hypothesis", "change",
+        "", "", "0.7", "0.8", "0.1", "keep", "", "", "",
+    ])
+    (factory_dir / "results.tsv").write_text(buf.getvalue())
+
+    all_records, outcomes, histories = _load_from_reports([project])
+
+    assert len(all_records) == 1
+    assert len(outcomes) == 1
+
+
+def test_reflect_uses_registry_fallback(tmp_path: Path) -> None:
+    """reflect_on_experiments should fall back to discover_projects when registry is empty."""
+    import csv
+    import io
+
+    projects_dir = tmp_path / "projects"
+    project = projects_dir / "proj1"
+    factory_dir = project / ".factory"
+    factory_dir.mkdir(parents=True)
+
+    columns = [
+        "id", "timestamp", "hypothesis", "change_summary", "issue_number",
+        "pr_number", "score_before", "score_after", "delta", "verdict",
+        "cost_usd", "notes", "research_citations",
+    ]
+    buf = io.StringIO()
+    writer = csv.writer(buf, dialect="excel-tab")
+    writer.writerow(columns)
+    for i in range(6):
+        writer.writerow([
+            i + 1, "2026-01-01T00:00:00",
+            "Add tests for coverage", "Added tests",
+            "", "", "0.7", "0.8", "0.1", "keep", "", "", "",
+        ])
+    (factory_dir / "results.tsv").write_text(buf.getvalue())
+
+    candidates = reflect_on_experiments(projects_dir)
+    assert isinstance(candidates, dict)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,149 @@
+"""Tests for factory.registry — global project registry."""
+
+from pathlib import Path
+
+from factory.registry import (
+    _load_registry,
+    get_project_paths,
+    list_projects,
+    populate_from_directory,
+    register_project,
+    update_project_stats,
+)
+
+
+def test_register_project(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    project = tmp_path / "my-project"
+    project.mkdir()
+
+    register_project(project, registry_path=registry_path)
+
+    entries = list_projects(registry_path=registry_path)
+    assert len(entries) == 1
+    assert entries[0].name == "my-project"
+    assert entries[0].path == str(project.resolve())
+
+
+def test_register_project_idempotent(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    project = tmp_path / "my-project"
+    project.mkdir()
+
+    register_project(project, registry_path=registry_path)
+    register_project(project, registry_path=registry_path)
+
+    entries = list_projects(registry_path=registry_path)
+    assert len(entries) == 1
+
+
+def test_update_project_stats(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    project = tmp_path / "my-project"
+    project.mkdir()
+
+    register_project(project, registry_path=registry_path)
+    update_project_stats(
+        project, experiment_count=5, latest_score=0.85,
+        registry_path=registry_path,
+    )
+
+    entries = list_projects(registry_path=registry_path)
+    assert entries[0].experiment_count == 5
+    assert entries[0].latest_score == 0.85
+    assert entries[0].last_experiment_at is not None
+
+
+def test_update_project_stats_not_found(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    project = tmp_path / "my-project"
+    project.mkdir()
+
+    # Should not raise — just logs a warning
+    update_project_stats(
+        project, experiment_count=5,
+        registry_path=registry_path,
+    )
+
+
+def test_get_project_paths(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    project1 = tmp_path / "project1"
+    project1.mkdir()
+    project2 = tmp_path / "project2"
+    project2.mkdir()
+
+    register_project(project1, registry_path=registry_path)
+    register_project(project2, registry_path=registry_path)
+
+    paths = get_project_paths(registry_path=registry_path)
+    assert len(paths) == 2
+
+
+def test_get_project_paths_filters_missing(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    project = tmp_path / "exists"
+    project.mkdir()
+    missing = tmp_path / "gone"
+    missing.mkdir()
+
+    register_project(project, registry_path=registry_path)
+    register_project(missing, registry_path=registry_path)
+
+    # Remove "gone" after registration
+    missing.rmdir()
+
+    paths = get_project_paths(registry_path=registry_path)
+    assert len(paths) == 1
+    assert paths[0] == project.resolve()
+
+
+def test_load_registry_missing(tmp_path: Path) -> None:
+    registry_path = tmp_path / "nonexistent.json"
+    registry = _load_registry(registry_path)
+    assert registry.projects == []
+
+
+def test_load_registry_corrupt(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text("not json")
+    registry = _load_registry(registry_path)
+    assert registry.projects == []
+
+
+def test_populate_from_directory(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+
+    # Create a project with .factory/results.tsv
+    project = tmp_path / "projects" / "proj1"
+    factory_dir = project / ".factory"
+    factory_dir.mkdir(parents=True)
+    (factory_dir / "results.tsv").write_text("id\ttimestamp\thypothesis\n")
+
+    added = populate_from_directory(
+        tmp_path / "projects", registry_path=registry_path,
+    )
+    assert added == 1
+
+    entries = list_projects(registry_path=registry_path)
+    assert len(entries) == 1
+    assert entries[0].name == "proj1"
+
+
+def test_populate_from_directory_idempotent(tmp_path: Path) -> None:
+    registry_path = tmp_path / "registry.json"
+
+    project = tmp_path / "projects" / "proj1"
+    factory_dir = project / ".factory"
+    factory_dir.mkdir(parents=True)
+    (factory_dir / "results.tsv").write_text("id\ttimestamp\thypothesis\n")
+
+    added1 = populate_from_directory(
+        tmp_path / "projects", registry_path=registry_path,
+    )
+    added2 = populate_from_directory(
+        tmp_path / "projects", registry_path=registry_path,
+    )
+
+    assert added1 == 1
+    assert added2 == 0

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,178 @@
+"""Tests for factory.report — performance reports."""
+
+from pathlib import Path
+
+from factory.report import (
+    build_performance_report,
+    load_performance_report,
+    parse_ceo_verdicts,
+    parse_observations,
+    save_performance_report,
+)
+
+
+def _make_factory_dir(project: Path) -> Path:
+    factory_dir = project / ".factory"
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    (factory_dir / "experiments").mkdir(exist_ok=True)
+    (factory_dir / "reviews").mkdir(exist_ok=True)
+    (factory_dir / "strategy").mkdir(exist_ok=True)
+    return factory_dir
+
+
+def _write_results_tsv(factory_dir: Path, rows: list[dict]) -> None:
+    import csv
+    import io
+
+    columns = [
+        "id", "timestamp", "hypothesis", "change_summary", "issue_number",
+        "pr_number", "score_before", "score_after", "delta", "verdict",
+        "cost_usd", "notes", "research_citations",
+    ]
+    buf = io.StringIO()
+    writer = csv.writer(buf, dialect="excel-tab")
+    writer.writerow(columns)
+    for row in rows:
+        writer.writerow([row.get(c, "") for c in columns])
+    (factory_dir / "results.tsv").write_text(buf.getvalue())
+
+
+def test_parse_ceo_verdicts(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    (factory_dir / "reviews" / "ceo-verdict-researcher.md").write_text(
+        "## CEO Review: Researcher Agent\n"
+        "- **Verdict:** PROCEED\n"
+        "- **Rationale:** Good research coverage\n"
+        "- **Issues found:** none\n"
+    )
+    (factory_dir / "reviews" / "ceo-verdict-builder.md").write_text(
+        "## CEO Review: Builder Agent\n"
+        "- **Verdict:** REDIRECT\n"
+        "- **Rationale:** Missing tests for experiment 3\n"
+        "- **Issues found:**\n"
+        "- No unit tests\n"
+        "- Missing error handling\n"
+    )
+
+    verdicts = parse_ceo_verdicts(project)
+    assert len(verdicts) == 2
+
+    researcher_v = next(v for v in verdicts if v.role == "researcher")
+    assert researcher_v.verdict == "PROCEED"
+    assert "coverage" in researcher_v.rationale.lower()
+
+    builder_v = next(v for v in verdicts if v.role == "builder")
+    assert builder_v.verdict == "REDIRECT"
+    assert len(builder_v.issues) == 2
+
+
+def test_parse_ceo_verdicts_empty(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    verdicts = parse_ceo_verdicts(project)
+    assert verdicts == []
+
+
+def test_parse_observations(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    (factory_dir / "strategy" / "observations.md").write_text(
+        "## Code Quality\nThe code has good test coverage.\n\n"
+        "## Performance\nSlow startup time observed.\n"
+    )
+
+    observations = parse_observations(project)
+    assert len(observations) >= 2
+    assert any("Code Quality" in o.content for o in observations)
+
+
+def test_parse_observations_with_archive(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    archive_dir = factory_dir / "archive"
+    archive_dir.mkdir()
+    (archive_dir / "note1.md").write_text(
+        "# Experiment Note\nSome learning from experiment 1 that is long enough to be included."
+    )
+
+    observations = parse_observations(project)
+    assert any("archive" in o.tags for o in observations)
+
+
+def test_build_performance_report(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    _write_results_tsv(factory_dir, [
+        {
+            "id": "1", "timestamp": "2026-01-01T00:00:00",
+            "hypothesis": "Add tests", "change_summary": "Added unit tests",
+            "verdict": "keep", "score_before": "0.7", "score_after": "0.8",
+            "delta": "0.1",
+        },
+        {
+            "id": "2", "timestamp": "2026-01-02T00:00:00",
+            "hypothesis": "Fix lint", "change_summary": "Fixed linting",
+            "verdict": "revert", "score_before": "0.8", "score_after": "0.75",
+            "delta": "-0.05",
+        },
+    ])
+
+    report = build_performance_report(project)
+    assert report.project_name == "proj"
+    assert report.total_experiments == 2
+    assert report.keep_count == 1
+    assert report.revert_count == 1
+    assert report.keep_rate == 0.5
+    assert report.latest_score == 0.75
+
+
+def test_save_and_load_performance_report(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+    _write_results_tsv(factory_dir, [])
+
+    path = save_performance_report(project)
+    assert path.exists()
+
+    loaded = load_performance_report(project)
+    assert loaded is not None
+    assert loaded.project_name == "proj"
+    assert loaded.total_experiments == 0
+
+
+def test_load_performance_report_missing(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    loaded = load_performance_report(project)
+    assert loaded is None
+
+
+def test_load_performance_report_corrupt(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+    (factory_dir / "performance_report.json").write_text("not json")
+    loaded = load_performance_report(project)
+    assert loaded is None
+
+
+def test_verdict_patterns_in_report(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    _write_results_tsv(factory_dir, [])
+
+    (factory_dir / "reviews" / "ceo-verdict-researcher.md").write_text(
+        "- **Verdict:** PROCEED\n- **Rationale:** ok\n"
+    )
+    (factory_dir / "reviews" / "ceo-verdict-builder.md").write_text(
+        "- **Verdict:** REDIRECT\n- **Rationale:** bad\n"
+    )
+
+    report = build_performance_report(project)
+    assert "researcher:PROCEED" in report.verdict_patterns
+    assert "builder:REDIRECT" in report.verdict_patterns


### PR DESCRIPTION
## Summary

Implements issue #173 — closes all 4 data gaps in the ACE self-improvement pipeline:

- **Performance reports** (`.factory/performance_report.json`) — consolidated per-project report merging experiment records, CEO review verdicts, and archivist observations into a single structured file for ACE consumption
- **Global project registry** (`~/.factory/registry.json`) — auto-populated from `store.begin()`/`finalize()`, replaces fragile `--projects-dir` directory scanning with `get_project_paths()` (falls back to `discover_projects()` for migration)
- **Vault dependency removed** — archivist, CEO, and researcher prompts no longer reference Obsidian, `obsidian-cli`, or `$FACTORY_VAULT_PATH`; `.factory/archive/` is the only write target
- **Reflector enhanced** — new `_verdict_bullets()` generates playbook items from CEO REDIRECT/ABORT patterns, new `_observation_bullets()` generates items from archivist observation coverage

### New modules
- `factory/registry.py` — atomic load/save of `~/.factory/registry.json`, idempotent registration, stale filtering
- `factory/report.py` — CEO verdict parsing, observation extraction, report building

### New CLI commands
- `factory report-update <path>` — builds/updates performance report
- `factory registry-list` — prints registered projects table

### New models (strict Pydantic v2)
- `AgentVerdict`, `Observation`, `PerformanceReport`, `ProjectEntry`, `ProjectRegistry`

### Test coverage
- 26 new tests across `test_registry.py`, `test_report.py`, `test_reflector_enhanced.py`
- Registry isolation fixture in conftest.py prevents test pollution of `~/.factory/registry.json`
- All 1350 tests pass, ruff clean, mypy clean

Closes #173

## Test plan
- [x] `pytest -v` — 1350 passed, 0 failed
- [x] `ruff check .` — all checks passed
- [x] `mypy factory/` — no issues found
- [x] `factory report-update .` — generates performance_report.json
- [x] `factory registry-list` — prints registered projects
- [x] Registry isolation: tests don't pollute `~/.factory/registry.json`
- [x] Archivist prompt: zero Obsidian/vault references
- [x] CEO prompt: zero `--projects-dir` or vault references
- [x] Researcher prompt: zero vault references
- [x] Backward compat: TSV fallback in reflector, discover_projects() fallback in registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)