### PR TITLE
Branch isolation via git worktrees (Issue #240 Part 1)

### DIFF
--- a/factory/agents/prompts/builder.md
+++ b/factory/agents/prompts/builder.md
@@ -19,14 +19,15 @@ You will be given:
 
 ## Workflow
 
+**Important:** Your working directory is a git worktree, not the main repo. The branch has already been created for you — do NOT create a new branch. Commit directly to the current branch.
+
 ```bash
 # 1. Read the issue
 gh issue view $ISSUE_NUM -R $REPO
 
-# 2. Prepare your branch
+# 2. Verify your branch (already set up by the worktree)
 cd $PROJECT_PATH
-git checkout $TARGET_BRANCH
-git checkout -b feature/$FEATURE_NAME
+git branch --show-current
 
 # 3. Read project context
 cat CLAUDE.md
@@ -44,7 +45,7 @@ cat factory.md
 # 6. Commit and open PR
 git add <changed files>
 git commit -m "<descriptive message>"
-gh pr create --base $TARGET_BRANCH \
+gh pr create --base main \
     --title "<issue title>" \
     --body "Closes #$ISSUE_NUM
 

--- a/factory/agents/prompts/builder.md
+++ b/factory/agents/prompts/builder.md
@@ -45,7 +45,7 @@ cat factory.md
 # 6. Commit and open PR
 git add <changed files>
 git commit -m "<descriptive message>"
-gh pr create --base main \
+gh pr create --base $TARGET_BRANCH \
     --title "<issue title>" \
     --body "Closes #$ISSUE_NUM
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1053,7 +1053,7 @@ factory agent builder --task "Implement GitHub issue #$ISSUE_NUM in <owner>/<rep
 1. Read the issue: gh issue view $ISSUE_NUM
 2. cd $PROJECT_PATH, read CLAUDE.md and factory.md
 3. Read the CEO-approved strategy at .factory/reviews/ceo-verdict-strategist.md
-4. git checkout -b experiment/$EXP_ID-$SHORT_DESCRIPTION (e.g. experiment/3-add-retry-logic)
+4. The worktree already has its own branch — do NOT create a new branch. Commit directly to the current branch.
 5. Implement exactly what the issue describes
 6. If the issue has an '## Execution Step' section: after implementing code changes, execute those commands. The task is NOT complete until the output artifacts listed in '## Execution Acceptance Criteria' exist and are non-empty. Code-only completion for an operational issue is a failure.
 7. Run tests and evals
@@ -1090,13 +1090,12 @@ If Builder fails (no PR opened), see Error Recovery below.
 **Step 3 — Additional checks (apply when relevant):**
 
 - **If the PR touches UI/frontend code** (HTML, CSS, JS, templates, dashboard endpoints):
-  - Checkout the PR branch locally (`git checkout <branch>`)
+  - The worktree already has the PR branch checked out — no need to switch branches
   - Kill and restart the dev server (`lsof -ti:<port> | xargs kill`, then restart) — the running process serves stale code
   - Use Playwright MCP to navigate to the affected page and take a screenshot
   - Verify the change renders correctly — tests passing does NOT mean the UI works
   - If Playwright reveals bugs, add them to the issue list
   - This is MANDATORY when the Focus Directive targets UI/UX — no exceptions
-  - After verification, checkout the target branch again (`git checkout main`)
 - **If the GitHub issue has an `## Execution Step` section** (operational or mixed hypothesis):
   - Read the `## Execution Acceptance Criteria` section from the GitHub issue (`gh issue view $ISSUE_NUM`) to get the expected output artifacts
   - Check if those artifacts exist in the project: `ls -la <artifact paths>`
@@ -1363,9 +1362,8 @@ factory review \
     --hypothesis "<hypothesis>" \
     --pr $PR_NUM
 
-# Close PR and finalize
+# Close PR and finalize — worktree cleanup is handled by the CLI
 gh pr close <pr-number>
-cd "$PROJECT_PATH" && git checkout main
 factory finalize "$PROJECT_PATH" \
     --id $EXP_ID --verdict revert \
     --hypothesis "<hypothesis>" --summary "<changes — reverted>" \
@@ -1799,7 +1797,7 @@ factory agent builder --task "Implement GitHub issue #$ISSUE_NUM in <owner>/<rep
 1. Read the issue: gh issue view $ISSUE_NUM
 2. cd $PROJECT_PATH, read CLAUDE.md and factory.md
 3. Read the CEO-approved strategy at .factory/reviews/ceo-verdict-strategist.md
-4. git checkout -b experiment/$EXP_ID-$SHORT_DESCRIPTION
+4. The worktree already has its own branch — do NOT create a new branch. Commit directly to the current branch.
 5. Implement exactly what the hypothesis describes
 
 ## Surface Constraints — CRITICAL
@@ -1959,9 +1957,8 @@ factory review \
     --hypothesis "$HYPOTHESIS" \
     --pr $PR_NUM
 
+# Close PR and finalize — worktree cleanup is handled by the CLI
 gh pr close $PR_NUM
-cd "$PROJECT_PATH" && git checkout $TARGET_BRANCH
-
 factory finalize "$PROJECT_PATH" \
     --id $EXP_ID --verdict revert \
     --hypothesis "$HYPOTHESIS" --summary "$CHANGES — reverted" \

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1570,7 +1570,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             mark_read(project_path, pending_ids)
         prompt = resolve_prompt("ceo", wt_path)
         runner = get_runner(runner_name)
-        runner.interactive_run(
+        return runner.interactive_run(
             prompt, task, wt_path,
             model=model, role="ceo", dangerously_skip_permissions=True
         )

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1496,6 +1496,11 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     _print_banner(banner_mode)
     _ensure_dashboard(project_path)
 
+    from factory.worktree import create_worktree, prune_stale, remove_worktree
+    pruned = prune_stale(project_path)
+    if pruned:
+        print(f"  Cleaned {len(pruned)} stale worktree(s)", file=sys.stderr)
+
     if focus:
         from factory.study import add_backlog_item
         add_backlog_item(project_path, focus)
@@ -1505,6 +1510,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
 
+    base_branch = branch or "main"
+    wt_path, wt_branch = create_worktree(project_path, base_branch)
+
     if interactive_existing:
         ceo_mode = "improve"
     elif mode == "interactive" or research_ideation:
@@ -1512,7 +1520,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     else:
         ceo_mode = mode
     task = _build_ceo_task(
-        project_path, ceo_mode, context, focus=focus, prompt_file=prompt_file,
+        wt_path, ceo_mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
         discover_only=discover_only, no_github=no_github,
         interactive_idea=interactive_idea,
@@ -1528,41 +1536,44 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         # Uses completion guard to auto-resume on premature exit
         from factory.ceo_completion import run_ceo_with_completion_guard
 
-        result, code = _run(run_ceo_with_completion_guard(
-            project_path,
-            task,
-            mode=mode,
-            runner_name=runner_name,
-            model=model,
-            timeout=7200.0,
-        ))
-        print(result)
-        if code == 0:
-            if pending_ids:
-                mark_read(project_path, pending_ids)
-        if code != 0:
-            return code
-        return _chain_modes(
-            project_path, focus=focus,
-            min_growth=min_growth, max_new=max_new, branch=branch,
-            already_improved=mode in ("improve", "meta") or discover_only,
-            model=model, no_github=no_github,
-        )
+        try:
+            result, code = _run(run_ceo_with_completion_guard(
+                wt_path,
+                task,
+                mode=mode,
+                runner_name=runner_name,
+                model=model,
+                timeout=7200.0,
+            ))
+            print(result)
+            if code == 0:
+                if pending_ids:
+                    mark_read(project_path, pending_ids)
+            if code != 0:
+                return code
+            return _chain_modes(
+                project_path, focus=focus,
+                min_growth=min_growth, max_new=max_new, branch=branch,
+                already_improved=mode in ("improve", "meta") or discover_only,
+                model=model, no_github=no_github,
+            )
+        finally:
+            remove_worktree(project_path, wt_path, wt_branch)
 
     # Interactive foreground mode: use runner's interactive_exec.
     # Mark read before exec — interactive_exec replaces the process via os.execvp
-    # so there's no post-execution hook. If the session fails to launch, messages
-    # are lost. This is accepted: the user is at the terminal and can re-send.
+    # so there's no post-execution hook. Worktree cleanup happens via prune_stale
+    # at next factory startup.
     if pending_ids:
         print(
             f"Consuming {len(pending_ids)} message(s): {', '.join(pending_ids)}",
             file=sys.stderr,
         )
         mark_read(project_path, pending_ids)
-    prompt = resolve_prompt("ceo", project_path)
+    prompt = resolve_prompt("ceo", wt_path)
     runner = get_runner(runner_name)
     runner.interactive_exec(
-        prompt, task, project_path,
+        prompt, task, wt_path,
         model=model, role="ceo", dangerously_skip_permissions=True
     )
 
@@ -2235,6 +2246,7 @@ def _run_single_cycle(
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
     from factory.agents.runner import invoke_agent
+    from factory.worktree import create_worktree, remove_worktree
 
     if focus:
         from factory.study import add_backlog_item
@@ -2245,30 +2257,36 @@ def _run_single_cycle(
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
 
-    task = _build_ceo_task(
-        project_path, mode, context, focus=focus, prompt_file=prompt_file,
-        min_growth=min_growth, max_new=max_new, branch=branch,
-        discover_only=discover_only, no_github=no_github,
-        messages=pending,
-        issue_number=issue_number,
-        issue_url=issue_url,
-    )
+    base_branch = branch or "main"
+    wt_path, wt_branch = create_worktree(project_path, base_branch)
 
-    result, code = _run(invoke_agent(
-        "ceo",
-        task,
-        project_path,
-        timeout=7200.0,
-        dangerously_skip_permissions=True,
-        model=model,
-    ))
+    try:
+        task = _build_ceo_task(
+            wt_path, mode, context, focus=focus, prompt_file=prompt_file,
+            min_growth=min_growth, max_new=max_new, branch=branch,
+            discover_only=discover_only, no_github=no_github,
+            messages=pending,
+            issue_number=issue_number,
+            issue_url=issue_url,
+        )
 
-    if code == 0:
-        if pending_ids:
-            mark_read(project_path, pending_ids)
+        result, code = _run(invoke_agent(
+            "ceo",
+            task,
+            wt_path,
+            timeout=7200.0,
+            dangerously_skip_permissions=True,
+            model=model,
+        ))
 
-    print(result)
-    return code
+        if code == 0:
+            if pending_ids:
+                mark_read(project_path, pending_ids)
+
+        print(result)
+        return code
+    finally:
+        remove_worktree(project_path, wt_path, wt_branch)
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -2326,6 +2344,11 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     _print_banner(mode)
     _ensure_dashboard(project_path)
+
+    from factory.worktree import prune_stale
+    pruned = prune_stale(project_path)
+    if pruned:
+        print(f"  Cleaned {len(pruned)} stale worktree(s)", file=sys.stderr)
 
     budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch)
     skip_improve = mode in ("improve", "meta") or discover_only

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1560,22 +1560,22 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         finally:
             remove_worktree(project_path, wt_path, wt_branch)
 
-    # Interactive foreground mode: use runner's interactive_exec.
-    # Mark read before exec — interactive_exec replaces the process via os.execvp
-    # so there's no post-execution hook. Worktree cleanup happens via prune_stale
-    # at next factory startup.
-    if pending_ids:
-        print(
-            f"Consuming {len(pending_ids)} message(s): {', '.join(pending_ids)}",
-            file=sys.stderr,
+    # Interactive foreground mode: use subprocess.run so we can clean up the worktree.
+    try:
+        if pending_ids:
+            print(
+                f"Consuming {len(pending_ids)} message(s): {', '.join(pending_ids)}",
+                file=sys.stderr,
+            )
+            mark_read(project_path, pending_ids)
+        prompt = resolve_prompt("ceo", wt_path)
+        runner = get_runner(runner_name)
+        runner.interactive_run(
+            prompt, task, wt_path,
+            model=model, role="ceo", dangerously_skip_permissions=True
         )
-        mark_read(project_path, pending_ids)
-    prompt = resolve_prompt("ceo", wt_path)
-    runner = get_runner(runner_name)
-    runner.interactive_exec(
-        prompt, task, wt_path,
-        model=model, role="ceo", dangerously_skip_permissions=True
-    )
+    finally:
+        remove_worktree(project_path, wt_path, wt_branch)
 
 
 def _is_github_url(path: str) -> bool:

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -9,7 +9,7 @@ import shutil
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import NoReturn
+import subprocess as _subprocess
 
 from factory.runners._stream import should_stream, stream_subprocess
 from factory.runners.usage import (
@@ -279,7 +279,7 @@ class BobRunner:
 
         return stdout, return_code
 
-    def interactive_exec(
+    def interactive_run(
         self,
         prompt: str,
         task: str,
@@ -288,18 +288,20 @@ class BobRunner:
         model: str | None = None,
         role: str = "ceo",
         dangerously_skip_permissions: bool = False,
-    ) -> NoReturn:
-        """Replace process with interactive Bob Shell session."""
+    ) -> int:
+        """Run an interactive Bob Shell session as a subprocess.
+
+        Returns the exit code so the caller can clean up in a finally block.
+        """
         project_path = self._find_project_path(cwd)
 
-        # Persist key for nested subagent spawns (before dry-run check so file exists)
         _persist_key(project_path)
 
         if is_dry_run():
             yolo_flag = " --yolo" if dangerously_skip_permissions else ""
-            print(f"[DRY-RUN] Would exec: bob --chat-mode=factory-{role}{yolo_flag}")
+            print(f"[DRY-RUN] Would run: bob --chat-mode=factory-{role}{yolo_flag}")
             print(f"[DRY-RUN] Task: {task[:200]}...")
-            raise SystemExit(0)
+            return 0
 
         _check_auth(cwd)
 
@@ -307,10 +309,7 @@ class BobRunner:
             check_ceilings(project_path, self.cycle_start)
         except CeilingExceededError as e:
             print(f"ERROR: {e}")
-            raise SystemExit(1) from e
-
-        # NOTE: Custom modes are not supported in Bob Shell (unlike Claude Code).
-        # The agent role definition is injected via the prompt instead.
+            return 1
 
         chat_mode = _BOB_CHAT_MODE
         full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
@@ -323,15 +322,14 @@ class BobRunner:
         if dangerously_skip_permissions:
             cmd.append("--yolo")
 
-        logger.info("BobRunner interactive_exec: cwd=%s, chat_mode=%s", cwd, chat_mode)
+        logger.info("BobRunner interactive_run: cwd=%s, chat_mode=%s", cwd, chat_mode)
 
-        # Ensure bob's bin directory is first in PATH so the correct Node is found
         bob_bin_dir = _get_bob_bin_dir()
         if bob_bin_dir and not os.environ.get("PATH", "").startswith(bob_bin_dir):
             os.environ["PATH"] = f"{bob_bin_dir}:{os.environ.get('PATH', '')}"
 
-        os.chdir(cwd)
-        os.execvp("bob", cmd)
+        result = _subprocess.run(cmd, cwd=cwd)
+        return result.returncode
 
     def _find_project_path(self, cwd: Path) -> Path:
         """Find the project root (directory containing .factory/)."""

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import subprocess
 from pathlib import Path
-from typing import NoReturn
 
 from factory.runners._stream import should_stream, stream_subprocess
 
@@ -86,7 +86,7 @@ class ClaudeRunner:
 
         return stdout, proc.returncode or 0
 
-    def interactive_exec(
+    def interactive_run(
         self,
         prompt: str,
         task: str,
@@ -95,18 +95,12 @@ class ClaudeRunner:
         model: str | None = None,
         role: str = "ceo",
         dangerously_skip_permissions: bool = False,
-    ) -> NoReturn:
-        """Replace process with interactive Claude Code session.
+    ) -> int:
+        """Run an interactive Claude Code session as a subprocess.
 
-        Args:
-            prompt: The system prompt to append.
-            task: The initial user message.
-            cwd: Working directory (os.chdir is called before exec).
-            model: Optional model override.
-            role: Agent role (unused by claude, but kept for API compatibility).
-            dangerously_skip_permissions: If True, skip permission prompts.
+        Returns the exit code so the caller can clean up in a finally block.
         """
-        _ = role  # unused by claude runner
+        _ = role
         cmd = [
             "claude",
             "--append-system-prompt", prompt,
@@ -118,7 +112,7 @@ class ClaudeRunner:
             cmd.extend(["--model", model])
             os.environ["FACTORY_MODEL"] = model
 
-        logger.info("ClaudeRunner interactive_exec: cwd=%s", cwd)
+        logger.info("ClaudeRunner interactive_run: cwd=%s", cwd)
 
-        os.chdir(cwd)
-        os.execvp("claude", cmd)
+        result = subprocess.run(cmd, cwd=cwd)
+        return result.returncode

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import NoReturn, Protocol
+from typing import Protocol
 
 
 class Runner(Protocol):
@@ -38,7 +38,7 @@ class Runner(Protocol):
         """
         ...
 
-    def interactive_exec(
+    def interactive_run(
         self,
         prompt: str,
         task: str,
@@ -47,17 +47,21 @@ class Runner(Protocol):
         model: str | None = None,
         role: str = "ceo",
         dangerously_skip_permissions: bool = False,
-    ) -> NoReturn:
-        """Replace the current process with an interactive CLI session.
+    ) -> int:
+        """Run an interactive CLI session as a subprocess (returns on exit).
 
-        This function does not return — it calls os.execvp to replace the process.
+        Unlike interactive_exec, this uses subprocess.run so the caller regains
+        control after the session finishes — enabling cleanup in finally blocks.
 
         Args:
             prompt: The system prompt to append.
             task: The initial user message.
-            cwd: Working directory (os.chdir is called before exec).
+            cwd: Working directory for the subprocess.
             model: Optional model override.
             role: Agent role name (used for logging and output prefixing).
             dangerously_skip_permissions: If True, skip permission prompts (--yolo for bob).
+
+        Returns:
+            The subprocess exit code.
         """
         ...

--- a/factory/store.py
+++ b/factory/store.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Literal
 
 import structlog
+from filelock import FileLock
 
 from factory.models import (
     CompositeScore,
@@ -155,6 +156,7 @@ class ExperimentStore:
     def __init__(self, project_path: Path) -> None:
         self.project_path = project_path
         self.factory_dir = project_path / ".factory"
+        self._lock = FileLock(self.factory_dir / ".store.lock")
 
     async def init(self, config: FactoryConfig) -> None:
         """Create .factory/ structure with config.json, results.tsv, experiments/, strategy/."""
@@ -305,14 +307,16 @@ class ExperimentStore:
         Idempotent: if the next experiment dir already exists (e.g. from a
         previous interrupted run), return its ID without crashing.
         Also registers the project in the global registry (non-blocking).
+        Uses filelock for safe concurrent ID allocation.
         """
-        exp_id = await self.next_id()
-        log.info("experiment_begin", exp_id=exp_id, hypothesis=hypothesis[:80])
-        exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
-        exp_dir.mkdir(parents=True, exist_ok=True)
-        hyp_path = exp_dir / "hypothesis.md"
-        if not hyp_path.exists():
-            hyp_path.write_text(hypothesis)
+        with self._lock:
+            exp_id = await self.next_id()
+            log.info("experiment_begin", exp_id=exp_id, hypothesis=hypothesis[:80])
+            exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
+            exp_dir.mkdir(parents=True, exist_ok=True)
+            hyp_path = exp_dir / "hypothesis.md"
+            if not hyp_path.exists():
+                hyp_path.write_text(hypothesis)
 
         try:
             from factory.registry import register_project
@@ -354,6 +358,7 @@ class ExperimentStore:
 
         Creates the experiment directory if it is missing (e.g. after git clean).
         Computes delta from score_before/score_after if not already set.
+        Uses filelock for safe concurrent TSV append.
         """
         delta = record.delta
         if delta is None and record.score_before is not None and record.score_after is not None:
@@ -365,33 +370,35 @@ class ExperimentStore:
             verdict=record.verdict,
             delta=delta,
         )
-        exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
-        exp_dir.mkdir(parents=True, exist_ok=True)
 
-        record_dump = record.model_dump()
-        record_dump["delta"] = delta
-        (exp_dir / "verdict.json").write_text(
-            json.dumps(record_dump, indent=2, default=str) + "\n"
-        )
+        with self._lock:
+            exp_dir = self.factory_dir / "experiments" / f"{exp_id:03d}"
+            exp_dir.mkdir(parents=True, exist_ok=True)
 
-        tsv_path = self.factory_dir / "results.tsv"
-        with open(tsv_path, "a", newline="") as f:
-            writer = csv.writer(f, dialect="excel-tab")
-            writer.writerow([
-                record.id,
-                record.timestamp.isoformat(),
-                record.hypothesis,
-                record.change_summary,
-                record.issue_number if record.issue_number is not None else "",
-                record.pr_number if record.pr_number is not None else "",
-                record.score_before if record.score_before is not None else "",
-                record.score_after if record.score_after is not None else "",
-                delta if delta is not None else "",
-                record.verdict,
-                record.cost_usd if record.cost_usd is not None else "",
-                record.notes,
-                "|".join(record.research_citations) if record.research_citations else "",
-            ])
+            record_dump = record.model_dump()
+            record_dump["delta"] = delta
+            (exp_dir / "verdict.json").write_text(
+                json.dumps(record_dump, indent=2, default=str) + "\n"
+            )
+
+            tsv_path = self.factory_dir / "results.tsv"
+            with open(tsv_path, "a", newline="") as f:
+                writer = csv.writer(f, dialect="excel-tab")
+                writer.writerow([
+                    record.id,
+                    record.timestamp.isoformat(),
+                    record.hypothesis,
+                    record.change_summary,
+                    record.issue_number if record.issue_number is not None else "",
+                    record.pr_number if record.pr_number is not None else "",
+                    record.score_before if record.score_before is not None else "",
+                    record.score_after if record.score_after is not None else "",
+                    delta if delta is not None else "",
+                    record.verdict,
+                    record.cost_usd if record.cost_usd is not None else "",
+                    record.notes,
+                    "|".join(record.research_citations) if record.research_citations else "",
+                ])
 
         try:
             from factory.registry import update_project_stats

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -1,0 +1,105 @@
+"""Git worktree lifecycle management for experiment isolation."""
+
+import secrets
+import shutil
+import subprocess
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
+    """Create an isolated worktree for a factory run.
+
+    Returns (worktree_path, branch_name).
+    """
+    run_id = secrets.token_hex(4)
+    branch = f"factory/run-{run_id}"
+    wt_dir = project_path / ".factory" / "worktrees" / f"run-{run_id}"
+
+    log.info("worktree_create", branch=branch, path=str(wt_dir))
+
+    subprocess.run(
+        ["git", "worktree", "add", str(wt_dir), "-b", branch, base_branch],
+        cwd=project_path,
+        check=True,
+        capture_output=True,
+    )
+
+    factory_real = (project_path / ".factory").resolve()
+    wt_factory = wt_dir / ".factory"
+    if wt_factory.exists() or wt_factory.is_symlink():
+        if wt_factory.is_dir() and not wt_factory.is_symlink():
+            shutil.rmtree(wt_factory)
+        else:
+            wt_factory.unlink()
+    wt_factory.symlink_to(factory_real)
+
+    log.info("worktree_created", branch=branch, path=str(wt_dir))
+    return wt_dir, branch
+
+
+def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> None:
+    """Remove a worktree and its branch. Safe to call on already-removed paths."""
+    log.info("worktree_remove", branch=branch, path=str(worktree_path))
+
+    if worktree_path.exists():
+        shutil.rmtree(worktree_path)
+
+    subprocess.run(
+        ["git", "worktree", "prune"],
+        cwd=project_path,
+        capture_output=True,
+    )
+
+    subprocess.run(
+        ["git", "branch", "-D", branch],
+        cwd=project_path,
+        capture_output=True,
+    )
+
+
+def prune_stale(project_path: Path) -> list[str]:
+    """Clean up stale worktrees from crashed runs. Returns list of pruned entries."""
+    factory_dir = project_path / ".factory"
+    if not factory_dir.is_dir():
+        return []
+
+    result = subprocess.run(
+        ["git", "worktree", "prune", "--verbose"],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    pruned = [line for line in result.stderr.splitlines() if "Removing" in line]
+
+    wt_parent = factory_dir / "worktrees"
+    if wt_parent.exists():
+        active = _list_active_worktrees(project_path)
+        for d in wt_parent.iterdir():
+            if d.is_dir() and str(d.resolve()) not in active:
+                shutil.rmtree(d)
+                pruned.append(f"Removed orphaned directory: {d.name}")
+                log.info("worktree_pruned_orphan", name=d.name)
+
+    if pruned:
+        log.info("worktree_prune_complete", pruned_count=len(pruned))
+
+    return pruned
+
+
+def _list_active_worktrees(project_path: Path) -> set[str]:
+    """Return set of absolute paths for all active worktrees."""
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        line.split(" ", 1)[1]
+        for line in result.stdout.splitlines()
+        if line.startswith("worktree ")
+    }

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -15,9 +15,11 @@ def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path
 
     Returns (worktree_path, branch_name).
     """
+    project_path = project_path.resolve()
     run_id = secrets.token_hex(4)
     branch = f"factory/run-{run_id}"
-    wt_dir = project_path / ".factory" / "worktrees" / f"run-{run_id}"
+    factory_dir = project_path / ".factory"
+    wt_dir = factory_dir / "worktrees" / f"run-{run_id}"
 
     log.info("worktree_create", branch=branch, path=str(wt_dir))
 
@@ -28,14 +30,17 @@ def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path
         capture_output=True,
     )
 
-    factory_real = (project_path / ".factory").resolve()
+    # Symlink worktree/.factory → the real .factory dir (resolved absolute path).
+    # The worktree lives inside .factory/worktrees/, so this is inherently circular
+    # for recursive traversal — but safe because shutil.rmtree and os.walk don't
+    # follow symlinks by default.
     wt_factory = wt_dir / ".factory"
     if wt_factory.exists() or wt_factory.is_symlink():
         if wt_factory.is_dir() and not wt_factory.is_symlink():
             shutil.rmtree(wt_factory)
         else:
             wt_factory.unlink()
-    wt_factory.symlink_to(factory_real)
+    wt_factory.symlink_to(factory_dir)
 
     log.info("worktree_created", branch=branch, path=str(wt_dir))
     return wt_dir, branch
@@ -80,9 +85,16 @@ def prune_stale(project_path: Path) -> list[str]:
         active = _list_active_worktrees(project_path)
         for d in wt_parent.iterdir():
             if d.is_dir() and str(d.resolve()) not in active:
+                run_id = d.name.removeprefix("run-")
                 shutil.rmtree(d)
                 pruned.append(f"Removed orphaned directory: {d.name}")
                 log.info("worktree_pruned_orphan", name=d.name)
+                branch = f"factory/run-{run_id}"
+                subprocess.run(
+                    ["git", "branch", "-D", branch],
+                    cwd=project_path,
+                    capture_output=True,
+                )
 
     if pruned:
         log.info("worktree_prune_complete", pruned_count=len(pruned))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "uvicorn[standard]>=0.34",
     "mcp>=1.27.0",
     "pyyaml>=6.0",
+    "filelock>=3.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -42,6 +43,7 @@ factory = "factory.cli:main"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = ["real_worktree: use real git worktree functions instead of mocks"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -22,6 +23,31 @@ def _isolate_registry(tmp_path: Path) -> None:
     os.environ["FACTORY_REGISTRY_DIR"] = str(tmp_path / ".factory-test-registry")
     yield  # type: ignore[misc]
     os.environ.pop("FACTORY_REGISTRY_DIR", None)
+
+
+@pytest.fixture(autouse=True)
+def _mock_worktree(tmp_path: Path, request: pytest.FixtureRequest) -> None:
+    """Stub worktree functions for tests that don't exercise worktree logic.
+
+    Tests in test_worktree.py opt out via the 'real_worktree' marker.
+    """
+    if "real_worktree" in {m.name for m in request.node.iter_markers()}:
+        yield  # type: ignore[misc]
+        return
+
+    def _fake_create(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
+        return project_path, "factory/run-fake0000"
+
+    def _fake_remove(project_path: Path, worktree_path: Path, branch: str) -> None:
+        pass
+
+    def _fake_prune(project_path: Path) -> list[str]:
+        return []
+
+    with patch("factory.worktree.create_worktree", side_effect=_fake_create), \
+         patch("factory.worktree.remove_worktree", side_effect=_fake_remove), \
+         patch("factory.worktree.prune_stale", side_effect=_fake_prune):
+        yield  # type: ignore[misc]
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,13 @@
 """Tests for factory.cli — CLI subcommand routing."""
 
 import asyncio
+import contextlib
 import json
 import signal
 import threading
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
@@ -22,6 +23,20 @@ def _mock_invoke_agent_ok():
 
 def _mock_invoke_agent_fail():
     return AsyncMock(return_value=("Error: agent failed", 1))
+
+
+@contextlib.contextmanager
+def _mock_foreground():
+    """Mock the interactive foreground path: subprocess.run inside ClaudeRunner,
+    worktree lifecycle, and dashboard.  Yields the subprocess.run mock."""
+    mock_run = MagicMock(return_value=MagicMock(returncode=0))
+    with patch("factory.runners.claude.subprocess.run", mock_run), \
+         patch("factory.worktree.create_worktree",
+               side_effect=lambda p, b="main": (p, "factory/run-test")), \
+         patch("factory.worktree.remove_worktree"), \
+         patch("factory.worktree.prune_stale", return_value=[]), \
+         patch("factory.cli._ensure_dashboard"):
+        yield mock_run
 
 
 class TestParser:
@@ -138,11 +153,10 @@ class TestCmdCeoInteractive:
     def test_interactive_focus_allowed_existing_project(self, tmp_path):
         """--focus + --mode interactive is allowed when path is an existing directory."""
         (tmp_path / ".git").mkdir()
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "interactive", "--focus", "auth layer"])
-        mock_exec.assert_called_once()
-        cmd = mock_exec.call_args[0][1]
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Interactive Improvement Mode (Phase 0)" in task
@@ -154,32 +168,29 @@ class TestCmdCeoInteractive:
         err = capsys.readouterr().err.lower()
         assert "provide" in err or "error" in err
 
-    def test_interactive_foreground_uses_execvp(self, tmp_path):
-        """--mode interactive launches via os.execvp (foreground)."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+    def test_interactive_foreground_uses_subprocess_run(self, tmp_path):
+        """--mode interactive launches via subprocess.run (foreground)."""
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "interactive"])
-        mock_exec.assert_called_once()
-        cmd = mock_exec.call_args[0][1]
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
         assert cmd[0] == "claude"
         assert "--dangerously-skip-permissions" in cmd
 
     def test_interactive_existing_has_improvement_block(self, tmp_path):
         """--mode interactive on an existing directory injects Improvement Mode block."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "interactive"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Interactive Improvement Mode (Phase 0)" in task
 
     def test_interactive_new_idea_has_ideation_block(self):
         """--mode interactive with a non-directory path injects Ideation Mode block."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", "build a cool CLI tool", "--mode", "interactive"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Interactive Ideation Mode (Phase 0)" in task
@@ -187,30 +198,27 @@ class TestCmdCeoInteractive:
 
     def test_interactive_task_contains_idea_text(self):
         """--mode interactive with raw idea text includes it in the Phase 0 block."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", "distributed eval runner", "--mode", "interactive"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "distributed eval runner" in task
 
     def test_interactive_existing_mode_is_improve(self, tmp_path):
         """--mode interactive on existing dir sets Mode: improve in the CEO task."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "interactive"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "Mode: improve" in task
 
     def test_interactive_new_idea_mode_is_build(self):
         """--mode interactive with new idea sets Mode: build in the CEO task."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", "weather CLI", "--mode", "interactive"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "Mode: build" in task
@@ -274,11 +282,10 @@ class TestCmdCeoResearchIdeation:
               "target": 0.9, "run_command": "python run.py",
               "result_path": "results.json"}
         (factory_dir / "config.json").write_text(json.dumps(_make_config(research_target=rt)))
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "research", "--focus", "tokenizer"])
-        mock_exec.assert_called_once()
-        cmd = mock_exec.call_args[0][1]
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Focus Directive" in task
@@ -307,21 +314,19 @@ class TestCmdCeoResearchIdeation:
         assert result == 1
         assert "research_target" in capsys.readouterr().err
 
-    def test_research_ideation_foreground_uses_execvp(self):
-        """--mode research with idea string launches via os.execvp."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+    def test_research_ideation_foreground_uses_subprocess_run(self):
+        """--mode research with idea string launches via subprocess.run."""
+        with _mock_foreground() as mock_run:
             main(["ceo", "swe-bench solver agent", "--mode", "research"])
-        mock_exec.assert_called_once()
-        cmd = mock_exec.call_args[0][1]
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
         assert cmd[0] == "claude"
 
     def test_research_ideation_task_has_research_phase_0(self):
         """--mode research with idea injects Research Ideation Phase 0 block."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", "swe-bench solver agent", "--mode", "research"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Research Ideation Mode (Phase 0)" in task
@@ -329,30 +334,27 @@ class TestCmdCeoResearchIdeation:
 
     def test_research_ideation_task_mode_is_build(self):
         """--mode research with idea sets Mode: build (not research) since it enters ideation first."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", "swe-bench solver agent", "--mode", "research"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "Mode: build" in task
 
     def test_research_ideation_no_interactive_block(self):
         """--mode research should NOT inject Interactive Ideation block."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", "swe-bench solver agent", "--mode", "research"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Interactive Ideation Mode" not in task
 
     def test_research_ideation_mentions_research_config(self):
         """--mode research ideation task mentions research config fields."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", "swe-bench solver agent", "--mode", "research"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "Research Target" in task
@@ -368,10 +370,9 @@ class TestCmdCeoResearchIdeation:
               "target": 0.9, "run_command": "python run.py",
               "result_path": "results.json"}
         (factory_dir / "config.json").write_text(json.dumps(_make_config(research_target=rt)))
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "research"])
-        cmd = mock_exec.call_args[0][1]
+        cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Research Ideation Mode" not in task
@@ -1005,33 +1006,29 @@ class TestCmdCeo:
         call_kwargs = mock_agent.call_args[1]
         assert call_kwargs["timeout"] == 7200.0
 
-    def test_ceo_foreground_uses_execvp(self, tmp_path):
-        """cmd_ceo (default) launches claude interactively via os.execvp."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+    def test_ceo_foreground_uses_subprocess_run(self, tmp_path):
+        """cmd_ceo (default) launches claude interactively via subprocess.run."""
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path)])
-        mock_exec.assert_called_once()
-        cmd = mock_exec.call_args[0][1]
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
         assert cmd[0] == "claude"
         assert "--append-system-prompt" in cmd
         assert "--dangerously-skip-permissions" in cmd
 
     def test_ceo_foreground_passes_task_as_prompt(self, tmp_path):
         """Foreground mode passes the task as the initial user message."""
