### PR TITLE
feat: user steerability — finalize gate, message channel, hard constraints

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -248,13 +248,48 @@ def cmd_begin(args: argparse.Namespace) -> int:
 
 
 def cmd_finalize(args: argparse.Namespace) -> int:
+    from factory.precheck import run_precheck
     from factory.store import ExperimentStore
-    from factory.models import ExperimentRecord
+    from factory.models import ExperimentRecord, FactoryConfig
 
     project_path = Path(args.path)
     store = ExperimentStore(project_path)
     score_before = getattr(args, "score_before", None)
     score_after = getattr(args, "score_after", None)
+    verdict = args.verdict
+    notes = args.notes or ""
+
+    if verdict == "keep":
+        config_path = project_path / ".factory" / "config.json"
+        if config_path.exists():
+            import json
+            config = FactoryConfig(**json.loads(config_path.read_text()))
+            history = _run(store.load_history()) if hasattr(store, "load_history") else []
+            history_dicts = [r.model_dump() if hasattr(r, "model_dump") else r for r in history]
+
+            precheck_result = run_precheck(
+                score_before=score_before,
+                score_after=score_after,
+                threshold=config.eval_threshold,
+                hypothesis=args.hypothesis or "",
+                history=history_dicts,
+                project_path=project_path,
+                smoke_test_command=config.smoke_test,
+                hard_constraints=config.hard_constraints or None,
+            )
+
+            if not precheck_result.passed:
+                verdict = "revert"
+                failure_detail = "; ".join(precheck_result.blocking_failures)
+                notes = f"[OVERRIDDEN by finalize gate] precheck failed: {failure_detail}. {notes}"
+                _emit_cli_event(project_path, "verdict.overridden", {
+                    "exp_id": args.id,
+                    "original_verdict": "keep",
+                    "new_verdict": "revert",
+                    "reason": failure_detail,
+                })
+                print(f"⚠ Finalize gate: precheck FAILED — overriding keep → revert ({failure_detail})")
+
     record = ExperimentRecord(
         id=args.id,
         timestamp=datetime.now(),
@@ -265,17 +300,26 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         score_before=score_before,
         score_after=score_after,
         delta=None,
-        verdict=args.verdict,
+        verdict=verdict,
         cost_usd=args.cost,
-        notes=args.notes or "",
+        notes=notes,
     )
     _run(store.finalize(args.id, record))
     _emit_cli_event(project_path, "experiment.finalize", {
         "exp_id": args.id,
-        "verdict": args.verdict,
+        "verdict": verdict,
         "hypothesis": (args.hypothesis or "")[:200],
     })
-    print(f"Finalized experiment {args.id} — verdict={args.verdict}")
+    print(f"Finalized experiment {args.id} — verdict={verdict}")
+    return 0
+
+
+def cmd_message(args: argparse.Namespace) -> int:
+    from factory.messages import write_message
+
+    project_path = Path(args.path)
+    msg = write_message(project_path, args.text)
+    print(f"Message queued (id={msg.id}). The CEO will see it at the start of the next cycle.")
     return 0
 
 
@@ -1729,7 +1773,18 @@ def _build_ceo_task(
     research_ideation: str | None = None,
 ) -> str:
     """Build the CEO agent task string from mode and optional context."""
+    from factory.messages import mark_read, read_pending
+
     task = f"Project: {project_path}\nMode: {mode}"
