### PR TITLE
Welcome Wizard — interactive CLI entry point

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -187,28 +187,24 @@ Factory command vocabulary:
 - `factory ceo <path> --focus <N>` — target a specific GitHub issue number
 
 Rules:
-1. The user's EXACT input must appear VERBATIM in the command field — never summarize or shorten it
+1. The user's EXACT input must appear VERBATIM in quoted arguments — never summarize or shorten it
 2. Return 2-3 suggestions as a JSON array
 3. Each element: {"label": "short title", "explanation": "one sentence why", "command": "factory ceo ..."}
 4. First suggestion should be the most likely intent
 5. You may add a "tip" field on the first element with brief advice
+6. If the user mentions fixing, improving, or working on an EXISTING project/repo, suggest `factory ceo <path>` or `factory ceo <path> --focus "..."` — add a tip telling them to replace <path> with the actual path. Do NOT wrap the input in quotes as a new idea when the intent is clearly about an existing project.
 
 User input: """
 
 
-def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
-    """Classify user input via headless runner call. Falls back to defaults on failure."""
+def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
+    """Classify user input via headless runner call. Returns None on failure."""
     from factory.runners import get_runner
-
-    default_suggestions = [
-        {"label": "Brainstorm and refine the idea first (recommended)", "explanation": "Research the space, refine the spec, then build.", "command": f'factory ceo {shlex.quote(user_input)} --mode interactive'},
-        {"label": "Build the project directly", "explanation": "Skip brainstorming and start building immediately.", "command": f'factory ceo {shlex.quote(user_input)}'},
-    ]
 
     try:
         runner = get_runner()
     except Exception:
-        return default_suggestions
+        return None
 
     prompt = _CLASSIFICATION_PROMPT + json.dumps(user_input)
     task = "Respond with ONLY a JSON array. No markdown, no explanation."
@@ -220,7 +216,7 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
 
         result, code = _run(runner.headless(
             prompt, task, Path.cwd(),
-            timeout=30.0,
+            timeout=60.0,
             dangerously_skip_permissions=True,
             role="wizard",
         ))
@@ -229,33 +225,56 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
         spinner.join(timeout=2.0)
 
         if code != 0:
-            return default_suggestions
+            return None
 
         text = result.strip()
         start = text.find("[")
         end = text.rfind("]")
         if start == -1 or end == -1:
-            return default_suggestions
+            return None
         parsed = json.loads(text[start:end + 1])
         if not isinstance(parsed, list) or len(parsed) == 0:
-            return default_suggestions
+            return None
         for item in parsed:
             if not isinstance(item, dict) or "command" not in item or "label" not in item:
-                return default_suggestions
+                return None
         return parsed[:3]
     except Exception:
         stop_event.set()
         spinner.join(timeout=2.0)
-        return default_suggestions
+        return None
 
 
 _EXAMPLES_BLOCK = """\
   Examples:
