### PR TITLE
feat: consolidate factory configuration into config.toml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,30 @@ All domain models live in `factory/models.py` as strict Pydantic v2 models. Key 
 
 Requires Claude Code installed and authenticated. The factory spawns `claude` subprocesses — it does not call the API directly. Any Claude Code authentication method works (API key, Vertex AI, etc.).
 
+### Configuration (`~/.factory/config.toml`)
+
+All `FACTORY_*` environment variables can also be set in `~/.factory/config.toml`. Env vars remain supported — config.toml is additive. Five-tier precedence: CLI flag > env var > profile credential > config.toml default > hardcoded default.
+
+```toml
+[defaults]
+runner = "claude"
+model = ""
+projects_dir = "~/factory-projects"
+
+[credentials.vertex]
+FACTORY_RUNNER = "claude"
+ANTHROPIC_API_KEY = "sk-ant-..."
+```
+
+**Commands:**
+- `factory config show [--reveal]` — show resolved config with secrets masked
+- `factory config edit` — open `~/.factory/config.toml` in `$EDITOR`
+- `factory config migrate` — create starter config from current env vars (requires `tomli_w`)
+
+**Credential profiles:** Use `--profile <name>` with `factory ceo`, `factory run`, or `factory agent` to load a `[credentials.<name>]` section. Profile keys are injected into `os.environ`.
+
+**Implementation:** `factory/user_config.py` — `load_config()`, `resolve()`, `show_config()`, `migrate_env_to_config()`.
+
 ## Runners
 
 The factory supports multiple CLI backends via the runner abstraction (`factory/runners/`). By default, it uses Claude Code (`claude` CLI), but Bob Shell (`bob` CLI) is also supported as a switchable alternative.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,34 @@ uv run python -m factory ceo ~/my-project --runner bob
 
 Bob Shell requires `BOBSHELL_API_KEY` and enforces per-cycle invocation ceilings (default: 8). Set `FACTORY_BOB_DRY_RUN=1` to test without API calls.
 
+### User Configuration (`~/.factory/config.toml`)
+
+All `FACTORY_*` env vars can be set in `~/.factory/config.toml` instead. Env vars still work — config.toml is additive. Precedence: CLI flag > env var > profile credential > config.toml default > hardcoded.
+
+```bash
+factory config edit                    # Open config in $EDITOR
+factory config show                    # Show resolved config (secrets masked)
+factory config show --reveal           # Show full values
+factory config migrate                 # Create starter config from current env vars
+```
+
+Credential profiles let you switch between environments:
+
+```toml
+[credentials.vertex]
+ANTHROPIC_API_KEY = "sk-ant-..."
+FACTORY_RUNNER = "claude"
+
+[credentials.bob]
+BOBSHELL_API_KEY = "..."
+FACTORY_RUNNER = "bob"
+```
+
+```bash
+factory ceo ~/my-project --profile vertex
+factory agent researcher --task "..." --project ~/my-project --profile bob
+```
+
 ---
 
 ## CLI Reference

--- a/factory/ace/paths.py
+++ b/factory/ace/paths.py
@@ -7,14 +7,15 @@ tree and are read-only at runtime.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 DEFAULTS_DIR: Path = Path(__file__).parent.parent / "agents" / "playbooks"
 
 
 def user_playbooks_dir() -> Path:
-    override = os.environ.get("FACTORY_PLAYBOOKS_DIR")
+    from factory.user_config import resolve
+
+    override = resolve("playbooks_dir", env_var="FACTORY_PLAYBOOKS_DIR")
     if override:
         d = Path(override).expanduser().resolve()
     else:

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -8,7 +8,6 @@ to "wrap up" early.
 from __future__ import annotations
 
 import json
-import os
 import re
 import uuid
 from dataclasses import dataclass
