### PR TITLE
Wizard: redirect long input to file before classification

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -19,6 +19,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+log = structlog.get_logger()
+_WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
+
 if TYPE_CHECKING:
     from factory.messages import Message
 
@@ -176,7 +179,7 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
         ]
 
     if _safe_is_file(expanded):
-        if expanded.parent == Path("~/.factory").expanduser() and expanded.name == "wizard_input.md":
+        if expanded == _WIZARD_INPUT_PATH.expanduser():
             return [
                 {"label": "Build from this idea", "explanation": "Build the project directly.", "command": f'factory ceo {shlex.quote(stripped)} --mode build'},
                 {"label": "Brainstorm and refine first", "explanation": "Discuss and refine the idea interactively.", "command": f'factory ceo {shlex.quote(stripped)} --mode interactive'},
@@ -566,8 +569,7 @@ def _welcome_wizard() -> int:
         and not _safe_is_file(_expanded_check)
         and not _is_github_url(user_input)
     ):
-        log = structlog.get_logger()
-        wizard_file = Path("~/.factory/wizard_input.md").expanduser()
+        wizard_file = _WIZARD_INPUT_PATH.expanduser()
         wizard_file.parent.mkdir(parents=True, exist_ok=True)
         wizard_file.write_text(user_input)
         log.info("wizard.long_input_redirect", file=str(wizard_file), length=len(user_input))

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -10,6 +10,7 @@ import re
 import shlex
 import signal
 import subprocess
+import structlog
 import sys
 import tempfile
 import threading
@@ -565,8 +566,6 @@ def _welcome_wizard() -> int:
         and not _safe_is_file(_expanded_check)
         and not _is_github_url(user_input)
     ):
-        import structlog
-
         log = structlog.get_logger()
         wizard_file = Path("~/.factory/wizard_input.md").expanduser()
         wizard_file.parent.mkdir(parents=True, exist_ok=True)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -175,6 +175,11 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
         ]
 
     if _safe_is_file(expanded):
+        if expanded.parent == Path("~/.factory").expanduser() and expanded.name == "wizard_input.md":
+            return [
+                {"label": "Build from this idea", "explanation": "Build the project directly.", "command": f'factory ceo {shlex.quote(stripped)} --mode build'},
+                {"label": "Brainstorm and refine first", "explanation": "Discuss and refine the idea interactively.", "command": f'factory ceo {shlex.quote(stripped)} --mode interactive'},
+            ]
         return [
             {"label": "Build from this spec file", "explanation": "Use the file as a project specification.", "command": f'factory ceo {shlex.quote(stripped)} --mode build'},
         ]
@@ -551,6 +556,23 @@ def _welcome_wizard() -> int:
             return 130
         if not user_input:
             return 0
+
+    # -- long-input redirect -----------------------------------------------
+    _expanded_check = Path(user_input).expanduser()
+    if (
+        len(user_input) > 200
+        and not _safe_is_dir(_expanded_check)
+        and not _safe_is_file(_expanded_check)
+        and not _is_github_url(user_input)
+    ):
+        import structlog
+
+        log = structlog.get_logger()
+        wizard_file = Path("~/.factory/wizard_input.md").expanduser()
+        wizard_file.parent.mkdir(parents=True, exist_ok=True)
+        wizard_file.write_text(user_input)
+        log.info("wizard.long_input_redirect", file=str(wizard_file), length=len(user_input))
+        user_input = str(wizard_file)
 
     # -- classification ---------------------------------------------------
     follow_ups: list[dict[str, object]] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
-from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo
+from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo, _quick_classify, _welcome_wizard
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -1586,3 +1586,141 @@ class TestInteractiveFileInput:
         spec_path = matches[0] / ".factory" / "strategy" / "current.md"
         assert spec_path.exists()
         assert "Build a CLI todo app" in spec_path.read_text()
