### PR TITLE
Add session naming to factory-spawned Claude Code sessions

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -101,6 +101,7 @@ async def invoke_agent(
     model: str | None = None,
     runner_name: str | None = None,
     _track_failures: bool = True,
+    session_name: str | None = None,
 ) -> tuple[str, int]:
     """Invoke a Claude Code agent with the resolved prompt + task.
 
@@ -114,6 +115,8 @@ async def invoke_agent(
         runner_name: CLI backend to use ("claude" or "bob"). Defaults to FACTORY_RUNNER env var.
         _track_failures: If True (default), track consecutive failures globally.
             Set to False when called from invoke_agents_parallel to avoid race conditions.
+        session_name: Optional session name for /resume identification.
+            If not provided, defaults to "factory: {project_name}/{role}".
 
     Returns (stdout, return_code).
 
@@ -131,6 +134,8 @@ async def invoke_agent(
 
     runner = get_runner(runner_name, project_path=project_path)
 
+    agent_session_name = session_name or f"factory: {project_path.resolve().name}/{role}"
+
     try:
         stdout, return_code = await runner.headless(
             prompt=prompt,
@@ -140,6 +145,7 @@ async def invoke_agent(
             model=model,
             dangerously_skip_permissions=dangerously_skip_permissions,
             role=role,
+            session_name=agent_session_name,
         )
     except Exception as e:
         logger.error("%s agent failed: %s", role, e)

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -385,6 +385,7 @@ async def run_ceo_with_completion_guard(
     model: str | None = None,
     timeout: float = 3600.0,
     max_respawns: int | None = None,
+    session_name: str | None = None,
 ) -> tuple[str, int]:
     """Spawn CEO; if it exits with planned work undone, re-spawn until done or cap hit.
 
@@ -399,6 +400,7 @@ async def run_ceo_with_completion_guard(
         model: Optional model override.
         timeout: Timeout per CEO spawn in seconds.
         max_respawns: Max re-spawns (default from env or 5).
+        session_name: Optional session name for /resume identification.
 
     Returns:
         (final_output, exit_code)
@@ -413,6 +415,7 @@ async def run_ceo_with_completion_guard(
         return await invoke_agent(
             "ceo", initial_task, project_path,
             timeout=timeout, model=model, runner_name=runner_name,
+            session_name=session_name,
         )
 
     if max_respawns is None:
@@ -451,6 +454,7 @@ async def run_ceo_with_completion_guard(
         result, code = await invoke_agent(
             "ceo", task, project_path,
             timeout=timeout, model=model, runner_name=runner_name,
+            session_name=session_name,
         )
         final_output = result
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2141,6 +2141,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         issue_url=issue_url,
     )
 
+    session_name = f"factory: {project_path.resolve().name}"
+
     if headless:
         # Non-interactive pipe mode (for scripting, cron, tmux)
         # Uses completion guard to auto-resume on premature exit
@@ -2154,6 +2156,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 runner_name=runner_name,
                 model=model,
                 timeout=7200.0,
+                session_name=session_name,
             ))
             print(result)
             if code == 0:
@@ -2182,7 +2185,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         runner = get_runner(runner_name)
         return runner.interactive_run(
             prompt, task, wt_path,
-            model=model, role="ceo", dangerously_skip_permissions=True
+            model=model, role="ceo", dangerously_skip_permissions=True,
+            session_name=session_name,
         )
     finally:
         remove_worktree(project_path, wt_path, wt_branch)

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -198,6 +198,7 @@ class BobRunner:
         model: str | None = None,
         dangerously_skip_permissions: bool = True,
         role: str = "unknown",
+        session_name: str | None = None,
     ) -> tuple[str, int]:
         """Run a headless Bob Shell invocation.
 
@@ -208,6 +209,7 @@ class BobRunner:
         "Argument list too long" errors, consider reducing prompt size or using a
         file-based approach for prompt injection.
         """
+        _ = session_name
         self._role = role
         project_path = self._find_project_path(cwd)
 
@@ -288,11 +290,13 @@ class BobRunner:
         model: str | None = None,
         role: str = "ceo",
         dangerously_skip_permissions: bool = False,
+        session_name: str | None = None,
     ) -> int:
         """Run an interactive Bob Shell session as a subprocess.
 
         Returns the exit code so the caller can clean up in a finally block.
         """
+        _ = session_name
         project_path = self._find_project_path(cwd)
 
         _persist_key(project_path)

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -28,6 +28,7 @@ class ClaudeRunner:
         model: str | None = None,
         dangerously_skip_permissions: bool = True,
         role: str = "unknown",
