### PR TITLE
fix: defer project directory creation until just before worktree setup

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2200,6 +2200,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     interactive_idea: str | None = None
     interactive_existing: bool = False
     research_ideation: str | None = None
+    deferred_spec: str | None = None
+    needs_materialize = False
     if mode == "interactive" and _interactive_is_existing:
         project_path, context = _resolve_input(raw_path, dir_name=dir_name)
         interactive_existing = True
@@ -2209,16 +2211,16 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             interactive_idea = resolved_file.read_text()
             slug = _slugify(dir_name) if dir_name else _slugify(resolved_file.stem.split("—")[0].strip())
             project_path = _dedupe_project_path(_get_projects_dir() / slug, interactive_idea)
-            _ensure_repo(project_path)
-            _persist_spec(project_path, interactive_idea)
+            deferred_spec = interactive_idea
+            needs_materialize = True
             print(f"Idea file: {resolved_file.name}")
             print(f"Project directory: {project_path}")
         else:
             interactive_idea = raw_path
             slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
             project_path = _dedupe_project_path(_get_projects_dir() / slug, raw_path)
-            _ensure_repo(project_path)
-            _persist_spec(project_path, raw_path)
+            deferred_spec = raw_path
+            needs_materialize = True
         context = None
     elif mode == "research" and not _safe_is_dir(resolved := Path(raw_path).expanduser()) and not _safe_is_file(resolved):
         # New research project from idea — enter research ideation
@@ -2233,10 +2235,13 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         research_ideation = raw_path
         slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
         project_path = _dedupe_project_path(_get_projects_dir() / slug, raw_path)
-        _ensure_repo(project_path)
+        needs_materialize = True
         context = None
     else:
         project_path, context = _resolve_input(raw_path, dir_name=dir_name)
+        if context is not None and not (project_path / ".git").is_dir():
+            deferred_spec = context
+            needs_materialize = True
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
     issue_number: int | None = None
@@ -2305,6 +2310,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
 
+    if needs_materialize:
+        _materialize_project(project_path, deferred_spec)
     base_branch = branch or _read_target_branch(project_path)
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
@@ -2380,6 +2387,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             )
         finally:
             remove_worktree(project_path, wt_path, wt_branch)
+            if needs_materialize and _is_scaffold_only(project_path):
+                import shutil
+                shutil.rmtree(project_path, ignore_errors=True)
 
     # Interactive foreground mode: use subprocess.run so we can clean up the worktree.
     try:
@@ -2398,6 +2408,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         )
     finally:
         remove_worktree(project_path, wt_path, wt_branch)
+        if needs_materialize and _is_scaffold_only(project_path):
+            import shutil
+            shutil.rmtree(project_path, ignore_errors=True)
 
 
 def _is_github_url(path: str) -> bool:
@@ -2453,8 +2466,6 @@ def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | N
         idea_content = expanded.read_text()
         slug = _slugify(dir_name) if dir_name else _slugify(expanded.stem.split("\u2014")[0].strip())
         project_path = _dedupe_project_path(_get_projects_dir() / slug, idea_content)
-        _ensure_repo(project_path)
-        _persist_spec(project_path, idea_content)
         print(f"Idea file: {expanded.name}")
         print(f"Project directory: {project_path}")
         return project_path, idea_content
@@ -2469,8 +2480,6 @@ def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | N
     # 4. Raw prompt
     slug = _slugify(dir_name) if dir_name else _extract_project_name(raw)
     project_path = _dedupe_project_path(_get_projects_dir() / slug, raw)
-    _ensure_repo(project_path)
-    _persist_spec(project_path, raw)
     print(f"New project from prompt: {project_path}")
     return project_path, raw
 
@@ -2640,6 +2649,39 @@ def _resolve_focus_issue(
         file=sys.stderr,
     )
     return issue_spec.title, context, issue_spec.number, issue_spec.url
