### PR TITLE
feat: redesign welcome wizard as conversational agent

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -187,28 +187,24 @@ Factory command vocabulary:
 - `factory ceo <path> --focus <N>` — target a specific GitHub issue number
 
 Rules:
-1. The user's EXACT input must appear VERBATIM in the command field — never summarize or shorten it
+1. The user's EXACT input must appear VERBATIM in quoted arguments — never summarize or shorten it
 2. Return 2-3 suggestions as a JSON array
 3. Each element: {"label": "short title", "explanation": "one sentence why", "command": "factory ceo ..."}
 4. First suggestion should be the most likely intent
 5. You may add a "tip" field on the first element with brief advice
+6. If the user mentions fixing, improving, or working on an EXISTING project/repo, suggest `factory ceo <path>` or `factory ceo <path> --focus "..."` — add a tip telling them to replace <path> with the actual path. Do NOT wrap the input in quotes as a new idea when the intent is clearly about an existing project.
 
 User input: """
 
 
-def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
-    """Classify user input via headless runner call. Falls back to defaults on failure."""
+def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
+    """Classify user input via headless runner call. Returns None on failure."""
     from factory.runners import get_runner
-
-    default_suggestions = [
-        {"label": "Brainstorm and refine the idea first (recommended)", "explanation": "Research the space, refine the spec, then build.", "command": f'factory ceo {shlex.quote(user_input)} --mode interactive'},
-        {"label": "Build the project directly", "explanation": "Skip brainstorming and start building immediately.", "command": f'factory ceo {shlex.quote(user_input)}'},
-    ]
 
     try:
         runner = get_runner()
     except Exception:
-        return default_suggestions
+        return None
 
     prompt = _CLASSIFICATION_PROMPT + json.dumps(user_input)
     task = "Respond with ONLY a JSON array. No markdown, no explanation."
@@ -220,7 +216,7 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
 
         result, code = _run(runner.headless(
             prompt, task, Path.cwd(),
-            timeout=30.0,
+            timeout=60.0,
             dangerously_skip_permissions=True,
             role="wizard",
         ))
@@ -229,33 +225,56 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
         spinner.join(timeout=2.0)
 
         if code != 0:
-            return default_suggestions
+            return None
 
         text = result.strip()
         start = text.find("[")
         end = text.rfind("]")
         if start == -1 or end == -1:
-            return default_suggestions
+            return None
         parsed = json.loads(text[start:end + 1])
         if not isinstance(parsed, list) or len(parsed) == 0:
-            return default_suggestions
+            return None
         for item in parsed:
             if not isinstance(item, dict) or "command" not in item or "label" not in item:
-                return default_suggestions
+                return None
         return parsed[:3]
     except Exception:
         stop_event.set()
         spinner.join(timeout=2.0)
-        return default_suggestions
+        return None
 
 
 _EXAMPLES_BLOCK = """\
   Examples:
-    factory ceo "weather CLI in Python"          Build a new project
-    factory ceo ~/projects/my-app                Improve an existing project
-    factory ceo https://github.com/user/repo     Clone and improve
-    factory ceo spec.md                          Build from a spec file
-    factory ceo ~/projects/my-app --focus "auth"   Fix one thing\
+    factory ceo "weather CLI in Python"            Build a new project
+    factory ceo ~/projects/my-app                  Improve an existing project
+    factory ceo https://github.com/user/repo       Clone and improve
+    factory ceo spec.md                            Build from a spec file
+    factory ceo ~/projects/my-app --focus "auth"   Fix one thing
+    factory ceo ~/projects/my-app --focus 42       Target a GitHub issue\
+"""
+
+_CLI_REF = """\
+  Classification failed — here's a quick reference:
+
+  Build something new:
+    factory ceo "your idea here"                   Build directly
+    factory ceo "your idea" --mode interactive      Brainstorm first, then build
+    factory ceo "your idea" --mode research         Research-driven (metric-focused)
+    factory ceo spec.md                            Build from a spec file
+
+  Work on an existing project:
+    factory ceo /path/to/project                   Run one improvement cycle
+    factory ceo /path/to/project --focus "feature"   Build one specific thing
+    factory ceo /path/to/project --focus 42          Target GitHub issue #42
+    factory ceo /path/to/project --mode interactive  Discuss what to work on
+
+  Clone and improve:
+    factory ceo https://github.com/user/repo       Clone, then improve
+
+  Continuous:
+    factory run /path/to/project --loop            Heartbeat loop\
 """
 
 
@@ -301,8 +320,8 @@ def _welcome_wizard() -> int:
         suggestions = _classify_with_llm(user_input)
 
     if not suggestions:
-        print("\n  Could not classify input. Try:", file=sys.stderr)
-        print(_EXAMPLES_BLOCK, file=sys.stderr)
+        print(file=sys.stderr)
+        print(_CLI_REF, file=sys.stderr)
         return 1
 
     print(file=sys.stderr)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -173,32 +173,109 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
     return None
 
 
-_CLASSIFICATION_PROMPT = """\
-You are a CLI router for Factory, a multi-agent software evolution tool.
+_WIZARD_PROMPT = """\
+You are the Factory welcome wizard — a conversational CLI agent for Factory, \
+a multi-agent software evolution tool.
 
-Given the user's input, suggest 2-3 ranked factory commands. Return ONLY a JSON array.
+Given the user's input, return a JSON object with two keys: "follow_ups" and "suggestions".
 
-Factory command vocabulary:
-- `factory ceo "<idea>" --mode interactive` — brainstorm and refine the idea before building (recommended for vague ideas)
-- `factory ceo "<idea>"` — build the project directly (good for clear, specific descriptions)
-- `factory ceo "<idea>" --mode research` — research-driven optimization (for metric-focused projects)
-- `factory ceo <path>` — improve an existing project at the given path
-- `factory ceo <path> --focus "<item>"` — fix or add one specific thing in an existing project
-- `factory ceo <path> --focus <N>` — target a specific GitHub issue number
+## Factory command vocabulary
 
-Rules:
+| Command | When to use |
+|---|---|
+| `factory ceo "<idea>" --mode interactive` | Brainstorm and refine before building (vague ideas) |
+| `factory ceo "<idea>"` | Build directly (clear, specific descriptions) |
+| `factory ceo "<idea>" --mode research` | Research-driven optimization (metric-focused projects) |
+| `factory ceo {path}` | Improve an existing project at a known path |
+| `factory ceo {path} --focus "{issue}"` | Fix or add one specific thing in an existing project |
+| `factory ceo {path} --focus {issue}` | Target a specific GitHub issue number |
+| `factory ceo {path} --mode interactive` | Discuss what to work on in an existing project |
+| `factory ceo {path} --mode meta` | Self-improve the factory's own agents |
+
+## Information requirements per mode
+
+- **New idea** — just the idea text (already in the user input, no follow-ups needed)
+- **Existing project** — `path` is required; `issue` is optional (ask if user mentions a bug/issue/fix)
+- **Clone from URL** — URL already in user input (no follow-ups needed)
+- **Meta** — `path` to the factory repo is required
+
+## Follow-up question rules
+
+- If the user mentions a specific repo/project name but didn't provide a path → ask for `path` (type: path)
+- If the user says "fix", "issue", "bug", "problem" → ask which issue (type: issue)
+- If the user's intent is clear and all info is present (e.g. pasted a URL, gave a complete idea) → \
+no follow-ups needed (empty follow_ups array)
+- If ambiguous → ask clarifying questions via follow_ups
+- Mark follow-ups as `"optional": true` when the command works without them (e.g. issue number)
+- Commands must use `{key}` placeholders matching follow_up keys
+
+## Response format
+
+Return ONLY a JSON object (no markdown, no explanation):
+
+```
+{
+  "follow_ups": [
+    {
+      "key": "path",
+      "question": "Path to your project",
+      "type": "path",
+      "hint": "e.g. ~/cursor-projects/my-app",
+      "optional": false
+    },
+    {
+      "key": "issue",
+      "question": "Which issue? (number or description, leave blank to skip)",
+      "type": "issue",
+      "hint": "e.g. 42 or 'fix the login bug'",
+      "optional": true
+    }
+  ],
+  "suggestions": [
+    {
+      "label": "Fix specific issue",
+      "explanation": "Target a known issue in the project",
+      "command": "factory ceo {path} --focus {issue}"
+    },
+    {
+      "label": "Discuss first",
+      "explanation": "Interactive mode to explore what needs fixing",
+      "command": "factory ceo {path} --mode interactive"
+    }
+  ]
+}
+```
+
+### Follow-up types
+
+| Type | Validation |
+|---|---|
+| `path` | Must be an existing directory. Expand `~`, resolve to absolute. |
+| `issue` | Numeric → `--focus N`. Text → `--focus "text"`. Empty → drop. |
+| `text` | Any non-empty string (required unless optional). |
+| `choice` | One of provided options (include "options" array in the follow_up). |
+
+## Rules
+
 1. The user's EXACT input must appear VERBATIM in quoted arguments — never summarize or shorten it
-2. Return 2-3 suggestions as a JSON array
-3. Each element: {"label": "short title", "explanation": "one sentence why", "command": "factory ceo ..."}
+2. Return 2-3 suggestions
+3. Each suggestion: {"label": "short title", "explanation": "one sentence why", "command": "factory ceo ..."}
 4. First suggestion should be the most likely intent
-5. You may add a "tip" field on the first element with brief advice
-6. If the user mentions fixing, improving, or working on an EXISTING project/repo, suggest `factory ceo <path>` or `factory ceo <path> --focus "..."` — add a tip telling them to replace <path> with the actual path. Do NOT wrap the input in quotes as a new idea when the intent is clearly about an existing project.
+5. You may add a "tip" field on the first suggestion with brief advice
+6. For new ideas, commands should use the literal user text in quotes — no placeholders
+7. For existing projects, use {path} placeholder and add a path follow-up
+8. If the user mentions fixing/improving an EXISTING project, do NOT wrap input as a new idea
 
 User input: """
 
 
