### PR TITLE
Implement inner/outer loop Python infrastructure

### DIFF
--- a/factory/checkpoint.py
+++ b/factory/checkpoint.py
@@ -25,6 +25,8 @@ class CheckpointState(BaseModel):
     last_eval_scores: dict[str, float]
     current_hypothesis: str | None
     completed_hypotheses: list[int] = []
+    plateau_count: int = 0
+    loop_level: str = "inner"
     timestamp: str
 
 

--- a/factory/models.py
+++ b/factory/models.py
@@ -143,6 +143,36 @@ class TierWeights(BaseModel):
     spec_compliance: float | None = None
 
 
+class AggregateMethod(str, Enum):
+    """Aggregation strategy for multi-run inner loop results."""
+
+    mean = "mean"
+    median = "median"
+    max = "max"
+    all_pass = "all_pass"
+
+
+class InnerLoopConfig(BaseModel):
+    """Inner loop (multi-run) configuration for research mode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    runs_per_cycle: int = 1
+    aggregate: AggregateMethod = AggregateMethod.mean
+    max_runs_per_cycle: int | None = None
+
+
+class OuterLoopConfig(BaseModel):
+    """Outer loop (escalation) configuration for research mode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    plateau_threshold: int = 3
+    max_escalation_cycles: int | None = None
+    inner_surfaces: list[str] = []
+    outer_surfaces: list[str] = []
+
+
 class FactoryConfig(BaseModel):
     """Machine-readable config stored at .factory/config.json."""
 
@@ -168,6 +198,8 @@ class FactoryConfig(BaseModel):
     eval_spec: list[str] = []
     hygiene_weights: TierWeights | None = None
     growth_weights: TierWeights | None = None
+    inner_loop: InnerLoopConfig | None = None
+    outer_loop: OuterLoopConfig | None = None
 
 
 # ── eval ──────────────────────────────────────────────────────────

--- a/factory/research/runner.py
+++ b/factory/research/runner.py
@@ -12,7 +12,14 @@ from pathlib import Path
 
 import structlog
 
-from factory.models import ResearchTarget, ResultParseError, RunResult, RunStatus
+from factory.models import (
+    AggregateMethod,
+    InnerLoopConfig,
+    ResearchTarget,
+    ResultParseError,
+    RunResult,
+    RunStatus,
+)
 
 log = structlog.get_logger()
 
@@ -294,3 +301,87 @@ def _save_artifacts(run_dir: Path, result: RunResult, config: ResearchTarget) ->
         "duration_seconds": result.duration_seconds,
         "command": config.run_command,
     })
+
+
+# ── multi-run execution ────────────────────────────────────────
+
+
+async def execute_multi_run(
+    run_cmd: str,
+    config: InnerLoopConfig,
+    *,
+    cwd: Path | None = None,
+) -> float:
+    """Run *run_cmd* ``config.runs_per_cycle`` times and aggregate the scores.
+
+    Each invocation must exit 0 and print a single float to stdout (the score).
+    Non-zero exits are treated as score 0.0 for ``mean``/``median``/``max`` and
+    as a failure for ``all_pass``.
+
+    Aggregation methods:
+    - **mean**: arithmetic mean of all scores
+    - **median**: median of all scores
+    - **max**: maximum score
+    - **all_pass**: 1.0 if every run exited 0 with score > 0, else 0.0
+
+    Returns the aggregated score as a float.
+    """
+    import statistics
+    import subprocess as sp
+
+    n = config.runs_per_cycle
+    scores: list[float] = []
+    all_ok = True
+
+    log.info("multi_run_start", command=run_cmd, runs=n, aggregate=config.aggregate.value)
+
+    for i in range(n):
+        try:
+            result = sp.run(
+                run_cmd,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=3600,
+                cwd=cwd,
+            )
+        except sp.TimeoutExpired:
+            log.warning("multi_run_timeout", run=i + 1)
+            scores.append(0.0)
+            all_ok = False
+            continue
+
+        if result.returncode != 0:
+            log.warning("multi_run_nonzero_exit", run=i + 1, returncode=result.returncode)
+            scores.append(0.0)
+            all_ok = False
+            continue
+
+        stdout = result.stdout.strip()
+        try:
+            score = float(stdout)
+        except ValueError:
+            log.warning("multi_run_parse_error", run=i + 1, stdout=stdout[:200])
+            scores.append(0.0)
+            all_ok = False
+            continue
+
+        scores.append(score)
+        log.debug("multi_run_result", run=i + 1, score=score)
+
+    if not scores:
+        return 0.0
+
+    if config.aggregate == AggregateMethod.mean:
+        agg = statistics.mean(scores)
+    elif config.aggregate == AggregateMethod.median:
+        agg = statistics.median(scores)
+    elif config.aggregate == AggregateMethod.max:
+        agg = max(scores)
+    elif config.aggregate == AggregateMethod.all_pass:
+        agg = 1.0 if all_ok and all(s > 0 for s in scores) else 0.0
+    else:  # pragma: no cover
+        agg = statistics.mean(scores)
+
+    log.info("multi_run_complete", aggregate=config.aggregate.value, result=agg, runs=n)
+    return agg