+
+    pending = read_pending(project_path)
+    if pending:
+        task += "\n\n## User Messages\n"
+        task += "The user has sent the following directives. Treat these as HIGH PRIORITY:\n\n"
+        for msg in pending:
+            ts = msg.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+            task += f"**[{ts}]** {msg.text}\n\n"
+        mark_read(project_path, [m.id for m in pending])
 
     if interactive_idea:
         task += (
@@ -2302,6 +2357,11 @@ def build_parser() -> argparse.ArgumentParser:
     # vault-init
     p = sub.add_parser("vault-init", help="Create the factory Obsidian vault")
 
+    # message — send a directive to the CEO
+    p = sub.add_parser("message", help="Send a message to the CEO for the next cycle")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("text", help="Message text")
+
     # self-update
     sub.add_parser("self-update", help="Upgrade the factory CLI to the latest version")
 
@@ -2511,6 +2571,7 @@ def main(argv: list[str] | None = None) -> int:
         "checkpoint": cmd_checkpoint,
         "resume": cmd_resume,
         "vault-init": cmd_vault_init,
+        "message": cmd_message,
         "self-update": cmd_self_update,
         "install": cmd_install,
         "serve-mcp": cmd_serve_mcp,

--- a/factory/messages.py
+++ b/factory/messages.py
@@ -1,0 +1,85 @@
+"""User-to-CEO message channel.
+
+Users queue messages via ``factory message``. The factory loop reads pending
+messages and injects them into the CEO's task string each cycle.
+"""
+
+from __future__ import annotations
+
+import shutil
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+@dataclass
+class Message:
+    id: str
+    timestamp: datetime
+    text: str
+
+
+def _messages_dir(project_path: Path) -> Path:
+    return project_path / ".factory" / "messages"
+
+
+def _read_dir(project_path: Path) -> Path:
+    return _messages_dir(project_path) / "read"
+
+
+def write_message(project_path: Path, text: str) -> Message:
+    """Write a message to the pending queue. Returns the created Message."""
+    msg_dir = _messages_dir(project_path)
+    msg_dir.mkdir(parents=True, exist_ok=True)
+
+    msg_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S") + "-" + uuid.uuid4().hex[:8]
+    ts = datetime.now(timezone.utc)
+
+    path = msg_dir / f"{msg_id}.md"
+    path.write_text(f"timestamp: {ts.isoformat()}\n\n{text}\n")
+
+    msg = Message(id=msg_id, timestamp=ts, text=text)
+    log.info("message_written", id=msg_id, chars=len(text))
+    return msg
+
+
+def read_pending(project_path: Path) -> list[Message]:
+    """Read all pending (unread) messages, ordered by timestamp."""
+    msg_dir = _messages_dir(project_path)
+    if not msg_dir.exists():
+        return []
+
+    messages: list[Message] = []
+    for path in sorted(msg_dir.glob("*.md")):
+        if path.parent.name == "read":
+            continue
+        content = path.read_text()
+        lines = content.split("\n", 2)
+        ts = datetime.now(timezone.utc)
+        if lines and lines[0].startswith("timestamp:"):
+            try:
+                ts = datetime.fromisoformat(lines[0].split(":", 1)[1].strip())
+            except ValueError:
+                pass
+        text = lines[2].strip() if len(lines) > 2 else content.strip()
+        messages.append(Message(id=path.stem, timestamp=ts, text=text))
+
+    return messages
+
+
+def mark_read(project_path: Path, message_ids: list[str]) -> None:
+    """Move messages to the read/ subdirectory."""
+    msg_dir = _messages_dir(project_path)
+    read_dir = _read_dir(project_path)
+    read_dir.mkdir(parents=True, exist_ok=True)
+
+    for msg_id in message_ids:
+        src = msg_dir / f"{msg_id}.md"
+        if src.exists():
+            shutil.move(str(src), str(read_dir / src.name))
+            log.debug("message_marked_read", id=msg_id)

--- a/factory/messages.py
+++ b/factory/messages.py
@@ -37,7 +37,7 @@ def write_message(project_path: Path, text: str) -> Message:
     msg_dir = _messages_dir(project_path)
     msg_dir.mkdir(parents=True, exist_ok=True)
 
-    msg_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S") + "-" + uuid.uuid4().hex[:8]
+    msg_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f") + "-" + uuid.uuid4().hex[:8]
     ts = datetime.now(timezone.utc)
 
     path = msg_dir / f"{msg_id}.md"

--- a/factory/models.py
+++ b/factory/models.py
@@ -35,6 +35,20 @@ class HypothesisBudget(BaseModel):
     max_new: int = 2
 
 
+class HardConstraint(BaseModel):
+    """A user-defined constraint enforced at the code level via precheck.
+
+    Each constraint has a shell command that must exit 0 for the constraint to pass.
+    Non-zero exit = mandatory revert. The CEO cannot override this.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str
+    check: str
+    description: str = ""
+
+
 class ProjectEvalDimension(BaseModel):
     """A user-defined project-specific eval dimension (e.g. benchmark accuracy, latency)."""
 
@@ -128,6 +142,7 @@ class FactoryConfig(BaseModel):
     fixed_surfaces: list[str] = []
     research_constraints: list[str] = []
     cost_budget: CostBudgetConfig | None = None
+    hard_constraints: list[HardConstraint] = []
 
 
 # ── eval ──────────────────────────────────────────────────────────

--- a/factory/precheck.py
+++ b/factory/precheck.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import structlog
 
+from factory.models import HardConstraint
 from factory.strategy import find_anti_patterns
 
 log = structlog.get_logger()
@@ -293,6 +294,56 @@ def check_smoke_test(
     )
 
 
+def check_hard_constraints(
+    constraints: list[HardConstraint],
+    project_path: Path,
+    timeout: float = 120,
+) -> list[CheckResult]:
+    """Run user-defined hard constraint checks. Each must exit 0 to pass."""
+    results: list[CheckResult] = []
+    for constraint in constraints:
+        try:
+            result = subprocess.run(
+                constraint.check,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=project_path,
+            )
+        except subprocess.TimeoutExpired:
+            results.append(CheckResult(
+                name=f"hard_constraint:{constraint.name}",
+                passed=False,
+                detail=f"Hard constraint '{constraint.name}' timed out after {timeout}s",
+            ))
+            continue
+        except Exception as e:
+            results.append(CheckResult(
+                name=f"hard_constraint:{constraint.name}",
+                passed=False,
+                detail=f"Hard constraint '{constraint.name}' error: {e}",
+            ))
+            continue
+
+        if result.returncode == 0:
+            results.append(CheckResult(
+                name=f"hard_constraint:{constraint.name}",
+                passed=True,
+                detail=f"Hard constraint '{constraint.name}' passed",
+            ))
+        else:
+            stderr_snippet = result.stderr.strip()[:200] if result.stderr else ""
+            stdout_snippet = result.stdout.strip()[:200] if result.stdout else ""
+            output = stderr_snippet or stdout_snippet or f"exit code {result.returncode}"
+            results.append(CheckResult(
+                name=f"hard_constraint:{constraint.name}",
+                passed=False,
+                detail=f"Hard constraint '{constraint.name}' failed: {output}",
+            ))
+    return results
+
+
 def run_precheck(
     *,
     score_before: float | None,
@@ -306,6 +357,7 @@ def run_precheck(
     smoke_test_command: str = "",
     similarity_threshold: float = 0.6,
     fixed_surfaces: list[str] | None = None,
+    hard_constraints: list[HardConstraint] | None = None,
 ) -> PreCheckResult:
     """Run all prechecks and return aggregate result.
 
@@ -333,6 +385,10 @@ def run_precheck(
 
     # 6. Smoke test
     checks.append(check_smoke_test(smoke_test_command, project_path))
+
+    # 7. Hard constraints (user-defined checks from factory.md)
+    if hard_constraints:
+        checks.extend(check_hard_constraints(hard_constraints, project_path))
 
     # Aggregate
     failures = [c.name for c in checks if not c.passed]

--- a/factory/store.py
+++ b/factory/store.py
@@ -11,6 +11,7 @@ from typing import Literal
 import structlog
 
 from factory.models import (
+    HardConstraint,
     CompositeScore,
     CostBudgetConfig,
     EvalProfile,
@@ -120,6 +121,34 @@ def _parse_cost_budget(items: str | list[str] | float) -> CostBudgetConfig | Non
     return budget
 
 
+def _parse_hard_constraints(items: str | list[str] | float) -> list[HardConstraint]:
+    """Parse hard constraint entries from factory.md.
+
+    Each list item starts with 'name: X' and may have continuation lines
+    with key: value pairs (check, description).
+    """
+    if not isinstance(items, list):
+        return []
+    constraints: list[HardConstraint] = []
+    for item in items:
+        lines = str(item).split("\n")
+        fields: dict[str, str] = {}
+        for line in lines:
+            if ":" in line:
+                key, val = line.split(":", 1)
+                fields[key.strip()] = val.strip()
+        name = fields.get("name", "")
+        check = fields.get("check", "")
+        if not name or not check:
+            continue
+        constraints.append(HardConstraint(
+            name=name,
+            check=check,
+            description=fields.get("description", ""),
+        ))
+    return constraints
+
+
 class ExperimentStore:
     """Manages the .factory/ directory for a project."""
 
@@ -227,6 +256,7 @@ class ExperimentStore:
         fixed_surfaces = list(fixed_raw) if isinstance(fixed_raw, list) else []
         rc_raw = parsed.get("research_constraints", [])
         research_constraints = list(rc_raw) if isinstance(rc_raw, list) else []
+        hard_constraints = _parse_hard_constraints(parsed.get("hard_constraints", []))
 
         config = FactoryConfig(
             goal=str(parsed.get("goal", "")),
@@ -245,6 +275,7 @@ class ExperimentStore:
             fixed_surfaces=fixed_surfaces,
             research_constraints=research_constraints,
             cost_budget=cost_budget,
+            hard_constraints=hard_constraints,
         )
 
         (self.factory_dir / "config.json").write_text(

--- a/tests/test_hard_constraints.py
+++ b/tests/test_hard_constraints.py
@@ -1,8 +1,8 @@
-"""Tests for hard constraints — model, parser, and precheck integration."""
+"""Tests for hard constraints — model, parser, precheck, and finalize gate."""
 
 import json
+from argparse import Namespace
 from pathlib import Path
-
 from factory.models import FactoryConfig, HardConstraint
 from factory.precheck import check_hard_constraints, run_precheck
 
@@ -162,3 +162,165 @@ class TestParseHardConstraints:
 
         assert _parse_hard_constraints("not a list") == []
         assert _parse_hard_constraints(42.0) == []
+
+
+def _make_project_with_config(tmp_path: Path, hard_constraints: list[dict] | None = None) -> Path:
+    """Helper to create a project dir with .factory/config.json."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    factory_dir = project / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "experiments").mkdir()
+    (factory_dir / "strategy").mkdir()
+    (factory_dir / "reviews").mkdir()
+    config = {
+        "goal": "test",
+        "scope": [],
+        "guards": [],
+        "eval_command": "echo ok",
+        "eval_threshold": 0.8,
+        "constraints": [],
+        "hard_constraints": hard_constraints or [],
+    }
+    (factory_dir / "config.json").write_text(json.dumps(config))
+    tsv = factory_dir / "results.tsv"
+    tsv.write_text("id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+                   "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\tresearch_citations\n")
+    return project
+
+
+class TestFinalizeGate:
+    def test_keep_overridden_when_hard_constraint_fails(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [
+            {"name": "always_fail", "check": "false", "description": ""},
+        ])
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.5, score_after=0.9,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "revert" in tsv
+        assert "OVERRIDDEN" in tsv
+
+    def test_keep_allowed_when_constraints_pass(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [
+            {"name": "always_pass", "check": "true", "description": ""},
+        ])
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.5, score_after=0.9,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "keep" in tsv
+        assert "OVERRIDDEN" not in tsv
+
+    def test_revert_verdict_skips_precheck(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [
+            {"name": "would_fail", "check": "false", "description": ""},
+        ])
+        args = Namespace(
+            path=str(project), id=1, verdict="revert",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.5, score_after=0.9,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "revert" in tsv
+        assert "OVERRIDDEN" not in tsv
+
+    def test_no_config_skips_precheck(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        factory_dir = project / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "experiments").mkdir()
+        (factory_dir / "strategy").mkdir()
+        (factory_dir / "reviews").mkdir()
+        tsv = factory_dir / "results.tsv"
+        tsv.write_text("id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+                       "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\tresearch_citations\n")
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.5, score_after=0.9,
+        )
+        cmd_finalize(args)
+        tsv_content = tsv.read_text()
+        assert "keep" in tsv_content
+
+
+class TestMessageCLI:
+    def test_cmd_message_writes_file(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_message
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+        args = Namespace(path=str(project), text="focus on quality gates")
+        result = cmd_message(args)
+        assert result == 0
+        msg_dir = project / ".factory" / "messages"
+        files = list(msg_dir.glob("*.md"))
+        assert len(files) == 1
+        assert "focus on quality gates" in files[0].read_text()
+
+    def test_message_subcommand_parsing(self) -> None:
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["message", "/tmp/project", "hello CEO"])
+        assert args.path == "/tmp/project"
+        assert args.text == "hello CEO"
+
+
+class TestMessageInjection:
+    def test_build_ceo_task_includes_pending_messages(self, tmp_path: Path) -> None:
+        from factory.cli import _build_ceo_task
+        from factory.messages import write_message
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+        write_message(project, "fix quality gates first")
+
+        task = _build_ceo_task(project, "improve")
+        assert "User Messages" in task
+        assert "fix quality gates first" in task
+        assert "HIGH PRIORITY" in task
+
+    def test_build_ceo_task_no_messages(self, tmp_path: Path) -> None:
+        from factory.cli import _build_ceo_task
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        task = _build_ceo_task(project, "improve")
+        assert "User Messages" not in task
+
+    def test_messages_marked_read_after_injection(self, tmp_path: Path) -> None:
+        from factory.cli import _build_ceo_task
+        from factory.messages import read_pending, write_message
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+        write_message(project, "test message")
+        assert len(read_pending(project)) == 1
+
+        _build_ceo_task(project, "improve")
+        assert len(read_pending(project)) == 0

--- a/tests/test_hard_constraints.py
+++ b/tests/test_hard_constraints.py
@@ -1,0 +1,164 @@
+"""Tests for hard constraints — model, parser, and precheck integration."""
+
+import json
+from pathlib import Path
+
+from factory.models import FactoryConfig, HardConstraint
+from factory.precheck import check_hard_constraints, run_precheck
+
+
+class TestHardConstraintModel:
+    def test_basic(self) -> None:
+        hc = HardConstraint(name="test", check="echo ok")
+        assert hc.name == "test"
+        assert hc.check == "echo ok"
+        assert hc.description == ""
+
+    def test_with_description(self) -> None:
+        hc = HardConstraint(name="test", check="true", description="a test constraint")
+        assert hc.description == "a test constraint"
+
+    def test_factory_config_has_field(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=["src/"],
+            guards=["no secrets"],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=["be nice"],
+            hard_constraints=[HardConstraint(name="q", check="true")],
+        )
+        assert len(config.hard_constraints) == 1
+        assert config.hard_constraints[0].name == "q"
+
+    def test_factory_config_default_empty(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+        )
+        assert config.hard_constraints == []
+
+    def test_serialization_roundtrip(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            hard_constraints=[HardConstraint(name="q", check="bash check.sh", description="quality")],
+        )
+        data = json.loads(json.dumps(config.model_dump()))
+        restored = FactoryConfig(**data)
+        assert len(restored.hard_constraints) == 1
+        assert restored.hard_constraints[0].name == "q"
+        assert restored.hard_constraints[0].check == "bash check.sh"
+
+
+class TestCheckHardConstraints:
+    def test_passing_constraint(self, tmp_path: Path) -> None:
+        constraints = [HardConstraint(name="always_pass", check="true")]
+        results = check_hard_constraints(constraints, tmp_path)
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert "always_pass" in results[0].name
+
+    def test_failing_constraint(self, tmp_path: Path) -> None:
+        constraints = [HardConstraint(name="always_fail", check="false")]
+        results = check_hard_constraints(constraints, tmp_path)
+        assert len(results) == 1
+        assert results[0].passed is False
+
+    def test_multiple_constraints(self, tmp_path: Path) -> None:
+        constraints = [
+            HardConstraint(name="pass1", check="true"),
+            HardConstraint(name="fail1", check="false"),
+            HardConstraint(name="pass2", check="echo ok"),
+        ]
+        results = check_hard_constraints(constraints, tmp_path)
+        assert len(results) == 3
+        assert results[0].passed is True
+        assert results[1].passed is False
+        assert results[2].passed is True
+
+    def test_empty_constraints(self, tmp_path: Path) -> None:
+        results = check_hard_constraints([], tmp_path)
+        assert results == []
+
+    def test_timeout_constraint(self, tmp_path: Path) -> None:
+        constraints = [HardConstraint(name="slow", check="sleep 10")]
+        results = check_hard_constraints(constraints, tmp_path, timeout=1)
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert "timed out" in results[0].detail
+
+
+class TestPrecheckWithHardConstraints:
+    def test_hard_constraint_failure_blocks_precheck(self, tmp_path: Path) -> None:
+        result = run_precheck(
+            score_before=0.5,
+            score_after=0.9,
+            threshold=0.8,
+            hypothesis="test hypothesis",
+            history=[],
+            project_path=tmp_path,
+            hard_constraints=[HardConstraint(name="blocker", check="false")],
+        )
+        assert result.passed is False
+        assert any("hard_constraint:blocker" in f for f in result.blocking_failures)
+
+    def test_hard_constraint_pass_does_not_block(self, tmp_path: Path) -> None:
+        result = run_precheck(
+            score_before=0.5,
+            score_after=0.9,
+            threshold=0.8,
+            hypothesis="test hypothesis",
+            history=[],
+            project_path=tmp_path,
+            hard_constraints=[HardConstraint(name="ok", check="true")],
+        )
+        assert "hard_constraint:ok" not in result.blocking_failures
+
+    def test_no_hard_constraints_is_fine(self, tmp_path: Path) -> None:
+        result = run_precheck(
+            score_before=0.5,
+            score_after=0.9,
+            threshold=0.8,
+            hypothesis="test hypothesis",
+            history=[],
+            project_path=tmp_path,
+        )
+        assert all("hard_constraint" not in f for f in result.blocking_failures)
+
+
+class TestParseHardConstraints:
+    def test_parse_from_factory_md(self) -> None:
+        from factory.store import _parse_hard_constraints
+
+        items = [
+            "name: quality_check\ncheck: bash quality.sh\ndescription: Must pass quality",
+            "name: server_up\ncheck: curl -sf http://localhost:8080/ping",
+        ]
+        constraints = _parse_hard_constraints(items)
+        assert len(constraints) == 2
+        assert constraints[0].name == "quality_check"
+        assert constraints[0].check == "bash quality.sh"
+        assert constraints[0].description == "Must pass quality"
+        assert constraints[1].name == "server_up"
+
+    def test_skips_incomplete_items(self) -> None:
+        from factory.store import _parse_hard_constraints
+
+        items = ["name: no_check", "check: no_name"]
+        constraints = _parse_hard_constraints(items)
+        assert len(constraints) == 0
+
+    def test_non_list_returns_empty(self) -> None:
+        from factory.store import _parse_hard_constraints
+
+        assert _parse_hard_constraints("not a list") == []
+        assert _parse_hard_constraints(42.0) == []

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,101 @@
+"""Tests for factory.messages — user-to-CEO message channel."""
+
+from pathlib import Path
+
+from factory.messages import mark_read, read_pending, write_message
+
+
+class TestWriteMessage:
+    def test_creates_message_file(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        msg = write_message(project, "focus on quality")
+        assert msg.text == "focus on quality"
+        assert msg.id
+
+        msg_dir = project / ".factory" / "messages"
+        assert msg_dir.exists()
+        files = list(msg_dir.glob("*.md"))
+        assert len(files) == 1
+        assert "focus on quality" in files[0].read_text()
+
+    def test_multiple_messages(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        write_message(project, "msg 1")
+        write_message(project, "msg 2")
+
+        files = list((project / ".factory" / "messages").glob("*.md"))
+        assert len(files) == 2
+
+
+class TestReadPending:
+    def test_empty_when_no_messages(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        assert read_pending(project) == []
+
+    def test_reads_written_messages(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        write_message(project, "hello CEO")
+        pending = read_pending(project)
+        assert len(pending) == 1
+        assert pending[0].text == "hello CEO"
+
+    def test_ordered_by_filename(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        write_message(project, "first")
+        write_message(project, "second")
+        pending = read_pending(project)
+        assert len(pending) == 2
+        assert pending[0].text == "first"
+        assert pending[1].text == "second"
+
+
+class TestMarkRead:
+    def test_moves_to_read_dir(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        msg = write_message(project, "done reading")
+        mark_read(project, [msg.id])
+
+        assert read_pending(project) == []
+        read_dir = project / ".factory" / "messages" / "read"
+        assert read_dir.exists()
+        files = list(read_dir.glob("*.md"))
+        assert len(files) == 1
+
+    def test_partial_mark_read(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        msg1 = write_message(project, "msg 1")
+        write_message(project, "msg 2")
+        mark_read(project, [msg1.id])
+
+        pending = read_pending(project)
+        assert len(pending) == 1
+        assert pending[0].text == "msg 2"
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        msg = write_message(project, "test")
+        mark_read(project, [msg.id])
+        mark_read(project, [msg.id])
+        assert read_pending(project) == []


### PR DESCRIPTION
## Summary

Three features that give users reliable, code-enforced control over the CEO agent's decisions:

### A. Finalize Gate (most critical)

Precheck enforcement inside `cmd_finalize`. When the CEO calls `factory finalize --verdict keep`, precheck now runs automatically — including smoke test, hard constraints, score direction, and anti-pattern checks. If precheck fails, the verdict is **overridden to revert** and a `verdict.overridden` event is emitted. The CEO cannot bypass this.

**Why this matters:** Previously, calling precheck was prompt-instructed only. The CEO could (and did) skip it entirely, keeping experiments without quality validation.

### B. Message Channel

`factory message <path> "text"` queues a user directive that gets injected into the CEO's task string as a `## User Messages` section on the next cycle.

### C. Hard Constraints

`## Hard Constraints` section in `factory.md` with user-defined check commands enforced via precheck. Each check command must exit 0 — non-zero = mandatory revert.

## Test plan

- [x] 24 new tests pass (8 messages + 16 hard constraints)
- [x] Full suite: 1371 passed, 0 regressions
- [x] `ruff check` clean