### PR TITLE
docs: add 'Built with the Factory' showcase section

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,24 @@ Run meta mode on a regular cadence — weekly is a good default. It needs at lea
 
 ---
 
+## Built with the Factory
+
+Real projects built, improved, or researched using the Factory — from one-line ideas to running systems.
+
+| Project | What it does | Mode |
+|---------|-------------|------|
+| **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
+| **HMMT math solver** | Multi-agent team (Explorer, Theorist, Computationalist, Critic, Synthesizer) that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
+| **Text/Sketch → CAD** | Converts natural language descriptions and hand-drawn sketches into executable CadQuery Python code for 3D model generation | Research |
+| **HLS design space explorer** | Multi-agent system for hardware synthesis optimization — each sub-function gets its own optimizer agent, then an ILP solver finds the global optimum | Build |
+| **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
+| **Client inquiry agent** | AI agent that drafts and optimizes client responses using company knowledge bases | Build + Improve |
+| **The Factory itself** | The factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |
+
+Built something with the Factory? Open a PR to add it here — a one-liner is all it takes. It helps others see what's possible.
+
+---
+
 ## Runners
 
 The factory supports multiple CLI backends. By default it uses **Claude Code** (`claude` CLI). **Bob Shell** (`bob` CLI) is available as an alternative:

--- a/README.md
+++ b/README.md
@@ -283,9 +283,9 @@ Real projects built, improved, or researched using the Factory — from one-line
 | **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
 | **HMMT math solver** | Multi-agent team (Explorer, Theorist, Computationalist, Critic, Synthesizer) that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
 | **Text/Sketch → CAD** | Converts natural language descriptions and hand-drawn sketches into executable CadQuery Python code for 3D model generation | Research |
-| **HLS design space explorer** | Multi-agent system for hardware synthesis optimization — each sub-function gets its own optimizer agent, then an ILP solver finds the global optimum | Build |
+| **HLS design space explorer** | Multi-agent system for chip design optimization — each sub-function gets its own optimizer agent exploring pragma/code variants, then an ILP solver finds the global optimum | Build |
 | **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
-| **Client inquiry agent** | AI agent that drafts and optimizes client responses using company knowledge bases | Build + Improve |
+| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase using the factory's focused improve loop | Focus + Improve |
 | **The Factory itself** | The factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |
 
 Built something with the Factory? Open a PR to add it here — a one-liner is all it takes. It helps others see what's possible.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Real projects built, improved, or researched using the Factory — from one-line
 | **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
 | **HMMT math solver** | Multi-agent team (Explorer, Theorist, Computationalist, Critic, Synthesizer) that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
 | **Text/Sketch → CAD** | Converts natural language descriptions and hand-drawn sketches into executable CadQuery Python code for 3D model generation | Research |
-| **HLS design space explorer** | Multi-agent system for chip design optimization — each sub-function gets its own optimizer agent exploring pragma/code variants, then an ILP solver finds the global optimum | Build |
+| **HLS design space explorer** | Parallel AI agents optimize HLS sub-kernels (pragma tuning, code transforms), then an ILP solver composes the globally optimal design under area constraints — achieving optimal speedups on cryptographic benchmarks | Build |
 | **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
 | **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase using the factory's focused improve loop | Focus + Improve |
 | **The Factory itself** | The factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Run meta mode on a regular cadence — weekly is a good default. It needs at lea
 
 ## Built with the Factory
 
-The factory is used to build and improve projects daily. Here are a few examples across different modes:
+The factory has shipped something every day for the last 30 days — products, research experiments, production features, papers. Here are a few examples:
 
 | Project | What it does | Mode |
 |---------|-------------|------|

--- a/README.md
+++ b/README.md
@@ -276,19 +276,20 @@ Run meta mode on a regular cadence — weekly is a good default. It needs at lea
 
 ## Built with the Factory
 
-Real projects built, improved, or researched using the Factory — from one-line ideas to running systems.
+The factory is used to build and improve projects daily. Here are a few examples across different modes:
 
 | Project | What it does | Mode |
 |---------|-------------|------|
 | **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
 | **HMMT math solver** | Multi-agent team (Explorer, Theorist, Computationalist, Critic, Synthesizer) that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
 | **Text/Sketch → CAD** | Converts natural language descriptions and hand-drawn sketches into executable CadQuery Python code for 3D model generation | Research |
-| **HLS design space explorer** | Parallel AI agents optimize HLS sub-kernels (pragma tuning, code transforms), then an ILP solver composes the globally optimal design under area constraints — achieving optimal speedups on cryptographic benchmarks | Build |
+| **HLS design space explorer** | Per-function AI agents explore HLS pragma/code variants in parallel, an ILP solver finds the optimal combination under area constraints, then global expert agents apply cross-function optimizations (dataflow, inlining) — achieving up to 92% execution time reduction on cryptographic benchmarks | Build |
 | **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
-| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase using the factory's focused improve loop | Focus + Improve |
+| **Group chat digest** | Turns iMessage group chats into weekly family newsletters with AI-curated highlights and photo selection | Build + Improve |
+| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase | Focus + Improve |
 | **The Factory itself** | The factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |
 