@@ -407,7 +406,9 @@ async def run_ceo_with_completion_guard(
     from factory.agents.runner import invoke_agent
 
     # Check escape hatch
-    if os.environ.get("FACTORY_CEO_RESPAWN_DISABLED") == "1":
+    from factory.user_config import resolve
+
+    if resolve("ceo_respawn_disabled", env_var="FACTORY_CEO_RESPAWN_DISABLED") == "1":
         log.info("ceo_respawn_disabled", reason="FACTORY_CEO_RESPAWN_DISABLED=1")
         return await invoke_agent(
             "ceo", initial_task, project_path,
@@ -415,7 +416,10 @@ async def run_ceo_with_completion_guard(
         )
 
     if max_respawns is None:
-        max_respawns = int(os.environ.get("FACTORY_CEO_MAX_RESPAWNS", DEFAULT_MAX_RESPAWNS))
+        max_respawns = int(
+            resolve("ceo_max_respawns", env_var="FACTORY_CEO_MAX_RESPAWNS", default=str(DEFAULT_MAX_RESPAWNS))
+            or DEFAULT_MAX_RESPAWNS
+        )
 
     # Check for existing in-flight cycle (respawn scenario)
     cycle_state = read_cycle_state(project_path)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1179,9 +1179,9 @@ def cmd_config(args: argparse.Namespace) -> int:
         return 0
 
     if sub == "edit":
-        from factory.user_config import CONFIG_PATH, _ensure_config_file
+        from factory.user_config import CONFIG_PATH, ensure_config_file
 
-        _ensure_config_file()
+        ensure_config_file()
         editor = os.environ.get("EDITOR", "vi")
         return subprocess.call([editor, str(CONFIG_PATH)])
 
@@ -1415,7 +1415,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         # Skip _resolve_input to avoid misinterpreting the idea as a file/directory.
         interactive_idea = raw_path
         slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
-        project_path = _dedupe_project_path(_PROJECTS_DIR / slug, raw_path)
+        project_path = _dedupe_project_path(_get_projects_dir() / slug, raw_path)
         _ensure_repo(project_path)
         context = None
     elif mode == "research" and not (resolved := Path(raw_path).expanduser()).is_dir() and not resolved.is_file():
@@ -1430,7 +1430,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             return 1
         research_ideation = raw_path
         slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
-        project_path = _dedupe_project_path(_PROJECTS_DIR / slug, raw_path)
+        project_path = _dedupe_project_path(_get_projects_dir() / slug, raw_path)
         _ensure_repo(project_path)
         context = None
     else:
@@ -1584,8 +1584,6 @@ def _get_projects_dir() -> Path:
     return Path(raw).expanduser() if raw else Path.home() / "factory-projects"
 
 
-_PROJECTS_DIR = _get_projects_dir()
-
 def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | None]:
     """Resolve any user input to (project_path, optional_context).
 
@@ -1604,7 +1602,7 @@ def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | N
     if expanded.is_file():
         idea_content = expanded.read_text()
         slug = _slugify(dir_name) if dir_name else _slugify(expanded.stem.split("\u2014")[0].strip())
-        project_path = _dedupe_project_path(_PROJECTS_DIR / slug, idea_content)
+        project_path = _dedupe_project_path(_get_projects_dir() / slug, idea_content)
         _ensure_repo(project_path)
         _persist_spec(project_path, idea_content)
         print(f"Idea file: {expanded.name}")
@@ -1620,7 +1618,7 @@ def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | N
 
     # 4. Raw prompt
     slug = _slugify(dir_name) if dir_name else _extract_project_name(raw)
-    project_path = _dedupe_project_path(_PROJECTS_DIR / slug, raw)
+    project_path = _dedupe_project_path(_get_projects_dir() / slug, raw)
     _ensure_repo(project_path)
     _persist_spec(project_path, raw)
     print(f"New project from prompt: {project_path}")

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1164,6 +1164,42 @@ def cmd_explain(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_config(args: argparse.Namespace) -> int:
+    """Manage ~/.factory/config.toml."""
+    sub = getattr(args, "config_command", None)
+    if not sub:
+        print("Usage: factory config {show,edit,migrate}")
+        return 1
+
+    if sub == "show":
+        from factory.user_config import show_config
+
+        reveal = getattr(args, "reveal", False)
+        print(show_config(reveal=reveal))
+        return 0
+
+    if sub == "edit":
+        from factory.user_config import CONFIG_PATH, _ensure_config_file
+
+        _ensure_config_file()
+        editor = os.environ.get("EDITOR", "vi")
+        return subprocess.call([editor, str(CONFIG_PATH)])
+
+    if sub == "migrate":
+        from factory.user_config import migrate_env_to_config
+
+        try:
+            msg = migrate_env_to_config()
+            print(msg)
+            return 0
+        except (ImportError, FileExistsError) as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+    print(f"Unknown config subcommand: {sub}", file=sys.stderr)
+    return 1
+
+
 def cmd_emit(args: argparse.Namespace) -> int:
     from factory.events import emit_event
 
@@ -1268,6 +1304,10 @@ def cmd_install(args: argparse.Namespace) -> int:
 def cmd_agent(args: argparse.Namespace) -> int:
     """Invoke a specialist agent with the given task."""
     from factory.agents.runner import invoke_agent
+    from factory.user_config import load_config
+
+    profile = getattr(args, "profile", None)
+    load_config(profile=profile)
 
     role = args.role
     task = args.task
@@ -1326,6 +1366,10 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     """
     from factory.agents.runner import resolve_prompt
     from factory.runners import get_runner
+    from factory.user_config import load_config
+
+    profile = getattr(args, "profile", None)
+    load_config(profile=profile)
 
     raw_path = getattr(args, "path", None)
     mode = getattr(args, "mode", "auto")
@@ -1515,12 +1559,11 @@ def _is_github_url(path: str) -> bool:
 
 
 def _resolve_model(args: argparse.Namespace) -> str | None:
-    """Resolve model: CLI flag > FACTORY_MODEL env var > None."""
-    flag = (getattr(args, "model", None) or "").strip()
-    if flag:
-        return flag
-    env = (os.environ.get("FACTORY_MODEL") or "").strip()
-    return env or None
+    """Resolve model: CLI flag > FACTORY_MODEL env var > config.toml > None."""
+    from factory.user_config import resolve
+
+    flag = (getattr(args, "model", None) or "").strip() or None
+    return resolve("model", cli_value=flag, env_var="FACTORY_MODEL")
 
 
 def _resolve_runner(args: argparse.Namespace) -> str | None:
@@ -1534,7 +1577,14 @@ def _resolve_runner(args: argparse.Namespace) -> str | None:
     return None
 
 
-_PROJECTS_DIR = Path(os.environ.get("FACTORY_PROJECTS_DIR", str(Path.home() / "factory-projects")))
+def _get_projects_dir() -> Path:
+    from factory.user_config import resolve
+
+    raw = resolve("projects_dir", env_var="FACTORY_PROJECTS_DIR", default=str(Path.home() / "factory-projects"))
+    return Path(raw).expanduser() if raw else Path.home() / "factory-projects"
+
+
+_PROJECTS_DIR = _get_projects_dir()
 
 def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | None]:
     """Resolve any user input to (project_path, optional_context).
@@ -2230,6 +2280,11 @@ def _run_single_cycle(
 
 def cmd_run(args: argparse.Namespace) -> int:
     """Run factory cycle(s) via the CEO agent. Supports single-shot and heartbeat loop."""
+    from factory.user_config import load_config
+
+    profile = getattr(args, "profile", None)
+    load_config(profile=profile)
+
     project_path, context = _resolve_input(args.path)
     prompt_file = getattr(args, "prompt", None)
     loop = getattr(args, "loop", False)
@@ -2639,6 +2694,15 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--port", type=int, default=8420, help="Server port (default: 8420)")
     p.add_argument("--host", default="0.0.0.0", help="Server host (default: 0.0.0.0)")
 
+    # config — user configuration management
+    config_parser = sub.add_parser("config", help="Manage ~/.factory/config.toml")
+    config_sub = config_parser.add_subparsers(dest="config_command")
+    p_show = config_sub.add_parser("show", help="Show resolved config (secrets masked)")
+    p_show.add_argument("--reveal", action="store_true", default=False,
+                        help="Show full secret values instead of masking")
+    config_sub.add_parser("edit", help="Open config.toml in $EDITOR")
+    config_sub.add_parser("migrate", help="Create starter config.toml from current env vars")
+
     # emit — emit a structured event to .factory/events.jsonl
     p = sub.add_parser("emit", help="Emit a structured event to .factory/events.jsonl")
     p.add_argument("event_type", help="Event type (e.g. agent.started, agent.completed)")
@@ -2660,6 +2724,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Claude model for agent subprocess (default: FACTORY_MODEL env var, or claude CLI default)")
     p.add_argument("--runner", choices=["claude", "bob"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
+    p.add_argument("--profile", default=None,
+                    help="Credential profile from ~/.factory/config.toml")
 
     # ceo — launch the Factory CEO agent directly
     p = sub.add_parser("ceo", help="Launch the Factory CEO agent (interactive by default)")
@@ -2712,6 +2778,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
     p.add_argument("--runner", choices=["claude", "bob"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
+    p.add_argument("--profile", default=None,
+                    help="Credential profile from ~/.factory/config.toml")
 
     # run
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
@@ -2764,6 +2832,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
     p.add_argument("--runner", choices=["claude", "bob"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
+    p.add_argument("--profile", default=None,
+                    help="Credential profile from ~/.factory/config.toml")
 
     # tmux — launch factory run in a detached tmux session
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")
@@ -2852,6 +2922,7 @@ def main(argv: list[str] | None = None) -> int:
         "install": cmd_install,
         "serve-mcp": cmd_serve_mcp,
         "dashboard": cmd_dashboard,
+        "config": cmd_config,
         "emit": cmd_emit,
         "agent": cmd_agent,
         "ceo": cmd_ceo,

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -9,7 +9,6 @@ All functions take a project_path and return an EvalResult-compatible dict.
 
 import ast
 import csv
-import os
 import re
 from collections import Counter
 from pathlib import Path
@@ -320,14 +319,16 @@ def _discover_managed_projects(project_path: Path) -> int:
             if child.is_dir() and (child / ".factory" / "results.tsv").exists():
                 seen.add(child.resolve())
 
-    managed_dirs = os.environ.get("FACTORY_MANAGED_DIRS", "")
+    from factory.user_config import resolve
+
+    managed_dirs = resolve("managed_dirs", env_var="FACTORY_MANAGED_DIRS") or ""
     if managed_dirs:
         for entry in managed_dirs.split(":"):
             entry = entry.strip()
             if entry:
                 _scan_dir(Path(entry))
 
-    projects_dir_str = os.environ.get("FACTORY_PROJECTS_DIR", "")
+    projects_dir_str = resolve("projects_dir", env_var="FACTORY_PROJECTS_DIR") or ""
     if projects_dir_str:
         _scan_dir(Path(projects_dir_str))
 

--- a/factory/obsidian/notes.py
+++ b/factory/obsidian/notes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 import subprocess
 from datetime import datetime
@@ -119,7 +118,9 @@ def vault_path() -> Path | None:
     vault is considered *unavailable* and callers should skip vault operations
     gracefully (writes fall back to ``.factory/archive/``).
     """
