### PR TITLE
fix: don't misclassify built repos as REPO_INCOMPLETE (#378)

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2256,6 +2256,12 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         if issue_resolved:
             title, context, issue_number, issue_url = issue_resolved
             focus = f"{title} (issue #{issue_number})"
+
+    # Factory-managed repos commit factory.md but gitignore .factory/. Bootstrap
+    # config.json from factory.md so detection sees a built project and routes to
+    # improve (where --focus is valid) instead of misclassifying it (issue #378).
+    _ensure_factory_config(project_path)
+
     force_fresh = mode == "auto-fresh"
     if mode in ("auto", "auto-fresh"):
         mode = _auto_detect_mode(
@@ -2876,6 +2882,40 @@ def _has_research_target(project_path: Path) -> bool:
         return False
 
 
+def _ensure_factory_config(project_path: Path) -> None:
+    """Bootstrap ``.factory/config.json`` from a committed ``factory.md`` if needed.
+
+    Factory-managed repos commit ``factory.md`` but gitignore ``.factory/``, so a
+    fresh checkout has no ``config.json``. Without it, state detection can't tell
+    the repo is factory-managed (it falls through to the open-issue heuristic) and
+    improve/``--focus`` runs are rejected. When ``factory.md`` exists and
+    ``config.json`` does not — and we're not mid-discovery (no ``eval_profile.json``)
+    — parse ``factory.md`` into ``config.json``, exactly as ``factory init`` does.
+    Non-destructive: reads ``factory.md`` and writes ``config.json``/scaffolding only.
+    """
+    factory_md = project_path / "factory.md"
+    config_json = project_path / ".factory" / "config.json"
+    eval_profile = project_path / ".factory" / "eval_profile.json"
+    if config_json.exists() or not factory_md.exists() or eval_profile.exists():
+        return
+    try:
+        from factory.store import ExperimentStore, ensure_factory_dir
+
+        store = ExperimentStore(project_path)
+        ensure_factory_dir(store.factory_dir)
+        config = _run(store.reparse_config())
+        _run(store.init(config))
+        print(
+            f"  Bootstrapped .factory/config.json from factory.md (goal={config.goal!r})",
+            file=sys.stderr,
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort bootstrap, never block the run
+        print(
+            f"  Warning: could not bootstrap config from factory.md: {e}",
+            file=sys.stderr,
+        )
+
+
 def _auto_detect_mode(project_path: Path, has_prompt: bool = False, force_fresh: bool = False) -> str:
     """Detect the right mode based on project state.
 
@@ -3282,6 +3322,11 @@ def cmd_run(args: argparse.Namespace) -> int:
             title, context, issue_number, issue_url = issue_resolved
             focus = f"{title} (issue #{issue_number})"
     mode = getattr(args, "mode", "auto")
+
+    # Bootstrap config.json from a committed factory.md (see _ensure_factory_config)
+    # so factory-managed repos route to improve instead of being misclassified (#378).
+    _ensure_factory_config(project_path)
+
     force_fresh = mode == "auto-fresh"
     if mode in ("auto", "auto-fresh"):
         mode = _auto_detect_mode(

--- a/factory/state.py
+++ b/factory/state.py
@@ -1,5 +1,6 @@
 """Project state detection — determines which mode the factory should operate in."""
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -8,6 +9,70 @@ import structlog
 from factory.models import ProjectState
 
 log = structlog.get_logger()
+
+# Build/manifest files that mark a configured, real project.
+_MANIFEST_FILES = (
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+    "Package.swift",
+    "pom.xml",
+    "build.gradle",
+)
+
+# Source extensions used to confirm a populated source tree.
+_SOURCE_EXTENSIONS = (
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".go", ".swift", ".java", ".rb",
+)
+
+# Directories never counted as project source.
+_SKIP_DIRS = {
+    ".git", ".venv", "venv", "env", "node_modules", "__pycache__",
+    "dist", "build", ".factory", ".mypy_cache", ".pytest_cache", ".ruff_cache",
+}
+
+# A repo with a manifest plus this many source files is clearly built.
+_SOURCE_THRESHOLD = 3
+
+
+def _has_substantial_source(project_path: Path) -> bool:
+    """True if the repo has a manifest plus a populated source tree.
+
+    Walks the tree (pruning vendored/build/hidden dirs) and stops as soon as the
+    source-file threshold is reached, so this stays cheap even on large repos.
+    """
+    if not any((project_path / m).exists() for m in _MANIFEST_FILES):
+        return False
+    found = 0
+    for root, dirs, files in os.walk(project_path):
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS and not d.startswith(".")]
+        for name in files:
+            if name.endswith(_SOURCE_EXTENSIONS):
+                found += 1
+                if found >= _SOURCE_THRESHOLD:
+                    return True
+    return False
+
+
+def _is_built_project(project_path: Path) -> bool:
+    """True if the repo is already a real, built project.
+
+    A committed ``factory.md`` marks a factory-managed project; substantial
+    source marks any other built codebase. Either way the repo is *not* an
+    unbuilt scaffold, so the open plan/implementation-issue heuristic — which
+    keys off the factory's own ``implementation`` backlog label — must not
+    classify it as ``REPO_INCOMPLETE`` (see issue #378).
+    """
+    if (project_path / "factory.md").exists():
+        log.debug("built_project", reason="factory_md")
+        return True
+    if _has_substantial_source(project_path):
+        log.debug("built_project", reason="substantial_source")
+        return True
+    return False
 
 
 def _has_open_plan_issues(project_path: Path) -> bool:
@@ -60,8 +125,12 @@ def detect_state(project_path: Path) -> ProjectState:
       1. Path doesn't exist or has no .git -> NO_REPO
       2. eval_profile.json exists with human_reviewed=False -> EVALS_PENDING_REVIEW
       3. .factory/config.json exists -> HAS_FACTORY
-      4. Has .git, open plan/implementation GitHub issues -> REPO_INCOMPLETE
-      5. Has .git, no open issues -> NO_FACTORY
+      4. Not a built project, open plan/implementation GitHub issues -> REPO_INCOMPLETE
+      5. Otherwise -> NO_FACTORY
+
+    A built/factory-managed repo (committed ``factory.md`` or substantial source)
+    is never REPO_INCOMPLETE: the open-issue heuristic keys off the factory's own
+    ``implementation`` backlog label, which a mature repo accumulates (issue #378).
     """
     log.debug("detect_state_start", project=str(project_path))
 
@@ -80,7 +149,10 @@ def detect_state(project_path: Path) -> ProjectState:
         log.info("detect_state_result", state=ProjectState.HAS_FACTORY.value)
         return ProjectState.HAS_FACTORY
 
-    if _has_open_plan_issues(project_path):
+    # A built/factory-managed repo is never "incomplete" — skip the open-issue
+    # heuristic (and its network call) entirely. Only an unbuilt scaffold with
+    # open planning issues routes to Build mode.
+    if not _is_built_project(project_path) and _has_open_plan_issues(project_path):
         log.info("detect_state_result", state=ProjectState.REPO_INCOMPLETE.value)
         return ProjectState.REPO_INCOMPLETE
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
-from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo, _materialize_project, _is_scaffold_only, _quick_classify, _welcome_wizard
+from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo, _materialize_project, _is_scaffold_only, _quick_classify, _welcome_wizard, _ensure_factory_config
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -2000,3 +2000,84 @@ class TestDeferredCreationFlow:
         project_path, context = _resolve_input(str(tmp_path))
         assert project_path == tmp_path
         assert context is None
+
+
+# Minimal valid factory.md with a ## Goal section (modeled on templates/factory_config.md).
+_MINIMAL_FACTORY_MD = (
+    "# Factory Configuration\n\n"
+    "## Goal\nBuild a test widget\n\n"
+    "## Scope\n\n### Modifiable\n- src/**/*.py\n\n"
+    "## Guards\n- Do not delete tests\n\n"
+    "## Eval\n\n### Command\n```bash\npython eval/score.py\n```\n\n"
+    "### Threshold\n0.8\n\n"
+    "## Constraints\n- Prefer small changes\n"
+)
+
+
+class TestEnsureFactoryConfig:
+    """Tests for _ensure_factory_config — bootstrap config.json from committed factory.md."""
+
+    def test_ensure_factory_config_bootstraps_from_factory_md(self, tmp_path):
+        """factory.md present, no config.json, no eval_profile.json -> config.json created."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "factory.md").write_text(_MINIMAL_FACTORY_MD)
+        config_json = project / ".factory" / "config.json"
+        assert not config_json.exists()
+
+        _ensure_factory_config(project)
+
+        assert config_json.exists()
+        config = json.loads(config_json.read_text())
+        assert config["goal"] == "Build a test widget"
+
+    def test_ensure_factory_config_noop_when_config_exists(self, tmp_path):
+        """Existing config.json is left untouched (no overwrite, no raise)."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "factory.md").write_text(_MINIMAL_FACTORY_MD)
+        factory_dir = project / ".factory"
+        factory_dir.mkdir()
+        config_json = factory_dir / "config.json"
+        sentinel = '{"goal": "pre-existing"}\n'
+        config_json.write_text(sentinel)
+
+        _ensure_factory_config(project)
+
+        assert config_json.read_text() == sentinel
+
+    def test_ensure_factory_config_noop_when_factory_md_absent(self, tmp_path):
+        """No factory.md -> no config.json created, no raise."""
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        _ensure_factory_config(project)
+
+        assert not (project / ".factory" / "config.json").exists()
+
+    def test_ensure_factory_config_noop_when_mid_discovery(self, tmp_path):
+        """eval_profile.json present (mid-discovery) -> bootstrap skipped, no config.json."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "factory.md").write_text(_MINIMAL_FACTORY_MD)
+        factory_dir = project / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "eval_profile.json").write_text("{}")
+
+        _ensure_factory_config(project)
+
+        assert not (factory_dir / "config.json").exists()
+
+    def test_ensure_factory_config_malformed_does_not_raise(self, tmp_path):
+        """Unparseable factory.md is best-effort — exception is caught, no raise, no config.json."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        # A non-numeric threshold makes reparse_config raise ValueError while parsing.
+        (project / "factory.md").write_text(
+            "# Factory\n\n## Goal\nBroken\n\n## Threshold\nnot-a-number\n"
+        )
+
+        # Should swallow the parse error rather than propagate it.
+        _ensure_factory_config(project)
+
+        assert not (project / ".factory" / "config.json").exists()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -129,7 +129,53 @@ class TestHasOpenPlanIssues:
 
 class TestDetectStateWithIssues:
     def test_repo_incomplete_with_open_issues(self, tmp_project):
-        """detect_state returns REPO_INCOMPLETE when plan issues exist."""
+        """detect_state returns REPO_INCOMPLETE when plan issues exist on an unbuilt repo."""
         mock_result = type("R", (), {"returncode": 0, "stdout": '[{"number": 1}]'})()
         with patch("factory.state.subprocess.run", return_value=mock_result):
             assert detect_state(tmp_project) == ProjectState.REPO_INCOMPLETE
+
+    def test_built_repo_not_incomplete_despite_open_issues(self, python_project):
+        """A built repo (manifest + source) is NOT REPO_INCOMPLETE even with open issues.
+
+        Regression test for #378: the open-issue heuristic keys off the factory's own
+        'implementation' backlog label, so a mature repo must not be misclassified.
+        """
+        import subprocess as _sp
+
+        _sp.run(["git", "init"], cwd=python_project, capture_output=True, check=True)
+        # gh is never even called for a built repo — but mock it to prove the point.
+        open_issues = type("R", (), {"returncode": 0, "stdout": '[{"number": 1}]'})()
+        with patch("factory.state.subprocess.run", return_value=open_issues):
+            assert detect_state(python_project) == ProjectState.NO_FACTORY
+
+    def test_factory_md_repo_not_incomplete_despite_open_issues(self, tmp_project):
+        """A repo with a committed factory.md is factory-managed → never REPO_INCOMPLETE."""
+        (tmp_project / "factory.md").write_text("# Factory Configuration\n## Goal\nx\n")
+        open_issues = type("R", (), {"returncode": 0, "stdout": '[{"number": 1}]'})()
+        with patch("factory.state.subprocess.run", return_value=open_issues):
+            assert detect_state(tmp_project) == ProjectState.NO_FACTORY
+
+
+class TestIsBuiltProject:
+    def test_bare_repo_not_built(self, tmp_project):
+        from factory.state import _is_built_project
+
+        assert _is_built_project(tmp_project) is False
+
+    def test_factory_md_is_built(self, tmp_project):
+        from factory.state import _is_built_project
+
+        (tmp_project / "factory.md").write_text("# Factory Configuration\n")
+        assert _is_built_project(tmp_project) is True
+
+    def test_manifest_plus_source_is_built(self, python_project):
+        from factory.state import _is_built_project
+
+        assert _is_built_project(python_project) is True
+
+    def test_manifest_without_source_not_built(self, tmp_project):
+        """A manifest alone (empty source tree) is not enough — it's a scaffold."""
+        from factory.state import _is_built_project
+
+        (tmp_project / "pyproject.toml").write_text('[project]\nname = "x"\n')
+        assert _is_built_project(tmp_project) is False


### PR DESCRIPTION
## Summary

Fixes #378. `factory ceo <built-repo> --focus "<item>"` was rejected on mature, actively-developed repositories because state detection classified them as `REPO_INCOMPLETE` → `build` mode, and `--focus` is only valid in `improve`/`research` mode.

The trigger: `_has_open_plan_issues()` returns `True` for any open issue labeled `plan` **or** `implementation` — but `implementation` is the **factory's own** experiment-backlog label ("Factory experiment implementation"). So a repo with a rich factory backlog (the sign of a *mature* project) looked "not yet built".

## Changes

- **`factory/state.py`** — adds `_is_built_project()`: a repo with a committed `factory.md` (factory-managed) **or** a manifest (`pyproject.toml`, `package.json`, …) plus ≥3 source files (`_has_substantial_source`) is a real, built project. `detect_state()` now only routes to `REPO_INCOMPLETE` when `not _is_built_project() and _has_open_plan_issues()`. The source walk prunes vendored/build/hidden dirs and short-circuits at the threshold, so it stays cheap. Built repos also skip the `gh` network call entirely.
- **`factory/cli.py`** — adds `_ensure_factory_config()`, called from `cmd_ceo` and `cmd_run` before detection. Factory-managed repos commit `factory.md` but gitignore `.factory/`, so a fresh checkout has no `config.json` and detection can't short-circuit to `HAS_FACTORY`. When `factory.md` exists and `config.json` doesn't (and we're not mid-discovery), it parses `factory.md` into `config.json` exactly as `factory init` does. Best-effort and non-destructive — never blocks the run.
- **`tests/test_state.py`** — regression tests: built repo (manifest+source) and `factory.md` repo with open issues both resolve to `NO_FACTORY` (not `REPO_INCOMPLETE`), plus `_is_built_project` unit coverage (bare repo, factory.md, manifest+source, manifest-without-source).

## Verification

- `pytest tests/test_state.py` — 21 passed
- Full suite — 2124 passed, 3 skipped
- `ruff check` — clean · `mypy factory/state.py` — clean

## Note on process

This run's factory worktree and `.factory/` state were torn down mid-session, so the standard agent pipeline could not execute. The fix already existed (complete and tested) in the working tree; it was verified directly and shipped here as a draft PR for human review. **Not merged** — left open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)