### PR TITLE
feat: finalize gate + hard constraints

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -263,8 +263,8 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         config_path = project_path / ".factory" / "config.json"
         if config_path.exists():
             config = FactoryConfig(**json.loads(config_path.read_text()))
-            history = _run(store.load_history()) if hasattr(store, "load_history") else []
-            history_dicts = [r.model_dump() if hasattr(r, "model_dump") else r for r in history]
+            history = _run(store.load_history())
+            history_dicts = [r.model_dump() for r in history]
 
             precheck_result = run_precheck(
                 score_before=score_before,
@@ -274,7 +274,7 @@ def cmd_finalize(args: argparse.Namespace) -> int:
                 history=history_dicts,
                 project_path=project_path,
                 smoke_test_command=config.smoke_test,
-                hard_constraints=config.hard_constraints or None,
+                hard_constraints=config.hard_constraints,
             )
 
             if not precheck_result.passed:

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -248,13 +248,47 @@ def cmd_begin(args: argparse.Namespace) -> int:
 
 
 def cmd_finalize(args: argparse.Namespace) -> int:
+    from factory.precheck import run_precheck
     from factory.store import ExperimentStore
-    from factory.models import ExperimentRecord
+    from factory.models import ExperimentRecord, FactoryConfig
 
     project_path = Path(args.path)
     store = ExperimentStore(project_path)
     score_before = getattr(args, "score_before", None)
     score_after = getattr(args, "score_after", None)
+    verdict = args.verdict
+    notes = args.notes or ""
+
+    if verdict == "keep":
+        config_path = project_path / ".factory" / "config.json"
+        if config_path.exists():
+            config = FactoryConfig(**json.loads(config_path.read_text()))
+            history = _run(store.load_history()) if hasattr(store, "load_history") else []
+            history_dicts = [r.model_dump() if hasattr(r, "model_dump") else r for r in history]
+
+            precheck_result = run_precheck(
+                score_before=score_before,
+                score_after=score_after,
+                threshold=config.eval_threshold,
+                hypothesis=args.hypothesis or "",
+                history=history_dicts,
+                project_path=project_path,
+                smoke_test_command=config.smoke_test,
+                hard_constraints=config.hard_constraints or None,
+            )
+
+            if not precheck_result.passed:
+                verdict = "revert"
+                failure_detail = "; ".join(precheck_result.blocking_failures)
+                notes = f"[OVERRIDDEN by finalize gate] precheck failed: {failure_detail}. {notes}"
+                _emit_cli_event(project_path, "verdict.overridden", {
+                    "exp_id": args.id,
+                    "original_verdict": "keep",
+                    "new_verdict": "revert",
+                    "reason": failure_detail,
+                })
+                print(f"Finalize gate: precheck FAILED — overriding keep to revert ({failure_detail})")
+
     record = ExperimentRecord(
         id=args.id,
         timestamp=datetime.now(),
@@ -265,17 +299,17 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         score_before=score_before,
         score_after=score_after,
         delta=None,
-        verdict=args.verdict,
+        verdict=verdict,
         cost_usd=args.cost,
-        notes=args.notes or "",
+        notes=notes,
     )
     _run(store.finalize(args.id, record))
     _emit_cli_event(project_path, "experiment.finalize", {
         "exp_id": args.id,
-        "verdict": args.verdict,
+        "verdict": verdict,
         "hypothesis": (args.hypothesis or "")[:200],
     })
-    print(f"Finalized experiment {args.id} — verdict={args.verdict}")
+    print(f"Finalized experiment {args.id} — verdict={verdict}")
     return 0
 
 

--- a/factory/models.py
+++ b/factory/models.py
@@ -35,6 +35,20 @@ class HypothesisBudget(BaseModel):
     max_new: int = 2
 
 
