### PR TITLE
feat: add Codex runner for OpenAI Codex CLI support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,11 +140,12 @@ The factory supports multiple CLI backends via the runner abstraction (`factory/
 - Ceiling violations emit events to `.factory/events.jsonl` and abort with an actionable error message
 
 **Codex specifics:**
-- Requires `CODEX_API_KEY` environment variable (or set via config.toml profile)
+- Requires `CODEX_API_KEY` (or `OPENAI_API_KEY`) environment variable (or set via config.toml profile)
+- `CODEX_API_KEY` is auto-mapped to `OPENAI_API_KEY` in subprocess env if needed
 - Headless mode uses `codex exec` with `--sandbox workspace-write --ask-for-approval never`
 - Model selection via `--model` flag (e.g., `gpt-5.4`, `gpt-5.2-codex`)
 - Progress streams to stderr, final message to stdout (matches factory capture model)
-- Install: `npm install -g @openai/codex` or `brew install --cask codex`
+- Install: `npm install -g @openai/codex`
 
 **Codex dry-run mode:** Set `FACTORY_CODEX_DRY_RUN=1` to test Codex integration without spending tokens.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,9 +122,9 @@ ANTHROPIC_API_KEY = "sk-ant-..."
 
 ## Runners
 
-The factory supports multiple CLI backends via the runner abstraction (`factory/runners/`). By default, it uses Claude Code (`claude` CLI), but Bob Shell (`bob` CLI) is also supported as a switchable alternative.
+The factory supports multiple CLI backends via the runner abstraction (`factory/runners/`). By default, it uses Claude Code (`claude` CLI). Bob Shell (`bob` CLI) and OpenAI Codex (`codex` CLI) are also supported as switchable alternatives.
 
-**Runner selection:** Set `FACTORY_RUNNER=bob` to use Bob Shell, or pass `--runner bob` to individual commands. Default is `claude`.
+**Runner selection:** Set `FACTORY_RUNNER=codex` (or `bob`) to switch backends, or pass `--runner codex` to individual commands. Default is `claude`.
 
 **Bob Shell specifics:**
 - Requires `BOBSHELL_API_KEY` environment variable to be set
@@ -138,6 +138,23 @@ The factory supports multiple CLI backends via the runner abstraction (`factory/
 - All invocations are logged to `.factory/bob_usage.jsonl`
 - When ≤2 invocations remain before the ceiling, a warning is logged and emitted to `.factory/events.jsonl` (type: `bob.ceiling_warning`)
 - Ceiling violations emit events to `.factory/events.jsonl` and abort with an actionable error message
+
+**Codex specifics:**
+- Requires `CODEX_API_KEY` environment variable (or set via config.toml profile)
+- Headless mode uses `codex exec` with `--sandbox workspace-write --ask-for-approval never`
+- Model selection via `--model` flag (e.g., `gpt-5.4`, `gpt-5.2-codex`)
+- Progress streams to stderr, final message to stdout (matches factory capture model)
+- Install: `npm install -g @openai/codex` or `brew install --cask codex`
+
+**Codex dry-run mode:** Set `FACTORY_CODEX_DRY_RUN=1` to test Codex integration without spending tokens.
+
+**Codex config profile example** (`~/.factory/config.toml`):
+```toml
+[credentials.codex]
+FACTORY_RUNNER = "codex"
+CODEX_API_KEY = "..."
+```
+Then run: `factory ceo /path/to/project --profile codex`
 
 **Important:** Target projects should add `.factory/` to their `.gitignore`. The factory writes experiment data, usage logs, and potentially sensitive auth files (`.factory/.bob_auth`) to this directory. These are project-local artifacts that should not be committed to version control.
 

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -8,24 +8,28 @@ from typing import Literal
 from factory.runners._stream import should_stream, stream_subprocess
 from factory.runners.bob import BobRunner, is_dry_run
 from factory.runners.claude import ClaudeRunner
+from factory.runners.codex import CodexRunner, is_codex_dry_run
 from factory.runners.protocol import Runner
 
 __all__ = [
     "Runner",
     "ClaudeRunner",
     "BobRunner",
+    "CodexRunner",
     "get_runner",
     "RunnerName",
     "is_dry_run",
+    "is_codex_dry_run",
     "should_stream",
     "stream_subprocess",
 ]
 
-RunnerName = Literal["claude", "bob"]
+RunnerName = Literal["claude", "bob", "codex"]
 
 _RUNNERS: dict[str, type[Runner]] = {
     "claude": ClaudeRunner,  # type: ignore[dict-item]
     "bob": BobRunner,  # type: ignore[dict-item]
+    "codex": CodexRunner,  # type: ignore[dict-item]
 }
 
 
@@ -38,7 +42,7 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
     3. Default to "claude"
 
     Args:
-        name: Runner name ("claude" or "bob").
+        name: Runner name ("claude", "bob", or "codex").
         project_path: Path to the project. Passed to BobRunner for cycle state lookup.
 
     Raises:

--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -16,25 +16,33 @@ _auth_checked = False
 
 
 class CodexAuthError(Exception):
-    """Raised when CODEX_API_KEY is not set."""
+    """Raised when neither CODEX_API_KEY nor OPENAI_API_KEY is set."""
 
     def __init__(self) -> None:
         super().__init__(
-            "CODEX_API_KEY environment variable is not set. "
+            "CODEX_API_KEY (or OPENAI_API_KEY) environment variable is not set. "
             "Set it directly or add it to a config.toml credential profile: "
             "[credentials.codex] CODEX_API_KEY = \"...\""
         )
 
 
 def _check_auth() -> None:
-    """Check that CODEX_API_KEY is set (once per process)."""
+    """Check that CODEX_API_KEY or OPENAI_API_KEY is set (once per process)."""
     global _auth_checked  # noqa: PLW0603
     if _auth_checked:
         return
-    if os.environ.get("CODEX_API_KEY"):
+    if os.environ.get("CODEX_API_KEY") or os.environ.get("OPENAI_API_KEY"):
         _auth_checked = True
         return
     raise CodexAuthError()
+
+
+def _make_codex_env() -> dict[str, str]:
+    """Build subprocess env: strip VIRTUAL_ENV, ensure OPENAI_API_KEY is set."""
+    env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    if "OPENAI_API_KEY" not in env and "CODEX_API_KEY" in env:
+        env["OPENAI_API_KEY"] = env["CODEX_API_KEY"]
+    return env
 
 
 def is_codex_dry_run() -> bool:
@@ -85,7 +93,7 @@ class CodexRunner:
 
         logger.info("CodexRunner headless: cwd=%s, model=%s, role=%s", cwd, model, role)
 
-        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        env = _make_codex_env()
 
         stream = should_stream()
         prefix = f"[codex:{role}]" if stream else None
@@ -154,7 +162,8 @@ class CodexRunner:
 
         logger.info("CodexRunner interactive_run: cwd=%s", cwd)
 
-        result = subprocess.run(cmd, cwd=cwd)
+        env = _make_codex_env()
+        result = subprocess.run(cmd, cwd=cwd, env=env)
         return result.returncode
 
     def _dry_run_response(self, role: str, cwd: Path, task: str) -> tuple[str, int]:

--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -1,0 +1,171 @@
+"""CodexRunner — OpenAI Codex CLI backend implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from factory.runners._stream import should_stream, stream_subprocess
+
+logger = logging.getLogger(__name__)
+
+_auth_checked = False
+
+
+class CodexAuthError(Exception):
+    """Raised when CODEX_API_KEY is not set."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "CODEX_API_KEY environment variable is not set. "
+            "Set it directly or add it to a config.toml credential profile: "
+            "[credentials.codex] CODEX_API_KEY = \"...\""
+        )
+
+
+def _check_auth() -> None:
+    """Check that CODEX_API_KEY is set (once per process)."""
+    global _auth_checked  # noqa: PLW0603
+    if _auth_checked:
+        return
+    if os.environ.get("CODEX_API_KEY"):
+        _auth_checked = True
+        return
+    raise CodexAuthError()
+
+
+def is_codex_dry_run() -> bool:
+    """Return True if Codex dry-run mode is enabled."""
+    from factory.user_config import resolve
+
+    val = resolve("codex_dry_run", env_var="FACTORY_CODEX_DRY_RUN") or ""
+    return val.lower() in ("1", "true", "yes")
+
+
+class CodexRunner:
+    """Runner implementation for OpenAI Codex CLI."""
+
+    name: str = "codex"
+
+    async def headless(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        timeout: float = 600.0,
+        model: str | None = None,
+        dangerously_skip_permissions: bool = True,
+        role: str = "unknown",
+    ) -> tuple[str, int]:
+        """Run a headless Codex CLI invocation via ``codex exec``.
+
+        Codex exec streams progress to stderr and writes only the final
+        agent message to stdout, which aligns with the factory's capture model.
+
+        Returns (stdout, return_code).
+        """
+        if is_codex_dry_run():
+            return self._dry_run_response(role, cwd, task)
+
+        _check_auth()
+
+        full_prompt = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
+
+        cmd = ["codex", "exec", full_prompt]
+
+        if dangerously_skip_permissions:
+            cmd.extend(["--sandbox", "workspace-write", "--ask-for-approval", "never"])
+
+        if model:
+            cmd.extend(["--model", model])
+
+        logger.info("CodexRunner headless: cwd=%s, model=%s, role=%s", cwd, model, role)
+
+        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+
+        stream = should_stream()
+        prefix = f"[codex:{role}]" if stream else None
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                stream_subprocess(proc, stream=stream, prefix=prefix),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()  # type: ignore[union-attr]
+            await proc.wait()  # type: ignore[union-attr]
+            logger.error("CodexRunner timed out after %ss", timeout)
+            return f"Agent timed out after {timeout}s", 1
+        except FileNotFoundError:
+            logger.error("'codex' CLI not found on PATH")
+            return "Error: 'codex' CLI not found on PATH", 1
+
+        stdout = stdout_bytes.decode()
+        stderr = stderr_bytes.decode()
+
+        if proc.returncode != 0:
+            logger.warning("CodexRunner exited with code %d: %s", proc.returncode, stderr[:200])
+
+        return stdout, proc.returncode or 0
+
+    def interactive_run(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        model: str | None = None,
+        role: str = "ceo",
+        dangerously_skip_permissions: bool = False,
+    ) -> int:
+        """Run an interactive Codex CLI session as a subprocess.
+
+        Returns the exit code so the caller can clean up in a finally block.
+        """
+        _ = role
+
+        if is_codex_dry_run():
+            print("[DRY-RUN] Would exec: codex (interactive)")
+            print(f"[DRY-RUN] Task: {task[:200]}...")
+            return 0
+
+        _check_auth()
+
+        full_prompt = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
+
+        cmd = ["codex", full_prompt]
+
+        if dangerously_skip_permissions:
+            cmd.extend(["--sandbox", "workspace-write", "--ask-for-approval", "never"])
+
+        if model:
+            cmd.extend(["--model", model])
+
+        logger.info("CodexRunner interactive_run: cwd=%s", cwd)
+
+        result = subprocess.run(cmd, cwd=cwd)
+        return result.returncode
+
+    def _dry_run_response(self, role: str, cwd: Path, task: str) -> tuple[str, int]:
+        """Return a stub response for dry-run mode."""
+        response = (
+            f"[DRY-RUN] CodexRunner would have executed:\n"
+            f"  role: {role}\n"
+            f"  cwd: {cwd}\n"
+            f"  task: {task[:100]}...\n"
+            f"\n"
+            f"Dry-run stub response: Task acknowledged."
+        )
+        logger.info("CodexRunner dry-run: role=%s, cwd=%s", role, cwd)
+        return response, 0