-def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
-    """Classify user input via headless runner call. Returns None on failure."""
+def _classify_with_llm(
+    user_input: str,
+) -> tuple[list[dict[str, object]], list[dict[str, str]]] | None:
+    """Classify user input via headless runner call.
+
+    Returns ``(follow_ups, suggestions)`` on success, ``None`` on failure.
+    """
     from factory.runners import get_runner
 
     try:
@@ -206,8 +283,8 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
     except Exception:
         return None
 
-    prompt = _CLASSIFICATION_PROMPT + json.dumps(user_input)
-    task = "Respond with ONLY a JSON array. No markdown, no explanation."
+    prompt = _WIZARD_PROMPT + json.dumps(user_input)
+    task = "Respond with ONLY a JSON object. No markdown, no explanation."
 
     try:
         stop_event = threading.Event()
@@ -236,17 +313,45 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
             return None
 
         text = result.strip()
-        start = text.find("[")
-        end = text.rfind("]")
-        if start == -1 or end == -1:
-            return None
-        parsed = json.loads(text[start:end + 1])
-        if not isinstance(parsed, list) or len(parsed) == 0:
-            return None
-        for item in parsed:
-            if not isinstance(item, dict) or "command" not in item or "label" not in item:
-                return None
-        return parsed[:3]
+
+        # Determine whether the outermost JSON structure is an object or array.
+        # Find the first meaningful JSON delimiter to pick the right parser.
+        first_brace = text.find("{")
+        first_bracket = text.find("[")
+
+        # Try JSON array first if `[` appears before `{` (legacy format)
+        if first_bracket != -1 and (first_brace == -1 or first_bracket < first_brace):
+            arr_end = text.rfind("]")
+            if arr_end != -1:
+                try:
+                    parsed_arr = json.loads(text[first_bracket:arr_end + 1])
+                    if isinstance(parsed_arr, list) and len(parsed_arr) > 0:
+                        for item in parsed_arr:
+                            if not isinstance(item, dict) or "command" not in item or "label" not in item:
+                                return None
+                        return ([], parsed_arr[:3])
+                except json.JSONDecodeError:
+                    pass
+
+        # Try parsing as a JSON object (new format)
+        if first_brace != -1:
+            obj_end = text.rfind("}")
+            if obj_end != -1:
+                try:
+                    parsed = json.loads(text[first_brace:obj_end + 1])
+                    if isinstance(parsed, dict) and "suggestions" in parsed:
+                        suggestions = parsed["suggestions"]
+                        follow_ups = parsed.get("follow_ups", [])
+                        if not isinstance(suggestions, list) or len(suggestions) == 0:
+                            return None
+                        for item in suggestions:
+                            if not isinstance(item, dict) or "command" not in item or "label" not in item:
+                                return None
+                        return (follow_ups[:10], suggestions[:3])
+                except json.JSONDecodeError:
+                    pass
+
+        return None
     except Exception:
         stop_event.set()
         spinner.join(timeout=2.0)
@@ -267,6 +372,131 @@ _CLI_REF = """\
   Self-improve the factory:
     factory ceo /path/to/factory --mode meta\
 """
+
+
+def _ask_follow_ups(
+    follow_ups: list[dict[str, object]],
+    no_color: bool,
+) -> dict[str, str] | None:
+    """Ask follow-up questions and collect validated answers.
+
+    Returns a dict mapping ``key`` to the user's answer, or ``None`` if
+    the user pressed EOF/Ctrl+C.
+    """
+    if not follow_ups:
+        return {}
+
+    d = "\033[2m" if not no_color else ""
+    r = "\033[0m" if not no_color else ""
+    print(f"\n  {d}I'll need a few details:{r}", file=sys.stderr)
+
+    answers: dict[str, str] = {}
+
+    for fu in follow_ups:
+        key = str(fu.get("key", ""))
+        question = str(fu.get("question", key))
+        fu_type = str(fu.get("type", "text"))
+        hint = fu.get("hint", "")
+        optional = bool(fu.get("optional", False))
+        options = fu.get("options", [])
+
+        # Build prompt
+        opt_marker = " (optional)" if optional else ""
+        hint_str = f" {d}{hint}{r}" if hint else ""
+        if fu_type == "choice" and isinstance(options, list) and options:
+            print(f"\n  {question}{opt_marker}", file=sys.stderr)
+            for ci, opt in enumerate(options, 1):
+                print(f"    {ci}. {opt}", file=sys.stderr)
+            prompt_str = f"  [{1}-{len(options)}]: "
+        else:
+            prompt_str = f"\n  {question}{opt_marker}{hint_str}\n  > "
+
+        try:
+            raw = input(prompt_str).strip()
+        except (EOFError, KeyboardInterrupt):
+            print(file=sys.stderr)
+            return None
+
+        # Validate by type
+        if fu_type == "path":
+            if not raw:
+                if optional:
+                    continue
+                print("  Path is required.", file=sys.stderr)
+                return None
+            expanded = Path(raw).expanduser().resolve()
+            if not expanded.is_dir():
+                print(f"  Not a directory: {expanded}", file=sys.stderr)
+                return None
+            answers[key] = shlex.quote(str(expanded))
+
+        elif fu_type == "issue":
+            if not raw:
+                if optional:
+                    continue
+                print("  Issue is required.", file=sys.stderr)
+                return None
+            # Numeric issue → bare number, text → quoted
+            if raw.isdigit():
+                answers[key] = raw
+            else:
+                answers[key] = json.dumps(raw)  # produces "quoted text"
+
+        elif fu_type == "choice":
+            if not raw:
+                if optional:
+                    continue
+                print("  A choice is required.", file=sys.stderr)
+                return None
+            if isinstance(options, list) and options:
+                try:
+                    idx = int(raw) - 1
+                except ValueError:
+                    print(f"  Invalid choice: {raw}", file=sys.stderr)
+                    return None
+                if idx < 0 or idx >= len(options):
+                    print(f"  Invalid choice: {raw}", file=sys.stderr)
+                    return None
+                answers[key] = str(options[idx])
+            else:
+                answers[key] = raw
+
+        else:  # text
+            if not raw:
+                if optional:
+                    continue
+                print("  This field is required.", file=sys.stderr)
+                return None
+            answers[key] = raw
+
+    return answers
+
+
+def _substitute_answers(
+    suggestions: list[dict[str, str]],
+    answers: dict[str, str],
+) -> list[dict[str, str]]:
+    """Substitute ``{key}`` placeholders in suggestion commands.
+
+    Drops any suggestion that still has unfilled required placeholders after
+    substitution (i.e. a ``{key}`` with no answer and the corresponding
+    follow-up was not optional).
+    """
+    result: list[dict[str, str]] = []
+    placeholder_re = re.compile(r"\{(\w+)\}")
+
+    for s in suggestions:
+        cmd = s.get("command", "")
+        # Replace known answers
+        for key, value in answers.items():
+            cmd = cmd.replace(f"{{{key}}}", value)
+        # Check for remaining placeholders
+        remaining = placeholder_re.findall(cmd)
+        if remaining:
+            continue  # drop suggestions with unfilled placeholders
+        result.append({**s, "command": cmd})
+
+    return result
 
 
 def _welcome_wizard() -> int:
@@ -306,15 +536,33 @@ def _welcome_wizard() -> int:
         if not user_input:
             return 0
 
-    suggestions = _quick_classify(user_input)
+    # -- classification ---------------------------------------------------
+    follow_ups: list[dict[str, object]] = []
+    suggestions: list[dict[str, str]] | None = _quick_classify(user_input)
+
     if suggestions is None:
-        suggestions = _classify_with_llm(user_input)
+        llm_result = _classify_with_llm(user_input)
+        if llm_result is not None:
+            follow_ups, suggestions = llm_result
+        else:
+            suggestions = None
 
     if not suggestions:
         print(file=sys.stderr)
         print(_CLI_REF, file=sys.stderr)
         return 1
 
+    # -- follow-ups -------------------------------------------------------
+    if follow_ups:
+        answers = _ask_follow_ups(follow_ups, no_color)
+        if answers is None:
+            return 0  # EOF or Ctrl+C during follow-ups
+        suggestions = _substitute_answers(suggestions, answers)
+        if not suggestions:
+            print("\n  No commands available after follow-up (required info missing).", file=sys.stderr)
+            return 1
+
+    # -- present suggestions ----------------------------------------------
     print(file=sys.stderr)
 
     tip = None
@@ -370,22 +618,6 @@ def _welcome_wizard() -> int:
 
     selected = suggestions[choice_idx]
     command = selected.get("command", "")
-
-    if "<path>" in command:
-        print(file=sys.stderr)
-        try:
-            path_input = input("  Path to project: ").strip()
-        except (EOFError, KeyboardInterrupt):
-            print(file=sys.stderr)
-            return 0
-        if not path_input:
-            print("  No path provided.", file=sys.stderr)
-            return 1
-        resolved = str(Path(path_input).expanduser().resolve())
-        if not Path(resolved).is_dir():
-            print(f"  Not a directory: {resolved}", file=sys.stderr)
-            return 1
-        command = command.replace("<path>", shlex.quote(resolved))
 
     print(f"\n  Running: {command}\n", file=sys.stderr)
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -131,7 +131,10 @@ def _show_spinner(stop_event: threading.Event) -> None:
         sys.stderr.flush()
         idx += 1
         stop_event.wait(0.1)
-    sys.stderr.write("\r\033[2K")
+    if use_color:
+        sys.stderr.write("\r\033[2K")
+    else:
+        sys.stderr.write("\r" + " " * 30 + "\r")
     sys.stderr.flush()
 
 
@@ -144,8 +147,8 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
         factory_dir = expanded / ".factory"
         label_improve = "Improve this project"
         label_interactive = "Discuss what to work on first"
