### PR TITLE
fix: correct HypothesisBudget fields and harden read_config

### DIFF
--- a/factory.md
+++ b/factory.md
@@ -63,7 +63,7 @@ main
 
 ## Hypothesis Budget
 <!-- Controls how many hypotheses the Strategist generates per cycle. -->
-<!-- These are defaults — override per-run with --min-growth, --min-fix, --max-total -->
+<!-- These are defaults — override per-run with --min-growth, --max-new -->
 
 - min_growth: 2
 - max_new: 2

--- a/factory.md
+++ b/factory.md
@@ -66,8 +66,7 @@ main
 <!-- These are defaults — override per-run with --min-growth, --min-fix, --max-total -->
 
 - min_growth: 2
-- min_fix: 0
-- max_total: 7
+- max_new: 2
 
 ## Smoke Test
 <!-- Optional e2e smoke test command. Failure = mandatory revert. -->

--- a/factory/store.py
+++ b/factory/store.py
@@ -478,10 +478,26 @@ class ExperimentStore:
 
     async def read_config(self) -> FactoryConfig:
         """Read .factory/config.json and return a FactoryConfig."""
-        log.debug("read_config", path=str(self.factory_dir / "config.json"))
         config_path = self.factory_dir / "config.json"
-        data = json.loads(config_path.read_text())
-        return FactoryConfig(**data)
+        log.debug("read_config", path=str(config_path))
+        if not config_path.exists():
+            raise FileNotFoundError(
+                f"{config_path} not found. Run 'factory init' first to create it from factory.md."
+            )
+        try:
+            data = json.loads(config_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"{config_path} contains invalid JSON: {exc}. "
+                "Run 'factory init --reparse' to regenerate it from factory.md."
+            ) from exc
+        try:
+            return FactoryConfig(**data)
+        except Exception as exc:
+            raise ValueError(
+                f"{config_path} failed validation: {exc}. "
+                "Run 'factory init --reparse' to regenerate it from factory.md."
+            ) from exc
 
     async def save_eval_profile(self, profile: EvalProfile) -> None:
         """Write .factory/eval_profile.json."""

--- a/factory/store.py
+++ b/factory/store.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 import structlog
 from filelock import FileLock
+from pydantic import ValidationError
 
 from factory.models import (
     CompositeScore,
@@ -493,7 +494,7 @@ class ExperimentStore:
             ) from exc
         try:
             return FactoryConfig(**data)
-        except Exception as exc:
+        except (ValidationError, TypeError, KeyError) as exc:
             raise ValueError(
                 f"{config_path} failed validation: {exc}. "
                 "Run 'factory init --reparse' to regenerate it from factory.md."

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -124,6 +124,23 @@ class TestReadConfig:
         assert config.goal == sample_config.goal
         assert config.eval_threshold == sample_config.eval_threshold
 
+    async def test_read_config_missing_file(self, store):
+        store.factory_dir.mkdir(parents=True, exist_ok=True)
+        with pytest.raises(FileNotFoundError, match="Run 'factory init'"):
+            await store.read_config()
+
+    async def test_read_config_invalid_json(self, store):
+        store.factory_dir.mkdir(parents=True, exist_ok=True)
+        (store.factory_dir / "config.json").write_text("{bad json")
+        with pytest.raises(ValueError, match="invalid JSON"):
+            await store.read_config()
+
+    async def test_read_config_invalid_schema(self, store):
+        store.factory_dir.mkdir(parents=True, exist_ok=True)
+        (store.factory_dir / "config.json").write_text('{"not_a_field": true}')
+        with pytest.raises(ValueError, match="failed validation"):
+            await store.read_config()
+
 
 class TestEvalProfile:
     async def test_save_and_read_profile(self, store, sample_config):


### PR DESCRIPTION
## Summary
- **factory.md** had `min_fix` and `max_total` in the Hypothesis Budget section, but the `HypothesisBudget` model only accepts `min_growth` and `max_new` (`extra="forbid"`). Running `factory init` crashes with a Pydantic `ValidationError`, leaving `config.json` unwritten. Updated to the correct field names.
- **`read_config()`** had no error handling — missing file, bad JSON, or validation failures all produced raw exceptions. Added actionable error messages pointing the user to `factory init --reparse`.

## Context
Reported by mizmo after a fresh factory install — the CEO agent reported `.factory/config.json` as "corrupt" because it was never successfully written.

## Test plan
- [x] `pytest tests/test_models.py tests/test_cli.py -x -q` — 202 passed
- [x] `ruff check factory/store.py` — clean
- [x] Verified `factory init --reparse` succeeds on the factory repo after the fix (was crashing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)