+        session_name: str | None = None,
     ) -> tuple[str, int]:
         """Run a headless Claude Code invocation.
 
@@ -39,6 +40,7 @@ class ClaudeRunner:
             model: Optional model override.
             dangerously_skip_permissions: If True, skip permission prompts.
             role: Agent role (used for streaming prefix).
+            session_name: Optional session name for identification in /resume.
 
         Returns (stdout, return_code).
         """
@@ -47,6 +49,8 @@ class ClaudeRunner:
             cmd.append("--dangerously-skip-permissions")
         if model:
             cmd.extend(["--model", model])
+        if session_name:
+            cmd.extend(["--name", session_name])
 
         logger.info("ClaudeRunner headless: cwd=%s, model=%s", cwd, model)
 
@@ -95,6 +99,7 @@ class ClaudeRunner:
         model: str | None = None,
         role: str = "ceo",
         dangerously_skip_permissions: bool = False,
+        session_name: str | None = None,
     ) -> int:
         """Run an interactive Claude Code session as a subprocess.
 
@@ -111,6 +116,8 @@ class ClaudeRunner:
         if model:
             cmd.extend(["--model", model])
             os.environ["FACTORY_MODEL"] = model
+        if session_name:
+            cmd.extend(["--name", session_name])
 
         logger.info("ClaudeRunner interactive_run: cwd=%s", cwd)
 

--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -68,6 +68,7 @@ class CodexRunner:
         model: str | None = None,
         dangerously_skip_permissions: bool = True,
         role: str = "unknown",
+        session_name: str | None = None,
     ) -> tuple[str, int]:
         """Run a headless Codex CLI invocation via ``codex exec``.
 
@@ -76,6 +77,7 @@ class CodexRunner:
 
         Returns (stdout, return_code).
         """
+        _ = session_name
         if is_codex_dry_run():
             return self._dry_run_response(role, cwd, task)
 
@@ -136,12 +138,13 @@ class CodexRunner:
         model: str | None = None,
         role: str = "ceo",
         dangerously_skip_permissions: bool = False,
+        session_name: str | None = None,
     ) -> int:
         """Run an interactive Codex CLI session as a subprocess.
 
         Returns the exit code so the caller can clean up in a finally block.
         """
-        _ = role
+        _ = role, session_name
 
         if is_codex_dry_run():
             print("[DRY-RUN] Would exec: codex (interactive)")

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -21,6 +21,7 @@ class Runner(Protocol):
         model: str | None = None,
         dangerously_skip_permissions: bool = True,
         role: str = "unknown",
+        session_name: str | None = None,
     ) -> tuple[str, int]:
         """Run a headless (non-interactive) agent invocation.
 
@@ -32,6 +33,7 @@ class Runner(Protocol):
             model: Optional model override.
             dangerously_skip_permissions: If True, skip permission prompts.
             role: Agent role name (used for logging and output prefixing).
+            session_name: Optional session name for identification in /resume.
 
         Returns:
             (stdout, return_code) tuple.
@@ -47,6 +49,7 @@ class Runner(Protocol):
         model: str | None = None,
         role: str = "ceo",
         dangerously_skip_permissions: bool = False,
+        session_name: str | None = None,
     ) -> int:
         """Run an interactive CLI session as a subprocess (returns on exit).
 
@@ -60,6 +63,7 @@ class Runner(Protocol):
             model: Optional model override.
             role: Agent role name (used for logging and output prefixing).
             dangerously_skip_permissions: If True, skip permission prompts (--yolo for bob).
+            session_name: Optional session name for identification in /resume.
 
         Returns:
             The subprocess exit code.


### PR DESCRIPTION
Closes #335

## Changes

- Added `session_name: str | None = None` parameter to `Runner` protocol's `headless()` and `interactive_run()` methods
- `ClaudeRunner` passes `--name <session_name>` to the `claude` CLI for both interactive and headless modes
- `BobRunner` and `CodexRunner` accept and silently ignore the parameter (no equivalent CLI flag)
- `cmd_ceo()` computes `session_name = f"factory: {project_path.resolve().name}"` and passes it through both interactive and headless paths
- `invoke_agent()` auto-generates agent-level names as `factory: {project_name}/{role}` (e.g., `factory: my-app/builder`)
- `run_ceo_with_completion_guard()` forwards `session_name` through respawn cycles

All 1854 tests pass. No eval regression.