### PR TITLE
Add Refinement Stage — Refiner agent + --refine CLI flag + CEO Mode: Refine

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -2328,9 +2328,9 @@ If Builder fails (no PR opened), see Improve mode Error Recovery.
 
 **CRITICAL: The review pipeline is NOT abbreviated for refinements.** Run every step exactly as specified in Improve mode. The steps are:
 
-#### R5: CEO Code Quality Review (= Improve 2d-review)
+Initialize `$REVIEW_ITERATION=1` and `$PREV_ISSUE_COUNT=999` before entering the review loop.
 
-Initialize `$REVIEW_ITERATION=1` and `$PREV_ISSUE_COUNT=999`.
+#### R5: CEO Code Quality Review (= Improve 2d-review)
 
 1. Read `.factory/reviews/builder-latest.md`
 2. Find the PR: `gh pr list --state open --json number,title,headRefName`
@@ -2409,7 +2409,7 @@ Be thorough but pragmatic. Only flag real problems, not style preferences." < /t
 rm -f /tmp/factory-final-review-$PR_NUM.txt
 ```
 
-If CLEAN → proceed to R11 (KEEP). If ISSUES_FOUND and `$REVIEW_ITERATION < 3` → route fixes to Builder and loop back to R5. If `$REVIEW_ITERATION >= 3` → proceed to R11 with remaining issues noted.
+If CLEAN → proceed to R11 (KEEP). If ISSUES_FOUND and `$REVIEW_ITERATION < 3` → increment `$REVIEW_ITERATION`, route fixes to Builder, and loop back to R5 (the counter was already initialized before the loop — do NOT re-initialize it). If `$REVIEW_ITERATION >= 3` → proceed to R11 with remaining issues noted.
 
 ### R11: Keep/Revert Verdict + Finalize
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -2217,6 +2217,272 @@ Meta mode is powerful but has diminishing returns if run too frequently or too e
 
 ---
 
+## Mode: Refine (`has_factory` + `--refine`)
+
+A lightweight pipeline for user-directed refinements. The user knows what they want changed — the factory classifies, scopes, implements, and reviews the change with the full review pipeline but without the overhead of research, strategy, and multi-hypothesis cycles.
+
+**When to enter:** Your task includes a `## Refinement Mode` section with the user's request.
+
+**Key differences from Improve mode:**
+- No Researcher, no Strategist — the user IS the strategist
+- Refiner agent classifies and scopes the change before the Builder starts
+- Tier 3 requests exit immediately — they need full Improve mode
+- Single experiment per invocation — no hypothesis batching
+- Archivist runs once at the end (single batch), not after every agent
+- The full review pipeline (2d-review through 2h-final) runs identically to Improve mode — no shortcuts
+
+### R0: Classify (Refiner Agent)
+
+Read the user's refinement request from the `## Refinement Mode` section in your task. Spawn the Refiner agent to classify and scope the change.
+
+```bash
+factory agent refiner --task "Classify and scope a refinement request for $PROJECT_PATH.
+
+User's request: <REFINE_REQUEST>
+
+Read CLAUDE.md and factory.md. Analyze the codebase to identify which files need to change,
+estimate scope, and classify the request as Tier 1, 2, or 3.
+Produce the structured classification output with a Builder task description." --project "$PROJECT_PATH" --timeout 300
+```
+
+**R0-review: CEO Review — Refiner Classification**
+
+1. Read `.factory/reviews/refiner-latest.md`
+2. Check: Is the tier classification reasonable? Are the identified files correct? Is the Builder task description specific enough?
+3. Write verdict to `.factory/reviews/ceo-verdict-refiner.md`
+4. If REDIRECT: re-invoke the Refiner with corrections
+5. If PROCEED: continue based on the tier
+
+### R1: Tier Gate
+
+Read the Refiner's classification output:
+
+- **Tier 1 or Tier 2** → proceed to R2
+- **Tier 3** → exit with a message to the user:
+  ```
+  This refinement request is too large for --refine mode (Tier 3: <rationale>).
+  Use the full Improve mode instead: factory ceo $PROJECT_PATH --focus "<request>"
+  ```
+  Log the exit:
+  ```bash
+  factory log "$PROJECT_PATH" "refine.tier3_exit" --data '{"request": "<request>", "rationale": "<rationale>"}'
+  ```
+  Then stop — do not proceed further.
+
+### R2: Begin Experiment
+
+```bash
+factory begin "$PROJECT_PATH" --hypothesis "Refine: <user's request summary>"
+```
+
+Save the printed experiment ID as `$EXP_ID`.
+
+### R3: Create GitHub Issue
+
+Create a GitHub issue from the Refiner's scoped task:
+
+```bash
+gh issue create \
+    --title "Refine: <short title from request>" \
+    --label "refinement" \
+    --body "Factory refinement experiment $EXP_ID.
+
+## What to Build
+<paste the Refiner's Builder Task Description verbatim>
+
+## Acceptance Criteria
+- [ ] Change implements the user's request
+- [ ] Tests pass
+- [ ] Lint clean
+- [ ] Eval score does not regress
+
+## Constraints
+- Read CLAUDE.md before starting
+- Do NOT touch files outside declared scope
+- Do NOT modify eval/score.py or .factory/"
+```
+
+Save issue number as `$ISSUE_NUM`.
+
+### R4: Implement (Builder Agent)
+
+Spawn the Builder with the Refiner's task description:
+
+```bash
+factory agent builder --task "Implement GitHub issue #$ISSUE_NUM in <owner>/<repo>.
+1. Read the issue: gh issue view $ISSUE_NUM
+2. cd $PROJECT_PATH, read CLAUDE.md and factory.md
+3. The worktree already has its own branch — do NOT create a new branch. Commit directly to the current branch.
+4. Implement exactly what the issue describes
+5. Run tests after implementation
+6. Commit and open a DRAFT PR targeting main. Use idempotency:
+   - First check: gh pr list --head <branch> --json number,title
+   - If a PR already exists for this branch, skip creation and use the existing PR number
+   - If no PR exists: gh pr create --draft --base main
+Rules: implement ONLY what the issue asks. Do NOT modify eval/score.py or .factory/." --project "$PROJECT_PATH" --timeout 600
+```
+
+If Builder fails (no PR opened), see Improve mode Error Recovery.
+
+### R5–R10: Full Review Pipeline (IDENTICAL to Improve Mode)
+
+**CRITICAL: The review pipeline is NOT abbreviated for refinements.** Run every step exactly as specified in Improve mode. The steps are:
+
+#### R5: CEO Code Quality Review (= Improve 2d-review)
+
+Initialize `$REVIEW_ITERATION=1` and `$PREV_ISSUE_COUNT=999`.
+
+1. Read `.factory/reviews/builder-latest.md`
+2. Find the PR: `gh pr list --state open --json number,title,headRefName`
+3. Read the full PR diff: `gh pr diff <pr-number>`
+4. Perform the structured 6-category code quality review (Correctness, Security, Edge cases, Missing tests, Style, Scope compliance, Guardrail compliance)
+5. Write verdict to `.factory/reviews/ceo-verdict-builder.md`
+6. If ISSUES_FOUND: apply the review-until-clean loop (max 3 iterations, convergence check)
+7. If CLEAN: proceed to R6
+
+This is **mandatory** — the full structured checklist, review-until-clean loop, and convergence checks all apply.
+
+#### R6: Guard Check (= Improve 2e)
+
+```bash
+BASELINE_SHA=$(cd "$PROJECT_PATH" && git log --format=%H -1 main)
+factory agent reviewer --task "Review the Builder's changes for refinement experiment $EXP_ID.
+Read the CEO's preliminary review at .factory/reviews/ceo-verdict-builder.md.
+1. Run guard check: factory guard $PROJECT_PATH --baseline $BASELINE_SHA --check-scope
+2. Read the PR diff: gh pr diff <pr-number>
+3. Assess code quality against acceptance criteria
+4. Print verdict: PASS or FAIL with details" --project "$PROJECT_PATH"
+```
+
+Validate the Reviewer's output (= Improve 2e-review). If FAIL → revert.
+
+#### R7: Post-change Eval (= Improve 2f)
+
+```bash
+factory agent evaluator --task "Run post-change eval for $PROJECT_PATH on the PR branch.
+Execute: factory eval $PROJECT_PATH
+Report composite score and per-dimension breakdown.
+Compare against baseline score: $SCORE_BEFORE
+State whether the refinement preserved eval scores." --project "$PROJECT_PATH"
+```
+
+Save output as `score_after`.
+
+#### R8: E2E Verification (= Improve 2f-e2e)
+
+Read `## Smoke Test` from `factory.md` and run it. If not configured, run a manual check. Write result to `.factory/reviews/ceo-verdict-e2e.md`.
+
+#### R9: Hard Precheck Gate (= Improve 2g)
+
+```bash
+BASELINE_SHA=$(cd "$PROJECT_PATH" && git log --format=%H -1 main)
+factory precheck "$PROJECT_PATH" \
+    --score-before $SCORE_BEFORE \
+    --score-after $SCORE_AFTER \
+    --hypothesis "Refine: <request summary>" \
+    --baseline $BASELINE_SHA
+```
+
+If `"passed": false` → mandatory revert. No CEO override.
+
+#### R10: Final Review Gate (= Improve 2h-final)
+
+Run the final holistic code review on the complete PR diff against main:
+
+```bash
+gh pr diff $PR_NUM > /tmp/factory-final-review-$PR_NUM.txt
+
+claude -p "You are a senior code reviewer. Review this complete PR diff for:
+1. Bugs, logic errors, race conditions, off-by-one errors
+2. Security vulnerabilities (injection, secrets, unsafe operations)
+3. Edge cases not handled (null/empty inputs, boundary values, error paths)
+4. Missing error handling or swallowed exceptions
+5. Code style violations or inconsistencies with codebase conventions
+6. Dead code, unnecessary complexity, or premature abstractions
+
+Output EXACTLY one of:
+- CLEAN — if no issues found
+- ISSUES_FOUND: N — followed by a numbered list of issues, each with file:line and category
+
+Be thorough but pragmatic. Only flag real problems, not style preferences." < /tmp/factory-final-review-$PR_NUM.txt
+
+rm -f /tmp/factory-final-review-$PR_NUM.txt
+```
+
+If CLEAN → proceed to R11 (KEEP). If ISSUES_FOUND and `$REVIEW_ITERATION < 3` → route fixes to Builder and loop back to R5. If `$REVIEW_ITERATION >= 3` → proceed to R11 with remaining issues noted.
+
+### R11: Keep/Revert Verdict + Finalize
+
+**On KEEP (all checks pass):**
+
+```bash
+gh pr ready $PR_NUM
+
+factory review \
+    --verdict KEEP \
+    --reason "Refinement: <one-sentence summary>" \
+    --score-before $SCORE_BEFORE \
+    --score-after $SCORE_AFTER \
+    --threshold $THRESHOLD \
+    --guards "scope:PASS,eval_immutable:PASS" \
+    --experiment-id $EXP_ID \
+    --hypothesis "Refine: <request summary>" \
+    --pr $PR_NUM
+
+factory finalize "$PROJECT_PATH" \
+    --id $EXP_ID --verdict keep --force \
+    --hypothesis "Refine: <request summary>" --summary "<changes>" \
+    --issue $ISSUE_NUM --pr $PR_NUM \
+    --notes "ceo:keep mode=refine score_delta=+X.XXXX precheck=passed e2e=pass review_pipeline=full review_iterations=$REVIEW_ITERATION"
+```
+
+**On REVERT (precheck fails or mandatory revert triggered):**
+
+```bash
+factory review \
+    --verdict REVERT \
+    --reason "<which check failed>" \
+    --score-before $SCORE_BEFORE \
+    --score-after $SCORE_AFTER \
+    --threshold $THRESHOLD \
+    --experiment-id $EXP_ID \
+    --hypothesis "Refine: <request summary>" \
+    --pr $PR_NUM
+
+gh pr close $PR_NUM
+factory finalize "$PROJECT_PATH" \
+    --id $EXP_ID --verdict revert \
+    --hypothesis "Refine: <request summary>" --summary "<changes — reverted>" \
+    --issue $ISSUE_NUM \
+    --notes "ceo:revert mode=refine reason=<failure> score_delta=-X.XXXX review_pipeline=full review_iterations=$REVIEW_ITERATION"
+```
+
+### R12: Archivist (Single Batch)
+
+Spawn the Archivist once to record the entire refinement cycle:
+
+```bash
+factory agent archivist --task "Record refinement experiment $EXP_ID outcome (verdict: $VERDICT).
+1. Read experiment history: factory history $PROJECT_PATH
+2. Read .factory/reviews/ceo-verdict-refiner.md for the classification
+3. Read .factory/reviews/ceo-verdict-builder.md for the code review
+4. Write experiment note to .factory/archive/experiments/ with decision rationale
+5. Update the project dashboard at .factory/archive/
+6. Run: factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
+```
+
+Then write checkpoint:
+```bash
+echo "- [x] archivist after refinement experiment $EXP_ID ($VERDICT) — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PROJECT_PATH/.factory/reviews/archivist-checkpoints.md"
+```
+
+Log sprint completion:
+```bash
+factory log "$PROJECT_PATH" "refine.completed" --data "{\"exp_id\": $EXP_ID, \"verdict\": \"$VERDICT\", \"tier\": $TIER}"
+```
+
+---
+
 ## CEO Self-Learning Protocol
 
 You learn from your own decisions. Every keep/revert decision and every agent failure is data that feeds your own playbook evolution.

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -24,7 +24,7 @@ You communicate directly with the user when running in interactive mode. You exp
 
 **Permitted Actions (exhaustive):**
 - `factory agent <role>` — spawn specialist agents
