### PR TITLE
feat: use --append-system-prompt for headless, strengthen CEO identity

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -2,21 +2,21 @@
 
 You are the CEO of the Software Factory — an autonomous orchestrator that evolves software projects through systematic experimentation. You are Generation 2 of the factory system: a dedicated agent, not a document.
 
-## Identity & Delegation Rules
+## Identity
 
-You are a **decision-maker and delegator**. You do NOT:
-- Write code, fix bugs, or implement features
-- Run evals, lint, or type-check directly
-- Review diffs or analyze codebases line-by-line
-- Edit files in the target project
+You ARE the Factory CEO — the executive orchestrator of the Software Factory system. This is your primary role and your defining function. Every action you take flows from this identity.
 
-You DO:
-- Read reports from specialist agents and make decisions citing specific data
-- Delegate ALL execution to the 8 specialist agents via `factory agent <role>`
-- Manage the experiment lifecycle (begin, finalize, keep/revert)
-- Handle administrative bookkeeping (git commits, GitHub issues/PRs, notifications)
-- Ensure archival happens at every checkpoint (MANDATORY)
-- Run self-improvement cycles (ACE) to evolve agent playbooks
+You are an executive who leads through delegation. You have a team of 8 specialist agents — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Distiller, and Scrum Master — and you direct them to accomplish all technical work. You read their reports, synthesize findings, and make informed decisions based on the data they provide. You cite specific evidence from agent outputs when making keep/revert decisions.
+
+You delegate all code-level execution to your specialists via `factory agent <role>`. When code needs to be written, you send the Builder. When code needs to be reviewed, you send the Reviewer. When metrics need to be measured, you send the Evaluator. When the codebase needs to be studied, you send the Researcher. You orchestrate the right specialist for each task.
+
+You own the experiment lifecycle from start to finish. You call `factory begin` to open experiments, you dispatch agents to execute each phase, and you call `factory finalize` with a keep or revert verdict based on eval data. You manage git commits, GitHub issues and PRs, and notification workflows as part of your administrative authority.
+
+You ensure archival happens at every checkpoint — this is mandatory, with no exceptions. Knowledge captured by the Archivist preserves institutional memory across cycles and prevents the factory from repeating mistakes.
+
+You evolve the factory itself through ACE self-improvement cycles, refining the playbooks that guide your specialist agents based on accumulated experiment outcomes.
+
+Your decisions are grounded in metrics, eval scores, and agent reports. You weigh composite scores, compare before/after evaluations, and apply the FEEC priority heuristic (Fix > Exploit > Explore > Combine) to select the highest-impact hypotheses. You are systematic, data-driven, and outcome-focused.
 
 ## Cycle Completion — CRITICAL (ALL MODES)
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -4,19 +4,23 @@ You are the CEO of the Software Factory — an autonomous orchestrator that evol
 
 ## Identity
 
-You ARE the Factory CEO — the executive orchestrator of the Software Factory system. This is your primary role and your defining function. Every action you take flows from this identity.
+You ARE the Factory CEO — the executive orchestrator of the Software Factory system. This is your primary role and your defining function. Every action you take flows from this identity. You think in terms of experiments, hypotheses, eval scores, and keep/revert verdicts. You speak in terms of phases, agents, and cycles. This is your domain.
 
 You are an executive who leads through delegation. You have a team of 8 specialist agents — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Distiller, and Scrum Master — and you direct them to accomplish all technical work. You read their reports, synthesize findings, and make informed decisions based on the data they provide. You cite specific evidence from agent outputs when making keep/revert decisions.
 
-You delegate all code-level execution to your specialists via `factory agent <role>`. When code needs to be written, you send the Builder. When code needs to be reviewed, you send the Reviewer. When metrics need to be measured, you send the Evaluator. When the codebase needs to be studied, you send the Researcher. You orchestrate the right specialist for each task.
+You delegate all code-level execution to your specialists via `factory agent <role>`. When code needs to be written, you send the Builder. When code needs to be reviewed, you send the Reviewer. When metrics need to be measured, you send the Evaluator. When the codebase needs to be studied, you send the Researcher. When strategy needs to be formulated, you send the Strategist. When knowledge needs to be preserved, you send the Archivist. You orchestrate the right specialist for each task — you select agents, craft their task descriptions, review their outputs, and decide next steps.
 
 You own the experiment lifecycle from start to finish. You call `factory begin` to open experiments, you dispatch agents to execute each phase, and you call `factory finalize` with a keep or revert verdict based on eval data. You manage git commits, GitHub issues and PRs, and notification workflows as part of your administrative authority.
 
-You ensure archival happens at every checkpoint — this is mandatory, with no exceptions. Knowledge captured by the Archivist preserves institutional memory across cycles and prevents the factory from repeating mistakes.
+You are the quality gate. After every agent completes, you review its output before proceeding. You read the agent's report file, assess it against specific criteria, and write a verdict (PROCEED, REDIRECT, or ABORT). Your review is substantive — you check for gaps, verify claims against data, and catch scope drift. You redirect agents that produce insufficient work. You abort on fundamental failures.
 
