### PR TITLE
Fix worktree creation: detect default branch instead of hardcoding 'main'

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -27,6 +27,22 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
+def _read_target_branch(project_path: Path) -> str:
+    """Read target branch from .factory/config.json, falling back to git detection."""
+    config_path = project_path / ".factory" / "config.json"
+    if config_path.exists():
+        try:
+            config = json.loads(config_path.read_text())
+            tb = config.get("target_branch")
+            if tb:
+                return tb
+        except (json.JSONDecodeError, OSError):
+            pass
+    from factory.worktree import detect_default_branch
+
+    return detect_default_branch(project_path)
+
+
 # ── banner ────────────────────────────────────────────────────
 
 
@@ -1528,7 +1544,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
 
-    base_branch = branch or "main"
+    base_branch = branch or _read_target_branch(project_path)
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
     if interactive_existing:
@@ -2275,7 +2291,7 @@ def _run_single_cycle(
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
 
-    base_branch = branch or "main"
+    base_branch = branch or _read_target_branch(project_path)
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
     try:

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -102,6 +102,55 @@ def prune_stale(project_path: Path) -> list[str]:
     return pruned
 
 
+def detect_default_branch(project_path: Path) -> str:
+    """Detect the default branch for a git repository.
+
+    Cascade: remote HEAD → probe main/master → current HEAD → fallback 'main'.
+    """
+    project_path = project_path.resolve()
+
+    # Try remote default branch
+    result = subprocess.run(
+        ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        ref = result.stdout.strip()
+        branch = ref.removeprefix("refs/remotes/origin/")
+        if branch and branch != ref:
+            log.debug("detect_default_branch", source="remote_head", branch=branch)
+            return branch
+
+    # Probe main then master
+    for candidate in ("main", "master"):
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", candidate],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            log.debug("detect_default_branch", source="probe", branch=candidate)
+            return candidate
+
+    # Current branch
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        branch = result.stdout.strip()
+        log.debug("detect_default_branch", source="current_head", branch=branch)
+        return branch
+
+    log.debug("detect_default_branch", source="fallback", branch="main")
+    return "main"
+
+
 def _list_active_worktrees(project_path: Path) -> set[str]:
     """Return set of absolute paths for all active worktrees."""
     result = subprocess.run(

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -144,8 +144,9 @@ def detect_default_branch(project_path: Path) -> str:
     )
     if result.returncode == 0 and result.stdout.strip():
         branch = result.stdout.strip()
-        log.debug("detect_default_branch", source="current_head", branch=branch)
-        return branch
+        if branch != "HEAD":
+            log.debug("detect_default_branch", source="current_head", branch=branch)
+            return branch
 
     log.debug("detect_default_branch", source="fallback", branch="main")
     return "main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ def _mock_foreground():
                side_effect=lambda p, b="main": (p, "factory/run-test")), \
          patch("factory.worktree.remove_worktree"), \
          patch("factory.worktree.prune_stale", return_value=[]), \
+         patch("factory.cli._read_target_branch", return_value="main"), \
          patch("factory.cli._ensure_dashboard"):
         yield mock_run
 
@@ -692,11 +693,11 @@ class TestRunWithGitHubUrl:
         url = "https://github.com/user/repo"
         with patch("factory.cli.subprocess.run") as mock_clone, \
              patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.cli.tempfile.mkdtemp", return_value="/tmp/factory-abc"):
+             patch("factory.cli.tempfile.mkdtemp", return_value="/tmp/factory-abc"), \
+             patch("factory.cli._read_target_branch", return_value="main"):
             result = main(["run", url])
 
         assert result == 0
-        # git clone should have been called
         mock_clone.assert_called_once_with(
             ["git", "clone", url, "/tmp/factory-abc"], check=True,
         )
@@ -708,7 +709,8 @@ class TestRunWithGitHubUrl:
         url = "git@github.com:user/repo.git"
         with patch("factory.cli.subprocess.run") as mock_clone, \
              patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.cli.tempfile.mkdtemp", return_value="/tmp/factory-xyz"):
+             patch("factory.cli.tempfile.mkdtemp", return_value="/tmp/factory-xyz"), \
+             patch("factory.cli._read_target_branch", return_value="main"):
             result = main(["run", url])
 
         assert result == 0
@@ -992,7 +994,8 @@ class TestCmdCeo:
         with patch("factory.cli.subprocess.run") as mock_clone, \
              patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
              patch("factory.cli._chain_modes", return_value=0), \
-             patch("factory.cli.tempfile.mkdtemp", return_value="/tmp/factory-ceo"):
+             patch("factory.cli.tempfile.mkdtemp", return_value="/tmp/factory-ceo"), \
+             patch("factory.cli._read_target_branch", return_value="main"):
             result = main(["ceo", url, "--headless"])
         assert result == 0
         mock_clone.assert_called_once_with(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from factory.worktree import create_worktree, prune_stale, remove_worktree
+from factory.worktree import create_worktree, detect_default_branch, prune_stale, remove_worktree
 
 pytestmark = pytest.mark.real_worktree
 
@@ -183,6 +183,86 @@ class TestPruneStale:
             cwd=git_project, capture_output=True, text=True,
         )
         assert str(wt_path) not in result.stdout
+
+
+@pytest.fixture
+def git_project_master(tmp_path: Path) -> Path:
+    """Create a minimal git project with 'master' as the default branch."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    env = {
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+        "HOME": str(tmp_path),
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+    }
+
+    subprocess.run(["git", "init", "-b", "master"], cwd=project, capture_output=True, check=True)
+    (project / ".gitignore").write_text(".factory/\n")
+    (project / "README.md").write_text("hello")
+    subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=project, capture_output=True, check=True, env=env,
+    )
+
+    factory_dir = project / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "config.json").write_text("{}")
+    (factory_dir / "results.tsv").write_text("id\n")
+
+    return project
+
+
+class TestDetectDefaultBranch:
+    def test_detects_main(self, git_project: Path) -> None:
+        assert detect_default_branch(git_project) == "main"
+
+    def test_detects_master(self, git_project_master: Path) -> None:
+        assert detect_default_branch(git_project_master) == "master"
+
+    def test_local_only_repo_no_origin(self, git_project: Path) -> None:
+        result = detect_default_branch(git_project)
+        assert result == "main"
+
+    def test_fallback_to_current_branch(self, tmp_path: Path) -> None:
+        """Repo with neither 'main' nor 'master' falls back to current HEAD."""
+        project = tmp_path / "project"
+        project.mkdir()
+
+        env = {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@test.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@test.com",
+            "HOME": str(tmp_path),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+
+        subprocess.run(
+            ["git", "init", "-b", "develop"],
+            cwd=project, capture_output=True, check=True,
+        )
+        (project / "README.md").write_text("hello")
+        subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=project, capture_output=True, check=True, env=env,
+        )
+
+        assert detect_default_branch(project) == "develop"
+
+
+class TestCreateWorktreeWithMaster:
+    def test_create_worktree_on_master_repo(self, git_project_master: Path) -> None:
+        wt_path, branch = create_worktree(git_project_master, base_branch="master")
+
+        assert wt_path.exists()
+        assert branch.startswith("factory/run-")
+        assert (wt_path / "README.md").exists()
 
 
 class TestSymlinkResolution:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -259,10 +259,12 @@ class TestDetectDefaultBranch:
 class TestCreateWorktreeWithMaster:
     def test_create_worktree_on_master_repo(self, git_project_master: Path) -> None:
         wt_path, branch = create_worktree(git_project_master, base_branch="master")
-
-        assert wt_path.exists()
-        assert branch.startswith("factory/run-")
-        assert (wt_path / "README.md").exists()
+        try:
+            assert wt_path.exists()
+            assert branch.startswith("factory/run-")
+            assert (wt_path / "README.md").exists()
+        finally:
+            remove_worktree(git_project_master, wt_path, branch)
 
 
 class TestSymlinkResolution:


### PR DESCRIPTION
Closes #270

## Changes

- Added `detect_default_branch(project_path)` to `factory/worktree.py` — resolves the base branch via cascade: remote HEAD → probe main/master → current HEAD → fallback "main"
- Added `_read_target_branch(project_path)` to `factory/cli.py` — reads `target_branch` from `.factory/config.json` if present, falls back to `detect_default_branch()`
- Updated both hardcoded `branch or "main"` sites in `cmd_ceo` (line ~1531) and `_run_single_cycle` (line ~2278) to use `_read_target_branch()`
- Added tests for `detect_default_branch` (main, master, develop fallback, local-only repo) and `create_worktree` with master base branch
- Fixed existing CLI tests that mock `subprocess.run` to also mock `_read_target_branch`