-        with patch("factory.cli.os.execvp") as mock_exec, \
-             patch("factory.cli.os.chdir"):
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path)])
-        cmd = mock_exec.call_args[0][1]
-        # Last arg (before flags) should be the task string
-        # The task contains the project path
+        cmd = mock_run.call_args[0][0]
         assert any(str(tmp_path) in arg for arg in cmd)
 
-    def test_ceo_foreground_chdir_to_project(self, tmp_path):
-        """Foreground mode changes cwd to the project directory."""
-        with patch("factory.cli.os.execvp"), \
-             patch("factory.cli.os.chdir") as mock_chdir:
+    def test_ceo_foreground_cwd_is_project(self, tmp_path):
+        """Foreground mode passes cwd to subprocess.run."""
+        with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path)])
-        mock_chdir.assert_called_once_with(tmp_path)
+        call_kwargs = mock_run.call_args[1]
+        assert call_kwargs["cwd"] == tmp_path
 
     def test_ceo_parser_has_headless_flag(self):
         """Parser accepts --headless flag."""

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -110,18 +110,19 @@ class TestClaudeRunner:
                 assert cmd[asp_idx + 1] == "You are the CEO."
                 assert cmd[p_idx + 1] == "Run the experiment"
 
-    async def test_interactive_exec_uses_append_system_prompt(self, tmp_path: Path) -> None:
-        """interactive_exec() uses --append-system-prompt (not --system-prompt)."""
+    async def test_interactive_run_uses_append_system_prompt(self, tmp_path: Path) -> None:
+        """interactive_run() uses --append-system-prompt (not --system-prompt)."""
         runner = ClaudeRunner()
 