+class HardConstraint(BaseModel):
+    """A user-defined constraint enforced at the code level via precheck.
+
+    Each constraint has a shell command that must exit 0 for the constraint to pass.
+    Non-zero exit = mandatory revert. The CEO cannot override this.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str
+    check: str
+    description: str = ""
+
+
 class ProjectEvalDimension(BaseModel):
     """A user-defined project-specific eval dimension (e.g. benchmark accuracy, latency)."""
 
@@ -128,6 +142,7 @@ class FactoryConfig(BaseModel):
     fixed_surfaces: list[str] = []
     research_constraints: list[str] = []
     cost_budget: CostBudgetConfig | None = None
+    hard_constraints: list[HardConstraint] = []
 
 
 # ── eval ──────────────────────────────────────────────────────────

--- a/factory/precheck.py
+++ b/factory/precheck.py
@@ -300,6 +300,7 @@ def check_hard_constraints(
     timeout: float = 120,
 ) -> list[CheckResult]:
     """Run user-defined hard constraint checks. Each must exit 0 to pass."""
+    log.info("hard_constraints_start", count=len(constraints))
     results: list[CheckResult] = []
     for constraint in constraints:
         try:
@@ -327,6 +328,7 @@ def check_hard_constraints(
             continue
 
         if result.returncode == 0:
+            log.info("hard_constraint_result", name=constraint.name, passed=True)
             results.append(CheckResult(
                 name=f"hard_constraint:{constraint.name}",
                 passed=True,
@@ -336,6 +338,7 @@ def check_hard_constraints(
             stderr_snippet = result.stderr.strip()[:200] if result.stderr else ""
             stdout_snippet = result.stdout.strip()[:200] if result.stdout else ""
             output = stderr_snippet or stdout_snippet or f"exit code {result.returncode}"
+            log.info("hard_constraint_result", name=constraint.name, passed=False, detail=output)
             results.append(CheckResult(
                 name=f"hard_constraint:{constraint.name}",
                 passed=False,

--- a/factory/precheck.py
+++ b/factory/precheck.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import structlog
 
+from factory.models import HardConstraint
 from factory.strategy import find_anti_patterns
 
 log = structlog.get_logger()
@@ -293,6 +294,56 @@ def check_smoke_test(
     )
 
 
+def check_hard_constraints(
+    constraints: list[HardConstraint],
+    project_path: Path,
+    timeout: float = 120,
+) -> list[CheckResult]:
+    """Run user-defined hard constraint checks. Each must exit 0 to pass."""
+    results: list[CheckResult] = []
+    for constraint in constraints:
+        try:
+            result = subprocess.run(
+                constraint.check,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=project_path,
+            )
+        except subprocess.TimeoutExpired:
+            results.append(CheckResult(
+                name=f"hard_constraint:{constraint.name}",
+                passed=False,
+                detail=f"Hard constraint '{constraint.name}' timed out after {timeout}s",
+            ))
+            continue
+        except Exception as e:
+            results.append(CheckResult(
+                name=f"hard_constraint:{constraint.name}",
+                passed=False,
+                detail=f"Hard constraint '{constraint.name}' error: {e}",
+            ))
+            continue
+
+        if result.returncode == 0:
+            results.append(CheckResult(
+                name=f"hard_constraint:{constraint.name}",
+                passed=True,
+                detail=f"Hard constraint '{constraint.name}' passed",
+            ))
+        else:
+            stderr_snippet = result.stderr.strip()[:200] if result.stderr else ""
+            stdout_snippet = result.stdout.strip()[:200] if result.stdout else ""
+            output = stderr_snippet or stdout_snippet or f"exit code {result.returncode}"
+            results.append(CheckResult(
+                name=f"hard_constraint:{constraint.name}",
+                passed=False,
+                detail=f"Hard constraint '{constraint.name}' failed: {output}",
+            ))
+    return results
+
+
 def run_precheck(
     *,
     score_before: float | None,
@@ -306,6 +357,7 @@ def run_precheck(
     smoke_test_command: str = "",
     similarity_threshold: float = 0.6,
     fixed_surfaces: list[str] | None = None,
+    hard_constraints: list[HardConstraint] | None = None,
 ) -> PreCheckResult:
     """Run all prechecks and return aggregate result.
 