+
+
+def _materialize_project(project_path: Path, spec: str | None = None) -> None:
+    """Create git repo and optionally persist spec. Single choke point for deferred creation."""
+    _ensure_repo(project_path)
+    if spec:
+        _persist_spec(project_path, spec)
+
+
+def _is_scaffold_only(project_path: Path) -> bool:
+    """Return True if project_path is empty scaffolding that can be safely removed.
+
+    A project is considered scaffold-only when it has exactly 1 git commit
+    (the initial empty commit from _ensure_repo) and the only non-.git content
+    is .factory/strategy/current.md.
+    """
+    if not project_path.is_dir():
+        return False
+    git_dir = project_path / ".git"
+    if not git_dir.is_dir():
+        return False
+    result = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD"],
+        cwd=project_path, capture_output=True, text=True,
+    )
+    if result.returncode != 0 or result.stdout.strip() != "1":
+        return False
+    non_git = [
+        p for p in project_path.rglob("*")
+        if p.is_file() and ".git" not in p.parts
+    ]
+    allowed = {project_path / ".factory" / "strategy" / "current.md"}
+    return all(p in allowed for p in non_git)
 
 
 def _persist_spec(project_path: Path, spec: str) -> None:
@@ -3204,6 +3246,9 @@ def _run_single_cycle(
         return code
     finally:
         remove_worktree(project_path, wt_path, wt_branch)
+        if _is_scaffold_only(project_path):
+            import shutil
+            shutil.rmtree(project_path, ignore_errors=True)
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -3281,6 +3326,9 @@ def cmd_run(args: argparse.Namespace) -> int:
     pruned = prune_stale(project_path)
     if pruned:
         print(f"  Cleaned {len(pruned)} stale worktree(s)", file=sys.stderr)
+
+    if context is not None and not (project_path / ".git").is_dir():
+        _materialize_project(project_path, context)
 
     budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch)
     skip_improve = mode in ("improve", "meta") or discover_only

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3246,9 +3246,6 @@ def _run_single_cycle(
         return code
     finally:
         remove_worktree(project_path, wt_path, wt_branch)
-        if _is_scaffold_only(project_path):
-            import shutil
-            shutil.rmtree(project_path, ignore_errors=True)
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -3322,13 +3319,14 @@ def cmd_run(args: argparse.Namespace) -> int:
     _print_banner(mode)
     _ensure_dashboard(project_path)
 
-    from factory.worktree import prune_stale
-    pruned = prune_stale(project_path)
-    if pruned:
-        print(f"  Cleaned {len(pruned)} stale worktree(s)", file=sys.stderr)
-
     if context is not None and not (project_path / ".git").is_dir():
         _materialize_project(project_path, context)
+
+    from factory.worktree import prune_stale
+    if project_path.is_dir():
+        pruned = prune_stale(project_path)
+        if pruned:
+            print(f"  Cleaned {len(pruned)} stale worktree(s)", file=sys.stderr)
 
     budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch)
     skip_improve = mode in ("improve", "meta") or discover_only

--- a/factory/store.py
+++ b/factory/store.py
@@ -3,7 +3,6 @@
 import csv
 import io
 import json
-import re
 import subprocess
 from datetime import datetime
 from pathlib import Path