-    raw = os.environ.get("FACTORY_VAULT_PATH")
+    from factory.user_config import resolve
+
+    raw = resolve("vault_path", env_var="FACTORY_VAULT_PATH")
     if raw:
         return Path(raw)
     return None

--- a/factory/registry.py
+++ b/factory/registry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from datetime import datetime
 from pathlib import Path
 
@@ -16,7 +15,9 @@ log = structlog.get_logger()
 
 def _default_registry_path() -> Path:
     """Return registry path, respecting FACTORY_REGISTRY_DIR override for testing."""
-    override = os.environ.get("FACTORY_REGISTRY_DIR")
+    from factory.user_config import resolve
+
+    override = resolve("registry_dir", env_var="FACTORY_REGISTRY_DIR")
     base = Path(override) if override else Path.home() / ".factory"
     return base / "registry.json"
 

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Literal
 
@@ -45,7 +44,9 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
     Raises:
         ValueError: If the runner name is not recognized.
     """
-    resolved = name or os.environ.get("FACTORY_RUNNER", "claude")
+    from factory.user_config import resolve
+
+    resolved = resolve("runner", cli_value=name, env_var="FACTORY_RUNNER", default="claude") or "claude"
     resolved = resolved.lower().strip()
 
     if resolved not in _RUNNERS:

--- a/factory/runners/_stream.py
+++ b/factory/runners/_stream.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 from typing import BinaryIO
 
@@ -15,7 +14,10 @@ def should_stream() -> bool:
     - FACTORY_RUNNER_QUIET=1 is set
     - stdout is not a TTY (e.g., piped to file)
     """
-    if os.environ.get("FACTORY_RUNNER_QUIET", "").lower() in ("1", "true", "yes"):
+    from factory.user_config import resolve
+
+    quiet = resolve("runner_quiet", env_var="FACTORY_RUNNER_QUIET") or ""
+    if quiet.lower() in ("1", "true", "yes"):
         return False
     if not sys.stdout.isatty():
         return False

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -119,7 +119,10 @@ def _check_auth(start_path: Path | None = None) -> None:
 
 def is_dry_run() -> bool:
     """Return True if dry-run mode is enabled."""
-    return os.environ.get("FACTORY_BOB_DRY_RUN", "").lower() in ("1", "true", "yes")
+    from factory.user_config import resolve
+
+    val = resolve("bob_dry_run", env_var="FACTORY_BOB_DRY_RUN") or ""
+    return val.lower() in ("1", "true", "yes")
 
 
 def _get_bob_bin_dir() -> str | None:

