### PR TITLE
docs: document inner/outer loop config for research mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ The Factory operates at two levels, like a researcher who both runs experiments 
 
 **Outer loop (meta-harness):** When inner-loop improvements plateau, the Factory restructures the harness itself — adding new agents, changing the pipeline architecture, introducing A/B strategy frameworks. The system under test evolves, not just its parameters.
 
+Configure these in `factory.md` to control automatic loop transitions:
+
+```markdown
+## Inner Loop
+- runs_per_cycle: 5
+- aggregate: mean
+- plateau_threshold: 3
+- max_inner_runs_per_cycle: 10
+
+## Outer Loop Surfaces
+- max_outer_cycles: 5
+- inner: prompts/*.md
+- outer: src/**/*.py
+```
+
+The factory runs the harness N times per cycle, aggregates scores, and when improvements plateau for the configured threshold, automatically expands the scope to outer surfaces. See the [Configuration Reference](docs/configuration.md#inner-loop) for field details.
+
 ### Example: HMMT math competition solver
 
 The Factory built a multi-agent system to solve [HMMT February 2026 Combinatorics Problem 7](https://www.hmmt.org/) (decagonal prism plane partitions, answer: 1574). Here's what actually happened:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,6 +202,46 @@ Additional rules for the research loop. Only used in research mode.
 - Each experiment must complete within 30 minutes
 ```
 
+### `## Inner Loop`
+
+Multi-run configuration for research mode. Runs the evaluation harness multiple times per cycle and aggregates the metric. Useful for stochastic pipelines where a single run doesn't give a reliable signal. Only used in research mode.
+
+```markdown
+## Inner Loop
+- runs_per_cycle: 5
+- aggregate: mean
+- plateau_threshold: 3
+- max_inner_runs_per_cycle: 10
+```
+
+| Field | Purpose | Default |
+|-------|---------|---------|
+| `runs_per_cycle` | Number of times to run the harness per cycle | `1` |
+| `aggregate` | How to combine scores: `mean`, `median`, `max`, `all_pass` | `mean` |
+| `plateau_threshold` | Consecutive non-improving cycles before triggering outer loop | `3` |
+| `max_inner_runs_per_cycle` | Optional cap on runs per cycle | None |
+
+### `## Outer Loop Surfaces`
+
+Surface scoping for inner/outer loop transitions. When inner loop improvements plateau, the factory expands the Builder's scope to include outer surfaces for architectural changes. Only used in research mode.
+
+```markdown
+## Outer Loop Surfaces
+- max_outer_cycles: 5
+- inner: prompts/*.md
+- inner: config/*.yaml
+- outer: src/**/*.py
+- outer: agents/**/*.md
+```
+
+| Field | Purpose |
+|-------|---------|
+| `max_outer_cycles` | Maximum outer loop expansions before stopping |
+| `inner: <glob>` | Narrow surfaces used during inner loop (one per line) |
+| `outer: <glob>` | Additional surfaces unlocked after plateau (one per line) |
+
+Entries use prefix format — `inner:` and `outer:` followed by a glob pattern. Multiple entries per type are allowed.
+
 ### `## Cost Budget`
 
 Per-cycle or total budget constraints for research experiments.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -245,9 +245,22 @@ The research target is configured in `factory.md`:
 - eval/
 - data/ground_truth.json
 - tests/
+
+## Inner Loop
+- runs_per_cycle: 5
+- aggregate: mean
+- plateau_threshold: 3
+- max_inner_runs_per_cycle: 10
+
+## Outer Loop Surfaces
+- max_outer_cycles: 5
+- inner: prompts/*.md
+- outer: src/**/*.py
 ```
 
 **Mutable surfaces** are files the Builder can change. **Fixed surfaces** are ground truth data and eval infrastructure that must never be modified. Fixed surfaces are fingerprinted for leakage detection.
+
+**Inner Loop** is for stochastic harnesses — it runs the eval N times per cycle, aggregates via `mean`/`median`/`max`/`all_pass`, and detects plateau after N consecutive non-improving cycles. **Outer Loop Surfaces** defines narrow (inner) and wide (outer) scopes — when the inner loop plateaus, the factory expands mutable surfaces to include outer surfaces for architectural changes. Both sections are optional and independent.
 
 ### The research cycle
 


### PR DESCRIPTION
Closes the documentation gap left after PR #353 fixed inner/outer loop field names.

## Changes

- **README.md**: Added a config example and explanation to the "Inner loop + outer loop" subsection, linking to the configuration reference
- **docs/getting-started.md**: Added Inner Loop and Outer Loop Surfaces sections to the research project config example, with a paragraph explaining both
- **docs/configuration.md**: Added full reference sections for `## Inner Loop` and `## Outer Loop Surfaces` with field tables, between Cost Budget and .factory/ Directory

All field names match the template at `templates/factory_config.md` and the models fixed in #353.

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-check field names against `factory/models.py` and `templates/factory_config.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)