-    factory ceo "weather CLI in Python"          Build a new project
-    factory ceo ~/projects/my-app                Improve an existing project
-    factory ceo https://github.com/user/repo     Clone and improve
-    factory ceo spec.md                          Build from a spec file
-    factory ceo ~/projects/my-app --focus "auth"   Fix one thing\
+    factory ceo "weather CLI in Python"            Build a new project
+    factory ceo ~/projects/my-app                  Improve an existing project
+    factory ceo https://github.com/user/repo       Clone and improve
+    factory ceo spec.md                            Build from a spec file
+    factory ceo ~/projects/my-app --focus "auth"   Fix one thing
+    factory ceo ~/projects/my-app --focus 42       Target a GitHub issue\
+"""
+
+_CLI_REF = """\
+  Classification failed — here's a quick reference:
+
+  Build something new:
+    factory ceo "your idea here"                   Build directly
+    factory ceo "your idea" --mode interactive      Brainstorm first, then build
+    factory ceo "your idea" --mode research         Research-driven (metric-focused)
+    factory ceo spec.md                            Build from a spec file
+
+  Work on an existing project:
+    factory ceo /path/to/project                   Run one improvement cycle
+    factory ceo /path/to/project --focus "feature"   Build one specific thing
+    factory ceo /path/to/project --focus 42          Target GitHub issue #42
+    factory ceo /path/to/project --mode interactive  Discuss what to work on
+
+  Clone and improve:
+    factory ceo https://github.com/user/repo       Clone, then improve
+
+  Continuous:
+    factory run /path/to/project --loop            Heartbeat loop\
 """
 
 
@@ -301,8 +320,8 @@ def _welcome_wizard() -> int:
         suggestions = _classify_with_llm(user_input)
 
     if not suggestions:
-        print("\n  Could not classify input. Try:", file=sys.stderr)
-        print(_EXAMPLES_BLOCK, file=sys.stderr)
+        print(file=sys.stderr)
+        print(_CLI_REF, file=sys.stderr)
         return 1
 
     print(file=sys.stderr)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -131,7 +131,10 @@ def _show_spinner(stop_event: threading.Event) -> None:
         sys.stderr.flush()
         idx += 1
         stop_event.wait(0.1)
-    sys.stderr.write("\r\033[2K")
+    if use_color:
+        sys.stderr.write("\r\033[2K")
+    else:
+        sys.stderr.write("\r" + " " * 30 + "\r")
     sys.stderr.flush()
 
 
@@ -144,8 +147,8 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
         factory_dir = expanded / ".factory"
         label_improve = "Improve this project"
         label_interactive = "Discuss what to work on first"
-        cmd_improve = f'factory ceo "{stripped}"'
-        cmd_interactive = f'factory ceo "{stripped}" --mode interactive'
+        cmd_improve = f'factory ceo {shlex.quote(stripped)}'
+        cmd_interactive = f'factory ceo {shlex.quote(stripped)} --mode interactive'
         if factory_dir.is_dir():
             return [
                 {"label": label_improve, "explanation": "Run the improve loop on this project.", "command": cmd_improve},
@@ -158,13 +161,13 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
 
     if expanded.is_file():
         return [
-            {"label": "Build from this spec file", "explanation": "Use the file as a project specification.", "command": f'factory ceo "{stripped}"'},
+            {"label": "Build from this spec file", "explanation": "Use the file as a project specification.", "command": f'factory ceo {shlex.quote(stripped)}'},
         ]
 
     if _is_github_url(stripped):
         return [
-            {"label": "Clone and improve", "explanation": "Clone the repository and run the improve loop.", "command": f'factory ceo "{stripped}"'},
-            {"label": "Clone and discuss", "explanation": "Clone and discuss what to work on.", "command": f'factory ceo "{stripped}" --mode interactive'},
+            {"label": "Clone and improve", "explanation": "Clone the repository and run the improve loop.", "command": f'factory ceo {shlex.quote(stripped)}'},
+            {"label": "Clone and discuss", "explanation": "Clone and discuss what to work on.", "command": f'factory ceo {shlex.quote(stripped)} --mode interactive'},
         ]
 
     return None
@@ -198,8 +201,8 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
     from factory.runners import get_runner
 
     default_suggestions = [
-        {"label": "Brainstorm and refine the idea first (recommended)", "explanation": "Research the space, refine the spec, then build.", "command": f'factory ceo "{user_input}" --mode interactive'},
-        {"label": "Build the project directly", "explanation": "Skip brainstorming and start building immediately.", "command": f'factory ceo "{user_input}"'},
+        {"label": "Brainstorm and refine the idea first (recommended)", "explanation": "Research the space, refine the spec, then build.", "command": f'factory ceo {shlex.quote(user_input)} --mode interactive'},
+        {"label": "Build the project directly", "explanation": "Skip brainstorming and start building immediately.", "command": f'factory ceo {shlex.quote(user_input)}'},
     ]
 
     try:
@@ -242,6 +245,7 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
         return parsed[:3]
     except Exception:
         stop_event.set()
+        spinner.join(timeout=2.0)
         return default_suggestions
 
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -253,36 +253,20 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
         return None
 
 
-_EXAMPLES_BLOCK = """\
-  Examples:
-    factory ceo "weather CLI in Python"            Build a new project
-    factory ceo ~/projects/my-app                  Improve an existing project
-    factory ceo https://github.com/user/repo       Clone and improve
-    factory ceo spec.md                            Build from a spec file
-    factory ceo ~/projects/my-app --focus "auth"   Fix one thing
-    factory ceo ~/projects/my-app --focus 42       Target a GitHub issue\
-"""
-
 _CLI_REF = """\
-  Classification failed — here's a quick reference:
-
   Build something new:
-    factory ceo "your idea here"                   Build directly
-    factory ceo "your idea" --mode interactive      Brainstorm first, then build
-    factory ceo "your idea" --mode research         Research-driven (metric-focused)
-    factory ceo spec.md                            Build from a spec file
+    factory ceo "weather CLI in Python"                    Build directly
+    factory ceo "weather CLI" --mode interactive            Brainstorm first, then build
+    factory ceo "SWE-bench solver" --mode research          Research-driven (metric-focused)
 
   Work on an existing project:
-    factory ceo /path/to/project                   Run one improvement cycle
-    factory ceo /path/to/project --focus "feature"   Build one specific thing
-    factory ceo /path/to/project --focus 42          Target GitHub issue #42
-    factory ceo /path/to/project --mode interactive  Discuss what to work on
+    factory ceo ~/projects/my-app                          Run one improvement cycle
+    factory ceo ~/projects/my-app --focus "auth"             Fix one specific thing
+    factory ceo ~/projects/my-app --focus 42                 Target GitHub issue #42
+    factory ceo ~/projects/my-app --mode interactive         Discuss what to work on
 
