### PR TITLE
docs: document Clean PR Mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ The factory is a **three-layer system** with a dedicated CEO agent as the orches
 
 ### Layer 1: Python CLI (`factory/`)
 
-Pure tools that don't make decisions. Entry point is `factory/cli.py` → `factory.cli:main` (registered as `factory` script in pyproject.toml). Each subcommand is a `cmd_*` function dispatched via a handler dict.
+Pure tools that don't make decisions. Entry point is `factory/cli.py` → `factory.cli:main` (registered as `factory` script in pyproject.toml). Each subcommand is a `cmd_*` function dispatched via a handler dict. Key modules include `factory/clean_pr.py` (Clean PR Mode — strips non-essential artifacts from PRs before pushing to external repos).
 
 ### Layer 2: CEO Agent (`factory/agents/prompts/ceo.md`)
 
@@ -90,7 +90,7 @@ Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent 
 
 ### Models
 
-All domain models live in `factory/models.py` as strict Pydantic v2 models. Key types: `ProjectState` (enum), `FactoryConfig`, `EvalProfile` / `EvalDimension`, `CompositeScore` / `EvalResult`, `ExperimentRecord`, `CrossProjectInsights`, `AgentVerdict`, `Observation`, `PerformanceReport`, `ProjectEntry` / `ProjectRegistry`. The `Notifier` protocol defines the async notification interface.
+All domain models live in `factory/models.py` as strict Pydantic v2 models. Key types: `ProjectState` (enum), `FactoryConfig`, `EvalProfile` / `EvalDimension`, `CompositeScore` / `EvalResult`, `ExperimentRecord`, `CrossProjectInsights`, `AgentVerdict`, `Observation`, `PerformanceReport`, `ProjectEntry` / `ProjectRegistry`. The `Notifier` protocol defines the async notification interface. `FactoryConfig` includes `clean_pr` (bool), `clean_pr_include` (list[str]), and `clean_pr_exclude` (list[str]) for Clean PR Mode — stripping non-essential artifacts from PRs before pushing to external repos.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ See the [full setup guide](docs/setup.md) for authentication and environment var
 | **Improve an existing project** | `uv run factory ceo /path/to/project` |
 | **Fix or add one thing** | `uv run factory ceo /path --focus "add dark mode"` |
 | **Target a GitHub issue** | `uv run factory ceo /path --focus 42` |
+| **Contribute to an upstream repo** | `uv run factory ceo https://github.com/user/repo --clean-pr` |
 | **Optimize a metric (research)** | `uv run factory ceo "build a harness to solve HMMT Feb 2026 C7" --mode research` |
 
 ---
@@ -133,6 +134,31 @@ uv run factory ceo ~/my-app --refine "add rate limiting to the API"
 ```
 
 There's no cap on refinements. Advisory warnings appear at 5 and 10 to flag context growth, but the user decides when to stop.
+
+---
+
+## Clean PR Mode
+
+When contributing factory-managed code to an upstream repository, you typically don't want eval scripts, benchmarks, `.factory/` data, or eval test files in the PR. Clean PR Mode strips these non-essential artifacts from the commit before pushing, keeping only the production code.
+
+```bash
+# Enable via CLI flag
+uv run factory ceo https://github.com/user/repo --clean-pr
+
+# Strip artifacts from an existing experiment
+uv run factory clean-pr ~/my-project --exp 3
+```
+
+Configure in `factory.md` for persistent use:
+
+```markdown
+## Clean PR
+- clean_pr: true
+- clean_pr_include: ["src/**", "lib/**"]
+- clean_pr_exclude: ["src/internal/**"]
+```
+
+Default excludes: `eval/score.py`, `benchmarks/**`, `tests/eval_*`, `.factory/**`. Resolution precedence: CLI flag > `config.json` > default (`false`). The welcome wizard auto-suggests `--clean-pr` when the input is a GitHub URL.
 
 ---
 
@@ -282,6 +308,7 @@ uv run factory dashboard                        # Live web dashboard on :8420
 uv run factory discover <path>                  # Auto-detect eval profile
 uv run factory config show                      # Show resolved config
 uv run factory refine-status <path>              # Refinement state + regrounding
+uv run factory clean-pr <path> --exp N          # Strip artifacts from experiment PR
 uv run factory tmux-ls                          # List active tmux sessions
 uv run factory tmux-stop --path <path>          # Stop a tmux session
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,6 +136,27 @@ curl -sf http://localhost:8000/health
 
 Good smoke tests are fast (under 30s), test the core user flow, and catch integration issues that unit tests miss.
 
+### `## Clean PR`
+
+Strips non-essential artifacts (eval scripts, benchmarks, `.factory/` data, eval test files) from PRs before pushing to external repositories. Useful when contributing factory-managed code to upstream repos that don't want factory infrastructure.
+
+```markdown
+## Clean PR
+- clean_pr: true
+- clean_pr_include: ["src/**", "lib/**"]
+- clean_pr_exclude: ["src/internal/**"]
+```
+
+| Field | Purpose | Default |
+|-------|---------|---------|
+| `clean_pr` | Enable clean PR mode | `false` |
+| `clean_pr_include` | Include-only glob patterns — if set, only matching files survive | `[]` |
+| `clean_pr_exclude` | Additional exclude patterns beyond defaults | `[]` |
+
+Default excludes (always applied): `eval/score.py`, `benchmarks/**`, `tests/eval_*`, `.factory/**`. A file matched by both include and exclude is excluded (exclude wins).
+
+Resolution precedence: CLI flag (`--clean-pr` / `--no-clean-pr`) > `config.json` > default (`false`).
+
 ### `## Constraints`
 
 Soft rules that guide behavior but don't block merges:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -194,6 +194,15 @@ factory ceo ~/my-project --refine "add rate limiting to the API"
 
 This routes through the **Refiner** agent (scopes the change) → **Builder** (implements) → full review pipeline → keep/revert verdict. Mutually exclusive with `--mode`, `--prompt`, and `--focus`.
 
+### `--clean-pr` — strip artifacts for upstream
+
+When contributing factory-managed code to an external repository, use `--clean-pr` to strip eval scripts, benchmarks, `.factory/` data, and eval test files from the PR before pushing. The welcome wizard auto-suggests this flag when the input is a GitHub URL.
+
+```bash
+factory ceo https://github.com/user/repo --clean-pr
+factory clean-pr ~/my-project --exp 3
+```
+
 ### Post-cycle refinement loop
 
 In foreground mode, the CEO doesn't exit after a cycle — it stays active and waits for follow-up requests. Just type what you want changed:


### PR DESCRIPTION
Closes #364

## Changes

- **README.md**: Added "Contribute to an upstream repo" row to the quick-reference table, a new "Clean PR Mode" section between Post-Cycle Refinement and Auto-Research Mode, and `factory clean-pr` to the CLI Quick Reference
- **CLAUDE.md**: Mentioned `factory/clean_pr.py` in Layer 1 description and added `clean_pr` / `clean_pr_include` / `clean_pr_exclude` fields to the FactoryConfig documentation
- **docs/configuration.md**: Added a `## Clean PR` section with config fields, defaults, and resolution precedence
- **docs/getting-started.md**: Added `--clean-pr` subsection under "Steering the Factory" with usage examples