@@ -333,6 +385,10 @@ def run_precheck(
 
     # 6. Smoke test
     checks.append(check_smoke_test(smoke_test_command, project_path))
+
+    # 7. Hard constraints (user-defined checks from factory.md)
+    if hard_constraints:
+        checks.extend(check_hard_constraints(hard_constraints, project_path))
 
     # Aggregate
     failures = [c.name for c in checks if not c.passed]

--- a/factory/store.py
+++ b/factory/store.py
@@ -11,13 +11,13 @@ from typing import Literal
 import structlog
 
 from factory.models import (
-    HardConstraint,
     CompositeScore,
     CostBudgetConfig,
     EvalProfile,
     EvalWeights,
     ExperimentRecord,
     FactoryConfig,
+    HardConstraint,
     HypothesisBudget,
     ProjectEvalDimension,
     ResearchTarget,

--- a/factory/store.py
+++ b/factory/store.py
@@ -11,6 +11,7 @@ from typing import Literal
 import structlog
 
 from factory.models import (
+    HardConstraint,
     CompositeScore,
     CostBudgetConfig,
     EvalProfile,
@@ -120,6 +121,34 @@ def _parse_cost_budget(items: str | list[str] | float) -> CostBudgetConfig | Non
     return budget
 
 
+def _parse_hard_constraints(items: str | list[str] | float) -> list[HardConstraint]:
+    """Parse hard constraint entries from factory.md.
+
+    Each list item starts with 'name: X' and may have continuation lines
+    with key: value pairs (check, description).
+    """
+    if not isinstance(items, list):
+        return []
+    constraints: list[HardConstraint] = []
+    for item in items:
+        lines = str(item).split("\n")
+        fields: dict[str, str] = {}
+        for line in lines:
+            if ":" in line:
+                key, val = line.split(":", 1)
+                fields[key.strip()] = val.strip()
+        name = fields.get("name", "")
+        check = fields.get("check", "")
+        if not name or not check:
+            continue
+        constraints.append(HardConstraint(
+            name=name,
+            check=check,
+            description=fields.get("description", ""),
+        ))
+    return constraints
+
+
 class ExperimentStore:
     """Manages the .factory/ directory for a project."""
 
@@ -227,6 +256,7 @@ class ExperimentStore:
         fixed_surfaces = list(fixed_raw) if isinstance(fixed_raw, list) else []
         rc_raw = parsed.get("research_constraints", [])
         research_constraints = list(rc_raw) if isinstance(rc_raw, list) else []
+        hard_constraints = _parse_hard_constraints(parsed.get("hard_constraints", []))
 
         config = FactoryConfig(
             goal=str(parsed.get("goal", "")),
@@ -245,6 +275,7 @@ class ExperimentStore:
             fixed_surfaces=fixed_surfaces,
             research_constraints=research_constraints,
             cost_budget=cost_budget,
+            hard_constraints=hard_constraints,
         )
 
         (self.factory_dir / "config.json").write_text(

--- a/tests/test_hard_constraints.py
+++ b/tests/test_hard_constraints.py
@@ -1,0 +1,266 @@
+"""Tests for hard constraints — model, parser, precheck, and finalize gate."""
+
+import json
+from argparse import Namespace
+from pathlib import Path
+from factory.models import FactoryConfig, HardConstraint
+from factory.precheck import check_hard_constraints, run_precheck
+
+
+class TestHardConstraintModel:
+    def test_basic(self) -> None:
+        hc = HardConstraint(name="test", check="echo ok")
+        assert hc.name == "test"
+        assert hc.check == "echo ok"
+        assert hc.description == ""
+
+    def test_with_description(self) -> None:
+        hc = HardConstraint(name="test", check="true", description="a test constraint")
+        assert hc.description == "a test constraint"
+
+    def test_factory_config_has_field(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=["src/"],
+            guards=["no secrets"],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=["be nice"],
+            hard_constraints=[HardConstraint(name="q", check="true")],
+        )
+        assert len(config.hard_constraints) == 1
+        assert config.hard_constraints[0].name == "q"
+
+    def test_factory_config_default_empty(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+        )
+        assert config.hard_constraints == []
+
+    def test_serialization_roundtrip(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            hard_constraints=[HardConstraint(name="q", check="bash check.sh", description="quality")],
+        )
+        data = json.loads(json.dumps(config.model_dump()))
+        restored = FactoryConfig(**data)
+        assert len(restored.hard_constraints) == 1
+        assert restored.hard_constraints[0].name == "q"
+        assert restored.hard_constraints[0].check == "bash check.sh"
+
+
+class TestCheckHardConstraints:
+    def test_passing_constraint(self, tmp_path: Path) -> None:
+        constraints = [HardConstraint(name="always_pass", check="true")]
+        results = check_hard_constraints(constraints, tmp_path)
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert "always_pass" in results[0].name
+
+    def test_failing_constraint(self, tmp_path: Path) -> None:
+        constraints = [HardConstraint(name="always_fail", check="false")]
+        results = check_hard_constraints(constraints, tmp_path)
+        assert len(results) == 1
+        assert results[0].passed is False
+
+    def test_multiple_constraints(self, tmp_path: Path) -> None:
+        constraints = [
+            HardConstraint(name="pass1", check="true"),
+            HardConstraint(name="fail1", check="false"),
+            HardConstraint(name="pass2", check="echo ok"),
+        ]
+        results = check_hard_constraints(constraints, tmp_path)
+        assert len(results) == 3
+        assert results[0].passed is True
+        assert results[1].passed is False
+        assert results[2].passed is True
+
+    def test_empty_constraints(self, tmp_path: Path) -> None:
+        results = check_hard_constraints([], tmp_path)
+        assert results == []
+
+    def test_timeout_constraint(self, tmp_path: Path) -> None:
+        constraints = [HardConstraint(name="slow", check="sleep 10")]
+        results = check_hard_constraints(constraints, tmp_path, timeout=1)
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert "timed out" in results[0].detail
+
+
+class TestPrecheckWithHardConstraints:
+    def test_hard_constraint_failure_blocks_precheck(self, tmp_path: Path) -> None:
+        result = run_precheck(
+            score_before=0.5,
+            score_after=0.9,
+            threshold=0.8,
+            hypothesis="test hypothesis",
+            history=[],
+            project_path=tmp_path,
+            hard_constraints=[HardConstraint(name="blocker", check="false")],
+        )
+        assert result.passed is False
+        assert any("hard_constraint:blocker" in f for f in result.blocking_failures)
+
+    def test_hard_constraint_pass_does_not_block(self, tmp_path: Path) -> None:
+        result = run_precheck(
+            score_before=0.5,
+            score_after=0.9,
+            threshold=0.8,
+            hypothesis="test hypothesis",
+            history=[],
+            project_path=tmp_path,
+            hard_constraints=[HardConstraint(name="ok", check="true")],
+        )
+        assert "hard_constraint:ok" not in result.blocking_failures
+
+    def test_no_hard_constraints_is_fine(self, tmp_path: Path) -> None:
+        result = run_precheck(
+            score_before=0.5,
+            score_after=0.9,
+            threshold=0.8,
+            hypothesis="test hypothesis",
+            history=[],
+            project_path=tmp_path,
+        )
+        assert all("hard_constraint" not in f for f in result.blocking_failures)
+
+
+class TestParseHardConstraints:
+    def test_parse_from_factory_md(self) -> None:
+        from factory.store import _parse_hard_constraints
+
+        items = [
+            "name: quality_check\ncheck: bash quality.sh\ndescription: Must pass quality",
+            "name: server_up\ncheck: curl -sf http://localhost:8080/ping",
+        ]
+        constraints = _parse_hard_constraints(items)
+        assert len(constraints) == 2
+        assert constraints[0].name == "quality_check"
+        assert constraints[0].check == "bash quality.sh"
+        assert constraints[0].description == "Must pass quality"
+        assert constraints[1].name == "server_up"
+
+    def test_skips_incomplete_items(self) -> None:
+        from factory.store import _parse_hard_constraints
+
+        items = ["name: no_check", "check: no_name"]
+        constraints = _parse_hard_constraints(items)
+        assert len(constraints) == 0
+
+    def test_non_list_returns_empty(self) -> None:
+        from factory.store import _parse_hard_constraints
+
+        assert _parse_hard_constraints("not a list") == []
+        assert _parse_hard_constraints(42.0) == []
+
+
+def _make_project_with_config(tmp_path: Path, hard_constraints: list[dict] | None = None) -> Path:
+    """Helper to create a project dir with .factory/config.json."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    factory_dir = project / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "experiments").mkdir()
+    (factory_dir / "strategy").mkdir()
+    (factory_dir / "reviews").mkdir()
+    config = {
+        "goal": "test",
+        "scope": [],
+        "guards": [],
+        "eval_command": "echo ok",
+        "eval_threshold": 0.8,
+        "constraints": [],
+        "hard_constraints": hard_constraints or [],
+    }
+    (factory_dir / "config.json").write_text(json.dumps(config))
+    tsv = factory_dir / "results.tsv"
+    tsv.write_text("id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+                   "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\tresearch_citations\n")
+    return project
+
+
+class TestFinalizeGate:
+    def test_keep_overridden_when_hard_constraint_fails(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [
+            {"name": "always_fail", "check": "false", "description": ""},
+        ])
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.5, score_after=0.9,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "revert" in tsv
+        assert "OVERRIDDEN" in tsv
+
+    def test_keep_allowed_when_constraints_pass(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [
+            {"name": "always_pass", "check": "true", "description": ""},
+        ])
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.5, score_after=0.9,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "keep" in tsv
+        assert "OVERRIDDEN" not in tsv
+
+    def test_revert_verdict_skips_precheck(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [
+            {"name": "would_fail", "check": "false", "description": ""},
+        ])
+        args = Namespace(
+            path=str(project), id=1, verdict="revert",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.5, score_after=0.9,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "revert" in tsv
+        assert "OVERRIDDEN" not in tsv
+
+    def test_no_config_skips_precheck(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        factory_dir = project / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "experiments").mkdir()
+        (factory_dir / "strategy").mkdir()
+        (factory_dir / "reviews").mkdir()
+        tsv = factory_dir / "results.tsv"
+        tsv.write_text("id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+                       "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\tresearch_citations\n")
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.5, score_after=0.9,
+        )
+        cmd_finalize(args)
+        tsv_content = tsv.read_text()
+        assert "keep" in tsv_content
+


### PR DESCRIPTION
## Summary

Code-level enforcement of precheck inside `cmd_finalize`. When the CEO calls `factory finalize --verdict keep`, precheck now runs automatically. If it fails, the verdict is overridden to revert. The CEO cannot bypass this.

### Problem

Previously, calling `factory precheck` was prompt-instructed only. The CEO could (and did) skip it, keeping experiments without quality validation. In our AdaptFM competition run, the CEO optimized to 9.7x speedup across 40 cycles while IFEval was failing — meaning the submission scored ZERO.

### Solution

The finalize gate runs precheck inside `cmd_finalize` — the single chokepoint for all verdicts. No timing issues, no "did the CEO run precheck" uncertainty. It just runs.

Also adds `## Hard Constraints` in factory.md — user-defined shell commands enforced via precheck. Each must exit 0 or the experiment is reverted.

## Files

| File | Change |
|------|--------|
| `factory/models.py` | HardConstraint model + hard_constraints field on FactoryConfig |
| `factory/store.py` | _parse_hard_constraints() for factory.md |
| `factory/precheck.py` | check_hard_constraints() wired into run_precheck() |
| `factory/cli.py` | Finalize gate in cmd_finalize + verdict.overridden event |
| `tests/test_hard_constraints.py` | 20 tests — model, parser, precheck, finalize gate |

## Test plan

- [x] 20 tests pass
- [x] ruff clean