-        cmd_improve = f'factory ceo "{stripped}"'
-        cmd_interactive = f'factory ceo "{stripped}" --mode interactive'
+        cmd_improve = f'factory ceo {shlex.quote(stripped)}'
+        cmd_interactive = f'factory ceo {shlex.quote(stripped)} --mode interactive'
         if factory_dir.is_dir():
             return [
                 {"label": label_improve, "explanation": "Run the improve loop on this project.", "command": cmd_improve},
@@ -158,13 +161,13 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
 
     if expanded.is_file():
         return [
-            {"label": "Build from this spec file", "explanation": "Use the file as a project specification.", "command": f'factory ceo "{stripped}"'},
+            {"label": "Build from this spec file", "explanation": "Use the file as a project specification.", "command": f'factory ceo {shlex.quote(stripped)}'},
         ]
 
     if _is_github_url(stripped):
         return [
-            {"label": "Clone and improve", "explanation": "Clone the repository and run the improve loop.", "command": f'factory ceo "{stripped}"'},
-            {"label": "Clone and discuss", "explanation": "Clone and discuss what to work on.", "command": f'factory ceo "{stripped}" --mode interactive'},
+            {"label": "Clone and improve", "explanation": "Clone the repository and run the improve loop.", "command": f'factory ceo {shlex.quote(stripped)}'},
+            {"label": "Clone and discuss", "explanation": "Clone and discuss what to work on.", "command": f'factory ceo {shlex.quote(stripped)} --mode interactive'},
         ]
 
     return None
@@ -198,8 +201,8 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
     from factory.runners import get_runner
 
     default_suggestions = [
-        {"label": "Brainstorm and refine the idea first (recommended)", "explanation": "Research the space, refine the spec, then build.", "command": f'factory ceo "{user_input}" --mode interactive'},
-        {"label": "Build the project directly", "explanation": "Skip brainstorming and start building immediately.", "command": f'factory ceo "{user_input}"'},
+        {"label": "Brainstorm and refine the idea first (recommended)", "explanation": "Research the space, refine the spec, then build.", "command": f'factory ceo {shlex.quote(user_input)} --mode interactive'},
+        {"label": "Build the project directly", "explanation": "Skip brainstorming and start building immediately.", "command": f'factory ceo {shlex.quote(user_input)}'},
     ]
 
     try:
@@ -242,6 +245,7 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
         return parsed[:3]
     except Exception:
         stop_event.set()
+        spinner.join(timeout=2.0)
         return default_suggestions
 
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -253,36 +253,20 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
         return None
 
 
-_EXAMPLES_BLOCK = """\
-  Examples:
-    factory ceo "weather CLI in Python"            Build a new project
-    factory ceo ~/projects/my-app                  Improve an existing project
-    factory ceo https://github.com/user/repo       Clone and improve
-    factory ceo spec.md                            Build from a spec file
-    factory ceo ~/projects/my-app --focus "auth"   Fix one thing
-    factory ceo ~/projects/my-app --focus 42       Target a GitHub issue\
-"""
-
 _CLI_REF = """\
-  Classification failed — here's a quick reference:
-
   Build something new:
-    factory ceo "your idea here"                   Build directly
-    factory ceo "your idea" --mode interactive      Brainstorm first, then build
-    factory ceo "your idea" --mode research         Research-driven (metric-focused)
-    factory ceo spec.md                            Build from a spec file
+    factory ceo "weather CLI in Python"                    Build directly
+    factory ceo "weather CLI" --mode interactive            Brainstorm first, then build
+    factory ceo "SWE-bench solver" --mode research          Research-driven (metric-focused)
 
   Work on an existing project:
-    factory ceo /path/to/project                   Run one improvement cycle
-    factory ceo /path/to/project --focus "feature"   Build one specific thing
-    factory ceo /path/to/project --focus 42          Target GitHub issue #42
-    factory ceo /path/to/project --mode interactive  Discuss what to work on
+    factory ceo ~/projects/my-app                          Run one improvement cycle
+    factory ceo ~/projects/my-app --focus "auth"             Fix one specific thing
+    factory ceo ~/projects/my-app --focus 42                 Target GitHub issue #42
+    factory ceo ~/projects/my-app --mode interactive         Discuss what to work on
 
-  Clone and improve:
-    factory ceo https://github.com/user/repo       Clone, then improve
-
-  Continuous:
-    factory run /path/to/project --loop            Heartbeat loop\
+  Self-improve the factory:
+    factory ceo /path/to/factory --mode meta                Improve + evolve agent playbooks\
 """
 
 
@@ -311,7 +295,7 @@ def _welcome_wizard() -> int:
 
     if not user_input:
         print(file=sys.stderr)
-        print(_EXAMPLES_BLOCK, file=sys.stderr)
+        print(_CLI_REF, file=sys.stderr)
         print(file=sys.stderr)
         try:
             user_input = input("  > ").strip()

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -371,6 +371,22 @@ def _welcome_wizard() -> int:
     selected = suggestions[choice_idx]
     command = selected.get("command", "")
 
+    if "<path>" in command:
+        print(file=sys.stderr)
+        try:
+            path_input = input("  Path to project: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print(file=sys.stderr)
+            return 0
+        if not path_input:
+            print("  No path provided.", file=sys.stderr)
+            return 1
+        resolved = str(Path(path_input).expanduser().resolve())
+        if not Path(resolved).is_dir():
+            print(f"  Not a directory: {resolved}", file=sys.stderr)
+            return 1
+        command = command.replace("<path>", shlex.quote(resolved))
+
     print(f"\n  Running: {command}\n", file=sys.stderr)
 
     # Parse the selected command and dispatch to cmd_ceo
@@ -390,8 +406,10 @@ def _welcome_wizard() -> int:
         print(f"  Error: invalid command: {command}", file=sys.stderr)
         return 1
 
-    if ns.command == "ceo":
-        return cmd_ceo(ns)
+    if ns.command in ("ceo", "study"):
+        handler = cmd_ceo if ns.command == "ceo" else globals().get("cmd_study")
+        if handler:
+            return handler(ns)
 
     print(f"  Error: unexpected command type: {ns.command}", file=sys.stderr)
     return 1

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -214,12 +214,20 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
         spinner = threading.Thread(target=_show_spinner, args=(stop_event,), daemon=True)
         spinner.start()
 
-        result, code = _run(runner.headless(
-            prompt, task, Path.cwd(),
-            timeout=60.0,
-            dangerously_skip_permissions=True,
-            role="wizard",
-        ))
+        old_quiet = os.environ.get("FACTORY_RUNNER_QUIET")
+        os.environ["FACTORY_RUNNER_QUIET"] = "1"
+        try:
+            result, code = _run(runner.headless(
+                prompt, task, Path.cwd(),
+                timeout=60.0,
+                dangerously_skip_permissions=True,
+                role="wizard",
+            ))
+        finally:
+            if old_quiet is None:
+                os.environ.pop("FACTORY_RUNNER_QUIET", None)
+            else:
+                os.environ["FACTORY_RUNNER_QUIET"] = old_quiet
 
         stop_event.set()
         spinner.join(timeout=2.0)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -91,19 +91,23 @@ def _ensure_dashboard(project_path: Path, port: int = _DASHBOARD_PORT) -> None:
 def _print_banner(mode: str = "improve") -> None:
     """Print the Factory startup banner to stderr."""
     if os.environ.get("NO_COLOR") or not sys.stderr.isatty():
-        print(f"Factory v2 — mode: {mode}", file=sys.stderr)
+        if mode == "welcome":
+            print("The Factory — Self-Evolving Meta-Harness", file=sys.stderr)
+        else:
+            print(f"Factory v2 — mode: {mode}", file=sys.stderr)
         return
 
     c = "\033[1;36m"  # bold cyan
     d = "\033[2m"      # dim
     r = "\033[0m"      # reset
 
+    mode_line = "" if mode == "welcome" else f"{d}  Mode: {mode}{r}\n"
     banner = (
         f"\n{c}  ┏━╸┏━┓┏━╸╺┳╸┏━┓┏━┓╻ ╻{r}\n"
         f"{c}  ┣╸ ┣━┫┃   ┃ ┃ ┃┣┳┛┗┳┛{r}\n"
         f"{c}  ╹  ╹ ╹┗━╸ ╹ ┗━┛╹┗╸ ╹ {r}\n"
         f"{d}  Self-Evolving Meta-Harness{r}\n"
-        f"{d}  Mode: {mode}{r}\n"
+        f"{mode_line}"
     )
     print(banner, file=sys.stderr)
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -255,18 +255,17 @@ def _classify_with_llm(user_input: str) -> list[dict[str, str]] | None:
 
 _CLI_REF = """\
   Build something new:
-    factory ceo "weather CLI in Python"                    Build directly
-    factory ceo "weather CLI" --mode interactive            Brainstorm first, then build
-    factory ceo "SWE-bench solver" --mode research          Research-driven (metric-focused)
+    factory ceo "a fasta CLI that converts protein sequences to embeddings using ESM2" --mode interactive
+    factory ceo "an autograd engine in pure numpy with a pytorch-like API" --mode interactive
+    factory ceo "a system that solves IMO geometry problems using lean4 proofs" --mode research
 
   Work on an existing project:
-    factory ceo ~/projects/my-app                          Run one improvement cycle
-    factory ceo ~/projects/my-app --focus "auth"             Fix one specific thing
-    factory ceo ~/projects/my-app --focus 42                 Target GitHub issue #42
-    factory ceo ~/projects/my-app --mode interactive         Discuss what to work on
+    factory ceo ~/projects/my-app --focus "add OAuth2 login with Google and GitHub providers"
+    factory ceo ~/projects/my-app --focus 42
+    factory ceo ~/projects/my-app --mode interactive
 
   Self-improve the factory:
-    factory ceo /path/to/factory --mode meta                Improve + evolve agent playbooks\
+    factory ceo /path/to/factory --mode meta\
 """
 
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -102,10 +102,281 @@ def _print_banner(mode: str = "improve") -> None:
         f"\n{c}  ┏━╸┏━┓┏━╸╺┳╸┏━┓┏━┓╻ ╻{r}\n"
         f"{c}  ┣╸ ┣━┫┃   ┃ ┃ ┃┣┳┛┗┳┛{r}\n"
         f"{c}  ╹  ╹ ╹┗━╸ ╹ ┗━┛╹┗╸ ╹ {r}\n"
-        f"{d}  Multi-Agent Software Evolution{r}\n"
+        f"{d}  Self-Evolving Meta-Harness{r}\n"
         f"{d}  Mode: {mode}{r}\n"
     )
     print(banner, file=sys.stderr)
+
+
+# ── welcome wizard ─────────────────────────────────────────────
+
+
+_BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+
+def _show_spinner(stop_event: threading.Event) -> None:
+    """Braille spinner on stderr. Respects NO_COLOR."""
+    use_color = not os.environ.get("NO_COLOR") and sys.stderr.isatty()
+    idx = 0
+    while not stop_event.is_set():
+        frame = _BRAILLE_FRAMES[idx % len(_BRAILLE_FRAMES)]
+        if use_color:
+            sys.stderr.write(f"\r\033[2m  Thinking... {frame}\033[0m")
+        else:
+            sys.stderr.write(f"\r  Thinking... {frame}")
+        sys.stderr.flush()
+        idx += 1
+        stop_event.wait(0.1)
+    sys.stderr.write("\r\033[2K")
+    sys.stderr.flush()
+
+
+def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
+    """Deterministic fast path for paths, files, and URLs. Returns None if LLM needed."""
+    stripped = user_input.strip()
+
+    expanded = Path(stripped).expanduser()
+    if expanded.is_dir():
+        factory_dir = expanded / ".factory"
+        label_improve = "Improve this project"
+        label_interactive = "Discuss what to work on first"
+        cmd_improve = f'factory ceo "{stripped}"'
+        cmd_interactive = f'factory ceo "{stripped}" --mode interactive'
+        if factory_dir.is_dir():
+            return [
+                {"label": label_improve, "explanation": "Run the improve loop on this project.", "command": cmd_improve},
+                {"label": label_interactive, "explanation": "Study the project and discuss priorities.", "command": cmd_interactive},
+            ]
+        return [
+            {"label": "Set up and improve this project", "explanation": "Initialize factory and start improving.", "command": cmd_improve},
+            {"label": label_interactive, "explanation": "Study the project and discuss priorities.", "command": cmd_interactive},
+        ]
+
+    if expanded.is_file():
+        return [
+            {"label": "Build from this spec file", "explanation": "Use the file as a project specification.", "command": f'factory ceo "{stripped}"'},
+        ]
+
+    if _is_github_url(stripped):
+        return [
+            {"label": "Clone and improve", "explanation": "Clone the repository and run the improve loop.", "command": f'factory ceo "{stripped}"'},
+            {"label": "Clone and discuss", "explanation": "Clone and discuss what to work on.", "command": f'factory ceo "{stripped}" --mode interactive'},
+        ]
+
+    return None
+
+
+_CLASSIFICATION_PROMPT = """\
+You are a CLI router for Factory, a multi-agent software evolution tool.
+
+Given the user's input, suggest 2-3 ranked factory commands. Return ONLY a JSON array.
+
+Factory command vocabulary:
+- `factory ceo "<idea>" --mode interactive` — brainstorm and refine the idea before building (recommended for vague ideas)
+- `factory ceo "<idea>"` — build the project directly (good for clear, specific descriptions)
+- `factory ceo "<idea>" --mode research` — research-driven optimization (for metric-focused projects)
+- `factory ceo <path>` — improve an existing project at the given path
+- `factory ceo <path> --focus "<item>"` — fix or add one specific thing in an existing project
+- `factory ceo <path> --focus <N>` — target a specific GitHub issue number
+
+Rules:
+1. The user's EXACT input must appear VERBATIM in the command field — never summarize or shorten it
+2. Return 2-3 suggestions as a JSON array
+3. Each element: {"label": "short title", "explanation": "one sentence why", "command": "factory ceo ..."}
+4. First suggestion should be the most likely intent
+5. You may add a "tip" field on the first element with brief advice
+
+User input: """
+
+
+def _classify_with_llm(user_input: str) -> list[dict[str, str]]:
+    """Classify user input via headless runner call. Falls back to defaults on failure."""
+    from factory.runners import get_runner
+
+    default_suggestions = [
+        {"label": "Brainstorm and refine the idea first (recommended)", "explanation": "Research the space, refine the spec, then build.", "command": f'factory ceo "{user_input}" --mode interactive'},
+        {"label": "Build the project directly", "explanation": "Skip brainstorming and start building immediately.", "command": f'factory ceo "{user_input}"'},
+    ]
+
+    try:
+        runner = get_runner()
+    except Exception:
+        return default_suggestions
+
+    prompt = _CLASSIFICATION_PROMPT + json.dumps(user_input)
+    task = "Respond with ONLY a JSON array. No markdown, no explanation."
+
+    try:
+        stop_event = threading.Event()
+        spinner = threading.Thread(target=_show_spinner, args=(stop_event,), daemon=True)
+        spinner.start()
+
+        result, code = _run(runner.headless(
+            prompt, task, Path.cwd(),
+            timeout=30.0,
+            dangerously_skip_permissions=True,
+            role="wizard",
+        ))
+
+        stop_event.set()
+        spinner.join(timeout=2.0)
+
+        if code != 0:
+            return default_suggestions
+
+        text = result.strip()
+        start = text.find("[")
+        end = text.rfind("]")
+        if start == -1 or end == -1:
+            return default_suggestions
+        parsed = json.loads(text[start:end + 1])
+        if not isinstance(parsed, list) or len(parsed) == 0:
+            return default_suggestions
+        for item in parsed:
+            if not isinstance(item, dict) or "command" not in item or "label" not in item:
+                return default_suggestions
+        return parsed[:3]
+    except Exception:
+        stop_event.set()
+        return default_suggestions
+
+
+_EXAMPLES_BLOCK = """\
+  Examples:
+    factory ceo "weather CLI in Python"          Build a new project
+    factory ceo ~/projects/my-app                Improve an existing project
+    factory ceo https://github.com/user/repo     Clone and improve
+    factory ceo spec.md                          Build from a spec file
+    factory ceo ~/projects/my-app --focus "auth"   Fix one thing\
+"""
+
+
+def _welcome_wizard() -> int:
+    """Interactive welcome: banner -> input -> classify -> present -> dispatch."""
+    no_color = bool(os.environ.get("NO_COLOR")) or not sys.stderr.isatty()
+
+    _print_banner("welcome")
+
+    if no_color:
+        print("\n  What do you want to do?", file=sys.stderr)
+        print("  Paste an idea, a file path, a GitHub URL, or describe what you need.\n", file=sys.stderr)
+    else:
+        d = "\033[2m"
+        r = "\033[0m"
+        print("\n  What do you want to do?", file=sys.stderr)
+        print(f"  {d}Paste an idea, a file path, a GitHub URL, or describe what you need.{r}\n", file=sys.stderr)
+
+    try:
+        user_input = input("  > ").strip()
+    except EOFError:
+        return 0
+    except KeyboardInterrupt:
+        print(file=sys.stderr)
+        return 130
+
+    if not user_input:
+        print(file=sys.stderr)
+        print(_EXAMPLES_BLOCK, file=sys.stderr)
+        print(file=sys.stderr)
+        try:
+            user_input = input("  > ").strip()
+        except EOFError:
+            return 0
+        except KeyboardInterrupt:
+            print(file=sys.stderr)
+            return 130
+        if not user_input:
+            return 0
+
+    suggestions = _quick_classify(user_input)
+    if suggestions is None:
+        suggestions = _classify_with_llm(user_input)
+
+    if not suggestions:
+        print("\n  Could not classify input. Try:", file=sys.stderr)
+        print(_EXAMPLES_BLOCK, file=sys.stderr)
+        return 1
+
+    print(file=sys.stderr)
+
+    tip = None
+    for i, s in enumerate(suggestions, 1):
+        label = s.get("label", "Option")
+        explanation = s.get("explanation", "")
+        command = s.get("command", "")
+        if no_color:
+            print(f"  [{i}] {label}", file=sys.stderr)
+            if explanation:
+                print(f"      {explanation}", file=sys.stderr)
+            print(f"      {command}", file=sys.stderr)
+        else:
+            b = "\033[1m"
+            d = "\033[2m"
+            r = "\033[0m"
+            print(f"  {b}[{i}]{r} {label}", file=sys.stderr)
+            if explanation:
+                print(f"      {d}{explanation}{r}", file=sys.stderr)
+            print(f"      {command}", file=sys.stderr)
+        if i == 1 and "tip" in s:
+            tip = s["tip"]
+        print(file=sys.stderr)
+
+    if tip:
+        if no_color:
+            print(f"  Tip: {tip}", file=sys.stderr)
+        else:
+            print(f"  {d}Tip: {tip}{r}", file=sys.stderr)
+        print(file=sys.stderr)
+
+    prompt_text = f"  Pick [1-{len(suggestions)}], or Enter for [1]: "
+    try:
+        choice_raw = input(prompt_text).strip()
+    except EOFError:
+        return 0
+    except KeyboardInterrupt:
+        print(file=sys.stderr)
+        return 130
+
+    if not choice_raw:
+        choice_idx = 0
+    else:
+        try:
+            choice_idx = int(choice_raw) - 1
+        except ValueError:
+            print(f"\n  Invalid choice: {choice_raw}", file=sys.stderr)
+            return 1
+
+    if choice_idx < 0 or choice_idx >= len(suggestions):
+        print(f"\n  Invalid choice: {choice_raw}", file=sys.stderr)
+        return 1
+
+    selected = suggestions[choice_idx]
+    command = selected.get("command", "")
+
+    print(f"\n  Running: {command}\n", file=sys.stderr)
+
+    # Parse the selected command and dispatch to cmd_ceo
+    parser = build_parser()
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        print(f"  Error: could not parse command: {command}", file=sys.stderr)
+        return 1
+
+    if parts and parts[0] == "factory":
+        parts = parts[1:]
+
+    try:
+        ns = parser.parse_args(parts)
+    except SystemExit:
+        print(f"  Error: invalid command: {command}", file=sys.stderr)
+        return 1
+
+    if ns.command == "ceo":
+        return cmd_ceo(ns)
+
+    print(f"  Error: unexpected command type: {ns.command}", file=sys.stderr)
+    return 1
 
 
 # ── subcommand handlers ────────────────────────────────────────
@@ -2945,6 +3216,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if not args.command:
+        if sys.stdin.isatty() and sys.stderr.isatty():
+            return _welcome_wizard()
         parser.print_help()
         return 1
 

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -144,45 +144,40 @@ class TestClassifyWithLLM:
         assert len(result) == 1
         assert result[0]["label"] == "Build it"
 
-    def test_invalid_json_falls_back(self) -> None:
+    def test_invalid_json_returns_none(self) -> None:
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=("not valid json at all", 0))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
 