-Built something with the Factory? Open a PR to add it here — a one-liner is all it takes. It helps others see what's possible.
+Built something with the Factory? Open a PR to add it here — it helps others see what's possible.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -209,6 +209,22 @@ graph LR
 | **Growth** (5 dimensions) | Capability evolution | API surface area, experiment diversity, observability |
 | **Project** (user-defined) | Domain-specific metrics | Benchmark accuracy, latency, win rate |
 
+## Built with the Factory
+
+Real projects built, improved, or researched using the Factory.
+
+| Project | What it does | Mode |
+|---------|-------------|------|
+| **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
+| **HMMT math solver** | Multi-agent team that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
+| **Text/Sketch → CAD** | Converts natural language and hand-drawn sketches into executable CadQuery code for 3D model generation | Research |
+| **HLS design space explorer** | Multi-agent system for hardware synthesis optimization with ILP-based global search | Build |
+| **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
+| **Client inquiry agent** | AI agent that drafts and optimizes client responses using company knowledge bases | Build + Improve |
+| **The Factory itself** | The factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |
+
+Built something with the Factory? [Open a PR](https://github.com/akashgit/remote-factory/pulls) to add it here.
+
 ## License
 
 [MIT](https://github.com/akashgit/remote-factory/blob/main/LICENSE) — Akash Srivastava

--- a/docs/index.md
+++ b/docs/index.md
@@ -218,9 +218,9 @@ Real projects built, improved, or researched using the Factory.
 | **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
 | **HMMT math solver** | Multi-agent team that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
 | **Text/Sketch → CAD** | Converts natural language and hand-drawn sketches into executable CadQuery code for 3D model generation | Research |
-| **HLS design space explorer** | Multi-agent system for hardware synthesis optimization with ILP-based global search | Build |
+| **HLS design space explorer** | Multi-agent system for chip design optimization — each sub-function gets its own optimizer agent, then an ILP solver finds the global optimum | Build |
 | **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
-| **Client inquiry agent** | AI agent that drafts and optimizes client responses using company knowledge bases | Build + Improve |
+| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase using the factory's focused improve loop | Focus + Improve |
 | **The Factory itself** | The factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |
 
 Built something with the Factory? [Open a PR](https://github.com/akashgit/remote-factory/pulls) to add it here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,7 +211,7 @@ graph LR
 
 ## Built with the Factory
 
-The factory is used to build and improve projects daily. Here are a few examples:
+The factory has shipped something every day for the last 30 days — products, research experiments, production features, papers. Here are a few examples:
 
 | Project | What it does | Mode |
 |---------|-------------|------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -218,7 +218,7 @@ Real projects built, improved, or researched using the Factory.
 | **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
 | **HMMT math solver** | Multi-agent team that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
 | **Text/Sketch → CAD** | Converts natural language and hand-drawn sketches into executable CadQuery code for 3D model generation | Research |
-| **HLS design space explorer** | Multi-agent system for chip design optimization — each sub-function gets its own optimizer agent, then an ILP solver finds the global optimum | Build |
+| **HLS design space explorer** | Parallel AI agents optimize HLS sub-kernels (pragma tuning, code transforms), then an ILP solver composes the globally optimal design under area constraints — achieving optimal speedups on cryptographic benchmarks | Build |
 | **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
 | **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase using the factory's focused improve loop | Focus + Improve |
 | **The Factory itself** | The factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,16 +211,17 @@ graph LR
 
 ## Built with the Factory
 
-Real projects built, improved, or researched using the Factory.
+The factory is used to build and improve projects daily. Here are a few examples:
 
 | Project | What it does | Mode |
 |---------|-------------|------|
 | **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
-| **HMMT math solver** | Multi-agent team that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
+| **HMMT math solver** | Multi-agent team (Explorer, Theorist, Computationalist, Critic, Synthesizer) that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
 | **Text/Sketch → CAD** | Converts natural language and hand-drawn sketches into executable CadQuery code for 3D model generation | Research |
-| **HLS design space explorer** | Parallel AI agents optimize HLS sub-kernels (pragma tuning, code transforms), then an ILP solver composes the globally optimal design under area constraints — achieving optimal speedups on cryptographic benchmarks | Build |
+| **HLS design space explorer** | Per-function AI agents explore HLS pragma/code variants in parallel, an ILP solver finds the optimal combination, then global expert agents apply cross-function optimizations — achieving up to 92% execution time reduction on cryptographic benchmarks | Build |
 | **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
-| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase using the factory's focused improve loop | Focus + Improve |
+| **Group chat digest** | Turns iMessage group chats into weekly family newsletters with AI-curated highlights and photo selection | Build + Improve |
+| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase | Focus + Improve |
 | **The Factory itself** | The factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |
 
 Built something with the Factory? [Open a PR](https://github.com/akashgit/remote-factory/pulls) to add it here.


### PR DESCRIPTION
## Summary
- Adds a "Built with the Factory" section to README.md and docs/index.md
- Lists 7 real projects across Build, Improve, Research, and Meta modes
- Includes a call-to-action for others to submit PRs adding their projects

## Projects listed
| Project | Mode |
|---------|------|
| SWE-bench solver | Research |
| HMMT math solver | Research |
| Text/Sketch → CAD | Research |
| HLS design space explorer | Build |
| Pluck (iOS app) | Build + Improve |
| Client inquiry agent | Build + Improve |
| The Factory itself | Meta |

## Test plan
- [x] Verify markdown renders correctly
- [x] No links to private repos — descriptions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)