### PR TITLE
Add eval_spec: testing instructions for Evaluator context injection

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -991,6 +991,8 @@ For each CEO-approved hypothesis in `strategy/current.md`, in priority order:
 factory agent evaluator --task "Run baseline eval for $PROJECT_PATH. Execute: factory eval $PROJECT_PATH. Parse and report composite score and per-dimension breakdown." --project "$PROJECT_PATH"
 ```
 
+**Eval Spec injection:** Before spawning the Evaluator, read `.factory/config.json` and check if `eval_spec` is non-empty. If so, append an `## Eval Spec` block to the Evaluator's `--task` string listing each spec item. The Evaluator will run these as qualitative checks alongside the quantitative eval.
+
 Save the output as `score_before`. If eval crashes, see Error Recovery below.
 
 #### 2b. Begin Experiment
@@ -1230,6 +1232,8 @@ Report composite score and per-dimension breakdown.
 Compare against baseline score: $SCORE_BEFORE
 State whether the hypothesis was validated." --project "$PROJECT_PATH"
 ```
+
+**Eval Spec injection:** Same as step 2a — read `.factory/config.json`, and if `eval_spec` is non-empty, append an `## Eval Spec` block to the Evaluator's `--task` string. For post-change evals, spec compliance results inform the CEO's verdict review as an advisory signal (does NOT override quantitative scores).
 
 Save output as `score_after`.
 
@@ -2204,6 +2208,7 @@ For hypotheses with non-overlapping file scopes, execute them in parallel:
    - Documented (clear commit messages, PR description)
    - Maintainable (clean code, no hacks)
 5. **When stuck**: Pick the simpler option, record reasoning in .factory/archive/, move on.
+6. **Eval Spec compliance** (advisory): If the Evaluator reported `### Spec Compliance` results, review them. Low compliance is a warning signal — note it in the verdict but do NOT override a quantitative KEEP based on spec checks alone. Spec compliance helps catch qualitative regressions that scores miss.
 
 ---
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -786,7 +786,7 @@ Eval dimensions have been auto-discovered. Verify they work and mark as reviewed
    FACTORY_HOME="$(factory home)"
    cp "$FACTORY_HOME/templates/factory_config.md" "$PROJECT_PATH/factory.md"
    ```
-   Fill in: Goal, Scope, Guards, Eval command, Threshold, and **Smoke Test** (the shell command that verifies the project runs E2E — e.g., `curl -sf http://localhost:8000/health` or `python main.py --self-test`).
+   Fill in: Goal, Scope, Guards, Eval command, Threshold, and **Smoke Test** (the shell command that verifies the project runs E2E — e.g., `curl -sf http://localhost:8000/health` or `python main.py --self-test`). If `.factory/eval_spec.json` exists (auto-generated during discovery), read it and populate the `## Eval Spec` section in `factory.md` with the generated items.
 
 4b. **If `.factory/strategy/current.md` contains a `## Research Configuration` section:**
    Populate the research sections in `factory.md` from the approved spec:

--- a/factory/agents/prompts/evaluator.md
+++ b/factory/agents/prompts/evaluator.md
@@ -60,4 +60,20 @@ For "before" evals, note the baseline and any dimensions at risk.>
 <How do these scores compare to the last 3 experiments? Improving/stable/declining?>
 ```
 
+### Eval Spec Checks
+<!-- Only include this section if an ## Eval Spec block was provided in your task -->
+| Check | Result | Notes |
+|-------|--------|-------|
+| <spec item 1> | PASS/FAIL | <what you observed> |
+| <spec item 2> | PASS/FAIL | <what you observed> |
+
+### Spec Compliance: N/M checks passed
+```
+
+## Eval Spec Handling
+
+If the CEO includes an `## Eval Spec` block in your task, follow each instruction and report results in the `### Eval Spec Checks` table above. These are qualitative, manual checks — run the commands, observe the behavior, and report honestly.
+
+**Important:** Spec checks are advisory only. They do NOT affect the composite score. A failing spec check does not change the PASS/FAIL status of the eval. The CEO uses spec compliance as an additional signal when making keep/revert decisions.
+
 **Exit condition:** Eval results printed to stdout with all sections populated, or error message printed if the eval command failed.

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -129,6 +129,7 @@ def cmd_detect(args: argparse.Namespace) -> int:
 
 
 def cmd_discover(args: argparse.Namespace) -> int:
+    from factory.discovery.eval_spec import generate_eval_spec
     from factory.discovery.generate import write_eval_script
     from factory.discovery.introspect import introspect_project
     from factory.discovery.profile import build_eval_profile
@@ -139,6 +140,8 @@ def cmd_discover(args: argparse.Namespace) -> int:
 
     profile = introspect_project(project_path)
     eval_profile = build_eval_profile(profile)
+
+    eval_spec = generate_eval_spec(profile, project_path)
 
     # Persist artifacts so detect_state can find them
     store = ExperimentStore(project_path)
@@ -151,11 +154,13 @@ def cmd_discover(args: argparse.Namespace) -> int:
         "language": profile.language,
         "framework": profile.framework,
         "dimensions": dims,
+        "eval_spec_count": len(eval_spec),
     })
 
     output = {
         "project": profile.model_dump(),
         "eval_profile": eval_profile.model_dump(),
+        "eval_spec": eval_spec,
     }
     print(json.dumps(output, indent=2))
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -149,6 +149,11 @@ def cmd_discover(args: argparse.Namespace) -> int:
     _run(store.save_eval_profile(eval_profile))
     write_eval_script(eval_profile, project_path)
 
+    if eval_spec:
+        (store.factory_dir / "eval_spec.json").write_text(
+            json.dumps(eval_spec, indent=2) + "\n"
+        )
+
     dims = [d.name for d in eval_profile.dimensions]
     _emit_cli_event(project_path, "discover.completed", {
         "language": profile.language,

--- a/factory/discovery/eval_spec.py
+++ b/factory/discovery/eval_spec.py
@@ -57,7 +57,11 @@ def generate_eval_spec(profile: ProjectProfile, project_path: Path) -> list[str]
         fw_specs = _FRAMEWORK_SPECS.get(profile.framework, [])
         items.extend(fw_specs)
 
-    if (project_path / "Dockerfile").exists() or (project_path / "docker-compose.yml").exists():
+    compose_files = ("docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml")
+    has_docker = (project_path / "Dockerfile").exists() or any(
+        (project_path / f).exists() for f in compose_files
+    )
+    if has_docker:
         items.append("Build and start Docker containers and verify services are healthy")
 
     if not items:

--- a/factory/discovery/eval_spec.py
+++ b/factory/discovery/eval_spec.py
@@ -57,6 +57,9 @@ def generate_eval_spec(profile: ProjectProfile, project_path: Path) -> list[str]
         fw_specs = _FRAMEWORK_SPECS.get(profile.framework, [])
         items.extend(fw_specs)
 
+    if (project_path / "Dockerfile").exists() or (project_path / "docker-compose.yml").exists():
+        items.append("Build and start Docker containers and verify services are healthy")
+
     if not items:
         items.append("Build and run the project's primary entry point without errors")
 

--- a/factory/discovery/eval_spec.py
+++ b/factory/discovery/eval_spec.py
@@ -1,0 +1,69 @@
+"""Auto-generate starter eval_spec items based on project profile."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import structlog
+
+from factory.models import ProjectProfile
+
+log = structlog.get_logger()
+
+_SPEC_BY_TYPE: dict[str, list[str]] = {
+    "web_app": [
+        "Start the dev server and confirm the landing page loads without errors",
+        "Verify the main navigation links resolve to valid pages",
+    ],
+    "service": [
+        "Start the service and confirm the health endpoint returns 200",
+        "Send a sample request to the primary API endpoint and verify the response schema",
+    ],
+    "cli_tool": [
+        "Run the CLI with --help and verify it prints usage information",
+        "Run the CLI with a sample input and verify it produces expected output",
+    ],
+    "library": [
+        "Import the package in a Python shell and verify no import errors",
+        "Run the primary example from the README or docs and verify it completes",
+    ],
+    "bot": [
+        "Start the bot process and verify it initializes without errors",
+        "Verify the bot responds to a basic health-check or /start command",
+    ],
+}
+
+_FRAMEWORK_SPECS: dict[str, list[str]] = {
+    "fastapi": [
+        "Verify /docs (Swagger UI) loads and lists all endpoints",
+    ],
+    "next.js": [
+        "Run the Next.js dev server and verify the home page renders",
+    ],
+    "django": [
+        "Run python manage.py check and verify no issues reported",
+    ],
+}
+
+
+def generate_eval_spec(profile: ProjectProfile, project_path: Path) -> list[str]:
+    """Produce starter eval_spec items based on project type and framework."""
+    items: list[str] = []
+
+    type_specs = _SPEC_BY_TYPE.get(profile.project_type, [])
+    items.extend(type_specs)
+
+    if profile.framework:
+        fw_specs = _FRAMEWORK_SPECS.get(profile.framework, [])
+        items.extend(fw_specs)
+
+    if not items:
+        items.append("Build and run the project's primary entry point without errors")
+
+    log.debug(
+        "generate_eval_spec",
+        project_type=profile.project_type,
+        framework=profile.framework,
+        item_count=len(items),
+    )
+    return items

--- a/factory/models.py
+++ b/factory/models.py
@@ -143,6 +143,7 @@ class FactoryConfig(BaseModel):
     research_constraints: list[str] = []
     cost_budget: CostBudgetConfig | None = None
     hard_constraints: list[HardConstraint] = []
+    eval_spec: list[str] = []
 
 
 # ── eval ──────────────────────────────────────────────────────────

--- a/factory/store.py
+++ b/factory/store.py
@@ -268,6 +268,8 @@ class ExperimentStore:
         rc_raw = parsed.get("research_constraints", [])
         research_constraints = list(rc_raw) if isinstance(rc_raw, list) else []
         hard_constraints = _parse_hard_constraints(parsed.get("hard_constraints", []))
+        es_raw = parsed.get("eval_spec", [])
+        eval_spec = list(es_raw) if isinstance(es_raw, list) else []
 
         config = FactoryConfig(
             goal=str(parsed.get("goal", "")),
@@ -287,6 +289,7 @@ class ExperimentStore:
             research_constraints=research_constraints,
             cost_budget=cost_budget,
             hard_constraints=hard_constraints,
+            eval_spec=eval_spec,
         )
 
         (self.factory_dir / "config.json").write_text(

--- a/factory/templates/factory_config.md
+++ b/factory/templates/factory_config.md
@@ -85,6 +85,16 @@ curl -sf http://localhost:8000/health
 ```
 -->
 
+## Eval Spec
+<!-- Testing instructions injected into the Evaluator's context. -->
+<!-- Each item describes a qualitative check the Evaluator should perform. -->
+<!-- Spec compliance is advisory — it does NOT affect the composite score. -->
+<!-- Example:
+- Run the CLI with --help and verify it prints usage info
+- Start the dev server and confirm the landing page loads
+- Verify the API returns JSON with the expected schema
+-->
+
 ## Constraints
 <!-- Soft rules that guide behavior but don't block commits. -->
 

--- a/factory/templates/factory_config.md
+++ b/factory/templates/factory_config.md
@@ -85,16 +85,6 @@ curl -sf http://localhost:8000/health
 ```
 -->
 
-## Eval Spec
-<!-- Testing instructions injected into the Evaluator's context. -->
-<!-- Each item describes a qualitative check the Evaluator should perform. -->
-<!-- Spec compliance is advisory — it does NOT affect the composite score. -->
-<!-- Example:
-- Run the CLI with --help and verify it prints usage info
-- Start the dev server and confirm the landing page loads
-- Verify the API returns JSON with the expected schema
--->
-
 ## Constraints
 <!-- Soft rules that guide behavior but don't block commits. -->
 

--- a/templates/factory_config.md
+++ b/templates/factory_config.md
@@ -85,6 +85,16 @@ curl -sf http://localhost:8000/health
 ```
 -->
 
+## Eval Spec
+<!-- Testing instructions injected into the Evaluator's context. -->
+<!-- Each item describes a qualitative check the Evaluator should perform. -->
+<!-- Spec compliance is advisory — it does NOT affect the composite score. -->
+<!-- Example:
+- Run the CLI with --help and verify it prints usage info
+- Start the dev server and confirm the landing page loads
+- Verify the API returns JSON with the expected schema
+-->
+
 ## Constraints
 <!-- Soft rules that guide behavior but don't block commits. -->
 

--- a/tests/test_eval_spec.py
+++ b/tests/test_eval_spec.py
@@ -154,3 +154,8 @@ class TestGenerateEvalSpec:
     def test_nextjs_framework(self, tmp_path):
         items = generate_eval_spec(self._profile("web_app", "next.js"), tmp_path)
         assert any("next" in i.lower() for i in items)
+
+    def test_docker_detection(self, tmp_path):
+        (tmp_path / "Dockerfile").write_text("FROM python:3.12")
+        items = generate_eval_spec(self._profile("cli_tool"), tmp_path)
+        assert any("docker" in i.lower() for i in items)

--- a/tests/test_eval_spec.py
+++ b/tests/test_eval_spec.py
@@ -1,0 +1,156 @@
+"""Tests for eval_spec: model field, store parsing, and discovery generation."""
+
+import json
+
+import pytest
+
+from factory.discovery.eval_spec import generate_eval_spec
+from factory.models import FactoryConfig, ProjectProfile
+from factory.store import ExperimentStore
+
+
+class TestFactoryConfigEvalSpec:
+    def test_default_empty(self):
+        config = FactoryConfig(
+            goal="Test", scope=[], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[],
+        )
+        assert config.eval_spec == []
+
+    def test_with_items(self):
+        config = FactoryConfig(
+            goal="Test", scope=[], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[],
+            eval_spec=["Run --help", "Check health endpoint"],
+        )
+        assert config.eval_spec == ["Run --help", "Check health endpoint"]
+
+    def test_roundtrip_json(self):
+        config = FactoryConfig(
+            goal="Test", scope=[], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[],
+            eval_spec=["Item one", "Item two"],
+        )
+        data = config.model_dump()
+        restored = FactoryConfig(**data)
+        assert restored.eval_spec == ["Item one", "Item two"]
+        assert restored == config
+
+    def test_backward_compat_no_eval_spec(self):
+        data = {
+            "goal": "Test", "scope": [], "guards": [],
+            "eval_command": "pytest", "eval_threshold": 0.8,
+            "constraints": [],
+        }
+        config = FactoryConfig(**data)
+        assert config.eval_spec == []
+
+
+class TestStoreParseEvalSpec:
+    @pytest.fixture
+    def store(self, tmp_path) -> ExperimentStore:
+        project = tmp_path / "project"
+        project.mkdir()
+        return ExperimentStore(project)
+
+    async def test_parse_eval_spec(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nTest project\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n- no deletes\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n- small changes\n\n"
+            "## Eval Spec\n"
+            "- Run the CLI with --help and verify usage output\n"
+            "- Start the server and check /health returns 200\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.eval_spec == [
+            "Run the CLI with --help and verify usage output",
+            "Start the server and check /health returns 200",
+        ]
+
+    async def test_parse_no_eval_spec_section(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nTest\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.eval_spec == []
+
+    async def test_eval_spec_persisted_to_config_json(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nTest\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Eval Spec\n"
+            "- Check API schema\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        await store.reparse_config()
+        data = json.loads((store.factory_dir / "config.json").read_text())
+        assert data["eval_spec"] == ["Check API schema"]
+
+
+class TestGenerateEvalSpec:
+    def _profile(self, project_type: str, framework: str | None = None) -> ProjectProfile:
+        return ProjectProfile(
+            name="test",
+            language="python",
+            framework=framework,
+            project_type=project_type,
+            has_tests=True,
+            has_linter=True,
+            has_type_checker=False,
+            has_ci=False,
+        )
+
+    def test_web_app(self, tmp_path):
+        items = generate_eval_spec(self._profile("web_app"), tmp_path)
+        assert len(items) >= 2
+        assert any("dev server" in i.lower() or "landing page" in i.lower() for i in items)
+
+    def test_cli_tool(self, tmp_path):
+        items = generate_eval_spec(self._profile("cli_tool"), tmp_path)
+        assert len(items) >= 2
+        assert any("--help" in i for i in items)
+
+    def test_service(self, tmp_path):
+        items = generate_eval_spec(self._profile("service"), tmp_path)
+        assert len(items) >= 2
+        assert any("health" in i.lower() for i in items)
+
+    def test_library(self, tmp_path):
+        items = generate_eval_spec(self._profile("library"), tmp_path)
+        assert len(items) >= 1
+        assert any("import" in i.lower() for i in items)
+
+    def test_bot(self, tmp_path):
+        items = generate_eval_spec(self._profile("bot"), tmp_path)
+        assert len(items) >= 1
+
+    def test_unknown_type_gets_fallback(self, tmp_path):
+        items = generate_eval_spec(self._profile("unknown"), tmp_path)
+        assert len(items) >= 1
+
+    def test_framework_adds_items(self, tmp_path):
+        items_no_fw = generate_eval_spec(self._profile("web_app"), tmp_path)
+        items_fastapi = generate_eval_spec(self._profile("web_app", "fastapi"), tmp_path)
+        assert len(items_fastapi) > len(items_no_fw)
+
+    def test_nextjs_framework(self, tmp_path):
+        items = generate_eval_spec(self._profile("web_app", "next.js"), tmp_path)
+        assert any("next" in i.lower() for i in items)


### PR DESCRIPTION
Closes #302

## Changes

- **factory/models.py**: Added `eval_spec: list[str] = []` field to `FactoryConfig` with empty default for backward compatibility
- **factory/store.py**: Parse `## Eval Spec` section from factory.md in `reparse_config()`, following the `mutable_surfaces` extraction pattern
- **factory/templates/factory_config.md**: Added documented `## Eval Spec` template section with examples after `## Smoke Test`
- **factory/agents/prompts/ceo.md**: Inject `eval_spec` into both Evaluator spawn points (step 2a baseline, step 2f post-change) and added spec compliance as advisory signal in Keep/Revert Decision Framework
- **factory/agents/prompts/evaluator.md**: Handle `## Eval Spec` instructions with compliance table (`### Eval Spec Checks`) and `### Spec Compliance: N/M checks passed` — explicitly advisory, does NOT affect composite score
- **factory/discovery/eval_spec.py**: New module with `generate_eval_spec(profile, project_path)` producing starter items based on project_type (web_app, service, cli_tool, library, bot) and framework (fastapi, next.js, django)
- **factory/cli.py**: Wired `generate_eval_spec()` into `cmd_discover`, included in JSON output and event data
- **tests/test_eval_spec.py**: 15 tests covering model serialization, store parsing, discovery generation for all project types and frameworks

## Test plan

- [x] All 15 new tests pass
- [x] Full test suite passes (1782 passed, 0 failures)
- [x] Lint clean (ruff)
- [x] Type check clean (mypy)
- [x] Existing configs without eval_spec remain valid (empty default)