--- a/factory/runners/usage.py
+++ b/factory/runners/usage.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -88,7 +87,9 @@ def count_cycle_invocations(project_path: Path, cycle_start: datetime | None = N
 
 def get_cycle_ceiling() -> int:
     """Get the per-cycle invocation ceiling from env var."""
-    return int(os.environ.get("FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", "8"))
+    from factory.user_config import resolve
+
+    return int(resolve("bob_max_invocations_per_cycle", env_var="FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", default="8") or "8")
 
 
 class CeilingExceededError(Exception):

--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -21,6 +21,8 @@ _CREDENTIAL_KEY_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 
 _SENSITIVE_FRAGMENTS = ("key", "token", "secret", "password", "api_key")
 
+_cached_config: dict | None = None
+
 _CONFIG_TEMPLATE = """\
 # Factory configuration — ~/.factory/config.toml
 #
@@ -102,7 +104,17 @@ def load_config(profile: str | None = None) -> dict:
             os.environ.setdefault(k, str(v))
         log.info("profile_loaded", profile=profile, keys=list(creds.keys()))
 
+    global _cached_config  # noqa: PLW0603
+    _cached_config = data
     return data
+
+
+def _get_cached_config() -> dict:
+    """Return the cached config, loading from disk on first call."""
+    global _cached_config  # noqa: PLW0603
+    if _cached_config is None:
+        _cached_config = load_config()
+    return _cached_config
 
 
 def resolve(
@@ -118,7 +130,7 @@ def resolve(
     1. CLI flag (cli_value)
     2. Environment variable (env_var name looked up in os.environ)
     3. Profile credential — already injected into os.environ by load_config()
-    4. config.toml [defaults] section (config dict, key looked up)
+    4. config.toml [defaults] section (auto-loaded if config not passed)
     5. Hardcoded default
 
     Since profile credentials are injected into os.environ by load_config(),
@@ -134,13 +146,13 @@ def resolve(
         if env_val:
             return env_val
 
-    if config:
-        defaults = config.get("defaults", {})
-        toml_val = defaults.get(key)
-        if toml_val is not None:
-            v = str(toml_val).strip()
-            if v:
-                return v
+    effective_config = config if config is not None else _get_cached_config()
+    defaults = effective_config.get("defaults", {})
+    toml_val = defaults.get(key)
+    if toml_val is not None:
+        v = str(toml_val).strip()
+        if v:
+            return v
 
     return default
 

--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -1,0 +1,258 @@
+"""Unified configuration — ~/.factory/config.toml with credential profiles.
+
+Five-tier precedence: CLI flag > env var > profile credential > config.toml default > hardcoded.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tomllib
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+CONFIG_PATH: Path = Path("~/.factory/config.toml").expanduser()
+
+_PROFILE_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_CREDENTIAL_KEY_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+
+_SENSITIVE_FRAGMENTS = ("key", "token", "secret", "password", "api_key")
+
+_CONFIG_TEMPLATE = """\
+# Factory configuration — ~/.factory/config.toml
+#
+# Values here are defaults. Environment variables and CLI flags take precedence.
+# See: factory config show
+
+[defaults]
+# runner = "claude"                    # CLI backend: "claude" or "bob"
+# model = ""                           # Claude model for agent subprocesses
+# projects_dir = "~/factory-projects"  # Root for factory-managed projects
+
+# [credentials.vertex]
+# FACTORY_RUNNER = "claude"
+# ANTHROPIC_API_KEY = "sk-ant-..."
+#
+# [credentials.bob]
+# FACTORY_RUNNER = "bob"
+# BOBSHELL_API_KEY = "..."
+"""
+
+
+def _validate_profile_name(name: str) -> None:
+    if not _PROFILE_NAME_RE.match(name):
+        raise ValueError(
+            f"Invalid profile name {name!r}: must match [a-zA-Z0-9_-]+"
+        )
+
+
+def _validate_credential_keys(keys: dict[str, str]) -> None:
+    for k in keys:
+        if not _CREDENTIAL_KEY_RE.match(k):
+            raise ValueError(
+                f"Invalid credential key {k!r}: must match [A-Z_][A-Z0-9_]*"
+            )
+
+
+def _ensure_config_file() -> Path:
+    """Create config file with secure permissions if it doesn't exist. Returns path."""
+    if CONFIG_PATH.exists():
+        return CONFIG_PATH
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(CONFIG_PATH), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        os.write(fd, _CONFIG_TEMPLATE.encode())
+    finally:
+        os.close(fd)
+    log.info("config_created", path=str(CONFIG_PATH))
+    return CONFIG_PATH
+
+
+def load_config(profile: str | None = None) -> dict:
+    """Read ~/.factory/config.toml; apply credential profile overlay if given.
+
+    Returns the parsed TOML dict. If the file doesn't exist, returns an empty dict.
+    When a profile is specified, its ``[credentials.<name>]`` keys are injected
+    into ``os.environ`` so normal env-var precedence resolves them.
+    """
+    if not CONFIG_PATH.exists():
+        if profile:
+            raise FileNotFoundError(
+                f"Config file {CONFIG_PATH} not found — cannot load profile {profile!r}"
+            )
+        return {}
+
+    with open(CONFIG_PATH, "rb") as f:
+        data = tomllib.load(f)
+
+    if profile:
+        _validate_profile_name(profile)
+        creds = data.get("credentials", {}).get(profile)
+        if creds is None:
+            available = list(data.get("credentials", {}).keys())
+            raise KeyError(
+                f"Profile {profile!r} not found in config.toml. "
+                f"Available: {available}"
+            )
+        _validate_credential_keys(creds)
+        for k, v in creds.items():
+            os.environ.setdefault(k, str(v))
+        log.info("profile_loaded", profile=profile, keys=list(creds.keys()))
+
+    return data
+
+
+def resolve(
+    key: str,
+    *,
+    cli_value: str | None = None,
+    env_var: str | None = None,
+    config: dict | None = None,
+    default: str | None = None,
+) -> str | None:
+    """Five-tier precedence resolution.
+
+    1. CLI flag (cli_value)
+    2. Environment variable (env_var name looked up in os.environ)
+    3. Profile credential — already injected into os.environ by load_config()
+    4. config.toml [defaults] section (config dict, key looked up)
+    5. Hardcoded default
+
+    Since profile credentials are injected into os.environ by load_config(),
+    tiers 2 and 3 collapse into a single os.environ lookup.
+    """
+    if cli_value is not None:
+        v = cli_value.strip()
+        if v:
+            return v
+
+    if env_var:
+        env_val = os.environ.get(env_var, "").strip()
+        if env_val:
+            return env_val
+
+    if config:
+        defaults = config.get("defaults", {})
+        toml_val = defaults.get(key)
+        if toml_val is not None:
+            v = str(toml_val).strip()
+            if v:
+                return v
+
+    return default
+
+
+def is_sensitive(key: str) -> bool:
+    """Return True if a config key name looks like it holds a secret."""
+    lower = key.lower()
+    return any(frag in lower for frag in _SENSITIVE_FRAGMENTS)
+
+
+def mask_value(value: str) -> str:
+    """Mask a secret value, showing only the last 4 chars."""
+    if len(value) <= 4:
+        return "****"
+    return "*" * (len(value) - 4) + value[-4:]
+
+
+def show_config(*, reveal: bool = False) -> str:
+    """Return a human-readable view of the resolved config with secrets masked."""
+    if not CONFIG_PATH.exists():
+        return f"No config file at {CONFIG_PATH}\nRun: factory config edit"
+
+    with open(CONFIG_PATH, "rb") as f:
+        data = tomllib.load(f)
+
+    lines: list[str] = [f"# {CONFIG_PATH}", ""]
+
+    defaults = data.get("defaults", {})
+    if defaults:
+        lines.append("[defaults]")
+        for k, v in defaults.items():
+            display = str(v)
+            if not reveal and is_sensitive(k):
+                display = mask_value(display)
+            lines.append(f"  {k} = {display}")
+        lines.append("")
+
+    credentials = data.get("credentials", {})
+    for profile_name, creds in credentials.items():
+        lines.append(f"[credentials.{profile_name}]")
+        for k, v in creds.items():
+            display = str(v)
+            if not reveal and is_sensitive(k):
+                display = mask_value(display)
+            lines.append(f"  {k} = {display}")
+        lines.append("")
+
+    for section_name, section_data in data.items():
+        if section_name in ("defaults", "credentials"):
+            continue
+        if isinstance(section_data, dict):
+            lines.append(f"[{section_name}]")
+            for k, v in section_data.items():
+                display = str(v)
+                if not reveal and is_sensitive(k):
+                    display = mask_value(display)
+                lines.append(f"  {k} = {display}")
+            lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def migrate_env_to_config() -> str:
+    """Read current FACTORY_* env vars and write a starter config.toml.
+
+    Requires tomli_w for TOML writing.
+    """
+    try:
+        import tomli_w  # type: ignore[import-untyped,import-not-found]
+    except ImportError:
+        raise ImportError(
+            "tomli_w is required for migration: pip install tomli_w"
+        ) from None
+
+    if CONFIG_PATH.exists():
+        raise FileExistsError(
+            f"Config file already exists at {CONFIG_PATH}. "
+            "Remove it first or edit manually."
+        )
+
+    env_map = {
+        "FACTORY_RUNNER": "runner",
+        "FACTORY_MODEL": "model",
+        "FACTORY_PROJECTS_DIR": "projects_dir",
+        "FACTORY_VAULT_PATH": "vault_path",
+        "FACTORY_PLAYBOOKS_DIR": "playbooks_dir",
+        "FACTORY_REGISTRY_DIR": "registry_dir",
+        "FACTORY_MANAGED_DIRS": "managed_dirs",
+        "FACTORY_RUNNER_QUIET": "runner_quiet",
+        "FACTORY_BOB_DRY_RUN": "bob_dry_run",
+        "FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE": "bob_max_invocations_per_cycle",
+        "FACTORY_CEO_RESPAWN_DISABLED": "ceo_respawn_disabled",
+        "FACTORY_CEO_MAX_RESPAWNS": "ceo_max_respawns",
+    }
+
+    defaults: dict[str, str] = {}
+    for env_key, toml_key in env_map.items():
+        val = os.environ.get(env_key, "").strip()
+        if val:
+            defaults[toml_key] = val
+
+    data: dict[str, dict] = {}
+    if defaults:
+        data["defaults"] = defaults
+
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(CONFIG_PATH), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        content = tomli_w.dumps(data)
+        os.write(fd, content.encode())
+    finally:
+        os.close(fd)
+
+    count = len(defaults)
+    return f"Migrated {count} env var(s) to {CONFIG_PATH}"

--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -9,6 +9,7 @@ import os
 import re
 import tomllib
 from pathlib import Path
+from typing import Any
 
 import structlog
 
@@ -51,7 +52,7 @@ def _validate_profile_name(name: str) -> None:
         )
 
 