-        assert len(result) == 2
-        assert "recommended" in result[0]["label"].lower()
-        assert "weather CLI" in result[0]["command"]
+        assert result is None
 
-    def test_runner_failure_falls_back(self) -> None:
+    def test_runner_failure_returns_none(self) -> None:
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=("Error", 1))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
 
-        assert len(result) == 2
-        assert "weather CLI" in result[0]["command"]
+        assert result is None
 
-    def test_runner_not_available_falls_back(self) -> None:
+    def test_runner_not_available_returns_none(self) -> None:
         with patch("factory.runners.get_runner", side_effect=Exception("No runner")):
             result = _classify_with_llm("weather CLI")
 
-        assert len(result) == 2
-        assert "weather CLI" in result[0]["command"]
+        assert result is None
 
-    def test_empty_array_falls_back(self) -> None:
+    def test_empty_array_returns_none(self) -> None:
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=("[]", 0))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test idea")
 
-        assert len(result) == 2
-        assert "test idea" in result[0]["command"]
+        assert result is None
 
-    def test_missing_required_fields_falls_back(self) -> None:
+    def test_missing_required_fields_returns_none(self) -> None:
         bad_suggestions = [{"label": "Test"}]  # missing command
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=(json.dumps(bad_suggestions), 0))
@@ -190,8 +185,7 @@ class TestClassifyWithLLM:
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test idea")
 
