### PR TITLE
Fix inner/outer loop semantics and add validated interactive extraction

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -456,7 +456,10 @@ Raw idea: <RAW_IDEA>
 
 This is a research project. You MUST include the Research Configuration section
 in your output with all fields filled (Research Target, Mutable Surfaces, Fixed
-Surfaces, Research Constraints, Cost Budget).
+Surfaces, Research Constraints, Cost Budget). If the harness is stochastic,
+include the Multi-Run section. If the project has a two-tier surface structure
+(narrow surfaces to try first, wider surfaces to unlock after plateau), include
+the Surface Scoping section.
 
 Read the research report at .factory/strategy/research.md for domain context, technology recommendations, and prior art.
 
@@ -472,6 +475,28 @@ Read `.factory/reviews/distiller-latest.md` and assess the draft:
 - Are features specific enough for a Builder agent?
 
 Write your review to `.factory/reviews/ceo-verdict-distiller.md`.
+
+### I1v: Research Config Validation (Research Ideation Only)
+
+If this is research ideation (`## Research Ideation Mode`), programmatically validate the Research Configuration from the Distiller's output before presenting to the user:
+
+1. **Run command check:** Verify the `Run Command` field specifies an executable command. If the project directory already exists, check that the command's entry point is present (e.g., the script file exists). Flag as ERROR if the run command is empty or references a clearly non-existent path.
+
+2. **Surface pattern validation:** For each glob pattern in Mutable Surfaces and Fixed Surfaces (and Inner/Outer Surfaces if Surface Scoping is included), check that the patterns match actual files in the project directory (if it exists). Flag as WARNING if a pattern matches zero files — it may be intentional for a new project, but the user should confirm.
+
+3. **Surface overlap check:** Verify there is no overlap between `Mutable Surfaces` and `Fixed Surfaces`. If Surface Scoping is configured, also verify no overlap between `Inner Surfaces` and `Outer Surfaces`. Flag as ERROR if any file would appear in both sets — the constraint system requires unambiguous classification.
+
+4. **Present validation results alongside the spec:** When presenting to the user (step I2), include any validation errors or warnings:
+   ```
+   RESEARCH CONFIG VALIDATION:
+   - [ERROR] Run command 'python benchmark.py' — file not found (will be created during build)
+   - [WARNING] Mutable surface 'prompts/*.md' matches 0 files (new project — expected)
+   - [OK] No overlap between mutable and fixed surfaces
+   ```
+
+5. **Re-validate after each Distiller iteration.** When the Distiller produces an updated draft (step I3), re-run this validation on the new output before returning to I2.
+
+If validation finds ERRORs, do NOT block — present them to the user as warnings. The project may not exist yet, so missing files are expected. The user decides whether to fix them or proceed.
 
 ### I2: Present to User
 
@@ -526,7 +551,7 @@ Read the full research report at .factory/strategy/research.md for context.
 Produce a complete updated specification." --project "$PROJECT_PATH" --timeout 300
 ```
 
-Read the Distiller's output and return to **I2** (present the updated draft to the user).
+Read the Distiller's output and return to **I1v** (re-validate the research config if in research ideation mode, then present the updated draft to the user at I2).
 
 ### I4: Finalize and Transition
 
@@ -892,7 +917,9 @@ Eval dimensions have been auto-discovered. Verify they work and mark as reviewed
    - Copy Fixed Surfaces patterns to `## Fixed Surfaces`
    - Copy Research Constraints to `## Research Constraints`
    - Copy Cost Budget to `## Cost Budget`
-   After `factory init`, the config parser will read these sections and populate `config.json` with `research_target`, `mutable_surfaces`, `fixed_surfaces`, etc.
+   - If the spec includes a `### Multi-Run` section, copy its fields (runs_per_cycle, aggregate, max_runs_per_cycle) to `## Multi-Run` in `factory.md`
+   - If the spec includes a `### Surface Scoping` section, copy its fields (plateau_threshold, max_escalation_cycles, inner_surfaces, outer_surfaces) to `## Surface Scoping` in `factory.md`
+   After `factory init`, the config parser will read these sections and populate `config.json` with `research_target`, `mutable_surfaces`, `fixed_surfaces`, etc. If Multi-Run or Surface Scoping sections are present, they will be parsed into the corresponding config fields when the Python infrastructure supports them.
 
 5. Initialize the factory store:
    ```bash
@@ -2090,6 +2117,22 @@ factory finalize "$PROJECT_PATH" \
     --issue $ISSUE_NUM \
     --notes "ceo:revert mode=research reason=$REVERT_REASON metric=$METRIC before=$BASELINE_METRIC after=$METRIC_AFTER hygiene=$HYGIENE_STATUS monotonic=$MONOTONIC_STATUS review_pipeline=full review_iterations=$REVIEW_ITERATION"
 ```
