### PR TITLE
Enforce spec depth in Distiller — grounding protocol + quantified constraints

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -413,7 +413,9 @@ factory agent distiller --task "Distill a project specification from research an
 
 Raw idea: <RAW_IDEA>
 
-Read the research report at .factory/strategy/research.md for domain context, technology recommendations, and prior art.
+MANDATORY: Read .factory/strategy/research.md FIRST. Extract specific findings before writing any spec content.
+
+Every Core Feature MUST have at least 3 sentences covering What (user-visible behavior), How (implementation approach), and Why (research-grounded rationale). A bulleted list of one-liners is NOT a spec.
 
 Produce a complete idea.md specification." --project "$PROJECT_PATH" --timeout 300
 ```
@@ -426,7 +428,9 @@ factory agent distiller --task "Distill an improvement specification for an exis
 Project: $PROJECT_PATH
 <If focus topic provided: Focus topic: <FOCUS_TOPIC>>
 
-Read the research report at .factory/strategy/research.md for project context, weak areas, and external best practices.
+MANDATORY: Read .factory/strategy/research.md FIRST. Extract specific findings before writing any spec content.
+
+Every Core Feature or Proposed Change MUST have at least 3 sentences covering What (user-visible behavior), How (implementation approach), and Why (research-grounded rationale). A bulleted list of one-liners is NOT a spec.
 
 This is an EXISTING project, not a new idea. Produce an improvement spec with these sections:
 
@@ -461,7 +465,9 @@ include the Multi-Run section. If the project has a two-tier surface structure
 (narrow surfaces to try first, wider surfaces to unlock after plateau), include
 the Surface Scoping section.
 
-Read the research report at .factory/strategy/research.md for domain context, technology recommendations, and prior art.
+MANDATORY: Read .factory/strategy/research.md FIRST. Extract specific findings before writing any spec content.
+
+Every Core Feature MUST have at least 3 sentences covering What (user-visible behavior), How (implementation approach), and Why (research-grounded rationale). A bulleted list of one-liners is NOT a spec.
 
 Produce a complete idea.md specification with research configuration." --project "$PROJECT_PATH" --timeout 300
 ```
@@ -473,6 +479,14 @@ Read `.factory/reviews/distiller-latest.md` and assess the draft:
 - Are the technology choices well-justified by research?
 - Is the scope achievable?
 - Are features specific enough for a Builder agent?
+
+**Quantitative depth checks (MANDATORY — REDIRECT if any fail):**
+
+1. **Depth check:** Read each Core Feature entry. Every feature MUST have 3+ sentences across its What/How/Why sub-fields. If any feature is a one-liner without the structured sub-fields, REDIRECT with: "Feature '<name>' is a one-liner — expand to What/How/Why with 3+ sentences total."
+
+2. **Research grounding check:** Architecture decisions and feature rationale must reference specific findings from `.factory/strategy/research.md`. If the spec contains no citations or rationale grounded in research, REDIRECT with: "No research grounding found — architecture decisions must cite findings from research.md."
+
+3. **Buildability check:** For each Core Feature, ask: could a Builder agent implement this feature from the spec alone, without asking clarifying questions? If any feature is too vague to implement (missing key details like data format, API shape, error handling approach), REDIRECT with: "Feature '<name>' is not buildable — a Builder would need to ask clarifying questions. Add implementation details."
 
 Write your review to `.factory/reviews/ceo-verdict-distiller.md`.
 

--- a/factory/agents/prompts/distiller.md
+++ b/factory/agents/prompts/distiller.md
@@ -44,6 +44,19 @@ When your task includes a `## Prior Draft` and `## User Feedback` section, you a
 - If the user's idea is too broad for a single project, narrow it to an achievable MVP and note what was deferred in Non-Goals
 - When your task explicitly states "This is a research project", the Research Configuration section is MANDATORY
 
+## Grounding Protocol (MANDATORY)
+
+Before writing any spec content, you MUST ground your decisions in research:
+
+1. **Read `.factory/strategy/research.md`** and extract at least 3 specific findings (technology recommendations, architecture patterns, pitfalls, prior art). These findings must appear as citations in your spec — not as vague references but as concrete decisions grounded in evidence.
+
+2. **Write a minimum of 3 sentences per Core Feature** covering:
+   - **What:** The user-visible behavior — what the feature does from the user's perspective
+   - **How:** The implementation approach — libraries, data flow, key functions
+   - **Why:** The research-grounded rationale — why this approach over alternatives
+
+3. **Self-check before outputting:** Review each Core Feature and verify it meets the 3-sentence minimum across What/How/Why. A feature description under 3 sentences is too thin. If you can't write 3+ sentences about a feature, it's either too vague (break it down) or too trivial (merge it into another feature).
+
 ## Output
 
 Write the idea.md content to stdout using this exact structure:
@@ -58,7 +71,10 @@ Write the idea.md content to stdout using this exact structure:
 <Bulleted list of concrete, buildable features. Each feature should be
 specific enough that a Builder agent can implement it in one PR.>
 
-- **<Feature Name>**: <What it does, how it works>
+- **<Feature Name>**
+  - **What:** <user-visible behavior — 1-2 sentences>
+  - **How:** <implementation approach — libraries, data flow, key functions — 1-2 sentences>
+  - **Why:** <rationale citing research or engineering tradeoffs — 1 sentence>
 - ...
 
 ## Architecture


### PR DESCRIPTION
Closes #340

## Changes
- **distiller.md — Grounding Protocol:** Added mandatory `## Grounding Protocol (MANDATORY)` section between Constraints and Output requiring the Distiller to read `research.md`, extract 3+ findings, and write 3+ sentences per Core Feature covering What/How/Why
- **distiller.md — Feature template:** Replaced one-liner `**<Feature Name>**: <What it does, how it works>` with structured What/How/Why sub-fields
- **ceo.md — I1 task descriptions:** Updated all three Distiller invocation tasks (regular, existing project, research) to include "MANDATORY: Read research.md FIRST" and the 3-sentence-per-feature minimum with "A bulleted list of one-liners is NOT a spec" warning
- **ceo.md — I1r review gate:** Expanded from 4 subjective questions to include 3 quantitative depth checks: depth check (3+ sentences per feature), research grounding check (citations from research.md), buildability check (implementable by a Builder alone)