### PR TITLE
feat: promote eval_spec to scored dimensions + within-tier weight config

### DIFF
--- a/factory/agents/prompts/evaluator.md
+++ b/factory/agents/prompts/evaluator.md
@@ -76,4 +76,19 @@ If the CEO includes an `## Eval Spec` block in your task, follow each instructio
 
 **Important:** Spec checks are advisory only. They do NOT affect the composite score. A failing spec check does not change the PASS/FAIL status of the eval. The CEO uses spec compliance as an additional signal when making keep/revert decisions.
 
+**Structured spec results:** After running spec checks, write a JSON file at `.factory/spec_results.json` with this exact format:
+
+```json
+{
+  "results": [
+    {"name": "spec item text", "passed": true},
+    {"name": "spec item text", "passed": false}
+  ],
+  "total": 2,
+  "passed": 1
+}
+```
+
+This file is consumed by the `spec_compliance` growth dimension. Always overwrite it after each eval run that includes spec checks. If no spec checks are defined, do not create or modify this file.
+
 **Exit condition:** Eval results printed to stdout with all sections populated, or error message printed if the eval command failed.

--- a/factory/discovery/eval_spec.py
+++ b/factory/discovery/eval_spec.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import re
+import tomllib
 from pathlib import Path
+from typing import Literal
 
 import structlog
 
-from factory.models import ProjectProfile
+from factory.models import ProjectEvalDimension, ProjectProfile
 
 log = structlog.get_logger()
 
@@ -74,3 +77,135 @@ def generate_eval_spec(profile: ProjectProfile, project_path: Path) -> list[str]
         item_count=len(items),
     )
     return items
+
+
+# ── Eval spec classification & promotion ─────────────────────────
+
+_EXECUTABLE_VERBS = frozenset({
+    "run", "start", "build", "execute", "deploy", "import",
+    "install", "launch", "open", "curl", "send", "hit",
+})
+
+_COMMAND_PATTERNS = re.compile(
+    r"(?:`[^`]+`|--\w+|\b(?:python|node|npm|cargo|go|docker|curl|make|pytest)\b)"
+)
+
+
+def classify_eval_spec_item(item: str) -> Literal["executable", "judgmental"]:
+    """Classify an eval_spec item as executable (automatable) or judgmental (manual)."""
+    lower = item.lower().strip()
+    if not lower:
+        return "judgmental"
+
+    first_word = lower.split()[0]
+    if first_word in _EXECUTABLE_VERBS:
+        return "executable"
+
+    if _COMMAND_PATTERNS.search(item):
+        return "executable"
+
+    return "judgmental"
+
+
+def _find_entry_point(project_path: Path) -> str | None:
+    """Find the main CLI entry point from pyproject.toml [project.scripts]."""
+    pyproject = project_path / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    try:
+        data = tomllib.loads(pyproject.read_text())
+        scripts = data.get("project", {}).get("scripts", {})
+        if scripts:
+            return next(iter(scripts))
+    except Exception:
+        pass
+    return None
+
+
+def _find_package_name(project_path: Path) -> str | None:
+    """Find the main Python package name by looking for dirs with __init__.py."""
+    skip = {"tests", "test", "docs", "scripts", "examples", "eval"}
+    for child in sorted(project_path.iterdir()):
+        if child.is_dir() and (child / "__init__.py").exists() and child.name not in skip:
+            return child.name
+    return None
+
+
+def _slugify(item: str) -> str:
+    """Convert an eval_spec item to a short slug for dimension naming."""
+    words = re.sub(r"[^a-z0-9\s]", "", item.lower()).split()[:4]
+    return "_".join(words) if words else "spec_check"
+
+
+def _generate_command(item: str, project_path: Path) -> str | None:
+    """Attempt to generate a shell command from an eval_spec item."""
+    lower = item.lower()
+
+    if "--help" in lower or "--version" in lower:
+        entry = _find_entry_point(project_path)
+        if entry:
+            flag = "--help" if "--help" in lower else "--version"
+            return f"{entry} {flag}"
+        return None
+
+    if "import" in lower and ("package" in lower or "module" in lower or "python" in lower):
+        pkg = _find_package_name(project_path)
+        if pkg:
+            return f'python -c "import {pkg}"'
+        return None
+
+    if "docker" in lower:
+        compose_files = ("docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml")
+        if any((project_path / f).exists() for f in compose_files):
+            return "docker compose build"
+        if (project_path / "Dockerfile").exists():
+            return "docker build -t spec-check ."
+        return None
+
+    if "manage.py" in lower:
+        if (project_path / "manage.py").exists():
+            if "check" in lower:
+                return "python manage.py check"
+            return "python manage.py check"
+        return None
+
+    # Backticked command extraction
+    backtick = re.search(r"`([^`]+)`", item)
+    if backtick:
+        cmd = backtick.group(1).strip()
+        if cmd and not cmd.startswith("#"):
+            return cmd
+
+    return None
+
+
+def generate_project_eval_from_spec(
+    eval_spec: list[str],
+    project_path: Path,
+) -> list[ProjectEvalDimension]:
+    """Generate ProjectEvalDimension entries for executable eval_spec items."""
+    dims: list[ProjectEvalDimension] = []
+
+    for item in eval_spec:
+        if classify_eval_spec_item(item) != "executable":
+            continue
+
+        command = _generate_command(item, project_path)
+        if not command:
+            continue
+
+        name = f"spec_{_slugify(item)}"
+        dims.append(ProjectEvalDimension(
+            name=name,
+            command=command,
+            parse="exit_code",
+            weight=1.0,
+            description=item,
+        ))
+
+    log.debug(
+        "generate_project_eval_from_spec",
+        total_items=len(eval_spec),
+        promoted=len(dims),
+    )
+    return dims