-        with patch("os.chdir"), patch("os.execvp") as mock_execvp:
-            runner.interactive_exec(
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(
                 prompt="You are the CEO.",
                 task="Start session",
                 cwd=tmp_path,
             )
 
-            cmd = mock_execvp.call_args[0][1]
+            cmd = mock_run.call_args[0][0]
             assert "--append-system-prompt" in cmd
             assert "--system-prompt" not in cmd
 
@@ -135,24 +136,23 @@ class TestBobRunner:
         monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
         assert is_dry_run() is False
 
-    def test_interactive_exec_dry_run(
+    def test_interactive_run_dry_run(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """interactive_exec prints dry-run message and exits."""
+        """interactive_run prints dry-run message and returns 0."""
         monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
         (tmp_path / ".factory").mkdir()
 
         runner = BobRunner()
 
-        with pytest.raises(SystemExit) as exc_info:
-            runner.interactive_exec(
-                prompt="Test prompt",
-                task="Test task",
-                cwd=tmp_path,
-                role="ceo",
-            )
+        code = runner.interactive_run(
+            prompt="Test prompt",
+            task="Test task",
+            cwd=tmp_path,
+            role="ceo",
+        )
 
-        assert exc_info.value.code == 0
+        assert code == 0
         captured = capsys.readouterr()
         assert "[DRY-RUN]" in captured.out
 

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,0 +1,228 @@
+"""Tests for factory/worktree.py — git worktree lifecycle management."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from factory.worktree import create_worktree, prune_stale, remove_worktree
+
+pytestmark = pytest.mark.real_worktree
+
+
+@pytest.fixture
+def git_project(tmp_path: Path) -> Path:
+    """Create a minimal git project with .factory/ directory."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    env = {
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+        "HOME": str(tmp_path),
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+    }
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=project, capture_output=True, check=True)
+    (project / ".gitignore").write_text(".factory/\n")
+    (project / "README.md").write_text("hello")
+    subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=project, capture_output=True, check=True, env=env,
+    )
+
+    factory_dir = project / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "config.json").write_text("{}")
+    (factory_dir / "results.tsv").write_text("id\n")
+
+    return project
+
+
+class TestCreateWorktree:
+    def test_creates_worktree_dir(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+
+        assert wt_path.exists()
+        assert wt_path.is_dir()
+        assert branch.startswith("factory/run-")
+        assert wt_path.parent == git_project / ".factory" / "worktrees"
+
+    def test_worktree_has_factory_symlink(self, git_project: Path) -> None:
+        wt_path, _ = create_worktree(git_project)
+
+        symlink = wt_path / ".factory"
+        assert symlink.is_symlink()
+        assert symlink.resolve() == (git_project / ".factory").resolve()
+
+    def test_worktree_contains_project_files(self, git_project: Path) -> None:
+        wt_path, _ = create_worktree(git_project)
+
+        assert (wt_path / "README.md").exists()
+        assert (wt_path / "README.md").read_text() == "hello"
+
+    def test_worktree_branch_is_checked_out(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=wt_path, capture_output=True, text=True,
+        )
+        assert result.stdout.strip() == branch
+
+    def test_worktree_uses_custom_base_branch(self, git_project: Path) -> None:
+        env = {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@test.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@test.com",
+            "HOME": str(git_project.parent),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+        subprocess.run(
+            ["git", "checkout", "-b", "develop"],
+            cwd=git_project, capture_output=True, check=True,
+        )
+        (git_project / "extra.txt").write_text("dev")
+        subprocess.run(["git", "add", "."], cwd=git_project, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "dev commit"],
+            cwd=git_project, capture_output=True, check=True, env=env,
+        )
+        subprocess.run(
+            ["git", "checkout", "main"],
+            cwd=git_project, capture_output=True, check=True,
+        )
+
+        wt_path, _ = create_worktree(git_project, base_branch="develop")
+        assert (wt_path / "extra.txt").exists()
+
+    def test_multiple_worktrees_coexist(self, git_project: Path) -> None:
+        wt1, br1 = create_worktree(git_project)
+        wt2, br2 = create_worktree(git_project)
+
+        assert wt1 != wt2
+        assert br1 != br2
+        assert wt1.exists()
+        assert wt2.exists()
+
+
+class TestRemoveWorktree:
+    def test_removes_worktree_completely(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+        assert wt_path.exists()
+
+        remove_worktree(git_project, wt_path, branch)
+
+        assert not wt_path.exists()
+
+        result = subprocess.run(
+            ["git", "branch", "--list", branch],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert branch not in result.stdout
+
+    def test_safe_on_already_removed_path(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+        remove_worktree(git_project, wt_path, branch)
+        remove_worktree(git_project, wt_path, branch)
+
+    def test_removes_from_worktree_list(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+        remove_worktree(git_project, wt_path, branch)
+
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert str(wt_path) not in result.stdout
+
+
+class TestPruneStale:
+    def test_no_op_without_factory_dir(self, tmp_path: Path) -> None:
+        project = tmp_path / "no-factory"
+        project.mkdir()
+        subprocess.run(["git", "init"], cwd=project, capture_output=True, check=True)
+
+        pruned = prune_stale(project)
+        assert pruned == []
+
+    def test_cleans_orphaned_directory(self, git_project: Path) -> None:
+        wt_dir = git_project / ".factory" / "worktrees"
+        wt_dir.mkdir(parents=True, exist_ok=True)
+        orphan = wt_dir / "run-deadbeef"
+        orphan.mkdir()
+        (orphan / "some_file.txt").write_text("stale")
+
+        pruned = prune_stale(git_project)
+        assert len(pruned) >= 1
+        assert not orphan.exists()
+
+    def test_preserves_active_worktrees(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+
+        pruned = prune_stale(git_project)
+        assert wt_path.exists()
+        for msg in pruned:
+            assert wt_path.name not in msg
+
+    def test_crash_recovery_cleans_all_artifacts(self, git_project: Path) -> None:
+        """Simulate a crash: create worktree, delete dir manually, then prune."""
+        wt_path, branch = create_worktree(git_project)
+        import shutil
+        shutil.rmtree(wt_path)
+
+        pruned = prune_stale(git_project)
+        assert len(pruned) >= 1
+
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert str(wt_path) not in result.stdout
+
+
+class TestSymlinkResolution:
+    def test_store_resolves_through_symlink(self, git_project: Path) -> None:
+        """ExperimentStore via worktree symlink writes to main .factory/."""
+        from factory.store import ExperimentStore
+
+        wt_path, _ = create_worktree(git_project)
+        store = ExperimentStore(wt_path)
+
+        assert store.factory_dir.resolve() == (git_project / ".factory").resolve()
+
+    def test_config_readable_through_symlink(self, git_project: Path) -> None:
+        wt_path, _ = create_worktree(git_project)
+
+        config_via_symlink = (wt_path / ".factory" / "config.json").read_text()
+        config_direct = (git_project / ".factory" / "config.json").read_text()
+        assert config_via_symlink == config_direct
+
+
+class TestFilelockConcurrency:
+    async def test_filelock_prevents_concurrent_begin(self, git_project: Path) -> None:
+        """Two stores targeting the same .factory/ get sequential IDs."""
+        import asyncio
+
+        from factory.store import ExperimentStore
+
+        (git_project / ".factory" / "experiments").mkdir(exist_ok=True)
+        (git_project / ".factory" / "results.tsv").write_text(
+            "id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+            "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\tresearch_citations\n"
+        )
+
+        store_a = ExperimentStore(git_project)
+        store_b = ExperimentStore(git_project)
+
+        id_a, id_b = await asyncio.gather(
+            store_a.begin("hypothesis A"),
+            store_b.begin("hypothesis B"),
+        )
+
+        assert id_a != id_b
+        assert {id_a, id_b} == {1, 2}

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -204,9 +204,10 @@ class TestSymlinkResolution:
 
 
 class TestFilelockConcurrency:
-    async def test_filelock_prevents_concurrent_begin(self, git_project: Path) -> None:
-        """Two stores targeting the same .factory/ get sequential IDs."""
+    def test_filelock_prevents_concurrent_begin(self, git_project: Path) -> None:
+        """Two stores targeting the same .factory/ get sequential IDs under real thread contention."""
         import asyncio
+        from concurrent.futures import ThreadPoolExecutor
 
         from factory.store import ExperimentStore
 
@@ -216,13 +217,19 @@ class TestFilelockConcurrency:
             "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\tresearch_citations\n"
         )
 
-        store_a = ExperimentStore(git_project)
-        store_b = ExperimentStore(git_project)
+        def begin_in_thread(hypothesis: str) -> int:
+            loop = asyncio.new_event_loop()
+            try:
+                store = ExperimentStore(git_project)
+                return loop.run_until_complete(store.begin(hypothesis))
+            finally:
+                loop.close()
 
-        id_a, id_b = await asyncio.gather(
-            store_a.begin("hypothesis A"),
-            store_b.begin("hypothesis B"),
-        )
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            fut_a = pool.submit(begin_in_thread, "hypothesis A")
+            fut_b = pool.submit(begin_in_thread, "hypothesis B")
+            id_a = fut_a.result()
+            id_b = fut_b.result()
 
         assert id_a != id_b
         assert {id_a, id_b} == {1, 2}

--- a/uv.lock
+++ b/uv.lock
@@ -434,6 +434,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1297,11 +1306,17 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "filelock" },
     { name = "mcp" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "structlog" },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+migrate = [
+    { name = "tomli-w" },
 ]
 
 [package.dev-dependencies]
@@ -1321,12 +1336,15 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "filelock", specifier = ">=3.0" },
     { name = "mcp", specifier = ">=1.27.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0" },
+    { name = "tomli-w", marker = "extra == 'migrate'", specifier = ">=1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
+provides-extras = ["migrate"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1584,6 +1602,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `factory/worktree.py` with `create_worktree`, `remove_worktree`, and `prune_stale` functions for worktree-per-experiment isolation
- Add `filelock` dependency and wrap `ExperimentStore.begin()` / `finalize()` for safe concurrent access
- Integrate worktree lifecycle into CLI: `cmd_ceo` and `_run_single_cycle` create/remove worktrees around CEO subprocess, `prune_stale` runs at startup for crash recovery
- Update CEO prompt to remove `git checkout -b` branch creation (worktree IS the branch) and `git checkout main` revert (worktree removal handles cleanup)
- Update Builder prompt with worktree awareness — no branch creation needed

## Test plan

- [x] 16 new tests in `tests/test_worktree.py` covering create, remove, prune, symlink resolution, and filelock concurrency
- [x] All 1662 existing tests pass (no regressions)
- [x] `ruff check` clean
- [x] `mypy factory/` clean

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)