### PR TITLE
Add --budget-conscious CLI flag for session-aware experiment execution

### DIFF
--- a/factory/agents/plugin.py
+++ b/factory/agents/plugin.py
@@ -6,9 +6,12 @@ import functools
 from dataclasses import dataclass
 from pathlib import Path
 
+import structlog
 import yaml
 
 from factory.agents.runner import _PROMPTS_DIR
+
+log = structlog.get_logger()
 
 _AGENTS_YML = Path(__file__).parent / "agents.yml"
 _PLUGIN_AGENTS_DIR = Path(__file__).resolve().parent.parent.parent / "agents"
@@ -31,12 +34,14 @@ def load_agent_config() -> dict[str, AgentMeta]:
     config: dict[str, AgentMeta] = {}
     for role, entry in raw.items():
         if not (_PROMPTS_DIR / f"{role}.md").exists():
+            log.debug("plugin_role_skipped", role=role, reason="no_prompt_file")
             continue
         config[role] = AgentMeta(
             description=entry.get("description", ""),
             model=entry["model"],
             tools=entry.get("tools", []),
         )
+    log.info("plugin_config_loaded", roles=list(config.keys()))
     return config
 
 
@@ -48,9 +53,11 @@ def generate_agent_content(role: str) -> str:
     """
     config = load_agent_config()
     if role not in config:
+        log.error("plugin_generate_unknown_role", role=role, available=list(config.keys()))
         raise ValueError(f"Unknown agent role: {role!r}")
 
     meta = config[role]
+    log.debug("plugin_generate", role=role, model=meta.model)
     prompt = (_PROMPTS_DIR / f"{role}.md").read_text()
     frontmatter = yaml.dump(
         {"name": role, "description": meta.description, "model": meta.model, "tools": meta.tools},

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -2006,6 +2006,30 @@ If the Builder doesn't produce a PR:
    ```
 4. Move to next hypothesis — do not retry the same failure more than once
 
+### Builder Failure Recovery Protocol
+
+Before re-spawning a Builder after a failure notification, the CEO MUST verify whether the Builder actually completed its work despite the error. Rate limits, timeouts, and network errors on the final notification can present as generic failures even when commits and PRs were successfully created.
+
+**Mandatory pre-respawn checks:**
+
+1. **Check for commits on the experiment branch:**
+   ```bash
+   cd "$PROJECT_PATH" && git log --oneline -5
+   ```
+   Look for commits related to the current hypothesis on the experiment branch.
+
+2. **Check for an open PR:**
+   ```bash
+   gh pr list --state open --json number,title,headRefName
+   ```
+   Look for a PR whose `headRefName` matches the experiment branch.
+
+3. **Decision logic:**
+   - **Commits exist AND/OR PR is open for this branch:** The Builder likely succeeded despite the error notification. Do NOT re-spawn. Skip directly to **2d-review** (CEO Review of the Builder PR) and continue the review pipeline using the existing PR.
+   - **No new commits AND no PR for the experiment branch:** The Builder genuinely failed. Proceed with the standard Builder Failure protocol above (read issue comments, finalize as error, or re-invoke once).
+
+**Why this matters:** Without these checks, a rate-limit or timeout on the Builder's last token presents as a generic failure, causing the CEO to spawn a duplicate Builder session. The second Builder creates redundant commits, conflicting PRs, and wastes an entire agent invocation. This was observed in issue #294.
+
 ### Eval Crash
 If `factory eval` fails without producing a valid score:
 1. Check eval script: `cat "$PROJECT_PATH/eval/score.py"`

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1949,6 +1949,20 @@ These are NOT optional. Skipping archival is a Sacred Rule 7 violation, equivale
 
 ---
 
+## Budget-Conscious Mode
+
+When your task string contains a `## Budget-Conscious Mode` section, apply the following three throttles to reduce session cost:
+
+1. **Skip Reviewer agent for small diffs.** After Step 2d (your own structured code review), check the diff size. If the diff is under 50 lines AND your 2d-review verdict is CLEAN or PROCEED, skip the separate Reviewer agent invocation in Step 2e. You still perform your own code review; this only skips the dedicated Reviewer agent session.
+
+2. **Cap REDIRECT iterations at 1 per agent.** Normally you may redirect an agent up to 2 times. In budget-conscious mode, cap at 1. If the first redirect does not resolve the issue, finalize the experiment as `error` with a note explaining why, rather than spending another agent session.
+
+3. **Defer operational execution.** For operational or mixed hypotheses (ones that require running commands, deploying, or executing scripts beyond tests), produce code-only PRs. Include execution instructions in the PR description under a `## Execution Steps` heading. Do NOT run the execution within the Builder session. The user will run execution between PRs.
+
+These throttles are additive to all other rules. Sacred Rules, guard checks, and eval requirements still apply in full.
+
+---
+
 ## Sacred Rules
 
 These are **inviolable**. Checked by `factory guard` before any change is kept. A violation means the change is reverted, no exceptions.

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -477,6 +477,148 @@ def cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_handoff(args: argparse.Namespace) -> int:
+    """Synthesize current .factory/ state into a single actionable handoff brief."""
+    from factory.ceo_completion import read_cycle_state
+    from factory.checkpoint import load_checkpoint
+
+    project_path = Path(args.path).resolve()
+    factory_dir = project_path / ".factory"
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    lines: list[str] = [f"# Factory Handoff — {project_path.name} @ {now}", ""]
+
+    # Mode and phase from cycle state
+    cycle = read_cycle_state(project_path) if factory_dir.is_dir() else None
+    mode = cycle.mode if cycle else "unknown"
+    lines.append(f"**Mode:** {mode}")
+
+    # Phase from checkpoint
+    ckpt = load_checkpoint(project_path) if factory_dir.is_dir() else None
+    if ckpt:
+        completed = ", ".join(ckpt.completed_agents) or "none"
+        pending = ", ".join(ckpt.pending_agents) or "none"
+        lines.append(f"**Phase:** completed=[{completed}], pending=[{pending}]")
+    else:
+        lines.append("**Phase:** no checkpoint")
+
+    # Git branch
+    try:
+        branch_result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=project_path, capture_output=True, text=True, timeout=5,
+        )
+        branch = branch_result.stdout.strip() or "detached HEAD"
+    except Exception:
+        branch = "unknown"
+    lines.append(f"**Branch:** {branch}")
+
+    # Open PRs
+    try:
+        pr_result = subprocess.run(
+            ["gh", "pr", "list", "--state", "open", "--limit", "10"],
+            cwd=project_path, capture_output=True, text=True, timeout=10,
+        )
+        prs = pr_result.stdout.strip() if pr_result.returncode == 0 else None
+    except Exception:
+        prs = None
+    lines.append(f"**Open PRs:** {prs or 'none'}")
+
+    # Focus from cycle state
+    if cycle and cycle.initial_prompt:
+        for line in cycle.initial_prompt.splitlines():
+            if "Target:" in line:
+                lines.append(f"**Focus:** {line.split('Target:', 1)[1].strip()}")
+                break
+
+    lines.append("")
+
+    # Last successful artifact
+    lines.append("## Last Successful Artifact")
+    latest_review = _find_latest_review(factory_dir)
+    if latest_review:
+        lines.append(f"{latest_review}")
+    else:
+        lines.append("No review artifacts found.")
+    lines.append("")
+
+    # Recommended next steps
+    lines.append("## Recommended Next Steps")
+    steps = _recommend_next_steps(mode, ckpt, factory_dir)
+    for i, step in enumerate(steps, 1):
+        lines.append(f"{i}. {step}")
+    lines.append("")
+
+    # Key files
+    lines.append("## Key Files")
+    lines.append("- Strategy: .factory/strategy/current.md")
+    lines.append("- Research: .factory/strategy/research.md")
+    lines.append("- Backlog: .factory/strategy/backlog.md")
+    lines.append("- Reviews: .factory/reviews/")
+    lines.append("")
+
+    # Pending work from backlog
+    lines.append("## Pending Work")
+    backlog_path = factory_dir / "strategy" / "backlog.md"
+    if backlog_path.is_file():
+        backlog = backlog_path.read_text().strip()
+        lines.append(backlog if backlog else "No pending items.")
+    else:
+        lines.append("No backlog file found.")
+
+    print("\n".join(lines))
+    return 0
+
+
+def _find_latest_review(factory_dir: Path) -> str | None:
+    """Find the most recently modified review file."""
+    reviews_dir = factory_dir / "reviews"
+    if not reviews_dir.is_dir():
+        return None
+    review_files = list(reviews_dir.glob("*-latest.md"))
+    if not review_files:
+        return None
+    latest = max(review_files, key=lambda f: f.stat().st_mtime)
+    return f"{latest.relative_to(factory_dir.parent)} (modified {datetime.fromtimestamp(latest.stat().st_mtime).strftime('%Y-%m-%d %H:%M')})"
+
+
+def _recommend_next_steps(mode: str, ckpt: object | None, factory_dir: Path) -> list[str]:
+    """Generate recommended next steps based on current state."""
+    from factory.checkpoint import CheckpointState
+
+    if isinstance(ckpt, CheckpointState) and ckpt.pending_agents:
+        return [
+            f"Resume pending agents: {', '.join(ckpt.pending_agents)}",
+            f"Run: factory ceo <path> --headless (mode will auto-detect to {mode})",
+        ]
+
+    strategy_path = factory_dir / "strategy" / "current.md"
+    has_strategy = strategy_path.is_file() and strategy_path.stat().st_size > 0
+
+    if mode == "build":
+        return ["Continue building the project", "Run: factory ceo <path>"]
+    elif mode == "discover":
+        return ["Run discovery to set up eval harness", "Run: factory ceo <path> --mode discover"]
+    elif mode == "research":
+        return [
+            "Continue research optimization loop",
+            "Run: factory ceo <path> --mode research --headless",
+        ]
+    elif mode == "improve" and has_strategy:
+        return [
+            "Execute next hypothesis from strategy",
+            "Run: factory ceo <path> --headless",
+        ]
+    elif mode == "improve":
+        return [
+            "Run study to generate observations and strategy",
+            "Run: factory ceo <path>",
+        ]
+    return [
+        "Review .factory/ state and decide next action",
+        "Run: factory status <path>",
+    ]
+
+
 def cmd_summary(args: argparse.Namespace) -> int:
     """Generate an end-of-session summary report."""
     from factory.summary import format_summary, generate_summary, save_summary
@@ -2337,6 +2479,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("status", help="Print project status summary")
     p.add_argument("path", help="Path to the project")
 
+    # handoff
+    p = sub.add_parser("handoff", help="Print a structured handoff brief for cross-session resume")
+    p.add_argument("path", help="Path to the project")
+
     # summary
     p = sub.add_parser("summary", help="Generate end-of-session summary report")
     p.add_argument("path", help="Path to the project")
@@ -2685,6 +2831,7 @@ def main(argv: list[str] | None = None) -> int:
         "deferred-list": cmd_backlog_list,
         "backlog-add": cmd_backlog_add,
         "status": cmd_status,
+        "handoff": cmd_handoff,
         "summary": cmd_summary,
         "research": cmd_research,
         "backfill-citations": cmd_backfill_citations,

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1371,6 +1371,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context), force_fresh=force_fresh)
     discover_only = getattr(args, "discover_only", False)
     no_github = getattr(args, "no_github", False)
+    budget_conscious = getattr(args, "budget_conscious", False)
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)
@@ -1410,6 +1411,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         project_path, ceo_mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
         discover_only=discover_only, no_github=no_github,
+        budget_conscious=budget_conscious,
         interactive_idea=interactive_idea,
         research_ideation=research_ideation,
         messages=pending,
@@ -1859,6 +1861,7 @@ def _build_ceo_task(
     branch: str | None = None,
     discover_only: bool = False,
     no_github: bool = False,
+    budget_conscious: bool = False,
     interactive_idea: str | None = None,
     research_ideation: str | None = None,
     messages: list[Message] | None = None,
@@ -1993,6 +1996,23 @@ def _build_ceo_task(
             "skip it and note what was skipped in the experiment log."
         )
 
+    if budget_conscious:
+        task += (
+            "\n\n## Budget-Conscious Mode\n\n"
+            "The user has passed --budget-conscious. Apply these three throttles:\n\n"
+            "1. **Skip Reviewer agent for small diffs.** If the diff is under 50 lines "
+            "AND your own 2d-review verdict is CLEAN or PROCEED, skip the separate "
+            "Reviewer agent invocation (step 2e). You still perform your own structured "
+            "code review in step 2d.\n\n"
+            "2. **Cap REDIRECT iterations at 1 per agent.** If the first redirect does "
+            "not resolve the issue, finalize the experiment as error rather than spending "
+            "another agent session.\n\n"
+            "3. **Defer operational execution.** For operational or mixed hypotheses, "
+            "produce code-only PRs with execution instructions in the PR description. "
+            "Do NOT run the execution within the Builder session. The user will run "
+            "execution between PRs."
+        )
+
     return task
 
 
@@ -2050,6 +2070,7 @@ def _run_single_cycle(
     branch: str | None = None,
     discover_only: bool = False,
     no_github: bool = False,
+    budget_conscious: bool = False,
     model: str | None = None,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
@@ -2068,6 +2089,7 @@ def _run_single_cycle(
         project_path, mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
         discover_only=discover_only, no_github=no_github,
+        budget_conscious=budget_conscious,
         messages=pending,
     )
 
@@ -2106,6 +2128,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     focus = getattr(args, "focus", None)
     discover_only = getattr(args, "discover_only", False)
     no_github = getattr(args, "no_github", False)
+    budget_conscious = getattr(args, "budget_conscious", False)
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)
@@ -2133,7 +2156,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     if not loop:
         code = _run_single_cycle(
             project_path, mode, context, focus=focus, prompt_file=prompt_file,
-            discover_only=discover_only, no_github=no_github, model=model,
+            discover_only=discover_only, no_github=no_github,
+            budget_conscious=budget_conscious, model=model,
             **budget_kwargs,
         )
         if code != 0:
@@ -2167,7 +2191,8 @@ def cmd_run(args: argparse.Namespace) -> int:
 
             _run_single_cycle(
                 project_path, mode, context, focus=focus, prompt_file=prompt_file,
-                discover_only=discover_only, no_github=no_github, model=model,
+                discover_only=discover_only, no_github=no_github,
+                budget_conscious=budget_conscious, model=model,
                 **budget_kwargs,
             )
             _chain_modes(
@@ -2530,6 +2555,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-github", action="store_true", default=False,
         help="Disable GitHub operations (issue creation, PR posting, cloning)",
     )
+    p.add_argument(
+        "--budget-conscious", action="store_true", default=False,
+        help="Enable budget-conscious mode: skip Reviewer for small diffs, cap redirects, defer execution",
+    )
     p.add_argument("--min-growth", type=int, default=None,
                     help="Minimum guaranteed growth hypotheses (default: 2)")
     p.add_argument("--max-new", type=int, default=None,
@@ -2567,6 +2596,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--no-github", action="store_true", default=False,
         help="Disable GitHub operations (issue creation, PR posting, cloning)",
+    )
+    p.add_argument(
+        "--budget-conscious", action="store_true", default=False,
+        help="Enable budget-conscious mode: skip Reviewer for small diffs, cap redirects, defer execution",
     )
     p.add_argument(
         "--loop", action="store_true", default=False,

--- a/factory/mcp_server.py
+++ b/factory/mcp_server.py
@@ -167,14 +167,17 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
 
     handler = handlers.get(name)
     if handler is None:
+        log.warning("mcp_tool_unknown", tool=name)
         return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]
 
+    log.info("mcp_tool_call", tool=name, arguments=arguments)
     result_text = await handler(arguments)
     return [TextContent(type="text", text=result_text)]
 
 
 async def run_server() -> None:
     """Start the MCP stdio server."""
+    log.info("mcp_server_starting")
     async with stdio_server() as (read_stream, write_stream):
         await server.run(
             read_stream,

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -6,10 +6,14 @@ import os
 from pathlib import Path
 from typing import Literal
 
+import structlog
+
 from factory.runners._stream import should_stream, stream_subprocess
 from factory.runners.bob import BobRunner, is_dry_run
 from factory.runners.claude import ClaudeRunner
 from factory.runners.protocol import Runner
+
+log = structlog.get_logger()
 
 __all__ = [
     "Runner",
@@ -47,9 +51,11 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
     """
     resolved = name or os.environ.get("FACTORY_RUNNER", "claude")
     resolved = resolved.lower().strip()