--- a/factory/discovery/eval_spec.py
+++ b/factory/discovery/eval_spec.py
@@ -164,8 +164,6 @@ def _generate_command(item: str, project_path: Path) -> str | None:
 
     if "manage.py" in lower:
         if (project_path / "manage.py").exists():
-            if "check" in lower:
-                return "python manage.py check"
             return "python manage.py check"
         return None
 
@@ -186,6 +184,8 @@ def generate_project_eval_from_spec(
     """Generate ProjectEvalDimension entries for executable eval_spec items."""
     dims: list[ProjectEvalDimension] = []
 
+    used_slugs: dict[str, int] = {}
+
     for item in eval_spec:
         if classify_eval_spec_item(item) != "executable":
             continue
@@ -194,7 +194,13 @@ def generate_project_eval_from_spec(
         if not command:
             continue
 
-        name = f"spec_{_slugify(item)}"
+        base = f"spec_{_slugify(item)}"
+        if base in used_slugs:
+            used_slugs[base] += 1
+            name = f"{base}_{used_slugs[base]}"
+        else:
+            used_slugs[base] = 1
+            name = base
         dims.append(ProjectEvalDimension(
             name=name,
             command=command,

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -456,7 +456,7 @@ def eval_spec_compliance(project_path: Path) -> dict:
                 "details": "No spec checks recorded — neutral score",
             }
 
-        score = passed / total
+        score = min(passed / total, 1.0)
         return {
             "name": "spec_compliance",
             "score": round(score, 4),

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -456,7 +456,7 @@ def eval_spec_compliance(project_path: Path) -> dict:
                 "details": "No spec checks recorded — neutral score",
             }
 
-        score = min(passed / total, 1.0)
+        score = max(0.0, min(passed / total, 1.0))
         return {
             "name": "spec_compliance",
             "score": round(score, 4),

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -9,18 +9,21 @@ All functions take a project_path and return an EvalResult-compatible dict.
 
 import ast
 import csv
+import json
 import re
+import time
 from collections import Counter
 from pathlib import Path
 
 # Relative weights within the growth category (sum to 1.0).
 # The runner normalizes these so that growth gets 50% of the composite.
 GROWTH_WEIGHTS = {
-    "capability_surface": 0.28,
-    "experiment_diversity": 0.22,
-    "observability": 0.20,
-    "research_grounding": 0.16,
-    "factory_effectiveness": 0.14,
+    "capability_surface": 0.25,
+    "experiment_diversity": 0.20,
+    "observability": 0.18,
+    "research_grounding": 0.14,
+    "factory_effectiveness": 0.13,
+    "spec_compliance": 0.10,
 }
 
 
@@ -412,6 +415,65 @@ def eval_factory_effectiveness(project_path: Path) -> dict:
         }
 
 
+def eval_spec_compliance(project_path: Path) -> dict:
+    """Measure eval spec compliance from .factory/spec_results.json.
+
+    Score = passed/total. Returns neutral 0.5 if file is missing or stale (>24h).
+    """
+    spec_path = project_path / ".factory" / "spec_results.json"
+    weight = GROWTH_WEIGHTS["spec_compliance"]
+
+    if not spec_path.exists():
+        return {
+            "name": "spec_compliance",
+            "score": 0.5,
+            "weight": weight,
+            "passed": True,
+            "details": "spec_results.json not found — neutral score",
+        }
+
+    try:
+        mtime = spec_path.stat().st_mtime
+        if time.time() - mtime > 86400:
+            return {
+                "name": "spec_compliance",
+                "score": 0.5,
+                "weight": weight,
+                "passed": True,
+                "details": "spec_results.json is stale (>24h) — neutral score",
+            }
+
+        data = json.loads(spec_path.read_text())
+        total = int(data.get("total", 0))
+        passed = int(data.get("passed", 0))
+
+        if total == 0:
+            return {
+                "name": "spec_compliance",
+                "score": 0.5,
+                "weight": weight,
+                "passed": True,
+                "details": "No spec checks recorded — neutral score",
+            }
+
+        score = passed / total
+        return {
+            "name": "spec_compliance",
+            "score": round(score, 4),
+            "weight": weight,
+            "passed": score >= 0.5,
+            "details": f"{passed}/{total} spec checks passed",
+        }
+    except Exception as exc:
+        return {
+            "name": "spec_compliance",
+            "score": 0.5,
+            "weight": weight,
+            "passed": True,
+            "details": f"Error reading spec_results.json: {exc} — neutral score",
+        }
+
+
 def compute_growth_results(project_path: Path) -> list[dict]:
     """Compute all growth dimensions for a project. Returns list of result dicts."""
     return [
@@ -420,6 +482,7 @@ def compute_growth_results(project_path: Path) -> list[dict]:
         eval_observability(project_path),
         eval_research_grounding(project_path),
         eval_factory_effectiveness(project_path),
+        eval_spec_compliance(project_path),
     ]
 
 

--- a/factory/eval/runner.py
+++ b/factory/eval/runner.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from factory.eval.growth import compute_growth_results
 from factory.eval.hygiene import compute_hygiene_results
 from factory.eval.scorer import compute_composite
-from factory.models import CompositeScore, EvalResult, EvalWeights, ProjectEvalDimension
+from factory.models import CompositeScore, EvalResult, EvalWeights, ProjectEvalDimension, TierWeights
 
 
 def _error_score(message: str, details: str = "") -> CompositeScore:
@@ -65,10 +65,26 @@ def _effective_weights(
 def _normalize_tier(
     results: list[EvalResult],
     target_weight: float,
+    weight_overrides: dict[str, float] | None = None,
 ) -> list[EvalResult]:
-    """Normalize a list of EvalResults so their weights sum to target_weight."""
+    """Normalize a list of EvalResults so their weights sum to target_weight.
+
+    If weight_overrides is provided, matching dimension weights are replaced
+    before normalization (sparse override).
+    """
     if not results or target_weight <= 0:
         return []
+    if weight_overrides:
+        results = [
+            EvalResult(
+                name=r.name,
+                score=r.score,
+                weight=weight_overrides.get(r.name, r.weight),
+                passed=r.passed,
+                details=r.details,
+            )
+            for r in results
+        ]
     weight_sum = sum(r.weight for r in results)
     if weight_sum <= 0:
         return results
@@ -90,15 +106,18 @@ def _merge_all(
     growth_results: list[EvalResult],
     custom_project_results: list[EvalResult] | None = None,
     eval_weights: EvalWeights | None = None,
+    hygiene_weight_overrides: dict[str, float] | None = None,
+    growth_weight_overrides: dict[str, float] | None = None,
 ) -> list[EvalResult]:
     """Merge mandatory hygiene + project additions + mandatory growth + custom project eval.
 
     Weight distribution (three tiers):
       - Hygiene (mandatory 6 + eval/score.py additions): configurable (default 50%)
-      - Growth (mandatory 5): configurable (default 50%)
+      - Growth (mandatory 5+): configurable (default 50%)
       - Project eval (user-defined in factory.md): configurable (default 0%, auto 50% when present)
 
     When custom_project_results is non-empty, weights shift to accommodate project eval.
+    Within-tier weight overrides are applied before normalization.
     """
     mandatory_names = {r.name for r in hygiene_results} | {r.name for r in growth_results}
     additional = [r for r in project_results if r.name not in mandatory_names]
@@ -108,8 +127,8 @@ def _merge_all(
     weights = eval_weights or EvalWeights()
     h_w, g_w, p_w = _effective_weights(weights, bool(custom))
 
-    normalized_hygiene = _normalize_tier(all_hygiene, h_w)
-    normalized_growth = _normalize_tier(growth_results, g_w)
+    normalized_hygiene = _normalize_tier(all_hygiene, h_w, hygiene_weight_overrides)
+    normalized_growth = _normalize_tier(growth_results, g_w, growth_weight_overrides)
     normalized_project = _normalize_tier(custom, p_w)
 
     return normalized_hygiene + normalized_growth + normalized_project
@@ -238,14 +257,18 @@ async def run_eval(
     project_eval: list[ProjectEvalDimension] | None = None,
     eval_weights: EvalWeights | None = None,
     skip_project_eval: bool = False,
+    hygiene_weights: TierWeights | None = None,
+    growth_weights: TierWeights | None = None,
+    eval_spec: list[str] | None = None,
 ) -> CompositeScore:
     """Compute mandatory dimensions + project-specific additions + custom project eval.
 
     1. Compute 6 mandatory hygiene dimensions (auto-detect project tooling)
     2. Run project's eval/score.py for additional dimensions (optional)
-    3. Compute 5 mandatory growth dimensions
+    3. Compute 6 mandatory growth dimensions
     4. Run custom project eval dimensions from factory.md (if configured)
-    5. Merge all with configurable weight split
+    4b. Auto-promote executable eval_spec items to project eval
+    5. Merge all with configurable weight split (with optional within-tier overrides)
     6. Return composite score
     """
     # Step 1: Mandatory hygiene (always runs)
@@ -264,11 +287,31 @@ async def run_eval(
     if project_eval and not skip_project_eval:
         custom_results = await _run_custom_project_eval(project_eval, project_path)
 
+    # Step 4b: Auto-promote executable eval_spec items to project eval
+    if eval_spec and not skip_project_eval:
+        from factory.discovery.eval_spec import generate_project_eval_from_spec
+        auto_promoted = generate_project_eval_from_spec(eval_spec, project_path)
+        if auto_promoted:
+            auto_results = await _run_custom_project_eval(auto_promoted, project_path)
+            custom_results.extend(auto_results)
+
+    # Convert TierWeights to sparse override dicts
+    h_overrides = (
+        {k: v for k, v in hygiene_weights.model_dump().items() if v is not None}
+        if hygiene_weights else None
+    )
+    g_overrides = (
+        {k: v for k, v in growth_weights.model_dump().items() if v is not None}
+        if growth_weights else None
+    )
+
     # Step 5: Merge all dimensions with weight split
     merged = _merge_all(
         hygiene_results, project_results, growth_results,
         custom_project_results=custom_results,
         eval_weights=eval_weights,
+        hygiene_weight_overrides=h_overrides or None,
+        growth_weight_overrides=g_overrides or None,
     )
 
     # Step 6: Compute composite

--- a/factory/models.py
+++ b/factory/models.py
@@ -121,6 +121,28 @@ class ResultParseError(Exception):
     """Raised when a result file cannot be parsed to extract the target metric."""
 
 
+class TierWeights(BaseModel):
+    """Sparse within-tier weight overrides for hygiene or growth dimensions.
+
+    Only set the dimensions you want to override — unset fields (None) keep defaults.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    tests: float | None = None
+    lint: float | None = None
+    type_check: float | None = None
+    coverage: float | None = None
+    guard_patterns: float | None = None
+    config_parser: float | None = None
+    capability_surface: float | None = None
+    experiment_diversity: float | None = None
+    observability: float | None = None
+    research_grounding: float | None = None
+    factory_effectiveness: float | None = None
+    spec_compliance: float | None = None
+
+
 class FactoryConfig(BaseModel):
     """Machine-readable config stored at .factory/config.json."""
 
@@ -144,6 +166,8 @@ class FactoryConfig(BaseModel):
     cost_budget: CostBudgetConfig | None = None
     hard_constraints: list[HardConstraint] = []
     eval_spec: list[str] = []
+    hygiene_weights: TierWeights | None = None
+    growth_weights: TierWeights | None = None
 
 
 # ── eval ──────────────────────────────────────────────────────────

--- a/factory/store.py
+++ b/factory/store.py
@@ -23,6 +23,7 @@ from factory.models import (
     HypothesisBudget,
     ProjectEvalDimension,
     ResearchTarget,
+    TierWeights,
 )
 
 log = structlog.get_logger()
@@ -159,6 +160,18 @@ def _parse_hard_constraints(items: str | list[str] | float) -> list[HardConstrai
     return constraints
 
 
+def _parse_tier_weights(items: str | list[str] | float) -> TierWeights | None:
+    """Parse within-tier weight overrides from factory.md."""
+    kv = _parse_kv_list(items, float)
+    if not kv:
+        return None
+    valid_fields = set(TierWeights.model_fields.keys())
+    filtered = {k: float(str(v)) for k, v in kv.items() if k in valid_fields}
+    if not filtered:
+        return None
+    return TierWeights(**filtered)
+
+
 class ExperimentStore:
     """Manages the .factory/ directory for a project."""
 
@@ -270,6 +283,8 @@ class ExperimentStore:
         hard_constraints = _parse_hard_constraints(parsed.get("hard_constraints", []))
         es_raw = parsed.get("eval_spec", [])
         eval_spec = list(es_raw) if isinstance(es_raw, list) else []
+        hygiene_tier_weights = _parse_tier_weights(parsed.get("hygiene_weights", []))
+        growth_tier_weights = _parse_tier_weights(parsed.get("growth_weights", []))
 
         config = FactoryConfig(
             goal=str(parsed.get("goal", "")),
@@ -290,6 +305,8 @@ class ExperimentStore:
             cost_budget=cost_budget,
             hard_constraints=hard_constraints,
             eval_spec=eval_spec,
+            hygiene_weights=hygiene_tier_weights,
+            growth_weights=growth_tier_weights,
         )
 
         (self.factory_dir / "config.json").write_text(

--- a/factory/templates/factory_config.md
+++ b/factory/templates/factory_config.md
@@ -75,24 +75,6 @@ main
 - project: 0.50
 -->
 
-## Hygiene Weights
-<!-- Within-tier weight overrides for hygiene dimensions. -->
-<!-- Only specify dimensions you want to change — unset dimensions keep defaults. -->
-<!-- Weights are normalized within the tier, so they don't need to sum to 1.0. -->
-<!-- Example:
-- tests: 0.40
-- coverage: 0.30
-- lint: 0.10
--->
-
-## Growth Weights
-<!-- Within-tier weight overrides for growth dimensions. -->
-<!-- Only specify dimensions you want to change — unset dimensions keep defaults. -->
-<!-- Example:
-- capability_surface: 0.30
-- spec_compliance: 0.20
--->
-
 ## Smoke Test
 <!-- Optional shell command that must pass before any change is kept. -->
 <!-- If configured, this runs as part of `factory precheck` — failure = mandatory revert. -->

--- a/factory/templates/factory_config.md
+++ b/factory/templates/factory_config.md
@@ -75,6 +75,24 @@ main
 - project: 0.50
 -->
 
+## Hygiene Weights
+<!-- Within-tier weight overrides for hygiene dimensions. -->
+<!-- Only specify dimensions you want to change — unset dimensions keep defaults. -->
+<!-- Weights are normalized within the tier, so they don't need to sum to 1.0. -->
+<!-- Example:
+- tests: 0.40
+- coverage: 0.30
+- lint: 0.10
+-->
+
+## Growth Weights
+<!-- Within-tier weight overrides for growth dimensions. -->
+<!-- Only specify dimensions you want to change — unset dimensions keep defaults. -->
+<!-- Example:
+- capability_surface: 0.30
+- spec_compliance: 0.20
+-->
+
 ## Smoke Test
 <!-- Optional shell command that must pass before any change is kept. -->
 <!-- If configured, this runs as part of `factory precheck` — failure = mandatory revert. -->

--- a/templates/factory_config.md
+++ b/templates/factory_config.md
@@ -75,6 +75,24 @@ main
 - project: 0.50
 -->
 
+## Hygiene Weights
+<!-- Within-tier weight overrides for hygiene dimensions. -->
+<!-- Only specify dimensions you want to change — unset dimensions keep defaults. -->
+<!-- Weights are normalized within the tier, so they don't need to sum to 1.0. -->
+<!-- Example:
+- tests: 0.40
+- coverage: 0.30
+- lint: 0.10
+-->
+
+## Growth Weights
+<!-- Within-tier weight overrides for growth dimensions. -->
+<!-- Only specify dimensions you want to change — unset dimensions keep defaults. -->
+<!-- Example:
+- capability_surface: 0.30
+- spec_compliance: 0.20
+-->
+
 ## Smoke Test
 <!-- Optional shell command that must pass before any change is kept. -->
 <!-- If configured, this runs as part of `factory precheck` — failure = mandatory revert. -->

--- a/tests/eval/test_runner.py
+++ b/tests/eval/test_runner.py
@@ -7,11 +7,11 @@ from factory.eval.runner import run_eval
 
 class TestRunEval:
     async def test_always_has_mandatory_dimensions(self, tmp_path):
-        """Even with no project eval, all 11 mandatory dimensions are present."""
+        """Even with no project eval, all 12 mandatory dimensions are present."""
         # No eval/score.py — just mandatory dimensions
         result = await run_eval("true", tmp_path, threshold=0.0)
         names = {r.name for r in result.results}
-        # 6 hygiene + 5 growth = 11 mandatory
+        # 6 hygiene + 6 growth = 12 mandatory
         assert "tests" in names
         assert "lint" in names
         assert "type_check" in names
@@ -23,7 +23,8 @@ class TestRunEval:
         assert "observability" in names
         assert "research_grounding" in names
         assert "factory_effectiveness" in names
-        assert len(result.results) >= 11
+        assert "spec_compliance" in names
+        assert len(result.results) >= 12
 
     async def test_project_additions_merged(self, tmp_path):
         """Project eval/score.py can add extra dimensions beyond the 11."""
@@ -37,10 +38,10 @@ class TestRunEval:
         )
         result = await run_eval(f"{sys.executable} {script}", tmp_path, threshold=0.0)
         names = {r.name for r in result.results}
-        # 11 mandatory + 2 project additions
+        # 12 mandatory + 2 project additions
         assert "ui_renders" in names
         assert "api_health" in names
-        assert len(result.results) >= 13
+        assert len(result.results) >= 14
 
     async def test_project_cannot_override_mandatory(self, tmp_path):
         """If project eval returns a dimension with the same name as mandatory, it's ignored."""
@@ -61,8 +62,8 @@ class TestRunEval:
         """If project eval command fails, mandatory dimensions still run."""
         result = await run_eval("nonexistent_command_xyz", tmp_path, threshold=0.0)
         names = {r.name for r in result.results}
-        # All 11 mandatory should still be present
-        assert len(names) >= 11
+        # All 12 mandatory should still be present
+        assert len(names) >= 12
         assert "tests" in names
         assert "capability_surface" in names
 
@@ -79,7 +80,7 @@ class TestRunEval:
         result = await run_eval(f"{sys.executable} {script}", tmp_path, threshold=0.0, timeout=1.0)
         # Mandatory dimensions still computed
         names = {r.name for r in result.results}
-        assert len(names) >= 11
+        assert len(names) >= 12
 
     async def test_weight_split_is_50_50(self, tmp_path):
         """Hygiene dimensions get 50% total weight, growth gets 50%."""
@@ -87,7 +88,7 @@ class TestRunEval:
         hygiene_names = {"tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser"}
         growth_names = {
             "capability_surface", "experiment_diversity", "observability",
-            "research_grounding", "factory_effectiveness",
+            "research_grounding", "factory_effectiveness", "spec_compliance",
         }
         hygiene_weight = sum(r.weight for r in result.results if r.name in hygiene_names)
         growth_weight = sum(r.weight for r in result.results if r.name in growth_names)

--- a/tests/test_eval_growth.py
+++ b/tests/test_eval_growth.py
@@ -56,16 +56,16 @@ class TestGrowthWeights:
         """Growth weights (before runner normalization) should sum to 1.0."""
         assert abs(sum(GROWTH_WEIGHTS.values()) - 1.0) < 1e-9
 
-    def test_five_dimensions(self):
-        assert len(GROWTH_WEIGHTS) == 5
+    def test_six_dimensions(self):
+        assert len(GROWTH_WEIGHTS) == 6
 
-    def test_compute_growth_results_returns_five(self):
+    def test_compute_growth_results_returns_six(self):
         results = compute_growth_results(PROJECT_ROOT)
-        assert len(results) == 5
+        assert len(results) == 6
         names = {r["name"] for r in results}
         assert names == {
             "capability_surface", "experiment_diversity", "observability",
-            "research_grounding", "factory_effectiveness",
+            "research_grounding", "factory_effectiveness", "spec_compliance",
         }
 
 
@@ -95,7 +95,7 @@ class TestMergeWithGrowth:
         assert abs(hygiene_weight + growth_weight - 1.0) < 1e-9
 
     def test_total_dimensions(self):
-        """Should be hygiene dims + 5 growth dims."""
+        """Should be hygiene dims + 6 growth dims."""
         hygiene_results = [
             EvalResult(name="tests", score=1.0, weight=0.5, passed=True, details=""),
             EvalResult(name="lint", score=1.0, weight=0.5, passed=True, details=""),
@@ -104,7 +104,7 @@ class TestMergeWithGrowth:
             EvalResult(**r) for r in compute_growth_results(PROJECT_ROOT)
         ]
         merged = _merge_all(hygiene_results, [], growth_results)
-        assert len(merged) == 7  # 2 hygiene + 5 growth
+        assert len(merged) == 8  # 2 hygiene + 6 growth
 
     def test_project_additions_merged(self):
         """Project-specific additions are merged into the hygiene half."""
@@ -119,7 +119,7 @@ class TestMergeWithGrowth:
             EvalResult(**r) for r in compute_growth_results(PROJECT_ROOT)
         ]
         merged = _merge_all(hygiene_results, project_results, growth_results)
-        assert len(merged) == 8  # 2 hygiene + 1 project + 5 growth
+        assert len(merged) == 9  # 2 hygiene + 1 project + 6 growth
         names = {r.name for r in merged}
         assert "ui_renders" in names
 

--- a/tests/test_eval_spec_classify.py
+++ b/tests/test_eval_spec_classify.py
@@ -1,0 +1,120 @@
+"""Tests for eval_spec item classification and auto-promotion."""
+
+import pytest
+
+from factory.discovery.eval_spec import (
+    classify_eval_spec_item,
+    generate_project_eval_from_spec,
+)
+
+
+class TestClassifyEvalSpecItem:
+    @pytest.mark.parametrize("item", [
+        "Run the CLI with --help and verify it prints usage info",
+        "Start the dev server and confirm the landing page loads",
+        "Build and start Docker containers and verify services are healthy",
+        "Import the package in a Python shell and verify no import errors",
+        "Execute the test suite and check all tests pass",
+        "Deploy the service to staging and verify health endpoint",
+        "Launch the application and verify it starts without errors",
+        "Install dependencies and verify build succeeds",
+    ])
+    def test_executable_verb_items(self, item):
+        assert classify_eval_spec_item(item) == "executable"
+
+    @pytest.mark.parametrize("item", [
+        "Verify the code follows clean architecture principles",
+        "Check that error messages are user-friendly",
+        "Ensure the documentation is up to date",
+        "Confirm the API design follows REST best practices",
+        "The UI should be responsive on mobile devices",
+    ])
+    def test_judgmental_items(self, item):
+        assert classify_eval_spec_item(item) == "judgmental"
+
+    def test_backtick_command_is_executable(self):
+        assert classify_eval_spec_item("Verify `pytest -v` runs cleanly") == "executable"
+
+    def test_flag_pattern_is_executable(self):
+        assert classify_eval_spec_item("Check the --verbose flag works") == "executable"
+
+    def test_tool_name_is_executable(self):
+        assert classify_eval_spec_item("Verify python can import the module") == "executable"
+
+    def test_empty_string_is_judgmental(self):
+        assert classify_eval_spec_item("") == "judgmental"
+
+    def test_whitespace_only_is_judgmental(self):
+        assert classify_eval_spec_item("   ") == "judgmental"
+
+
+class TestGenerateProjectEvalFromSpec:
+    def test_help_flag_promotion(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "myapp"\nversion = "0.1.0"\n\n'
+            '[project.scripts]\nmyapp = "myapp.cli:main"\n'
+        )
+        spec = ["Run the CLI with --help and verify it prints usage info"]
+        dims = generate_project_eval_from_spec(spec, tmp_path)
+        assert len(dims) == 1
+        assert dims[0].command == "myapp --help"
+        assert dims[0].parse == "exit_code"
+        assert dims[0].name.startswith("spec_")
+
+    def test_import_promotion(self, tmp_path):
+        pkg_dir = tmp_path / "mypackage"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        spec = ["Import the package in a Python shell and verify no import errors"]
+        dims = generate_project_eval_from_spec(spec, tmp_path)
+        assert len(dims) == 1
+        assert 'import mypackage' in dims[0].command
+
+    def test_docker_promotion(self, tmp_path):
+        (tmp_path / "docker-compose.yml").write_text("version: '3'\n")
+        spec = ["Build and start Docker containers and verify services are healthy"]
+        dims = generate_project_eval_from_spec(spec, tmp_path)
+        assert len(dims) == 1
+        assert "docker compose build" in dims[0].command
+
+    def test_judgmental_items_skipped(self, tmp_path):
+        spec = [
+            "Verify the code follows clean architecture principles",
+            "Ensure documentation is comprehensive",
+        ]
+        dims = generate_project_eval_from_spec(spec, tmp_path)
+        assert len(dims) == 0
+
+    def test_backtick_command_extraction(self, tmp_path):
+        spec = ["Run `echo hello` and verify output"]
+        dims = generate_project_eval_from_spec(spec, tmp_path)
+        assert len(dims) == 1
+        assert dims[0].command == "echo hello"
+
+    def test_no_entry_point_skips_help(self, tmp_path):
+        spec = ["Run the CLI with --help and verify it prints usage info"]
+        dims = generate_project_eval_from_spec(spec, tmp_path)
+        assert len(dims) == 0
+
+    def test_mixed_spec_items(self, tmp_path):
+        pkg_dir = tmp_path / "mypkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        spec = [
+            "Import the package in a Python shell and verify no errors",
+            "Verify the API design is RESTful",
+            "Run `echo test` to verify shell works",
+        ]
+        dims = generate_project_eval_from_spec(spec, tmp_path)
+        assert len(dims) == 2
+
+    def test_empty_spec_returns_empty(self, tmp_path):
+        dims = generate_project_eval_from_spec([], tmp_path)
+        assert dims == []
+
+    def test_manage_py_promotion(self, tmp_path):
+        (tmp_path / "manage.py").write_text("#!/usr/bin/env python\n")
+        spec = ["Run python manage.py check and verify no issues reported"]
+        dims = generate_project_eval_from_spec(spec, tmp_path)
+        assert len(dims) == 1
+        assert dims[0].command == "python manage.py check"

--- a/tests/test_eval_weights.py
+++ b/tests/test_eval_weights.py
@@ -1,0 +1,74 @@
+"""Tests for within-tier weight override normalization."""
+
+from factory.eval.runner import _normalize_tier
+from factory.models import EvalResult
+
+
+class TestNormalizeTierOverrides:
+    def test_no_overrides_preserves_behavior(self):
+        results = [
+            EvalResult(name="a", score=1.0, weight=0.6, passed=True, details=""),
+            EvalResult(name="b", score=0.5, weight=0.4, passed=True, details=""),
+        ]
+        normalized = _normalize_tier(results, 0.5)
+        assert len(normalized) == 2
+        assert abs(sum(r.weight for r in normalized) - 0.5) < 1e-9
+
+    def test_sparse_override_changes_relative_weights(self):
+        results = [
+            EvalResult(name="tests", score=1.0, weight=0.30, passed=True, details=""),
+            EvalResult(name="lint", score=0.8, weight=0.15, passed=True, details=""),
+            EvalResult(name="coverage", score=0.6, weight=0.25, passed=True, details=""),
+        ]
+        overrides = {"tests": 0.50}
+        normalized = _normalize_tier(results, 1.0, weight_overrides=overrides)
+        assert len(normalized) == 3
+        assert abs(sum(r.weight for r in normalized) - 1.0) < 1e-9
+        tests_r = next(r for r in normalized if r.name == "tests")
+        lint_r = next(r for r in normalized if r.name == "lint")
+        assert tests_r.weight > lint_r.weight
+
+    def test_override_all_dimensions(self):
+        results = [
+            EvalResult(name="a", score=1.0, weight=0.5, passed=True, details=""),
+            EvalResult(name="b", score=0.5, weight=0.5, passed=True, details=""),
+        ]
+        overrides = {"a": 3.0, "b": 1.0}
+        normalized = _normalize_tier(results, 1.0, weight_overrides=overrides)
+        a_r = next(r for r in normalized if r.name == "a")
+        b_r = next(r for r in normalized if r.name == "b")
+        assert abs(a_r.weight - 0.75) < 1e-9
+        assert abs(b_r.weight - 0.25) < 1e-9
+
+    def test_override_nonexistent_dim_ignored(self):
+        results = [
+            EvalResult(name="a", score=1.0, weight=0.5, passed=True, details=""),
+        ]
+        overrides = {"nonexistent": 99.0}
+        normalized = _normalize_tier(results, 1.0, weight_overrides=overrides)
+        assert len(normalized) == 1
+        assert abs(normalized[0].weight - 1.0) < 1e-9
+
+    def test_empty_results_returns_empty(self):
+        assert _normalize_tier([], 0.5, weight_overrides={"a": 1.0}) == []
+
+    def test_zero_target_returns_empty(self):
+        results = [
+            EvalResult(name="a", score=1.0, weight=1.0, passed=True, details=""),
+        ]
+        assert _normalize_tier(results, 0.0, weight_overrides={"a": 2.0}) == []
+
+    def test_scores_preserved_through_override(self):
+        results = [
+            EvalResult(name="a", score=0.9, weight=0.5, passed=True, details="detail_a"),
+            EvalResult(name="b", score=0.3, weight=0.5, passed=False, details="detail_b"),
+        ]
+        overrides = {"a": 2.0}
+        normalized = _normalize_tier(results, 1.0, weight_overrides=overrides)
+        a_r = next(r for r in normalized if r.name == "a")
+        b_r = next(r for r in normalized if r.name == "b")
+        assert a_r.score == 0.9
+        assert b_r.score == 0.3
+        assert a_r.details == "detail_a"
+        assert a_r.passed is True
+        assert b_r.passed is False

--- a/tests/test_spec_compliance.py
+++ b/tests/test_spec_compliance.py
@@ -1,0 +1,110 @@
+"""Tests for spec_compliance growth dimension edge cases."""
+
+import json
+import time
+
+from factory.eval.growth import eval_spec_compliance
+
+
+class TestSpecComplianceMissing:
+    def test_missing_file_returns_neutral(self, tmp_path):
+        result = eval_spec_compliance(tmp_path)
+        assert result["name"] == "spec_compliance"
+        assert result["score"] == 0.5
+        assert result["passed"] is True
+        assert "not found" in result["details"]
+
+    def test_missing_factory_dir_returns_neutral(self, tmp_path):
+        result = eval_spec_compliance(tmp_path / "nonexistent")
+        assert result["score"] == 0.5
+
+
+class TestSpecComplianceStale:
+    def test_stale_file_returns_neutral(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        spec_path = factory_dir / "spec_results.json"
+        spec_path.write_text(json.dumps({"results": [], "total": 3, "passed": 3}))
+        # Set mtime to 25 hours ago
+        old_time = time.time() - 90000
+        import os
+        os.utime(spec_path, (old_time, old_time))
+
+        result = eval_spec_compliance(tmp_path)
+        assert result["score"] == 0.5
+        assert "stale" in result["details"]
+
+
+class TestSpecComplianceScoring:
+    def test_all_passed(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "spec_results.json").write_text(json.dumps({
+            "results": [
+                {"name": "check 1", "passed": True},
+                {"name": "check 2", "passed": True},
+            ],
+            "total": 2,
+            "passed": 2,
+        }))
+        result = eval_spec_compliance(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+        assert "2/2" in result["details"]
+
+    def test_partial_pass(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "spec_results.json").write_text(json.dumps({
+            "results": [
+                {"name": "check 1", "passed": True},
+                {"name": "check 2", "passed": False},
+                {"name": "check 3", "passed": False},
+            ],
+            "total": 3,
+            "passed": 1,
+        }))
+        result = eval_spec_compliance(tmp_path)
+        assert abs(result["score"] - 1 / 3) < 1e-4
+        assert result["passed"] is False
+
+    def test_all_failed(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "spec_results.json").write_text(json.dumps({
+            "results": [{"name": "check 1", "passed": False}],
+            "total": 1,
+            "passed": 0,
+        }))
+        result = eval_spec_compliance(tmp_path)
+        assert result["score"] == 0.0
+        assert result["passed"] is False
+
+    def test_zero_total_returns_neutral(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "spec_results.json").write_text(json.dumps({
+            "results": [],
+            "total": 0,
+            "passed": 0,
+        }))
+        result = eval_spec_compliance(tmp_path)
+        assert result["score"] == 0.5
+        assert "No spec checks" in result["details"]
+
+
+class TestSpecComplianceErrors:
+    def test_invalid_json_returns_neutral(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "spec_results.json").write_text("{bad json")
+        result = eval_spec_compliance(tmp_path)
+        assert result["score"] == 0.5
+        assert "Error" in result["details"]
+
+    def test_missing_keys_returns_neutral(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "spec_results.json").write_text(json.dumps({}))
+        result = eval_spec_compliance(tmp_path)
+        assert result["score"] == 0.5

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -411,6 +411,119 @@ class TestReparseResearchTarget:
         assert config.research_target is None
 
 
+class TestTierWeightsParsing:
+    """Tests for parsing ## Hygiene Weights and ## Growth Weights from factory.md."""
+
+    async def test_parse_hygiene_weights(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nTest project\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n- no deletes\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n- small changes\n\n"
+            "## Hygiene Weights\n"
+            "- tests: 0.40\n"
+            "- coverage: 0.30\n"
+            "- lint: 0.10\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.hygiene_weights is not None
+        assert config.hygiene_weights.tests == 0.40
+        assert config.hygiene_weights.coverage == 0.30
+        assert config.hygiene_weights.lint == 0.10
+        assert config.hygiene_weights.type_check is None
+
+    async def test_parse_growth_weights(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nTest project\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Growth Weights\n"
+            "- capability_surface: 0.30\n"
+            "- spec_compliance: 0.20\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.growth_weights is not None
+        assert config.growth_weights.capability_surface == 0.30
+        assert config.growth_weights.spec_compliance == 0.20
+        assert config.growth_weights.observability is None
+
+    async def test_both_tier_weights(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nTest\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Hygiene Weights\n"
+            "- tests: 0.50\n\n"
+            "## Growth Weights\n"
+            "- factory_effectiveness: 0.25\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.hygiene_weights is not None
+        assert config.hygiene_weights.tests == 0.50
+        assert config.growth_weights is not None
+        assert config.growth_weights.factory_effectiveness == 0.25
+
+    async def test_no_tier_weights_backward_compat(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nNormal project\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n- no deletes\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n- small changes\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.hygiene_weights is None
+        assert config.growth_weights is None
+
+    async def test_invalid_dim_name_ignored(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nTest\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Hygiene Weights\n"
+            "- tests: 0.40\n"
+            "- nonexistent_dim: 0.99\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.hygiene_weights is not None
+        assert config.hygiene_weights.tests == 0.40
+
+    async def test_tier_weights_roundtrip_config_json(self, store, sample_config):
+        """TierWeights should survive write → read via config.json."""
+        from factory.models import TierWeights
+        config = sample_config.model_copy(update={
+            "hygiene_weights": TierWeights(tests=0.40, lint=0.20),
+        })
+        await store.init(config)
+        loaded = await store.read_config()
+        assert loaded.hygiene_weights is not None
+        assert loaded.hygiene_weights.tests == 0.40
+        assert loaded.hygiene_weights.lint == 0.20
+        assert loaded.hygiene_weights.coverage is None
+
+
 class TestEnsureFactoryDir:
     """Regression tests for broken symlink handling (issue #276)."""
 


### PR DESCRIPTION
Closes #312

## Changes

- **Within-tier weight configurability**: Added `TierWeights` model to `models.py` with optional per-dimension float fields. `reparse_config()` in `store.py` parses `## Hygiene Weights` / `## Growth Weights` sections from factory.md. `_normalize_tier()` in `runner.py` accepts optional weight overrides, threaded through `_merge_all()` and `run_eval()`. Template sections added to `factory_config.md`.

- **spec_compliance growth dimension**: Added `eval_spec_compliance()` to `growth.py` that reads `.factory/spec_results.json` (score = passed/total, neutral 0.5 if missing/stale). Added `spec_compliance` at 0.10 weight to `GROWTH_WEIGHTS` (redistributed from existing dims). Updated Evaluator prompt to write structured spec results.

- **Auto-promote executable eval_spec items**: Added `classify_eval_spec_item()` deterministic heuristic and `generate_project_eval_from_spec()` to `eval_spec.py`. Executable spec items are auto-promoted to `ProjectEvalDimension` entries and merged with user-defined project_eval in `run_eval()`. `eval_spec` remains `list[str]` in config — classification happens at eval time.

- **Tests**: 4 new/updated test files covering weight override normalization, spec_compliance edge cases, eval_spec classification, and store config parsing. All 1899 tests pass.