### PR TITLE
feat: add structlog to uninstrumented runner and agent modules

### DIFF
--- a/factory/agents/plugin.py
+++ b/factory/agents/plugin.py
@@ -6,11 +6,14 @@ import functools
 from dataclasses import dataclass
 from pathlib import Path
 
+import structlog
 import yaml
 
 from factory.ace.injector import inject_playbook
 from factory.ace.paths import DEFAULTS_DIR as _PLAYBOOKS_DIR
 from factory.agents.runner import _PROMPTS_DIR
+
+log = structlog.get_logger()
 
 _AGENTS_YML = Path(__file__).parent / "agents.yml"
 _PLUGIN_AGENTS_DIR_CANDIDATE = Path(__file__).resolve().parent.parent.parent / "agents"
@@ -34,12 +37,14 @@ def load_agent_config() -> dict[str, AgentMeta]:
     config: dict[str, AgentMeta] = {}
     for role, entry in raw.items():
         if not (_PROMPTS_DIR / f"{role}.md").exists():
+            log.debug("plugin.skipped", role=role, reason="no_prompt_file")
             continue
         config[role] = AgentMeta(
             description=entry.get("description", ""),
             model=entry["model"],
             tools=entry.get("tools", []),
         )
+    log.info("plugin.config_loaded", roles=list(config.keys()), count=len(config))
     return config
 
 
@@ -51,6 +56,7 @@ def generate_agent_content(role: str) -> str:
     """
     config = load_agent_config()
     if role not in config:
+        log.error("plugin.unknown_role", role=role, available=list(config.keys()))
         raise ValueError(f"Unknown agent role: {role!r}")
 
     meta = config[role]

--- a/factory/mcp_server.py
+++ b/factory/mcp_server.py
@@ -167,14 +167,21 @@ async def call_tool(name: str, arguments: dict) -> list[TextContent]:
 
     handler = handlers.get(name)
     if handler is None:
+        log.warning("mcp.unknown_tool", tool=name)
         return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]
 
-    result_text = await handler(arguments)
+    log.debug("mcp.tool_call", tool=name, arguments=arguments)
+    try:
+        result_text = await handler(arguments)
+    except Exception:
+        log.exception("mcp.tool_error", tool=name)
+        raise
     return [TextContent(type="text", text=result_text)]
 
 
 async def run_server() -> None:
     """Start the MCP stdio server."""
+    log.info("mcp.server_starting")
     async with stdio_server() as (read_stream, write_stream):
         await server.run(
             read_stream,

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
+import structlog
+
 from factory.runners._stream import should_stream, stream_subprocess
 from factory.runners.bob import BobRunner, is_dry_run
 from factory.runners.claude import ClaudeRunner
 from factory.runners.codex import CodexRunner, is_codex_dry_run
 from factory.runners.protocol import Runner
+
+log = structlog.get_logger()
 
 __all__ = [
     "Runner",
@@ -52,16 +56,21 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
 
     resolved = resolve("runner", cli_value=name, env_var="FACTORY_RUNNER", default="claude") or "claude"
     resolved = resolved.lower().strip()
+    log.debug("runner.resolving", requested=name, resolved=resolved)
 
     if resolved not in _RUNNERS:
         available = ", ".join(_RUNNERS.keys())
+        log.error("runner.unknown", runner=resolved, available=list(_RUNNERS.keys()))
         raise ValueError(f"Unknown runner '{resolved}'. Available: {available}")
 
     if resolved == "bob":
+        log.info("runner.selected", runner="bob", project_path=str(project_path))
         return BobRunner(project_path=project_path)
+    log.info("runner.selected", runner=resolved)
     return _RUNNERS[resolved]()
 
 
 def register_runner(name: str, runner_class: type[Runner]) -> None:
     """Register a runner implementation (used by bob module on import)."""
+    log.debug("runner.registered", name=name, cls=runner_class.__name__)
     _RUNNERS[name] = runner_class

--- a/factory/runners/_stream.py
+++ b/factory/runners/_stream.py
@@ -6,6 +6,10 @@ import asyncio
 import sys
 from typing import BinaryIO
 
+import structlog
+
+log = structlog.get_logger()
+
 
 def should_stream() -> bool:
     """Determine if we should stream subprocess output to the terminal.
@@ -69,6 +73,8 @@ async def stream_subprocess(
     Returns:
         (stdout_bytes, stderr_bytes) tuple with all collected output.
     """
+    log.debug("stream.start", pid=proc.pid, streaming=stream, prefix=prefix)
+
     stdout_buf: list[bytes] = []
     stderr_buf: list[bytes] = []
 
@@ -96,4 +102,13 @@ async def stream_subprocess(
 
     await proc.wait()
 
-    return b"".join(stdout_buf), b"".join(stderr_buf)
+    stdout_bytes = b"".join(stdout_buf)
+    stderr_bytes = b"".join(stderr_buf)
+    log.debug(
+        "stream.end",
+        pid=proc.pid,
+        returncode=proc.returncode,
+        stdout_len=len(stdout_bytes),
+        stderr_len=len(stderr_bytes),
+    )
+    return stdout_bytes, stderr_bytes


### PR DESCRIPTION
## Summary
- Add structured logging to 4 modules on the agent invocation path: `runners/__init__.py`, `runners/_stream.py`, `agents/plugin.py`, `mcp_server.py`
- 13 log statements covering runner selection, stream lifecycle, plugin registration, and MCP tool calls
- MCP tool arguments logged at DEBUG level (not INFO) to avoid leaking sensitive data

Closes #354