--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -31,7 +31,7 @@ _CONFIG_TEMPLATE = """\
 # See: factory config show
 
 [defaults]
-# runner = "claude"                    # CLI backend: "claude" or "bob"
+# runner = "claude"                    # CLI backend: "claude", "bob", or "codex"
 # model = ""                           # Claude model for agent subprocesses
 # projects_dir = "~/factory-projects"  # Root for factory-managed projects
 
@@ -42,6 +42,10 @@ _CONFIG_TEMPLATE = """\
 # [credentials.bob]
 # FACTORY_RUNNER = "bob"
 # BOBSHELL_API_KEY = "..."
+#
+# [credentials.codex]
+# FACTORY_RUNNER = "codex"
+# CODEX_API_KEY = "..."
 """
 
 

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -1,0 +1,451 @@
+"""Tests for factory/runners/codex.py — CodexRunner implementation."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from factory.runners import CodexRunner, get_runner, is_codex_dry_run
+from factory.runners.codex import CodexAuthError, _check_auth
+
+
+class TestGetRunnerCodex:
+    def test_explicit_codex(self) -> None:
+        runner = get_runner("codex")
+        assert runner.name == "codex"
+
+    def test_from_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_RUNNER", "codex")
+        runner = get_runner()
+        assert runner.name == "codex"
+
+    def test_explicit_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_RUNNER", "codex")
+        runner = get_runner("claude")
+        assert runner.name == "claude"
+
+
+class TestCodexDryRun:
+    def test_dry_run_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_CODEX_DRY_RUN", "1")
+        assert is_codex_dry_run() is True
+
+    def test_dry_run_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        assert is_codex_dry_run() is False
+
+    def test_dry_run_true_word(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_CODEX_DRY_RUN", "true")
+        assert is_codex_dry_run() is True
+
+    async def test_headless_dry_run_returns_stub(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_CODEX_DRY_RUN", "1")
+
+        runner = CodexRunner()
+        stdout, code = await runner.headless(
+            prompt="You are a test agent.",
+            task="Say hello",
+            cwd=tmp_path,
+            role="researcher",
+        )
+
+        assert code == 0
+        assert "[DRY-RUN]" in stdout
+        assert "researcher" in stdout
+
+    def test_interactive_run_dry_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("FACTORY_CODEX_DRY_RUN", "1")
+
+        runner = CodexRunner()
+        code = runner.interactive_run(
+            prompt="Test prompt",
+            task="Test task",
+            cwd=tmp_path,
+            role="ceo",
+        )
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "[DRY-RUN]" in captured.out
+
+
+class TestCodexAuth:
+    def test_auth_fails_without_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        with pytest.raises(CodexAuthError, match="CODEX_API_KEY"):
+            _check_auth()
+
+        codex_module._auth_checked = False
+
+    def test_auth_passes_with_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        _check_auth()
+        assert codex_module._auth_checked is True
+
+        codex_module._auth_checked = False
+
+    async def test_headless_fails_without_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+        with pytest.raises(CodexAuthError):
+            await runner.headless(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                role="researcher",
+            )
+
+        codex_module._auth_checked = False
+
+
+class TestCodexHeadless:
+    async def test_builds_correct_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+
+        with patch(
+            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"output", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                stdout, code = await runner.headless(
+                    prompt="You are a test agent.",
+                    task="Say hello",
+                    cwd=tmp_path,
+                    timeout=60.0,
+                    model="gpt-5.4",
+                )
+
+                assert code == 0
+                assert stdout == "output"
+
+                call_args = mock_exec.call_args[0]
+                assert call_args[0] == "codex"
+                assert call_args[1] == "exec"
+                assert "--sandbox" in call_args
+                assert "workspace-write" in call_args
+                assert "--ask-for-approval" in call_args
+                assert "never" in call_args
+                assert "--model" in call_args
+                assert "gpt-5.4" in call_args
+
+        codex_module._auth_checked = False
+
+    async def test_combines_prompt_and_task(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+
+        with patch(
+            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"ok", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(
+                    prompt="You are the CEO.",
+                    task="Run the experiment",
+                    cwd=tmp_path,
+                )
+
+                call_args = mock_exec.call_args[0]
+                # Third arg (index 2) is the combined prompt+task
+                full_prompt = call_args[2]
+                assert "You are the CEO." in full_prompt
+                assert "Run the experiment" in full_prompt
+                assert "## Current Task" in full_prompt
+
+        codex_module._auth_checked = False
+
+    async def test_no_sandbox_flags_when_permissions_not_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+
+        with patch(
+            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"ok", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    dangerously_skip_permissions=False,
+                )
+
+                call_args = mock_exec.call_args[0]
+                assert "--sandbox" not in call_args
+                assert "--ask-for-approval" not in call_args
+
+        codex_module._auth_checked = False
+
+    async def test_no_model_flag_when_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+
+        with patch(
+            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"ok", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    model=None,
+                )
+
+                call_args = mock_exec.call_args[0]
+                assert "--model" not in call_args
+
+        codex_module._auth_checked = False
+
+    async def test_handles_timeout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio as aio
+
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        with patch("factory.runners.codex.asyncio.wait_for", side_effect=aio.TimeoutError):
+            with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.kill = AsyncMock()
+                mock_proc.wait = AsyncMock()
+                mock_exec.return_value = mock_proc
+
+                runner = CodexRunner()
+                stdout, code = await runner.headless(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    role="researcher",
+                    timeout=0.1,
+                )
+
+        assert code == 1
+        assert "timed out" in stdout.lower()
+        codex_module._auth_checked = False
+
+    async def test_handles_missing_binary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            side_effect=FileNotFoundError,
+        ):
+            runner = CodexRunner()
+            stdout, code = await runner.headless(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+            )
+
+        assert code == 1
+        assert "not found" in stdout.lower()
+        codex_module._auth_checked = False
+
+    async def test_strips_virtual_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+
+        with patch(
+            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b"ok", b"")
+
+            with patch(
+                "asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                )
+
+                call_kwargs = mock_exec.call_args.kwargs
+                assert "VIRTUAL_ENV" not in call_kwargs["env"]
+
+        codex_module._auth_checked = False
+
+
+class TestCodexStreaming:
+    async def test_uses_streaming_prefix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        monkeypatch.delenv("FACTORY_RUNNER_QUIET", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+
+        with patch("factory.runners.codex.should_stream", return_value=True):
+            with patch(
+                "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+            ) as mock_stream:
+                mock_stream.return_value = (b"output\n", b"")
+
+                with patch(
+                    "asyncio.create_subprocess_exec", new_callable=AsyncMock
+                ) as mock_exec:
+                    mock_proc = AsyncMock()
+                    mock_proc.returncode = 0
+                    mock_exec.return_value = mock_proc
+
+                    await runner.headless(
+                        prompt="Test",
+                        task="Test",
+                        cwd=tmp_path,
+                        role="builder",
+                    )
+
+                    mock_stream.assert_called_once()
+                    call_kwargs = mock_stream.call_args.kwargs
+                    assert call_kwargs["stream"] is True
+                    assert call_kwargs["prefix"] == "[codex:builder]"
+
+        codex_module._auth_checked = False
+
+
+class TestCodexInteractive:
+    def test_interactive_run_builds_correct_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            code = runner.interactive_run(
+                prompt="You are the CEO.",
+                task="Start session",
+                cwd=tmp_path,
+                model="gpt-5.4",
+                dangerously_skip_permissions=True,
+            )
+
+            assert code == 0
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == "codex"
+            assert "--sandbox" in cmd
+            assert "workspace-write" in cmd
+            assert "--model" in cmd
+            assert "gpt-5.4" in cmd
+
+        codex_module._auth_checked = False
+
+    def test_interactive_run_no_sandbox_without_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+        import factory.runners.codex as codex_module
+        codex_module._auth_checked = False
+
+        runner = CodexRunner()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                dangerously_skip_permissions=False,
+            )
+
+            cmd = mock_run.call_args[0][0]
+            assert "--sandbox" not in cmd
+
+        codex_module._auth_checked = False

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -5,8 +5,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import factory.runners.codex as codex_module
 from factory.runners import CodexRunner, get_runner, is_codex_dry_run
 from factory.runners.codex import CodexAuthError, _check_auth
+
+
+@pytest.fixture(autouse=True)
+def _reset_codex_auth() -> None:
+    codex_module._auth_checked = False
 
 
 class TestGetRunnerCodex:
@@ -76,31 +82,31 @@ class TestCodexDryRun:
 class TestCodexAuth:
     def test_auth_fails_without_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("CODEX_API_KEY", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
         with pytest.raises(CodexAuthError, match="CODEX_API_KEY"):
             _check_auth()
 
-        codex_module._auth_checked = False
-
-    def test_auth_passes_with_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_auth_passes_with_codex_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
         _check_auth()
         assert codex_module._auth_checked is True
 
-        codex_module._auth_checked = False
+    def test_auth_passes_with_openai_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+
+        _check_auth()
+        assert codex_module._auth_checked is True
 
     async def test_headless_fails_without_key(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
         with pytest.raises(CodexAuthError):
@@ -111,7 +117,34 @@ class TestCodexAuth:
                 role="researcher",
             )
 
-        codex_module._auth_checked = False
+
+class TestCodexEnvMapping:
+    def test_codex_key_mapped_to_openai(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "my-codex-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        from factory.runners.codex import _make_codex_env
+
+        env = _make_codex_env()
+        assert env["OPENAI_API_KEY"] == "my-codex-key"
+        assert "VIRTUAL_ENV" not in env
+
+    def test_openai_key_not_overridden(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "codex-key")
+        monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+
+        from factory.runners.codex import _make_codex_env
+
+        env = _make_codex_env()
+        assert env["OPENAI_API_KEY"] == "openai-key"
+
+    def test_virtual_env_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
+
+        from factory.runners.codex import _make_codex_env
+
+        env = _make_codex_env()
+        assert "VIRTUAL_ENV" not in env
 
 
 class TestCodexHeadless:
@@ -120,8 +153,6 @@ class TestCodexHeadless:
     ) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
 
@@ -158,15 +189,11 @@ class TestCodexHeadless:
                 assert "--model" in call_args
                 assert "gpt-5.4" in call_args
 
-        codex_module._auth_checked = False
-
     async def test_combines_prompt_and_task(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
 
@@ -189,21 +216,16 @@ class TestCodexHeadless:
                 )
 
                 call_args = mock_exec.call_args[0]
-                # Third arg (index 2) is the combined prompt+task
                 full_prompt = call_args[2]
                 assert "You are the CEO." in full_prompt
                 assert "Run the experiment" in full_prompt
                 assert "## Current Task" in full_prompt
-
-        codex_module._auth_checked = False
 
     async def test_no_sandbox_flags_when_permissions_not_skipped(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
 
@@ -230,15 +252,11 @@ class TestCodexHeadless:
                 assert "--sandbox" not in call_args
                 assert "--ask-for-approval" not in call_args
 
-        codex_module._auth_checked = False
-
     async def test_no_model_flag_when_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
 
@@ -264,8 +282,6 @@ class TestCodexHeadless:
                 call_args = mock_exec.call_args[0]
                 assert "--model" not in call_args
 
-        codex_module._auth_checked = False
-
     async def test_handles_timeout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -273,8 +289,6 @@ class TestCodexHeadless:
 
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         with patch("factory.runners.codex.asyncio.wait_for", side_effect=aio.TimeoutError):
             with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
@@ -294,15 +308,12 @@ class TestCodexHeadless:
 
         assert code == 1
         assert "timed out" in stdout.lower()
-        codex_module._auth_checked = False
 
     async def test_handles_missing_binary(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         with patch(
             "asyncio.create_subprocess_exec",
@@ -318,16 +329,14 @@ class TestCodexHeadless:
 
         assert code == 1
         assert "not found" in stdout.lower()
-        codex_module._auth_checked = False
 
-    async def test_strips_virtual_env(
+    async def test_passes_env_with_openai_key(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
 
@@ -351,8 +360,7 @@ class TestCodexHeadless:
 
                 call_kwargs = mock_exec.call_args.kwargs
                 assert "VIRTUAL_ENV" not in call_kwargs["env"]
-
-        codex_module._auth_checked = False
+                assert call_kwargs["env"]["OPENAI_API_KEY"] == "test-key"
 
 
 class TestCodexStreaming:
@@ -362,8 +370,6 @@ class TestCodexStreaming:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
         monkeypatch.delenv("FACTORY_RUNNER_QUIET", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
 
@@ -392,8 +398,6 @@ class TestCodexStreaming:
                     assert call_kwargs["stream"] is True
                     assert call_kwargs["prefix"] == "[codex:builder]"
 
-        codex_module._auth_checked = False
-
 
 class TestCodexInteractive:
     def test_interactive_run_builds_correct_command(
@@ -401,8 +405,6 @@ class TestCodexInteractive:
     ) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
 
@@ -424,15 +426,11 @@ class TestCodexInteractive:
             assert "--model" in cmd
             assert "gpt-5.4" in cmd
 
-        codex_module._auth_checked = False
-
     def test_interactive_run_no_sandbox_without_skip(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
-        import factory.runners.codex as codex_module
-        codex_module._auth_checked = False
 
         runner = CodexRunner()
 
@@ -448,4 +446,24 @@ class TestCodexInteractive:
             cmd = mock_run.call_args[0][0]
             assert "--sandbox" not in cmd
 
-        codex_module._auth_checked = False
+    def test_interactive_run_passes_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
+        monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
+
+        runner = CodexRunner()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+            )
+
+            call_kwargs = mock_run.call_args.kwargs
+            assert "VIRTUAL_ENV" not in call_kwargs["env"]
+            assert call_kwargs["env"]["OPENAI_API_KEY"] == "test-key"


### PR DESCRIPTION
## Summary

- Adds `CodexRunner` (`factory/runners/codex.py`) implementing the `Runner` protocol for OpenAI's Codex CLI
- Headless mode uses `codex exec` with `--sandbox workspace-write --ask-for-approval never`
- Auth via `CODEX_API_KEY` env var or `~/.factory/config.toml` credential profile (integrates with PR #241)
- Includes dry-run mode (`FACTORY_CODEX_DRY_RUN=1`), streaming output with `[codex:<role>]` prefix, model passthrough (`--model`)
- Registered in runner abstraction alongside Claude and Bob: `FACTORY_RUNNER=codex` or `--runner codex`

## Usage

```bash
# Direct
CODEX_API_KEY="..." factory ceo /path --runner codex

# Via config.toml profile
factory ceo /path --profile codex
```

## Test plan

- [x] 21 new tests covering: runner routing, dry-run, auth, command construction, sandbox/model flags, timeout, missing binary, VIRTUAL_ENV stripping, streaming, interactive mode
- [x] Full suite: 1762 passed, 0 failures
- [x] `ruff check .` clean
- [x] `mypy factory/` clean