### PR TITLE
fix: provide git identity in _ensure_repo for CI

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1757,7 +1757,8 @@ def _ensure_repo(project_path: Path) -> None:
     if not (project_path / ".git").is_dir():
         subprocess.run(["git", "init"], cwd=project_path, capture_output=True, check=True)
         subprocess.run(
-            ["git", "commit", "--allow-empty", "-m", "Initial commit"],
+            ["git", "-c", "user.name=Factory", "-c", "user.email=factory@localhost",
+             "commit", "--allow-empty", "-m", "Initial commit"],
             cwd=project_path, capture_output=True, check=True,
         )
 


### PR DESCRIPTION
## Summary

- `_ensure_repo()` passes `-c user.name=Factory -c user.email=factory@localhost` to `git commit`, fixing the 14 test failures on CI where GitHub Actions runners have no git identity configured
- Root cause: PR #280 added `git commit --allow-empty` to `_ensure_repo()` but `git commit` requires `user.name`/`user.email`

Fixes all 14 CI failures introduced by #280.

## Test plan

- [x] `pytest` — 1730 tests pass locally
- [x] `ruff check` — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)