### PR TITLE
fix: interactive mode crash on file input and empty-repo worktree creation

### DIFF
--- a/factory.md
+++ b/factory.md
@@ -66,7 +66,8 @@ main
 <!-- These are defaults — override per-run with --min-growth, --min-fix, --max-total -->
 
 - min_growth: 2
-- max_new: 2
+- min_fix: 0
+- max_total: 7
 
 ## Smoke Test
 <!-- Optional e2e smoke test command. Failure = mandatory revert. -->

--- a/factory.md
+++ b/factory.md
@@ -66,8 +66,7 @@ main
 <!-- These are defaults — override per-run with --min-growth, --min-fix, --max-total -->
 
 - min_growth: 2
-- min_fix: 0
-- max_total: 7
+- max_new: 2
 
 ## Smoke Test
 <!-- Optional e2e smoke test command. Failure = mandatory revert. -->

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1456,10 +1456,20 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         project_path, context = _resolve_input(raw_path, dir_name=dir_name)
         interactive_existing = True
     elif mode == "interactive":
-        interactive_idea = raw_path
-        slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
-        project_path = _dedupe_project_path(_get_projects_dir() / slug, raw_path)
-        _ensure_repo(project_path)
+        resolved_file = Path(raw_path).expanduser()
+        if resolved_file.is_file():
+            interactive_idea = resolved_file.read_text()
+            slug = _slugify(dir_name) if dir_name else _slugify(resolved_file.stem.split("—")[0].strip())
+            project_path = _dedupe_project_path(_get_projects_dir() / slug, interactive_idea)
+            _ensure_repo(project_path)
+            _persist_spec(project_path, interactive_idea)
+            print(f"Idea file: {resolved_file.name}")
+            print(f"Project directory: {project_path}")
+        else:
+            interactive_idea = raw_path
+            slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
+            project_path = _dedupe_project_path(_get_projects_dir() / slug, raw_path)
+            _ensure_repo(project_path)
         context = None
     elif mode == "research" and not (resolved := Path(raw_path).expanduser()).is_dir() and not resolved.is_file():
         # New research project from idea — enter research ideation
@@ -1741,10 +1751,14 @@ def _slugify(text: str) -> str:
 
 
 def _ensure_repo(project_path: Path) -> None:
-    """Create directory + git init if needed."""
+    """Create directory + git init (with initial commit) if needed."""
     project_path.mkdir(parents=True, exist_ok=True)
     if not (project_path / ".git").is_dir():
         subprocess.run(["git", "init"], cwd=project_path, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "Initial commit"],
+            cwd=project_path, capture_output=True, check=True,
+        )
 
 
 def _read_prompt_file(project_path: Path, prompt_file: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import json
 import signal
+import subprocess
 import threading
 from datetime import datetime
 from pathlib import Path
@@ -11,7 +12,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
-from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task
+from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -1496,3 +1497,70 @@ class TestSacredRule8Present:
         assert '8. **Do not do another agent\'s job**' in ceo_prompt, (
             "Sacred Rule 8 must be a numbered item (8.) in the Sacred Rules section"
         )
+
+
+class TestEnsureRepo:
+    """Tests for _ensure_repo() — verifies repos are initialized with at least one commit."""
+
+    def test_new_repo_has_commit(self, tmp_path):
+        """_ensure_repo() should create a repo with at least one commit."""
+        project = tmp_path / "new-project"
+        _ensure_repo(project)
+        result = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=project, capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert int(result.stdout.strip()) >= 1
+
+    def test_new_repo_has_valid_branch(self, tmp_path):
+        """_ensure_repo() should produce a repo with a resolvable default branch ref."""
+        project = tmp_path / "new-project"
+        _ensure_repo(project)
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=project, capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        branch = result.stdout.strip()
+        assert branch and branch != "HEAD"
+
+    def test_idempotent_on_existing_repo(self, tmp_path):
+        """Calling _ensure_repo() on an already-initialized repo should be a no-op."""
+        project = tmp_path / "existing"
+        _ensure_repo(project)
+        count_before = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=project, capture_output=True, text=True,
+        ).stdout.strip()
+        _ensure_repo(project)
+        count_after = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=project, capture_output=True, text=True,
+        ).stdout.strip()
+        assert count_before == count_after
+
+
+class TestInteractiveFileInput:
+    """Tests for interactive mode with file path input (Bug 1 fix)."""
+
+    def test_file_content_becomes_interactive_idea(self, tmp_path):
+        """When --mode interactive receives a file path, the file content should be used as the idea."""
+        spec_file = tmp_path / "my-cool-app.md"
+        spec_file.write_text("Build a weather dashboard with real-time updates")
+        with _mock_foreground() as mock_run:
+            main(["ceo", str(spec_file), "--mode", "interactive"])
+        cmd = mock_run.call_args[0][0]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "Build a weather dashboard with real-time updates" in task
+
+    def test_slug_derived_from_filename(self, tmp_path, capsys):
+        """The project slug should come from the file stem, not the full path."""
+        spec_file = tmp_path / "weather-dashboard.md"
+        spec_file.write_text("Build a weather dashboard")
+        with _mock_foreground():
+            main(["ceo", str(spec_file), "--mode", "interactive"])
+        output = capsys.readouterr().out
+        assert "weather-dashboard" in output
+        assert "Idea file: weather-dashboard.md" in output


### PR DESCRIPTION
Closes #279

## Changes

- **Bug 1 — Interactive mode file detection**: Added `is_file()` check in the `elif mode == "interactive":` branch. When the input is a file, reads the content as the idea, derives the slug from the filename stem (not the full path), persists the spec, and prints diagnostics. Non-file inputs fall through to the existing raw-idea behavior. Mirrors the pattern in `_resolve_input()`.

- **Bug 2 — `_ensure_repo()` initial commit**: After `git init`, now runs `git commit --allow-empty -m "Initial commit"` so the repo has at least one commit and a valid default branch ref. This prevents `git worktree add` from failing with exit status 128 on all new-project code paths.

- **Tests added**:
  - `TestEnsureRepo`: 3 tests verifying the repo has at least one commit, a valid branch ref, and that `_ensure_repo()` is idempotent on existing repos
  - `TestInteractiveFileInput`: 2 tests verifying file content becomes the interactive idea and the slug is derived from the filename