### PR TITLE
Fix committed .factory symlink and add defensive mkdir helper

### DIFF
--- a/.factory
+++ b/.factory
@@ -1,1 +1,0 @@
-/Users/akash/cursor-projects/remote-factory/.factory

--- a/factory/checkpoint.py
+++ b/factory/checkpoint.py
@@ -30,8 +30,9 @@ class CheckpointState(BaseModel):
 
 def save_checkpoint(project_path: Path, state: CheckpointState) -> None:
     """Serialize checkpoint state to .factory/checkpoint.json."""
+    from factory.store import ensure_factory_dir
     factory_dir = project_path / ".factory"
-    factory_dir.mkdir(parents=True, exist_ok=True)
+    ensure_factory_dir(factory_dir)
     checkpoint_path = factory_dir / _CHECKPOINT_FILE
     checkpoint_path.write_text(state.model_dump_json(indent=2))
     log.info("checkpoint.saved", path=str(checkpoint_path))

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -116,7 +116,7 @@ def cmd_discover(args: argparse.Namespace) -> int:
     from factory.discovery.generate import write_eval_script
     from factory.discovery.introspect import introspect_project
     from factory.discovery.profile import build_eval_profile
-    from factory.store import ExperimentStore
+    from factory.store import ExperimentStore, ensure_factory_dir
 
     project_path = Path(args.path)
     _emit_cli_event(project_path, "discover.started", {"path": str(project_path)})
@@ -126,7 +126,7 @@ def cmd_discover(args: argparse.Namespace) -> int:
 
     # Persist artifacts so detect_state can find them
     store = ExperimentStore(project_path)
-    store.factory_dir.mkdir(exist_ok=True)
+    ensure_factory_dir(store.factory_dir)
     _run(store.save_eval_profile(eval_profile))
     write_eval_script(eval_profile, project_path)
 
@@ -161,7 +161,7 @@ def cmd_discover(args: argparse.Namespace) -> int:
 
 
 def cmd_init(args: argparse.Namespace) -> int:
-    from factory.store import ExperimentStore
+    from factory.store import ExperimentStore, ensure_factory_dir
 
     project_path = Path(args.path)
     store = ExperimentStore(project_path)
@@ -172,7 +172,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         return 1
 
     # Ensure .factory/ dir exists so reparse_config can write config.json
-    store.factory_dir.mkdir(exist_ok=True)
+    ensure_factory_dir(store.factory_dir)
     config = _run(store.reparse_config())
 
     if args.reparse:

--- a/factory/events.py
+++ b/factory/events.py
@@ -29,8 +29,9 @@ def emit_event(
         "data": data or {},
     }
 
+    from factory.store import ensure_factory_dir
     events_dir = project_path / ".factory"
-    events_dir.mkdir(parents=True, exist_ok=True)
+    ensure_factory_dir(events_dir)
     events_file = events_dir / "events.jsonl"
 
     with open(events_file, "a") as f:

--- a/factory/store.py
+++ b/factory/store.py
@@ -27,6 +27,14 @@ from factory.models import (
 log = structlog.get_logger()
 
 
+def ensure_factory_dir(path: Path) -> None:
+    """Create a .factory directory, removing a broken symlink first if present."""
+    if path.is_symlink() and not path.exists():
+        log.warning("ensure_factory_dir_removing_broken_symlink", path=str(path))
+        path.unlink()
+    path.mkdir(parents=True, exist_ok=True)
+
+
 TSV_COLUMNS = [
     "id", "timestamp", "hypothesis", "change_summary", "issue_number",
     "pr_number", "score_before", "score_after", "delta", "verdict",
@@ -161,7 +169,7 @@ class ExperimentStore:
     async def init(self, config: FactoryConfig) -> None:
         """Create .factory/ structure with config.json, results.tsv, experiments/, strategy/."""
         log.info("store_init", project=str(self.project_path), goal=config.goal)
-        self.factory_dir.mkdir(exist_ok=True)
+        ensure_factory_dir(self.factory_dir)
         (self.factory_dir / "experiments").mkdir(exist_ok=True)
         (self.factory_dir / "strategy").mkdir(exist_ok=True)
         (self.factory_dir / "agents").mkdir(exist_ok=True)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -11,7 +11,7 @@ from factory.models import (
     EvalProfile,
     ExperimentRecord,
 )
-from factory.store import ExperimentStore
+from factory.store import ExperimentStore, ensure_factory_dir
 
 
 @pytest.fixture
@@ -392,3 +392,44 @@ class TestReparseResearchTarget:
         store.factory_dir.mkdir(exist_ok=True)
         config = await store.reparse_config()
         assert config.research_target is None
+
+
+class TestEnsureFactoryDir:
+    """Regression tests for broken symlink handling (issue #276)."""
+
+    def test_creates_directory(self, tmp_path):
+        target = tmp_path / ".factory"
+        ensure_factory_dir(target)
+        assert target.is_dir()
+
+    def test_existing_directory_is_noop(self, tmp_path):
+        target = tmp_path / ".factory"
+        target.mkdir()
+        (target / "config.json").write_text("{}")
+        ensure_factory_dir(target)
+        assert target.is_dir()
+        assert (target / "config.json").read_text() == "{}"
+
+    def test_broken_symlink_replaced_with_directory(self, tmp_path):
+        target = tmp_path / ".factory"
+        target.symlink_to("/nonexistent/path/that/does/not/exist")
+        assert target.is_symlink()
+        assert not target.exists()
+        ensure_factory_dir(target)
+        assert target.is_dir()
+        assert not target.is_symlink()
+
+    async def test_store_init_with_broken_symlink(self, tmp_path, sample_config):
+        """ExperimentStore.init handles a broken symlink at .factory/ gracefully."""
+        project = tmp_path / "project"
+        project.mkdir()
+        broken_link = project / ".factory"
+        broken_link.symlink_to("/nonexistent/absolute/path")
+        assert broken_link.is_symlink()
+        assert not broken_link.exists()
+
+        store = ExperimentStore(project)
+        await store.init(sample_config)
+        assert store.factory_dir.is_dir()
+        assert not store.factory_dir.is_symlink()
+        assert (store.factory_dir / "config.json").exists()


### PR DESCRIPTION
Closes #277

## Changes

- **Untracked `.factory` symlink**: `git rm --cached .factory` removes the accidentally committed symlink (mode `120000`, blob `5a8fd4de`) from `e0d17a7`. `.factory/` is already in `.gitignore` so it won't be re-added.
- **Added `ensure_factory_dir(path)` helper** in `factory/store.py`: checks for broken symlinks before `mkdir(parents=True, exist_ok=True)`, following the existing defensive pattern in `worktree.py:37-43`.
- **Applied helper at all 5 root-level `.factory` creation sites**: `store.py` (`ExperimentStore.init`), `cli.py` (`cmd_discover`, `cmd_init`), `checkpoint.py` (`save_checkpoint`), `events.py` (`emit_event`).
- **Added 4 regression tests**: `TestEnsureFactoryDir` covers directory creation, idempotency, broken symlink replacement, and full `ExperimentStore.init` with a broken symlink.

All 1727 tests pass. Lint and type checks clean.