### PR TITLE
Add OpenSkies Airline Corpus to Built with the Factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The Factory improves itself. Every keep/revert decision becomes training data �
 | **HLS design space explorer** | Per-function AI agents + ILP solver for HLS optimization — 92% execution time reduction | Build |
 | **Pluck** | iOS app that extracts structured data from screenshots using on-device AI | Build + Improve |
 | **[SDG Hub](https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub)** | Agent-maintained open-source framework for synthetic data generation | Build + Improve |
+| **[OpenSkies Airline Corpus](https://github.com/lukeinglis/OpenSkiesAirline)** | 85-document fictional airline corpus for RAG/fine-tuning evaluation with cross-document consistency validation | Interactive + Improve |
 | **The Factory itself** | Runs on itself in meta mode — agent playbooks are evolved from its own experiment outcomes | Meta |
 
 Built something with the Factory? Open a PR to add it here.


### PR DESCRIPTION
Adds [OpenSkies Airline Corpus](https://github.com/lukeinglis/OpenSkiesAirline) to the "Built with the Factory" section.

**What it is:** An 85-document fictional airline company corpus designed for RAG and fine-tuning evaluation. Covers 7 organizational categories (corporate, regulatory, operational, customer-facing, finance/HR, IT, miscellaneous) with internally consistent facts, cross-document references, and format diversity (tabular, procedural, legal, narrative, informal).

**How it was built:** Interactive mode to ideate and initialize, then 3 Improve cycles (10 experiments, 9 kept, 1 reverted) to populate all 85 documents with a custom 6-dimension eval harness tracking coverage, completeness, quality, diversity, and cross-document consistency.