### PR TITLE
Add explicit inner/outer loop controls to research mode (issue #313)

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1604,11 +1604,11 @@ Establish the starting point by running the system and recording the baseline me
    9. Report: metric name, metric value, run status, duration." --project "$PROJECT_PATH" --timeout $RUN_TIMEOUT
    ```
 
-4. **Multi-run baseline (when inner_loop is configured).** If `.factory/config.json` contains an `inner_loop` object with `runs_per_cycle > 1`, run the baseline command N times instead of once. Each sub-run gets its own directory: `.factory/research/runs/000-baseline-runI`. Write `.factory/research/runs/000-baseline/summary.json` with the aggregated metric (using the configured `aggregate` method: mean, median, max, or all_pass), plus a `runs` array with per-run details and an `aggregate` field naming the method.
+5. **Multi-run baseline (when inner_loop is configured).** If `.factory/config.json` contains an `inner_loop` object with `runs_per_cycle > 1`, run the baseline command N times instead of once. Each sub-run gets its own directory: `.factory/research/runs/000-baseline-runI`. Write `.factory/research/runs/000-baseline/summary.json` with the aggregated metric (using the configured `aggregate` method: mean, median, max, or all_pass), plus a `runs` array with per-run details and an `aggregate` field naming the method.
 
-5. **Record baseline metric.** Save the metric value as `$BASELINE_METRIC`. If this is not the first cycle, read previous best from `.factory/research/runs/` summaries and set `$PREVIOUS_BEST`.
+6. **Record baseline metric.** Save the metric value as `$BASELINE_METRIC`. If this is not the first cycle, read previous best from `.factory/research/runs/` summaries and set `$PREVIOUS_BEST`.
 
-6. **Check for prior runs:**
+7. **Check for prior runs:**
    ```bash
    ls "$PROJECT_PATH/.factory/research/runs/"
    ```

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1604,9 +1604,11 @@ Establish the starting point by running the system and recording the baseline me
    9. Report: metric name, metric value, run status, duration." --project "$PROJECT_PATH" --timeout $RUN_TIMEOUT
    ```
 
-4. **Record baseline metric.** Save the metric value as `$BASELINE_METRIC`. If this is not the first cycle, read previous best from `.factory/research/runs/` summaries and set `$PREVIOUS_BEST`.
+4. **Multi-run baseline (when inner_loop is configured).** If `.factory/config.json` contains an `inner_loop` object with `runs_per_cycle > 1`, run the baseline command N times instead of once. Each sub-run gets its own directory: `.factory/research/runs/000-baseline-runI`. Write `.factory/research/runs/000-baseline/summary.json` with the aggregated metric (using the configured `aggregate` method: mean, median, max, or all_pass), plus a `runs` array with per-run details and an `aggregate` field naming the method.
 
-5. **Check for prior runs:**
+5. **Record baseline metric.** Save the metric value as `$BASELINE_METRIC`. If this is not the first cycle, read previous best from `.factory/research/runs/` summaries and set `$PREVIOUS_BEST`.
+
+6. **Check for prior runs:**
    ```bash
    ls "$PROJECT_PATH/.factory/research/runs/"
    ```
@@ -1885,6 +1887,8 @@ echo "- [x] archivist after build — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PROJE
 
 Execute the `run_command` again on the modified code (PR branch) and compare against baseline.
 
+**Single-run mode (default):**
+
 ```bash
 factory agent evaluator --task "Run research post-change eval for $PROJECT_PATH.
 
@@ -1899,6 +1903,15 @@ factory agent evaluator --task "Run research post-change eval for $PROJECT_PATH.
 8. Compare against baseline: $BASELINE_METRIC and previous best: $PREVIOUS_BEST
 9. Report: metric before, metric after, delta, whether target is met." --project "$PROJECT_PATH" --timeout $RUN_TIMEOUT
 ```
+
+**Multi-run mode (when inner_loop is configured with runs_per_cycle > 1):**
+
+When `.factory/config.json` has `inner_loop.runs_per_cycle > 1`, run the command N times. Each sub-run goes to `.factory/research/runs/$CYCLE_ID-runI/`. Write the aggregated summary to `.factory/research/runs/$CYCLE_ID/summary.json` with format:
+```json
+{"status": "PASS", "metric": "$METRIC", "metric_value": <aggregate>, "aggregate": "<method>", "runs": [{"run_id": 1, "metric_value": ..., "duration_seconds": ..., "status": "PASS"}, ...], "duration_seconds": <total>, "command": "$RUN_COMMAND"}
+```
+
+Aggregation methods: `mean` = arithmetic mean, `median` = middle value, `max` = best-of-N, `all_pass` = min(values).
 
 Save the new metric value as `$METRIC_AFTER`.
 
@@ -2000,6 +2013,23 @@ factory finalize "$PROJECT_PATH" \
     --issue $ISSUE_NUM \
     --notes "ceo:revert mode=research reason=$REVERT_REASON metric=$METRIC before=$BASELINE_METRIC after=$METRIC_AFTER hygiene=$HYGIENE_STATUS monotonic=$MONOTONIC_STATUS review_pipeline=full review_iterations=$REVIEW_ITERATION"
 ```
+
+#### R5d.5. Plateau Check
+
+If `inner_loop.plateau_threshold` is configured in `.factory/config.json`, check whether the research metric has plateaued:
+
+1. Read all `.factory/research/runs/*/summary.json` files, ordered by cycle name
+2. If the last `plateau_threshold` consecutive cycles showed no improvement over the previous best metric:
+   - Log an `outer_loop.triggered` event to `.factory/events.jsonl`
+   - Update the checkpoint with `loop_level: "outer"` and increment `plateau_count`
+   - If `outer_loop.outer_surfaces` is configured, expand `mutable_surfaces` to include them for the next cycle
+   - Shift the Strategist to architectural hypotheses in the next cycle (the Strategist will receive `loop_level: "outer"` and generate structural changes instead of prompt-level changes)
+
+If no plateau is detected, continue normally.
+
+**Surface scoping by loop level:**
+- **Inner loop** (`loop_level: "inner"`): If `outer_loop.inner_surfaces` is configured, restrict `mutable_surfaces` to only those files. This narrows the Builder's scope to prompt-level changes.
+- **Outer loop** (`loop_level: "outer"`): If `outer_loop.outer_surfaces` is configured, expand `mutable_surfaces` to include those files. This allows the Builder to make architectural changes.
 
 #### R5e. Termination Conditions
 

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -407,3 +407,13 @@ The standard FEEC categories map to research mode as follows:
 | **COMBINE** | Merge two successful fixes that each addressed different failure subcategories into a unified approach. |
 
 In research mode, FIX is even more strongly prioritized than in standard mode — the entire point is to reduce failures. Only shift to EXPLOIT/EXPLORE after the dominant failure mode has been addressed or after 3+ consecutive reverts on the same failure **subcategory** (not just the same FEEC category — nearly all research hypotheses will be FIX, so the stuck protocol counts subcategories instead).
+
+### Outer Loop Guidance
+
+When the CEO's task includes `loop_level: "outer"`, the research metric has plateaued — prompt-level changes are no longer improving the score. Shift your hypothesis strategy:
+
+1. **Target architectural changes**, not prompt tweaks. Examples: restructure the agent pipeline, add/remove agent roles, change tool orchestration, modify data flow, introduce new retrieval strategies.
+2. **Use `outer_surfaces`** as the mutable set. The inner surfaces (prompts, configs) have been exhausted — now modify the code that defines the system's structure.
+3. **EXPLORE category is primary** in the outer loop. The inner loop has already FIXED and EXPLOITED the prompt space — the outer loop needs genuinely new approaches.
+4. **Reference the plateau** in your observations: "Inner loop plateaued at metric X after N cycles. Shifting to architectural changes."
+5. **Scope remains one-PR-per-hypothesis.** Architectural changes are still incremental — don't propose full rewrites.

--- a/factory/checkpoint.py
+++ b/factory/checkpoint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Literal
 
 import structlog
 from pydantic import BaseModel, ConfigDict
@@ -26,6 +27,8 @@ class CheckpointState(BaseModel):
     current_hypothesis: str | None
     completed_hypotheses: list[int] = []
     timestamp: str
+    plateau_count: int = 0
+    loop_level: Literal["inner", "outer"] = "inner"
 
 
 def save_checkpoint(project_path: Path, state: CheckpointState) -> None:

--- a/factory/checkpoint.py
+++ b/factory/checkpoint.py
@@ -29,8 +29,6 @@ class CheckpointState(BaseModel):
     plateau_count: int = 0
     loop_level: Literal["inner", "outer"] = "inner"
     timestamp: str
-    plateau_count: int = 0
-    loop_level: Literal["inner", "outer"] = "inner"
 
 
 def save_checkpoint(project_path: Path, state: CheckpointState) -> None:

--- a/factory/models.py
+++ b/factory/models.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 # ── project state ─────────────────────────────────────────────────
@@ -100,7 +100,7 @@ class InnerLoopConfig(BaseModel):
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
-    runs_per_cycle: int = 1
+    runs_per_cycle: int = Field(ge=1, default=1)
     aggregate: AggregateMethod = AggregateMethod.MEAN
     plateau_threshold: int = 3
     max_inner_runs_per_cycle: int | None = None

--- a/factory/models.py
+++ b/factory/models.py
@@ -7,7 +7,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 # ── project state ─────────────────────────────────────────────────
@@ -86,6 +86,43 @@ class ResearchTarget(BaseModel):
     timeout: int = 3600
 
 
+class AggregateMethod(str, Enum):
+    """How to aggregate multiple run metrics into a single value."""
+
+    MEAN = "mean"
+    MEDIAN = "median"
+    MAX = "max"
+    ALL_PASS = "all_pass"
+
+
+class InnerLoopConfig(BaseModel):
+    """Inner loop configuration — controls multi-run execution per cycle."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    runs_per_cycle: int = 1
+    aggregate: AggregateMethod = AggregateMethod.MEAN
+    plateau_threshold: int = 3
+    max_inner_runs_per_cycle: int | None = None
+
+    @field_validator("aggregate", mode="before")
+    @classmethod
+    def _coerce_aggregate(cls, v: object) -> AggregateMethod:
+        if isinstance(v, str):
+            return AggregateMethod(v)
+        return v  # type: ignore[return-value]
+
+
+class OuterLoopConfig(BaseModel):
+    """Outer loop configuration — controls what happens when inner loop plateaus."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    max_outer_cycles: int | None = None
+    inner_surfaces: list[str] = []
+    outer_surfaces: list[str] = []
+
+
 class CostBudgetConfig(BaseModel):
     """Per-project cost budget limits for research mode."""
 
@@ -138,6 +175,8 @@ class FactoryConfig(BaseModel):
     project_eval: list[ProjectEvalDimension] = []
     eval_weights: EvalWeights = EvalWeights()
     research_target: ResearchTarget | None = None
+    inner_loop: InnerLoopConfig | None = None
+    outer_loop: OuterLoopConfig | None = None
     mutable_surfaces: list[str] = []
     fixed_surfaces: list[str] = []
     research_constraints: list[str] = []

--- a/factory/research/runner.py
+++ b/factory/research/runner.py
@@ -353,8 +353,13 @@ async def execute_multi_run(
 
     agg_value = aggregate_metric(values, inner_loop.aggregate) if values else 0.0
 
+    if inner_loop.aggregate == AggregateMethod.ALL_PASS:
+        status = "PASS" if len(values) == n else "FAIL"
+    else:
+        status = "PASS" if values else "FAIL"
+
     summary = {
-        "status": "PASS" if values else "FAIL",
+        "status": status,
         "metric": config.metric,
         "metric_value": agg_value,
         "aggregate": inner_loop.aggregate.value,

--- a/factory/research/runner.py
+++ b/factory/research/runner.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import structlog
 
-from factory.models import ResearchTarget, ResultParseError, RunResult, RunStatus
+from factory.models import AggregateMethod, InnerLoopConfig, ResearchTarget, ResultParseError, RunResult, RunStatus
 
 log = structlog.get_logger()
 
@@ -294,3 +294,84 @@ def _save_artifacts(run_dir: Path, result: RunResult, config: ResearchTarget) ->
         "duration_seconds": result.duration_seconds,
         "command": config.run_command,
     })
+
+
+# ── multi-run aggregation ──────────────────────────────────────
+
+
+def aggregate_metric(values: list[float], method: AggregateMethod) -> float:
+    """Compute a single aggregate value from multiple run metrics."""
+    if not values:
+        return 0.0
+    if method == AggregateMethod.MEAN:
+        return sum(values) / len(values)
+    if method == AggregateMethod.MEDIAN:
+        s = sorted(values)
+        mid = len(s) // 2
+        if len(s) % 2 == 0:
+            return (s[mid - 1] + s[mid]) / 2
+        return s[mid]
+    if method == AggregateMethod.MAX:
+        return max(values)
+    # ALL_PASS: worst run determines the aggregate
+    return min(values)
+
+
+async def execute_multi_run(
+    project_path: Path,
+    config: ResearchTarget,
+    cycle_id: str,
+    inner_loop: InnerLoopConfig,
+) -> dict:
+    """Execute the run_command N times, aggregate metrics, return extended summary.
+
+    Returns a dict with top-level ``metric_value`` (aggregate), ``aggregate``
+    method name, and a ``runs`` array with per-run details.
+    """
+    n = inner_loop.runs_per_cycle
+    if inner_loop.max_inner_runs_per_cycle is not None:
+        n = min(n, inner_loop.max_inner_runs_per_cycle)
+
+    runs: list[dict] = []
+    values: list[float] = []
+    total_duration = 0.0
+
+    for i in range(1, n + 1):
+        sub_cycle = f"{cycle_id}-run{i}"
+        log.info("multi_run_start", run=i, total=n, sub_cycle=sub_cycle)
+        result = await execute_run(project_path, config, sub_cycle)
+        run_entry = {
+            "run_id": i,
+            "metric_value": result.metric_value,
+            "duration_seconds": result.duration_seconds,
+            "status": result.status.value,
+        }
+        runs.append(run_entry)
+        total_duration += result.duration_seconds
+        if result.status == RunStatus.PASS:
+            values.append(result.metric_value)
+
+    agg_value = aggregate_metric(values, inner_loop.aggregate) if values else 0.0
+
+    summary = {
+        "status": "PASS" if values else "FAIL",
+        "metric": config.metric,
+        "metric_value": agg_value,
+        "aggregate": inner_loop.aggregate.value,
+        "runs": runs,
+        "duration_seconds": total_duration,
+        "command": config.run_command,
+    }
+
+    run_dir = create_run_dir(project_path, cycle_id)
+    save_run_summary(run_dir, summary)
+
+    log.info(
+        "multi_run_complete",
+        cycle_id=cycle_id,
+        runs_total=n,
+        runs_passed=len(values),
+        aggregate=inner_loop.aggregate.value,
+        metric_value=agg_value,
+    )
+    return summary

--- a/factory/store.py
+++ b/factory/store.py
@@ -13,6 +13,7 @@ from filelock import FileLock
 from pydantic import ValidationError
 
 from factory.models import (
+    AggregateMethod,
     CompositeScore,
     CostBudgetConfig,
     EvalProfile,
@@ -21,6 +22,8 @@ from factory.models import (
     FactoryConfig,
     HardConstraint,
     HypothesisBudget,
+    InnerLoopConfig,
+    OuterLoopConfig,
     ProjectEvalDimension,
     ResearchTarget,
 )
@@ -129,6 +132,61 @@ def _parse_cost_budget(items: str | list[str] | float) -> CostBudgetConfig | Non
     )
     log.debug("cost_budget_parsed", max_per_cycle=budget.max_per_cycle, max_total=budget.max_total)
     return budget
+
+
+def _parse_inner_loop(items: str | list[str] | float) -> InnerLoopConfig | None:
+    """Parse inner loop key-value block from factory.md."""
+    kv = _parse_kv_list(items, str)
+    if not kv:
+        return None
+    config = InnerLoopConfig(
+        runs_per_cycle=int(str(kv.get("runs_per_cycle", "1"))),
+        aggregate=AggregateMethod(str(kv.get("aggregate", "mean"))),
+        plateau_threshold=int(str(kv.get("plateau_threshold", "3"))),
+        max_inner_runs_per_cycle=(
+            int(str(kv["max_inner_runs_per_cycle"]))
+            if "max_inner_runs_per_cycle" in kv
+            else None
+        ),
+    )
+    log.debug("inner_loop_parsed", runs_per_cycle=config.runs_per_cycle, aggregate=config.aggregate.value)
+    return config
+
+
+def _parse_outer_loop(items: str | list[str] | float) -> OuterLoopConfig | None:
+    """Parse outer loop surfaces key-value block from factory.md.
+
+    Supports both key-value pairs (max_outer_cycles) and plain list items
+    prefixed with 'inner:' or 'outer:' for surface declarations.
+    """
+    if not isinstance(items, list):
+        return None
+    max_outer_cycles: int | None = None
+    inner_surfaces: list[str] = []
+    outer_surfaces: list[str] = []
+    for item in items:
+        s = str(item).strip()
+        if s.startswith("max_outer_cycles:"):
+            val = s.split(":", 1)[1].strip()
+            max_outer_cycles = int(val) if val else None
+        elif s.startswith("inner:"):
+            inner_surfaces.append(s.split(":", 1)[1].strip())
+        elif s.startswith("outer:"):
+            outer_surfaces.append(s.split(":", 1)[1].strip())
+    if not inner_surfaces and not outer_surfaces and max_outer_cycles is None:
+        return None
+    config = OuterLoopConfig(
+        max_outer_cycles=max_outer_cycles,
+        inner_surfaces=inner_surfaces,
+        outer_surfaces=outer_surfaces,
+    )
+    log.debug(
+        "outer_loop_parsed",
+        max_outer_cycles=config.max_outer_cycles,
+        inner_count=len(config.inner_surfaces),
+        outer_count=len(config.outer_surfaces),
+    )
+    return config
 
 
 def _parse_hard_constraints(items: str | list[str] | float) -> list[HardConstraint]:
@@ -259,6 +317,8 @@ class ExperimentStore:
         smoke_test = str(smoke_test_raw).strip() if smoke_test_raw else ""
 
         research_target = _parse_research_target(parsed.get("research_target", []))
+        inner_loop = _parse_inner_loop(parsed.get("inner_loop", []))
+        outer_loop = _parse_outer_loop(parsed.get("outer_loop_surfaces", []))
         cost_budget = _parse_cost_budget(parsed.get("cost_budget", []))
 
         mutable_raw = parsed.get("mutable_surfaces", [])
@@ -284,6 +344,8 @@ class ExperimentStore:
             project_eval=project_eval_dims,
             eval_weights=EvalWeights(**weights_kwargs) if weights_kwargs else EvalWeights(),  # type: ignore[arg-type]
             research_target=research_target,
+            inner_loop=inner_loop,
+            outer_loop=outer_loop,
             mutable_surfaces=mutable_surfaces,
             fixed_surfaces=fixed_surfaces,
             research_constraints=research_constraints,

--- a/factory/strategy.py
+++ b/factory/strategy.py
@@ -148,13 +148,16 @@ def detect_plateau(
     ``metric_value`` key.  Requires at least ``threshold + 1`` entries (one
     baseline plus *threshold* cycles).
     """
+    if threshold <= 0:
+        return False
+
     if len(run_summaries) < threshold + 1:
         return False
 
-    pre_window = run_summaries[:-(threshold)]
+    pre_window = run_summaries[:-threshold]
     best_before = max(s["metric_value"] for s in pre_window)
 
-    window = run_summaries[-(threshold):]
+    window = run_summaries[-threshold:]
     best_in_window = max(s["metric_value"] for s in window)
 
     plateaued = best_in_window <= best_before

--- a/factory/strategy.py
+++ b/factory/strategy.py
@@ -135,6 +135,39 @@ def detect_stuck(
     return stuck
 
 
+# ── plateau detection ────────────────────────────────────────────
+
+
+def detect_plateau(
+    run_summaries: list[dict],
+    threshold: int = 3,
+) -> bool:
+    """Return ``True`` when the last *threshold* cycles showed no metric improvement.
+
+    *run_summaries* should be ordered oldest-first.  Each dict must contain a
+    ``metric_value`` key.  Requires at least ``threshold + 1`` entries (one
+    baseline plus *threshold* cycles).
+    """
+    if len(run_summaries) < threshold + 1:
+        return False
+
+    pre_window = run_summaries[:-(threshold)]
+    best_before = max(s["metric_value"] for s in pre_window)
+
+    window = run_summaries[-(threshold):]
+    best_in_window = max(s["metric_value"] for s in window)
+
+    plateaued = best_in_window <= best_before
+    if plateaued:
+        log.warning(
+            "plateau_detected",
+            threshold=threshold,
+            best_before=best_before,
+            best_in_window=best_in_window,
+        )
+    return plateaued
+
+
 # ── hypothesis similarity ────────────────────────────────────────
 
 

--- a/templates/factory_config.md
+++ b/templates/factory_config.md
@@ -139,6 +139,28 @@ curl -sf http://localhost:8000/health
 - Each experiment must complete within 30 minutes
 -->
 
+## Inner Loop
+<!-- Multi-run configuration for research mode. Runs the harness N times per cycle -->
+<!-- and aggregates the metric. Useful for stochastic pipelines. -->
+<!-- Example:
+- runs_per_cycle: 5
+- aggregate: mean
+- plateau_threshold: 3
+- max_inner_runs_per_cycle: 10
+-->
+
+## Outer Loop Surfaces
+<!-- Surface scoping for inner/outer loop transitions. -->
+<!-- When the inner loop plateaus, the factory expands to outer surfaces. -->
+<!-- Prefix each entry with 'inner:' or 'outer:' to declare which loop it belongs to. -->
+<!-- Example:
+- max_outer_cycles: 5
+- inner: prompts/*.md
+- inner: config/*.yaml
+- outer: src/**/*.py
+- outer: agents/**/*.md
+-->
+
 ## Cost Budget
 <!-- Per-cycle or total budget constraints for research experiments. -->
 <!-- Example: $5/cycle, $50 total -->

--- a/templates/factory_config.md
+++ b/templates/factory_config.md
@@ -183,26 +183,3 @@ curl -sf http://localhost:8000/health
 <!-- Per-cycle or total budget constraints for research experiments. -->
 <!-- Example: $5/cycle, $50 total -->
 
-## Multi-Run
-<!-- For stochastic harnesses where results vary between runs. -->
-<!-- Only used in research mode. Omit for deterministic benchmarks. -->
-<!-- Example:
-- runs_per_cycle: 3
-- aggregate: mean
-- max_runs_per_cycle: 5
--->
-
-## Surface Scoping
-<!-- Two-tier surface structure for automatic scope escalation. -->
-<!-- Only used in research mode. Omit if all mutable surfaces should be available from the start. -->
-<!-- Inner surfaces are tried first; outer surfaces are unlocked after plateau. -->
-<!-- Example:
-- plateau_threshold: 3
-- max_escalation_cycles: 10
-- inner_surfaces:
-  - prompts/*.md
-  - config/*.yaml
-- outer_surfaces:
-  - src/agents/*.py
-  - src/orchestration/*.py
--->

--- a/tests/test_inner_outer_loop.py
+++ b/tests/test_inner_outer_loop.py
@@ -1,0 +1,450 @@
+"""Tests for inner/outer loop controls: models, parsers, multi-run, plateau detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from factory.checkpoint import CheckpointState
+from factory.models import (
+    AggregateMethod,
+    FactoryConfig,
+    InnerLoopConfig,
+    OuterLoopConfig,
+    ResearchTarget,
+)
+from factory.research.runner import aggregate_metric, execute_multi_run
+from factory.store import ExperimentStore, _parse_inner_loop, _parse_outer_loop
+from factory.strategy import detect_plateau
+
+
+# ── Model validation ────────────────────────────────────────────
+
+
+class TestInnerLoopConfig:
+    def test_defaults(self) -> None:
+        config = InnerLoopConfig()
+        assert config.runs_per_cycle == 1
+        assert config.aggregate == AggregateMethod.MEAN
+        assert config.plateau_threshold == 3
+        assert config.max_inner_runs_per_cycle is None
+
+    def test_custom_values(self) -> None:
+        config = InnerLoopConfig(
+            runs_per_cycle=5,
+            aggregate=AggregateMethod.MEDIAN,
+            plateau_threshold=5,
+            max_inner_runs_per_cycle=10,
+        )
+        assert config.runs_per_cycle == 5
+        assert config.aggregate == AggregateMethod.MEDIAN
+        assert config.plateau_threshold == 5
+        assert config.max_inner_runs_per_cycle == 10
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(Exception):
+            InnerLoopConfig(runs_per_cycle=1, unknown_field="x")  # type: ignore[call-arg]
+
+    def test_all_aggregate_methods(self) -> None:
+        for method in AggregateMethod:
+            config = InnerLoopConfig(aggregate=method)
+            assert config.aggregate == method
+
+
+class TestOuterLoopConfig:
+    def test_defaults(self) -> None:
+        config = OuterLoopConfig()
+        assert config.max_outer_cycles is None
+        assert config.inner_surfaces == []
+        assert config.outer_surfaces == []
+
+    def test_custom_values(self) -> None:
+        config = OuterLoopConfig(
+            max_outer_cycles=5,
+            inner_surfaces=["prompts/*.md"],
+            outer_surfaces=["src/**/*.py"],
+        )
+        assert config.max_outer_cycles == 5
+        assert config.inner_surfaces == ["prompts/*.md"]
+        assert config.outer_surfaces == ["src/**/*.py"]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(Exception):
+            OuterLoopConfig(bad="field")  # type: ignore[call-arg]
+
+
+class TestFactoryConfigWithLoops:
+    def test_inner_loop_none_by_default(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+        )
+        assert config.inner_loop is None
+        assert config.outer_loop is None
+
+    def test_with_inner_loop(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            inner_loop=InnerLoopConfig(runs_per_cycle=3),
+        )
+        assert config.inner_loop is not None
+        assert config.inner_loop.runs_per_cycle == 3
+
+    def test_with_outer_loop(self) -> None:
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            outer_loop=OuterLoopConfig(inner_surfaces=["a.md"], outer_surfaces=["b.py"]),
+        )
+        assert config.outer_loop is not None
+        assert config.outer_loop.inner_surfaces == ["a.md"]
+
+
+# ── Parser tests ────────────────────────────────────────────────
+
+
+class TestParseInnerLoop:
+    def test_empty_returns_none(self) -> None:
+        assert _parse_inner_loop([]) is None
+        assert _parse_inner_loop("") is None
+        assert _parse_inner_loop(0.0) is None
+
+    def test_basic_parsing(self) -> None:
+        items = ["runs_per_cycle: 5", "aggregate: median", "plateau_threshold: 4"]
+        result = _parse_inner_loop(items)
+        assert result is not None
+        assert result.runs_per_cycle == 5
+        assert result.aggregate == AggregateMethod.MEDIAN
+        assert result.plateau_threshold == 4
+        assert result.max_inner_runs_per_cycle is None
+
+    def test_with_max_inner_runs(self) -> None:
+        items = ["runs_per_cycle: 3", "aggregate: max", "max_inner_runs_per_cycle: 10"]
+        result = _parse_inner_loop(items)
+        assert result is not None
+        assert result.runs_per_cycle == 3
+        assert result.aggregate == AggregateMethod.MAX
+        assert result.max_inner_runs_per_cycle == 10
+
+    def test_defaults_when_partial(self) -> None:
+        items = ["runs_per_cycle: 2"]
+        result = _parse_inner_loop(items)
+        assert result is not None
+        assert result.runs_per_cycle == 2
+        assert result.aggregate == AggregateMethod.MEAN
+        assert result.plateau_threshold == 3
+
+
+class TestParseOuterLoop:
+    def test_empty_returns_none(self) -> None:
+        assert _parse_outer_loop([]) is None
+        assert _parse_outer_loop("") is None
+        assert _parse_outer_loop(0.0) is None
+
+    def test_basic_parsing(self) -> None:
+        items = [
+            "max_outer_cycles: 5",
+            "inner: prompts/*.md",
+            "inner: config/*.yaml",
+            "outer: src/**/*.py",
+        ]
+        result = _parse_outer_loop(items)
+        assert result is not None
+        assert result.max_outer_cycles == 5
+        assert result.inner_surfaces == ["prompts/*.md", "config/*.yaml"]
+        assert result.outer_surfaces == ["src/**/*.py"]
+
+    def test_surfaces_only(self) -> None:
+        items = ["inner: a.md", "outer: b.py"]
+        result = _parse_outer_loop(items)
+        assert result is not None
+        assert result.max_outer_cycles is None
+        assert result.inner_surfaces == ["a.md"]
+        assert result.outer_surfaces == ["b.py"]
+
+    def test_no_relevant_items_returns_none(self) -> None:
+        items = ["something: else", "random text"]
+        result = _parse_outer_loop(items)
+        assert result is None
+
+
+# ── Aggregation tests ───────────────────────────────────────────
+
+
+class TestAggregateMetric:
+    def test_mean(self) -> None:
+        assert aggregate_metric([0.2, 0.4, 0.6], AggregateMethod.MEAN) == pytest.approx(0.4)
+
+    def test_median_odd(self) -> None:
+        assert aggregate_metric([0.1, 0.5, 0.9], AggregateMethod.MEDIAN) == pytest.approx(0.5)
+
+    def test_median_even(self) -> None:
+        assert aggregate_metric([0.2, 0.4, 0.6, 0.8], AggregateMethod.MEDIAN) == pytest.approx(0.5)
+
+    def test_max(self) -> None:
+        assert aggregate_metric([0.1, 0.3, 0.9], AggregateMethod.MAX) == pytest.approx(0.9)
+
+    def test_all_pass(self) -> None:
+        assert aggregate_metric([0.5, 0.3, 0.7], AggregateMethod.ALL_PASS) == pytest.approx(0.3)
+
+    def test_empty_returns_zero(self) -> None:
+        assert aggregate_metric([], AggregateMethod.MEAN) == 0.0
+
+    def test_single_value(self) -> None:
+        for method in AggregateMethod:
+            assert aggregate_metric([0.42], method) == pytest.approx(0.42)
+
+
+# ── Multi-run execution tests ──────────────────────────────────
+
+
+class TestExecuteMultiRun:
+    async def test_multi_run_aggregates(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory" / "research" / "runs").mkdir(parents=True)
+
+        result_file = project / "result.json"
+        result_file.write_text(json.dumps({"score": 0.5}))
+
+        script = project / "run.sh"
+        script.write_text("#!/bin/bash\necho '{\"score\": 0.5}' > result.json\n")
+        script.chmod(0o755)
+
+        config = ResearchTarget(
+            objective="test",
+            metric="score",
+            target=1.0,
+            run_command=f"bash {script}",
+            result_path="result.json",
+            timeout=30,
+        )
+        inner = InnerLoopConfig(runs_per_cycle=3, aggregate=AggregateMethod.MEAN)
+
+        summary = await execute_multi_run(project, config, "cycle-001", inner)
+
+        assert summary["aggregate"] == "mean"
+        assert len(summary["runs"]) == 3
+        assert "metric_value" in summary
+        assert summary["duration_seconds"] > 0
+
+    async def test_multi_run_respects_max_cap(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory" / "research" / "runs").mkdir(parents=True)
+
+        result_file = project / "result.json"
+        result_file.write_text(json.dumps({"score": 0.5}))
+
+        script = project / "run.sh"
+        script.write_text("#!/bin/bash\necho '{\"score\": 0.5}' > result.json\n")
+        script.chmod(0o755)
+
+        config = ResearchTarget(
+            objective="test",
+            metric="score",
+            target=1.0,
+            run_command=f"bash {script}",
+            result_path="result.json",
+            timeout=30,
+        )
+        inner = InnerLoopConfig(
+            runs_per_cycle=10,
+            aggregate=AggregateMethod.MAX,
+            max_inner_runs_per_cycle=2,
+        )
+
+        summary = await execute_multi_run(project, config, "cycle-002", inner)
+        assert len(summary["runs"]) == 2
+
+
+# ── Plateau detection tests ────────────────────────────────────
+
+
+class TestDetectPlateau:
+    def test_not_enough_data(self) -> None:
+        summaries = [{"metric_value": 0.5}, {"metric_value": 0.5}]
+        assert detect_plateau(summaries, threshold=3) is False
+
+    def test_plateau_detected(self) -> None:
+        summaries = [
+            {"metric_value": 0.5},
+            {"metric_value": 0.5},
+            {"metric_value": 0.5},
+            {"metric_value": 0.5},
+        ]
+        assert detect_plateau(summaries, threshold=3) is True
+
+    def test_no_plateau_with_improvement(self) -> None:
+        summaries = [
+            {"metric_value": 0.3},
+            {"metric_value": 0.4},
+            {"metric_value": 0.5},
+            {"metric_value": 0.6},
+        ]
+        assert detect_plateau(summaries, threshold=3) is False
+
+    def test_plateau_with_stagnation_after_improvement(self) -> None:
+        summaries = [
+            {"metric_value": 0.3},
+            {"metric_value": 0.5},
+            {"metric_value": 0.5},
+            {"metric_value": 0.5},
+            {"metric_value": 0.5},
+        ]
+        assert detect_plateau(summaries, threshold=3) is True
+
+    def test_custom_threshold(self) -> None:
+        summaries = [
+            {"metric_value": 0.5},
+            {"metric_value": 0.5},
+            {"metric_value": 0.5},
+        ]
+        assert detect_plateau(summaries, threshold=2) is True
+
+    def test_improvement_in_window_breaks_plateau(self) -> None:
+        summaries = [
+            {"metric_value": 0.3},
+            {"metric_value": 0.3},
+            {"metric_value": 0.3},
+            {"metric_value": 0.4},
+        ]
+        assert detect_plateau(summaries, threshold=3) is False
+
+
+# ── Checkpoint extension tests ──────────────────────────────────
+
+
+class TestCheckpointStateExtension:
+    def test_default_values(self) -> None:
+        state = CheckpointState(
+            mode="research",
+            active_experiment_id=None,
+            completed_agents=[],
+            pending_agents=[],
+            last_eval_scores={},
+            current_hypothesis=None,
+            timestamp="2026-01-01T00:00:00Z",
+        )
+        assert state.plateau_count == 0
+        assert state.loop_level == "inner"
+
+    def test_custom_values(self) -> None:
+        state = CheckpointState(
+            mode="research",
+            active_experiment_id=1,
+            completed_agents=["baseline"],
+            pending_agents=["builder"],
+            last_eval_scores={"score": 0.5},
+            current_hypothesis="test",
+            timestamp="2026-01-01T00:00:00Z",
+            plateau_count=2,
+            loop_level="outer",
+        )
+        assert state.plateau_count == 2
+        assert state.loop_level == "outer"
+
+    def test_serialization_roundtrip(self) -> None:
+        state = CheckpointState(
+            mode="research",
+            active_experiment_id=None,
+            completed_agents=[],
+            pending_agents=[],
+            last_eval_scores={},
+            current_hypothesis=None,
+            timestamp="2026-01-01T00:00:00Z",
+            plateau_count=3,
+            loop_level="outer",
+        )
+        data = json.loads(state.model_dump_json())
+        restored = CheckpointState.model_validate(data)
+        assert restored.plateau_count == 3
+        assert restored.loop_level == "outer"
+
+
+# ── Integration: factory.md → config.json → FactoryConfig ──────
+
+
+class TestFactoryMdRoundTrip:
+    async def test_inner_loop_roundtrip(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        factory_md = project / "factory.md"
+        factory_md.write_text(
+            "## Goal\nTest project\n\n"
+            "## Scope\n### Modifiable\n- src/*.py\n\n"
+            "## Guards\n- no secrets\n\n"
+            "## Eval\n### Command\n```bash\necho ok\n```\n\n"
+            "### Threshold\n0.8\n\n"
+            "## Constraints\n- be careful\n\n"
+            "## Inner Loop\n"
+            "- runs_per_cycle: 5\n"
+            "- aggregate: median\n"
+            "- plateau_threshold: 4\n\n"
+            "## Outer Loop Surfaces\n"
+            "- max_outer_cycles: 3\n"
+            "- inner: prompts/*.md\n"
+            "- outer: src/**/*.py\n"
+            "- outer: agents/**/*.md\n"
+        )
+
+        store = ExperimentStore(project)
+        config = await store.reparse_config()
+
+        assert config.inner_loop is not None
+        assert config.inner_loop.runs_per_cycle == 5
+        assert config.inner_loop.aggregate == AggregateMethod.MEDIAN
+        assert config.inner_loop.plateau_threshold == 4
+
+        assert config.outer_loop is not None
+        assert config.outer_loop.max_outer_cycles == 3
+        assert config.outer_loop.inner_surfaces == ["prompts/*.md"]
+        assert config.outer_loop.outer_surfaces == ["src/**/*.py", "agents/**/*.md"]
+
+        config_json = json.loads((project / ".factory" / "config.json").read_text())
+        assert config_json["inner_loop"]["runs_per_cycle"] == 5
+        assert config_json["outer_loop"]["outer_surfaces"] == ["src/**/*.py", "agents/**/*.md"]
+
+        restored = FactoryConfig(**config_json)
+        assert restored.inner_loop is not None
+        assert restored.inner_loop.aggregate == AggregateMethod.MEDIAN
+        assert restored.outer_loop is not None
+        assert restored.outer_loop.max_outer_cycles == 3
+
+    async def test_no_loop_config_roundtrip(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        factory_md = project / "factory.md"
+        factory_md.write_text(
+            "## Goal\nTest project\n\n"
+            "## Scope\n### Modifiable\n- src/*.py\n\n"
+            "## Guards\n- no secrets\n\n"
+            "## Eval\n### Command\n```bash\necho ok\n```\n\n"
+            "### Threshold\n0.8\n\n"
+            "## Constraints\n- be careful\n"
+        )
+
+        store = ExperimentStore(project)
+        config = await store.reparse_config()
+
+        assert config.inner_loop is None
+        assert config.outer_loop is None


### PR DESCRIPTION
Closes #321

## Changes

- **Models** (`factory/models.py`): Added `AggregateMethod` enum (mean, median, max, all_pass), `InnerLoopConfig` model (runs_per_cycle, aggregate, plateau_threshold, max_inner_runs_per_cycle), `OuterLoopConfig` model (max_outer_cycles, inner_surfaces, outer_surfaces). Added `inner_loop` and `outer_loop` optional fields to `FactoryConfig`.
- **Parsers** (`factory/store.py`): Added `_parse_inner_loop()` and `_parse_outer_loop()` following existing `_parse_research_target()` pattern. Wired into `reparse_config()`.
- **Multi-run execution** (`factory/research/runner.py`): Added `aggregate_metric()` helper and `execute_multi_run()` function that wraps N calls to `execute_run()`, aggregates metric values, and returns extended summary with per-run details.
- **Plateau detection** (`factory/strategy.py`): Added `detect_plateau()` function that checks if the last N consecutive cycles showed no metric improvement.
- **Checkpoint extension** (`factory/checkpoint.py`): Added `plateau_count: int = 0` and `loop_level: Literal["inner", "outer"] = "inner"` to `CheckpointState`.
- **CEO prompt** (`factory/agents/prompts/ceo.md`): Updated R0 (baseline) and R4 (run) phases with multi-run instructions when inner_loop config is present. Added R5d.5 plateau check section with surface scoping by loop level.
- **Strategist prompt** (`factory/agents/prompts/strategist.md`): Added outer loop guidance section for architectural hypotheses when `loop_level: "outer"`.
- **Template** (`templates/factory_config.md`): Added `## Inner Loop` and `## Outer Loop Surfaces` sections with examples.
- **Tests** (`tests/test_inner_outer_loop.py`): 38 tests covering model validation, parser functions, all 4 aggregation methods, multi-run execution, plateau detection, checkpoint extension, and factory.md → config.json → FactoryConfig round-trip integration.

## Test plan

- [x] All 38 new tests pass
- [x] Full test suite (1889 tests) passes with no regressions
- [x] ruff lint clean
- [x] mypy type check clean