+    log.info("runner_resolve", requested=name, resolved=resolved)
 
     if resolved not in _RUNNERS:
         available = ", ".join(_RUNNERS.keys())
+        log.error("runner_unknown", runner=resolved, available=available)
         raise ValueError(f"Unknown runner '{resolved}'. Available: {available}")
 
     if resolved == "bob":
@@ -59,4 +65,5 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
 
 def register_runner(name: str, runner_class: type[Runner]) -> None:
     """Register a runner implementation (used by bob module on import)."""
+    log.debug("runner_register", name=name, cls=runner_class.__name__)
     _RUNNERS[name] = runner_class

--- a/factory/runners/_stream.py
+++ b/factory/runners/_stream.py
@@ -7,6 +7,10 @@ import os
 import sys
 from typing import BinaryIO
 
+import structlog
+
+log = structlog.get_logger()
+
 
 def should_stream() -> bool:
     """Determine if we should stream subprocess output to the terminal.
@@ -67,6 +71,8 @@ async def stream_subprocess(
     Returns:
         (stdout_bytes, stderr_bytes) tuple with all collected output.
     """
+    log.debug("stream_start", pid=proc.pid, streaming=stream, prefix=prefix)
+
     stdout_buf: list[bytes] = []
     stderr_buf: list[bytes] = []
 
