### PR TITLE
fix: force-add agents/ in plugin workflow to bypass .gitignore

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -32,7 +32,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B plugin
-          git add agents/
+          git add -f agents/
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "build: generate plugin agent files from $(git rev-parse --short main)"
           git push --force origin plugin


### PR DESCRIPTION
## Summary
- The `agents/` directory is in `.gitignore` (generated output), so `git add agents/` silently skips it
- Use `git add -f agents/` to force-add despite the gitignore rule

## Test plan
- [ ] Verify the plugin workflow succeeds on next push to main