+
+#### R5d.5. Plateau Detection and Surface Scope Expansion
+
+If Surface Scoping is configured in the research config (`.factory/config.json` contains `surface_scoping` with `inner_surfaces`, `outer_surfaces`, and `plateau_threshold`), check for plateau after each verdict:
+
+1. **Count consecutive non-improving cycles.** Read the last N experiment verdicts from `.factory/research/runs/*/summary.json` (where N = `plateau_threshold`). A cycle is "non-improving" if the metric did not increase compared to the previous best.
+
+2. **If consecutive non-improving cycles >= `plateau_threshold`:**
+   - The inner surface scope has been exhausted. Expand the Strategist's mutable surface scope to include both inner and outer surfaces.
+   - Update `$MUTABLE_SURFACES` to include the outer surface patterns in addition to the inner surface patterns.
+   - Log: `factory log "$PROJECT_PATH" "research.plateau_detected" --data '{"consecutive_no_improvement": N, "expanding_surfaces": true}'`
+   - On the next Strategist invocation, pass the expanded surface set and note: "The mutable surface scope has been expanded. Improvements within the inner surface scope have plateaued after N consecutive cycles. You now have access to the outer surfaces in addition to the inner surfaces. Target the expanded mutable surfaces."
+
+3. **If `max_escalation_cycles` is configured** and the number of cycles since surface expansion exceeds the cap, proceed to termination — the expanded surface scope has also been exhausted.
+
+4. **If Surface Scoping is NOT configured**, skip this step entirely — the standard mutable surfaces apply throughout.
 
 #### R5e. Termination Conditions
 

--- a/factory/agents/prompts/distiller.md
+++ b/factory/agents/prompts/distiller.md
@@ -109,7 +109,24 @@ These are fingerprinted for leakage detection.>
 
 ### Cost Budget
 <Optional: per-cycle or total budget constraints>