+
+
+class TestWizardLongInputRedirect:
+    """Tests for wizard long-input redirect to ~/.factory/wizard_input.md."""
+
+    def _make_input_fn(self, first_response):
+        """Return an input() replacement that returns first_response then raises EOFError."""
+        call_count = 0
+
+        def _input(prompt=""):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return first_response
+            raise EOFError
+
+        return _input
+
+    def test_long_input_triggers_file_write(self, tmp_path, monkeypatch):
+        """Input >200 chars is written to ~/.factory/wizard_input.md with matching content."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+
+        long_input = "a" * 250
+        monkeypatch.setattr("builtins.input", self._make_input_fn(long_input))
+
+        _welcome_wizard()
+
+        assert wizard_file.exists()
+        assert wizard_file.read_text() == long_input
+
+    def test_short_input_no_file_written(self, tmp_path, monkeypatch):
+        """Input <=200 chars does NOT write a file."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+
+        short_input = "Build a weather CLI"
+        monkeypatch.setattr("builtins.input", self._make_input_fn(short_input))
+
+        with patch("factory.cli._classify_with_llm", return_value=([], [
+            {"label": "Build", "explanation": "Build it.", "command": "factory ceo 'Build a weather CLI' --mode build"},
+        ])):
+            _welcome_wizard()
+
+        assert not wizard_file.exists()
+
+    def test_long_path_not_redirected(self, tmp_path, monkeypatch):
+        """A long string that is an existing directory is NOT redirected."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+
+        long_dir = tmp_path / ("a" * 210)
+        long_dir.mkdir()
+
+        monkeypatch.setattr("builtins.input", self._make_input_fn(str(long_dir)))
+
+        _welcome_wizard()
+
+        assert not wizard_file.exists()
+
+    def test_long_url_not_redirected(self, tmp_path, monkeypatch):
+        """A long GitHub URL is NOT redirected."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+
+        long_url = "https://github.com/user/" + "r" * 200
+        monkeypatch.setattr("builtins.input", self._make_input_fn(long_url))
+
+        _welcome_wizard()
+
+        assert not wizard_file.exists()
+
+    def test_wizard_file_inside_factory_dir(self, tmp_path, monkeypatch):
+        """The written file is inside ~/.factory/."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        long_input = "x" * 250
+        monkeypatch.setattr("builtins.input", self._make_input_fn(long_input))
+
+        _welcome_wizard()
+
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+        assert wizard_file.exists()
+        assert wizard_file.parent == fake_home / ".factory"
+
+
+class TestQuickClassifyWizardFile:
+    """Tests for _quick_classify returning two options for wizard-generated files."""
+
+    def test_wizard_file_returns_two_options(self, tmp_path, monkeypatch):
+        """_quick_classify returns build and interactive options for wizard_input.md."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+        wizard_file.parent.mkdir(parents=True)
+        wizard_file.write_text("some long idea text")
+
+        result = _quick_classify(str(wizard_file))
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["label"] == "Build from this idea"
+        assert "--mode build" in result[0]["command"]
+        assert result[1]["label"] == "Brainstorm and refine first"
+        assert "--mode interactive" in result[1]["command"]
+
+    def test_regular_file_returns_one_option(self, tmp_path):
+        """_quick_classify returns one option for a regular spec file."""
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# My project spec")
+
+        result = _quick_classify(str(spec_file))
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["label"] == "Build from this spec file"
+
+    def test_wizard_file_with_tilde_path(self, tmp_path, monkeypatch):
+        """_quick_classify handles ~/. factory/wizard_input.md with tilde expansion."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+        wizard_file.parent.mkdir(parents=True)
+        wizard_file.write_text("idea content")
+
+        result = _quick_classify("~/.factory/wizard_input.md")
+        assert result is not None
+        assert len(result) == 2


### PR DESCRIPTION
Closes #332

## Changes

- **`_welcome_wizard`**: After capturing user input, if `len(user_input) > 200` and the input isn't a directory, file, or GitHub URL, write the full text to `~/.factory/wizard_input.md` and set `user_input` to that file path. Logs the redirect via structlog.
- **`_quick_classify`**: When the detected file is `~/.factory/wizard_input.md`, return two options — "Build from this idea" (`--mode build`) and "Brainstorm and refine first" (`--mode interactive`) — preserving the mode choice the LLM path would have offered.
- **Tests**: 8 new tests covering long input redirect, short input passthrough, long path/URL exclusions, wizard file location, and `_quick_classify` two-option behavior for wizard files.

All 177 tests pass. Lint and type checks clean.