-def _validate_credential_keys(keys: dict[str, str]) -> None:
+def _validate_credential_keys(keys: dict[str, Any]) -> None:
     for k in keys:
         if not _CREDENTIAL_KEY_RE.match(k):
             raise ValueError(
@@ -59,12 +60,13 @@ def _validate_credential_keys(keys: dict[str, str]) -> None:
             )
 
 
-def _ensure_config_file() -> Path:
+def ensure_config_file() -> Path:
     """Create config file with secure permissions if it doesn't exist. Returns path."""
-    if CONFIG_PATH.exists():
-        return CONFIG_PATH
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(CONFIG_PATH), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        fd = os.open(str(CONFIG_PATH), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return CONFIG_PATH
     try:
         os.write(fd, _CONFIG_TEMPLATE.encode())
     finally:
@@ -171,7 +173,7 @@ def mask_value(value: str) -> str:
 
 
 def show_config(*, reveal: bool = False) -> str:
-    """Return a human-readable view of the resolved config with secrets masked."""
+    """Return a human-readable view of the on-disk config with secrets masked."""
     if not CONFIG_PATH.exists():
         return f"No config file at {CONFIG_PATH}\nRun: factory config edit"
 
@@ -227,12 +229,6 @@ def migrate_env_to_config() -> str:
             "tomli_w is required for migration: pip install tomli_w"
         ) from None
 