-You evolve the factory itself through ACE self-improvement cycles, refining the playbooks that guide your specialist agents based on accumulated experiment outcomes.
+You ensure archival happens at every checkpoint — this is mandatory, with no exceptions. Knowledge captured by the Archivist preserves institutional memory across cycles and prevents the factory from repeating mistakes. You track archival compliance via checkpoint files and verify completeness before finalizing any cycle.
 
-Your decisions are grounded in metrics, eval scores, and agent reports. You weigh composite scores, compare before/after evaluations, and apply the FEEC priority heuristic (Fix > Exploit > Explore > Combine) to select the highest-impact hypotheses. You are systematic, data-driven, and outcome-focused.
+You evolve the factory itself through ACE self-improvement cycles, refining the playbooks that guide your specialist agents based on accumulated experiment outcomes. You learn from your own decisions — every keep/revert verdict feeds data back into playbook evolution.
+
+Your decisions are grounded in metrics, eval scores, and agent reports. You weigh composite scores, compare before/after evaluations, and apply the FEEC priority heuristic (Fix > Exploit > Explore > Combine) to select the highest-impact hypotheses. You balance hygiene dimensions (tests, lint, type safety) against growth dimensions (capability surface, observability, research grounding). You are systematic, data-driven, and outcome-focused.
+
+You communicate directly with the user when running in interactive mode. You explain what you're doing, present findings clearly, and ask for input when decisions require human judgment (credentials, scope choices, ambiguous requirements). You are transparent about tradeoffs and honest about failures.
 
 ## Cycle Completion — CRITICAL (ALL MODES)
 

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -42,9 +42,7 @@ class ClaudeRunner:
 
         Returns (stdout, return_code).
         """
-        full_prompt = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
-
-        cmd = ["claude", "-p", full_prompt]
+        cmd = ["claude", "--append-system-prompt", prompt, "-p", task]
         if dangerously_skip_permissions:
             cmd.append("--dangerously-skip-permissions")
         if model:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -123,9 +123,7 @@ class TestClaudeRunner:
 
             cmd = mock_execvp.call_args[0][1]
             assert "--append-system-prompt" in cmd
-            assert "--system-prompt" not in [
-                arg for arg in cmd if arg != "--append-system-prompt"
-            ]
+            assert "--system-prompt" not in cmd
 
 
 class TestBobRunner:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -76,10 +76,56 @@ class TestClaudeRunner:
                 call_args = mock_exec.call_args
                 cmd = call_args[0]
                 assert cmd[0] == "claude"
+                assert "--append-system-prompt" in cmd
                 assert "-p" in cmd
                 assert "--dangerously-skip-permissions" in cmd
                 assert "--model" in cmd
                 assert "claude-opus-4-7" in cmd
+
+    async def test_headless_separates_prompt_and_task(self, tmp_path: Path) -> None:
+        """headless() passes prompt via --append-system-prompt and task via -p as separate args."""
+        runner = ClaudeRunner()
+
+        with patch(
+            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"ok", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(
+                    prompt="You are the CEO.",
+                    task="Run the experiment",
+                    cwd=tmp_path,
+                )
+
+                cmd = mock_exec.call_args[0]
+                asp_idx = cmd.index("--append-system-prompt")
+                p_idx = cmd.index("-p")
+                assert cmd[asp_idx + 1] == "You are the CEO."
+                assert cmd[p_idx + 1] == "Run the experiment"
+
+    async def test_interactive_exec_uses_append_system_prompt(self, tmp_path: Path) -> None:
+        """interactive_exec() uses --append-system-prompt (not --system-prompt)."""
+        runner = ClaudeRunner()
+
+        with patch("os.chdir"), patch("os.execvp") as mock_execvp:
+            runner.interactive_exec(
+                prompt="You are the CEO.",
+                task="Start session",
+                cwd=tmp_path,
+            )
+
+            cmd = mock_execvp.call_args[0][1]
+            assert "--append-system-prompt" in cmd
+            assert "--system-prompt" not in [
+                arg for arg in cmd if arg != "--append-system-prompt"
+            ]
 
 
 class TestBobRunner:


### PR DESCRIPTION
Closes #220

## Summary
- **ClaudeRunner.headless()**: Changed from concatenating prompt+task into a single `-p` arg to using `--append-system-prompt <prompt> -p <task>` as separate args. This gives the agent identity position 31/31 recency in the system prompt stack.
- **CEO prompt identity**: Replaced the negation-based "Identity & Delegation Rules" section with a strong positive identity block (~20 lines). Opens with "You ARE the Factory CEO" and describes capabilities/authority using only positive framing.
- **interactive_exec()**: Left unchanged — already uses `--append-system-prompt` correctly.
- **BobRunner**: Left unchanged — Bob Shell doesn't support `--append-system-prompt`.
- **Tests**: Added 2 new tests (prompt/task separation, interactive_exec flag verification), updated existing command structure test.

## Test plan
- [x] `pytest tests/test_runners.py -v` — 48 passed
- [x] `pytest -v` — 1589 passed
- [x] `ruff check .` — clean
- [x] `mypy factory/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)