### PR TITLE
feat: research mode dashboard view (Issue #264)

### DIFF
--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -34,6 +34,7 @@ _STATIC_DIR = Path(__file__).parent / "static"
 _VERDICT_RE = re.compile(r"\*\*Verdict:\*\*\s*(PROCEED|REDIRECT|ABORT)")
 _RATIONALE_RE = re.compile(r"\*\*Rationale:\*\*\s*(.+?)(?:\n|$)")
 _ISSUES_RE = re.compile(r"\*\*Issues found:\*\*\s*(.+?)(?:\n\*\*|\Z)", re.DOTALL)
+_FAILURE_CAT_RE = re.compile(r"^\s*[-*]\s*\**([^:*]+?)\**\s*:\s*(\d+)")
 
 
 def _read_text_safe(path: Path) -> str | None:
@@ -94,6 +95,86 @@ def _parse_diff_stats(diff_text: str) -> dict[str, int]:
         elif line.startswith("-") and not line.startswith("---"):
             deletions += 1
     return {"files_changed": files, "insertions": insertions, "deletions": deletions}
+
+
+def _parse_failure_categories(text: str) -> dict[str, int]:
+    """Parse failure categories and counts from failure_analysis.md content."""
+    categories: dict[str, int] = {}
+    for line in text.splitlines():
+        m = _FAILURE_CAT_RE.match(line)
+        if m:
+            cat = m.group(1).strip()
+            count = int(m.group(2))
+            categories[cat] = categories.get(cat, 0) + count
+    return categories
+
+
+def _load_research_runs(factory_dir: Path) -> dict[str, Any]:
+    """Load research run data from .factory/research/runs/ directory."""
+    empty: dict[str, Any] = {
+        "cycles": [],
+        "failure_distribution": {},
+        "ratchet": {"labels": [], "scores": [], "best": []},
+    }
+    runs_dir = factory_dir / "research" / "runs"
+    if not runs_dir.exists():
+        return empty
+
+    cycles: list[dict[str, Any]] = []
+    all_failures: dict[str, int] = {}
+
+    run_dirs = sorted(
+        (d for d in runs_dir.iterdir() if d.is_dir()),
+        key=lambda d: d.name,
+    )
+
+    prev_score: float | None = None
+    for run_dir in run_dirs:
+        summary = _read_json_safe(run_dir / "summary.json")
+        if summary is None:
+            continue
+
+        metric_value = summary.get("metric_value")
+        delta: float | None = None
+        if metric_value is not None and prev_score is not None:
+            delta = round(metric_value - prev_score, 4)
+        prev_score = metric_value
+
+        failure_cats: dict[str, int] = {}
+        failure_md = _read_text_safe(run_dir / "failure_analysis.md")
+        if failure_md:
+            failure_cats = _parse_failure_categories(failure_md)
+            for cat, count in failure_cats.items():
+                all_failures[cat] = all_failures.get(cat, 0) + count
+
+        dominant_failure: str | None = None
+        if failure_cats:
+            dominant_failure = max(failure_cats, key=failure_cats.get)  # type: ignore[arg-type]
+
+        cycles.append({
+            "name": run_dir.name,
+            "metric_value": metric_value,
+            "status": summary.get("status"),
+            "duration": summary.get("duration"),
+            "delta": delta,
+            "dominant_failure": dominant_failure,
+        })
+
+    labels = [c["name"] for c in cycles]
+    scores = [c["metric_value"] for c in cycles]
+    best: list[float | None] = []
+    current_best: float | None = None
+    for s in scores:
+        if s is not None:
+            if current_best is None or s > current_best:
+                current_best = s
+        best.append(current_best)
+
+    return {
+        "cycles": cycles,
+        "failure_distribution": all_failures,
+        "ratchet": {"labels": labels, "scores": scores, "best": best},
+    }
 
 
 def _resolve_experiment_id(
@@ -529,6 +610,26 @@ def create_app(projects_dir: Path) -> FastAPI:
         return JSONResponse(
             {"phase": phase, "status": status, "data": data, "verdict": verdict}
         )
+
+    @app.get("/api/projects/{name}/research-runs")
+    async def project_research_runs(name: str) -> dict[str, Any]:
+        _validate_path_segment(name)
+        log.info(
+            "dashboard_request",
+            endpoint="/api/projects/{name}/research-runs",
+            project=name,
+        )
+        path = projects_dir / name
+        factory_dir = path / ".factory"
+        return _load_research_runs(factory_dir)
+
+    @app.get("/research/{name}", response_class=HTMLResponse)
+    async def research_view(name: str) -> HTMLResponse:
+        _validate_path_segment(name)
+        log.info(
+            "dashboard_request", endpoint="/research/{name}", project=name
+        )
+        return HTMLResponse((_STATIC_DIR / "research.html").read_text())
 
     @app.get("/api/events/stream")
     async def event_stream(request: Request) -> StreamingResponse:

--- a/factory/dashboard/static/research.html
+++ b/factory/dashboard/static/research.html
@@ -68,7 +68,7 @@ code{background:var(--border);padding:2px 6px;border-radius:4px;font-size:12px}
     </div>
   </div>
 </main>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
 <script>
 var projectName = decodeURIComponent(
   window.location.pathname.split('/').filter(Boolean).pop() || ''
@@ -105,7 +105,9 @@ function renderTable(cycles) {
     var tr = document.createElement('tr');
     var delta = c.delta != null ? (c.delta >= 0 ? '+' : '') + c.delta.toFixed(4) : '—';
     var deltaClass = c.delta != null ? (c.delta >= 0 ? 'delta-pos' : 'delta-neg') : '';
-    var statusClass = 'status-' + (c.status || 'unknown');
+    var allowedStatuses = ['completed', 'failed', 'running', 'unknown'];
+    var statusSuffix = allowedStatuses.indexOf(c.status) !== -1 ? c.status : 'unknown';
+    var statusClass = 'status-' + statusSuffix;
     var score = c.metric_value != null ? c.metric_value.toFixed(4) : '—';
     var dur = c.duration != null ? Math.round(c.duration) : '—';
     var failHtml = c.dominant_failure

--- a/factory/dashboard/static/research.html
+++ b/factory/dashboard/static/research.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Research — Factory Dashboard</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0d1117;--surface:#161b22;--border:#30363d;
+  --text:#e6edf3;--text-dim:#7d8590;--accent:#58a6ff;
+  --green:#3fb950;--red:#f85149;--yellow:#d29922;
+}
+body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;font-size:14px;line-height:1.5}
+header{display:flex;align-items:center;justify-content:space-between;padding:12px 24px;border-bottom:1px solid var(--border);background:var(--surface)}
+.logo{font-weight:700;font-size:16px;letter-spacing:2px;color:var(--accent)}
+.header-info{display:flex;align-items:center;gap:16px}
+.back-link{color:var(--accent);text-decoration:none;font-size:13px}
+.back-link:hover{text-decoration:underline}
+main{max-width:1200px;margin:24px auto;padding:0 24px;display:flex;flex-direction:column;gap:20px}
+.panel{background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:20px}
+.panel h2{font-size:15px;font-weight:600;margin-bottom:12px;color:var(--text)}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th,td{padding:8px 12px;text-align:left;border-bottom:1px solid var(--border)}
+th{color:var(--text-dim);font-weight:500;font-size:12px;text-transform:uppercase;letter-spacing:0.5px}
+.delta-pos{color:var(--green)}.delta-neg{color:var(--red)}
+.status-completed{color:var(--green)}.status-failed{color:var(--red)}.status-running{color:var(--yellow)}
+.badge{display:inline-block;padding:2px 8px;border-radius:12px;font-size:11px;font-weight:500;background:var(--border);color:var(--text-dim)}
+.no-data{text-align:center;padding:40px;color:var(--text-dim)}
+.no-data h2{color:var(--text);margin-bottom:8px}
+.chart-container{position:relative;height:300px}
+code{background:var(--border);padding:2px 6px;border-radius:4px;font-size:12px}
+</style>
+</head>
+<body>
+<header>
+  <div class="logo">FACTORY</div>
+  <div class="header-info">
+    <span id="project-name" style="font-weight:600"></span>
+    <a href="/" class="back-link">&larr; Dashboard</a>
+  </div>
+</header>
+<main>
+  <div class="panel no-data" id="no-data" style="display:none">
+    <h2>No Research Data</h2>
+    <p>No research runs found for this project. Run <code>factory ceo /path --mode research</code> to start.</p>
+  </div>
+  <div id="content" style="display:none">
+    <div class="panel">
+      <h2>Per-Cycle Metrics</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Cycle</th><th>Score</th><th>&Delta;</th>
+            <th>Status</th><th>Duration (s)</th><th>Dominant Failure</th>
+          </tr>
+        </thead>
+        <tbody id="cycle-tbody"></tbody>
+      </table>
+    </div>
+    <div class="panel">
+      <h2>Failure Distribution</h2>
+      <div class="chart-container"><canvas id="failure-chart"></canvas></div>
+    </div>
+    <div class="panel">
+      <h2>Ratchet Progress</h2>
+      <div class="chart-container"><canvas id="ratchet-chart"></canvas></div>
+    </div>
+  </div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+var projectName = decodeURIComponent(
+  window.location.pathname.split('/').filter(Boolean).pop() || ''
+);
+document.getElementById('project-name').textContent = 'Research — ' + projectName;
+document.title = 'Research — ' + projectName;
+
+function escapeHtml(s) {
+  var d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+async function loadData() {
+  try {
+    var resp = await fetch('/api/projects/' + encodeURIComponent(projectName) + '/research-runs');
+    if (!resp.ok) { document.getElementById('no-data').style.display = ''; return; }
+    var data = await resp.json();
+  } catch (e) { document.getElementById('no-data').style.display = ''; return; }
+
+  if (!data.cycles || data.cycles.length === 0) {
+    document.getElementById('no-data').style.display = '';
+    return;
+  }
+  document.getElementById('content').style.display = '';
+  renderTable(data.cycles);
+  renderFailureChart(data.failure_distribution);
+  renderRatchetChart(data.ratchet);
+}
+
+function renderTable(cycles) {
+  var tbody = document.getElementById('cycle-tbody');
+  cycles.forEach(function(c) {
+    var tr = document.createElement('tr');
+    var delta = c.delta != null ? (c.delta >= 0 ? '+' : '') + c.delta.toFixed(4) : '—';
+    var deltaClass = c.delta != null ? (c.delta >= 0 ? 'delta-pos' : 'delta-neg') : '';
+    var statusClass = 'status-' + (c.status || 'unknown');
+    var score = c.metric_value != null ? c.metric_value.toFixed(4) : '—';
+    var dur = c.duration != null ? Math.round(c.duration) : '—';
+    var failHtml = c.dominant_failure
+      ? '<span class="badge">' + escapeHtml(c.dominant_failure) + '</span>'
+      : '—';
+    tr.innerHTML =
+      '<td>' + escapeHtml(c.name) + '</td>' +
+      '<td>' + score + '</td>' +
+      '<td class="' + deltaClass + '">' + delta + '</td>' +
+      '<td class="' + statusClass + '">' + escapeHtml(c.status || '—') + '</td>' +
+      '<td>' + dur + '</td>' +
+      '<td>' + failHtml + '</td>';
+    tbody.appendChild(tr);
+  });
+}
+
+function renderFailureChart(distribution) {
+  var categories = Object.keys(distribution);
+  var counts = Object.values(distribution);
+  if (categories.length === 0) return;
+  var ctx = document.getElementById('failure-chart').getContext('2d');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: categories,
+      datasets: [{
+        label: 'Failures',
+        data: counts,
+        backgroundColor: '#f85149cc',
+        borderColor: '#f85149',
+        borderWidth: 1,
+        borderRadius: 4
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { ticks: { color: '#7d8590' }, grid: { color: '#30363d' } },
+        y: { beginAtZero: true, ticks: { color: '#7d8590', stepSize: 1 }, grid: { color: '#30363d' } }
+      }
+    }
+  });
+}
+
+function renderRatchetChart(ratchet) {
+  if (!ratchet.labels.length) return;
+  var ctx = document.getElementById('ratchet-chart').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: ratchet.labels,
+      datasets: [
+        {
+          label: 'Score',
+          data: ratchet.scores,
+          borderColor: '#58a6ff',
+          backgroundColor: '#58a6ff33',
+          fill: false,
+          tension: 0.1,
+          pointRadius: 4,
+          pointBackgroundColor: '#58a6ff'
+        },
+        {
+          label: 'Best (Ratchet)',
+          data: ratchet.best,
+          borderColor: '#3fb950',
+          backgroundColor: '#3fb95033',
+          fill: true,
+          borderDash: [5, 3],
+          tension: 0,
+          pointRadius: 0
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { labels: { color: '#e6edf3' } } },
+      scales: {
+        x: { ticks: { color: '#7d8590' }, grid: { color: '#30363d' } },
+        y: { ticks: { color: '#7d8590' }, grid: { color: '#30363d' }, beginAtZero: true }
+      }
+    }
+  });
+}
+
+loadData();
+</script>
+</body>
+</html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -14,7 +14,9 @@ from factory.dashboard.app import (
     create_app,
     _load_experiment_dimensions,
     _load_latest_dimensions,
+    _load_research_runs,
     _parse_diff_stats,
+    _parse_failure_categories,
     _parse_single_verdict,
     _project_summary,
     _load_tsv,
@@ -776,3 +778,184 @@ class TestModeAwarePhaseDetail:
         """Generic phase names (backward compat) should not return 400."""
         resp = phase_client.get("/api/projects/proj-phase/phase-detail/Research")
         assert resp.status_code == 200
+
+
+# ── Research Dashboard Tests ──
+
+
+@pytest.fixture()
+def research_projects_dir(tmp_path: Path) -> Path:
+    """Create a project with .factory/research/runs/ data for research view tests."""
+    proj = tmp_path / "proj-research"
+    runs_dir = proj / ".factory" / "research" / "runs"
+
+    # Baseline cycle
+    baseline = runs_dir / "000-baseline"
+    baseline.mkdir(parents=True)
+    (baseline / "summary.json").write_text(json.dumps({
+        "metric_value": 0.45,
+        "status": "completed",
+        "duration": 120,
+    }))
+
+    # Cycle 1 — score improves
+    cycle_1 = runs_dir / "cycle-001"
+    cycle_1.mkdir()
+    (cycle_1 / "summary.json").write_text(json.dumps({
+        "metric_value": 0.52,
+        "status": "completed",
+        "duration": 95,
+    }))
+    (cycle_1 / "failure_analysis.md").write_text(
+        "- timeout: 3\n- assertion_error: 2\n"
+    )
+
+    # Cycle 2 — score dips
+    cycle_2 = runs_dir / "cycle-002"
+    cycle_2.mkdir()
+    (cycle_2 / "summary.json").write_text(json.dumps({
+        "metric_value": 0.48,
+        "status": "completed",
+        "duration": 110,
+    }))
+    (cycle_2 / "failure_analysis.md").write_text(
+        "- timeout: 1\n- connection_error: 4\n"
+    )
+
+    # Cycle 3 — score recovers to new high
+    cycle_3 = runs_dir / "cycle-003"
+    cycle_3.mkdir()
+    (cycle_3 / "summary.json").write_text(json.dumps({
+        "metric_value": 0.60,
+        "status": "completed",
+        "duration": 80,
+    }))
+
+    # Empty project (no research data)
+    empty_proj = tmp_path / "proj-empty"
+    (empty_proj / ".factory").mkdir(parents=True)
+
+    return tmp_path
+
+
+@pytest.fixture()
+def research_client(research_projects_dir: Path) -> TestClient:
+    app = create_app(research_projects_dir)
+    return TestClient(app)
+
+
+class TestParseFailureCategories:
+    def test_basic_parsing(self):
+        text = "- timeout: 3\n- assertion_error: 2\n"
+        cats = _parse_failure_categories(text)
+        assert cats == {"timeout": 3, "assertion_error": 2}
+
+    def test_bold_categories(self):
+        text = "- **timeout**: 5\n- **parse_error**: 1\n"
+        cats = _parse_failure_categories(text)
+        assert cats == {"timeout": 5, "parse_error": 1}
+
+    def test_asterisk_bullets(self):
+        text = "* timeout: 2\n* flaky: 1\n"
+        cats = _parse_failure_categories(text)
+        assert cats == {"timeout": 2, "flaky": 1}
+
+    def test_ignores_non_matching_lines(self):
+        text = "# Failure Analysis\n\nSome description.\n\n- timeout: 3\n"
+        cats = _parse_failure_categories(text)
+        assert cats == {"timeout": 3}
+
+    def test_empty_text(self):
+        assert _parse_failure_categories("") == {}
+
+
+class TestLoadResearchRuns:
+    def test_loads_all_cycles(self, research_projects_dir: Path):
+        factory_dir = research_projects_dir / "proj-research" / ".factory"
+        data = _load_research_runs(factory_dir)
+        assert len(data["cycles"]) == 4
+
+    def test_cycle_fields(self, research_projects_dir: Path):
+        factory_dir = research_projects_dir / "proj-research" / ".factory"
+        data = _load_research_runs(factory_dir)
+        baseline = data["cycles"][0]
+        assert baseline["name"] == "000-baseline"
+        assert baseline["metric_value"] == 0.45
+        assert baseline["status"] == "completed"
+        assert baseline["duration"] == 120
+        assert baseline["delta"] is None
+        assert baseline["dominant_failure"] is None
+
+    def test_delta_calculation(self, research_projects_dir: Path):
+        factory_dir = research_projects_dir / "proj-research" / ".factory"
+        data = _load_research_runs(factory_dir)
+        cycle_1 = data["cycles"][1]
+        assert cycle_1["delta"] == pytest.approx(0.07)
+        cycle_2 = data["cycles"][2]
+        assert cycle_2["delta"] == pytest.approx(-0.04)
+
+    def test_dominant_failure(self, research_projects_dir: Path):
+        factory_dir = research_projects_dir / "proj-research" / ".factory"
+        data = _load_research_runs(factory_dir)
+        assert data["cycles"][1]["dominant_failure"] == "timeout"
+        assert data["cycles"][2]["dominant_failure"] == "connection_error"
+        assert data["cycles"][3]["dominant_failure"] is None
+
+    def test_failure_distribution_aggregated(self, research_projects_dir: Path):
+        factory_dir = research_projects_dir / "proj-research" / ".factory"
+        data = _load_research_runs(factory_dir)
+        dist = data["failure_distribution"]
+        assert dist["timeout"] == 4
+        assert dist["assertion_error"] == 2
+        assert dist["connection_error"] == 4
+
+    def test_ratchet_monotonic(self, research_projects_dir: Path):
+        factory_dir = research_projects_dir / "proj-research" / ".factory"
+        data = _load_research_runs(factory_dir)
+        ratchet = data["ratchet"]
+        assert ratchet["labels"] == ["000-baseline", "cycle-001", "cycle-002", "cycle-003"]
+        assert ratchet["scores"] == [0.45, 0.52, 0.48, 0.60]
+        assert ratchet["best"] == [0.45, 0.52, 0.52, 0.60]
+        for i in range(1, len(ratchet["best"])):
+            assert ratchet["best"][i] >= ratchet["best"][i - 1]
+
+    def test_no_research_dir(self, research_projects_dir: Path):
+        factory_dir = research_projects_dir / "proj-empty" / ".factory"
+        data = _load_research_runs(factory_dir)
+        assert data["cycles"] == []
+        assert data["failure_distribution"] == {}
+        assert data["ratchet"] == {"labels": [], "scores": [], "best": []}
+
+    def test_skips_dirs_without_summary(self, tmp_path: Path):
+        runs_dir = tmp_path / ".factory" / "research" / "runs" / "no-summary"
+        runs_dir.mkdir(parents=True)
+        data = _load_research_runs(tmp_path / ".factory")
+        assert data["cycles"] == []
+
+
+class TestResearchDashboardAPI:
+    def test_research_runs_endpoint(self, research_client: TestClient):
+        resp = research_client.get("/api/projects/proj-research/research-runs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["cycles"]) == 4
+        assert "failure_distribution" in data
+        assert "ratchet" in data
+
+    def test_research_runs_no_data(self, research_client: TestClient):
+        resp = research_client.get("/api/projects/proj-empty/research-runs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cycles"] == []
+
+    def test_research_view_returns_html(self, research_client: TestClient):
+        resp = research_client.get("/research/proj-research")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert "failure-chart" in resp.text
+        assert "ratchet-chart" in resp.text
+        assert "Chart" in resp.text
+
+    def test_research_view_invalid_name(self, research_client: TestClient):
+        resp = research_client.get("/research/../etc")
+        assert resp.status_code in (400, 404, 422)


### PR DESCRIPTION
## Summary
- Add research mode dashboard page with per-cycle metrics table, failure distribution bar chart, and ratchet progress line chart
- New routes: `GET /api/projects/{name}/research-runs` (JSON API) and `GET /research/{name}` (HTML page)
- XSS protection via status allowlist for CSS class attributes
- SRI integrity hash on Chart.js CDN script
- 16 new tests covering parsing, data loading, API endpoints, and HTML rendering

Supersedes #263 (rebased after #259 was squash-merged).

Experiment 68 from Meta mode cycle.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>