### PR TITLE
fix: persist spec for raw-idea interactive mode

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1470,6 +1470,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
             project_path = _dedupe_project_path(_get_projects_dir() / slug, raw_path)
             _ensure_repo(project_path)
+            _persist_spec(project_path, raw_path)
         context = None
     elif mode == "research" and not (resolved := Path(raw_path).expanduser()).is_dir() and not resolved.is_file():
         # New research project from idea — enter research ideation

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1564,3 +1564,14 @@ class TestInteractiveFileInput:
         output = capsys.readouterr().out
         assert "weather-dashboard" in output
         assert "Idea file: weather-dashboard.md" in output
+
+    def test_raw_idea_persists_spec(self, tmp_path):
+        """When --mode interactive receives a raw string, the spec should be persisted."""
+        with _mock_foreground(), \
+             patch("factory.cli._get_projects_dir", return_value=tmp_path):
+            main(["ceo", "Build a CLI todo app", "--mode", "interactive"])
+        matches = [p for p in tmp_path.iterdir() if p.is_dir()]
+        assert len(matches) == 1
+        spec_path = matches[0] / ".factory" / "strategy" / "current.md"
+        assert spec_path.exists()
+        assert "Build a CLI todo app" in spec_path.read_text()


### PR DESCRIPTION
## Summary

- Adds missing `_persist_spec()` call in the raw-idea `else` branch of interactive mode, so `.factory/strategy/current.md` is written for string inputs — matching the file-input branch and `_resolve_input()` behavior
- Adds `test_raw_idea_persists_spec` to verify the spec file is created

Follow-up to #280 which fixed interactive file-input handling but left a gap in the raw-idea path.

## Test plan

- [x] `pytest tests/test_cli.py -v` — 168 tests pass
- [x] `ruff check` — clean
- [ ] Manual: `factory ceo "Build a todo app" --mode interactive` writes `.factory/strategy/current.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)