@@ -94,4 +100,14 @@ async def stream_subprocess(
 
     await proc.wait()
 
-    return b"".join(stdout_buf), b"".join(stderr_buf)
+    stdout_bytes = b"".join(stdout_buf)
+    stderr_bytes = b"".join(stderr_buf)
+    log.debug(
+        "stream_end",
+        pid=proc.pid,
+        returncode=proc.returncode,
+        stdout_bytes=len(stdout_bytes),
+        stderr_bytes=len(stderr_bytes),
+    )
+
+    return stdout_bytes, stderr_bytes

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import NoReturn, Protocol
 
+import structlog
+
+log = structlog.get_logger()
+
 
 class Runner(Protocol):
     """Protocol for CLI backend implementations (claude, bob, etc.)."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, AsyncMock
 
 import pytest
 
-from factory.cli import main, build_parser, _is_github_url, _slugify, _resolve_input, _persist_spec, _has_research_target
+from factory.cli import main, build_parser, _build_ceo_task, _is_github_url, _slugify, _resolve_input, _persist_spec, _has_research_target
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -1186,3 +1186,52 @@ class TestResearchMode:
         from factory.cli import _auto_detect_mode
         mode = _auto_detect_mode(tmp_project, force_fresh=True)
         assert mode == "improve"
+
+
+class TestBudgetConscious:
+    def test_parser_ceo_accepts_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path", "--budget-conscious"])
+        assert args.budget_conscious is True
+
+    def test_parser_ceo_default_false(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path"])
+        assert args.budget_conscious is False
+
+    def test_parser_run_accepts_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--budget-conscious"])
+        assert args.budget_conscious is True
+
+    def test_parser_run_default_false(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path"])
+        assert args.budget_conscious is False
+
+    def test_build_ceo_task_injects_section(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "improve", budget_conscious=True)
+        assert "## Budget-Conscious Mode" in task
+        assert "Skip Reviewer agent" in task
+        assert "Cap REDIRECT iterations at 1" in task
+        assert "Defer operational execution" in task
+
+    def test_build_ceo_task_omits_section_when_false(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "improve", budget_conscious=False)
+        assert "## Budget-Conscious Mode" not in task
+
+    def test_ceo_headless_passes_flag(self, tmp_path):
+        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
+             patch("factory.cli._chain_modes", return_value=0):
+            result = main(["ceo", str(tmp_path), "--headless", "--budget-conscious"])
+        assert result == 0
+        task = mock_agent.call_args[0][1]
+        assert "## Budget-Conscious Mode" in task
+
+    def test_run_passes_flag(self, tmp_path):
+        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
+             patch("factory.cli._chain_modes", return_value=0):
+            result = main(["run", str(tmp_path), "--budget-conscious"])
+        assert result == 0
+        task = mock_agent.call_args[0][1]
+        assert "## Budget-Conscious Mode" in task

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1235,3 +1235,61 @@ class TestBudgetConscious:
         assert result == 0
         task = mock_agent.call_args[0][1]
         assert "## Budget-Conscious Mode" in task
+
+
+class TestCmdHandoff:
+    def test_handoff_parser(self):
+        parser = build_parser()
+        args = parser.parse_args(["handoff", "/some/path"])
+        assert args.command == "handoff"
+        assert args.path == "/some/path"
+
+    def test_handoff_minimal_factory(self, tmp_project, capsys, sample_config):
+        """Handoff works with a minimal .factory/ directory (just config.json)."""
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+        result = main(["handoff", str(tmp_project)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "# Factory Handoff" in out
+        assert "**Mode:**" in out
+        assert "**Phase:**" in out
+        assert "**Branch:**" in out
+        assert "**Open PRs:**" in out
+        assert "## Last Successful Artifact" in out
+        assert "## Recommended Next Steps" in out
+        assert "## Key Files" in out
+        assert "## Pending Work" in out
+
+    def test_handoff_with_full_state(self, tmp_project, capsys, sample_config):
+        """Handoff includes data from reviews and backlog when present."""
+        store = ExperimentStore(tmp_project)
+        asyncio.run(store.init(sample_config))
+
+        # Create review file
+        reviews_dir = tmp_project / ".factory" / "reviews"
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        (reviews_dir / "builder-latest.md").write_text("Builder output here.")
+
+        # Create backlog
+        strategy_dir = tmp_project / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True, exist_ok=True)
+        (strategy_dir / "backlog.md").write_text("- Add caching layer\n- Fix auth bug\n")
+
+        result = main(["handoff", str(tmp_project)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "builder-latest.md" in out
+        assert "Add caching layer" in out
+        assert "Fix auth bug" in out
+
+    def test_handoff_missing_files(self, tmp_path, capsys):
+        """Handoff does not crash when .factory/ directory is absent."""
+        (tmp_path / ".git").mkdir()
+        result = main(["handoff", str(tmp_path)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "# Factory Handoff" in out
+        assert "no checkpoint" in out
+        assert "No review artifacts found" in out
+        assert "No backlog file found" in out


### PR DESCRIPTION
Closes #349

## Changes

- Added `--budget-conscious` boolean flag to both `factory ceo` and `factory run` argparse definitions, following the same pattern as `--no-github`
- When set, `_build_ceo_task()` appends a `## Budget-Conscious Mode` markdown section to the CEO task string with three throttles:
  1. Skip Reviewer agent (step 2e) for diffs under 50 lines when CEO's own review verdict is CLEAN/PROCEED
  2. Cap REDIRECT iterations at 1 per agent (instead of default 2)
  3. Defer operational execution: produce code-only PRs with execution instructions in PR description
- Added a `## Budget-Conscious Mode` section to the CEO prompt (`factory/agents/prompts/ceo.md`) defining the protocol
- Added 8 unit tests validating parser flags, task injection, and end-to-end flag propagation through `cmd_ceo` and `cmd_run`