### PR TITLE
feat: add meta mode Phase 3 — classify and contribute upstream

### DIFF
--- a/factory/ace/contributor.py
+++ b/factory/ace/contributor.py
@@ -8,7 +8,6 @@ can submit PRs to the factory repo.
 from __future__ import annotations
 
 import difflib
-import json
 import re
 import subprocess
 from datetime import datetime, timezone

--- a/factory/ace/contributor.py
+++ b/factory/ace/contributor.py
@@ -1,0 +1,780 @@
+"""Contribution pipeline for meta mode.
+
+Classifies evolved playbook items as general (upstream PR candidates) vs
+project-specific (local only), generates diffs, packages evidence, and
+can submit PRs to the factory repo.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+import structlog
+from pydantic import BaseModel, Field
+
+from factory.ace.models import Playbook, PlaybookItem
+from factory.ace.paths import DEFAULTS_DIR, user_playbooks_dir
+from factory.insights import classify_hypothesis, discover_projects, load_all_histories
+from factory.models import ExperimentRecord
+
+log = structlog.get_logger()
+
+# ── Constants ──────────────────────────────────────────────────────
+
+FACTORY_INTERNAL_KEYWORDS: set[str] = {
+    "prompt", "agent", "eval", "hypothesis", "experiment", "score",
+    "playbook", "reviewer", "builder", "strategist", "evaluator",
+    "archivist", "researcher", "ceo", "guard", "precheck", "ace",
+    "meta", "factory", "type checker", "linter", "tests", "ci",
+    "type check", "lint", "precommit",
+}
+
+DOMAIN_SPECIFIC_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(p, re.IGNORECASE)
+    for p in [
+        r"\breact\b", r"\bangular\b", r"\bvue\b", r"\bdjango\b",
+        r"\brails\b", r"\bflask\b", r"\bfastapi\b", r"\bplaywright\b",
+        r"\bselenium\b", r"\bpuppeteer\b", r"\bgraphql\b",
+        r"\bpostgres(?:ql)?\b", r"\bmongodb\b", r"\bredis\b",
+        r"\bdocker\b", r"\bkubernetes\b", r"\biframe\b",
+        r"\bwebpack\b", r"\bnext\.?js\b", r"\bexpress\b",
+        r"\bspring\b", r"\blaravel\b", r"\bswift(?:ui)?\b",
+        r"\bkotlin\b", r"\bmigration\b",
+    ]
+]
+
+_CATEGORY_SCORES: dict[str, float] = {
+    "prompt_engineering": 0.9,
+    "agent_improvement": 0.9,
+    "eval_improvement": 0.9,
+    "infrastructure": 0.9,
+    "observability": 0.7,
+    "coverage": 0.7,
+    "testing": 0.7,
+    "lint": 0.7,
+    "type_safety": 0.7,
+    "refactoring": 0.5,
+    "performance": 0.5,
+    "feature": 0.3,
+    "bugfix": 0.5,
+}
+
+_WEIGHTS = {
+    "cross_project_prevalence": 0.40,
+    "domain_independence": 0.25,
+    "evidence_strength": 0.20,
+    "category_signal": 0.15,
+}
+
+_CANDIDATES_FILE = ".factory/contribution_candidates.json"
+
+
+# ── Models ─────────────────────────────────────────────────────────
+
+
+class ClassifiedItem(BaseModel):
+    """A PlaybookItem with generality classification metadata.
+
+    Uses composition since PlaybookItem has extra='forbid'.
+    """
+
+    item: PlaybookItem
+    role: str = ""
+    generality_score: float = 0.0
+    classification: Literal["general", "specific", "uncertain"] = "uncertain"
+    source_projects: list[str] = Field(default_factory=list)
+    evidence: list[str] = Field(default_factory=list)
+
+    @property
+    def cross_project_count(self) -> int:
+        return len(set(self.source_projects))
+
+
+class EvidencePackage(BaseModel):
+    """Cross-project evidence supporting a contribution candidate."""
+
+    cross_project_stats: dict[str, float] = Field(default_factory=dict)
+    total_experiments: int = 0
+    total_projects: int = 0
+    example_experiments: list[str] = Field(default_factory=list)
+    category: str = ""
+    confidence: float = 0.0
+
+
+class ContributionReport(BaseModel):
+    """Classification results from meta mode evolution analysis."""
+
+    general_items: list[ClassifiedItem] = Field(default_factory=list)
+    specific_items: list[ClassifiedItem] = Field(default_factory=list)
+    uncertain_items: list[ClassifiedItem] = Field(default_factory=list)
+    generated_at: str = ""
+
+
+# ── Fuzzy matching ─────────────────────────────────────────────────
+
+
+def _fuzzy_match(text_a: str, text_b: str, threshold: float = 0.75) -> bool:
+    """Match using SequenceMatcher, consistent with reflector.py."""
+    return difflib.SequenceMatcher(None, text_a.lower(), text_b.lower()).ratio() >= threshold
+
+
+# ── Classification ─────────────────────────────────────────────────
+
+
+def score_cross_project_prevalence(
+    classified: ClassifiedItem,
+    cross_project_data: dict[str, list[ExperimentRecord]],
+) -> float:
+    """Score based on how many projects show evidence for this item.
+
+    Linear scoring: min(1.0, matching_projects / 3), with a 0.1 bonus
+    when the cross-project keep rate is >= 80%.
+    """
+    matching_projects: list[str] = []
+    kept_count = 0
+    total_matches = 0
+
+    for project_name, experiments in cross_project_data.items():
+        project_matched = False
+        for exp in experiments:
+            if _fuzzy_match(classified.item.content, exp.hypothesis):
+                project_matched = True
+                total_matches += 1
+                if exp.verdict == "keep":
+                    kept_count += 1
+        if project_matched:
+            matching_projects.append(project_name)
+
+    classified.source_projects = matching_projects
+
+    if not matching_projects:
+        return 0.0
+
+    score = min(1.0, len(matching_projects) / 3)
+    if total_matches > 0 and (kept_count / total_matches) >= 0.80:
+        score = min(1.0, score + 0.1)
+
+    return score
+
+
+def score_domain_independence(classified: ClassifiedItem) -> float:
+    """Score based on whether content is factory-internal vs domain-specific.
+
+    Returns ratio of factory keyword matches to total keyword matches.
+    Returns 0.5 when no keywords match either set.
+    """
+    text_lower = classified.item.content.lower()
+    factory_matches = sum(1 for kw in FACTORY_INTERNAL_KEYWORDS if kw in text_lower)
+    domain_matches = sum(1 for p in DOMAIN_SPECIFIC_PATTERNS if p.search(classified.item.content))
+
+    total = factory_matches + domain_matches
+    if total == 0:
+        return 0.5
+    return factory_matches / total
+
+
+def score_evidence_strength(classified: ClassifiedItem) -> float:
+    """Score based on helpful/harmful counters and observation volume."""
+    total = classified.item.helpful + classified.item.harmful
+
+    if total < 3:
+        return 0.2
+
+    net_ratio = classified.item.helpful / max(1, total)
+    volume_bonus = min(1.0, total / 10)
+    score = 0.6 * net_ratio + 0.4 * volume_bonus
+
+    if classified.item.helpful > 0 and classified.item.harmful > 0:
+        score = max(0.0, score - 0.2)
+
+    return score
+
+
+def score_category_signal(classified: ClassifiedItem) -> float:
+    """Score based on the hypothesis category's inherent generality."""
+    category = classify_hypothesis(classified.item.content)
+    return _CATEGORY_SCORES.get(category, 0.5)
+
+
+def classify_item(
+    item: PlaybookItem,
+    cross_project_data: dict[str, list[ExperimentRecord]],
+    role: str = "",
+) -> ClassifiedItem:
+    """Classify a single playbook item on the general-vs-specific spectrum.
+
+    Weighted composite: cross-project prevalence (40%), domain independence (25%),
+    evidence strength (20%), category signal (15%).
+    """
+    classified = ClassifiedItem(item=item, role=role)
+
+    signals = {
+        "cross_project_prevalence": score_cross_project_prevalence(classified, cross_project_data),
+        "domain_independence": score_domain_independence(classified),
+        "evidence_strength": score_evidence_strength(classified),
+        "category_signal": score_category_signal(classified),
+    }
+
+    classified.generality_score = sum(signals[k] * _WEIGHTS[k] for k in signals)
+
+    if classified.generality_score >= 0.65:
+        classified.classification = "general"
+    elif classified.generality_score <= 0.35:
+        classified.classification = "specific"
+    else:
+        classified.classification = "uncertain"
+
+    return classified
+
+
+def classify_evolved_playbooks(
+    project_path: Path,
+) -> ContributionReport:
+    """Full pipeline: load playbooks, load cross-project data, classify all items.
+
+    Discovers sibling projects to build cross-project evidence, loads the
+    user's evolved playbooks, diffs them against factory defaults, and
+    classifies each evolved item.
+    """
+    projects_dir = project_path.parent
+    project_paths = discover_projects(projects_dir)
+    cross_project_data = load_all_histories(project_paths) if project_paths else {}
+
+    evolved_dir = user_playbooks_dir()
+    general: list[ClassifiedItem] = []
+    specific: list[ClassifiedItem] = []
+    uncertain: list[ClassifiedItem] = []
+
+    for pb_file in sorted(evolved_dir.glob("*.md")):
+        role = pb_file.stem
+        evolved = Playbook.from_markdown(pb_file.read_text())
+
+        default_path = DEFAULTS_DIR / f"{role}.md"
+        default = (
+            Playbook.from_markdown(default_path.read_text())
+            if default_path.exists()
+            else Playbook.empty(role)
+        )
+
+        diffs = diff_playbooks(evolved, default)
+        for d in diffs:
+            evolved_item = d.get("evolved_item")
+            if evolved_item is None:
+                continue
+
+            classified = classify_item(evolved_item, cross_project_data, role=role)
+
+            if classified.classification == "general":
+                general.append(classified)
+            elif classified.classification == "specific":
+                specific.append(classified)
+            else:
+                uncertain.append(classified)
+
+    log.info(
+        "classify_evolved_playbooks_complete",
+        general=len(general),
+        specific=len(specific),
+        uncertain=len(uncertain),
+    )
+
+    return ContributionReport(
+        general_items=general,
+        specific_items=specific,
+        uncertain_items=uncertain,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+# ── Diff & Contribution ───────────────────────────────────────────
+
+
+def diff_playbooks(
+    evolved: Playbook,
+    default: Playbook,
+) -> list[dict]:
+    """Diff evolved playbooks against factory defaults.
+
+    Matches items by fuzzy content similarity (SequenceMatcher >= 0.75)
+    since IDs are reassigned by the curator across evolution cycles.
+
+    Returns list of dicts with keys: diff_type, evolved_item, default_item, diff_text.
+    """
+    diffs: list[dict] = []
+    matched_default_indices: set[int] = set()
+
+    for evolved_item in evolved.items:
+        best_match_idx: int | None = None
+        best_ratio = 0.0
+
+        for i, default_item in enumerate(default.items):
+            if i in matched_default_indices:
+                continue
+            ratio = difflib.SequenceMatcher(
+                None, evolved_item.content.lower(), default_item.content.lower()
+            ).ratio()
+            if ratio >= 0.75 and ratio > best_ratio:
+                best_ratio = ratio
+                best_match_idx = i
+
+        if best_match_idx is not None:
+            matched_default_indices.add(best_match_idx)
+            matched = default.items[best_match_idx]
+            if (
+                evolved_item.content != matched.content
+                or evolved_item.helpful != matched.helpful
+                or evolved_item.harmful != matched.harmful
+            ):
+                diffs.append({
+                    "diff_type": "modified",
+                    "evolved_item": evolved_item,
+                    "default_item": matched,
+                    "diff_text": _make_unified_diff(matched, evolved_item),
+                })
+        else:
+            diffs.append({
+                "diff_type": "added",
+                "evolved_item": evolved_item,
+                "default_item": None,
+                "diff_text": _make_unified_diff(None, evolved_item),
+            })
+
+    for i, default_item in enumerate(default.items):
+        if i not in matched_default_indices:
+            diffs.append({
+                "diff_type": "removed",
+                "evolved_item": None,
+                "default_item": default_item,
+                "diff_text": _make_unified_diff(default_item, None),
+            })
+
+    return diffs
+
+
+def _make_unified_diff(
+    default_item: PlaybookItem | None,
+    evolved_item: PlaybookItem | None,
+) -> str:
+    old = [default_item.to_line()] if default_item else []
+    new = [evolved_item.to_line()] if evolved_item else []
+    return "\n".join(difflib.unified_diff(
+        old, new, fromfile="default", tofile="evolved", lineterm=""
+    ))
+
+
+def package_evidence(
+    classified: ClassifiedItem,
+    cross_project_data: dict[str, list[ExperimentRecord]],
+) -> EvidencePackage:
+    """Assemble cross-project evidence for a contribution candidate."""
+    stats: dict[str, float] = {}
+    examples: list[str] = []
+    total_matching = 0
+
+    for project_name, experiments in cross_project_data.items():
+        matching = [
+            e for e in experiments
+            if _fuzzy_match(classified.item.content, e.hypothesis)
+        ]
+        if not matching:
+            continue
+
+        kept = sum(1 for e in matching if e.verdict == "keep")
+        stats[project_name] = round(kept / len(matching), 2)
+        total_matching += len(matching)
+
+        for exp in matching:
+            if len(examples) < 5:
+                examples.append(f"{project_name}: {exp.hypothesis}")
+
+    return EvidencePackage(
+        cross_project_stats=stats,
+        total_experiments=total_matching,
+        total_projects=len(stats),
+        example_experiments=examples,
+        category=classify_hypothesis(classified.item.content),
+        confidence=round(min(1.0, total_matching / 10), 2),
+    )
+
+
+def generate_pr_body(
+    candidates: list[ClassifiedItem],
+    evidence_map: dict[str, EvidencePackage] | None = None,
+) -> str:
+    """Generate a structured PR body with evidence for upstream contribution."""
+    if not candidates:
+        return (
+            "## Meta Mode Contribution\n\n"
+            "No items were identified as generally useful for upstream contribution.\n"
+        )
+
+    if evidence_map is None:
+        evidence_map = {}
+
+    total_projects = len({p for c in candidates for p in c.source_projects})
+
+    lines: list[str] = [
+        "## Meta Mode Contribution\n",
+        f"These playbook improvements were identified as generally useful across "
+        f"{total_projects} projects during meta mode evolution.\n",
+        "### Changes\n",
+    ]
+
+    by_role: dict[str, list[ClassifiedItem]] = {}
+    for c in candidates:
+        by_role.setdefault(c.role, []).append(c)
+
+    for role in sorted(by_role):
+        lines.append(f"#### {role.title()} Playbook\n")
+        for c in by_role[role]:
+            ev = evidence_map.get(c.item.id)
+            if ev and ev.total_projects > 0:
+                avg_keep = sum(ev.cross_project_stats.values()) / len(ev.cross_project_stats)
+                lines.append(
+                    f'- "{c.item.content}"\n'
+                    f"  - Evidence: {avg_keep:.0%} keep rate across "
+                    f"{ev.total_projects} projects ({ev.total_experiments} experiments)\n"
+                    f"  - Generality score: {c.generality_score:.2f}\n"
+                )
+            else:
+                lines.append(
+                    f'- "{c.item.content}"\n'
+                    f"  - Generality score: {c.generality_score:.2f}\n"
+                )
+
+    lines.append("### Evidence Summary\n")
+    lines.append("| Item | Projects | Generality |")
+    lines.append("|------|----------|------------|")
+    for c in candidates:
+        content_short = c.item.content[:50] + ("..." if len(c.item.content) > 50 else "")
+        lines.append(f"| {content_short} | {c.cross_project_count} | {c.generality_score:.2f} |")
+
+    lines.append("")
+    lines.append("### Methodology\n")
+    lines.append(
+        "Classification used cross-project prevalence (40%), domain independence (25%), "
+        "evidence strength (20%), and category signal (15%).\n"
+    )
+    lines.append("---")
+    lines.append("*Generated by factory meta mode*\n")
+
+    return "\n".join(lines)
+
+
+def prepare_contribution(
+    candidates: list[ClassifiedItem],
+    factory_repo_path: Path,
+    cross_project_data: dict[str, list[ExperimentRecord]] | None = None,
+) -> dict:
+    """Generate file change specs for a contribution branch.
+
+    Reads existing default playbooks from factory_repo_path, merges in
+    the general items via fuzzy matching, and returns a specification dict.
+    Does NOT execute git.
+    """
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    branch_name = f"meta-contrib/{today}-playbook-updates"
+
+    evidence_map: dict[str, EvidencePackage] = {}
+    if cross_project_data:
+        for c in candidates:
+            evidence_map[c.item.id] = package_evidence(c, cross_project_data)
+
+    by_role: dict[str, list[ClassifiedItem]] = {}
+    for c in candidates:
+        by_role.setdefault(c.role, []).append(c)
+
+    file_changes: list[dict] = []
+    changed_roles: list[str] = []
+
+    for role, role_items in sorted(by_role.items()):
+        default_path = factory_repo_path / "factory" / "agents" / "playbooks" / f"{role}.md"
+        if default_path.exists():
+            default_pb = Playbook.from_markdown(default_path.read_text())
+        else:
+            default_pb = Playbook.empty(role)
+
+        for c in role_items:
+            matched = False
+            for i, existing in enumerate(default_pb.items):
+                ratio = difflib.SequenceMatcher(
+                    None, c.item.content.lower(), existing.content.lower()
+                ).ratio()
+                if ratio >= 0.75:
+                    default_pb.items[i] = c.item
+                    matched = True
+                    break
+            if not matched:
+                default_pb.items.append(c.item)
+
+        file_changes.append({
+            "path": f"factory/agents/playbooks/{role}.md",
+            "content": default_pb.to_markdown(),
+            "change_type": "modify",
+        })
+        changed_roles.append(role)
+
+    n_items = len(candidates)
+    roles_str = ", ".join(changed_roles)
+
+    return {
+        "branch_name": branch_name,
+        "file_changes": file_changes,
+        "commit_message": (
+            f"Update playbook items from meta mode analysis\n\n"
+            f"Add/update {n_items} generally-useful playbook items "
+            f"across {len(changed_roles)} roles ({roles_str}).\n\n"
+            f"Items were classified as general via cross-project prevalence analysis."
+        ),
+        "pr_title": f"Meta mode: update {n_items} playbook items ({roles_str})",
+        "pr_body": generate_pr_body(candidates, evidence_map),
+    }
+
+
+# ── Summary ────────────────────────────────────────────────────────
+
+
+def render_generality_bar(score: float, width: int = 10) -> str:
+    """Render a visual bar for generality score. E.g., '████████░░ 0.85'"""
+    filled = round(score * width)
+    return "█" * filled + "░" * (width - filled) + f" {score:.2f}"
+
+
+def explain_specificity(item: ClassifiedItem) -> str:
+    """Why an item is classified as project-specific."""
+    reasons: list[str] = []
+
+    if item.cross_project_count <= 1:
+        reasons.append("single-project signal")
+
+    domain_kws: list[str] = []
+    for p in DOMAIN_SPECIFIC_PATTERNS:
+        m = p.search(item.item.content)
+        if m:
+            domain_kws.append(m.group(0))
+    if domain_kws:
+        reasons.append(f"domain-specific ({', '.join(domain_kws)})")
+
+    total = item.item.helpful + item.item.harmful
+    if total < 3:
+        reasons.append("low evidence")
+
+    if item.item.harmful > 0 and item.item.helpful > 0 and item.cross_project_count > 1:
+        reasons.append("high variance across projects")
+
+    if total > 0 and (item.item.helpful / total) < 0.50:
+        reasons.append("low consensus")
+
+    if not reasons:
+        reasons.append("below generality threshold")
+
+    return ", ".join(reasons[:2])
+
+
+def explain_uncertainty(item: ClassifiedItem) -> str:
+    """What would resolve an uncertain classification."""
+    reasons: list[str] = []
+
+    if item.cross_project_count < 3:
+        reasons.append(
+            f"needs more cross-project evidence (currently {item.cross_project_count}/3 threshold)"
+        )
+
+    if item.item.harmful > 0 and item.item.helpful > 0:
+        reasons.append("mixed signals: helpful in some projects, harmful in others")
+
+    total = item.item.helpful + item.item.harmful
+    if total < 5:
+        reasons.append(f"insufficient observations ({total} total, need 5+)")
+
+    if not reasons:
+        reasons.append("borderline generality score")
+
+    return reasons[0]
+
+
+def render_summary(report: ContributionReport) -> str:
+    """Generate a terminal-formatted meta mode summary."""
+    total = len(report.general_items) + len(report.specific_items) + len(report.uncertain_items)
+
+    roles: set[str] = set()
+    for c in report.general_items:
+        roles.add(c.role)
+    for c in report.specific_items:
+        roles.add(c.role)
+    for c in report.uncertain_items:
+        roles.add(c.role)
+
+    double_line = "═" * 60
+    single_line = "─" * 60
+
+    sections: list[str] = [
+        double_line,
+        "                    META MODE SUMMARY",
+        double_line,
+        "",
+        "PLAYBOOK EVOLUTION COMPLETE",
+        f"  {total} items evolved across {len(roles)} roles",
+        (
+            f"  {len(report.general_items)} general (upstream candidates)"
+            f"  |  {len(report.specific_items)} specific (local only)"
+            f"  |  {len(report.uncertain_items)} uncertain"
+        ),
+    ]
+
+    if report.general_items:
+        sections.extend(["", single_line, "GENERAL IMPROVEMENTS (upstream candidates)", single_line, ""])
+        for idx, c in enumerate(report.general_items, 1):
+            bar = render_generality_bar(c.generality_score)
+            total_exp = c.item.helpful + c.item.harmful
+            category = classify_hypothesis(c.item.content)
+            sections.append(f'  {idx}. [{c.role}] "{c.item.content}"')
+            sections.append(
+                f"     Generality: {bar}  |  {c.cross_project_count} projects"
+                f"  |  {total_exp} experiments"
+            )
+            sections.append(f"     Category: {category}")
+            sections.append("")
+
+    if report.specific_items:
+        sections.extend([single_line, "PROJECT-SPECIFIC IMPROVEMENTS (staying local)", single_line, ""])
+        for idx, c in enumerate(report.specific_items, 1):
+            bar = render_generality_bar(c.generality_score)
+            total_exp = c.item.helpful + c.item.harmful
+            why = explain_specificity(c)
+            p_label = "project" if c.cross_project_count == 1 else "projects"
+            sections.append(f'  {idx}. [{c.role}] "{c.item.content}"')
+            sections.append(
+                f"     Generality: {bar}  |  {c.cross_project_count} {p_label}"
+                f"  |  {total_exp} experiments"
+            )
+            sections.append(f"     Why local: {why}")
+            sections.append("")
+
+    if report.uncertain_items:
+        sections.extend([single_line, "UNCERTAIN (needs more data)", single_line, ""])
+        for idx, c in enumerate(report.uncertain_items, 1):
+            bar = render_generality_bar(c.generality_score)
+            total_exp = c.item.helpful + c.item.harmful
+            needs = explain_uncertainty(c)
+            sections.append(f'  {idx}. [{c.role}] "{c.item.content}"')
+            sections.append(
+                f"     Generality: {bar}  |  {c.cross_project_count} projects"
+                f"  |  {total_exp} experiments"
+            )
+            sections.append(f"     Needs: {needs}")
+            sections.append("")
+
+    sections.extend([
+        double_line,
+        "Run `factory contribute` to select items for upstream PR.",
+        double_line,
+    ])
+
+    return "\n".join(sections)
+
+
+# ── Submit ─────────────────────────────────────────────────────────
+
+
+def execute_contribution(contribution_spec: dict, factory_repo_path: Path) -> str:
+    """Execute git/gh commands to submit a contribution PR.
+
+    Returns the PR URL on success, or an error message on failure.
+    Cleans up the branch on error.
+    """
+    branch = contribution_spec["branch_name"]
+
+    try:
+        subprocess.run(
+            ["git", "checkout", "-b", branch],
+            cwd=factory_repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        for change in contribution_spec["file_changes"]:
+            file_path = factory_repo_path / change["path"]
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.write_text(change["content"])
+
+        paths = [c["path"] for c in contribution_spec["file_changes"]]
+        subprocess.run(
+            ["git", "add"] + paths,
+            cwd=factory_repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", contribution_spec["commit_message"]],
+            cwd=factory_repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        subprocess.run(
+            ["git", "push", "-u", "origin", branch],
+            cwd=factory_repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        result = subprocess.run(
+            [
+                "gh", "pr", "create",
+                "--title", contribution_spec["pr_title"],
+                "--body", contribution_spec["pr_body"],
+            ],
+            cwd=factory_repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    except subprocess.CalledProcessError as exc:
+        log.error("contribution_failed", error=str(exc), stderr=exc.stderr)
+        subprocess.run(
+            ["git", "checkout", "-"],
+            cwd=factory_repo_path,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "branch", "-D", branch],
+            cwd=factory_repo_path,
+            capture_output=True,
+        )
+        return f"Error: {exc.stderr or str(exc)}"
+
+
+# ── Persistence ────────────────────────────────────────────────────
+
+
+def save_candidates(report: ContributionReport, project_path: Path) -> None:
+    """Persist classification results to .factory/contribution_candidates.json."""
+    out = project_path / _CANDIDATES_FILE
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(report.model_dump_json(indent=2))
+    log.info("save_candidates", path=str(out), general=len(report.general_items))
+
+
+def load_candidates(project_path: Path) -> ContributionReport | None:
+    """Load previously saved classification results."""
+    path = project_path / _CANDIDATES_FILE
+    if not path.exists():
+        return None
+    try:
+        return ContributionReport.model_validate_json(path.read_text())
+    except Exception:
+        log.warning("load_candidates_failed", path=str(path))
+        return None

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -287,6 +287,7 @@ At the start of every cycle, create a task list using `TaskCreate` **before spaw
 | 3 | Execute — Builder + Review + Eval | Executing experiment |
 | 4 | Final Archive & Summary | Archiving cycle results |
 | 5 | Evolve playbooks — ACE | Evolving agent playbooks |
+| 6 | Classify & Contribute | Classifying evolved items |
 
 ### Status Transition Rules
 
@@ -2363,6 +2364,53 @@ factory agent archivist --task "Record ACE playbook evolution.
 ```
 
 Note: Evolved playbooks are stored in `~/.factory/playbooks/` (user-local), NOT in the factory source tree. They are never committed to the factory repo — they are personal to each user's experiment history.
+
+### Phase 3: Classify and Contribute (after ACE evolution)
+
+After ACE evolution completes, classify evolved playbook items and present the user with upstream contribution options.
+
+#### M4: Classify Evolved Items
+
+```bash
+factory contribute --classify "$PROJECT_PATH"
+```
+
+This scores each evolved playbook item on the general-vs-specific spectrum using:
+- Cross-project prevalence (40%): does this pattern appear across multiple projects?
+- Domain independence (25%): does it reference factory internals or project-specific patterns?
+- Evidence strength (20%): how many observations support it?
+- Category signal (15%): is the hypothesis category inherently general?
+
+Items scoring >= 0.65 are flagged as general (upstream candidates). Items scoring <= 0.35 stay local (project-specific). Items between 0.35 and 0.65 are marked uncertain (need more data).
+
+#### M5: Present Summary to User
+
+The classification summary is printed automatically by M4. It shows:
+- **General improvements** with generality scores, cross-project evidence, and keep rates — these are candidates for upstream contribution
+- **Project-specific improvements** with "Why local" explanations — these stay in the user's local playbooks
+- **Uncertain items** with "Needs" explanations — these need more cross-project data to classify
+
+Present the summary to the user and explain what it means. The user decides what happens next.
+
+#### M6: User-Approved Contribution (optional)
+
+If the user wants to contribute general items upstream:
+
+```bash
+factory contribute --submit "$PROJECT_PATH" --all
+```
+
+This creates a PR against the remote-factory repo with:
+- Updated default playbook files with the general items merged in
+- Evidence package (cross-project stats, experiment examples)
+- Clear PR description explaining the classification methodology
+
+**Important**: Never auto-submit contributions. Always present the summary (M5) and wait for explicit user approval. The user may choose to:
+- Contribute all general items (`--all`)
+- Skip contribution entirely
+- Ask questions about specific items before deciding
+
+If the user skips contribution, that is fine — the local playbooks already have all the evolved items. Contribution is about improving the factory defaults for all users.
 
 ### Meta Mode Cadence
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1333,6 +1333,86 @@ def cmd_ace_stats(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_contribute(args: argparse.Namespace) -> int:
+    """Classify evolved playbooks and contribute general improvements upstream."""
+    project_path = Path(args.path).resolve()
+    projects_dir_raw = getattr(args, "projects_dir", None)
+    if projects_dir_raw:
+        projects_dir = Path(projects_dir_raw).expanduser().resolve()
+    else:
+        from factory.registry import get_project_paths
+        reg_paths = get_project_paths()
+        if reg_paths:
+            projects_dir = reg_paths[0].parent
+        else:
+            projects_dir = project_path.parent
+
+    if args.submit:
+        from factory.ace.contributor import (
+            execute_contribution,
+            load_candidates,
+            prepare_contribution,
+        )
+
+        report = load_candidates(project_path)
+        if report is None:
+            print("No contribution candidates found. Run 'factory contribute --classify' first.")
+            return 1
+
+        general = report.general_items
+        if not general:
+            print("No general items to contribute.")
+            return 0
+
+        factory_home = subprocess.run(
+            ["factory", "home"], capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        factory_repo_path = Path(factory_home).parent
+
+        from factory.insights import discover_projects, load_all_histories
+        project_paths = discover_projects(projects_dir)
+        cross_project_data = load_all_histories(project_paths) if project_paths else {}
+        spec = prepare_contribution(general, factory_repo_path, cross_project_data)
+
+        dry_run = getattr(args, "dry_run", False)
+        if dry_run:
+            print(spec)
+            return 0
+
+        result = execute_contribution(spec, factory_repo_path)
+        print(f"Contribution submitted: {result}")
+        _emit_cli_event(project_path, "contribute.submit_complete", {
+            "items": len(general),
+        })
+        return 0
+
+    if args.status:
+        from factory.ace.contributor import load_candidates
+
+        report = load_candidates(project_path)
+        if report is None:
+            print("No pending contributions.")
+            return 0
+
+        print(f"Pending: {len(report.general_items)} general, {len(report.specific_items)} specific, {len(report.uncertain_items)} uncertain")
+        return 0
+
+    # Default: --classify
+    from factory.ace.contributor import (
+        classify_evolved_playbooks,
+        render_summary,
+        save_candidates,
+    )
+
+    report = classify_evolved_playbooks(project_path)
+    print(render_summary(report))
+    save_candidates(report, project_path)
+    _emit_cli_event(project_path, "contribute.classify_complete", {
+        "total": len(report.general_items) + len(report.specific_items) + len(report.uncertain_items),
+    })
+    return 0
+
+
 def cmd_digest(args: argparse.Namespace) -> int:
     from factory.digest import format_digest, scan_vault
 
@@ -3469,6 +3549,16 @@ def build_parser() -> argparse.ArgumentParser:
     # ace-stats
     sub.add_parser("ace-stats", help="Print playbook item counters for all roles")
 
+    # contribute
+    p = sub.add_parser("contribute", help="Classify evolved playbooks and contribute general improvements upstream")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--classify", action="store_true", help="Classify evolved items and show summary")
+    p.add_argument("--submit", action="store_true", help="Create PR with approved general items")
+    p.add_argument("--status", action="store_true", help="Show pending contribution candidates")
+    p.add_argument("--all", action="store_true", help="Submit all general items without selection")
+    p.add_argument("--projects-dir", default=None, help="Directory containing factory-managed projects")
+    p.add_argument("--dry-run", action="store_true", default=False, help="Show what would be done without writing")
+
     # digest
     p = sub.add_parser("digest", help="Summarize recent factory activity across projects")
     p.add_argument("--date", default=None, help="Show activity for a specific date (YYYY-MM-DD)")
@@ -3823,6 +3913,7 @@ def main(argv: list[str] | None = None) -> int:
         "registry-list": cmd_registry_list,
         "ace": cmd_ace,
         "ace-stats": cmd_ace_stats,
+        "contribute": cmd_contribute,
         "digest": cmd_digest,
         "archive": cmd_archive,
         "precheck": cmd_precheck,

--- a/tests/test_contributor.py
+++ b/tests/test_contributor.py
@@ -1,16 +1,24 @@
 """Tests for factory/ace/contributor.py — classification, diffing, summary, PR body, persistence."""
 
+import argparse
+import subprocess
 from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 from factory.ace.contributor import (
     ClassifiedItem,
     ContributionReport,
+    EvidencePackage,
+    classify_evolved_playbooks,
     classify_item,
     diff_playbooks,
+    execute_contribution,
     explain_specificity,
     explain_uncertainty,
     generate_pr_body,
     load_candidates,
+    package_evidence,
+    prepare_contribution,
     render_generality_bar,
     render_summary,
     save_candidates,
@@ -20,6 +28,7 @@ from factory.ace.contributor import (
     score_evidence_strength,
 )
 from factory.ace.models import Playbook, PlaybookItem
+from factory.cli import cmd_contribute
 from factory.models import ExperimentRecord
 
 
@@ -317,3 +326,456 @@ class TestPersistence:
         assert loaded.general_items[0].item.content == "General rule"
         assert loaded.specific_items[0].item.content == "Specific rule"
         assert loaded.generated_at == report.generated_at
+
+    def test_load_candidates_missing_file(self, tmp_path):
+        result = load_candidates(tmp_path / "nonexistent")
+        assert result is None
+
+    def test_load_candidates_corrupt_file(self, tmp_path):
+        out = tmp_path / ".factory" / "contribution_candidates.json"
+        out.parent.mkdir(parents=True)
+        out.write_text("not valid json {{{")
+        result = load_candidates(tmp_path)
+        assert result is None
+
+
+# ── classify_evolved_playbooks ─────────────────────────────────
+
+
+class TestClassifyEvolvedPlaybooks:
+    def test_full_pipeline(self, tmp_path):
+        pb_content = (
+            "---\nrole: builder\nupdated: 2026-01-01\nitem_count: 1\n---\n\n"
+            "## Behavioral Playbook — Builder\n\n### DO\n"
+            "- [bldr-001] helpful=5 harmful=0 :: Improve agent prompt eval scoring\n"
+        )
+        evolved_dir = tmp_path / "evolved"
+        evolved_dir.mkdir()
+        (evolved_dir / "builder.md").write_text(pb_content)
+
+        defaults_dir = tmp_path / "defaults"
+        defaults_dir.mkdir()
+
+        project_path = tmp_path / "my-project"
+        project_path.mkdir()
+
+        with (
+            patch("factory.ace.contributor.user_playbooks_dir", return_value=evolved_dir),
+            patch("factory.ace.contributor.DEFAULTS_DIR", defaults_dir),
+            patch("factory.ace.contributor.discover_projects", return_value=[]),
+            patch("factory.ace.contributor.load_all_histories", return_value={}),
+        ):
+            report = classify_evolved_playbooks(project_path)
+
+        assert isinstance(report, ContributionReport)
+        total = len(report.general_items) + len(report.specific_items) + len(report.uncertain_items)
+        assert total == 1
+        all_items = report.general_items + report.specific_items + report.uncertain_items
+        assert all_items[0].item.content == "Improve agent prompt eval scoring"
+        assert all_items[0].role == "builder"
+
+    def test_with_default_playbook(self, tmp_path):
+        evolved_dir = tmp_path / "evolved"
+        evolved_dir.mkdir()
+        (evolved_dir / "strategist.md").write_text(
+            "---\nrole: strategist\nupdated: 2026-01-01\nitem_count: 1\n---\n\n"
+            "## Behavioral Playbook — Strategist\n\n### DO\n"
+            "- [strat-001] helpful=8 harmful=0 :: Improve agent prompt clarity and structure\n"
+        )
+
+        defaults_dir = tmp_path / "defaults"
+        defaults_dir.mkdir()
+        (defaults_dir / "strategist.md").write_text(
+            "---\nrole: strategist\nupdated: 2025-01-01\nitem_count: 1\n---\n\n"
+            "## Behavioral Playbook — Strategist\n\n### DO\n"
+            "- [strat-001] helpful=2 harmful=0 :: Improve agent prompt clarity and structure\n"
+        )
+
+        project_path = tmp_path / "my-project"
+        project_path.mkdir()
+
+        with (
+            patch("factory.ace.contributor.user_playbooks_dir", return_value=evolved_dir),
+            patch("factory.ace.contributor.DEFAULTS_DIR", defaults_dir),
+            patch("factory.ace.contributor.discover_projects", return_value=[]),
+            patch("factory.ace.contributor.load_all_histories", return_value={}),
+        ):
+            report = classify_evolved_playbooks(project_path)
+
+        total = len(report.general_items) + len(report.specific_items) + len(report.uncertain_items)
+        assert total == 1
+
+
+# ── diff_playbooks: content-changed-but-matched branch ─────────
+
+
+class TestDiffPlaybooksContentChanged:
+    def test_content_different_but_fuzzy_matched(self):
+        evolved = Playbook(role="test", items=[
+            PlaybookItem(
+                id="e-001",
+                content="Always run unit tests and integration tests before committing",
+                helpful=5,
+                harmful=0,
+            ),
+        ])
+        default = Playbook(role="test", items=[
+            PlaybookItem(
+                id="d-001",
+                content="Always run unit tests before committing",
+                helpful=5,
+                harmful=0,
+            ),
+        ])
+        diffs = diff_playbooks(evolved, default)
+        assert len(diffs) == 1
+        assert diffs[0]["diff_type"] == "modified"
+        assert diffs[0]["evolved_item"].content == "Always run unit tests and integration tests before committing"
+        assert diffs[0]["default_item"].content == "Always run unit tests before committing"
+
+
+# ── package_evidence ───────────────────────────────────────────
+
+
+class TestPackageEvidence:
+    def test_with_matching_experiments(self):
+        c = _classified("Add logging to all modules", helpful=5, source_projects=["a", "b"])
+        data = {
+            "proj-a": [
+                _experiment("Add logging to all modules", verdict="keep", id=1),
+                _experiment("Add logging to all modules", verdict="keep", id=2),
+            ],
+            "proj-b": [
+                _experiment("Add logging to all modules", verdict="revert", id=3),
+            ],
+            "proj-c": [
+                _experiment("Unrelated hypothesis", verdict="keep", id=4),
+            ],
+        }
+        ev = package_evidence(c, data)
+        assert isinstance(ev, EvidencePackage)
+        assert ev.total_projects == 2
+        assert ev.total_experiments == 3
+        assert "proj-a" in ev.cross_project_stats
+        assert "proj-b" in ev.cross_project_stats
+        assert "proj-c" not in ev.cross_project_stats
+        assert ev.cross_project_stats["proj-a"] == 1.0
+        assert ev.cross_project_stats["proj-b"] == 0.0
+        assert len(ev.example_experiments) == 3
+        assert ev.confidence == 0.3
+        assert ev.category != ""
+
+    def test_examples_capped_at_five(self):
+        c = _classified("Common rule across many projects", helpful=10)
+        data = {}
+        for i in range(8):
+            data[f"proj-{i}"] = [
+                _experiment("Common rule across many projects", verdict="keep", id=i),
+            ]
+        ev = package_evidence(c, data)
+        assert len(ev.example_experiments) == 5
+
+    def test_no_matches(self):
+        c = _classified("Unique rule", helpful=1)
+        data = {
+            "proj-a": [_experiment("Totally different hypothesis")],
+        }
+        ev = package_evidence(c, data)
+        assert ev.total_projects == 0
+        assert ev.total_experiments == 0
+        assert ev.example_experiments == []
+
+
+# ── generate_pr_body with evidence ─────────────────────────────
+
+
+class TestGeneratePrBodyWithEvidence:
+    def test_evidence_includes_keep_rate(self):
+        candidates = [
+            _classified("Improve prompt clarity", helpful=8, role="strategist", source_projects=["a", "b"]),
+        ]
+        candidates[0].generality_score = 0.8
+        evidence_map = {
+            candidates[0].item.id: EvidencePackage(
+                cross_project_stats={"proj-a": 0.9, "proj-b": 0.8},
+                total_experiments=10,
+                total_projects=2,
+                example_experiments=["proj-a: Improve prompt clarity"],
+                category="prompt_engineering",
+                confidence=0.8,
+            ),
+        }
+        body = generate_pr_body(candidates, evidence_map)
+        assert "keep rate" in body
+        assert "2 projects" in body
+        assert "10 experiments" in body
+        assert "85%" in body
+
+
+# ── prepare_contribution ───────────────────────────────────────
+
+
+class TestPrepareContribution:
+    def test_basic_contribution(self, tmp_path):
+        factory_repo = tmp_path / "factory-repo"
+        playbooks_dir = factory_repo / "factory" / "agents" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+
+        (playbooks_dir / "strategist.md").write_text(
+            "---\nrole: strategist\nupdated: 2025-01-01\nitem_count: 1\n---\n\n"
+            "## Behavioral Playbook — Strategist\n\n### DO\n"
+            "- [strat-001] helpful=2 harmful=0 :: Existing rule about prompts\n"
+        )
+
+        candidates = [
+            _classified("Brand new rule about testing", helpful=10, role="strategist", source_projects=["a", "b", "c"]),
+        ]
+        candidates[0].generality_score = 0.8
+
+        result = prepare_contribution(candidates, factory_repo)
+
+        assert "branch_name" in result
+        assert result["branch_name"].startswith("meta-contrib/")
+        assert len(result["file_changes"]) == 1
+        assert result["file_changes"][0]["path"] == "factory/agents/playbooks/strategist.md"
+        assert "Brand new rule about testing" in result["file_changes"][0]["content"]
+        assert "Existing rule about prompts" in result["file_changes"][0]["content"]
+        assert "commit_message" in result
+        assert "pr_title" in result
+        assert "pr_body" in result
+        assert "Meta Mode Contribution" in result["pr_body"]
+
+    def test_fuzzy_merge_updates_existing(self, tmp_path):
+        factory_repo = tmp_path / "factory-repo"
+        playbooks_dir = factory_repo / "factory" / "agents" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+
+        (playbooks_dir / "builder.md").write_text(
+            "---\nrole: builder\nupdated: 2025-01-01\nitem_count: 1\n---\n\n"
+            "## Behavioral Playbook — Builder\n\n### DO\n"
+            "- [bldr-001] helpful=2 harmful=0 :: Always run tests before committing\n"
+        )
+
+        candidates = [
+            _classified(
+                "Always run tests before committing changes to the repo",
+                helpful=10, role="builder", source_projects=["a", "b"],
+            ),
+        ]
+        candidates[0].generality_score = 0.75
+
+        result = prepare_contribution(candidates, factory_repo)
+
+        content = result["file_changes"][0]["content"]
+        assert "Always run tests before committing changes to the repo" in content
+        lines = [line for line in content.splitlines() if line.startswith("- [")]
+        assert len(lines) == 1
+
+    def test_no_existing_default(self, tmp_path):
+        factory_repo = tmp_path / "factory-repo"
+        playbooks_dir = factory_repo / "factory" / "agents" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+
+        candidates = [
+            _classified("New rule", helpful=5, role="reviewer", source_projects=["a"]),
+        ]
+        candidates[0].generality_score = 0.7
+
+        result = prepare_contribution(candidates, factory_repo)
+
+        assert result["file_changes"][0]["path"] == "factory/agents/playbooks/reviewer.md"
+        assert "New rule" in result["file_changes"][0]["content"]
+
+    def test_with_cross_project_data(self, tmp_path):
+        factory_repo = tmp_path / "factory-repo"
+        playbooks_dir = factory_repo / "factory" / "agents" / "playbooks"
+        playbooks_dir.mkdir(parents=True)
+
+        candidates = [
+            _classified("Improve logging", helpful=8, role="builder", source_projects=["a", "b"]),
+        ]
+        candidates[0].generality_score = 0.8
+
+        cross_project_data = {
+            "proj-a": [_experiment("Improve logging", verdict="keep")],
+            "proj-b": [_experiment("Improve logging", verdict="keep")],
+        }
+
+        result = prepare_contribution(candidates, factory_repo, cross_project_data)
+
+        assert "keep rate" in result["pr_body"]
+
+
+# ── explain_specificity branches ───────────────────────────────
+
+
+class TestExplainSpecificityBranches:
+    def test_domain_keywords(self):
+        c = _classified("Use Django REST framework for API endpoints", helpful=5, source_projects=["a", "b", "c"])
+        reason = explain_specificity(c)
+        assert "domain-specific" in reason
+        assert "Django" in reason
+
+    def test_low_evidence(self):
+        c = _classified("Some rule with little data", helpful=1, harmful=0, source_projects=["a", "b", "c"])
+        reason = explain_specificity(c)
+        assert "low evidence" in reason
+
+    def test_high_variance(self):
+        c = _classified("Rule that varies across projects", helpful=5, harmful=3, source_projects=["a", "b"])
+        reason = explain_specificity(c)
+        assert "high variance" in reason
+
+    def test_low_consensus(self):
+        c = _classified("Divisive rule", helpful=2, harmful=3, source_projects=["a", "b", "c"])
+        reason = explain_specificity(c)
+        assert "low consensus" in reason
+
+    def test_fallback(self):
+        c = _classified(
+            "Improve agent prompt eval scoring for experiments",
+            helpful=10, harmful=0, source_projects=["a", "b", "c"],
+        )
+        reason = explain_specificity(c)
+        assert "below generality threshold" in reason
+
+
+# ── explain_uncertainty branches ───────────────────────────────
+
+
+class TestExplainUncertaintyBranches:
+    def test_mixed_signals(self):
+        c = _classified(helpful=8, harmful=4, source_projects=["a", "b", "c"])
+        reason = explain_uncertainty(c)
+        assert "mixed signals" in reason
+
+    def test_insufficient_observations(self):
+        c = _classified(helpful=3, harmful=0, source_projects=["a", "b", "c"])
+        reason = explain_uncertainty(c)
+        assert "insufficient observations" in reason
+
+
+# ── execute_contribution ───────────────────────────────────────
+
+
+class TestExecuteContribution:
+    def _make_spec(self):
+        return {
+            "branch_name": "meta-contrib/2026-05-25-playbook-updates",
+            "file_changes": [
+                {"path": "factory/agents/playbooks/builder.md", "content": "updated content"},
+            ],
+            "commit_message": "Update playbook items",
+            "pr_title": "Meta mode: update 1 playbook item",
+            "pr_body": "## Meta Mode Contribution\n\nTest body",
+        }
+
+    @patch("factory.ace.contributor.subprocess.run")
+    def test_success(self, mock_run, tmp_path):
+        pr_url = "https://github.com/org/repo/pull/42"
+        mock_run.return_value = MagicMock(stdout=pr_url, returncode=0)
+
+        result = execute_contribution(self._make_spec(), tmp_path)
+
+        assert result == pr_url
+        assert mock_run.call_count == 5
+
+        calls = mock_run.call_args_list
+        assert calls[0][0][0] == ["git", "checkout", "-b", "meta-contrib/2026-05-25-playbook-updates"]
+        assert calls[1][0][0] == ["git", "add", "factory/agents/playbooks/builder.md"]
+        assert calls[2][0][0][0:2] == ["git", "commit"]
+        assert calls[3][0][0][0:2] == ["git", "push"]
+        assert calls[4][0][0][0:2] == ["gh", "pr"]
+
+    @patch("factory.ace.contributor.subprocess.run")
+    def test_error_cleans_up_branch(self, mock_run, tmp_path):
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, "git", stderr="branch already exists"),
+        ]
+
+        call_count = 0
+
+        def side_effect_fn(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise subprocess.CalledProcessError(1, "git", stderr="branch already exists")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = side_effect_fn
+
+        result = execute_contribution(self._make_spec(), tmp_path)
+
+        assert result.startswith("Error:")
+        assert "branch already exists" in result
+        assert mock_run.call_count == 3
+
+
+# ── cmd_contribute CLI ─────────────────────────────────────────
+
+
+class TestCmdContribute:
+    def _make_args(self, path="/tmp/test-project", submit=False, status=False):
+        args = argparse.Namespace()
+        args.path = path
+        args.submit = submit
+        args.status = status
+        args.projects_dir = None
+        args.dry_run = False
+        return args
+
+    @patch("factory.cli._emit_cli_event")
+    @patch("factory.cli.cmd_contribute.__module__", "factory.cli")
+    @patch("factory.ace.contributor.save_candidates")
+    @patch("factory.ace.contributor.render_summary", return_value="SUMMARY OUTPUT")
+    @patch("factory.ace.contributor.classify_evolved_playbooks")
+    def test_classify(self, mock_classify, mock_render, mock_save, mock_emit):
+        report = ContributionReport(
+            general_items=[_classified("General", helpful=10, source_projects=["a", "b"])],
+            specific_items=[],
+            uncertain_items=[],
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        mock_classify.return_value = report
+
+        args = self._make_args()
+        with patch("factory.registry.get_project_paths", return_value=[]):
+            ret = cmd_contribute(args)
+
+        assert ret == 0
+        mock_classify.assert_called_once()
+        mock_render.assert_called_once_with(report)
+        mock_save.assert_called_once()
+
+    @patch("factory.ace.contributor.load_candidates", return_value=None)
+    def test_status_no_candidates(self, mock_load, capsys):
+        args = self._make_args(status=True)
+        ret = cmd_contribute(args)
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "No pending contributions" in captured.out
+
+    @patch("factory.ace.contributor.load_candidates")
+    def test_status_with_candidates(self, mock_load, capsys):
+        report = ContributionReport(
+            general_items=[_classified("G1", helpful=5)],
+            specific_items=[_classified("S1", helpful=2), _classified("S2", helpful=1)],
+            uncertain_items=[],
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        mock_load.return_value = report
+
+        args = self._make_args(status=True)
+        ret = cmd_contribute(args)
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "1 general" in captured.out
+        assert "2 specific" in captured.out
+
+    @patch("factory.ace.contributor.load_candidates", return_value=None)
+    def test_submit_no_candidates(self, mock_load, capsys):
+        args = self._make_args(submit=True)
+        ret = cmd_contribute(args)
+        assert ret == 1
+        captured = capsys.readouterr()
+        assert "No contribution candidates found" in captured.out

--- a/tests/test_contributor.py
+++ b/tests/test_contributor.py
@@ -2,8 +2,6 @@
 
 from datetime import datetime
 
-import pytest
-
 from factory.ace.contributor import (
     ClassifiedItem,
     ContributionReport,

--- a/tests/test_contributor.py
+++ b/tests/test_contributor.py
@@ -1,0 +1,321 @@
+"""Tests for factory/ace/contributor.py — classification, diffing, summary, PR body, persistence."""
+
+from datetime import datetime
+
+import pytest
+
+from factory.ace.contributor import (
+    ClassifiedItem,
+    ContributionReport,
+    classify_item,
+    diff_playbooks,
+    explain_specificity,
+    explain_uncertainty,
+    generate_pr_body,
+    load_candidates,
+    render_generality_bar,
+    render_summary,
+    save_candidates,
+    score_category_signal,
+    score_cross_project_prevalence,
+    score_domain_independence,
+    score_evidence_strength,
+)
+from factory.ace.models import Playbook, PlaybookItem
+from factory.models import ExperimentRecord
+
+
+# ── helpers ─────────────────────────────────────────────────────
+
+
+def _item(content: str, helpful: int = 0, harmful: int = 0, section: str = "DO") -> PlaybookItem:
+    return PlaybookItem(id="test-001", content=content, helpful=helpful, harmful=harmful, section=section)
+
+
+def _classified(
+    content: str = "Test rule",
+    helpful: int = 0,
+    harmful: int = 0,
+    role: str = "strategist",
+    source_projects: list[str] | None = None,
+) -> ClassifiedItem:
+    item = _item(content, helpful=helpful, harmful=harmful)
+    return ClassifiedItem(
+        item=item,
+        role=role,
+        source_projects=source_projects or [],
+    )
+
+
+def _experiment(
+    hypothesis: str,
+    verdict: str = "keep",
+    id: int = 1,
+) -> ExperimentRecord:
+    return ExperimentRecord(
+        id=id,
+        timestamp=datetime.now(),
+        hypothesis=hypothesis,
+        change_summary="test change",
+        issue_number=None,
+        pr_number=None,
+        score_before=None,
+        score_after=None,
+        delta=None,
+        verdict=verdict,
+        cost_usd=None,
+        notes="",
+    )
+
+
+# ── Classification: cross-project prevalence ────────────────────
+
+
+class TestScoreCrossProjectPrevalence:
+    def test_no_match(self):
+        c = _classified("Completely unrelated rule")
+        score = score_cross_project_prevalence(c, {})
+        assert score == 0.0
+
+    def test_one_project(self):
+        c = _classified("Add logging to all modules")
+        data = {
+            "proj-a": [_experiment("Add logging to all modules")],
+        }
+        score = score_cross_project_prevalence(c, data)
+        assert abs(score - 1 / 3) < 0.15
+
+    def test_three_projects(self):
+        c = _classified("Add logging to all modules")
+        data = {
+            "proj-a": [_experiment("Add logging to all modules")],
+            "proj-b": [_experiment("Add logging to all modules")],
+            "proj-c": [_experiment("Add logging to all modules")],
+        }
+        score = score_cross_project_prevalence(c, data)
+        assert score == 1.0
+
+
+# ── Classification: domain independence ─────────────────────────
+
+
+class TestScoreDomainIndependence:
+    def test_factory_keywords(self):
+        c = _classified("Improve agent prompt eval scoring for experiments")
+        score = score_domain_independence(c)
+        assert score > 0.7
+
+    def test_domain_keywords(self):
+        c = _classified("Use React hooks with Django REST framework and PostgreSQL")
+        score = score_domain_independence(c)
+        assert score < 0.3
+
+    def test_neutral(self):
+        c = _classified("Keep variables short and descriptive")
+        score = score_domain_independence(c)
+        assert score == 0.5
+
+
+# ── Classification: evidence strength ───────────────────────────
+
+
+class TestScoreEvidenceStrength:
+    def test_low(self):
+        c = _classified(helpful=1, harmful=0)
+        score = score_evidence_strength(c)
+        assert score == 0.2
+
+    def test_high(self):
+        c = _classified(helpful=12, harmful=1)
+        score = score_evidence_strength(c)
+        assert score > 0.5
+
+
+# ── Classification: category signal ─────────────────────────────
+
+
+class TestScoreCategorySignal:
+    def test_general(self):
+        c = _classified("Improve agent prompt clarity and structure")
+        score = score_category_signal(c)
+        assert score == 0.9
+
+    def test_specific(self):
+        c = _classified("Add user dashboard feature with sidebar navigation")
+        score = score_category_signal(c)
+        assert score == 0.3
+
+
+# ── Classification: end-to-end ──────────────────────────────────
+
+
+class TestClassifyItem:
+    def test_general(self):
+        item = _item("Improve agent prompt eval scoring", helpful=10, harmful=0)
+        data = {
+            f"proj-{i}": [_experiment("Improve agent prompt eval scoring")]
+            for i in range(3)
+        }
+        result = classify_item(item, data, role="strategist")
+        assert result.classification == "general"
+
+    def test_specific(self):
+        item = _item("Add React component for Django admin", helpful=1, harmful=0)
+        result = classify_item(item, {}, role="builder")
+        assert result.classification == "specific"
+
+    def test_uncertain(self):
+        item = _item("Improve test coverage for modules", helpful=4, harmful=2)
+        data = {
+            "proj-a": [_experiment("Improve test coverage for modules")],
+        }
+        result = classify_item(item, data, role="strategist")
+        assert result.classification == "uncertain"
+
+
+# ── Diff ────────────────────────────────────────────────────────
+
+
+class TestDiffPlaybooks:
+    def test_added(self):
+        evolved = Playbook(role="test", items=[
+            _item("Brand new rule", helpful=3),
+        ])
+        default = Playbook.empty("test")
+        diffs = diff_playbooks(evolved, default)
+        assert len(diffs) == 1
+        assert diffs[0]["diff_type"] == "added"
+        assert diffs[0]["evolved_item"].content == "Brand new rule"
+        assert "+[test-001]" in diffs[0]["diff_text"] or "Brand new rule" in diffs[0]["diff_text"]
+
+    def test_modified(self):
+        evolved = Playbook(role="test", items=[
+            _item("Updated version of rule", helpful=5),
+        ])
+        default = Playbook(role="test", items=[
+            _item("Updated version of rule", helpful=2),
+        ])
+        diffs = diff_playbooks(evolved, default)
+        assert len(diffs) == 1
+        assert diffs[0]["diff_type"] == "modified"
+
+    def test_removed(self):
+        evolved = Playbook.empty("test")
+        default = Playbook(role="test", items=[
+            _item("Old rule that was removed"),
+        ])
+        diffs = diff_playbooks(evolved, default)
+        assert len(diffs) == 1
+        assert diffs[0]["diff_type"] == "removed"
+        assert diffs[0]["default_item"].content == "Old rule that was removed"
+        assert diffs[0]["evolved_item"] is None
+
+    def test_fuzzy_matching(self):
+        evolved = Playbook(role="test", items=[
+            PlaybookItem(id="e-001", content="Always run tests before committing changes", helpful=5, harmful=0),
+        ])
+        default = Playbook(role="test", items=[
+            PlaybookItem(id="d-001", content="Always run tests before committing", helpful=2, harmful=0),
+        ])
+        diffs = diff_playbooks(evolved, default)
+        assert len(diffs) == 1
+        assert diffs[0]["diff_type"] == "modified"
+
+
+# ── Summary: render_generality_bar ──────────────────────────────
+
+
+class TestRenderGeneralityBar:
+    def test_zero(self):
+        bar = render_generality_bar(0.0)
+        assert bar.startswith("░" * 10)
+        assert "0.00" in bar
+
+    def test_half(self):
+        bar = render_generality_bar(0.5)
+        assert "█████" in bar
+        assert "0.50" in bar
+
+    def test_full(self):
+        bar = render_generality_bar(1.0)
+        assert bar.startswith("█" * 10)
+        assert "1.00" in bar
+
+
+# ── Summary: explain_specificity ────────────────────────────────
+
+
+class TestExplainSpecificity:
+    def test_single_project(self):
+        c = _classified(helpful=5, harmful=0, source_projects=["proj-a"])
+        reason = explain_specificity(c)
+        assert "single-project signal" in reason
+
+
+# ── Summary: explain_uncertainty ────────────────────────────────
+
+
+class TestExplainUncertainty:
+    def test_low_projects(self):
+        c = _classified(helpful=5, harmful=0, source_projects=["proj-a"])
+        reason = explain_uncertainty(c)
+        assert "threshold" in reason
+
+
+# ── Summary: render_summary ─────────────────────────────────────
+
+
+class TestRenderSummary:
+    def test_all_sections(self):
+        report = ContributionReport(
+            general_items=[_classified("General rule", helpful=10, source_projects=["a", "b", "c"])],
+            specific_items=[_classified("Specific rule", helpful=2, source_projects=["a"])],
+            uncertain_items=[_classified("Uncertain rule", helpful=4, source_projects=["a", "b"])],
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        text = render_summary(report)
+        assert "META MODE SUMMARY" in text
+        assert "factory contribute" in text
+        assert "GENERAL IMPROVEMENTS" in text
+        assert "PROJECT-SPECIFIC" in text
+        assert "UNCERTAIN" in text
+
+
+# ── PR body ─────────────────────────────────────────────────────
+
+
+class TestGeneratePrBody:
+    def test_empty(self):
+        body = generate_pr_body([])
+        assert "No items" in body
+
+    def test_with_candidates(self):
+        candidates = [
+            _classified("Improve prompt clarity", helpful=8, role="strategist", source_projects=["a", "b"]),
+        ]
+        candidates[0].generality_score = 0.8
+        body = generate_pr_body(candidates)
+        assert "Methodology" in body
+        assert "Improve prompt clarity" in body
+        assert "Meta Mode Contribution" in body
+
+
+# ── Persistence ─────────────────────────────────────────────────
+
+
+class TestPersistence:
+    def test_save_load_roundtrip(self, tmp_path):
+        report = ContributionReport(
+            general_items=[_classified("General rule", helpful=10, source_projects=["a", "b", "c"])],
+            specific_items=[_classified("Specific rule", helpful=2, source_projects=["a"])],
+            uncertain_items=[],
+            generated_at="2026-01-01T00:00:00Z",
+        )
+        save_candidates(report, tmp_path)
+        loaded = load_candidates(tmp_path)
+        assert loaded is not None
+        assert len(loaded.general_items) == 1
+        assert len(loaded.specific_items) == 1
+        assert loaded.general_items[0].item.content == "General rule"
+        assert loaded.specific_items[0].item.content == "Specific rule"
+        assert loaded.generated_at == report.generated_at


### PR DESCRIPTION
## Summary

- Adds a contribution pipeline to meta mode that classifies evolved playbook items as **general** (upstream-worthy) vs **project-specific** (local only), then lets users contribute the general ones back as PRs
- New `factory contribute` CLI command with `--classify`, `--submit`, and `--status` subcommands
- CEO prompt updated with Phase 3 (M4/M5/M6) that runs after ACE evolution

## Motivation

Currently, meta mode evolves playbooks locally via ACE — all learnings stay in `~/.factory/playbooks/` and never flow back upstream. This means every user independently re-discovers the same improvements. With this change, the factory can identify patterns that are universally useful across diverse projects and contribute them back to the default playbooks, closing the self-improvement loop: **the more the factory is used, the better it becomes for everyone**.

## How it works

### Classification engine (`factory/ace/contributor.py`)

Each evolved playbook item is scored on a general-vs-specific spectrum using four weighted signals:

| Signal | Weight | What it measures |
|--------|--------|------------------|
| Cross-project prevalence | 40% | Does this pattern appear across 3+ unrelated projects? |
| Domain independence | 25% | Does it reference factory internals or project-specific frameworks? |
| Evidence strength | 20% | How many observations (helpful/harmful) support it? |
| Category signal | 15% | Is the hypothesis category inherently general (e.g., prompt_engineering) or specific (e.g., feature)? |

Items scoring ≥ 0.65 are classified as **general**, ≤ 0.35 as **specific**, and between as **uncertain**.

### User experience

At the end of a meta mode run, users see a terminal summary:

```
════════════════════════════════════════════════════════════
                    META MODE SUMMARY
════════════════════════════════════════════════════════════

PLAYBOOK EVOLUTION COMPLETE
  9 items evolved across 5 roles
  3 general (upstream candidates)  |  3 specific (local only)  |  3 uncertain

────────────────────────────────────────────────────────────
GENERAL IMPROVEMENTS (upstream candidates)
────────────────────────────────────────────────────────────

  1. [strategist] "Always run type checkers after making changes"
     Generality: ████████░░ 0.81  |  5 projects  |  16 experiments
     Category: type_safety

────────────────────────────────────────────────────────────
PROJECT-SPECIFIC IMPROVEMENTS (staying local)
────────────────────────────────────────────────────────────

  1. [builder] "Use iframe wait patterns for Playwright tests"
     Generality: ██░░░░░░░░ 0.22  |  1 project  |  5 experiments
     Why local: single-project signal, domain-specific (Playwright)

════════════════════════════════════════════════════════════
Run `factory contribute` to select items for upstream PR.
════════════════════════════════════════════════════════════
```

Users can then run `factory contribute --submit` to create a PR, or skip — contribution is always opt-in.

### CLI commands

```bash
# Classify evolved items and show summary
factory contribute --classify /path/to/project

# Create PR with all general items
factory contribute --submit /path/to/project --all

# Check pending candidates
factory contribute --status
```

### CEO prompt changes

Phase 3 (steps M4/M5/M6) is added after Phase 2 (ACE). The CEO:
1. Runs `factory contribute --classify` to score evolved items
2. Presents the summary to the user
3. Waits for explicit approval before submitting — never auto-contributes

## Files changed

| File | Change |
|------|--------|
| `factory/ace/contributor.py` | **New** — classification engine, contribution pipeline, terminal summary, git/gh submit, JSON persistence (780 lines) |
| `factory/cli.py` | **Modified** — `factory contribute` command with `--classify`/`--submit`/`--status` subcommands |
| `factory/agents/prompts/ceo.md` | **Modified** — Phase 3 (M4/M5/M6) + task table entry |
| `tests/test_contributor.py` | **New** — 26 tests covering classification, diffing, summary, PR body, persistence |

## Design decisions

- **Composition over inheritance** for `ClassifiedItem` wrapping `PlaybookItem` (since `PlaybookItem` has `extra="forbid"`)
- **Reuses existing factory infrastructure**: `Playbook.from_markdown()`, `classify_hypothesis()`, `discover_projects()`, `load_all_histories()`, `DEFAULTS_DIR`, `user_playbooks_dir()`
- **`prepare_contribution()` returns specs without executing git** — keeps the module testable; `execute_contribution()` handles the actual git/gh commands separately
- **Fuzzy matching (SequenceMatcher ≥ 0.75)** for both cross-project evidence and playbook diffing, consistent with the existing reflector

## Test plan

- [x] 26 new tests pass (`pytest tests/test_contributor.py`)
- [x] 261 existing tests pass — zero regressions
- [x] `factory contribute --help` shows correct usage
- [x] All imports resolve correctly
- [ ] Manual test: run `factory contribute --classify` on a project with evolved playbooks
- [ ] Manual test: run `factory contribute --submit --dry-run` to verify PR spec generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)