### PR TITLE
Unify Phase 0 and Phase 0e — full ideation flow for existing projects

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -228,23 +228,26 @@ factory detect "$PROJECT_PATH"
 - `evals_pending_review` → **Review mode**
 - `has_factory` → **Improve mode** (or **Research mode** if `research_target` is configured and `--mode research` is set)
 
-**Exception:** If your task includes `## Interactive Ideation Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)`, enter Phase 0 first regardless of project state. After Phase 0 completes, proceed to Build mode. If your task includes `## Interactive Improvement Mode (Phase 0)`, enter Phase 0e first, then proceed to Improve mode.
+**Exception:** If your task includes `## Interactive Ideation Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)`, enter Phase 0 first regardless of project state. After Phase 0 completes, proceed to Build mode (for new ideas) or Improve mode (for existing projects).
 
 ---
 
 ## Phase 0: Ideation (Interactive Mode)
 
-This phase activates when your task includes a `## Interactive Ideation Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)` section. You are running in foreground interactive mode — the user can see your output and respond.
+This phase activates when your task includes a `## Interactive Ideation Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)` section. You are running in foreground interactive mode — the user can see your output and respond. This phase handles both **new ideas** and **existing projects**.
 
 **Research ideation** works identically to regular ideation, except the Distiller MUST produce a Research Configuration section in its output. See the I1 step below for how to instruct the Distiller.
 
 ### Purpose
 
-Transform a vague idea into a research-grounded, buildable project specification (idea.md) through iterative refinement with the user.
+- **New ideas:** Transform a vague idea into a research-grounded, buildable project specification (idea.md) through iterative refinement with the user.
+- **Existing projects:** Study the project and collaboratively decide what to improve next, producing an improvement spec through research and user feedback.
 
 ### I0: Research the Space (Researcher Agent)
 
-Tell the user you're researching the space, then spawn the Researcher:
+Tell the user you're researching the space, then spawn the Researcher.
+
+**For new ideas:**
 
 ```bash
 factory agent researcher --task "Mode 2 research for a new project idea.
@@ -267,6 +270,39 @@ Write a thorough research report to .factory/strategy/research.md covering:
 " --project "$PROJECT_PATH" --timeout 300
 ```
 
+**For existing projects** (task includes `existing_project: true`):
+
+First, gather local project context before spawning the Researcher:
+
+1. Read the project state: `factory detect "$PROJECT_PATH"`, read `factory.md`, `.factory/strategy/backlog.md`, `.factory/strategy/current.md`
+2. Check recent history: `factory history "$PROJECT_PATH"` — what was kept/reverted recently?
+3. Run current eval: `factory eval "$PROJECT_PATH"` — where are the weak dimensions?
+4. Check open issues: `gh issue list --state open --json number,title,labels` (if GitHub is available)
+
+Then spawn the Researcher with combined local + external research:
+
+```bash
+factory agent researcher --task "Mode 2 research for an existing project improvement.
+
+Project: $PROJECT_PATH
+<If focus topic provided: Focus topic: <FOCUS_TOPIC>>
+
+The project already exists and has a factory setup. Research:
+1. Study the local project: run 'factory study $PROJECT_PATH', read backlog at .factory/strategy/backlog.md, read eval scores, read recent experiment history via 'factory history $PROJECT_PATH'
+2. Analyze the codebase for weak areas and improvement opportunities
+3. Search the web for best practices related to the project's weak dimensions
+4. Check .factory/archive/ for prior knowledge and recurring patterns
+5. If a focus topic was provided, do deep research on that specific area
+
+Write a thorough research report to .factory/strategy/research.md covering:
+- Project health summary (eval scores, recent outcomes)
+- Weak dimensions and improvement opportunities
+- External best practices relevant to weak areas
+- Backlog items with context and prioritization advice
+- Recommendations for what to work on next
+" --project "$PROJECT_PATH" --timeout 300
+```
+
 ### I0r: CEO Review — Research
 
 Apply the standard CEO Review Gate:
@@ -280,7 +316,7 @@ Apply the standard CEO Review Gate:
 
 Spawn the Distiller to synthesize the research into a structured spec.
 