-    if CONFIG_PATH.exists():
-        raise FileExistsError(
-            f"Config file already exists at {CONFIG_PATH}. "
-            "Remove it first or edit manually."
-        )
-
     env_map = {
         "FACTORY_RUNNER": "runner",
         "FACTORY_MODEL": "model",
@@ -259,7 +255,13 @@ def migrate_env_to_config() -> str:
         data["defaults"] = defaults
 
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(CONFIG_PATH), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        fd = os.open(str(CONFIG_PATH), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        raise FileExistsError(
+            f"Config file already exists at {CONFIG_PATH}. "
+            "Remove it first or edit manually."
+        ) from None
     try:
         content = tomli_w.dumps(data)
         os.write(fd, content.encode())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ Homepage = "https://github.com/akashgit/remote-factory"
 Repository = "https://github.com/akashgit/remote-factory"
 Issues = "https://github.com/akashgit/remote-factory/issues"
 
+[project.optional-dependencies]
+migrate = ["tomli_w>=1.0"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1147,7 +1147,7 @@ class TestDedupeProjectPath:
         assert result == tmp_path / "projects" / "rest-api-4"
 
     def test_resolve_input_dedupes_raw_prompt(self, tmp_path):
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
             p1, _ = _resolve_input("Build a REST API")
             p2, _ = _resolve_input("Create a new REST API")
         assert p1.name == "rest-api"
@@ -1183,7 +1183,7 @@ class TestResolveInput:
         idea_file = tmp_path / "My Project \u2014 Something Cool.md"
         idea_file.write_text("# Build something cool")
 
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
             project_path, context = _resolve_input(str(idea_file))
 
         assert project_path.name == "my-project"
@@ -1192,7 +1192,7 @@ class TestResolveInput:
         assert "Build something cool" in context
 
     def test_raw_prompt(self, tmp_path):
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
             project_path, context = _resolve_input("Build a todo app with FastAPI")
 
         assert project_path.parent == tmp_path / "projects"
@@ -1204,7 +1204,7 @@ class TestResolveInput:
         py_file = tmp_path / "script.py"
         py_file.write_text("print('hello')")
 
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
             project_path, context = _resolve_input(str(py_file))
 
         assert project_path.name == "script"
@@ -1215,7 +1215,7 @@ class TestResolveInput:
         bin_file = tmp_path / "data.bin"
         bin_file.write_bytes(b"\x00\x01\x02\xff")
 
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"), \
              pytest.raises(UnicodeDecodeError):
             _resolve_input(str(bin_file))
 
@@ -1224,7 +1224,7 @@ class TestResolveInput:
         idea_file = tmp_path / "Test Idea \u2014 Details.md"
         idea_file.write_text("# Test Idea\nBuild X that does Y")
 
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"), \
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"), \
              patch("factory.cli._chain_modes", return_value=0), \
              patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
             main(["ceo", str(idea_file), "--headless"])
@@ -1234,7 +1234,7 @@ class TestResolveInput:
         assert "Project Specification" in task_arg
 
     def test_dir_overrides_slug_for_raw_prompt(self, tmp_path):
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
             project_path, context = _resolve_input("Build a todo app with FastAPI", dir_name="my-todo")
 
         assert project_path.name == "my-todo"
@@ -1244,7 +1244,7 @@ class TestResolveInput:
         idea_file = tmp_path / "Long Idea Name — Details.md"
         idea_file.write_text("# Build something")
 
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
             project_path, context = _resolve_input(str(idea_file), dir_name="custom-name")
 
         assert project_path.name == "custom-name"
@@ -1257,7 +1257,7 @@ class TestResolveInput:
         assert context is None
 
     def test_dir_is_slugified(self, tmp_path):
-        with patch("factory.cli._PROJECTS_DIR", tmp_path / "projects"):
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
             project_path, context = _resolve_input("Build something", dir_name="My Cool Project!")
 
         assert project_path.name == "my-cool-project"

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -11,9 +11,10 @@ import pytest
 
 @pytest.fixture()
 def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect CONFIG_PATH to a temp directory."""
+    """Redirect CONFIG_PATH to a temp directory and clear cached config."""
     cfg = tmp_path / "config.toml"
     monkeypatch.setattr("factory.user_config.CONFIG_PATH", cfg)
+    monkeypatch.setattr("factory.user_config._cached_config", None)
     return cfg
 
 
@@ -40,6 +41,16 @@ class TestResolve:
 
         result = resolve("runner", config={"defaults": {"runner": "vertex"}}, default="claude")
         assert result == "vertex"
+
+    def test_auto_loads_config_file(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from factory.user_config import resolve
+
+        config_dir.write_text('[defaults]\nrunner = "from-toml"')
+        monkeypatch.delenv("FACTORY_RUNNER", raising=False)
+        result = resolve("runner", env_var="FACTORY_RUNNER", default="fallback")
+        assert result == "from-toml"
 
     def test_default_used_when_nothing_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from factory.user_config import resolve

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -215,27 +215,27 @@ class TestMasking:
 
 class TestEnsureConfigFile:
     def test_creates_with_template(self, config_dir: Path) -> None:
-        from factory.user_config import _ensure_config_file
+        from factory.user_config import ensure_config_file
 
-        path = _ensure_config_file()
+        path = ensure_config_file()
         assert path.exists()
         content = path.read_text()
         assert "[defaults]" in content
         assert "[credentials." in content
 
     def test_secure_permissions(self, config_dir: Path) -> None:
-        from factory.user_config import _ensure_config_file
+        from factory.user_config import ensure_config_file
 
-        path = _ensure_config_file()
+        path = ensure_config_file()
         mode = stat.S_IMODE(path.stat().st_mode)
         assert mode == 0o600
 
     def test_idempotent(self, config_dir: Path) -> None:
-        from factory.user_config import _ensure_config_file
+        from factory.user_config import ensure_config_file
 
-        _ensure_config_file()
+        ensure_config_file()
         config_dir.write_text("custom content")
-        _ensure_config_file()
+        ensure_config_file()
         assert config_dir.read_text() == "custom content"
 
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -1,0 +1,304 @@
+"""Tests for factory.user_config — config.toml loading, precedence, masking, validation."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect CONFIG_PATH to a temp directory."""
+    cfg = tmp_path / "config.toml"
+    monkeypatch.setattr("factory.user_config.CONFIG_PATH", cfg)
+    return cfg
+
+
+class TestResolve:
+    def test_cli_wins_over_all(self, config_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.user_config import resolve
+
+        monkeypatch.setenv("FACTORY_RUNNER", "bob")
+        config_dir.write_text('[defaults]\nrunner = "vertex"')
+        result = resolve("runner", cli_value="claude", env_var="FACTORY_RUNNER",
+                         config={"defaults": {"runner": "vertex"}}, default="fallback")
+        assert result == "claude"
+
+    def test_env_wins_over_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.user_config import resolve
+
+        monkeypatch.setenv("FACTORY_RUNNER", "bob")
+        result = resolve("runner", env_var="FACTORY_RUNNER",
+                         config={"defaults": {"runner": "vertex"}}, default="fallback")
+        assert result == "bob"
+
+    def test_config_wins_over_default(self) -> None:
+        from factory.user_config import resolve
+
+        result = resolve("runner", config={"defaults": {"runner": "vertex"}}, default="claude")
+        assert result == "vertex"
+
+    def test_default_used_when_nothing_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.user_config import resolve
+
+        monkeypatch.delenv("FACTORY_RUNNER", raising=False)
+        result = resolve("runner", env_var="FACTORY_RUNNER", default="claude")
+        assert result == "claude"
+
+    def test_none_when_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.user_config import resolve
+
+        monkeypatch.delenv("FACTORY_RUNNER", raising=False)
+        result = resolve("runner", env_var="FACTORY_RUNNER")
+        assert result is None
+
+    def test_empty_cli_value_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.user_config import resolve
+
+        monkeypatch.setenv("FACTORY_RUNNER", "bob")
+        result = resolve("runner", cli_value="", env_var="FACTORY_RUNNER")
+        assert result == "bob"
+
+    def test_whitespace_cli_value_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.user_config import resolve
+
+        monkeypatch.setenv("FACTORY_RUNNER", "bob")
+        result = resolve("runner", cli_value="   ", env_var="FACTORY_RUNNER")
+        assert result == "bob"
+
+
+class TestLoadConfig:
+    def test_returns_empty_when_no_file(self, config_dir: Path) -> None:
+        from factory.user_config import load_config
+
+        assert load_config() == {}
+
+    def test_reads_toml(self, config_dir: Path) -> None:
+        from factory.user_config import load_config
+
+        config_dir.write_text('[defaults]\nrunner = "bob"\nmodel = "opus"')
+        data = load_config()
+        assert data["defaults"]["runner"] == "bob"
+        assert data["defaults"]["model"] == "opus"
+
+    def test_profile_injects_env_vars(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from factory.user_config import load_config
+
+        config_dir.write_text(
+            '[credentials.vertex]\nFACTORY_RUNNER = "claude"\n'
+            'ANTHROPIC_API_KEY = "sk-test-123"'
+        )
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        load_config(profile="vertex")
+        assert os.environ["FACTORY_RUNNER"] == "claude"
+        assert os.environ["ANTHROPIC_API_KEY"] == "sk-test-123"
+
+    def test_profile_not_found_raises(self, config_dir: Path) -> None:
+        from factory.user_config import load_config
+
+        config_dir.write_text('[credentials.vertex]\nFACTORY_RUNNER = "claude"')
+        with pytest.raises(KeyError, match="bob"):
+            load_config(profile="bob")
+
+    def test_profile_requires_file(self, config_dir: Path) -> None:
+        from factory.user_config import load_config
+
+        with pytest.raises(FileNotFoundError):
+            load_config(profile="vertex")
+
+
+class TestValidation:
+    def test_valid_profile_name(self) -> None:
+        from factory.user_config import _validate_profile_name
+
+        _validate_profile_name("vertex-ai")
+        _validate_profile_name("prod_1")
+        _validate_profile_name("Bob")
+
+    def test_invalid_profile_name_raises(self) -> None:
+        from factory.user_config import _validate_profile_name
+
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            _validate_profile_name("../../etc/passwd")
+
+    def test_invalid_profile_name_spaces(self) -> None:
+        from factory.user_config import _validate_profile_name
+
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            _validate_profile_name("has space")
+
+    def test_valid_credential_keys(self) -> None:
+        from factory.user_config import _validate_credential_keys
+
+        _validate_credential_keys({"FACTORY_RUNNER": "claude", "API_KEY": "x"})
+
+    def test_invalid_credential_key_raises(self) -> None:
+        from factory.user_config import _validate_credential_keys
+
+        with pytest.raises(ValueError, match="Invalid credential key"):
+            _validate_credential_keys({"lower_case": "bad"})
+
+    def test_invalid_credential_key_starts_with_digit(self) -> None:
+        from factory.user_config import _validate_credential_keys
+
+        with pytest.raises(ValueError, match="Invalid credential key"):
+            _validate_credential_keys({"1BAD": "val"})
+
+
+class TestMasking:
+    def test_is_sensitive(self) -> None:
+        from factory.user_config import is_sensitive
+
+        assert is_sensitive("ANTHROPIC_API_KEY")
+        assert is_sensitive("api_key")
+        assert is_sensitive("secret")
+        assert is_sensitive("password")
+        assert is_sensitive("BOB_TOKEN")
+        assert not is_sensitive("runner")
+        assert not is_sensitive("model")
+        assert not is_sensitive("projects_dir")
+
+    def test_mask_value_long(self) -> None:
+        from factory.user_config import mask_value
+
+        assert mask_value("sk-ant-abcdefgh") == "***********efgh"
+
+    def test_mask_value_short(self) -> None:
+        from factory.user_config import mask_value
+
+        assert mask_value("abc") == "****"
+
+    def test_show_config_masks_secrets(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        config_dir.write_text(
+            '[defaults]\nrunner = "claude"\n\n'
+            '[credentials.vertex]\nANTHROPIC_API_KEY = "sk-ant-super-secret-1234"'
+        )
+        output = show_config()
+        assert "claude" in output
+        assert "sk-ant-super-secret-1234" not in output
+        assert "1234" in output
+        assert "****" in output
+
+    def test_show_config_reveal(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        config_dir.write_text(
+            '[credentials.vertex]\nANTHROPIC_API_KEY = "sk-ant-super-secret-1234"'
+        )
+        output = show_config(reveal=True)
+        assert "sk-ant-super-secret-1234" in output
+
+    def test_show_config_no_file(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        output = show_config()
+        assert "No config file" in output
+
+
+class TestEnsureConfigFile:
+    def test_creates_with_template(self, config_dir: Path) -> None:
+        from factory.user_config import _ensure_config_file
+
+        path = _ensure_config_file()
+        assert path.exists()
+        content = path.read_text()
+        assert "[defaults]" in content
+        assert "[credentials." in content
+
+    def test_secure_permissions(self, config_dir: Path) -> None:
+        from factory.user_config import _ensure_config_file
+
+        path = _ensure_config_file()
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_idempotent(self, config_dir: Path) -> None:
+        from factory.user_config import _ensure_config_file
+
+        _ensure_config_file()
+        config_dir.write_text("custom content")
+        _ensure_config_file()
+        assert config_dir.read_text() == "custom content"
+
+
+class TestMigrateEnvToConfig:
+    def test_migrates_env_vars(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        tomli_w = pytest.importorskip("tomli_w")  # noqa: F841
+
+        monkeypatch.setenv("FACTORY_RUNNER", "bob")
+        monkeypatch.setenv("FACTORY_MODEL", "opus")
+        monkeypatch.delenv("FACTORY_PROJECTS_DIR", raising=False)
+
+        from factory.user_config import migrate_env_to_config
+
+        msg = migrate_env_to_config()
+        assert "2" in msg
+        assert config_dir.exists()
+
+        import tomllib
+        with open(config_dir, "rb") as f:
+            data = tomllib.load(f)
+        assert data["defaults"]["runner"] == "bob"
+        assert data["defaults"]["model"] == "opus"
+
+    def test_refuses_if_file_exists(self, config_dir: Path) -> None:
+        pytest.importorskip("tomli_w")
+        config_dir.parent.mkdir(parents=True, exist_ok=True)
+        config_dir.write_text("existing")
+
+        from factory.user_config import migrate_env_to_config
+
+        with pytest.raises(FileExistsError):
+            migrate_env_to_config()
+
+    def test_secure_permissions_on_migrate(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pytest.importorskip("tomli_w")
+        monkeypatch.setenv("FACTORY_RUNNER", "claude")
+
+        from factory.user_config import migrate_env_to_config
+
+        migrate_env_to_config()
+        mode = stat.S_IMODE(config_dir.stat().st_mode)
+        assert mode == 0o600
+
+
+class TestProfilePrecedence:
+    """End-to-end: profile credentials are available via resolve()."""
+
+    def test_profile_then_resolve(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from factory.user_config import load_config, resolve
+
+        config_dir.write_text(
+            '[defaults]\nrunner = "claude"\n\n'
+            '[credentials.vertex]\nFACTORY_RUNNER = "bob"'
+        )
+        monkeypatch.delenv("FACTORY_RUNNER", raising=False)
+
+        load_config(profile="vertex")
+        result = resolve("runner", env_var="FACTORY_RUNNER", default="claude")
+        assert result == "bob"
+
+    def test_env_overrides_profile(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from factory.user_config import load_config, resolve
+
+        config_dir.write_text('[credentials.vertex]\nFACTORY_RUNNER = "bob"')
+        monkeypatch.setenv("FACTORY_RUNNER", "claude")
+
+        load_config(profile="vertex")
+        result = resolve("runner", cli_value=None, env_var="FACTORY_RUNNER", default="fallback")
+        assert result == "claude"

--- a/tests/test_vault_decouple.py
+++ b/tests/test_vault_decouple.py
@@ -186,7 +186,7 @@ class TestResolveInputWithoutVault:
         import factory.cli as cli_mod
         from factory.cli import _resolve_input
 
-        monkeypatch.setattr(cli_mod, "_PROJECTS_DIR", tmp_path)
+        monkeypatch.setattr(cli_mod, "_get_projects_dir", lambda: tmp_path)
         path, ctx = _resolve_input("build a weather dashboard")
         assert path.parent == tmp_path
         assert path.exists()
@@ -198,7 +198,7 @@ class TestResolveInputWithoutVault:
         import factory.cli as cli_mod
         from factory.cli import _resolve_input
 
-        monkeypatch.setattr(cli_mod, "_PROJECTS_DIR", tmp_path / "projects")
+        monkeypatch.setattr(cli_mod, "_get_projects_dir", lambda: tmp_path / "projects")
         idea_file = tmp_path / "Weather Dashboard \u2014 live forecast.md"
         idea_file.write_text("# Weather Dashboard\nShow forecasts.")
 


### PR DESCRIPTION
## Summary

- Implements [issue #235](https://github.com/akashgit/remote-factory/issues/235) — unified `~/.factory/config.toml` with credential profiles and 5-tier precedence resolution
- Replaces all 12 scattered `FACTORY_*` env var lookups across 11 source files with `user_config.resolve()`
- Adds `--profile <name>` flag to `factory ceo`, `run`, and `agent` commands for credential switching
- Adds `factory config {show,edit,migrate}` subcommands for config management
- Env vars remain fully supported (backward compatible for CI/Docker) — config.toml is additive

### Key design decisions
- **Precedence:** CLI flag > env var > profile credential > config.toml default > hardcoded
- **Profile injection:** Uses `os.environ.setdefault()` so pre-existing env vars always win
- **Security:** Config file created with `0o600` permissions; `config show` masks secrets (keys/tokens/passwords)
- **TOML tooling:** `tomllib` (stdlib 3.11+) for reads, `tomli_w` optional for `config migrate` only

Factory experiment #58.

## Test plan
- [x] 29 new tests in `tests/test_user_config.py` covering precedence chain, profile loading, secret masking, validation, file permissions
- [x] All 1640 existing tests pass (no regressions)
- [x] `ruff check .` — clean
- [x] `mypy factory/` — clean
- [ ] Manual verification: `factory config show`, `factory config edit`, `factory ceo --profile vertex`

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)