-  Clone and improve:
-    factory ceo https://github.com/user/repo       Clone, then improve
-
-  Continuous:
-    factory run /path/to/project --loop            Heartbeat loop\
+  Self-improve the factory:
+    factory ceo /path/to/factory --mode meta                Improve + evolve agent playbooks\
 """
 
 
@@ -311,7 +295,7 @@ def _welcome_wizard() -> int:
 
     if not user_input:
         print(file=sys.stderr)
-        print(_EXAMPLES_BLOCK, file=sys.stderr)
+        print(_CLI_REF, file=sys.stderr)
         print(file=sys.stderr)
         try:
             user_input = input("  > ").strip()

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -371,6 +371,22 @@ def _welcome_wizard() -> int:
     selected = suggestions[choice_idx]
     command = selected.get("command", "")
 
+    if "<path>" in command:
+        print(file=sys.stderr)
+        try:
+            path_input = input("  Path to project: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print(file=sys.stderr)
+            return 0
+        if not path_input:
+            print("  No path provided.", file=sys.stderr)
+            return 1
+        resolved = str(Path(path_input).expanduser().resolve())
+        if not Path(resolved).is_dir():
+            print(f"  Not a directory: {resolved}", file=sys.stderr)
+            return 1
+        command = command.replace("<path>", shlex.quote(resolved))
+
     print(f"\n  Running: {command}\n", file=sys.stderr)
 
     # Parse the selected command and dispatch to cmd_ceo
@@ -390,8 +406,10 @@ def _welcome_wizard() -> int:
         print(f"  Error: invalid command: {command}", file=sys.stderr)
         return 1
 
-    if ns.command == "ceo":
-        return cmd_ceo(ns)
+    if ns.command in ("ceo", "study"):
+        handler = cmd_ceo if ns.command == "ceo" else globals().get("cmd_study")
+        if handler:
+            return handler(ns)
 
     print(f"  Error: unexpected command type: {ns.command}", file=sys.stderr)
     return 1

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -214,12 +214,20 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
         spinner = threading.Thread(target=_show_spinner, args=(stop_event,), daemon=True)
         spinner.start()
 
-        result, code = _run(runner.headless(
-            prompt, task, Path.cwd(),
-            timeout=60.0,
-            dangerously_skip_permissions=True,
-            role="wizard",
-        ))
+        old_quiet = os.environ.get("FACTORY_RUNNER_QUIET")
+        os.environ["FACTORY_RUNNER_QUIET"] = "1"
+        try:
+            result, code = _run(runner.headless(
+                prompt, task, Path.cwd(),
+                timeout=60.0,
+                dangerously_skip_permissions=True,
+                role="wizard",
+            ))
+        finally:
+            if old_quiet is None:
+                os.environ.pop("FACTORY_RUNNER_QUIET", None)
+            else:
+                os.environ["FACTORY_RUNNER_QUIET"] = old_quiet
 
         stop_event.set()
         spinner.join(timeout=2.0)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -91,19 +91,23 @@ def _ensure_dashboard(project_path: Path, port: int = _DASHBOARD_PORT) -> None:
 def _print_banner(mode: str = "improve") -> None:
     """Print the Factory startup banner to stderr."""
     if os.environ.get("NO_COLOR") or not sys.stderr.isatty():
-        print(f"Factory v2 — mode: {mode}", file=sys.stderr)
+        if mode == "welcome":
+            print("The Factory — Self-Evolving Meta-Harness", file=sys.stderr)
+        else:
+            print(f"Factory v2 — mode: {mode}", file=sys.stderr)
         return
 
     c = "\033[1;36m"  # bold cyan
     d = "\033[2m"      # dim
     r = "\033[0m"      # reset
 
+    mode_line = "" if mode == "welcome" else f"{d}  Mode: {mode}{r}\n"
     banner = (
         f"\n{c}  ┏━╸┏━┓┏━╸╺┳╸┏━┓┏━┓╻ ╻{r}\n"
         f"{c}  ┣╸ ┣━┫┃   ┃ ┃ ┃┣┳┛┗┳┛{r}\n"
         f"{c}  ╹  ╹ ╹┗━╸ ╹ ┗━┛╹┗╸ ╹ {r}\n"
         f"{d}  Self-Evolving Meta-Harness{r}\n"
-        f"{d}  Mode: {mode}{r}\n"
+        f"{mode_line}"
     )
     print(banner, file=sys.stderr)
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -255,18 +255,17 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
 
 _CLI_REF = """\
   Build something new:
-    factory ceo "weather CLI in Python"                    Build directly
-    factory ceo "weather CLI" --mode interactive            Brainstorm first, then build
-    factory ceo "SWE-bench solver" --mode research          Research-driven (metric-focused)
+    factory ceo "a fasta CLI that converts protein sequences to embeddings using ESM2" --mode interactive
+    factory ceo "an autograd engine in pure numpy with a pytorch-like API" --mode interactive
+    factory ceo "a system that solves IMO geometry problems using lean4 proofs" --mode research
 
   Work on an existing project:
-    factory ceo ~/projects/my-app                          Run one improvement cycle
-    factory ceo ~/projects/my-app --focus "auth"             Fix one specific thing
-    factory ceo ~/projects/my-app --focus 42                 Target GitHub issue #42
-    factory ceo ~/projects/my-app --mode interactive         Discuss what to work on
+    factory ceo ~/projects/my-app --focus "add OAuth2 login with Google and GitHub providers"
+    factory ceo ~/projects/my-app --focus 42
+    factory ceo ~/projects/my-app --mode interactive
 
   Self-improve the factory:
-    factory ceo /path/to/factory --mode meta                Improve + evolve agent playbooks\
+    factory ceo /path/to/factory --mode meta\
 """
 
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -102,10 +102,281 @@ def _print_banner(mode: str = "improve") -> None:
         f"\n{c}  ┏━╸┏━┓┏━╸╺┳╸┏━┓┏━┓╻ ╻{r}\n"
         f"{c}  ┣╸ ┣━┫┃   ┃ ┃ ┃┣┳┛┗┳┛{r}\n"
         f"{c}  ╹  ╹ ╹┗━╸ ╹ ┗━┛╹┗╸ ╹ {r}\n"
-        f"{d}  Multi-Agent Software Evolution{r}\n"
+        f"{d}  Self-Evolving Meta-Harness{r}\n"
         f"{d}  Mode: {mode}{r}\n"
     )
     print(banner, file=sys.stderr)
+
+
+# ── welcome wizard ─────────────────────────────────────────────
+
+
+_BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+
+def _show_spinner(stop_event: threading.Event) -> None:
+    """Braille spinner on stderr. Respects NO_COLOR."""
+    use_color = not os.environ.get("NO_COLOR") and sys.stderr.isatty()
+    idx = 0
+    while not stop_event.is_set():
+        frame = _BRAILLE_FRAMES[idx % len(_BRAILLE_FRAMES)]
+        if use_color:
+            sys.stderr.write(f"\r\033[2m  Thinking... {frame}\033[0m")
+        else:
+            sys.stderr.write(f"\r  Thinking... {frame}")
+        sys.stderr.flush()
+        idx += 1
+        stop_event.wait(0.1)
+    sys.stderr.write("\r\033[2K")
+    sys.stderr.flush()
+
+
+def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
+    """Deterministic fast path for paths, files, and URLs. Returns None if LLM needed."""
+    stripped = user_input.strip()
+
+    expanded = Path(stripped).expanduser()
+    if expanded.is_dir():
+        factory_dir = expanded / ".factory"
+        label_improve = "Improve this project"
+        label_interactive = "Discuss what to work on first"
+        cmd_improve = f'factory ceo "{stripped}"'
+        cmd_interactive = f'factory ceo "{stripped}" --mode interactive'
+        if factory_dir.is_dir():
+            return [
+                {"label": label_improve, "explanation": "Run the improve loop on this project.", "command": cmd_improve},
+                {"label": label_interactive, "explanation": "Study the project and discuss priorities.", "command": cmd_interactive},
+            ]
+        return [
+            {"label": "Set up and improve this project", "explanation": "Initialize factory and start improving.", "command": cmd_improve},
+            {"label": label_interactive, "explanation": "Study the project and discuss priorities.", "command": cmd_interactive},
+        ]
+
+    if expanded.is_file():
+        return [
+            {"label": "Build from this spec file", "explanation": "Use the file as a project specification.", "command": f'factory ceo "{stripped}"'},
+        ]
+
+    if _is_github_url(stripped):
+        return [
+            {"label": "Clone and improve", "explanation": "Clone the repository and run the improve loop.", "command": f'factory ceo "{stripped}"'},
+            {"label": "Clone and discuss", "explanation": "Clone and discuss what to work on.", "command": f'factory ceo "{stripped}" --mode interactive'},
+        ]
+
+    return None
+
+
+_CLASSIFICATION_PROMPT = """\
+You are a CLI router for Factory, a multi-agent software evolution tool.
+
+Given the user's input, suggest 2-3 ranked factory commands. Return ONLY a JSON array.
+
+Factory command vocabulary:
+- `factory ceo "<idea>" --mode interactive` — brainstorm and refine the idea before building (recommended for vague ideas)
+- `factory ceo "<idea>"` — build the project directly (good for clear, specific descriptions)
+- `factory ceo "<idea>" --mode research` — research-driven optimization (for metric-focused projects)
+- `factory ceo <path>` — improve an existing project at the given path
+- `factory ceo <path> --focus "<item>"` — fix or add one specific thing in an existing project
+- `factory ceo <path> --focus <N>` — target a specific GitHub issue number
+
+Rules:
+1. The user's EXACT input must appear VERBATIM in the command field — never summarize or shorten it
+2. Return 2-3 suggestions as a JSON array
+3. Each element: {"label": "short title", "explanation": "one sentence why", "command": "factory ceo ..."}
+4. First suggestion should be the most likely intent
+5. You may add a "tip" field on the first element with brief advice
+
+User input: """
+
+
+def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
+    """Classify user input via headless runner call. Falls back to defaults on failure."""
+    from factory.runners import get_runner
+
+    default_suggestions = [
+        {"label": "Brainstorm and refine the idea first (recommended)", "explanation": "Research the space, refine the spec, then build.", "command": f'factory ceo "{user_input}" --mode interactive'},
+        {"label": "Build the project directly", "explanation": "Skip brainstorming and start building immediately.", "command": f'factory ceo "{user_input}"'},
+    ]
+
+    try:
+        runner = get_runner()
+    except Exception:
+        return default_suggestions
+
+    prompt = _CLASSIFICATION_PROMPT + json.dumps(user_input)
+    task = "Respond with ONLY a JSON array. No markdown, no explanation."
+
+    try:
+        stop_event = threading.Event()
+        spinner = threading.Thread(target=_show_spinner, args=(stop_event,), daemon=True)
+        spinner.start()
+
+        result, code = _run(runner.headless(
+            prompt, task, Path.cwd(),
+            timeout=30.0,
+            dangerously_skip_permissions=True,
+            role="wizard",
+        ))
+
+        stop_event.set()
+        spinner.join(timeout=2.0)
+
+        if code != 0:
+            return default_suggestions
+
+        text = result.strip()
+        start = text.find("[")
+        end = text.rfind("]")
+        if start == -1 or end == -1:
+            return default_suggestions
+        parsed = json.loads(text[start:end + 1])
+        if not isinstance(parsed, list) or len(parsed) == 0:
+            return default_suggestions
+        for item in parsed:
+            if not isinstance(item, dict) or "command" not in item or "label" not in item:
+                return default_suggestions
+        return parsed[:3]
+    except Exception:
+        stop_event.set()
+        return default_suggestions
+
+
+_EXAMPLES_BLOCK = """\
+  Examples:
+    factory ceo "weather CLI in Python"          Build a new project
+    factory ceo ~/projects/my-app                Improve an existing project
+    factory ceo https://github.com/user/repo     Clone and improve
+    factory ceo spec.md                          Build from a spec file
+    factory ceo ~/projects/my-app --focus "auth"   Fix one thing\
+"""
+
+
+def _welcome_wizard() -> int:
+    """Interactive welcome: banner -> input -> classify -> present -> dispatch."""
+    no_color = bool(os.environ.get("NO_COLOR")) or not sys.stderr.isatty()
+
+    _print_banner("welcome")
+
+    if no_color:
+        print("\n  What do you want to do?", file=sys.stderr)
+        print("  Paste an idea, a file path, a GitHub URL, or describe what you need.\n", file=sys.stderr)
+    else:
+        d = "\033[2m"
+        r = "\033[0m"
+        print("\n  What do you want to do?", file=sys.stderr)
+        print(f"  {d}Paste an idea, a file path, a GitHub URL, or describe what you need.{r}\n", file=sys.stderr)
+
+    try:
+        user_input = input("  > ").strip()
+    except EOFError:
+        return 0
+    except KeyboardInterrupt:
+        print(file=sys.stderr)
+        return 130
+
+    if not user_input:
+        print(file=sys.stderr)
+        print(_EXAMPLES_BLOCK, file=sys.stderr)
+        print(file=sys.stderr)
+        try:
+            user_input = input("  > ").strip()
+        except EOFError:
+            return 0
+        except KeyboardInterrupt:
+            print(file=sys.stderr)
+            return 130
+        if not user_input:
+            return 0
+
+    suggestions = _quick_classify(user_input)
+    if suggestions is None:
+        suggestions = _classify_with_llm(user_input)
+
+    if not suggestions:
+        print("\n  Could not classify input. Try:", file=sys.stderr)
+        print(_EXAMPLES_BLOCK, file=sys.stderr)
+        return 1
+
+    print(file=sys.stderr)
+
+    tip = None
+    for i, s in enumerate(suggestions, 1):
+        label = s.get("label", "Option")
+        explanation = s.get("explanation", "")
+        command = s.get("command", "")
+        if no_color:
+            print(f"  [{i}] {label}", file=sys.stderr)
+            if explanation:
+                print(f"      {explanation}", file=sys.stderr)
+            print(f"      {command}", file=sys.stderr)
+        else:
+            b = "\033[1m"
+            d = "\033[2m"
+            r = "\033[0m"
+            print(f"  {b}[{i}]{r} {label}", file=sys.stderr)
+            if explanation:
+                print(f"      {d}{explanation}{r}", file=sys.stderr)
+            print(f"      {command}", file=sys.stderr)
+        if i == 1 and "tip" in s:
+            tip = s["tip"]
+        print(file=sys.stderr)
+
+    if tip:
+        if no_color:
+            print(f"  Tip: {tip}", file=sys.stderr)
+        else:
+            print(f"  {d}Tip: {tip}{r}", file=sys.stderr)
+        print(file=sys.stderr)
+
+    prompt_text = f"  Pick [1-{len(suggestions)}], or Enter for [1]: "
+    try:
+        choice_raw = input(prompt_text).strip()
+    except EOFError:
+        return 0
+    except KeyboardInterrupt:
+        print(file=sys.stderr)
+        return 130
+
+    if not choice_raw:
+        choice_idx = 0
+    else:
+        try:
+            choice_idx = int(choice_raw) - 1
+        except ValueError:
+            print(f"\n  Invalid choice: {choice_raw}", file=sys.stderr)
+            return 1
+
+    if choice_idx < 0 or choice_idx >= len(suggestions):
+        print(f"\n  Invalid choice: {choice_raw}", file=sys.stderr)
+        return 1
+
+    selected = suggestions[choice_idx]
+    command = selected.get("command", "")
+
+    print(f"\n  Running: {command}\n", file=sys.stderr)
+
+    # Parse the selected command and dispatch to cmd_ceo
+    parser = build_parser()
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        print(f"  Error: could not parse command: {command}", file=sys.stderr)
+        return 1
+
+    if parts and parts[0] == "factory":
+        parts = parts[1:]
+
+    try:
+        ns = parser.parse_args(parts)
+    except SystemExit:
+        print(f"  Error: invalid command: {command}", file=sys.stderr)
+        return 1
+
+    if ns.command == "ceo":
+        return cmd_ceo(ns)
+
+    print(f"  Error: unexpected command type: {ns.command}", file=sys.stderr)
+    return 1
 
 
 # ── subcommand handlers ────────────────────────────────────────
@@ -2945,6 +3216,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if not args.command:
+        if sys.stdin.isatty() and sys.stderr.isatty():
+            return _welcome_wizard()
         parser.print_help()
         return 1
 

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -144,45 +144,40 @@ class TestClassifyWithLLM:
         assert len(result) == 1
         assert result[0]["label"] == "Build it"
 
-    def test_invalid_json_falls_back(self) -> None:
+    def test_invalid_json_returns_none(self) -> None:
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=("not valid json at all", 0))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
 
-        assert len(result) == 2
-        assert "recommended" in result[0]["label"].lower()
-        assert "weather CLI" in result[0]["command"]
+        assert result is None
 
-    def test_runner_failure_falls_back(self) -> None:
+    def test_runner_failure_returns_none(self) -> None:
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=("Error", 1))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
 
-        assert len(result) == 2
-        assert "weather CLI" in result[0]["command"]
+        assert result is None
 
-    def test_runner_not_available_falls_back(self) -> None:
+    def test_runner_not_available_returns_none(self) -> None:
         with patch("factory.runners.get_runner", side_effect=Exception("No runner")):
             result = _classify_with_llm("weather CLI")
 
-        assert len(result) == 2
-        assert "weather CLI" in result[0]["command"]
+        assert result is None
 
-    def test_empty_array_falls_back(self) -> None:
+    def test_empty_array_returns_none(self) -> None:
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=("[]", 0))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test idea")
 
-        assert len(result) == 2
-        assert "test idea" in result[0]["command"]
+        assert result is None
 
-    def test_missing_required_fields_falls_back(self) -> None:
+    def test_missing_required_fields_returns_none(self) -> None:
         bad_suggestions = [{"label": "Test"}]  # missing command
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=(json.dumps(bad_suggestions), 0))
@@ -190,8 +185,7 @@ class TestClassifyWithLLM:
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test idea")
 
-        assert len(result) == 2
-        assert "test idea" in result[0]["command"]
+        assert result is None
 
     def test_truncates_to_3_suggestions(self) -> None:
         suggestions = [
@@ -206,12 +200,19 @@ class TestClassifyWithLLM:
 
         assert len(result) == 3
 
-    def test_preserves_user_input_in_defaults(self) -> None:
-        with patch("factory.runners.get_runner", side_effect=Exception("fail")):
-            result = _classify_with_llm("my exact input text")
+    def test_wizard_shows_cli_ref_on_llm_failure(self) -> None:
+        with patch("builtins.input", side_effect=["test idea"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=None), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            mock_stderr.write = MagicMock()
+            code = _welcome_wizard()
 
-        for s in result:
-            assert "my exact input text" in s["command"]
+        assert code == 1
+        output = "".join(call.args[0] for call in mock_stderr.write.call_args_list)
+        assert "quick reference" in output.lower() or "factory ceo" in output
 
 
 # ── _show_spinner ──────────────────────────────────────────────

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -465,5 +465,5 @@ class TestBannerUpdate:
             mock_stderr.isatty.return_value = False
             _print_banner("welcome")
 
-        # The no-color branch just prints "Factory v2 — mode: welcome"
-        # (tagline only appears in the ANSI branch)
+        # The no-color branch prints the tagline without mode for welcome
+        mock_stderr.write.assert_any_call("The Factory — Self-Evolving Meta-Harness")

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -311,6 +311,21 @@ class TestWizardDispatch:
         (tmp_path / ".factory").mkdir()
         with patch("builtins.input", side_effect=[str(tmp_path), ""]), \
              patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli.cmd_ceo", return_value=0), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_path_placeholder_prompts_for_path(self, tmp_path: Path) -> None:
+        suggestions = [
+            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
+        ]
+        with patch("builtins.input", side_effect=["fix a bug", "", str(tmp_path)]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
              patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
@@ -318,6 +333,50 @@ class TestWizardDispatch:
 
         assert code == 0
         mock_ceo.assert_called_once()
+        ns = mock_ceo.call_args[0][0]
+        assert str(tmp_path.resolve()) == ns.path
+
+    def test_path_placeholder_empty_returns_error(self) -> None:
+        suggestions = [
+            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
+        ]
+        with patch("builtins.input", side_effect=["fix a bug", "", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 1
+
+    def test_path_placeholder_nonexistent_returns_error(self) -> None:
+        suggestions = [
+            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
+        ]
+        with patch("builtins.input", side_effect=["fix a bug", "", "/nonexistent/path/xyz"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 1
+
+    def test_path_placeholder_eof_exits_cleanly(self) -> None:
+        suggestions = [
+            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
+        ]
+        with patch("builtins.input", side_effect=["fix a bug", "", EOFError]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
 
 
 # ── edge cases ─────────────────────────────────────────────────

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -1,0 +1,469 @@
+"""Tests for the welcome wizard in factory/cli.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from factory.cli import (
+    _classify_with_llm,
+    _quick_classify,
+    _show_spinner,
+    _welcome_wizard,
+    main,
+)
+
+
+# ── TTY detection ──────────────────────────────────────────────
+
+
+class TestTTYDetection:
+    """Wizard activates only when stdin+stderr are TTYs."""
+
+    def test_non_tty_prints_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Non-TTY falls through to argparse help (backward compatible)."""
+        with patch("sys.stdin") as mock_stdin, \
+             patch("sys.stderr") as mock_stderr:
+            mock_stdin.isatty.return_value = False
+            mock_stderr.isatty.return_value = False
+            code = main([])
+        assert code == 1
+
+    def test_tty_launches_wizard(self) -> None:
+        """TTY with no subcommand dispatches to _welcome_wizard."""
+        with patch("factory.cli._welcome_wizard", return_value=0) as mock_wizard, \
+             patch("sys.stdin") as mock_stdin, \
+             patch("sys.stderr") as mock_stderr:
+            mock_stdin.isatty.return_value = True
+            mock_stderr.isatty.return_value = True
+            code = main([])
+        assert code == 0
+        mock_wizard.assert_called_once()
+
+    def test_stdin_not_tty_stderr_tty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """If stdin is not a TTY (piped), falls through to help."""
+        with patch("sys.stdin") as mock_stdin, \
+             patch("sys.stderr") as mock_stderr:
+            mock_stdin.isatty.return_value = False
+            mock_stderr.isatty.return_value = True
+            code = main([])
+        assert code == 1
+
+
+# ── _quick_classify ────────────────────────────────────────────
+
+
+class TestQuickClassify:
+    """Deterministic fast path for paths, files, and URLs."""
+
+    def test_existing_dir_with_factory(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        result = _quick_classify(str(tmp_path))
+        assert result is not None
+        assert len(result) == 2
+        assert "Improve" in result[0]["label"]
+        assert str(tmp_path) in result[0]["command"]
+
+    def test_existing_dir_without_factory(self, tmp_path: Path) -> None:
+        result = _quick_classify(str(tmp_path))
+        assert result is not None
+        assert len(result) == 2
+        assert "Set up" in result[0]["label"]
+
+    def test_existing_file(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("Build a weather CLI")
+        result = _quick_classify(str(spec))
+        assert result is not None
+        assert len(result) == 1
+        assert "spec" in result[0]["label"].lower()
+        assert str(spec) in result[0]["command"]
+
+    def test_github_url(self) -> None:
+        url = "https://github.com/user/repo"
+        result = _quick_classify(url)
+        assert result is not None
+        assert len(result) == 2
+        assert "Clone" in result[0]["label"]
+        assert url in result[0]["command"]
+
+    def test_github_ssh_url(self) -> None:
+        url = "git@github.com:user/repo.git"
+        result = _quick_classify(url)
+        assert result is not None
+        assert "Clone" in result[0]["label"]
+
+    def test_free_text_returns_none(self) -> None:
+        result = _quick_classify("build me a weather CLI in Python")
+        assert result is None
+
+    def test_nonexistent_path_returns_none(self) -> None:
+        result = _quick_classify("/nonexistent/path/12345")
+        assert result is None
+
+    def test_preserves_user_input_verbatim(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        user_input = str(tmp_path)
+        result = _quick_classify(user_input)
+        assert result is not None
+        for s in result:
+            assert user_input in s["command"]
+
+
+# ── _classify_with_llm ────────────────────────────────────────
+
+
+class TestClassifyWithLLM:
+    """LLM-based classification with mocked runner."""
+
+    def test_valid_json_response(self) -> None:
+        suggestions = [
+            {"label": "Brainstorm first", "explanation": "Refine the idea.", "command": 'factory ceo "weather CLI" --mode interactive'},
+            {"label": "Build directly", "explanation": "Start building.", "command": 'factory ceo "weather CLI"'},
+        ]
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(suggestions), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("weather CLI")
+
+        assert len(result) == 2
+        assert result[0]["label"] == "Brainstorm first"
+
+    def test_json_with_markdown_wrapper(self) -> None:
+        raw = '```json\n[{"label": "Build it", "explanation": "Go.", "command": "factory ceo \\"test\\""}]\n```'
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(raw, 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("test")
+
+        assert len(result) == 1
+        assert result[0]["label"] == "Build it"
+
+    def test_invalid_json_falls_back(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=("not valid json at all", 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("weather CLI")
+
+        assert len(result) == 2
+        assert "recommended" in result[0]["label"].lower()
+        assert "weather CLI" in result[0]["command"]
+
+    def test_runner_failure_falls_back(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=("Error", 1))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("weather CLI")
+
+        assert len(result) == 2
+        assert "weather CLI" in result[0]["command"]
+
+    def test_runner_not_available_falls_back(self) -> None:
+        with patch("factory.runners.get_runner", side_effect=Exception("No runner")):
+            result = _classify_with_llm("weather CLI")
+
+        assert len(result) == 2
+        assert "weather CLI" in result[0]["command"]
+
+    def test_empty_array_falls_back(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=("[]", 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("test idea")
+
+        assert len(result) == 2
+        assert "test idea" in result[0]["command"]
+
+    def test_missing_required_fields_falls_back(self) -> None:
+        bad_suggestions = [{"label": "Test"}]  # missing command
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(bad_suggestions), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("test idea")
+
+        assert len(result) == 2
+        assert "test idea" in result[0]["command"]
+
+    def test_truncates_to_3_suggestions(self) -> None:
+        suggestions = [
+            {"label": f"Option {i}", "explanation": "desc", "command": f'factory ceo "x{i}"'}
+            for i in range(5)
+        ]
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(suggestions), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("test")
+
+        assert len(result) == 3
+
+    def test_preserves_user_input_in_defaults(self) -> None:
+        with patch("factory.runners.get_runner", side_effect=Exception("fail")):
+            result = _classify_with_llm("my exact input text")
+
+        for s in result:
+            assert "my exact input text" in s["command"]
+
+
+# ── _show_spinner ──────────────────────────────────────────────
+
+
+class TestShowSpinner:
+    """Spinner respects NO_COLOR and stops cleanly."""
+
+    def test_spinner_stops_on_event(self) -> None:
+        import threading
+        stop = threading.Event()
+        stop.set()
+        with patch("sys.stderr"):
+            _show_spinner(stop)
+
+    def test_spinner_respects_no_color(self) -> None:
+        import threading
+        stop = threading.Event()
+        stop.set()
+        with patch.dict("os.environ", {"NO_COLOR": "1"}), \
+             patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = False
+            _show_spinner(stop)
+
+
+# ── option selection + dispatch ────────────────────────────────
+
+
+class TestWizardDispatch:
+    """Tests for the full wizard flow: input -> classify -> select -> dispatch."""
+
+    def test_selects_default_option(self) -> None:
+        suggestions = [
+            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test" --mode interactive'},
+        ]
+        with patch("builtins.input", side_effect=["test idea", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+        mock_ceo.assert_called_once()
+
+    def test_selects_numbered_option(self) -> None:
+        suggestions = [
+            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
+            {"label": "Option 2", "explanation": "Second.", "command": 'factory ceo "test" --mode interactive'},
+        ]
+        with patch("builtins.input", side_effect=["test idea", "2"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+        mock_ceo.assert_called_once()
+        ns = mock_ceo.call_args[0][0]
+        assert ns.mode == "interactive"
+
+    def test_invalid_choice_returns_error(self) -> None:
+        suggestions = [
+            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test idea", "abc"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 1
+
+    def test_out_of_range_choice_returns_error(self) -> None:
+        suggestions = [
+            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test idea", "5"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 1
+
+    def test_fast_path_skips_llm(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        with patch("builtins.input", side_effect=[str(tmp_path), ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+        mock_ceo.assert_called_once()
+
+
+# ── edge cases ─────────────────────────────────────────────────
+
+
+class TestWizardEdgeCases:
+    """Empty input, EOF, Ctrl+C."""
+
+    def test_empty_input_shows_examples_then_exits(self) -> None:
+        with patch("builtins.input", side_effect=["", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_empty_then_valid_input(self) -> None:
+        suggestions = [
+            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["", "test idea", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+        mock_ceo.assert_called_once()
+
+    def test_eof_on_first_prompt(self) -> None:
+        with patch("builtins.input", side_effect=EOFError), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_eof_on_choice_prompt(self) -> None:
+        suggestions = [
+            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test", EOFError]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_ctrl_c_on_first_prompt(self) -> None:
+        with patch("builtins.input", side_effect=KeyboardInterrupt), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 130
+
+    def test_ctrl_c_on_choice_prompt(self) -> None:
+        suggestions = [
+            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test", KeyboardInterrupt]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 130
+
+    def test_eof_on_second_prompt_after_empty(self) -> None:
+        with patch("builtins.input", side_effect=["", EOFError]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_ctrl_c_on_second_prompt_after_empty(self) -> None:
+        with patch("builtins.input", side_effect=["", KeyboardInterrupt]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 130
+
+
+# ── NO_COLOR behavior ──────────────────────────────────────────
+
+
+class TestNOCOLOR:
+    """Wizard respects NO_COLOR env var."""
+
+    def test_no_color_plain_text(self, capsys: pytest.CaptureFixture[str]) -> None:
+        suggestions = [
+            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test", ""]), \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli.cmd_ceo", return_value=0), \
+             patch.dict("os.environ", {"NO_COLOR": "1"}):
+            code = _welcome_wizard()
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "\033[" not in captured.err
+
+
+# ── regression: existing subcommands ───────────────────────────
+
+
+class TestExistingSubcommands:
+    """Existing subcommands must work identically."""
+
+    def test_home_still_works(self) -> None:
+        code = main(["home"])
+        assert code == 0
+
+    def test_subcommand_not_affected(self) -> None:
+        with patch("factory.cli._welcome_wizard") as mock_wizard:
+            main(["home"])
+        mock_wizard.assert_not_called()
+
+
+# ── banner update ──────────────────────────────────────────────
+
+
+class TestBannerUpdate:
+    def test_banner_tagline(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from factory.cli import _print_banner
+
+        with patch("sys.stderr") as mock_stderr, \
+             patch.dict("os.environ", {"NO_COLOR": "1"}):
+            mock_stderr.isatty.return_value = False
+            _print_banner("welcome")
+
+        # The no-color branch just prints "Factory v2 — mode: welcome"
+        # (tagline only appears in the ANSI branch)


### PR DESCRIPTION
Closes #300

## Changes

- Added `_welcome_wizard()` as the interactive entry point when `factory` is run with no subcommand in a TTY
- Added `_quick_classify()` for deterministic fast-path classification of paths, files, and GitHub URLs (no LLM needed)
- Added `_classify_with_llm()` that calls the configured runner's `headless()` method with a classification prompt describing the factory command vocabulary
- Added `_show_spinner()` braille spinner on stderr that respects `NO_COLOR`
- Modified `main()` to dispatch to the wizard when no subcommand is given and stdin/stderr are TTYs; non-TTY falls through to argparse help (backward compatible)
- Updated `_print_banner()` tagline to "Self-Evolving Meta-Harness"
- User's exact input is preserved verbatim in all suggested commands
- Selected option dispatches to `cmd_ceo()` in the same session (no subprocess)
- 39 tests covering: TTY detection, fast-path classification, LLM classification (mocked), option selection dispatch, edge cases (empty input, EOF, Ctrl+C), NO_COLOR behavior, and regression tests for existing subcommands

## Test plan

- [x] `pytest tests/test_cli_wizard.py -v` — 39 tests pass
- [x] `pytest tests/test_cli.py -v` — 168 existing tests pass (no regressions)
- [x] `ruff check factory/cli.py tests/test_cli_wizard.py` — clean
- [x] `mypy factory/cli.py` — clean