-**For regular ideation** (`## Interactive Ideation Mode`):
+**For regular ideation on new ideas** (`## Interactive Ideation Mode` without `existing_project: true`):
 
 ```bash
 factory agent distiller --task "Distill a project specification from research and a raw idea.
@@ -290,6 +326,35 @@ Raw idea: <RAW_IDEA>
 Read the research report at .factory/strategy/research.md for domain context, technology recommendations, and prior art.
 
 Produce a complete idea.md specification." --project "$PROJECT_PATH" --timeout 300
+```
+
+**For existing projects** (`## Interactive Ideation Mode` with `existing_project: true`):
+
+```bash
+factory agent distiller --task "Distill an improvement specification for an existing project.
+
+Project: $PROJECT_PATH
+<If focus topic provided: Focus topic: <FOCUS_TOPIC>>
+
+Read the research report at .factory/strategy/research.md for project context, weak areas, and external best practices.
+
+This is an EXISTING project, not a new idea. Produce an improvement spec with these sections:
+
+## Improvement Goal
+<What we're trying to achieve — one clear sentence>
+
+## Current State
+<Summary of where the project stands — eval scores, recent experiments, known issues>
+
+## Proposed Changes
+<Specific changes to implement, scoped to one PR's worth of work each>
+
+## Success Criteria
+<How to verify the improvement worked — eval dimension targets, behavioral checks>
+
+## Scope Boundaries
+<What is in scope and what is explicitly out of scope for this improvement>
+" --project "$PROJECT_PATH" --timeout 300
 ```
 
 **For research ideation** (`## Research Ideation Mode`):
