### PR TITLE
Semantic branch names from available context (issue #350)

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -883,6 +883,7 @@ def cmd_precheck(args: argparse.Namespace) -> int:
             "hypothesis": r.hypothesis,
             "verdict": r.verdict,
             "delta": r.delta,
+            "notes": r.notes,
         }
         for r in records
     ]

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1557,7 +1557,11 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     pending_ids = [m.id for m in pending]
 
     base_branch = branch or _read_target_branch(project_path)
-    wt_path, wt_branch = create_worktree(project_path, base_branch)
+    wt_path, wt_branch = create_worktree(
+        project_path, base_branch,
+        hint=focus or interactive_idea or research_ideation or context,
+        mode=mode,
+    )
 
     if interactive_existing:
         ceo_mode = "interactive"
@@ -2309,7 +2313,11 @@ def _run_single_cycle(
     pending_ids = [m.id for m in pending]
 
     base_branch = branch or _read_target_branch(project_path)
-    wt_path, wt_branch = create_worktree(project_path, base_branch)
+    wt_path, wt_branch = create_worktree(
+        project_path, base_branch,
+        hint=focus or context,
+        mode=mode,
+    )
 
     try:
         task = _build_ceo_task(

--- a/factory/precheck.py
+++ b/factory/precheck.py
@@ -109,10 +109,26 @@ def check_scope(
         for line in result.stdout.splitlines()
         if line.startswith("VIOLATION:")
     ]
+
+    if not violations:
+        # Non-zero exit but no VIOLATION lines — likely a non-scope guard failure
+        # or subprocess infrastructure error. Not a scope violation.
+        log.warning(
+            "scope_check_ambiguous",
+            returncode=result.returncode,
+            stdout=result.stdout.strip()[:200],
+            stderr=result.stderr.strip()[:200],
+        )
+        return CheckResult(
+            name="scope",
+            passed=True,
+            detail=f"Guard exited non-zero but no scope violations found (rc={result.returncode})",
+        )
+
     return CheckResult(
         name="scope",
         passed=False,
-        detail=f"Guard violations: {'; '.join(violations) or result.stdout.strip()[:200]}",
+        detail=f"Guard violations: {'; '.join(violations)}",
     )
 
 

--- a/factory/strategy.py
+++ b/factory/strategy.py
@@ -156,6 +156,22 @@ def hypothesis_similarity(a: str, b: str) -> float:
     return score
 
 
+_INFRA_REVERT_MARKERS = frozenset({
+    "reason=precheck_failed",
+    "precheck_false_positive",
+    "precheck_bugs",
+    "reason=infrastructure",
+})
+
+
+def _is_infra_revert(notes: str) -> bool:
+    """Check if revert notes indicate infrastructure/precheck failure, not code defect."""
+    if not notes:
+        return False
+    notes_lower = notes.lower()
+    return any(marker in notes_lower for marker in _INFRA_REVERT_MARKERS)
+
+
 def find_anti_patterns(
     hypothesis: str,
     history: list[dict],
@@ -165,10 +181,18 @@ def find_anti_patterns(
 
     Returns a list of history entries that were reverted and have similarity
     above the threshold.  Each returned dict gets a ``"similarity"`` key added.
+
+    Experiments reverted for infrastructure/precheck reasons (indicated by
+    markers in the ``"notes"`` field) are excluded from matching — re-attempting
+    an experiment that failed due to tooling bugs is valid.
     """
     matches: list[dict] = []
     for entry in history:
         if entry.get("verdict") != "revert":
+            continue
+        # Skip experiments reverted for infrastructure/precheck reasons
+        notes = entry.get("notes", "")
+        if _is_infra_revert(notes):
             continue
         past_hyp = entry.get("hypothesis", "")
         sim = hypothesis_similarity(hypothesis, past_hyp)

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -1,8 +1,10 @@
 """Git worktree lifecycle management for experiment isolation."""
 
+import re
 import secrets
 import shutil
 import subprocess
+import unicodedata
 from pathlib import Path
 
 import structlog
@@ -10,16 +12,69 @@ import structlog
 log = structlog.get_logger()
 
 
-def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
+def _slugify(text: str, max_length: int = 40) -> str:
+    """Convert arbitrary text to a kebab-case slug suitable for branch names."""
+    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = text.strip("-")
+    if len(text) > max_length:
+        text = text[:max_length].rstrip("-")
+    return text or "unnamed"
+
+
+_FIX_KEYWORDS = frozenset({"bug", "crash", "error", "broken", "fail", "fix"})
+_DOCS_KEYWORDS = frozenset({"doc", "readme", "documentation", "docs"})
+_REFACTOR_KEYWORDS = frozenset({
+    "refactor", "cleanup", "rename", "reorganize", "restructure",
+})
+_TEST_KEYWORDS = frozenset({"test", "coverage", "spec"})
+_CHORE_KEYWORDS = frozenset({"chore", "ci", "infra", "config", "dependency", "deps"})
+_CHORE_MODES = frozenset({"discover", "meta"})
+
+
+def _classify_prefix(hint: str, mode: str = "improve") -> str:
+    """Keyword-match hint text to a conventional branch prefix."""
+    words = set(re.findall(r"[a-z]+", hint.lower()))
+    if words & _FIX_KEYWORDS:
+        return "fix"
+    if words & _DOCS_KEYWORDS:
+        return "docs"
+    if words & _REFACTOR_KEYWORDS:
+        return "refactor"
+    if words & _TEST_KEYWORDS:
+        return "test"
+    if words & _CHORE_KEYWORDS or mode in _CHORE_MODES:
+        return "chore"
+    return "feat"
+
+
+def create_worktree(
+    project_path: Path,
+    base_branch: str = "main",
+    *,
+    hint: str | None = None,
+    mode: str = "improve",
+) -> tuple[Path, str]:
     """Create an isolated worktree for a factory run.
 
     Returns (worktree_path, branch_name).
     """
     project_path = project_path.resolve()
-    run_id = secrets.token_hex(4)
-    branch = f"factory/run-{run_id}"
+    hex4 = secrets.token_hex(2)
     factory_dir = project_path / ".factory"
-    wt_dir = factory_dir / "worktrees" / f"run-{run_id}"
+
+    if hint:
+        prefix = _classify_prefix(hint, mode)
+        slug = _slugify(hint)
+        branch = f"factory/{prefix}/{slug}-{hex4}"
+        dir_name = f"{prefix}-{slug}-{hex4}"
+    else:
+        run_id = secrets.token_hex(4)
+        branch = f"factory/run-{run_id}"
+        dir_name = f"run-{run_id}"
+
+    wt_dir = factory_dir / "worktrees" / dir_name
 
     log.info("worktree_create", branch=branch, path=str(wt_dir))
 
@@ -41,6 +96,8 @@ def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path
         else:
             wt_factory.unlink()
     wt_factory.symlink_to(factory_dir)
+
+    (wt_dir / ".factory_branch").write_text(branch)
 
     log.info("worktree_created", branch=branch, path=str(wt_dir))
     return wt_dir, branch
@@ -85,11 +142,15 @@ def prune_stale(project_path: Path) -> list[str]:
         active = _list_active_worktrees(project_path)
         for d in wt_parent.iterdir():
             if d.is_dir() and str(d.resolve()) not in active:
-                run_id = d.name.removeprefix("run-")
+                marker = d / ".factory_branch"
+                if marker.is_file():
+                    branch = marker.read_text().strip()
+                else:
+                    run_id = d.name.removeprefix("run-")
+                    branch = f"factory/run-{run_id}"
                 shutil.rmtree(d)
                 pruned.append(f"Removed orphaned directory: {d.name}")
                 log.info("worktree_pruned_orphan", name=d.name)
-                branch = f"factory/run-{run_id}"
                 subprocess.run(
                     ["git", "branch", "-D", branch],
                     cwd=project_path,

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -97,7 +97,9 @@ def create_worktree(
             wt_factory.unlink()
     wt_factory.symlink_to(factory_dir)
 
-    (wt_dir / ".factory_branch").write_text(branch)
+    # Store branch marker as a sibling file (not inside the worktree) so it
+    # doesn't appear as untracked in the worktree's git status.
+    (wt_dir.parent / (dir_name + ".branch")).write_text(branch)
 
     log.info("worktree_created", branch=branch, path=str(wt_dir))
     return wt_dir, branch
@@ -109,6 +111,10 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
 
     if worktree_path.exists():
         shutil.rmtree(worktree_path)
+
+    marker = worktree_path.parent / (worktree_path.name + ".branch")
+    if marker.is_file():
+        marker.unlink()
 
     subprocess.run(
         ["git", "worktree", "prune"],
@@ -142,13 +148,15 @@ def prune_stale(project_path: Path) -> list[str]:
         active = _list_active_worktrees(project_path)
         for d in wt_parent.iterdir():
             if d.is_dir() and str(d.resolve()) not in active:
-                marker = d / ".factory_branch"
+                marker = wt_parent / (d.name + ".branch")
                 if marker.is_file():
                     branch = marker.read_text().strip()
                 else:
                     run_id = d.name.removeprefix("run-")
                     branch = f"factory/run-{run_id}"
                 shutil.rmtree(d)
+                if marker.is_file():
+                    marker.unlink()
                 pruned.append(f"Removed orphaned directory: {d.name}")
                 log.info("worktree_pruned_orphan", name=d.name)
                 subprocess.run(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def _mock_worktree(tmp_path: Path, request: pytest.FixtureRequest) -> None:
         yield  # type: ignore[misc]
         return
 
-    def _fake_create(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
+    def _fake_create(project_path: Path, base_branch: str = "main", **kw: object) -> tuple[Path, str]:
         return project_path, "factory/run-fake0000"
 
     def _fake_remove(project_path: Path, worktree_path: Path, branch: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ def _mock_foreground():
     mock_run = MagicMock(return_value=MagicMock(returncode=0))
     with patch("factory.runners.claude.subprocess.run", mock_run), \
          patch("factory.worktree.create_worktree",
-               side_effect=lambda p, b="main": (p, "factory/run-test")), \
+               side_effect=lambda p, b="main", **kw: (p, "factory/run-test")), \
          patch("factory.worktree.remove_worktree"), \
          patch("factory.worktree.prune_stale", return_value=[]), \
          patch("factory.cli._read_target_branch", return_value="main"), \

--- a/tests/test_precheck.py
+++ b/tests/test_precheck.py
@@ -183,6 +183,42 @@ class TestCheckScope:
         assert not r.passed
         assert "not found" in r.detail.lower()
 
+    @patch("factory.precheck.subprocess.run")
+    def test_nonzero_exit_no_violations_passes(self, mock_run):
+        """Non-zero exit with no VIOLATION lines should pass (not a scope issue)."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout='{"event": "guard_check", "dirty": true}\n',
+            stderr="",
+        )
+        r = check_scope(Path("/tmp/test"), "abc123")
+        assert r.passed
+        assert "no scope violations found" in r.detail.lower()
+
+    @patch("factory.precheck.subprocess.run")
+    def test_nonzero_exit_with_violations_fails(self, mock_run):
+        """Non-zero exit WITH VIOLATION lines should still fail."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="VIOLATION: modified eval/score.py\n",
+            stderr="",
+        )
+        r = check_scope(Path("/tmp/test"), "abc123")
+        assert not r.passed
+        assert "modified eval/score.py" in r.detail
+
+    @patch("factory.precheck.subprocess.run")
+    def test_nonzero_exit_stderr_only_passes(self, mock_run):
+        """Non-zero exit with only stderr output (no VIOLATION lines) should pass."""
+        mock_run.return_value = MagicMock(
+            returncode=2,
+            stdout="",
+            stderr="ImportError: No module named 'foo'",
+        )
+        r = check_scope(Path("/tmp/test"), "abc123")
+        assert r.passed
+        assert "rc=2" in r.detail
+
 
 # ── precheck: check_anti_pattern ──────────────────────────────
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -6,9 +6,11 @@ from factory.strategy import (
     _format_tier1,
     _format_tier2,
     _format_tier3,
+    _is_infra_revert,
     _record_to_dict,
     categorize_hypothesis,
     detect_stuck,
+    find_anti_patterns,
     format_tiered_history,
     rank_hypotheses,
 )
@@ -464,3 +466,134 @@ class TestRecordToDict:
 class TestMaxInlineHistory:
     def test_constant_value(self):
         assert MAX_INLINE_HISTORY == 10
+
+
+# ── _is_infra_revert ──────────────────────────────────────────────
+
+
+class TestIsInfraRevert:
+    def test_empty_notes(self):
+        assert _is_infra_revert("") is False
+
+    def test_none_like_empty(self):
+        # Caller passes empty string for None notes
+        assert _is_infra_revert("") is False
+
+    def test_precheck_failed_marker(self):
+        assert _is_infra_revert("reason=precheck_failed") is True
+
+    def test_precheck_false_positive_marker(self):
+        assert _is_infra_revert("Reverted due to precheck_false_positive in scope check") is True
+
+    def test_precheck_bugs_marker(self):
+        assert _is_infra_revert("precheck_bugs caused failure") is True
+
+    def test_infrastructure_reason(self):
+        assert _is_infra_revert("reason=infrastructure") is True
+
+    def test_case_insensitive(self):
+        assert _is_infra_revert("Reason=Precheck_Failed") is True
+        assert _is_infra_revert("REASON=INFRASTRUCTURE") is True
+
+    def test_normal_revert_notes(self):
+        assert _is_infra_revert("Score regressed from 0.85 to 0.70") is False
+
+    def test_unrelated_notes(self):
+        assert _is_infra_revert("Approach was fundamentally wrong") is False
+
+
+# ── find_anti_patterns: infra-revert exclusion ────────────────────
+
+
+class TestFindAntiPatternsInfraExclusion:
+    def test_skips_infra_revert(self):
+        """Experiments reverted for infra reasons should not trigger anti-pattern."""
+        history = [
+            {
+                "id": 1,
+                "hypothesis": "add structured logging to eval runner",
+                "verdict": "revert",
+                "notes": "reason=precheck_failed",
+            },
+        ]
+        matches = find_anti_patterns(
+            "add structured logging to eval runner",
+            history,
+            similarity_threshold=0.4,
+        )
+        assert matches == []
+
+    def test_still_catches_real_revert(self):
+        """Experiments reverted for code reasons should still trigger anti-pattern."""
+        history = [
+            {
+                "id": 1,
+                "hypothesis": "add structured logging to eval runner",
+                "verdict": "revert",
+                "notes": "Score regressed significantly",
+            },
+        ]
+        matches = find_anti_patterns(
+            "add structured logging to eval runner",
+            history,
+            similarity_threshold=0.4,
+        )
+        assert len(matches) == 1
+        assert matches[0]["id"] == 1
+
+    def test_mixed_infra_and_real_reverts(self):
+        """Only real reverts should be matched; infra reverts skipped."""
+        history = [
+            {
+                "id": 1,
+                "hypothesis": "add structured logging to eval runner",
+                "verdict": "revert",
+                "notes": "precheck_false_positive",
+            },
+            {
+                "id": 2,
+                "hypothesis": "add structured logging to eval runner",
+                "verdict": "revert",
+                "notes": "Approach caused regression",
+            },
+        ]
+        matches = find_anti_patterns(
+            "add structured logging to eval runner",
+            history,
+            similarity_threshold=0.4,
+        )
+        assert len(matches) == 1
+        assert matches[0]["id"] == 2
+
+    def test_no_notes_field_treated_as_real_revert(self):
+        """Entries without notes field should be treated as real reverts."""
+        history = [
+            {
+                "id": 1,
+                "hypothesis": "add structured logging to eval runner",
+                "verdict": "revert",
+            },
+        ]
+        matches = find_anti_patterns(
+            "add structured logging to eval runner",
+            history,
+            similarity_threshold=0.4,
+        )
+        assert len(matches) == 1
+
+    def test_empty_notes_treated_as_real_revert(self):
+        """Entries with empty notes should be treated as real reverts."""
+        history = [
+            {
+                "id": 1,
+                "hypothesis": "add structured logging to eval runner",
+                "verdict": "revert",
+                "notes": "",
+            },
+        ]
+        matches = find_anti_patterns(
+            "add structured logging to eval runner",
+            history,
+            similarity_threshold=0.4,
+        )
+        assert len(matches) == 1

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -181,7 +181,9 @@ class TestSemanticBranchNaming:
 
         assert branch.startswith("factory/feat/dashboard-ui-")
         assert wt_path.exists()
-        assert (wt_path / ".factory_branch").read_text() == branch
+        marker = wt_path.parent / (wt_path.name + ".branch")
+        assert marker.read_text() == branch
+        assert not (wt_path / ".factory_branch").exists()
 
     def test_fix_hint(self, git_project: Path) -> None:
         wt_path, branch = create_worktree(git_project, hint="fix login crash", mode="improve")
@@ -193,14 +195,17 @@ class TestSemanticBranchNaming:
         wt_path, branch = create_worktree(git_project)
 
         assert branch.startswith("factory/run-")
-        assert (wt_path / ".factory_branch").read_text() == branch
+        marker = wt_path.parent / (wt_path.name + ".branch")
+        assert marker.read_text() == branch
+        assert not (wt_path / ".factory_branch").exists()
 
     def test_factory_branch_marker_exists(self, git_project: Path) -> None:
         wt_path, branch = create_worktree(git_project, hint="add feature")
 
-        marker = wt_path / ".factory_branch"
+        marker = wt_path.parent / (wt_path.name + ".branch")
         assert marker.is_file()
         assert marker.read_text() == branch
+        assert not (wt_path / ".factory_branch").exists()
 
 
 class TestPruneWithMarker:
@@ -210,7 +215,7 @@ class TestPruneWithMarker:
 
         orphan = wt_dir / "feat-dashboard-ui-abcd"
         orphan.mkdir()
-        (orphan / ".factory_branch").write_text("factory/feat/dashboard-ui-abcd")
+        (wt_dir / "feat-dashboard-ui-abcd.branch").write_text("factory/feat/dashboard-ui-abcd")
         (orphan / "some_file.txt").write_text("stale")
 
         subprocess.run(
@@ -221,6 +226,7 @@ class TestPruneWithMarker:
         pruned = prune_stale(git_project)
         assert len(pruned) >= 1
         assert not orphan.exists()
+        assert not (wt_dir / "feat-dashboard-ui-abcd.branch").exists()
 
         result = subprocess.run(
             ["git", "branch", "--list", "factory/feat/dashboard-ui-abcd"],

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -5,7 +5,14 @@ from pathlib import Path
 
 import pytest
 
-from factory.worktree import create_worktree, detect_default_branch, prune_stale, remove_worktree
+from factory.worktree import (
+    _classify_prefix,
+    _slugify,
+    create_worktree,
+    detect_default_branch,
+    prune_stale,
+    remove_worktree,
+)
 
 pytestmark = pytest.mark.real_worktree
 
@@ -48,7 +55,7 @@ class TestCreateWorktree:
 
         assert wt_path.exists()
         assert wt_path.is_dir()
-        assert branch.startswith("factory/run-")
+        assert branch.startswith("factory/")
         assert wt_path.parent == git_project / ".factory" / "worktrees"
 
     def test_worktree_has_factory_symlink(self, git_project: Path) -> None:
@@ -108,6 +115,129 @@ class TestCreateWorktree:
         assert br1 != br2
         assert wt1.exists()
         assert wt2.exists()
+
+
+class TestSlugify:
+    def test_basic_text(self) -> None:
+        assert _slugify("dashboard UI") == "dashboard-ui"
+
+    def test_unicode(self) -> None:
+        assert _slugify("café résumé") == "cafe-resume"
+
+    def test_empty_string(self) -> None:
+        assert _slugify("") == "unnamed"
+
+    def test_only_special_chars(self) -> None:
+        assert _slugify("!!!") == "unnamed"
+
+    def test_long_text_truncated(self) -> None:
+        result = _slugify("a" * 100, max_length=20)
+        assert len(result) <= 20
+
+    def test_no_trailing_hyphen_after_truncation(self) -> None:
+        result = _slugify("hello-world-this-is-long", max_length=11)
+        assert not result.endswith("-")
+
+    def test_mixed_case_and_symbols(self) -> None:
+        assert _slugify("Fix Login Crash!!") == "fix-login-crash"
+
+
+class TestClassifyPrefix:
+    def test_fix_keywords(self) -> None:
+        assert _classify_prefix("fix login crash") == "fix"
+        assert _classify_prefix("bug in parser") == "fix"
+        assert _classify_prefix("error handling") == "fix"
+
+    def test_docs_keywords(self) -> None:
+        assert _classify_prefix("update documentation") == "docs"
+        assert _classify_prefix("add README section") == "docs"
+
+    def test_refactor_keywords(self) -> None:
+        assert _classify_prefix("refactor auth module") == "refactor"
+        assert _classify_prefix("cleanup old code") == "refactor"
+
+    def test_test_keywords(self) -> None:
+        assert _classify_prefix("add test coverage") == "test"
+
+    def test_chore_keywords(self) -> None:
+        assert _classify_prefix("update CI config") == "chore"
+        assert _classify_prefix("bump dependency versions") == "chore"
+
+    def test_chore_from_mode(self) -> None:
+        assert _classify_prefix("something random", mode="discover") == "chore"
+        assert _classify_prefix("something random", mode="meta") == "chore"
+
+    def test_default_feat(self) -> None:
+        assert _classify_prefix("dashboard UI") == "feat"
+        assert _classify_prefix("add new endpoint") == "feat"
+
+    def test_fix_takes_priority(self) -> None:
+        assert _classify_prefix("fix the test") == "fix"
+
+
+class TestSemanticBranchNaming:
+    def test_semantic_with_hint(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project, hint="dashboard UI", mode="improve")
+
+        assert branch.startswith("factory/feat/dashboard-ui-")
+        assert wt_path.exists()
+        assert (wt_path / ".factory_branch").read_text() == branch
+
+    def test_fix_hint(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project, hint="fix login crash", mode="improve")
+
+        assert branch.startswith("factory/fix/")
+        assert "login-crash" in branch
+
+    def test_fallback_without_hint(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+
+        assert branch.startswith("factory/run-")
+        assert (wt_path / ".factory_branch").read_text() == branch
+
+    def test_factory_branch_marker_exists(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project, hint="add feature")
+
+        marker = wt_path / ".factory_branch"
+        assert marker.is_file()
+        assert marker.read_text() == branch
+
+
+class TestPruneWithMarker:
+    def test_prune_reads_factory_branch_marker(self, git_project: Path) -> None:
+        wt_dir = git_project / ".factory" / "worktrees"
+        wt_dir.mkdir(parents=True, exist_ok=True)
+
+        orphan = wt_dir / "feat-dashboard-ui-abcd"
+        orphan.mkdir()
+        (orphan / ".factory_branch").write_text("factory/feat/dashboard-ui-abcd")
+        (orphan / "some_file.txt").write_text("stale")
+
+        subprocess.run(
+            ["git", "branch", "factory/feat/dashboard-ui-abcd"],
+            cwd=git_project, capture_output=True, check=True,
+        )
+
+        pruned = prune_stale(git_project)
+        assert len(pruned) >= 1
+        assert not orphan.exists()
+
+        result = subprocess.run(
+            ["git", "branch", "--list", "factory/feat/dashboard-ui-abcd"],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert "factory/feat/dashboard-ui-abcd" not in result.stdout
+
+    def test_prune_falls_back_for_legacy_dirs(self, git_project: Path) -> None:
+        wt_dir = git_project / ".factory" / "worktrees"
+        wt_dir.mkdir(parents=True, exist_ok=True)
+        orphan = wt_dir / "run-deadbeef"
+        orphan.mkdir()
+        (orphan / "some_file.txt").write_text("stale")
+
+        pruned = prune_stale(git_project)
+        assert len(pruned) >= 1
+        assert not orphan.exists()
 
 
 class TestRemoveWorktree:
@@ -261,7 +391,7 @@ class TestCreateWorktreeWithMaster:
         wt_path, branch = create_worktree(git_project_master, base_branch="master")
         try:
             assert wt_path.exists()
-            assert branch.startswith("factory/run-")
+            assert branch.startswith("factory/")
             assert (wt_path / "README.md").exists()
         finally:
             remove_worktree(git_project_master, wt_path, branch)


### PR DESCRIPTION
Closes #364

## Changes
- Added `_slugify(text, max_length)` — stdlib-only (re, unicodedata) kebab-case converter
- Added `_classify_prefix(hint, mode)` — keyword-matches hint text to conventional branch prefixes (fix/docs/refactor/test/chore/feat)
- Extended `create_worktree` with `hint` and `mode` kwargs: produces `factory/<prefix>/<slug>-<hex4>` when hint provided, falls back to `factory/run-<hex8>` without
- Writes `.factory_branch` marker file in worktree dir for branch name reconstruction
- Updated `prune_stale` to read `.factory_branch` marker, falling back to old `factory/run-` pattern for legacy dirs
- Updated `cmd_ceo` and `_run_single_cycle` call sites to pass `hint` and `mode`
- Added comprehensive tests for `_slugify`, `_classify_prefix`, semantic naming, fallback, and prune with marker
- Updated test mocks in conftest.py and test_cli.py to accept new kwargs