### PR TITLE
feat: add --dir parameter to factory ceo for explicit project directory naming

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1323,6 +1323,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     headless = getattr(args, "headless", False)
     prompt_file = getattr(args, "prompt", None)
     focus = getattr(args, "focus", None)
+    dir_name = getattr(args, "dir", None)
 
     if not raw_path:
         print("Error: provide a project path, GitHub URL, idea file, or prompt",
@@ -1360,7 +1361,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         # In interactive mode the positional arg is always an idea string, not a path.
         # Skip _resolve_input to avoid misinterpreting the idea as a file/directory.
         interactive_idea = raw_path
-        slug = _slugify(raw_path[:50])
+        slug = _slugify(dir_name) if dir_name else _slugify(raw_path[:50])
         project_path = _PROJECTS_DIR / slug
         _ensure_repo(project_path)
         context = None
@@ -1375,12 +1376,12 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                   "--focus targets existing backlog items.", file=sys.stderr)
             return 1
         research_ideation = raw_path
-        slug = _slugify(raw_path[:50])
+        slug = _slugify(dir_name) if dir_name else _slugify(raw_path[:50])
         project_path = _PROJECTS_DIR / slug
         _ensure_repo(project_path)
         context = None
     else:
-        project_path, context = _resolve_input(raw_path)
+        project_path, context = _resolve_input(raw_path, dir_name=dir_name)
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
     issue_number: int | None = None
@@ -1526,7 +1527,7 @@ def _resolve_runner(args: argparse.Namespace) -> str | None:
 
 _PROJECTS_DIR = Path(os.environ.get("FACTORY_PROJECTS_DIR", str(Path.home() / "factory-projects")))
 
-def _resolve_input(raw: str) -> tuple[Path, str | None]:
+def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | None]:
     """Resolve any user input to (project_path, optional_context).
 
     Handles four input types in priority order:
@@ -1543,7 +1544,7 @@ def _resolve_input(raw: str) -> tuple[Path, str | None]:
     # 2. Existing file (e.g. path to an idea/spec .md file)
     if expanded.is_file():
         idea_content = expanded.read_text()
-        slug = _slugify(expanded.stem.split("\u2014")[0].strip())
+        slug = _slugify(dir_name) if dir_name else _slugify(expanded.stem.split("\u2014")[0].strip())
         project_path = _PROJECTS_DIR / slug
         _ensure_repo(project_path)
         _persist_spec(project_path, idea_content)
@@ -1559,7 +1560,7 @@ def _resolve_input(raw: str) -> tuple[Path, str | None]:
         return Path(tmp_dir).resolve(), None
 
     # 4. Raw prompt
-    slug = _slugify(raw[:50])
+    slug = _slugify(dir_name) if dir_name else _slugify(raw[:50])
     project_path = _PROJECTS_DIR / slug
     _ensure_repo(project_path)
     _persist_spec(project_path, raw)
@@ -2629,6 +2630,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Target a specific item: backlog name ('dashboard UI'), issue number (42), "
              "URL (https://github.com/o/r/issues/42), or shorthand (owner/repo#42). "
              "Issue refs are auto-detected and fetched via gh/glab CLI",
+    )
+    p.add_argument(
+        "--dir", default=None,
+        help="Working directory name for the new project (overrides auto-derived name from prompt or idea file). "
+             "Ignored when pointing at an existing directory or GitHub URL.",
     )
     p.add_argument(
         "--headless", action="store_true", default=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1139,6 +1139,40 @@ class TestResolveInput:
         assert "Build X that does Y" in task_arg
         assert "Project Specification" in task_arg
 
+    def test_dir_overrides_slug_for_raw_prompt(self, tmp_path):
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+            project_path, context = _resolve_input("Build a todo app with FastAPI", dir_name="my-todo")
+
+        assert project_path.name == "my-todo"
+        assert (project_path / ".git").is_dir()
+
+    def test_dir_overrides_slug_for_idea_file(self, tmp_path):
+        idea_file = tmp_path / "Long Idea Name — Details.md"
+        idea_file.write_text("# Build something")
+
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+            project_path, context = _resolve_input(str(idea_file), dir_name="custom-name")
+
+        assert project_path.name == "custom-name"
+        assert (project_path / ".git").is_dir()
+
+    def test_dir_ignored_for_existing_directory(self, tmp_path):
+        project_path, context = _resolve_input(str(tmp_path), dir_name="ignored-name")
+
+        assert project_path == tmp_path
+        assert context is None
+
+    def test_dir_is_slugified(self, tmp_path):
+        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+            project_path, context = _resolve_input("Build something", dir_name="My Cool Project!")
+
+        assert project_path.name == "my-cool-project"
+
+    def test_ceo_parser_accepts_dir_argument(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "Build something", "--dir", "my-project"])
+        assert args.dir == "my-project"
+
 
 class TestResearchMode:
     def test_ceo_parser_accepts_research_mode(self):


### PR DESCRIPTION
Closes #227

## Changes

- Added `--dir` argument to the `ceo` subparser in `factory/cli.py`
- Read `dir_name` from args early in `cmd_ceo` alongside other args
- Applied `dir_name` override in interactive ideation and research ideation branches
- Added `dir_name: str | None = None` parameter to `_resolve_input`
- Applied override in case 2 (idea file) and case 4 (raw prompt) inside `_resolve_input`
- Passed `dir_name` through at the `_resolve_input` call site

## Behavior

- `factory ceo "Build a comprehensive e-commerce platform" --dir my-ecommerce` creates the project at `~/factory-projects/my-ecommerce`
- `--dir` is silently ignored when the positional arg is an existing directory or GitHub URL
- The `--dir` value is always slugified for filesystem safety

## Tests

5 new tests added to `TestResolveInput`:
- `test_dir_overrides_slug_for_raw_prompt`
- `test_dir_overrides_slug_for_idea_file`
- `test_dir_ignored_for_existing_directory`
- `test_dir_is_slugified`
- `test_ceo_parser_accepts_dir_argument`

197 tests pass. Lint and type checks clean.