### PR TITLE
feat: route factory sessions through proper agent identity flags

### DIFF
--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -42,9 +42,7 @@ class ClaudeRunner:
 
         Returns (stdout, return_code).
         """
-        full_prompt = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
-
-        cmd = ["claude", "-p", full_prompt]
+        cmd = ["claude", "--append-system-prompt", prompt, "-p", task]
         if dangerously_skip_permissions:
             cmd.append("--dangerously-skip-permissions")
         if model:
@@ -101,7 +99,7 @@ class ClaudeRunner:
         """Replace process with interactive Claude Code session.
 
         Args:
-            prompt: The system prompt to append.
+            prompt: The system prompt (replaces default).
             task: The initial user message.
             cwd: Working directory (os.chdir is called before exec).
             model: Optional model override.
@@ -111,7 +109,7 @@ class ClaudeRunner:
         _ = role  # unused by claude runner
         cmd = [
             "claude",
-            "--append-system-prompt", prompt,
+            "--system-prompt", prompt,
         ]
         if dangerously_skip_permissions:
             cmd.append("--dangerously-skip-permissions")

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -76,10 +76,57 @@ class TestClaudeRunner:
                 call_args = mock_exec.call_args
                 cmd = call_args[0]
                 assert cmd[0] == "claude"
+                assert "--append-system-prompt" in cmd
+                assert "You are a test agent." in cmd
                 assert "-p" in cmd
+                assert "Say hello" in cmd
                 assert "--dangerously-skip-permissions" in cmd
                 assert "--model" in cmd
                 assert "claude-opus-4-7" in cmd
+
+    async def test_headless_separates_prompt_and_task(self, tmp_path: Path) -> None:
+        """Prompt goes to --append-system-prompt, task goes to -p as separate args."""
+        runner = ClaudeRunner()
+
+        with patch(
+            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"ok", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(
+                    prompt="You are an agent.",
+                    task="Do the thing",
+                    cwd=tmp_path,
+                )
+
+                cmd = list(mock_exec.call_args[0])
+                asp_idx = cmd.index("--append-system-prompt")
+                assert cmd[asp_idx + 1] == "You are an agent."
+                p_idx = cmd.index("-p")
+                assert cmd[p_idx + 1] == "Do the thing"
+
+    def test_interactive_exec_uses_system_prompt(self, tmp_path: Path) -> None:
+        """interactive_exec() uses --system-prompt (not --append-system-prompt)."""
+        runner = ClaudeRunner()
+
+        with patch("os.chdir"), patch("os.execvp") as mock_execvp:
+            runner.interactive_exec(
+                prompt="You are the CEO.",
+                task="Run the factory",
+                cwd=tmp_path,
+            )
+
+            cmd = mock_execvp.call_args[0][1]
+            assert "--system-prompt" in cmd
+            assert "--append-system-prompt" not in cmd
+            assert "You are the CEO." in cmd
 
 
 class TestBobRunner:


### PR DESCRIPTION
## Summary
- **Headless subagents** (`headless()`): prompt now passed via `--append-system-prompt` with task as separate `-p` arg, instead of concatenating both into a single `-p` string. Preserves Claude Code's default tool guidance (~14-17K tokens).
- **Interactive CEO** (`interactive_exec()`): uses `--system-prompt` instead of `--append-system-prompt`, fully replacing the default system prompt so the user talks to the CEO exclusively.
- Added 2 new tests verifying correct CLI flag placement for both methods; updated existing test assertions.

Closes #217

## Test plan
- [x] `pytest tests/test_runners.py -v` — all 48 tests pass (3 new)
- [x] `ruff check .` — clean
- [x] `mypy factory/` — clean
- [x] Full suite `pytest -v` — 344 passed, no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)