@@ -389,82 +454,24 @@ When the user approves the spec:
    Read .factory/strategy/research.md (the research).
    Write project inception notes to .factory/archive/. Then run: factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
    ```
-4. **Transition to Build mode**: The spec is now persisted. Continue with **Mode: Build** starting from step B0 (Research). The Build-mode Researcher will do a more focused, implementation-oriented research pass using the approved spec as context.
+4. **Transition — route by project type:**
 
-**Important:** Do not skip Build mode's Research and Strategy steps just because Phase 0 did research. Phase 0 research is broad and exploratory (what should we build?). Build mode research is implementation-focused (how do we build it?).
+   **For new ideas** (no `existing_project: true` flag): Transition to **Build mode**. The spec is now persisted. Continue with Mode: Build starting from step B0 (Research). The Build-mode Researcher will do a more focused, implementation-oriented research pass using the approved spec as context.
+
+   **Important:** Do not skip Build mode's Research and Strategy steps just because Phase 0 did research. Phase 0 research is broad and exploratory (what should we build?). Build mode research is implementation-focused (how do we build it?).
+
+   **For existing projects** (`existing_project: true`): Transition to **Improve mode** with the approved spec as the focus:
+   1. Persist the improvement spec to `.factory/strategy/current.md`
+   2. Add the improvement goal to the backlog: `factory backlog-add "$PROJECT_PATH" "<improvement goal from spec>"`
+   3. Proceed to **Improve mode** (Step 0a: Observe) with the improvement spec as the `--focus` directive. Do NOT re-run Phase 0 steps — transition directly into the Improve pipeline.
 
 ### Ideation Rules
 
 - **Maximum 5 iterations.** If the user has not approved after 5 rounds of feedback, summarize the current state and ask them to either approve the latest draft or provide a final definitive direction.
-- **Do not build anything during Phase 0.** No code, no scaffolding, no repos beyond the project directory. Phase 0 produces only a spec document.
+- **Do not build anything during Phase 0.** No code, no scaffolding, no repos beyond the project directory. Phase 0 produces only a spec document (or improvement spec for existing projects).
 - **Research is optional on refinement.** Only re-spawn the Researcher if the user's feedback introduces genuinely new territory. Minor scope adjustments (add/remove features, change priorities) do not need new research.
 - **Be concise when presenting.** After the first full presentation, highlight what changed rather than re-presenting the entire spec. But always show the full spec so the user can read it in context.
-
----
-
-## Phase 0e: Ideation on Existing Projects
-
-This phase activates when your task includes a `## Interactive Improvement Mode (Phase 0)` section. You are running in foreground interactive mode on an **existing project** — the user can see your output and respond.
-
-### Purpose
-
-Study an existing project and collaboratively decide what to work on next before entering the standard Improve loop.
-
-### E0: Study the Project
-
-Before talking to the user, gather context:
-
-1. **Read the project state**: `factory detect "$PROJECT_PATH"`, read `factory.md`, `.factory/strategy/backlog.md`, `.factory/strategy/current.md`
-2. **Check recent history**: `factory history "$PROJECT_PATH"` — what was kept/reverted recently?
-3. **Run current eval**: `factory eval "$PROJECT_PATH"` — where are the weak dimensions?
-4. **Check open issues**: `gh issue list --state open --json number,title,labels` (if GitHub is available)
-5. **Read the backlog**: What items are pending? What was deferred from Build mode?
-
-### E0b: Optional Web Research
-
-If the discussion topic (from `--focus` or the user's initial question) requires **domain knowledge beyond the local codebase** — e.g., external APIs, industry standards, competitor analysis, library best practices — spawn the Researcher for targeted web research before presenting findings:
-
-```bash
-factory agent researcher --task "Research <topic>: gather current best practices, API docs, or prior art relevant to <focus>. Write findings to .factory/strategy/research.md. Summarize findings in 2-3 paragraphs." --project "$PROJECT_PATH" --timeout 300
-```
-
-**Skip this step** if the topic is purely about the project's own code, backlog, or eval scores — E0 already covers those.
-
-### E1: Present Findings
-
-Present a concise summary to the user:
-- **Project health**: composite score, weakest dimensions, recent experiment outcomes
-- **Backlog**: pending items, categorized by FEEC priority
-- **Open issues**: any GitHub issues that need attention
-- **Recommendations**: your top 2-3 suggestions for what to work on, with rationale
-
-If a `--focus` topic was provided, lead with that topic but still present the broader context.
-
-### E2: Discuss and Iterate
-
-The user may:
-- **Approve a recommendation** ("yes, do that", "go with option 2")
-- **Redirect** ("actually, let's focus on the auth system instead")
-- **Ask questions** ("what's the coverage situation?", "why did experiment 5 get reverted?")
-- **Provide requirements** ("I want WebSocket support, here's what it should do...")
-
-Respond naturally. If the user asks for deeper analysis, do it. If they want to explore a specific area, investigate. This is a conversation, not a form.
-
-### E3: Transition to Improve Mode
-
-When the user approves a direction:
-
-1. **Formulate the work** as a focus directive or set of backlog items
-2. **If it's a single item**: add it to the backlog via `factory backlog-add "$PROJECT_PATH" "<item>"`, then proceed to Improve mode with that as the focus
-3. **If it's multiple items**: add each to the backlog, then proceed to Improve mode normally (the Strategist will prioritize from the backlog)
-4. **Do NOT re-run Phase 0e steps** — transition directly into the Improve mode pipeline (Step 0a: Observe)
-
-### Phase 0e Rules
-
-- **Maximum 5 iterations** of back-and-forth before asking the user to commit to a direction
-- **Do not start building during Phase 0e** — this phase produces a plan, not code
-- **You already have project context** — don't spawn a Researcher to re-read local code you already studied in E0, but DO use E0b to research external topics when the discussion requires domain knowledge beyond the codebase
-- **Be opinionated** — the user wants your recommendation, not a menu of every possible option
+- **Be opinionated for existing projects.** The user wants your recommendation, not a menu of every possible option. Lead with your top suggestion based on the data.
 
 ---
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1559,7 +1559,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
     if interactive_existing:
-        ceo_mode = "interactive"
+        ceo_mode = "build"
     elif mode == "interactive" or research_ideation:
         ceo_mode = "build"
     else:
@@ -2081,17 +2081,19 @@ def _build_ceo_task(
 
     if interactive_existing:
         task += (
-            f"\n\n## Interactive Improvement Mode (Phase 0)\n\n"
-            f"You are in interactive mode on an **existing project** at `{project_path}`.\n\n"
-            f"Before running any experiments, study the project and discuss with the user "
-            f"what to work on. Follow the Phase 0e: Ideation on Existing Projects protocol "
-            f"in your system prompt.\n\n"
+            f"\n\n## Interactive Ideation Mode (Phase 0)\n\n"
+            f"**existing_project: true**\n\n"
+            f"You are in interactive ideation mode on an **existing project** at `{project_path}`.\n\n"
+            f"Before running any experiments, research the project (local study + external "
+            f"best practices), distill an improvement spec through user feedback, then "
+            f"transition to Improve mode. Follow the Phase 0: Ideation protocol in your "
+            f"system prompt — the existing-project conditionals in I0, I1, and I4 apply.\n\n"
         )
         if focus:
             task += (
-                f"**Discussion topic (from --focus):** {focus}\n\n"
+                f"**Focus topic (from --focus):** {focus}\n\n"
                 f"The user wants to discuss this specific topic. Use it to seed the "
-                f"conversation, but be open to the user redirecting.\n"
+                f"research and spec, but be open to the user redirecting.\n"
             )
         else:
             task += (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,7 +161,7 @@ class TestCmdCeoInteractive:
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Interactive Improvement Mode (Phase 0)" in task
+        assert "## Interactive Ideation Mode (Phase 0)" in task
         assert "auth layer" in task
 
     def test_no_path_fails(self, capsys):
@@ -179,14 +179,15 @@ class TestCmdCeoInteractive:
         assert cmd[0] == "claude"
         assert "--dangerously-skip-permissions" in cmd
 
-    def test_interactive_existing_has_improvement_block(self, tmp_path):
-        """--mode interactive on an existing directory injects Improvement Mode block."""
+    def test_interactive_existing_has_ideation_block(self, tmp_path):
+        """--mode interactive on an existing directory injects Ideation Mode block."""
         with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "interactive"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Interactive Improvement Mode (Phase 0)" in task
+        assert "## Interactive Ideation Mode (Phase 0)" in task
+        assert "existing_project: true" in task
 
     def test_interactive_new_idea_has_ideation_block(self):
         """--mode interactive with a non-directory path injects Ideation Mode block."""
@@ -207,14 +208,14 @@ class TestCmdCeoInteractive:
         task = cmd[dsp_idx + 1]
         assert "distributed eval runner" in task
 
-    def test_interactive_existing_mode_is_interactive(self, tmp_path):
-        """--mode interactive on existing dir sets Mode: interactive in the CEO task."""
+    def test_interactive_existing_mode_is_build(self, tmp_path):
+        """--mode interactive on existing dir sets Mode: build in the CEO task."""
         with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "interactive"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "Mode: interactive" in task
+        assert "Mode: build" in task
 
     def test_interactive_new_idea_mode_is_build(self):
         """--mode interactive with new idea sets Mode: build in the CEO task."""
@@ -1322,19 +1323,20 @@ class TestResearchMode:
 class TestBuildCeoTaskInteractive:
     """Unit tests for _build_ceo_task interactive_existing parameter."""
 
-    def test_existing_project_emits_improvement_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "improve", interactive_existing=True)
-        assert "## Interactive Improvement Mode (Phase 0)" in task
+    def test_existing_project_emits_ideation_section(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
+        assert "## Interactive Ideation Mode (Phase 0)" in task
+        assert "existing_project: true" in task
         assert "existing project" in task
 
     def test_existing_project_with_focus(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "improve", interactive_existing=True, focus="auth layer")
-        assert "## Interactive Improvement Mode (Phase 0)" in task
+        task = _build_ceo_task(tmp_path, "build", interactive_existing=True, focus="auth layer")
+        assert "## Interactive Ideation Mode (Phase 0)" in task
         assert "auth layer" in task
-        assert "Discussion topic" in task
+        assert "Focus topic" in task
 
     def test_existing_project_without_focus(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "improve", interactive_existing=True)
+        task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
         assert "No specific topic was provided" in task
 
     def test_new_idea_emits_ideation_section(self, tmp_path):
@@ -1342,13 +1344,22 @@ class TestBuildCeoTaskInteractive:
         assert "## Interactive Ideation Mode (Phase 0)" in task
         assert "weather CLI" in task
 
-    def test_existing_does_not_emit_ideation(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "improve", interactive_existing=True)
-        assert "## Interactive Ideation Mode" not in task
+    def test_existing_uses_same_header_as_new_idea(self, tmp_path):
+        """Both new ideas and existing projects use the same Phase 0 header."""
+        existing_task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
+        new_task = _build_ceo_task(tmp_path, "build", interactive_idea="weather CLI")
+        assert "## Interactive Ideation Mode (Phase 0)" in existing_task
+        assert "## Interactive Ideation Mode (Phase 0)" in new_task
 
-    def test_existing_mode_is_interactive(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "interactive", interactive_existing=True)
-        assert "Mode: interactive" in task
+    def test_existing_project_has_existing_flag(self, tmp_path):
+        """Existing project task includes the existing_project flag for CEO conditionals."""
+        task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
+        assert "existing_project: true" in task
+
+    def test_existing_mode_is_build(self, tmp_path):
+        """When ceo_mode is build (as set by cli.py), task shows Mode: build."""
+        task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
+        assert "Mode: build" in task
 
 
 class TestCmdHomeReturnsFactoryDir:


### PR DESCRIPTION
Closes #297

## Changes
- **ceo.md**: Removed Phase 0e section entirely. Expanded Phase 0 with existing-project conditionals in I0 (Researcher does local study + external research), I1 (Distiller produces improvement spec with goal/current-state/proposed-changes/success-criteria/scope), and I4 (existing projects transition to Improve mode with spec as `--focus`). Updated exception clause to remove Phase 0e trigger reference.
- **cli.py**: Changed `interactive_existing` block to inject `## Interactive Ideation Mode (Phase 0)` header (instead of `## Interactive Improvement Mode`) with `existing_project: true` flag and project context. Set `ceo_mode = "build"` (instead of `"interactive"`) so the unified Phase 0 activates correctly.
- **tests/test_cli.py**: Updated all existing interactive tests to match new header and mode. Added tests verifying `existing_project: true` flag, unified header between new ideas and existing projects, and `Mode: build` routing.

## Test plan
- [x] All 169 cli tests pass
- [x] Full suite: 1768 passed, 3 skipped, 0 failures
- [x] Lint (ruff): clean
- [x] Type check (mypy): clean
- [x] New-idea interactive flow is NOT regressed (same header, same mode)
- [x] Existing-project flow uses Phase 0 (not Phase 0e)