--- a/factory/store.py
+++ b/factory/store.py
@@ -13,6 +13,7 @@ from filelock import FileLock
 from pydantic import ValidationError
 
 from factory.models import (
+    AggregateMethod,
     CompositeScore,
     CostBudgetConfig,
     EvalProfile,
@@ -21,6 +22,8 @@ from factory.models import (
     FactoryConfig,
     HardConstraint,
     HypothesisBudget,
+    InnerLoopConfig,
+    OuterLoopConfig,
     ProjectEvalDimension,
     ResearchTarget,
     TierWeights,
@@ -172,6 +175,106 @@ def _parse_tier_weights(items: str | list[str] | float) -> TierWeights | None:
     return TierWeights(**filtered)
 
 
+def _parse_inner_loop(text: str) -> InnerLoopConfig | None:
+    """Parse ``## Multi-Run`` section from factory.md into an InnerLoopConfig.
+
+    Expected list items: ``runs_per_cycle``, ``aggregate``, ``max_runs_per_cycle``.
+    Returns None when the section is absent or contains no recognised keys.
+    """
+    # Extract the ## Multi-Run section from the full factory.md text
+    import re
+
+    match = re.search(
+        r"^##\s+Multi[_\s-]?Run\b(.*?)(?=^##\s|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL | re.IGNORECASE,
+    )
+    if not match:
+        return None
+
+    section = match.group(1)
+    items: list[str] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            items.append(stripped[2:].strip())
+
+    kv = _parse_kv_list(items, str)
+    if not kv:
+        return None
+
+    kwargs: dict[str, object] = {}
+    if "runs_per_cycle" in kv:
+        kwargs["runs_per_cycle"] = int(str(kv["runs_per_cycle"]))
+    if "aggregate" in kv:
+        agg_val = str(kv["aggregate"]).strip().lower()
+        kwargs["aggregate"] = AggregateMethod(agg_val)
+    if "max_runs_per_cycle" in kv:
+        kwargs["max_runs_per_cycle"] = int(str(kv["max_runs_per_cycle"]))
+
+    if not kwargs:
+        return None
+
+    config = InnerLoopConfig(**kwargs)  # type: ignore[arg-type]
+    log.debug("inner_loop_parsed", runs_per_cycle=config.runs_per_cycle, aggregate=config.aggregate)
+    return config
+
+
+def _parse_outer_loop(text: str) -> OuterLoopConfig | None:
+    """Parse ``## Surface Scoping`` section from factory.md into an OuterLoopConfig.
+
+    Expected list items: ``plateau_threshold``, ``max_escalation_cycles``,
+    ``inner_surfaces``, ``outer_surfaces``.
+    Returns None when the section is absent or contains no recognised keys.
+    """
+    import re
+
+    match = re.search(
+        r"^##\s+Surface[_\s-]?Scoping\b(.*?)(?=^##\s|\Z)",
+        text,
+        re.MULTILINE | re.DOTALL | re.IGNORECASE,
+    )
+    if not match:
+        return None
+
+    section = match.group(1)
+    items: list[str] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            items.append(stripped[2:].strip())
+
+    kv = _parse_kv_list(items, str)
+    if not kv:
+        return None
+
+    kwargs: dict[str, object] = {}
+    if "plateau_threshold" in kv:
+        kwargs["plateau_threshold"] = int(str(kv["plateau_threshold"]))
+    if "max_escalation_cycles" in kv:
+        kwargs["max_escalation_cycles"] = int(str(kv["max_escalation_cycles"]))
+
+    # inner_surfaces and outer_surfaces are comma-separated lists
+    if "inner_surfaces" in kv:
+        raw = str(kv["inner_surfaces"])
+        kwargs["inner_surfaces"] = [s.strip() for s in raw.split(",") if s.strip()]
+    if "outer_surfaces" in kv:
+        raw = str(kv["outer_surfaces"])
+        kwargs["outer_surfaces"] = [s.strip() for s in raw.split(",") if s.strip()]
+
+    if not kwargs:
+        return None
+
+    config = OuterLoopConfig(**kwargs)  # type: ignore[arg-type]
+    log.debug(
+        "outer_loop_parsed",
+        plateau_threshold=config.plateau_threshold,
+        inner_count=len(config.inner_surfaces),
+        outer_count=len(config.outer_surfaces),
+    )
+    return config
+
+
 class ExperimentStore:
     """Manages the .factory/ directory for a project."""
 
@@ -285,6 +388,8 @@ class ExperimentStore:
         eval_spec = list(es_raw) if isinstance(es_raw, list) else []
         hygiene_tier_weights = _parse_tier_weights(parsed.get("hygiene_weights", []))
         growth_tier_weights = _parse_tier_weights(parsed.get("growth_weights", []))
+        inner_loop = _parse_inner_loop(text)
+        outer_loop = _parse_outer_loop(text)
 
         config = FactoryConfig(
             goal=str(parsed.get("goal", "")),
@@ -307,6 +412,8 @@ class ExperimentStore:
             eval_spec=eval_spec,
             hygiene_weights=hygiene_tier_weights,
             growth_weights=growth_tier_weights,
+            inner_loop=inner_loop,
+            outer_loop=outer_loop,
         )
 
         (self.factory_dir / "config.json").write_text(
@@ -513,7 +620,7 @@ class ExperimentStore:
                 "Run 'factory init --reparse' to regenerate it from factory.md."
             ) from exc
         try:
-            return FactoryConfig(**data)
+            return FactoryConfig.model_validate(data, strict=False)
         except (ValidationError, TypeError, KeyError) as exc:
             raise ValueError(
                 f"{config_path} failed validation: {exc}. "

--- a/factory/strategy.py
+++ b/factory/strategy.py
@@ -21,6 +21,8 @@ from typing import Any
 
 import structlog
 
+from factory.models import ExperimentRecord
+
 log = structlog.get_logger()
 
 MAX_INLINE_HISTORY = 10
@@ -133,6 +135,50 @@ def detect_stuck(
             consecutive=len(tail),
         )
     return stuck
+
+
+# ── plateau detection ────────────────────────────────────────────
+
+
+def detect_plateau(
+    history: list[ExperimentRecord],
+    threshold: int = 3,
+) -> bool:
+    """Return ``True`` if the last *threshold* consecutive experiments showed no metric improvement.
+
+    "No improvement" means the ``score_after`` did not exceed the running best
+    score at that point in the history.  Experiments without a ``score_after``
+    are skipped (not counted toward the streak).
+
+    Returns ``False`` if there are fewer than *threshold* scored experiments.
+    """
+    scored = [r for r in history if r.score_after is not None]
+    if len(scored) < threshold:
+        return False
+
+    # Walk the scored history and compute whether each experiment improved
+    # over the previous best.
+    best = scored[0].score_after
+    assert best is not None  # guaranteed by filter above
+    no_improvement_streak = 0
+
+    for record in scored[1:]:
+        assert record.score_after is not None
+        if record.score_after > best:
+            best = record.score_after
+            no_improvement_streak = 0
+        else:
+            no_improvement_streak += 1
+
+    plateau = no_improvement_streak >= threshold
+    if plateau:
+        log.warning(
+            "plateau_detected",
+            streak=no_improvement_streak,
+            threshold=threshold,
+            best_score=best,
+        )
+    return plateau
 
 
 # ── hypothesis similarity ────────────────────────────────────────

--- a/tests/test_inner_outer_loop.py
+++ b/tests/test_inner_outer_loop.py
@@ -1,0 +1,391 @@
+"""Integration tests for inner/outer loop infrastructure.
+
+Covers:
+- factory.md -> config.json round-trip with Multi-Run and Surface Scoping
+- execute_multi_run() with deterministic commands and all aggregation methods
+- detect_plateau() with various history shapes
+- CheckpointState with new plateau_count and loop_level fields
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from factory.checkpoint import (
+    CheckpointState,
+    format_checkpoint,
+    load_checkpoint,
+    save_checkpoint,
+)
+from factory.models import (
+    AggregateMethod,
+    ExperimentRecord,
+    InnerLoopConfig,
+)
+from factory.research.runner import execute_multi_run
+from factory.store import ExperimentStore
+from factory.strategy import detect_plateau
+
+
+# ── helpers ─────────────────────────────────────────────────────
+
+
+def _make_record(
+    exp_id: int,
+    score_after: float | None,
+    verdict: str = "keep",
+) -> ExperimentRecord:
+    """Create a minimal ExperimentRecord for plateau detection tests."""
+    return ExperimentRecord(
+        id=exp_id,
+        timestamp=datetime(2026, 1, 1, 0, 0, 0),
+        hypothesis=f"H{exp_id}",
+        change_summary="",
+        issue_number=None,
+        pr_number=None,
+        score_before=None,
+        score_after=score_after,
+        delta=None,
+        verdict=verdict,
+        cost_usd=None,
+        notes="",
+    )
+
+
+# ── config round-trip ───────────────────────────────────────────
+
+
+class TestConfigRoundTrip:
+    """factory.md -> reparse_config -> config.json -> read_config round-trip."""
+
+    @pytest.fixture
+    def store(self, tmp_path: Path) -> ExperimentStore:
+        project = tmp_path / "project"
+        project.mkdir()
+        return ExperimentStore(project)
+
+    async def test_roundtrip_with_multi_run_and_surface_scoping(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch loop test\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n- no deletes\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n- small changes\n\n"
+            "## Multi-Run\n"
+            "- Runs per cycle: 5\n"
+            "- Aggregate: median\n"
+            "- Max runs per cycle: 10\n\n"
+            "## Surface Scoping\n"
+            "- Plateau threshold: 4\n"
+            "- Max escalation cycles: 8\n"
+            "- Inner surfaces: src/model.py, src/train.py\n"
+            "- Outer surfaces: config/arch.yaml\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+
+        # Step 1: Parse factory.md -> config.json
+        config = await store.reparse_config()
+
+        # Step 2: Verify inner_loop
+        assert config.inner_loop is not None
+        assert config.inner_loop.runs_per_cycle == 5
+        assert config.inner_loop.aggregate == AggregateMethod.median
+        assert config.inner_loop.max_runs_per_cycle == 10
+
+        # Step 3: Verify outer_loop
+        assert config.outer_loop is not None
+        assert config.outer_loop.plateau_threshold == 4
+        assert config.outer_loop.max_escalation_cycles == 8
+        assert config.outer_loop.inner_surfaces == ["src/model.py", "src/train.py"]
+        assert config.outer_loop.outer_surfaces == ["config/arch.yaml"]
+
+        # Step 4: Read back from config.json
+        loaded = await store.read_config()
+        assert loaded == config
+        assert loaded.inner_loop is not None
+        assert loaded.inner_loop.aggregate == AggregateMethod.median
+        assert loaded.outer_loop is not None
+        assert loaded.outer_loop.plateau_threshold == 4
+
+    async def test_roundtrip_without_loops_backward_compat(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nNormal project\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+
+        config = await store.reparse_config()
+        assert config.inner_loop is None
+        assert config.outer_loop is None
+
+        loaded = await store.read_config()
+        assert loaded.inner_loop is None
+        assert loaded.outer_loop is None
+
+    async def test_config_json_contains_loop_fields(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nTest\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Multi-Run\n"
+            "- Runs per cycle: 3\n"
+            "- Aggregate: all_pass\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        await store.reparse_config()
+
+        raw = json.loads((store.factory_dir / "config.json").read_text())
+        assert "inner_loop" in raw
+        assert raw["inner_loop"]["runs_per_cycle"] == 3
+        assert raw["inner_loop"]["aggregate"] == "all_pass"
+        assert raw["outer_loop"] is None
+
+
+# ── execute_multi_run ───────────────────────────────────────────
+
+
+class TestExecuteMultiRun:
+    async def test_mean_aggregation(self) -> None:
+        config = InnerLoopConfig(runs_per_cycle=3, aggregate=AggregateMethod.mean)
+        # echo scores: 0.8, 0.8, 0.8 -> mean = 0.8
+        score = await execute_multi_run("echo 0.8", config)
+        assert score == pytest.approx(0.8)
+
+    async def test_median_aggregation(self) -> None:
+        config = InnerLoopConfig(runs_per_cycle=3, aggregate=AggregateMethod.median)
+        score = await execute_multi_run("echo 0.5", config)
+        assert score == pytest.approx(0.5)
+
+    async def test_max_aggregation(self) -> None:
+        config = InnerLoopConfig(runs_per_cycle=3, aggregate=AggregateMethod.max)
+        score = await execute_multi_run("echo 0.9", config)
+        assert score == pytest.approx(0.9)
+
+    async def test_all_pass_success(self) -> None:
+        config = InnerLoopConfig(runs_per_cycle=3, aggregate=AggregateMethod.all_pass)
+        score = await execute_multi_run("echo 1.0", config)
+        assert score == 1.0
+
+    async def test_all_pass_failure(self) -> None:
+        config = InnerLoopConfig(runs_per_cycle=3, aggregate=AggregateMethod.all_pass)
+        score = await execute_multi_run("exit 1", config)
+        assert score == 0.0
+
+    async def test_single_run(self) -> None:
+        config = InnerLoopConfig(runs_per_cycle=1, aggregate=AggregateMethod.mean)
+        score = await execute_multi_run("echo 0.95", config)
+        assert score == pytest.approx(0.95)
+
+    async def test_nonzero_exit_contributes_zero(self) -> None:
+        """Non-zero exits produce 0.0 scores for mean/median/max."""
+        config = InnerLoopConfig(runs_per_cycle=1, aggregate=AggregateMethod.mean)
+        score = await execute_multi_run("exit 1", config)
+        assert score == 0.0
+
+    async def test_unparseable_output(self) -> None:
+        """Non-numeric stdout produces 0.0 score."""
+        config = InnerLoopConfig(runs_per_cycle=1, aggregate=AggregateMethod.mean)
+        score = await execute_multi_run("echo not_a_number", config)
+        assert score == 0.0
+
+    async def test_all_pass_zero_score(self) -> None:
+        """all_pass fails when a run outputs 0 (score not > 0)."""
+        config = InnerLoopConfig(runs_per_cycle=2, aggregate=AggregateMethod.all_pass)
+        score = await execute_multi_run("echo 0", config)
+        assert score == 0.0
+
+    async def test_cwd_parameter(self, tmp_path: Path) -> None:
+        """cwd parameter is passed to subprocess."""
+        config = InnerLoopConfig(runs_per_cycle=1, aggregate=AggregateMethod.mean)
+        score = await execute_multi_run("echo 0.75", config, cwd=tmp_path)
+        assert score == pytest.approx(0.75)
+
+
+# ── detect_plateau ──────────────────────────────────────────────
+
+
+class TestDetectPlateau:
+    def test_empty_history(self) -> None:
+        assert detect_plateau([], threshold=3) is False
+
+    def test_below_threshold(self) -> None:
+        history = [_make_record(1, 0.5), _make_record(2, 0.5)]
+        assert detect_plateau(history, threshold=3) is False
+
+    def test_at_threshold_no_plateau(self) -> None:
+        """Three experiments with continuous improvement = no plateau."""
+        history = [
+            _make_record(1, 0.5),
+            _make_record(2, 0.6),
+            _make_record(3, 0.7),
+        ]
+        assert detect_plateau(history, threshold=3) is False
+
+    def test_at_threshold_with_plateau(self) -> None:
+        """Three experiments where last 3 show no improvement."""
+        history = [
+            _make_record(1, 0.8),
+            _make_record(2, 0.7),
+            _make_record(3, 0.75),
+            _make_record(4, 0.78),
+        ]
+        # After record 1 (best=0.8), records 2, 3, 4 never exceed 0.8
+        # streak = 3 >= threshold=3
+        assert detect_plateau(history, threshold=3) is True
+
+    def test_above_threshold(self) -> None:
+        """Five flat experiments with threshold=3 => plateau."""
+        history = [
+            _make_record(1, 0.5),
+            _make_record(2, 0.5),
+            _make_record(3, 0.5),
+            _make_record(4, 0.5),
+            _make_record(5, 0.5),
+        ]
+        assert detect_plateau(history, threshold=3) is True
+
+    def test_improvement_resets_streak(self) -> None:
+        """A late improvement resets the no-improvement streak."""
+        history = [
+            _make_record(1, 0.5),
+            _make_record(2, 0.5),  # no improvement
+            _make_record(3, 0.5),  # no improvement
+            _make_record(4, 0.6),  # improvement! resets streak
+            _make_record(5, 0.55),  # no improvement (streak=1)
+        ]
+        assert detect_plateau(history, threshold=3) is False
+
+    def test_none_scores_skipped(self) -> None:
+        """Records with score_after=None are excluded from plateau analysis."""
+        history = [
+            _make_record(1, 0.5),
+            _make_record(2, None),
+            _make_record(3, 0.5),
+            _make_record(4, None),
+            _make_record(5, 0.5),
+        ]
+        # Only 3 scored records: [0.5, 0.5, 0.5]
+        # After first (best=0.5), two non-improvements -> streak=2 < threshold=3
+        assert detect_plateau(history, threshold=3) is False
+
+    def test_custom_threshold(self) -> None:
+        """Plateau detected with custom threshold=2."""
+        history = [
+            _make_record(1, 0.5),
+            _make_record(2, 0.5),
+            _make_record(3, 0.5),
+        ]
+        assert detect_plateau(history, threshold=2) is True
+
+    def test_single_record(self) -> None:
+        """Single record is never a plateau."""
+        assert detect_plateau([_make_record(1, 0.5)], threshold=1) is False
+
+
+# ── checkpoint extensions ───────────────────────────────────────
+
+
+class TestCheckpointExtensions:
+    def test_new_fields_defaults(self) -> None:
+        state = CheckpointState(
+            mode="research",
+            active_experiment_id=None,
+            completed_agents=[],
+            pending_agents=[],
+            last_eval_scores={},
+            current_hypothesis=None,
+            timestamp="2026-05-24T00:00:00",
+        )
+        assert state.plateau_count == 0
+        assert state.loop_level == "inner"
+
+    def test_new_fields_custom(self) -> None:
+        state = CheckpointState(
+            mode="research",
+            active_experiment_id=5,
+            completed_agents=["researcher"],
+            pending_agents=["builder"],
+            last_eval_scores={"accuracy": 0.85},
+            current_hypothesis="Try larger model",
+            plateau_count=3,
+            loop_level="outer",
+            timestamp="2026-05-24T12:00:00",
+        )
+        assert state.plateau_count == 3
+        assert state.loop_level == "outer"
+
+    def test_save_load_roundtrip_with_new_fields(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        state = CheckpointState(
+            mode="research",
+            active_experiment_id=10,
+            completed_agents=["researcher", "strategist"],
+            pending_agents=["builder"],
+            last_eval_scores={"acc": 0.9},
+            current_hypothesis="Scale up",
+            completed_hypotheses=[1, 2, 3],
+            plateau_count=2,
+            loop_level="outer",
+            timestamp="2026-05-24T15:00:00",
+        )
+        save_checkpoint(project, state)
+        loaded = load_checkpoint(project)
+        assert loaded is not None
+        assert loaded.plateau_count == 2
+        assert loaded.loop_level == "outer"
+        assert loaded == state
+
+    def test_backward_compat_without_new_fields(self, tmp_path: Path) -> None:
+        """Old checkpoint JSON without plateau_count/loop_level should use defaults."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        old_data = {
+            "mode": "improve",
+            "active_experiment_id": None,
+            "completed_agents": [],
+            "pending_agents": [],
+            "last_eval_scores": {},
+            "current_hypothesis": None,
+            "timestamp": "2026-01-01T00:00:00",
+        }
+        (project / ".factory" / "checkpoint.json").write_text(json.dumps(old_data))
+
+        loaded = load_checkpoint(project)
+        assert loaded is not None
+        assert loaded.plateau_count == 0
+        assert loaded.loop_level == "inner"
+
+    def test_format_checkpoint_includes_loop_info(self) -> None:
+        state = CheckpointState(
+            mode="research",
+            active_experiment_id=5,
+            completed_agents=[],
+            pending_agents=[],
+            last_eval_scores={},
+            current_hypothesis=None,
+            plateau_count=2,
+            loop_level="outer",
+            timestamp="2026-05-24T00:00:00",
+        )
+        output = format_checkpoint(state)
+        assert "research" in output

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import pytest
 from datetime import datetime
 
 from factory.models import (
+    AggregateMethod,
     CostBudget,
     CostBudgetConfig,
     CompositeScore,
@@ -14,6 +15,8 @@ from factory.models import (
     ExperimentRecord,
     FactoryConfig,
     Hypothesis,
+    InnerLoopConfig,
+    OuterLoopConfig,
     ProjectProfile,
     ProjectState,
     ResearchTarget,
@@ -315,6 +318,150 @@ class TestFactoryConfigResearchFields:
         assert restored.research_target is not None
         assert restored.research_target.objective == "Minimize loss"
         assert restored == config
+
+
+class TestAggregateMethod:
+    def test_all_values(self):
+        assert AggregateMethod.mean.value == "mean"
+        assert AggregateMethod.median.value == "median"
+        assert AggregateMethod.max.value == "max"
+        assert AggregateMethod.all_pass.value == "all_pass"
+
+    def test_count(self):
+        assert len(AggregateMethod) == 4
+
+    def test_string_coercion(self):
+        assert AggregateMethod("mean") == AggregateMethod.mean
+        assert AggregateMethod("all_pass") == AggregateMethod.all_pass
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            AggregateMethod("invalid")
+
+
+class TestInnerLoopConfig:
+    def test_defaults(self):
+        c = InnerLoopConfig()
+        assert c.runs_per_cycle == 1
+        assert c.aggregate == AggregateMethod.mean
+        assert c.max_runs_per_cycle is None
+
+    def test_custom_values(self):
+        c = InnerLoopConfig(
+            runs_per_cycle=5,
+            aggregate=AggregateMethod.median,
+            max_runs_per_cycle=10,
+        )
+        assert c.runs_per_cycle == 5
+        assert c.aggregate == AggregateMethod.median
+        assert c.max_runs_per_cycle == 10
+
+    def test_rejects_extra_fields(self):
+        with pytest.raises(Exception):
+            InnerLoopConfig(runs_per_cycle=1, extra="bad")
+
+    def test_strict_mode(self):
+        """Strict mode rejects string where int is expected."""
+        with pytest.raises(Exception):
+            InnerLoopConfig(runs_per_cycle="not_an_int")  # type: ignore[arg-type]
+
+    def test_roundtrip_json(self):
+        c = InnerLoopConfig(runs_per_cycle=3, aggregate=AggregateMethod.max)
+        data = c.model_dump()
+        restored = InnerLoopConfig(**data)
+        assert restored == c
+
+
+class TestOuterLoopConfig:
+    def test_defaults(self):
+        c = OuterLoopConfig()
+        assert c.plateau_threshold == 3
+        assert c.max_escalation_cycles is None
+        assert c.inner_surfaces == []
+        assert c.outer_surfaces == []
+
+    def test_custom_values(self):
+        c = OuterLoopConfig(
+            plateau_threshold=5,
+            max_escalation_cycles=10,
+            inner_surfaces=["src/*.py"],
+            outer_surfaces=["config/*.yaml"],
+        )
+        assert c.plateau_threshold == 5
+        assert c.max_escalation_cycles == 10
+        assert c.inner_surfaces == ["src/*.py"]
+        assert c.outer_surfaces == ["config/*.yaml"]
+
+    def test_rejects_extra_fields(self):
+        with pytest.raises(Exception):
+            OuterLoopConfig(plateau_threshold=3, extra="bad")
+
+    def test_strict_mode(self):
+        with pytest.raises(Exception):
+            OuterLoopConfig(plateau_threshold="not_an_int")  # type: ignore[arg-type]
+
+    def test_roundtrip_json(self):
+        c = OuterLoopConfig(
+            plateau_threshold=4,
+            inner_surfaces=["a.py", "b.py"],
+            outer_surfaces=["c.py"],
+        )
+        data = c.model_dump()
+        restored = OuterLoopConfig(**data)
+        assert restored == c
+
+
+class TestFactoryConfigInnerOuterLoop:
+    def test_defaults_none(self):
+        config = FactoryConfig(
+            goal="Test", scope=[], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[],
+        )
+        assert config.inner_loop is None
+        assert config.outer_loop is None
+
+    def test_with_inner_loop(self):
+        il = InnerLoopConfig(runs_per_cycle=3, aggregate=AggregateMethod.median)
+        config = FactoryConfig(
+            goal="Test", scope=[], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[], inner_loop=il,
+        )
+        assert config.inner_loop is not None
+        assert config.inner_loop.runs_per_cycle == 3
+        assert config.inner_loop.aggregate == AggregateMethod.median
+
+    def test_with_outer_loop(self):
+        ol = OuterLoopConfig(
+            plateau_threshold=5,
+            inner_surfaces=["src/"],
+            outer_surfaces=["config/"],
+        )
+        config = FactoryConfig(
+            goal="Test", scope=[], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[], outer_loop=ol,
+        )
+        assert config.outer_loop is not None
+        assert config.outer_loop.plateau_threshold == 5
+
+    def test_roundtrip_json_with_loops(self):
+        il = InnerLoopConfig(runs_per_cycle=5, aggregate=AggregateMethod.all_pass)
+        ol = OuterLoopConfig(
+            plateau_threshold=4,
+            max_escalation_cycles=8,
+            inner_surfaces=["src/model.py"],
+            outer_surfaces=["config/"],
+        )
+        config = FactoryConfig(
+            goal="Research", scope=["src/"], guards=[], eval_command="pytest",
+            eval_threshold=0.8, constraints=[], inner_loop=il, outer_loop=ol,
+        )
+        data = config.model_dump()
+        restored = FactoryConfig(**data)
+        assert restored == config
+        assert restored.inner_loop is not None
+        assert restored.inner_loop.aggregate == AggregateMethod.all_pass
+        assert restored.outer_loop is not None
+        assert restored.outer_loop.max_escalation_cycles == 8
 
 
 class TestCycleStateResearchMode:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -524,6 +524,167 @@ class TestTierWeightsParsing:
         assert loaded.hygiene_weights.coverage is None
 
 
+class TestParseInnerLoop:
+    """Tests for parsing ## Multi-Run section from factory.md."""
+
+    async def test_parse_inner_loop(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Multi-Run\n"
+            "- Runs per cycle: 5\n"
+            "- Aggregate: median\n"
+            "- Max runs per cycle: 10\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.inner_loop is not None
+        assert config.inner_loop.runs_per_cycle == 5
+        assert config.inner_loop.aggregate.value == "median"
+        assert config.inner_loop.max_runs_per_cycle == 10
+
+    async def test_parse_inner_loop_defaults(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Multi-Run\n"
+            "- Runs per cycle: 3\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.inner_loop is not None
+        assert config.inner_loop.runs_per_cycle == 3
+        assert config.inner_loop.aggregate.value == "mean"  # default
+        assert config.inner_loop.max_runs_per_cycle is None  # default
+
+    async def test_no_inner_loop_section(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nNormal\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.inner_loop is None
+
+    async def test_inner_loop_all_pass(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Multi-Run\n"
+            "- Runs per cycle: 3\n"
+            "- Aggregate: all_pass\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.inner_loop is not None
+        assert config.inner_loop.aggregate.value == "all_pass"
+
+
+class TestParseOuterLoop:
+    """Tests for parsing ## Surface Scoping section from factory.md."""
+
+    async def test_parse_outer_loop(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Surface Scoping\n"
+            "- Plateau threshold: 5\n"
+            "- Max escalation cycles: 10\n"
+            "- Inner surfaces: src/model.py, src/train.py\n"
+            "- Outer surfaces: config/hyperparams.yaml, config/arch.yaml\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.outer_loop is not None
+        assert config.outer_loop.plateau_threshold == 5
+        assert config.outer_loop.max_escalation_cycles == 10
+        assert config.outer_loop.inner_surfaces == ["src/model.py", "src/train.py"]
+        assert config.outer_loop.outer_surfaces == ["config/hyperparams.yaml", "config/arch.yaml"]
+
+    async def test_no_outer_loop_section(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nNormal\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.outer_loop is None
+
+    async def test_outer_loop_defaults(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Surface Scoping\n"
+            "- Plateau threshold: 4\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.outer_loop is not None
+        assert config.outer_loop.plateau_threshold == 4
+        assert config.outer_loop.max_escalation_cycles is None
+        assert config.outer_loop.inner_surfaces == []
+        assert config.outer_loop.outer_surfaces == []
+
+    async def test_both_loops_together(self, store):
+        factory_md = store.project_path / "factory.md"
+        factory_md.write_text(
+            "# Factory\n\n## Goal\nResearch\n\n"
+            "## Scope\n- src/\n\n"
+            "## Guards\n\n"
+            "## Eval\n```\npython eval.py\n```\n\n"
+            "## Threshold\n0.8\n\n"
+            "## Constraints\n\n"
+            "## Multi-Run\n"
+            "- Runs per cycle: 3\n"
+            "- Aggregate: mean\n\n"
+            "## Surface Scoping\n"
+            "- Plateau threshold: 5\n"
+            "- Inner surfaces: src/model.py\n"
+            "- Outer surfaces: config/\n"
+        )
+        store.factory_dir.mkdir(exist_ok=True)
+        config = await store.reparse_config()
+        assert config.inner_loop is not None
+        assert config.inner_loop.runs_per_cycle == 3
+        assert config.outer_loop is not None
+        assert config.outer_loop.plateau_threshold == 5
+
+
 class TestEnsureFactoryDir:
     """Regression tests for broken symlink handling (issue #276)."""
 


### PR DESCRIPTION
## Summary

- Add `AggregateMethod` enum, `InnerLoopConfig`, and `OuterLoopConfig` Pydantic v2 models to `factory/models.py`; extend `FactoryConfig` with optional `inner_loop` and `outer_loop` fields
- Add `_parse_inner_loop()` (## Multi-Run) and `_parse_outer_loop()` (## Surface Scoping) parsers in `factory/store.py`, wired into `reparse_config()`
- Add `execute_multi_run()` in `factory/research/runner.py` -- runs a command N times and aggregates results (mean/median/max/all_pass)
- Add `detect_plateau()` in `factory/strategy.py` -- detects when the last N experiments show no metric improvement
- Extend `CheckpointState` with `plateau_count` and `loop_level` fields for crash-resilient research loop state
- Fix `read_config()` to use `model_validate(strict=False)` for correct enum deserialization from JSON

## Test plan

- [x] Unit tests for `AggregateMethod`, `InnerLoopConfig`, `OuterLoopConfig` (validation, defaults, strict mode, extra=forbid, roundtrip)
- [x] Unit tests for `_parse_inner_loop()` and `_parse_outer_loop()` (present, absent, defaults, all aggregation methods, both loops together)
- [x] Integration test for factory.md -> config.json -> FactoryConfig round-trip with Multi-Run and Surface Scoping
- [x] Unit tests for `execute_multi_run()` (deterministic, all aggregation methods, error handling, cwd parameter)
- [x] Unit tests for `detect_plateau()` (empty history, below/at/above threshold, improvement reset, None scores, custom threshold)
- [x] Unit tests for `CheckpointState` with new fields (defaults, custom values, save/load roundtrip, backward compat)
- [x] Full suite: 1948 tests pass
- [x] `ruff check .` clean (on modified files)
- [x] `mypy factory/` clean (on modified files)

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)