--- a/tests/test_clean_pr.py
+++ b/tests/test_clean_pr.py
@@ -111,9 +111,10 @@ class TestStripPrArtifacts:
         repo = tmp_path / "repo"
         repo.mkdir()
         subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test"], cwd=repo, capture_output=True, check=True)
         subprocess.run(
-            ["git", "-c", "user.name=Test", "-c", "user.email=test@test",
-             "commit", "--allow-empty", "-m", "init"],
+            ["git", "commit", "--allow-empty", "-m", "init"],
             cwd=repo, capture_output=True, check=True,
         )
         subprocess.run(["git", "branch", "-M", "main"], cwd=repo, capture_output=True, check=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
-from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo, _quick_classify, _welcome_wizard
+from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo, _materialize_project, _is_scaffold_only, _quick_classify, _welcome_wizard
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -1137,7 +1137,8 @@ class TestDedupeProjectPath:
 
     def test_resolve_input_dedupes_raw_prompt(self, tmp_path):
         with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
-            p1, _ = _resolve_input("Build a REST API")
+            p1, ctx1 = _resolve_input("Build a REST API")
+            _materialize_project(p1, ctx1)
             p2, _ = _resolve_input("Create a new REST API")
         assert p1.name == "rest-api"
         assert p2.name == "rest-api-2"
@@ -1176,7 +1177,7 @@ class TestResolveInput:
             project_path, context = _resolve_input(str(idea_file))
 
         assert project_path.name == "my-project"
-        assert (project_path / ".git").is_dir()
+        assert not (project_path / ".git").is_dir()
         assert context is not None
         assert "Build something cool" in context
 
@@ -1186,7 +1187,7 @@ class TestResolveInput:
 
         assert project_path.parent == tmp_path / "projects"
         assert project_path.name == "todo-app-fastapi"
-        assert (project_path / ".git").is_dir()
+        assert not (project_path / ".git").is_dir()
         assert context == "Build a todo app with FastAPI"
 
     def test_non_md_file(self, tmp_path):
@@ -1197,7 +1198,7 @@ class TestResolveInput:
             project_path, context = _resolve_input(str(py_file))
 
         assert project_path.name == "script"
-        assert (project_path / ".git").is_dir()
+        assert not (project_path / ".git").is_dir()
         assert context == "print('hello')"
 
     def test_binary_file_raises(self, tmp_path):
@@ -1227,7 +1228,7 @@ class TestResolveInput:
             project_path, context = _resolve_input("Build a todo app with FastAPI", dir_name="my-todo")
 
         assert project_path.name == "my-todo"
-        assert (project_path / ".git").is_dir()
+        assert not (project_path / ".git").is_dir()
 
     def test_dir_overrides_slug_for_idea_file(self, tmp_path):
         idea_file = tmp_path / "Long Idea Name — Details.md"
@@ -1237,7 +1238,7 @@ class TestResolveInput:
             project_path, context = _resolve_input(str(idea_file), dir_name="custom-name")
 
         assert project_path.name == "custom-name"
-        assert (project_path / ".git").is_dir()
+        assert not (project_path / ".git").is_dir()
 
     def test_dir_ignored_for_existing_directory(self, tmp_path):
         project_path, context = _resolve_input(str(tmp_path), dir_name="ignored-name")
@@ -1889,3 +1890,113 @@ class TestQuickClassifyWizardFile:
         result = _quick_classify("~/.factory/wizard_input.md")
         assert result is not None
         assert len(result) == 2
+
+
+class TestMaterializeProject:
+    """Tests for _materialize_project — deferred directory creation."""
+
+    def test_creates_repo(self, tmp_path):
+        project = tmp_path / "new-project"
+        _materialize_project(project)
+        assert (project / ".git").is_dir()
+
+    def test_creates_repo_and_persists_spec(self, tmp_path):
+        project = tmp_path / "new-project"
+        _materialize_project(project, "Build a todo app")
+        assert (project / ".git").is_dir()
+        spec = (project / ".factory" / "strategy" / "current.md").read_text()
+        assert "Build a todo app" in spec
+
+    def test_no_spec_skips_persist(self, tmp_path):
+        project = tmp_path / "new-project"
+        _materialize_project(project, None)
+        assert (project / ".git").is_dir()
+        assert not (project / ".factory" / "strategy" / "current.md").exists()
+
+    def test_idempotent_on_existing_repo(self, tmp_path):
+        project = tmp_path / "existing"
+        _materialize_project(project, "first spec")
+        count_before = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=project, capture_output=True, text=True,
+        ).stdout.strip()
+        _materialize_project(project, "second spec")
+        count_after = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            cwd=project, capture_output=True, text=True,
+        ).stdout.strip()
+        assert count_before == count_after
+
+
+class TestIsScaffoldOnly:
+    """Tests for _is_scaffold_only — cleanup heuristic."""
+
+    def test_scaffold_project(self, tmp_path):
+        project = tmp_path / "scaffold"
+        _materialize_project(project, "some idea")
+        assert _is_scaffold_only(project) is True
+
+    def test_scaffold_without_spec(self, tmp_path):
+        project = tmp_path / "scaffold"
+        _materialize_project(project)
+        assert _is_scaffold_only(project) is True
+
+    def test_not_scaffold_with_extra_file(self, tmp_path):
+        project = tmp_path / "real"
+        _materialize_project(project, "some idea")
+        (project / "README.md").write_text("# Hello")
+        assert _is_scaffold_only(project) is False
+
+    def test_not_scaffold_with_extra_commit(self, tmp_path):
+        project = tmp_path / "real"
+        _materialize_project(project, "some idea")
+        (project / "README.md").write_text("# Hello")
+        subprocess.run(["git", "add", "README.md"], cwd=project, capture_output=True)
+        subprocess.run(
+            ["git", "-c", "user.name=Test", "-c", "user.email=t@t",
+             "commit", "-m", "second"],
+            cwd=project, capture_output=True,
+        )
+        assert _is_scaffold_only(project) is False
+
+    def test_nonexistent_dir(self, tmp_path):
+        assert _is_scaffold_only(tmp_path / "nope") is False
+
+    def test_no_git(self, tmp_path):
+        project = tmp_path / "nogit"
+        project.mkdir()
+        assert _is_scaffold_only(project) is False
+
+
+class TestDeferredCreationFlow:
+    """Integration tests: _resolve_input defers creation, _materialize_project creates."""
+
+    def test_resolve_then_materialize_file(self, tmp_path):
+        idea_file = tmp_path / "my-app.md"
+        idea_file.write_text("Build something cool")
+
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
+            project_path, context = _resolve_input(str(idea_file))
+
+        assert not project_path.exists()
+        _materialize_project(project_path, context)
+        assert (project_path / ".git").is_dir()
+        assert (project_path / ".factory" / "strategy" / "current.md").exists()
+
+    def test_resolve_then_materialize_raw_prompt(self, tmp_path):
+        with patch("factory.cli._get_projects_dir", return_value=tmp_path / "projects"):
+            project_path, context = _resolve_input("Build a weather CLI")
+
+        assert not project_path.exists()
+        _materialize_project(project_path, context)
+        assert (project_path / ".git").is_dir()
+        assert "Build a weather CLI" in (
+            project_path / ".factory" / "strategy" / "current.md"
+        ).read_text()
+
+    def test_existing_dir_not_affected(self, tmp_path):
+        """_resolve_input on existing dir returns it unchanged, _materialize_project is no-op."""
+        (tmp_path / ".git").mkdir()
+        project_path, context = _resolve_input(str(tmp_path))
+        assert project_path == tmp_path
+        assert context is None

