### PR TITLE
ux: improve error message for --focus on partially-initialized projects

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1419,6 +1419,14 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         print("Error: --focus (targeted mode) and --prompt are mutually exclusive. "
               "--focus builds one backlog item; --prompt executes a spec file.", file=sys.stderr)
         return 1
+    if focus:
+        factory_dir = project_path / ".factory"
+        if factory_dir.exists() and not (factory_dir / "config.json").exists():
+            print("Error: Project has partial factory state (.factory/ exists but is not initialized).\n"
+                  "This happens when the initial build completed but discovery/review did not finish.\n"
+                  f"Run 'factory ceo {project_path}' first to complete initialization, then use --focus.",
+                  file=sys.stderr)
+            return 1
     if focus and mode not in ("improve", "research"):
         print(f"Error: --focus (targeted mode) only works in improve or research mode, got '{mode}'. "
               "The project must already be built before targeting specific items.", file=sys.stderr)
@@ -2218,6 +2226,14 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("Error: --focus (targeted mode) and --prompt are mutually exclusive. "
               "--focus builds one backlog item; --prompt executes a spec file.", file=sys.stderr)
         return 1
+    if focus:
+        factory_dir = project_path / ".factory"
+        if factory_dir.exists() and not (factory_dir / "config.json").exists():
+            print("Error: Project has partial factory state (.factory/ exists but is not initialized).\n"
+                  "This happens when the initial build completed but discovery/review did not finish.\n"
+                  f"Run 'factory ceo {project_path}' first to complete initialization, then use --focus.",
+                  file=sys.stderr)
+            return 1
     if focus and mode not in ("improve", "research"):
         print(f"Error: --focus (targeted mode) only works in improve or research mode, got '{mode}'. "
               "The project must already be built before targeting specific items.", file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -353,6 +353,59 @@ class TestCmdCeoResearchIdeation:
         assert "Mode: research" in task
 
 
+class TestPartialFactoryDetection:
+    """Tests for partial factory state detection with --focus."""
+
+    def test_focus_partial_factory_errors(self, tmp_path, capsys):
+        """--focus on project with .factory/ but no config.json prints actionable error."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".factory").mkdir()
+        # No config.json — partial state
+
+        result = main(["ceo", str(tmp_path), "--mode", "improve", "--focus", "UI"])
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "partial factory state" in err
+        assert "factory ceo" in err
+        assert str(tmp_path) in err
+
+    def test_focus_complete_factory_works(self, tmp_path):
+        """--focus on project with complete .factory/ proceeds normally."""
+        (tmp_path / ".git").mkdir()
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "config.json").write_text(json.dumps(_make_config()))
+
+        with patch("factory.cli.os.execvp") as mock_exec, \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", str(tmp_path), "--mode", "improve", "--focus", "UI"])
+        mock_exec.assert_called_once()
+
+    def test_focus_no_factory_dir_proceeds(self, tmp_path, capsys):
+        """--focus on project without .factory/ does not error on partial check."""
+        (tmp_path / ".git").mkdir()
+        # No .factory/ at all — partial-factory check should pass, proceeds to exec
+
+        with patch("factory.cli.os.execvp") as mock_exec, \
+             patch("factory.cli.os.chdir"):
+            main(["ceo", str(tmp_path), "--mode", "improve", "--focus", "UI"])
+        # Should proceed to exec, not error on partial-factory
+        mock_exec.assert_called_once()
+        err = capsys.readouterr().err
+        assert "partial factory state" not in err
+
+    def test_run_partial_factory_errors(self, tmp_path, capsys):
+        """factory run --focus on partial factory also errors."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".factory").mkdir()
+        # No config.json — partial state
+
+        result = main(["run", str(tmp_path), "--mode", "improve", "--focus", "UI"])
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "partial factory state" in err
+
+
 class TestCmdDetect:
     def test_detect_no_repo(self, tmp_path, capsys):
         result = main(["detect", str(tmp_path / "nonexistent")])


### PR DESCRIPTION
## Summary
- Adds a **descriptive error message** when `--focus` is used on a project with partial factory state (`.factory/` exists but `config.json` is missing)
- Previously, users got a confusing error: `"--focus only works in improve or research mode, got 'discover'"`
- Now users get an actionable message explaining the situation and how to resolve it

**Note:** This does not fix the underlying issue of partial state occurring — it only improves the error messaging when it does. The partial state happens when a factory CEO session exits after Build mode but before Discover/Review complete (due to timeout, crash, or interruption).

## Changes
- `factory/cli.py`: Add partial-factory detection before `--focus` validation in both `cmd_ceo()` and `cmd_run()`
- `tests/test_cli.py`: Add 4 test cases covering the new error path

## Before
```
$ factory ceo /path --focus "add feature"
Error: --focus (targeted mode) only works in improve or research mode, got 'discover'.
```

## After
```
$ factory ceo /path --focus "add feature"
Error: Project has partial factory state (.factory/ exists but is not initialized).
This happens when the initial build completed but discovery/review did not finish.
Run 'factory ceo /path' first to complete initialization, then use --focus.
```

## Test plan
- [x] `test_focus_partial_factory_errors` - verifies the new error is printed
- [x] `test_focus_complete_factory_works` - verifies complete factory still works
- [x] `test_focus_no_factory_dir_proceeds` - verifies no `.factory/` dir proceeds normally
- [x] `test_run_partial_factory_errors` - verifies `factory run` also has the check

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)