### PR TITLE
Fix interactive mode on existing projects — banner, CEO mode, Phase 0e research

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -424,8 +424,8 @@ Before talking to the user, gather context:
 
 If the discussion topic (from `--focus` or the user's initial question) requires **domain knowledge beyond the local codebase** — e.g., external APIs, industry standards, competitor analysis, library best practices — spawn the Researcher for targeted web research before presenting findings:
 
-```
-factory agent researcher --task "Research <topic>: gather current best practices, API docs, or prior art relevant to <focus>. Summarize findings in 2-3 paragraphs." --project "$PROJECT_PATH"
+```bash
+factory agent researcher --task "Research <topic>: gather current best practices, API docs, or prior art relevant to <focus>. Write findings to .factory/strategy/research.md. Summarize findings in 2-3 paragraphs." --project "$PROJECT_PATH" --timeout 300
 ```
 
 **Skip this step** if the topic is purely about the project's own code, backlog, or eval scores — E0 already covers those.

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -420,6 +420,16 @@ Before talking to the user, gather context:
 4. **Check open issues**: `gh issue list --state open --json number,title,labels` (if GitHub is available)
 5. **Read the backlog**: What items are pending? What was deferred from Build mode?
 
+### E0b: Optional Web Research
+
+If the discussion topic (from `--focus` or the user's initial question) requires **domain knowledge beyond the local codebase** — e.g., external APIs, industry standards, competitor analysis, library best practices — spawn the Researcher for targeted web research before presenting findings:
+
+```
+factory agent researcher --task "Research <topic>: gather current best practices, API docs, or prior art relevant to <focus>. Summarize findings in 2-3 paragraphs." --project "$PROJECT_PATH"
+```
+
+**Skip this step** if the topic is purely about the project's own code, backlog, or eval scores — E0 already covers those.
+
 ### E1: Present Findings
 
 Present a concise summary to the user:
@@ -453,7 +463,7 @@ When the user approves a direction:
 
 - **Maximum 5 iterations** of back-and-forth before asking the user to commit to a direction
 - **Do not start building during Phase 0e** — this phase produces a plan, not code
-- **You already have project context** — don't spawn a Researcher just to re-read what you already studied in E0
+- **You already have project context** — don't spawn a Researcher to re-read local code you already studied in E0, but DO use E0b to research external topics when the discussion requires domain knowledge beyond the codebase
 - **Be opinionated** — the user wants your recommendation, not a menu of every possible option
 
 ---

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1506,7 +1506,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         return 1
 
     if interactive_existing:
-        banner_mode = "improve"
+        banner_mode = "interactive"
     elif mode in ("interactive", "research") and (interactive_idea or research_ideation):
         banner_mode = "ideation"
     else:
@@ -1532,7 +1532,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
     if interactive_existing:
-        ceo_mode = "improve"
+        ceo_mode = "interactive"
     elif mode == "interactive" or research_ideation:
         ceo_mode = "build"
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,14 +205,14 @@ class TestCmdCeoInteractive:
         task = cmd[dsp_idx + 1]
         assert "distributed eval runner" in task
 
-    def test_interactive_existing_mode_is_improve(self, tmp_path):
-        """--mode interactive on existing dir sets Mode: improve in the CEO task."""
+    def test_interactive_existing_mode_is_interactive(self, tmp_path):
+        """--mode interactive on existing dir sets Mode: interactive in the CEO task."""
         with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "interactive"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "Mode: improve" in task
+        assert "Mode: interactive" in task
 
     def test_interactive_new_idea_mode_is_build(self):
         """--mode interactive with new idea sets Mode: build in the CEO task."""
@@ -1342,9 +1342,9 @@ class TestBuildCeoTaskInteractive:
         task = _build_ceo_task(tmp_path, "improve", interactive_existing=True)
         assert "## Interactive Ideation Mode" not in task
 
-    def test_existing_mode_is_improve(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "improve", interactive_existing=True)
-        assert "Mode: improve" in task
+    def test_existing_mode_is_interactive(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "interactive", interactive_existing=True)
+        assert "Mode: interactive" in task
 
 
 class TestCmdHomeReturnsFactoryDir:


### PR DESCRIPTION
Closes #273

## Changes

- **`factory/cli.py:1509`** — Changed `banner_mode = "improve"` to `banner_mode = "interactive"` so the startup banner correctly shows "interactive" mode when running `--mode interactive` on existing projects
- **`factory/cli.py:1535`** — Changed `ceo_mode = "improve"` to `ceo_mode = "interactive"` so the CEO receives the correct mode string and event/log metadata reflects interactive mode
- **`factory/agents/prompts/ceo.md` Phase 0e** — Added an optional E0b step (between E0 and E1) that spawns the Researcher for external web research when the discussion topic requires domain knowledge beyond local code
- **`factory/agents/prompts/ceo.md` Phase 0e Rules** — Softened the "don't spawn a Researcher" rule to permit targeted research for external topics while still discouraging redundant local code re-reading
- **`tests/test_cli.py`** — Updated two tests to assert the corrected `"interactive"` mode instead of the buggy `"improve"`