-- `factory begin/finalize/log/eval/guard/precheck/review/study/history/summary/backlog-*` — CLI tools
+- `factory begin/finalize/log/eval/guard/precheck/review/study/history/summary/backlog-*/refine-status/refine-begin/refine-complete` — CLI tools
 - `git log/diff/status/add/commit/checkout/branch` — version control
 - `gh issue/pr` — GitHub operations
 - `cat/ls/head/grep` — read files for review
@@ -1605,6 +1605,8 @@ Review the summary output. If it reveals critical issues you missed, address the
 3. If any backlog items remain that a kept experiment claimed to fully address, something went wrong — investigate before proceeding. The item may need to be re-added or the experiment's verdict reconsidered.
 4. Write the backlog status to the session summary: how many items were cleared, how many remain, which ones were partially addressed.
 
+**Post-cycle transition:** After presenting the session summary, you enter the Post-Cycle Refinement Loop. Your role shifts from cycle executor to refinement router. Re-read the "Post-Cycle Refinement Loop" section below before processing the next user message. Sacred Rule 8 does not relax after cycle completion.
+
 ### Step 4: Notify
 
 ```bash
@@ -1616,6 +1618,103 @@ factory notify "$PROJECT_PATH"
 ```bash
 cd "$PROJECT_PATH" && git add .factory/ && git commit -m "factory: log experiment results and update strategy"
 ```
+
+---
+
+## Post-Cycle Refinement Loop (Foreground Only)
+
+After completing Steps 3-5, if you are running in foreground mode (not headless), enter the Post-Cycle Refinement Loop. This is your NEW primary role: you are now a refinement router, not a cycle executor.
+
+### IDENTITY REGROUNDING — READ THIS BEFORE EVERY USER MESSAGE
+
+You are the Factory CEO — an executive orchestrator. Your cycle is complete. Your role now is:
+- Present results to the user
+- Route refinement requests through the Refiner → Builder pipeline
+- Answer questions about what was built
+- Accept approval to finish
+
+You are NOT a coding assistant. You do NOT implement changes directly. Sacred Rule 8 is STILL in effect — it does not expire after the cycle.
+
+Before processing any user message in this loop, run:
+```bash
+factory refine-status "$PROJECT_PATH"
+```
+Read the output. It will remind you of your role and current state.
+
+### PC1: Present Summary and Wait
+
+Present the cycle results clearly:
+- What was built/improved (PRs with numbers, eval score deltas)
+- Current eval score and per-dimension breakdown
+- Remaining backlog items
+- Any open questions or items needing user input
+
+Then tell the user:
+"The cycle is complete. You can:
+- Request changes (I'll route them through the refinement pipeline)
+- Ask questions about what was built
+- Say 'done' or 'looks good' to finish"
+
+Wait for user input. Do NOT exit.
+
+### PC2: Classify User Input
+
+When the user types a message, classify it into ONE of these categories:
+
+1. **DONE** — approval/exit signals: "looks good", "done", "thanks", "merge it", "ship it", "approved", "LGTM"
+   → Exit gracefully. Commit any remaining `.factory/` state and say goodbye.
+
+2. **QUESTION** — pure information requests: "what does X do?", "why did you change Y?", "explain the architecture", "show me the diff"
+   → Answer the question directly (reading files and diffs is fine — Sacred Rule 8 allows file reads for review). Return to PC1 (wait for next input).
+
+3. **REFINEMENT** — any request to change, fix, add, remove, update, or improve something. This includes: "fix the typo in X", "add error handling to Y", "change the API response format", "make the tests more thorough", "update the prompt", "the button should be blue not green"
+   → Proceed to PC3. Do NOT implement it yourself. Do NOT "quickly fix" it. The ONLY path forward is PC3.
+
+**When in doubt, classify as REFINEMENT.** It is always safe to route through the Refiner — it is never safe to implement directly.
+
+### PC3: Execute Refinement
+
+Before spawning any agent, reground yourself:
+
+```bash
+factory refine-begin "$PROJECT_PATH" --request "<summary of user's request>"
+```
+
+This command:
+1. Records the refinement in the state file
+2. Outputs a regrounding message confirming your orchestrator role
+3. Returns the refinement sequence number
+
+Then execute the FULL Mode: Refine pipeline (R0-R12):
+
+1. **R0:** Spawn Refiner to classify and scope the request
+2. **R0-review:** CEO reviews Refiner output, writes verdict
+3. **R1:** Tier gate — if Tier 3, tell user to use `factory ceo --focus`
+4. **R2:** `factory begin` — new experiment
+5. **R3:** Create GitHub issue
+6. **R4:** Spawn Builder
+7. **R5-R10:** FULL review pipeline (structured checklist, review-until-clean, guard check, eval, E2E, precheck, final review) — IDENTICAL to Improve mode
+8. **R11:** Keep/revert verdict + finalize
+9. **R12:** Archivist (single batch)
+
+After R12 completes:
+```bash
+factory refine-complete "$PROJECT_PATH" --verdict "$VERDICT"
+```
+
+Return to **PC1** — present the updated results and wait for more input.
+
+### PC4: Refinement Guardrails
+
+- **No hard cap.** Refinements run for as long as the user needs them.
+- **Advisory warnings:** After 5 refinements in a single session, print:
+  "Advisory: 5 refinements completed in this session. Context window is growing. Quality may degrade over extended sessions. Consider starting a fresh session with `factory ceo /path` if you notice degradation."
+  After 10, print the warning again with stronger language.
+  These are WARNINGS, not limits. The user decides when to stop.
+- **Each refinement is a full experiment** with its own experiment ID, PR, and review pipeline. No shortcuts.
+- **Sacred Rule 8 applies at all times** — always route through Refiner → Builder. The CEO reads files and reviews diffs but never writes code.
+- **Sacred Rule 9 applies at all times** — every refinement gets the full 2d-review pipeline. "The change is small" is not a reason to skip review.
+- **Full review pipeline = Steps R5 through R10** — structured 6-category checklist + review-until-clean loop + guard check + eval + E2E + precheck + final headless review. ALL components. NO shortcuts. NO abbreviated reviews.
 
 ---
 

--- a/factory/agents/prompts/refiner.md
+++ b/factory/agents/prompts/refiner.md
@@ -1,0 +1,82 @@
+# Refiner Agent
+
+## Identity
+
+You are the Refiner agent for the Software Factory — a change classifier and scope analyst. You assess user-directed refinement requests, determine which files need to change, estimate the effort involved, and produce a structured classification that the CEO uses to route the work. You are a planner, not an implementer — you do NOT modify code.
+
+## Context
+
+You are invoked when a user requests a specific refinement via `factory ceo --refine "<request>"`. The CEO spawns you to classify the request before deciding how to proceed. You have access to the full project source code, CLAUDE.md, factory.md, and the user's refinement request.
+
+You will be given:
+- The user's refinement request (what they want changed)
+- The project path
+
+## Task
+
+1. **Read the project**: Check CLAUDE.md, factory.md, and relevant source files to understand the codebase
+2. **Analyze the request**: Understand what the user is asking for
+3. **Identify affected files**: List every file that would need to change, with specific line ranges where possible
+4. **Estimate scope**: Count files, estimate lines changed, assess complexity
+5. **Classify tier**: Assign Tier 1, 2, or 3 based on the scope assessment
+6. **Write Builder task**: Produce a precise, actionable task description for the Builder agent
+
+## Tier Classification
+
+| Tier | Scope | Examples | CEO Action |
+|------|-------|----------|------------|
+| **Tier 1** | 1-3 files, <50 lines changed, no new dependencies | Fix a typo, rename a variable, adjust a log message, update a prompt string, fix an off-by-one error | Proceed with refinement pipeline |
+| **Tier 2** | 3-8 files, 50-200 lines changed, may add minor dependencies | Add a CLI flag, implement a small feature, refactor a function across callers, add error handling to a module | Proceed with refinement pipeline |
+| **Tier 3** | 8+ files, 200+ lines changed, architectural changes, new modules | Add a new agent, redesign a subsystem, implement a complex feature with tests and docs | Exit — tell user to use full Improve mode |
+
+### Classification Rules
+
+- When in doubt between two tiers, choose the higher tier (conservative)
+- If the request is ambiguous or underspecified, classify as Tier 3 with a note explaining what clarification is needed
+- If the request would require modifying eval/score.py or .factory/ contents, classify as Tier 3
+- If the request requires adding new test files (not just modifying existing ones), bump up one tier
+
+## Output Format
+
+Produce your output in this exact format:
+
+```markdown
+## Refinement Classification
+
+### Request
+<verbatim copy of the user's refinement request>
+
+### Tier: <1|2|3>
+
+### Rationale
+<2-3 sentences explaining why this tier was chosen>
+
+### Files to Modify
+1. `<file_path>` — <what changes and why> (~<N> lines)
+2. `<file_path>` — <what changes and why> (~<N> lines)
+...
+
+### Estimated Scope
+- **Files:** <N>
+- **Lines changed:** ~<N>
+- **Complexity:** low | medium | high
+- **New dependencies:** none | <list>
+- **Test impact:** none | existing tests need updates | new tests needed
+
+### Builder Task Description
+
+<A precise, actionable task description for the Builder agent. This should be specific enough that the Builder can implement the change without needing to re-analyze the codebase. Include:
+- Exactly which files to modify
+- What to change in each file
+- Any constraints or gotchas
+- How to verify the change works>
+```
+
+## Constraints
+
+- Do NOT modify any files — you are a classifier only
+- Do NOT execute commands that change state (no git commits, no file writes)
+- You MAY read any file in the project to inform your classification
+- You MAY run read-only commands (grep, find, cat, git log, git diff) to understand the codebase
+- Be conservative in scope estimation — underestimating leads to incomplete Builder work
+- The Builder task description must be self-contained — the Builder should not need your full analysis, just the task

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 AgentRole = Literal[
     "researcher", "strategist", "builder", "reviewer", "evaluator",
-    "archivist", "distiller", "ceo", "failure_analyst",
+    "archivist", "distiller", "ceo", "failure_analyst", "refiner",
 ]
 
 # Consecutive failure tracking

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1998,6 +1998,11 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             print("Error: --refine and --focus are mutually exclusive.",
                   file=sys.stderr)
             return 1
+        refine_path = Path(raw_path).expanduser().resolve()
+        if not refine_path.is_dir():
+            print("Error: --refine requires an existing project directory, not a URL or idea.",
+                  file=sys.stderr)
+            return 1
 
     _interactive_is_existing = (
         mode == "interactive"

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1596,7 +1596,10 @@ def cmd_refine_complete(args: argparse.Namespace) -> int:
         print("Warning: no refinement entries found — nothing to complete.", file=sys.stderr)
         return 1
     last = state.entries[-1]
-    complete_refinement(project_path, verdict)
+    mutated = complete_refinement(project_path, verdict)
+    if not mutated:
+        print(f"Warning: refinement #{last.sequence} is already completed.", file=sys.stderr)
+        return 1
     _emit_cli_event(project_path, "refine.complete", {
         "sequence": last.sequence,
         "verdict": verdict,
@@ -2034,7 +2037,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     refine_request = getattr(args, "refine", None)
 
     if refine_request:
-        if mode in ("interactive", "research", "meta"):
+        if mode and mode != "auto":
             print(f"Error: --refine and --mode {mode} are mutually exclusive.",
                   file=sys.stderr)
             return 1

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1983,6 +1983,21 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         return 1
 
     no_github = getattr(args, "no_github", False)
+    refine_request = getattr(args, "refine", None)
+
+    if refine_request:
+        if mode in ("interactive", "research"):
+            print(f"Error: --refine and --mode {mode} are mutually exclusive.",
+                  file=sys.stderr)
+            return 1
+        if prompt_file:
+            print("Error: --refine and --prompt are mutually exclusive.",
+                  file=sys.stderr)
+            return 1
+        if focus:
+            print("Error: --refine and --focus are mutually exclusive.",
+                  file=sys.stderr)
+            return 1
 
     _interactive_is_existing = (
         mode == "interactive"
@@ -2139,6 +2154,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         messages=pending,
         issue_number=issue_number,
         issue_url=issue_url,
+        refine_request=refine_request,
     )
 
     if headless:
@@ -2633,6 +2649,7 @@ def _build_ceo_task(
     messages: list[Message] | None = None,
     issue_number: int | None = None,
     issue_url: str | None = None,
+    refine_request: str | None = None,
 ) -> str:
     """Build the CEO agent task string from mode and optional context."""
     task = f"Project: {project_path}\nMode: {mode}"
@@ -2798,6 +2815,22 @@ def _build_ceo_task(
             "- Clone from GitHub URLs\n\n"
             "Work locally only. When a GitHub operation would normally occur, "
             "skip it and note what was skipped in the experiment log."
+        )
+
+    if refine_request:
+        task += (
+            f"\n\n## Refinement Mode\n\n"
+            f"**User's refinement request:** {refine_request}\n\n"
+            f"You are in Refinement mode. Follow the `Mode: Refine` section in your "
+            f"system prompt. The pipeline is:\n\n"
+            f"1. Spawn the Refiner agent to classify and scope the request\n"
+            f"2. If Tier 3 → exit, tell user to use full Improve mode\n"
+            f"3. Begin experiment, create GitHub issue from Refiner's scoped task\n"
+            f"4. Spawn Builder with the Refiner's task description\n"
+            f"5. Run the FULL review pipeline (2d-review through 2h-final) — identical to Improve mode\n"
+            f"6. Keep/revert verdict + finalize\n"
+            f"7. Archivist (single batch)\n\n"
+            f"Do NOT skip the review pipeline. Do NOT abbreviate any step.\n"
         )
 
     return task
@@ -3351,7 +3384,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("agent", help="Invoke a specialist agent with a task")
     p.add_argument("role", choices=["researcher", "strategist", "builder", "reviewer",
                                      "evaluator", "archivist", "distiller", "ceo",
-                                     "failure_analyst"],
+                                     "failure_analyst", "refiner"],
                     help="Agent role to invoke")
     p.add_argument("--task", required=True, help="Task description for the agent")
     p.add_argument("--project", required=True, help="Path to the project")
@@ -3417,6 +3450,11 @@ def build_parser() -> argparse.ArgumentParser:
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
+    p.add_argument(
+        "--refine", default=None, metavar="REQUEST",
+        help="Refinement mode: classify and implement a user-directed change. "
+             "Mutually exclusive with --mode interactive, --mode research, --loop, --prompt, --focus",
+    )
 
     # run
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1572,8 +1572,8 @@ def cmd_refine_begin(args: argparse.Namespace) -> int:
     from factory.refine_state import begin_refinement, format_begin
 
     project_path = Path(args.path).resolve()
-    request = args.request
-    if not request or not request.strip():
+    request = (args.request or "").strip()
+    if not request:
         print("Error: --request must not be empty.", file=sys.stderr)
         return 1
     entry = begin_refinement(project_path, request)
@@ -2049,8 +2049,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             print("Error: --refine and --focus are mutually exclusive.",
                   file=sys.stderr)
             return 1
-        refine_path = Path(raw_path).expanduser().resolve()
-        if not refine_path.is_dir():
+        if not Path(raw_path).expanduser().resolve().is_dir():
             print("Error: --refine requires an existing project directory, not a URL or idea.",
                   file=sys.stderr)
             return 1

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1986,7 +1986,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     refine_request = getattr(args, "refine", None)
 
     if refine_request:
-        if mode in ("interactive", "research"):
+        if mode in ("interactive", "research", "meta"):
             print(f"Error: --refine and --mode {mode} are mutually exclusive.",
                   file=sys.stderr)
             return 1
@@ -3453,7 +3453,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--refine", default=None, metavar="REQUEST",
         help="Refinement mode: classify and implement a user-directed change. "
-             "Mutually exclusive with --mode interactive, --mode research, --loop, --prompt, --focus",
+             "Mutually exclusive with --mode interactive, --mode research, --mode meta, --prompt, --focus",
     )
 
     # run

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1557,6 +1557,54 @@ def cmd_validate_research(args: argparse.Namespace) -> int:
     return 1
 
 
+def cmd_refine_status(args: argparse.Namespace) -> int:
+    """Print refinement state and regrounding output."""
+    from factory.refine_state import format_status, read_state
+
+    project_path = Path(args.path).resolve()
+    state = read_state(project_path)
+    print(format_status(state))
+    return 0
+
+
+def cmd_refine_begin(args: argparse.Namespace) -> int:
+    """Record a new refinement entry and emit regrounding output."""
+    from factory.refine_state import begin_refinement, format_begin
+
+    project_path = Path(args.path).resolve()
+    request = args.request
+    if not request or not request.strip():
+        print("Error: --request must not be empty.", file=sys.stderr)
+        return 1
+    entry = begin_refinement(project_path, request)
+    _emit_cli_event(project_path, "refine.begin", {
+        "sequence": entry.sequence,
+        "request": request[:200],
+    })
+    print(format_begin(entry))
+    return 0
+
+
+def cmd_refine_complete(args: argparse.Namespace) -> int:
+    """Update the last refinement entry with a verdict."""
+    from factory.refine_state import complete_refinement, read_state
+
+    project_path = Path(args.path).resolve()
+    verdict = args.verdict
+    state = read_state(project_path)
+    if not state.entries:
+        print("Warning: no refinement entries found — nothing to complete.", file=sys.stderr)
+        return 1
+    last = state.entries[-1]
+    complete_refinement(project_path, verdict)
+    _emit_cli_event(project_path, "refine.complete", {
+        "sequence": last.sequence,
+        "verdict": verdict,
+    })
+    print(f"Refinement #{last.sequence} completed — verdict: {verdict}")
+    return 0
+
+
 def cmd_review(args: argparse.Namespace) -> int:
     """Format and optionally post a review on a GitHub PR."""
     from factory.review import ReviewPayload, format_review, post_review
@@ -3288,6 +3336,21 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--similarity-threshold", type=float, default=0.6,
                     help="Similarity threshold for anti-pattern detection (default: 0.6)")
 
+    # refine-status
+    p = sub.add_parser("refine-status", help="Print refinement state and regrounding output")
+    p.add_argument("path", help="Path to the project")
+
+    # refine-begin
+    p = sub.add_parser("refine-begin", help="Record a new refinement and emit regrounding output")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--request", required=True, help="Summary of the user's refinement request")
+
+    # refine-complete
+    p = sub.add_parser("refine-complete", help="Complete the current refinement with a verdict")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--verdict", required=True, choices=["keep", "revert", "error", "tier3_exit"],
+                    help="Refinement verdict")
+
     # review
     p = sub.add_parser("review", help="Format and post a structured review on a GitHub PR")
     p.add_argument("--verdict", required=True, choices=["keep", "revert", "KEEP", "REVERT"],
@@ -3595,6 +3658,9 @@ def main(argv: list[str] | None = None) -> int:
         "precheck": cmd_precheck,
         "leakage-check": cmd_leakage_check,
         "validate-research": cmd_validate_research,
+        "refine-status": cmd_refine_status,
+        "refine-begin": cmd_refine_begin,
+        "refine-complete": cmd_refine_complete,
         "review": cmd_review,
         "checkpoint": cmd_checkpoint,
         "resume": cmd_resume,

--- a/factory/models.py
+++ b/factory/models.py
@@ -479,3 +479,26 @@ class Notifier(Protocol):
         records: list[ExperimentRecord],
         composite: CompositeScore | None,
     ) -> None: ...
+
+
+# ── refinement state ─────────────────────────────────────────────
+
+
+class RefinementEntry(BaseModel):
+    """One refinement in a post-cycle refinement session."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    sequence: int
+    request: str
+    started_at: str
+    completed_at: str | None = None
+    verdict: str | None = None
+
+
+class RefinementState(BaseModel):
+    """Tracks refinements within a single post-cycle session."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    entries: list[RefinementEntry] = []

--- a/factory/refine_state.py
+++ b/factory/refine_state.py
@@ -6,8 +6,13 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+import structlog
+from pydantic import ValidationError
+
 from factory.agents.runner import IDENTITY_REANCHOR
 from factory.models import RefinementEntry, RefinementState
+
+log = structlog.get_logger()
 
 _STATE_DIR = "state"
 _STATE_FILE = "refinements.json"
@@ -18,12 +23,16 @@ def _state_path(project_path: Path) -> Path:
 
 
 def read_state(project_path: Path) -> RefinementState:
-    """Read refinement state from disk. Returns empty state if file missing."""
+    """Read refinement state from disk. Returns empty state if file missing or corrupted."""
     path = _state_path(project_path)
     if not path.exists():
         return RefinementState()
-    data = json.loads(path.read_text())
-    return RefinementState(**data)
+    try:
+        data = json.loads(path.read_text())
+        return RefinementState(**data)
+    except (json.JSONDecodeError, ValidationError) as exc:
+        log.warning("corrupted_refinement_state", path=str(path), error=str(exc))
+        return RefinementState()
 
 
 def begin_refinement(project_path: Path, request: str) -> RefinementEntry:
@@ -48,6 +57,9 @@ def complete_refinement(project_path: Path, verdict: str) -> None:
     if not state.entries:
         return
     last = state.entries[-1]
+    if last.verdict is not None:
+        log.warning("refinement_already_completed", sequence=last.sequence, existing_verdict=last.verdict)
+        return
     last.completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     last.verdict = verdict
     path = _state_path(project_path)

--- a/factory/refine_state.py
+++ b/factory/refine_state.py
@@ -51,19 +51,23 @@ def begin_refinement(project_path: Path, request: str) -> RefinementEntry:
     return entry
 
 
-def complete_refinement(project_path: Path, verdict: str) -> None:
-    """Update the last refinement entry with verdict and completion timestamp."""
+def complete_refinement(project_path: Path, verdict: str) -> bool:
+    """Update the last refinement entry with verdict and completion timestamp.
+
+    Returns True if state was mutated, False if already completed or no entries.
+    """
     state = read_state(project_path)
     if not state.entries:
-        return
+        return False
     last = state.entries[-1]
     if last.verdict is not None:
         log.warning("refinement_already_completed", sequence=last.sequence, existing_verdict=last.verdict)
-        return
+        return False
     last.completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     last.verdict = verdict
     path = _state_path(project_path)
     path.write_text(json.dumps(state.model_dump(), indent=2) + "\n")
+    return True
 
 
 def format_status(state: RefinementState) -> str:

--- a/factory/refine_state.py
+++ b/factory/refine_state.py
@@ -84,7 +84,7 @@ def format_status(state: RefinementState) -> str:
         lines.append("No refinements recorded yet. Entering post-cycle refinement loop.")
         lines.append("Route ALL change requests through Refiner → Builder (Sacred Rule 8).")
     else:
-        lines.append(f"Session refinements: {len(state.entries)}")
+        lines.append(f"Refinements recorded: {len(state.entries)}")
         for e in state.entries:
             if e.verdict:
                 lines.append(f'  #{e.sequence}: "{e.request}" → {e.verdict.upper()}')

--- a/factory/refine_state.py
+++ b/factory/refine_state.py
@@ -1,0 +1,114 @@
+"""Post-cycle refinement state tracking and identity regrounding."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from factory.agents.runner import IDENTITY_REANCHOR
+from factory.models import RefinementEntry, RefinementState
+
+_STATE_DIR = "state"
+_STATE_FILE = "refinements.json"
+
+
+def _state_path(project_path: Path) -> Path:
+    return project_path / ".factory" / _STATE_DIR / _STATE_FILE
+
+
+def read_state(project_path: Path) -> RefinementState:
+    """Read refinement state from disk. Returns empty state if file missing."""
+    path = _state_path(project_path)
+    if not path.exists():
+        return RefinementState()
+    data = json.loads(path.read_text())
+    return RefinementState(**data)
+
+
+def begin_refinement(project_path: Path, request: str) -> RefinementEntry:
+    """Create a new refinement entry and persist to disk."""
+    state = read_state(project_path)
+    sequence = len(state.entries) + 1
+    entry = RefinementEntry(
+        sequence=sequence,
+        request=request,
+        started_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    state.entries.append(entry)
+    path = _state_path(project_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state.model_dump(), indent=2) + "\n")
+    return entry
+
+
+def complete_refinement(project_path: Path, verdict: str) -> None:
+    """Update the last refinement entry with verdict and completion timestamp."""
+    state = read_state(project_path)
+    if not state.entries:
+        return
+    last = state.entries[-1]
+    last.completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    last.verdict = verdict
+    path = _state_path(project_path)
+    path.write_text(json.dumps(state.model_dump(), indent=2) + "\n")
+
+
+def format_status(state: RefinementState) -> str:
+    """Produce structured regrounding output for the CEO."""
+    lines = [
+        "═══ REFINEMENT STATUS ═══",
+        "Role: Factory CEO — Executive Orchestrator (refinement router)",
+        "Sacred Rule 8: ACTIVE — do NOT implement changes directly",
+        "Sacred Rule 9: ACTIVE — full review pipeline for every refinement",
+        "",
+    ]
+
+    if not state.entries:
+        lines.append("No refinements recorded yet. Entering post-cycle refinement loop.")
+        lines.append("Route ALL change requests through Refiner → Builder (Sacred Rule 8).")
+    else:
+        lines.append(f"Session refinements: {len(state.entries)}")
+        for e in state.entries:
+            if e.verdict:
+                lines.append(f'  #{e.sequence}: "{e.request}" → {e.verdict.upper()}')
+            else:
+                lines.append(f'  #{e.sequence}: "{e.request}" → IN PROGRESS')
+        lines.append("")
+        lines.append("REMINDER: Route ALL change requests through Refiner → Builder.")
+        lines.append("Questions and approvals may be handled directly.")
+
+    lines.append("═══════════════════════════")
+    lines.append(IDENTITY_REANCHOR)
+    return "\n".join(lines)
+
+
+def format_begin(entry: RefinementEntry) -> str:
+    """Produce begin output with regrounding for the CEO."""
+    lines = [
+        f'Refinement #{entry.sequence} registered: "{entry.request}"',
+        "You are the CEO. Proceed with Mode: Refine pipeline (R0-R12).",
+        "Do NOT implement this yourself — spawn the Refiner agent.",
+    ]
+
+    count = entry.sequence
+    if count >= 10:
+        lines.append("")
+        lines.append(
+            f"⚠ Advisory: This is refinement #{count}. Consider starting a fresh session."
+        )
+        lines.append(
+            "Context window is significantly loaded. Quality of agent outputs may be affected."
+        )
+    elif count >= 5:
+        lines.append("")
+        lines.append(
+            f"⚠ Advisory: This is refinement #{count} in this session."
+        )
+        lines.append(
+            "Extended sessions may experience quality degradation from context growth."
+        )
+        lines.append("This is an advisory — you may continue as long as needed.")
+
+    lines.append(IDENTITY_REANCHOR)
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1633,6 +1633,18 @@ class TestRefineFlag:
         assert result == 1
         assert "mutually exclusive" in capsys.readouterr().err
 
+    def test_refine_requires_existing_directory(self, capsys):
+        with _mock_foreground():
+            result = main(["ceo", "/nonexistent/path", "--refine", "fix bug"])
+        assert result == 1
+        assert "existing project directory" in capsys.readouterr().err
+
+    def test_refine_rejects_url(self, capsys):
+        with _mock_foreground():
+            result = main(["ceo", "https://github.com/user/repo", "--refine", "fix bug"])
+        assert result == 1
+        assert "existing project directory" in capsys.readouterr().err
+
 
 class TestBuildCeoTaskRefine:
     """Tests for _build_ceo_task refinement mode section."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1586,3 +1586,81 @@ class TestInteractiveFileInput:
         spec_path = matches[0] / ".factory" / "strategy" / "current.md"
         assert spec_path.exists()
         assert "Build a CLI todo app" in spec_path.read_text()
+
+
+class TestRefineFlag:
+    """Tests for --refine flag parsing and mutual exclusivity."""
+
+    def test_refine_flag_parsed(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path", "--refine", "fix the login bug"])
+        assert args.refine == "fix the login bug"
+
+    def test_refine_default_is_none(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path"])
+        assert args.refine is None
+
+    def test_refine_exclusive_with_interactive(self, tmp_path, capsys):
+        with _mock_foreground():
+            result = main(["ceo", str(tmp_path), "--refine", "fix bug", "--mode", "interactive"])
+        assert result == 1
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_refine_exclusive_with_research(self, tmp_path, capsys):
+        with _mock_foreground():
+            result = main(["ceo", str(tmp_path), "--refine", "fix bug", "--mode", "research"])
+        assert result == 1
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_refine_exclusive_with_meta(self, tmp_path, capsys):
+        with _mock_foreground():
+            result = main(["ceo", str(tmp_path), "--refine", "fix bug", "--mode", "meta"])
+        assert result == 1
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_refine_exclusive_with_prompt(self, tmp_path, capsys):
+        prompt_file = tmp_path / "spec.md"
+        prompt_file.write_text("some spec")
+        with _mock_foreground():
+            result = main(["ceo", str(tmp_path), "--refine", "fix bug", "--prompt", str(prompt_file)])
+        assert result == 1
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_refine_exclusive_with_focus(self, tmp_path, capsys):
+        with _mock_foreground():
+            result = main(["ceo", str(tmp_path), "--refine", "fix bug", "--focus", "auth"])
+        assert result == 1
+        assert "mutually exclusive" in capsys.readouterr().err
+
+
+class TestBuildCeoTaskRefine:
+    """Tests for _build_ceo_task refinement mode section."""
+
+    def test_refine_request_emits_section(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "build", refine_request="fix the login bug")
+        assert "## Refinement Mode" in task
+        assert "fix the login bug" in task
+        assert "Mode: Refine" in task
+
+    def test_no_refine_request_omits_section(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "build")
+        assert "## Refinement Mode" not in task
+
+    def test_refine_request_none_omits_section(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "build", refine_request=None)
+        assert "## Refinement Mode" not in task
+
+
+class TestRefinerPromptExists:
+    """Verify the refiner.md prompt file exists and has key sections."""
+
+    def test_refiner_prompt_file_exists(self):
+        prompt_path = Path(__file__).parent.parent / "factory" / "agents" / "prompts" / "refiner.md"
+        assert prompt_path.exists(), f"refiner.md not found at {prompt_path}"
+
+    def test_refiner_prompt_has_key_sections(self):
+        prompt_path = Path(__file__).parent.parent / "factory" / "agents" / "prompts" / "refiner.md"
+        content = prompt_path.read_text()
+        assert "Tier" in content, "refiner.md should reference Tier classification"
+        assert "Builder" in content or "builder" in content, "refiner.md should reference the Builder agent"

--- a/tests/test_refine_state.py
+++ b/tests/test_refine_state.py
@@ -202,7 +202,7 @@ class TestFormatStatus:
             ]
         )
         output = format_status(state)
-        assert "Session refinements: 2" in output
+        assert "Refinements recorded: 2" in output
         assert '"fix typo" → KEEP' in output
         assert '"add flag" → IN PROGRESS' in output
         assert "REMINDER" in output

--- a/tests/test_refine_state.py
+++ b/tests/test_refine_state.py
@@ -1,0 +1,349 @@
+"""Tests for factory.refine_state — refinement tracking and regrounding."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from factory.models import RefinementEntry, RefinementState
+from factory.refine_state import (
+    begin_refinement,
+    complete_refinement,
+    format_begin,
+    format_status,
+    read_state,
+)
+
+
+# ── model validation ─────────────────────────────────────────────
+
+
+class TestRefinementEntryModel:
+    def test_valid_entry(self) -> None:
+        entry = RefinementEntry(
+            sequence=1,
+            request="fix typo in README",
+            started_at="2026-05-24T12:00:00Z",
+        )
+        assert entry.sequence == 1
+        assert entry.request == "fix typo in README"
+        assert entry.completed_at is None
+        assert entry.verdict is None
+
+    def test_valid_entry_completed(self) -> None:
+        entry = RefinementEntry(
+            sequence=2,
+            request="add --verbose flag",
+            started_at="2026-05-24T12:00:00Z",
+            completed_at="2026-05-24T12:05:00Z",
+            verdict="keep",
+        )
+        assert entry.verdict == "keep"
+        assert entry.completed_at is not None
+
+    def test_strict_rejects_extras(self) -> None:
+        with pytest.raises(ValidationError):
+            RefinementEntry(
+                sequence=1,
+                request="test",
+                started_at="2026-05-24T12:00:00Z",
+                bogus_field="oops",
+            )
+
+    def test_defaults(self) -> None:
+        entry = RefinementEntry(
+            sequence=1, request="test", started_at="2026-05-24T12:00:00Z"
+        )
+        assert entry.completed_at is None
+        assert entry.verdict is None
+
+
+class TestRefinementStateModel:
+    def test_empty_state(self) -> None:
+        state = RefinementState()
+        assert state.entries == []
+
+    def test_state_with_entries(self) -> None:
+        state = RefinementState(
+            entries=[
+                RefinementEntry(
+                    sequence=1,
+                    request="fix typo",
+                    started_at="2026-05-24T12:00:00Z",
+                    verdict="keep",
+                ),
+            ]
+        )
+        assert len(state.entries) == 1
+
+    def test_strict_rejects_extras(self) -> None:
+        with pytest.raises(ValidationError):
+            RefinementState(entries=[], extra_field="nope")
+
+
+# ── read_state ───────────────────────────────────────────────────
+
+
+class TestReadState:
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        state = read_state(tmp_path)
+        assert state.entries == []
+
+    def test_reads_existing_file(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / ".factory" / "state"
+        state_dir.mkdir(parents=True)
+        data = {
+            "entries": [
+                {
+                    "sequence": 1,
+                    "request": "fix typo",
+                    "started_at": "2026-05-24T12:00:00Z",
+                    "completed_at": None,
+                    "verdict": None,
+                }
+            ]
+        }
+        (state_dir / "refinements.json").write_text(json.dumps(data))
+        state = read_state(tmp_path)
+        assert len(state.entries) == 1
+        assert state.entries[0].request == "fix typo"
+
+
+# ── begin_refinement ─────────────────────────────────────────────
+
+
+class TestBeginRefinement:
+    def test_creates_file_and_entry(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        entry = begin_refinement(tmp_path, "fix typo in README")
+        assert entry.sequence == 1
+        assert entry.request == "fix typo in README"
+        assert entry.started_at is not None
+
+        state = read_state(tmp_path)
+        assert len(state.entries) == 1
+
+    def test_appends_entries(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        begin_refinement(tmp_path, "first change")
+        entry2 = begin_refinement(tmp_path, "second change")
+        assert entry2.sequence == 2
+
+        state = read_state(tmp_path)
+        assert len(state.entries) == 2
+        assert state.entries[0].request == "first change"
+        assert state.entries[1].request == "second change"
+
+    def test_returns_correct_sequence_numbers(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        for i in range(5):
+            entry = begin_refinement(tmp_path, f"change {i}")
+            assert entry.sequence == i + 1
+
+
+# ── complete_refinement ──────────────────────────────────────────
+
+
+class TestCompleteRefinement:
+    def test_updates_last_entry(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        begin_refinement(tmp_path, "fix typo")
+        complete_refinement(tmp_path, "keep")
+
+        state = read_state(tmp_path)
+        assert state.entries[0].verdict == "keep"
+        assert state.entries[0].completed_at is not None
+
+    def test_no_entries_is_noop(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        complete_refinement(tmp_path, "keep")
+        state = read_state(tmp_path)
+        assert state.entries == []
+
+    def test_multiple_entries_updates_last(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir()
+        begin_refinement(tmp_path, "first")
+        complete_refinement(tmp_path, "keep")
+        begin_refinement(tmp_path, "second")
+        complete_refinement(tmp_path, "revert")
+
+        state = read_state(tmp_path)
+        assert state.entries[0].verdict == "keep"
+        assert state.entries[1].verdict == "revert"
+
+
+# ── format_status ────────────────────────────────────────────────
+
+
+class TestFormatStatus:
+    def test_empty_state_contains_regrounding(self) -> None:
+        output = format_status(RefinementState())
+        assert "Factory CEO" in output
+        assert "Sacred Rule 8" in output
+        assert "No refinements recorded" in output
+
+    def test_with_entries_shows_history(self) -> None:
+        state = RefinementState(
+            entries=[
+                RefinementEntry(
+                    sequence=1,
+                    request="fix typo",
+                    started_at="2026-05-24T12:00:00Z",
+                    verdict="keep",
+                ),
+                RefinementEntry(
+                    sequence=2,
+                    request="add flag",
+                    started_at="2026-05-24T12:05:00Z",
+                ),
+            ]
+        )
+        output = format_status(state)
+        assert "Session refinements: 2" in output
+        assert '"fix typo" → KEEP' in output
+        assert '"add flag" → IN PROGRESS' in output
+        assert "REMINDER" in output
+
+    def test_contains_identity_reanchor(self) -> None:
+        output = format_status(RefinementState())
+        assert "CEO IDENTITY RE-ANCHOR" in output
+
+
+# ── format_begin ─────────────────────────────────────────────────
+
+
+class TestFormatBegin:
+    def test_basic_output(self) -> None:
+        entry = RefinementEntry(
+            sequence=1,
+            request="fix typo",
+            started_at="2026-05-24T12:00:00Z",
+        )
+        output = format_begin(entry)
+        assert 'Refinement #1 registered: "fix typo"' in output
+        assert "spawn the Refiner agent" in output
+        assert "Advisory" not in output
+
+    def test_advisory_at_5(self) -> None:
+        entry = RefinementEntry(
+            sequence=5,
+            request="fifth change",
+            started_at="2026-05-24T12:00:00Z",
+        )
+        output = format_begin(entry)
+        assert "Advisory" in output
+        assert "refinement #5" in output
+        assert "quality degradation" in output
+
+    def test_stronger_advisory_at_10(self) -> None:
+        entry = RefinementEntry(
+            sequence=10,
+            request="tenth change",
+            started_at="2026-05-24T12:00:00Z",
+        )
+        output = format_begin(entry)
+        assert "Advisory" in output
+        assert "refinement #10" in output
+        assert "Consider starting a fresh session" in output
+
+    def test_contains_identity_reanchor(self) -> None:
+        entry = RefinementEntry(
+            sequence=1,
+            request="test",
+            started_at="2026-05-24T12:00:00Z",
+        )
+        output = format_begin(entry)
+        assert "CEO IDENTITY RE-ANCHOR" in output
+
+
+# ── CLI integration ──────────────────────────────────────────────
+
+
+class TestCLIIntegration:
+    def test_refine_status_registered(self) -> None:
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["refine-status", "/tmp/test-project"])
+        assert args.command == "refine-status"
+        assert args.path == "/tmp/test-project"
+
+    def test_refine_begin_registered(self) -> None:
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "refine-begin", "/tmp/test-project",
+            "--request", "fix the typo",
+        ])
+        assert args.command == "refine-begin"
+        assert args.request == "fix the typo"
+
+    def test_refine_complete_registered(self) -> None:
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args([
+            "refine-complete", "/tmp/test-project",
+            "--verdict", "keep",
+        ])
+        assert args.command == "refine-complete"
+        assert args.verdict == "keep"
+
+    def test_refine_status_callable(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_refine_status
+        import argparse
+
+        (tmp_path / ".factory").mkdir()
+        ns = argparse.Namespace(path=str(tmp_path))
+        result = cmd_refine_status(ns)
+        assert result == 0
+
+    def test_refine_begin_callable(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_refine_begin
+        import argparse
+
+        (tmp_path / ".factory").mkdir()
+        ns = argparse.Namespace(path=str(tmp_path), request="test change")
+        result = cmd_refine_begin(ns)
+        assert result == 0
+
+        state = read_state(tmp_path)
+        assert len(state.entries) == 1
+
+    def test_refine_complete_callable(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_refine_begin, cmd_refine_complete
+        import argparse
+
+        (tmp_path / ".factory").mkdir()
+        cmd_refine_begin(argparse.Namespace(path=str(tmp_path), request="test"))
+        result = cmd_refine_complete(
+            argparse.Namespace(path=str(tmp_path), verdict="keep")
+        )
+        assert result == 0
+
+        state = read_state(tmp_path)
+        assert state.entries[0].verdict == "keep"
+
+    def test_refine_complete_no_entries_returns_error(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_refine_complete
+        import argparse
+
+        (tmp_path / ".factory").mkdir()
+        result = cmd_refine_complete(
+            argparse.Namespace(path=str(tmp_path), verdict="keep")
+        )
+        assert result == 1
+
+    def test_handlers_in_dispatch(self) -> None:
+        from factory.cli import build_parser
+        parser = build_parser()
+        for cmd in ["refine-status", "refine-begin", "refine-complete"]:
+            # Should not raise
+            args = parser.parse_args([cmd, "/tmp/test"] if cmd == "refine-status"
+                                     else [cmd, "/tmp/test", "--request", "x"] if cmd == "refine-begin"
+                                     else [cmd, "/tmp/test", "--verdict", "keep"])
+            assert args.command == cmd


### PR DESCRIPTION
Closes #317

## Changes

- **New `factory/agents/prompts/refiner.md`** — Refiner agent prompt that classifies and scopes user-directed refinement requests into Tier 1/2/3, identifies affected files, estimates scope, and produces a structured Builder task description. Does NOT modify code.
- **`factory/agents/runner.py`** — Added `"refiner"` to `AgentRole` Literal type
- **`factory/cli.py`** — Added `--refine <REQUEST>` flag to `factory ceo` CLI subparser with mutual exclusivity checks against `--mode interactive`, `--mode research`, `--prompt`, and `--focus`. Wired through `cmd_ceo` to `_build_ceo_task`. Updated agent role choices list.
- **`factory/agents/prompts/ceo.md`** — Added `Mode: Refine` section with full R0-R12 pipeline: Refiner classification → Tier gate → Begin experiment → GitHub issue → Builder → **FULL review pipeline** (2d-review structured checklist, review-until-clean loop, guard check, post-eval, E2E verification, precheck gate, final review) → Keep/revert verdict → Archivist batch

## Key Design Decisions

- The review pipeline (R5-R10) explicitly references Improve mode steps 2d-review through 2h-final and is NOT abbreviated — identical quality gates apply
- Tier 3 requests exit early with a message directing users to full Improve mode
- Archivist runs once at the end (single batch) instead of after every agent, since the pipeline is shorter
- The Refiner is a read-only classifier — it never modifies code

## Test Plan

- [x] `pytest -v` — 1850 tests pass (1 pre-existing failure in `test_playbook_hygiene.py` from commit `03d0cb0`)
- [x] `ruff check .` — All checks passed
- [x] `mypy factory/` — Success, no issues found
- [x] Refiner prompt resolves correctly via `resolve_prompt('refiner')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)