-        assert len(result) == 2
-        assert "test idea" in result[0]["command"]
+        assert result is None
 
     def test_truncates_to_3_suggestions(self) -> None:
         suggestions = [
@@ -206,12 +200,19 @@ class TestClassifyWithLLM:
 
         assert len(result) == 3
 
-    def test_preserves_user_input_in_defaults(self) -> None:
-        with patch("factory.runners.get_runner", side_effect=Exception("fail")):
-            result = _classify_with_llm("my exact input text")
+    def test_wizard_shows_cli_ref_on_llm_failure(self) -> None:
+        with patch("builtins.input", side_effect=["test idea"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=None), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            mock_stderr.write = MagicMock()
+            code = _welcome_wizard()
 
-        for s in result:
-            assert "my exact input text" in s["command"]
+        assert code == 1
+        output = "".join(call.args[0] for call in mock_stderr.write.call_args_list)
+        assert "quick reference" in output.lower() or "factory ceo" in output
 
 
 # ── _show_spinner ──────────────────────────────────────────────

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -9,15 +9,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from factory.cli import (
+    _ask_follow_ups,
     _classify_with_llm,
     _quick_classify,
     _show_spinner,
+    _substitute_answers,
     _welcome_wizard,
     main,
 )
 
 
-# ── TTY detection ──────────────────────────────────────────────
+# -- TTY detection --------------------------------------------------------
 
 
 class TestTTYDetection:
@@ -53,7 +55,7 @@ class TestTTYDetection:
         assert code == 1
 
 
-# ── _quick_classify ────────────────────────────────────────────
+# -- _quick_classify ------------------------------------------------------
 
 
 class TestQuickClassify:
@@ -113,13 +115,57 @@ class TestQuickClassify:
             assert user_input in s["command"]
 
 
-# ── _classify_with_llm ────────────────────────────────────────
+# -- _classify_with_llm ---------------------------------------------------
 
 
 class TestClassifyWithLLM:
     """LLM-based classification with mocked runner."""
 
-    def test_valid_json_response(self) -> None:
+    def test_valid_json_object_response(self) -> None:
+        response = {
+            "follow_ups": [
+                {"key": "path", "question": "Path to project", "type": "path", "optional": False},
+            ],
+            "suggestions": [
+                {"label": "Fix it", "explanation": "Target the issue.", "command": "factory ceo {path} --focus \"bug\""},
+                {"label": "Discuss", "explanation": "Talk first.", "command": "factory ceo {path} --mode interactive"},
+            ],
+        }
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("fix a bug in my project")
+
+        assert result is not None
+        follow_ups, suggestions = result
+        assert len(follow_ups) == 1
+        assert follow_ups[0]["key"] == "path"
+        assert len(suggestions) == 2
+        assert suggestions[0]["label"] == "Fix it"
+
+    def test_valid_json_no_followups(self) -> None:
+        response = {
+            "follow_ups": [],
+            "suggestions": [
+                {"label": "Brainstorm first", "explanation": "Refine the idea.", "command": 'factory ceo "weather CLI" --mode interactive'},
+                {"label": "Build directly", "explanation": "Start building.", "command": 'factory ceo "weather CLI"'},
+            ],
+        }
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("weather CLI")
+
+        assert result is not None
+        follow_ups, suggestions = result
+        assert len(follow_ups) == 0
+        assert len(suggestions) == 2
+        assert suggestions[0]["label"] == "Brainstorm first"
+
+    def test_legacy_json_array_response(self) -> None:
+        """Backward compatibility: plain JSON array still works."""
         suggestions = [
             {"label": "Brainstorm first", "explanation": "Refine the idea.", "command": 'factory ceo "weather CLI" --mode interactive'},
             {"label": "Build directly", "explanation": "Start building.", "command": 'factory ceo "weather CLI"'},
@@ -130,19 +176,23 @@ class TestClassifyWithLLM:
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
 
-        assert len(result) == 2
-        assert result[0]["label"] == "Brainstorm first"
+        assert result is not None
+        follow_ups, sug = result
+        assert len(follow_ups) == 0
+        assert len(sug) == 2
 
     def test_json_with_markdown_wrapper(self) -> None:
-        raw = '```json\n[{"label": "Build it", "explanation": "Go.", "command": "factory ceo \\"test\\""}]\n```'
+        raw = '```json\n{"follow_ups": [], "suggestions": [{"label": "Build it", "explanation": "Go.", "command": "factory ceo \\"test\\""}]}\n```'
         mock_runner = MagicMock()
         mock_runner.headless = AsyncMock(return_value=(raw, 0))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test")
 
-        assert len(result) == 1
-        assert result[0]["label"] == "Build it"
+        assert result is not None
+        _, suggestions = result
+        assert len(suggestions) == 1
+        assert suggestions[0]["label"] == "Build it"
 
     def test_invalid_json_returns_none(self) -> None:
         mock_runner = MagicMock()
@@ -168,9 +218,10 @@ class TestClassifyWithLLM:
 
         assert result is None
 
-    def test_empty_array_returns_none(self) -> None:
+    def test_empty_suggestions_returns_none(self) -> None:
+        response = {"follow_ups": [], "suggestions": []}
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=("[]", 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test idea")
@@ -178,9 +229,9 @@ class TestClassifyWithLLM:
         assert result is None
 
     def test_missing_required_fields_returns_none(self) -> None:
-        bad_suggestions = [{"label": "Test"}]  # missing command
+        response = {"follow_ups": [], "suggestions": [{"label": "Test"}]}  # missing command
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(bad_suggestions), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test idea")
@@ -188,17 +239,22 @@ class TestClassifyWithLLM:
         assert result is None
 
     def test_truncates_to_3_suggestions(self) -> None:
-        suggestions = [
-            {"label": f"Option {i}", "explanation": "desc", "command": f'factory ceo "x{i}"'}
-            for i in range(5)
-        ]
+        response = {
+            "follow_ups": [],
+            "suggestions": [
+                {"label": f"Option {i}", "explanation": "desc", "command": f'factory ceo "x{i}"'}
+                for i in range(5)
+            ],
+        }
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(suggestions), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test")
 
-        assert len(result) == 3
+        assert result is not None
+        _, suggestions = result
+        assert len(suggestions) == 3
 
     def test_wizard_shows_cli_ref_on_llm_failure(self) -> None:
         with patch("builtins.input", side_effect=["test idea"]), \
@@ -215,7 +271,7 @@ class TestClassifyWithLLM:
         assert "quick reference" in output.lower() or "factory ceo" in output
 
 
-# ── _show_spinner ──────────────────────────────────────────────
+# -- _show_spinner ---------------------------------------------------------
 
 
 class TestShowSpinner:
@@ -238,20 +294,261 @@ class TestShowSpinner:
             _show_spinner(stop)
 
 
-# ── option selection + dispatch ────────────────────────────────
+# -- _ask_follow_ups -------------------------------------------------------
+
+
+class TestAskFollowUps:
+    """Follow-up question collection and validation."""
+
+    def test_empty_follow_ups_returns_empty_dict(self) -> None:
+        result = _ask_follow_ups([], no_color=True)
+        assert result == {}
+
+    def test_path_follow_up_validates_directory(self, tmp_path: Path) -> None:
+        follow_ups = [
+            {"key": "path", "question": "Project path", "type": "path", "optional": False},
+        ]
+        with patch("builtins.input", return_value=str(tmp_path)), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is not None
+        assert "path" in result
+        assert str(tmp_path.resolve()) in result["path"]
+
+    def test_path_follow_up_expands_tilde(self, tmp_path: Path) -> None:
+        follow_ups = [
+            {"key": "path", "question": "Project path", "type": "path", "optional": False},
+        ]
+        with patch("builtins.input", return_value=str(tmp_path)), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is not None
+        # Resolved path should be absolute
+        import shlex
+        unquoted = shlex.split(result["path"])[0]
+        assert Path(unquoted).is_absolute()
+
+    def test_path_follow_up_rejects_nonexistent(self) -> None:
+        follow_ups = [
+            {"key": "path", "question": "Project path", "type": "path", "optional": False},
+        ]
+        with patch("builtins.input", return_value="/nonexistent/xyz/12345"), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is None
+
+    def test_path_follow_up_empty_required_fails(self) -> None:
+        follow_ups = [
+            {"key": "path", "question": "Project path", "type": "path", "optional": False},
+        ]
+        with patch("builtins.input", return_value=""), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is None
+
+    def test_path_follow_up_empty_optional_skips(self) -> None:
+        follow_ups = [
+            {"key": "path", "question": "Project path", "type": "path", "optional": True},
+        ]
+        with patch("builtins.input", return_value=""), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result == {}
+
+    def test_issue_follow_up_numeric(self) -> None:
+        follow_ups = [
+            {"key": "issue", "question": "Issue number", "type": "issue", "optional": False},
+        ]
+        with patch("builtins.input", return_value="42"), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is not None
+        assert result["issue"] == "42"
+
+    def test_issue_follow_up_text(self) -> None:
+        follow_ups = [
+            {"key": "issue", "question": "Issue", "type": "issue", "optional": False},
+        ]
+        with patch("builtins.input", return_value="fix the login bug"), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is not None
+        assert result["issue"] == '"fix the login bug"'
+
+    def test_issue_follow_up_optional_empty_skips(self) -> None:
+        follow_ups = [
+            {"key": "issue", "question": "Issue", "type": "issue", "optional": True},
+        ]
+        with patch("builtins.input", return_value=""), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result == {}
+
+    def test_text_follow_up_required(self) -> None:
+        follow_ups = [
+            {"key": "topic", "question": "Topic", "type": "text", "optional": False},
+        ]
+        with patch("builtins.input", return_value="auth system"), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is not None
+        assert result["topic"] == "auth system"
+
+    def test_text_follow_up_required_empty_fails(self) -> None:
+        follow_ups = [
+            {"key": "topic", "question": "Topic", "type": "text", "optional": False},
+        ]
+        with patch("builtins.input", return_value=""), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is None
+
+    def test_text_follow_up_optional_empty_skips(self) -> None:
+        follow_ups = [
+            {"key": "topic", "question": "Topic", "type": "text", "optional": True},
+        ]
+        with patch("builtins.input", return_value=""), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result == {}
+
+    def test_choice_follow_up(self) -> None:
+        follow_ups = [
+            {"key": "mode", "question": "Which mode?", "type": "choice",
+             "options": ["interactive", "build", "research"], "optional": False},
+        ]
+        with patch("builtins.input", return_value="2"), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is not None
+        assert result["mode"] == "build"
+
+    def test_choice_follow_up_invalid_returns_none(self) -> None:
+        follow_ups = [
+            {"key": "mode", "question": "Which mode?", "type": "choice",
+             "options": ["interactive", "build"], "optional": False},
+        ]
+        with patch("builtins.input", return_value="5"), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is None
+
+    def test_eof_during_follow_up_returns_none(self) -> None:
+        follow_ups = [
+            {"key": "path", "question": "Path", "type": "path", "optional": False},
+        ]
+        with patch("builtins.input", side_effect=EOFError), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is None
+
+    def test_ctrl_c_during_follow_up_returns_none(self) -> None:
+        follow_ups = [
+            {"key": "path", "question": "Path", "type": "path", "optional": False},
+        ]
+        with patch("builtins.input", side_effect=KeyboardInterrupt), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is None
+
+    def test_multiple_follow_ups(self, tmp_path: Path) -> None:
+        follow_ups = [
+            {"key": "path", "question": "Path", "type": "path", "optional": False},
+            {"key": "issue", "question": "Issue", "type": "issue", "optional": True},
+        ]
+        with patch("builtins.input", side_effect=[str(tmp_path), "42"]), \
+             patch("sys.stderr"):
+            result = _ask_follow_ups(follow_ups, no_color=True)
+
+        assert result is not None
+        assert "path" in result
+        assert result["issue"] == "42"
+
+
+# -- _substitute_answers ---------------------------------------------------
+
+
+class TestSubstituteAnswers:
+    """Placeholder substitution and suggestion filtering."""
+
+    def test_substitutes_all_keys(self) -> None:
+        suggestions = [
+            {"label": "Fix", "command": "factory ceo {path} --focus {issue}"},
+        ]
+        answers = {"path": "/tmp/proj", "issue": "42"}
+        result = _substitute_answers(suggestions, answers)
+        assert len(result) == 1
+        assert result[0]["command"] == "factory ceo /tmp/proj --focus 42"
+
+    def test_drops_suggestion_with_unfilled_placeholder(self) -> None:
+        suggestions = [
+            {"label": "Fix", "command": "factory ceo {path} --focus {issue}"},
+            {"label": "Discuss", "command": "factory ceo {path} --mode interactive"},
+        ]
+        answers = {"path": "/tmp/proj"}  # no issue
+        result = _substitute_answers(suggestions, answers)
+        assert len(result) == 1
+        assert result[0]["label"] == "Discuss"
+        assert result[0]["command"] == "factory ceo /tmp/proj --mode interactive"
+
+    def test_keeps_suggestion_without_placeholders(self) -> None:
+        suggestions = [
+            {"label": "Build", "command": 'factory ceo "my idea" --mode interactive'},
+        ]
+        answers = {}
+        result = _substitute_answers(suggestions, answers)
+        assert len(result) == 1
+        assert result[0]["command"] == 'factory ceo "my idea" --mode interactive'
+
+    def test_drops_all_if_no_answers(self) -> None:
+        suggestions = [
+            {"label": "Fix", "command": "factory ceo {path} --focus {issue}"},
+        ]
+        answers = {}
+        result = _substitute_answers(suggestions, answers)
+        assert len(result) == 0
+
+    def test_preserves_other_fields(self) -> None:
+        suggestions = [
+            {"label": "Fix", "explanation": "Target it.", "command": "factory ceo {path}", "tip": "Go!"},
+        ]
+        answers = {"path": "/tmp/proj"}
+        result = _substitute_answers(suggestions, answers)
+        assert result[0]["label"] == "Fix"
+        assert result[0]["explanation"] == "Target it."
+        assert result[0]["tip"] == "Go!"
+
+
+# -- option selection + dispatch -------------------------------------------
 
 
 class TestWizardDispatch:
     """Tests for the full wizard flow: input -> classify -> select -> dispatch."""
 
     def test_selects_default_option(self) -> None:
-        suggestions = [
-            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test" --mode interactive'},
-        ]
+        llm_result = (
+            [],
+            [{"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test" --mode interactive'}],
+        )
         with patch("builtins.input", side_effect=["test idea", ""]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
@@ -261,14 +558,17 @@ class TestWizardDispatch:
         mock_ceo.assert_called_once()
 
     def test_selects_numbered_option(self) -> None:
-        suggestions = [
-            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
-            {"label": "Option 2", "explanation": "Second.", "command": 'factory ceo "test" --mode interactive'},
-        ]
+        llm_result = (
+            [],
+            [
+                {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
+                {"label": "Option 2", "explanation": "Second.", "command": 'factory ceo "test" --mode interactive'},
+            ],
+        )
         with patch("builtins.input", side_effect=["test idea", "2"]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
@@ -280,13 +580,14 @@ class TestWizardDispatch:
         assert ns.mode == "interactive"
 
     def test_invalid_choice_returns_error(self) -> None:
-        suggestions = [
-            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
-        ]
+        llm_result = (
+            [],
+            [{"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'}],
+        )
         with patch("builtins.input", side_effect=["test idea", "abc"]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
             code = _welcome_wizard()
@@ -294,13 +595,14 @@ class TestWizardDispatch:
         assert code == 1
 
     def test_out_of_range_choice_returns_error(self) -> None:
-        suggestions = [
-            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
-        ]
+        llm_result = (
+            [],
+            [{"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'}],
+        )
         with patch("builtins.input", side_effect=["test idea", "5"]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
             code = _welcome_wizard()
@@ -318,14 +620,19 @@ class TestWizardDispatch:
 
         assert code == 0
 
-    def test_path_placeholder_prompts_for_path(self, tmp_path: Path) -> None:
-        suggestions = [
-            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
-        ]
-        with patch("builtins.input", side_effect=["fix a bug", "", str(tmp_path)]), \
+    def test_follow_up_path_fills_command(self, tmp_path: Path) -> None:
+        """Follow-up for {path} asks user and substitutes into commands."""
+        llm_result = (
+            [{"key": "path", "question": "Path to project", "type": "path", "optional": False}],
+            [
+                {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo {path} --focus "fix bug"'},
+                {"label": "Discuss", "explanation": "Talk.", "command": "factory ceo {path} --mode interactive"},
+            ],
+        )
+        with patch("builtins.input", side_effect=["fix a bug", str(tmp_path), ""]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
@@ -336,50 +643,71 @@ class TestWizardDispatch:
         ns = mock_ceo.call_args[0][0]
         assert str(tmp_path.resolve()) == ns.path
 
-    def test_path_placeholder_empty_returns_error(self) -> None:
-        suggestions = [
-            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
-        ]
-        with patch("builtins.input", side_effect=["fix a bug", "", ""]), \
+    def test_follow_up_drops_unfilled_suggestions(self, tmp_path: Path) -> None:
+        """Suggestions with unfilled placeholders are dropped."""
+        llm_result = (
+            [
+                {"key": "path", "question": "Path", "type": "path", "optional": False},
+                {"key": "issue", "question": "Issue", "type": "issue", "optional": True},
+            ],
+            [
+                {"label": "Fix specific", "explanation": "Target.", "command": "factory ceo {path} --focus {issue}"},
+                {"label": "Discuss", "explanation": "Talk.", "command": "factory ceo {path} --mode interactive"},
+            ],
+        )
+        # User provides path but skips optional issue
+        with patch("builtins.input", side_effect=["fix a bug", str(tmp_path), "", ""]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
             code = _welcome_wizard()
 
-        assert code == 1
+        assert code == 0
+        mock_ceo.assert_called_once()
+        # The selected command should be the "Discuss" one (only surviving)
+        ns = mock_ceo.call_args[0][0]
+        assert ns.mode == "interactive"
 
-    def test_path_placeholder_nonexistent_returns_error(self) -> None:
-        suggestions = [
-            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
-        ]
-        with patch("builtins.input", side_effect=["fix a bug", "", "/nonexistent/path/xyz"]), \
+    def test_follow_up_eof_exits_cleanly(self) -> None:
+        llm_result = (
+            [{"key": "path", "question": "Path", "type": "path", "optional": False}],
+            [{"label": "Fix", "explanation": "Go.", "command": "factory ceo {path}"}],
+        )
+        with patch("builtins.input", side_effect=["fix a bug", EOFError]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
-             patch("os.environ", {}):
-            mock_stderr.isatty.return_value = True
-            code = _welcome_wizard()
-
-        assert code == 1
-
-    def test_path_placeholder_eof_exits_cleanly(self) -> None:
-        suggestions = [
-            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
-        ]
-        with patch("builtins.input", side_effect=["fix a bug", "", EOFError]), \
-             patch("sys.stderr") as mock_stderr, \
-             patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
             code = _welcome_wizard()
 
         assert code == 0
 
+    def test_all_suggestions_dropped_shows_error(self) -> None:
+        """If follow-ups result in all suggestions being dropped, return error."""
+        llm_result = (
+            [{"key": "path", "question": "Path", "type": "path", "optional": True}],
+            [
+                {"label": "Fix", "explanation": "Go.", "command": "factory ceo {path} --focus 42"},
+            ],
+        )
+        # User skips optional path, but it's the only suggestion and it has {path}
+        with patch("builtins.input", side_effect=["fix a bug", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            mock_stderr.write = MagicMock()
+            code = _welcome_wizard()
 
-# ── edge cases ─────────────────────────────────────────────────
+        assert code == 1
+
+
+# -- edge cases ------------------------------------------------------------
 
 
 class TestWizardEdgeCases:
@@ -395,13 +723,14 @@ class TestWizardEdgeCases:
         assert code == 0
 
     def test_empty_then_valid_input(self) -> None:
-        suggestions = [
-            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
-        ]
+        llm_result = (
+            [],
+            [{"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'}],
+        )
         with patch("builtins.input", side_effect=["", "test idea", ""]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
@@ -420,13 +749,14 @@ class TestWizardEdgeCases:
         assert code == 0
 
     def test_eof_on_choice_prompt(self) -> None:
-        suggestions = [
-            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
-        ]
+        llm_result = (
+            [],
+            [{"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'}],
+        )
         with patch("builtins.input", side_effect=["test", EOFError]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
             code = _welcome_wizard()
@@ -443,13 +773,14 @@ class TestWizardEdgeCases:
         assert code == 130
 
     def test_ctrl_c_on_choice_prompt(self) -> None:
-        suggestions = [
-            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
-        ]
+        llm_result = (
+            [],
+            [{"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'}],
+        )
         with patch("builtins.input", side_effect=["test", KeyboardInterrupt]), \
              patch("sys.stderr") as mock_stderr, \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
             code = _welcome_wizard()
@@ -475,19 +806,20 @@ class TestWizardEdgeCases:
         assert code == 130
 
 
-# ── NO_COLOR behavior ──────────────────────────────────────────
+# -- NO_COLOR behavior -----------------------------------------------------
 
 
 class TestNOCOLOR:
     """Wizard respects NO_COLOR env var."""
 
     def test_no_color_plain_text(self, capsys: pytest.CaptureFixture[str]) -> None:
-        suggestions = [
-            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
-        ]
+        llm_result = (
+            [],
+            [{"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'}],
+        )
         with patch("builtins.input", side_effect=["test", ""]), \
              patch("factory.cli._quick_classify", return_value=None), \
-             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli._classify_with_llm", return_value=llm_result), \
              patch("factory.cli.cmd_ceo", return_value=0), \
              patch.dict("os.environ", {"NO_COLOR": "1"}):
             code = _welcome_wizard()
@@ -497,7 +829,7 @@ class TestNOCOLOR:
         assert "\033[" not in captured.err
 
 
-# ── regression: existing subcommands ───────────────────────────
+# -- regression: existing subcommands -------------------------------------
 
 
 class TestExistingSubcommands:
@@ -513,7 +845,7 @@ class TestExistingSubcommands:
         mock_wizard.assert_not_called()
 
 
-# ── banner update ──────────────────────────────────────────────
+# -- banner update ---------------------------------------------------------
 
 
 class TestBannerUpdate:

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -465,5 +465,5 @@ class TestBannerUpdate:
             mock_stderr.isatty.return_value = False
             _print_banner("welcome")
 
-        # The no-color branch just prints "Factory v2 — mode: welcome"
-        # (tagline only appears in the ANSI branch)
+        # The no-color branch prints the tagline without mode for welcome
+        mock_stderr.write.assert_any_call("The Factory — Self-Evolving Meta-Harness")

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -311,6 +311,21 @@ class TestWizardDispatch:
         (tmp_path / ".factory").mkdir()
         with patch("builtins.input", side_effect=[str(tmp_path), ""]), \
              patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli.cmd_ceo", return_value=0), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_path_placeholder_prompts_for_path(self, tmp_path: Path) -> None:
+        suggestions = [
+            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
+        ]
+        with patch("builtins.input", side_effect=["fix a bug", "", str(tmp_path)]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
              patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
              patch("os.environ", {}):
             mock_stderr.isatty.return_value = True
@@ -318,6 +333,50 @@ class TestWizardDispatch:
 
         assert code == 0
         mock_ceo.assert_called_once()
+        ns = mock_ceo.call_args[0][0]
+        assert str(tmp_path.resolve()) == ns.path
+
+    def test_path_placeholder_empty_returns_error(self) -> None:
+        suggestions = [
+            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
+        ]
+        with patch("builtins.input", side_effect=["fix a bug", "", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 1
+
+    def test_path_placeholder_nonexistent_returns_error(self) -> None:
+        suggestions = [
+            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
+        ]
+        with patch("builtins.input", side_effect=["fix a bug", "", "/nonexistent/path/xyz"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 1
+
+    def test_path_placeholder_eof_exits_cleanly(self) -> None:
+        suggestions = [
+            {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo <path> --focus "fix bug"'},
+        ]
+        with patch("builtins.input", side_effect=["fix a bug", "", EOFError]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
 
 
 # ── edge cases ─────────────────────────────────────────────────

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -1,0 +1,469 @@
+"""Tests for the welcome wizard in factory/cli.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from factory.cli import (
+    _classify_with_llm,
+    _quick_classify,
+    _show_spinner,
+    _welcome_wizard,
+    main,
+)
+
+
+# ── TTY detection ──────────────────────────────────────────────
+
+
+class TestTTYDetection:
+    """Wizard activates only when stdin+stderr are TTYs."""
+
+    def test_non_tty_prints_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Non-TTY falls through to argparse help (backward compatible)."""
+        with patch("sys.stdin") as mock_stdin, \
+             patch("sys.stderr") as mock_stderr:
+            mock_stdin.isatty.return_value = False
+            mock_stderr.isatty.return_value = False
+            code = main([])
+        assert code == 1
+
+    def test_tty_launches_wizard(self) -> None:
+        """TTY with no subcommand dispatches to _welcome_wizard."""
+        with patch("factory.cli._welcome_wizard", return_value=0) as mock_wizard, \
+             patch("sys.stdin") as mock_stdin, \
+             patch("sys.stderr") as mock_stderr:
+            mock_stdin.isatty.return_value = True
+            mock_stderr.isatty.return_value = True
+            code = main([])
+        assert code == 0
+        mock_wizard.assert_called_once()
+
+    def test_stdin_not_tty_stderr_tty(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """If stdin is not a TTY (piped), falls through to help."""
+        with patch("sys.stdin") as mock_stdin, \
+             patch("sys.stderr") as mock_stderr:
+            mock_stdin.isatty.return_value = False
+            mock_stderr.isatty.return_value = True
+            code = main([])
+        assert code == 1
+
+
+# ── _quick_classify ────────────────────────────────────────────
+
+
+class TestQuickClassify:
+    """Deterministic fast path for paths, files, and URLs."""
+
+    def test_existing_dir_with_factory(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        result = _quick_classify(str(tmp_path))
+        assert result is not None
+        assert len(result) == 2
+        assert "Improve" in result[0]["label"]
+        assert str(tmp_path) in result[0]["command"]
+
+    def test_existing_dir_without_factory(self, tmp_path: Path) -> None:
+        result = _quick_classify(str(tmp_path))
+        assert result is not None
+        assert len(result) == 2
+        assert "Set up" in result[0]["label"]
+
+    def test_existing_file(self, tmp_path: Path) -> None:
+        spec = tmp_path / "spec.md"
+        spec.write_text("Build a weather CLI")
+        result = _quick_classify(str(spec))
+        assert result is not None
+        assert len(result) == 1
+        assert "spec" in result[0]["label"].lower()
+        assert str(spec) in result[0]["command"]
+
+    def test_github_url(self) -> None:
+        url = "https://github.com/user/repo"
+        result = _quick_classify(url)
+        assert result is not None
+        assert len(result) == 2
+        assert "Clone" in result[0]["label"]
+        assert url in result[0]["command"]
+
+    def test_github_ssh_url(self) -> None:
+        url = "git@github.com:user/repo.git"
+        result = _quick_classify(url)
+        assert result is not None
+        assert "Clone" in result[0]["label"]
+
+    def test_free_text_returns_none(self) -> None:
+        result = _quick_classify("build me a weather CLI in Python")
+        assert result is None
+
+    def test_nonexistent_path_returns_none(self) -> None:
+        result = _quick_classify("/nonexistent/path/12345")
+        assert result is None
+
+    def test_preserves_user_input_verbatim(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        user_input = str(tmp_path)
+        result = _quick_classify(user_input)
+        assert result is not None
+        for s in result:
+            assert user_input in s["command"]
+
+
+# ── _classify_with_llm ────────────────────────────────────────
+
+
+class TestClassifyWithLLM:
+    """LLM-based classification with mocked runner."""
+
+    def test_valid_json_response(self) -> None:
+        suggestions = [
+            {"label": "Brainstorm first", "explanation": "Refine the idea.", "command": 'factory ceo "weather CLI" --mode interactive'},
+            {"label": "Build directly", "explanation": "Start building.", "command": 'factory ceo "weather CLI"'},
+        ]
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(suggestions), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("weather CLI")
+
+        assert len(result) == 2
+        assert result[0]["label"] == "Brainstorm first"
+
+    def test_json_with_markdown_wrapper(self) -> None:
+        raw = '```json\n[{"label": "Build it", "explanation": "Go.", "command": "factory ceo \\"test\\""}]\n```'
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(raw, 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("test")
+
+        assert len(result) == 1
+        assert result[0]["label"] == "Build it"
+
+    def test_invalid_json_falls_back(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=("not valid json at all", 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("weather CLI")
+
+        assert len(result) == 2
+        assert "recommended" in result[0]["label"].lower()
+        assert "weather CLI" in result[0]["command"]
+
+    def test_runner_failure_falls_back(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=("Error", 1))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("weather CLI")
+
+        assert len(result) == 2
+        assert "weather CLI" in result[0]["command"]
+
+    def test_runner_not_available_falls_back(self) -> None:
+        with patch("factory.runners.get_runner", side_effect=Exception("No runner")):
+            result = _classify_with_llm("weather CLI")
+
+        assert len(result) == 2
+        assert "weather CLI" in result[0]["command"]
+
+    def test_empty_array_falls_back(self) -> None:
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=("[]", 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("test idea")
+
+        assert len(result) == 2
+        assert "test idea" in result[0]["command"]
+
+    def test_missing_required_fields_falls_back(self) -> None:
+        bad_suggestions = [{"label": "Test"}]  # missing command
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(bad_suggestions), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("test idea")
+
+        assert len(result) == 2
+        assert "test idea" in result[0]["command"]
+
+    def test_truncates_to_3_suggestions(self) -> None:
+        suggestions = [
+            {"label": f"Option {i}", "explanation": "desc", "command": f'factory ceo "x{i}"'}
+            for i in range(5)
+        ]
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(suggestions), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("test")
+
+        assert len(result) == 3
+
+    def test_preserves_user_input_in_defaults(self) -> None:
+        with patch("factory.runners.get_runner", side_effect=Exception("fail")):
+            result = _classify_with_llm("my exact input text")
+
+        for s in result:
+            assert "my exact input text" in s["command"]
+
+
+# ── _show_spinner ──────────────────────────────────────────────
+
+
+class TestShowSpinner:
+    """Spinner respects NO_COLOR and stops cleanly."""
+
+    def test_spinner_stops_on_event(self) -> None:
+        import threading
+        stop = threading.Event()
+        stop.set()
+        with patch("sys.stderr"):
+            _show_spinner(stop)
+
+    def test_spinner_respects_no_color(self) -> None:
+        import threading
+        stop = threading.Event()
+        stop.set()
+        with patch.dict("os.environ", {"NO_COLOR": "1"}), \
+             patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = False
+            _show_spinner(stop)
+
+
+# ── option selection + dispatch ────────────────────────────────
+
+
+class TestWizardDispatch:
+    """Tests for the full wizard flow: input -> classify -> select -> dispatch."""
+
+    def test_selects_default_option(self) -> None:
+        suggestions = [
+            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test" --mode interactive'},
+        ]
+        with patch("builtins.input", side_effect=["test idea", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+        mock_ceo.assert_called_once()
+
+    def test_selects_numbered_option(self) -> None:
+        suggestions = [
+            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
+            {"label": "Option 2", "explanation": "Second.", "command": 'factory ceo "test" --mode interactive'},
+        ]
+        with patch("builtins.input", side_effect=["test idea", "2"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+        mock_ceo.assert_called_once()
+        ns = mock_ceo.call_args[0][0]
+        assert ns.mode == "interactive"
+
+    def test_invalid_choice_returns_error(self) -> None:
+        suggestions = [
+            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test idea", "abc"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 1
+
+    def test_out_of_range_choice_returns_error(self) -> None:
+        suggestions = [
+            {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test idea", "5"]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 1
+
+    def test_fast_path_skips_llm(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        with patch("builtins.input", side_effect=[str(tmp_path), ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+        mock_ceo.assert_called_once()
+
+
+# ── edge cases ─────────────────────────────────────────────────
+
+
+class TestWizardEdgeCases:
+    """Empty input, EOF, Ctrl+C."""
+
+    def test_empty_input_shows_examples_then_exits(self) -> None:
+        with patch("builtins.input", side_effect=["", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_empty_then_valid_input(self) -> None:
+        suggestions = [
+            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["", "test idea", ""]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli.cmd_ceo", return_value=0) as mock_ceo, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+        mock_ceo.assert_called_once()
+
+    def test_eof_on_first_prompt(self) -> None:
+        with patch("builtins.input", side_effect=EOFError), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_eof_on_choice_prompt(self) -> None:
+        suggestions = [
+            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test", EOFError]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_ctrl_c_on_first_prompt(self) -> None:
+        with patch("builtins.input", side_effect=KeyboardInterrupt), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 130
+
+    def test_ctrl_c_on_choice_prompt(self) -> None:
+        suggestions = [
+            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test", KeyboardInterrupt]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 130
+
+    def test_eof_on_second_prompt_after_empty(self) -> None:
+        with patch("builtins.input", side_effect=["", EOFError]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 0
+
+    def test_ctrl_c_on_second_prompt_after_empty(self) -> None:
+        with patch("builtins.input", side_effect=["", KeyboardInterrupt]), \
+             patch("sys.stderr") as mock_stderr, \
+             patch("os.environ", {}):
+            mock_stderr.isatty.return_value = True
+            code = _welcome_wizard()
+
+        assert code == 130
+
+
+# ── NO_COLOR behavior ──────────────────────────────────────────
+
+
+class TestNOCOLOR:
+    """Wizard respects NO_COLOR env var."""
+
+    def test_no_color_plain_text(self, capsys: pytest.CaptureFixture[str]) -> None:
+        suggestions = [
+            {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+        ]
+        with patch("builtins.input", side_effect=["test", ""]), \
+             patch("factory.cli._quick_classify", return_value=None), \
+             patch("factory.cli._classify_with_llm", return_value=suggestions), \
+             patch("factory.cli.cmd_ceo", return_value=0), \
+             patch.dict("os.environ", {"NO_COLOR": "1"}):
+            code = _welcome_wizard()
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "\033[" not in captured.err
+
+
+# ── regression: existing subcommands ───────────────────────────
+
+
+class TestExistingSubcommands:
+    """Existing subcommands must work identically."""
+
+    def test_home_still_works(self) -> None:
+        code = main(["home"])
+        assert code == 0
+
+    def test_subcommand_not_affected(self) -> None:
+        with patch("factory.cli._welcome_wizard") as mock_wizard:
+            main(["home"])
+        mock_wizard.assert_not_called()
+
+
+# ── banner update ──────────────────────────────────────────────
+
+
+class TestBannerUpdate:
+    def test_banner_tagline(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from factory.cli import _print_banner
+
+        with patch("sys.stderr") as mock_stderr, \
+             patch.dict("os.environ", {"NO_COLOR": "1"}):
+            mock_stderr.isatty.return_value = False
+            _print_banner("welcome")
+
+        # The no-color branch just prints "Factory v2 — mode: welcome"
+        # (tagline only appears in the ANSI branch)


### PR DESCRIPTION
## Summary
- Replace dumb command router with intelligent conversational wizard
- Single LLM call returns both suggestions AND follow-up questions via new JSON format: `{follow_ups, suggestions}`
- Wizard asks follow-ups, validates inputs (path/issue/text/choice), substitutes `{key}` placeholders into commands
- Drops suggestions whose required placeholders weren't filled
- Backward compatible: legacy JSON array responses still work

Closes #304

## Test plan
- [x] Wizard follow-up flow with path validation (expand ~, resolve absolute, check exists)
- [x] Issue number and text parsing (numeric stays bare, text gets quoted)
- [x] Optional field handling (skipped fields don't block, suggestions with unfilled placeholders dropped)
- [x] `{key}` substitution in commands
- [x] Suggestions with unfilled placeholders dropped
- [x] `_quick_classify()` fast path unchanged
- [x] Existing subcommands unaffected
- [x] EOF/Ctrl+C handling during follow-ups
- [x] Choice type follow-ups with numbered options
- [x] NO_COLOR behavior preserved
- [x] All 67 wizard tests pass, all 168 CLI tests pass
- [x] ruff clean, no new mypy errors