+
+### Multi-Run (optional — for stochastic harnesses)
+- **Runs Per Cycle**: <N>
+- **Aggregate**: <mean|median|max|all_pass>
+- **Max Runs Per Cycle**: <optional cap>
+
+### Surface Scoping (optional — for automatic scope escalation)
+- **Plateau Threshold**: <consecutive cycles with no improvement before expanding, e.g. 3>
+- **Max Escalation Cycles**: <optional cap>
+- **Inner Surfaces**: <narrow mutable surfaces — one glob per line>
+- **Outer Surfaces**: <additional surfaces unlocked after plateau — one glob per line>
 ```
+
+**Conditional inclusion guidance:**
+
+- Include the **Multi-Run** section when the harness is stochastic (e.g., LLM-based evaluations, sampling-dependent benchmarks, randomized test suites). If the run command produces deterministic results, omit Multi-Run entirely.
+- Include the **Surface Scoping** section when the project has a natural two-tier surface structure — a narrow set of files to try first (inner surfaces) and additional files to unlock if improvements plateau (outer surfaces). If all mutable surfaces should be available from the start, omit Surface Scoping entirely.
+- Both sections are independent — a project may have Multi-Run without Surface Scoping, or vice versa.
 
 If the project is NOT a research project, do not include the Research Configuration section at all — omit it entirely. If unclear, flag it in Open Questions: "Should this project use research mode?"
 

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -407,3 +407,26 @@ The standard FEEC categories map to research mode as follows:
 | **COMBINE** | Merge two successful fixes that each addressed different failure subcategories into a unified approach. |
 
 In research mode, FIX is even more strongly prioritized than in standard mode — the entire point is to reduce failures. Only shift to EXPLOIT/EXPLORE after the dominant failure mode has been addressed or after 3+ consecutive reverts on the same failure **subcategory** (not just the same FEEC category — nearly all research hypotheses will be FIX, so the stuck protocol counts subcategories instead).
+
+## Outer Loop Guidance
+
+When operating in research mode with Surface Scoping configured, the research loop uses a two-tier surface structure:
+
+### Inner Loop (Default)
+
+The inner loop restricts `mutable_surfaces` to the **inner surface set** — the narrow set of files specified in the Surface Scoping configuration. All hypotheses must target files within this set. The metric, run command, and evaluation pipeline remain identical throughout.
+
+### Plateau Detection
+
+If improvements within the current surface scope have plateaued (as determined by the `plateau_threshold` — e.g., 3 consecutive cycles with no metric improvement), the CEO will expand the mutable surface scope to include the **outer surface set**.
+
+When you receive a task indicating that the surface scope has been expanded:
+1. **Target the expanded mutable surfaces.** You now have access to the outer surfaces in addition to the inner surfaces. Generate hypotheses that modify files in the newly available outer surface set.
+2. **Do not repeat exhausted approaches.** If the inner surface scope has been exhausted, do not propose minor variations of previously reverted hypotheses on the same files. The expansion happened because those surfaces could not yield further improvement.
+3. **The mechanism is the same.** The outer loop is not a different mode — it is the same auto-research loop with a wider set of mutable surfaces. The metric, run command, and evaluation pipeline are unchanged.
+
+### What NOT to Do
+
+- Do NOT describe the inner loop as "prompt-level changes" or "prompt tweaks." Inner surfaces may include any file type — prompts, configs, agent logic, tool definitions, few-shot examples.
+- Do NOT describe the outer loop as "architectural changes." Expanding to the outer surface scope is a surface expansion, not a mode switch.
+- Do NOT treat plateau as a failure. It is the expected signal that triggers scope expansion — the system is working as designed.

--- a/templates/factory_config.md
+++ b/templates/factory_config.md
@@ -160,3 +160,27 @@ curl -sf http://localhost:8000/health
 ## Cost Budget
 <!-- Per-cycle or total budget constraints for research experiments. -->
 <!-- Example: $5/cycle, $50 total -->
+
+## Multi-Run
+<!-- For stochastic harnesses where results vary between runs. -->
+<!-- Only used in research mode. Omit for deterministic benchmarks. -->
+<!-- Example:
+- runs_per_cycle: 3
+- aggregate: mean
+- max_runs_per_cycle: 5
+-->
+
+## Surface Scoping
+<!-- Two-tier surface structure for automatic scope escalation. -->
+<!-- Only used in research mode. Omit if all mutable surfaces should be available from the start. -->
+<!-- Inner surfaces are tried first; outer surfaces are unlocked after plateau. -->
+<!-- Example:
+- plateau_threshold: 3
+- max_escalation_cycles: 10
+- inner_surfaces:
+  - prompts/*.md
+  - config/*.yaml
+- outer_surfaces:
+  - src/agents/*.py
+  - src/orchestration/*.py
+-->


### PR DESCRIPTION
## Summary

Fixes #326. Prompt-only changes across 4 markdown files:

- **Distiller** (`factory/agents/prompts/distiller.md`): Added Multi-Run and Surface Scoping template sections to the Research Configuration, with conditional inclusion guidance for stochastic harnesses and two-tier surface structures
- **Strategist** (`factory/agents/prompts/strategist.md`): Added Outer Loop Guidance section using correct surface-scope framing -- inner/outer loops are the same mechanism with different mutable surface sets, not "prompt-level" vs "architectural" changes
- **CEO** (`factory/agents/prompts/ceo.md`): 5 changes:
  - I1 Distiller task updated to request Multi-Run and Surface Scoping sections for research projects
  - I1v validation step added between I1r and I2 to programmatically validate research config (run command, surface patterns, overlap checks) after each Distiller iteration
  - I3 feedback loop updated to route through I1v before I2 so validation runs on every iteration
  - Step 4b updated to copy Multi-Run and Surface Scoping config from approved spec to factory.md
  - R5d.5 plateau detection section added with correct surface-scope framing (no "prompt-level" or "architectural changes" language)
- **Template** (`templates/factory_config.md`): Added `## Multi-Run` and `## Surface Scoping` sections after `## Cost Budget`

No Python code was modified. Uses conditional language since Python infrastructure for these features is not yet implemented.

## Test plan

- [x] `ruff check .` clean (pre-existing errors only, no new ones)
- [x] `mypy factory/` clean (pre-existing errors only, no new ones)
- [x] No references to "prompt-level" or "prompt tweaks" in inner/outer loop context (verified via grep)
- [x] Distiller Research Configuration template includes Multi-Run and Surface Scoping sections
- [x] CEO has I1v validation step for research config
- [x] CEO step 4b copies Multi-Run and Surface Scoping to factory.md
- [x] No Python files changed -- prompt-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)