### PR TITLE
feat: add factory handoff CLI command for cross-session resume

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1115,6 +1115,16 @@ def cmd_summary(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_handoff(args: argparse.Namespace) -> int:
+    """Print a structured handoff brief for cross-session resume."""
+    from factory.handoff import generate_handoff
+
+    project_path = Path(args.path).resolve()
+    brief = generate_handoff(project_path)
+    print(brief)
+    return 0
+
+
 def cmd_export(args: argparse.Namespace) -> int:
     """Export a complete project snapshot as JSON to stdout."""
     from factory.store import ExperimentStore
@@ -3566,6 +3576,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("export", help="Export complete project snapshot as JSON to stdout")
     p.add_argument("path", help="Path to the project")
 
+    # handoff
+    p = sub.add_parser("handoff", help="Print a structured handoff brief for cross-session resume")
+    p.add_argument("path", help="Path to the project")
+
     # insights
     p = sub.add_parser("insights", help="Cross-project analysis of experiment histories")
     p.add_argument("path", help="Path to the project (insights.md written here)")
@@ -3960,6 +3974,7 @@ def main(argv: list[str] | None = None) -> int:
         "diff": cmd_diff,
         "explain": cmd_explain,
         "export": cmd_export,
+        "handoff": cmd_handoff,
         "insights": cmd_insights,
         "report-update": cmd_report_update,
         "registry-list": cmd_registry_list,

--- a/factory/handoff.py
+++ b/factory/handoff.py
@@ -1,0 +1,284 @@
+"""Generate a structured handoff brief for cross-session resume."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def generate_handoff(project_path: Path) -> str:
+    """Read 9 data sources and synthesize a structured markdown handoff brief."""
+    project_path = project_path.resolve()
+    factory_dir = project_path / ".factory"
+    sections: list[str] = []
+
+    sections.append(_section_project(project_path))
+    sections.append(_section_current_state(factory_dir))
+    sections.append(_section_score_trajectory(factory_dir))
+    sections.append(_section_in_progress(factory_dir))
+    sections.append(_section_pending(factory_dir))
+    sections.append(_section_recent_activity(factory_dir))
+    sections.append(_section_next_steps(factory_dir))
+
+    return "\n\n".join(sections) + "\n"
+
+
+def _section_project(project_path: Path) -> str:
+    lines = [f"# Handoff Brief: {project_path.name}", ""]
+
+    # Git state
+    branch = _git(project_path, "rev-parse", "--abbrev-ref", "HEAD")
+    lines.append(f"**Branch:** {branch or 'unknown'}")
+
+    commits = _git(project_path, "log", "--oneline", "-5")
+    if commits:
+        lines.append("")
+        lines.append("**Recent commits:**")
+        for c in commits.strip().splitlines():
+            lines.append(f"- {c}")
+
+    # Config
+    config_path = project_path / ".factory" / "config.json"
+    if config_path.is_file():
+        try:
+            config = json.loads(config_path.read_text())
+            if config.get("goal"):
+                lines.append(f"\n**Goal:** {config['goal']}")
+        except (json.JSONDecodeError, KeyError):
+            log.debug("handoff.parse_error", section="project_config")
+
+    return "\n".join(lines)
+
+
+def _section_current_state(factory_dir: Path) -> str:
+    lines = ["## Current State"]
+
+    # Checkpoint
+    checkpoint_path = factory_dir / "checkpoint.json"
+    if checkpoint_path.is_file():
+        try:
+            ckpt = json.loads(checkpoint_path.read_text())
+            lines.append(f"- **Mode:** {ckpt.get('mode', 'unknown')}")
+            if ckpt.get("active_experiment_id"):
+                lines.append(f"- **Active experiment:** {ckpt['active_experiment_id']}")
+            if ckpt.get("current_hypothesis"):
+                lines.append(f"- **Hypothesis:** {ckpt['current_hypothesis']}")
+            if ckpt.get("completed_agents"):
+                lines.append(f"- **Completed agents:** {', '.join(ckpt['completed_agents'])}")
+            if ckpt.get("pending_agents"):
+                lines.append(f"- **Pending agents:** {', '.join(ckpt['pending_agents'])}")
+        except (json.JSONDecodeError, KeyError):
+            lines.append("- Checkpoint file exists but could not be parsed")
+    else:
+        lines.append("- No checkpoint found")
+
+    # Cycle state
+    cycle_path = factory_dir / "state" / "cycle.json"
+    if cycle_path.is_file():
+        try:
+            cycle = json.loads(cycle_path.read_text())
+            lines.append(f"- **Cycle ID:** {cycle.get('cycle_id', 'unknown')}")
+            if cycle.get("respawns"):
+                lines.append(f"- **Respawns:** {cycle['respawns']}")
+        except (json.JSONDecodeError, KeyError):
+            log.debug("handoff.parse_error", section="cycle_state")
+
+    if len(lines) == 1:
+        lines.append("- No state data available")
+
+    return "\n".join(lines)
+
+
+def _section_score_trajectory(factory_dir: Path) -> str:
+    lines = ["## Score Trajectory"]
+
+    tsv_path = factory_dir / "results.tsv"
+    if not tsv_path.is_file():
+        lines.append("- No experiment history")
+        return "\n".join(lines)
+
+    try:
+        rows = tsv_path.read_text().strip().splitlines()
+        if len(rows) <= 1:
+            lines.append("- No experiments recorded")
+            return "\n".join(lines)
+
+        header = rows[0].split("\t")
+        data_rows = rows[1:]
+
+        score_after_idx = None
+        verdict_idx = None
+        for i, col in enumerate(header):
+            if col == "score_after":
+                score_after_idx = i
+            elif col == "verdict":
+                verdict_idx = i
+
+        kept = 0
+        reverted = 0
+        scores: list[float] = []
+
+        for row in data_rows:
+            cols = row.split("\t")
+            if verdict_idx is not None and verdict_idx < len(cols):
+                v = cols[verdict_idx]
+                if v == "keep":
+                    kept += 1
+                elif v == "revert":
+                    reverted += 1
+            if score_after_idx is not None and score_after_idx < len(cols):
+                try:
+                    scores.append(float(cols[score_after_idx]))
+                except (ValueError, IndexError):
+                    log.debug("handoff.parse_error", section="score_trajectory")
+
+        lines.append(f"- **Total experiments:** {len(data_rows)}")
+        lines.append(f"- **Kept:** {kept}, **Reverted:** {reverted}")
+        if scores:
+            lines.append(f"- **Latest score:** {scores[-1]:.3f}")
+            if len(scores) >= 2:
+                lines.append(f"- **Previous score:** {scores[-2]:.3f}")
+    except Exception:
+        lines.append("- Could not parse experiment history")
+
+    return "\n".join(lines)
+
+
+def _section_in_progress(factory_dir: Path) -> str:
+    lines = ["## What's In Progress"]
+
+    # Review verdicts show recent agent work
+    reviews_dir = factory_dir / "reviews"
+    if reviews_dir.is_dir():
+        latest_files = sorted(reviews_dir.glob("*-latest.md"))
+        if latest_files:
+            for f in latest_files[-3:]:
+                role = f.stem.replace("-latest", "")
+                lines.append(f"- **{role}** agent has output (see .factory/reviews/{f.name})")
+        else:
+            lines.append("- No recent agent outputs")
+    else:
+        lines.append("- No review artifacts")
+
+    # Strategy
+    strategy_path = factory_dir / "strategy" / "current.md"
+    if strategy_path.is_file():
+        content = strategy_path.read_text().strip()
+        if content:
+            preview = content[:200].replace("\n", " ")
+            suffix = "..." if len(content) > 200 else ""
+            lines.append(f"- **Active strategy:** {preview}{suffix}")
+
+    return "\n".join(lines)
+
+
+def _section_pending(factory_dir: Path) -> str:
+    lines = ["## What's Pending"]
+
+    # Backlog
+    backlog_path = factory_dir / "strategy" / "backlog.md"
+    if backlog_path.is_file():
+        content = backlog_path.read_text().strip()
+        if content:
+            items = [
+                line.lstrip("- ").strip()
+                for line in content.splitlines()
+                if line.strip().startswith("- ")
+            ]
+            if items:
+                lines.append(f"- **Backlog items:** {len(items)}")
+                for item in items[:5]:
+                    lines.append(f"  - {item}")
+                if len(items) > 5:
+                    lines.append(f"  - ... and {len(items) - 5} more")
+            else:
+                lines.append("- Backlog is empty")
+        else:
+            lines.append("- Backlog is empty")
+    else:
+        lines.append("- No backlog file")
+
+    return "\n".join(lines)
+
+
+def _section_recent_activity(factory_dir: Path) -> str:
+    lines = ["## Recent Activity"]
+
+    events_path = factory_dir / "events.jsonl"
+    if not events_path.is_file():
+        lines.append("- No events log")
+        return "\n".join(lines)
+
+    try:
+        all_lines = events_path.read_text().strip().splitlines()
+        recent = all_lines[-10:] if len(all_lines) > 10 else all_lines
+        if not recent:
+            lines.append("- Events log is empty")
+            return "\n".join(lines)
+
+        for event_line in recent:
+            try:
+                event = json.loads(event_line)
+                ts = event.get("timestamp", "")
+                if ts:
+                    try:
+                        dt = datetime.fromisoformat(ts)
+                        ts = dt.strftime("%H:%M:%S")
+                    except (ValueError, TypeError):
+                        ts = str(ts)[:8]
+                etype = event.get("type", "unknown")
+                lines.append(f"- [{ts}] {etype}")
+            except json.JSONDecodeError:
+                continue
+    except Exception:
+        lines.append("- Could not parse events log")
+
+    return "\n".join(lines)
+
+
+def _section_next_steps(factory_dir: Path) -> str:
+    lines = ["## Recommended Next Steps"]
+
+    checkpoint_path = factory_dir / "checkpoint.json"
+    has_checkpoint = checkpoint_path.is_file()
+
+    if has_checkpoint:
+        try:
+            ckpt = json.loads(checkpoint_path.read_text())
+            pending = ckpt.get("pending_agents", [])
+            mode = ckpt.get("mode", "improve")
+            if pending:
+                lines.append(f"1. Resume {mode} mode, continue with: {', '.join(pending)}")
+            else:
+                lines.append(f"1. Resume {mode} mode from checkpoint")
+            lines.append(f"2. Run: `factory ceo {factory_dir.parent} --mode {mode}`")
+        except (json.JSONDecodeError, KeyError):
+            lines.append("1. Checkpoint exists but is corrupt; consider clearing and starting fresh")
+            lines.append(f"2. Run: `factory ceo {factory_dir.parent}`")
+    else:
+        lines.append("1. No checkpoint; start a new cycle")
+        lines.append(f"2. Run: `factory ceo {factory_dir.parent}`")
+
+    return "\n".join(lines)
+
+
+def _git(project_path: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        log.debug("handoff.parse_error", section="git_command")
+    return None

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -1,0 +1,109 @@
+"""Tests for factory.handoff module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from factory.handoff import generate_handoff
+
+
+def test_generate_handoff_empty_project(tmp_path: Path) -> None:
+    """Handoff should not crash when .factory/ is missing or empty."""
+    brief = generate_handoff(tmp_path)
+    assert "# Handoff Brief:" in brief
+    assert "## Current State" in brief
+    assert "## Score Trajectory" in brief
+    assert "## What's In Progress" in brief
+    assert "## What's Pending" in brief
+    assert "## Recent Activity" in brief
+    assert "## Recommended Next Steps" in brief
+
+
+def test_generate_handoff_with_data(tmp_path: Path) -> None:
+    """Handoff should include data from populated .factory/ sources."""
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+
+    # Config
+    config = {"goal": "Build a weather CLI", "eval_command": "pytest", "eval_threshold": 0.8}
+    (factory_dir / "config.json").write_text(json.dumps(config))
+
+    # Checkpoint
+    checkpoint = {
+        "mode": "improve",
+        "active_experiment_id": 3,
+        "current_hypothesis": "add caching layer",
+        "completed_agents": ["researcher", "strategist"],
+        "pending_agents": ["builder", "reviewer"],
+        "timestamp": "2026-05-25T10:00:00",
+    }
+    (factory_dir / "checkpoint.json").write_text(json.dumps(checkpoint))
+
+    # Results TSV
+    tsv = "id\ttimestamp\thypothesis\tchange_summary\tscore_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\n"
+    tsv += "1\t2026-05-25T09:00:00\tadd tests\tfixed tests\t0.500\t0.600\t0.100\tkeep\t0.50\t\n"
+    tsv += "2\t2026-05-25T09:30:00\tadd lint\tfixed lint\t0.600\t0.700\t0.100\trevert\t0.30\t\n"
+    (factory_dir / "results.tsv").write_text(tsv)
+
+    # Backlog
+    strategy_dir = factory_dir / "strategy"
+    strategy_dir.mkdir()
+    (strategy_dir / "backlog.md").write_text("- Add error handling\n- Improve logging\n- Add docs\n")
+    (strategy_dir / "current.md").write_text("## Current Strategy\n\nFocus on reliability.\n")
+
+    # Events
+    events = [
+        json.dumps({"timestamp": "2026-05-25T09:00:00", "type": "experiment.begin"}),
+        json.dumps({"timestamp": "2026-05-25T09:30:00", "type": "experiment.finalize"}),
+    ]
+    (factory_dir / "events.jsonl").write_text("\n".join(events) + "\n")
+
+    # Reviews
+    reviews_dir = factory_dir / "reviews"
+    reviews_dir.mkdir()
+    (reviews_dir / "researcher-latest.md").write_text("Research findings here")
+
+    brief = generate_handoff(tmp_path)
+
+    assert "Build a weather CLI" in brief
+    assert "improve" in brief
+    assert "add caching layer" in brief
+    assert "builder, reviewer" in brief
+    assert "Total experiments:** 2" in brief
+    assert "Kept:** 1" in brief
+    assert "Reverted:** 1" in brief
+    assert "0.700" in brief
+    assert "Backlog items:** 3" in brief
+    assert "Add error handling" in brief
+    assert "experiment.begin" in brief
+    assert "researcher" in brief
+
+
+def test_generate_handoff_missing_individual_files(tmp_path: Path) -> None:
+    """Each section degrades gracefully when its source file is missing."""
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+
+    # Only provide config, everything else missing
+    config = {"goal": "Test project", "eval_command": "echo ok", "eval_threshold": 0.5}
+    (factory_dir / "config.json").write_text(json.dumps(config))
+
+    brief = generate_handoff(tmp_path)
+
+    assert "Test project" in brief
+    assert "No checkpoint found" in brief
+    assert "No experiment history" in brief
+    assert "No backlog file" in brief
+    assert "No events log" in brief
+    assert "No checkpoint; start a new cycle" in brief
+
+
+def test_cli_handoff_subcommand(tmp_path: Path) -> None:
+    """The CLI subparser for handoff is correctly wired."""
+    from factory.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["handoff", str(tmp_path)])
+    assert args.command == "handoff"
+    assert args.path == str(tmp_path)


### PR DESCRIPTION
## Summary
- New `factory/handoff.py` module with `generate_handoff()` that reads 9 data sources and synthesizes a structured markdown brief to stdout
- `cmd_handoff` added to CLI following the `cmd_export` pattern
- 4 tests covering empty, populated, partial data, and CLI wiring

Closes #352