--- a/tests/test_inner_outer_loop.py
+++ b/tests/test_inner_outer_loop.py
@@ -32,7 +32,7 @@ from factory.models import (
 )
 from factory.research.runner import aggregate_metric, execute_multi_run
 from factory.store import ExperimentStore, _parse_inner_loop, _parse_outer_loop
-from factory.strategy import detect_plateau, detect_research_plateau
+from factory.strategy import detect_research_plateau
 
 
 # ── Model validation ────────────────────────────────────────────

--- a/tests/test_vault_decouple.py
+++ b/tests/test_vault_decouple.py
@@ -184,13 +184,16 @@ class TestResolveInputWithoutVault:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
         import factory.cli as cli_mod
-        from factory.cli import _resolve_input
+        from factory.cli import _materialize_project, _resolve_input
 
         monkeypatch.setattr(cli_mod, "_get_projects_dir", lambda: tmp_path)
         path, ctx = _resolve_input("build a weather dashboard")
         assert path.parent == tmp_path
-        assert path.exists()
+        assert not path.exists()
         assert ctx == "build a weather dashboard"
+
+        _materialize_project(path, ctx)
+        assert path.exists()
 
     def test_idea_file(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,


### PR DESCRIPTION
Factory experiment 22. Fixes #358.

## Summary
- Defers _ensure_repo + _persist_spec from eager input resolution to just before create_worktree
- Adds _materialize_project helper as single choke point for deferred creation
- Adds _is_scaffold_only helper for cleanup heuristic (1 commit + only current.md)
- Cleanup in finally blocks removes scaffolding-only dirs on early exit
- 6 call sites updated across cmd_ceo and _resolve_input
- Tests updated to reflect deferred creation behavior + new test classes

## Test plan
- [x] TestMaterializeProject — creates repo, persists spec, idempotent
- [x] TestIsScaffoldOnly — scaffold detection, extra files, extra commits
- [x] TestDeferredCreationFlow — resolve then materialize for files and prompts
- [x] Existing TestResolveInput tests updated for deferred behavior