### PR TITLE
fix: stop treating the factory's own 'implementation' label as an unbuilt-repo signal (#378, #382)

### DIFF
--- a/factory/state.py
+++ b/factory/state.py
@@ -11,8 +11,12 @@ log = structlog.get_logger()
 
 
 def _has_open_plan_issues(project_path: Path) -> bool:
-    """Check GitHub for open issues with 'plan' or 'implementation' labels."""
-    for label in ("plan", "implementation"):
+    """Check GitHub for open issues with the 'plan' label."""
+    # NOTE: only 'plan' (an external scaffold convention) signals a genuinely
+    # unbuilt repo. Do NOT add 'implementation' — that is the factory's OWN
+    # backlog label, created by the CEO on already-built repos during Improve
+    # mode, so an open 'implementation' issue means the opposite of "unbuilt".
+    for label in ("plan",):
         try:
             result = subprocess.run(
                 ["gh", "issue", "list", "--label", label, "--state", "open", "--json", "number"],
@@ -60,7 +64,7 @@ def detect_state(project_path: Path) -> ProjectState:
       1. Path doesn't exist or has no .git -> NO_REPO
       2. eval_profile.json exists with human_reviewed=False -> EVALS_PENDING_REVIEW
       3. .factory/config.json exists -> HAS_FACTORY
-      4. Has .git, open plan/implementation GitHub issues -> REPO_INCOMPLETE
+      4. Has .git, open 'plan' GitHub issues -> REPO_INCOMPLETE
       5. Has .git, no open issues -> NO_FACTORY
     """
     log.debug("detect_state_start", project=str(project_path))

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -133,3 +133,19 @@ class TestDetectStateWithIssues:
         mock_result = type("R", (), {"returncode": 0, "stdout": '[{"number": 1}]'})()
         with patch("factory.state.subprocess.run", return_value=mock_result):
             assert detect_state(tmp_project) == ProjectState.REPO_INCOMPLETE
+
+    def test_implementation_only_issues_not_repo_incomplete(self, tmp_project):
+        """Regression (#378): an open 'implementation' issue must NOT flag an unbuilt repo.
+
+        'implementation' is the factory's OWN backlog label, created on already-built
+        repos. Only the external 'plan' label signals a genuinely unbuilt scaffold, so a
+        repo with only 'implementation' issues open must resolve to NO_FACTORY, not
+        REPO_INCOMPLETE.
+        """
+        def fake_run(args, **kwargs):
+            label = args[args.index("--label") + 1] if "--label" in args else ""
+            stdout = '[{"number": 1}]' if label == "implementation" else "[]"
+            return type("R", (), {"returncode": 0, "stdout": stdout})()
+
+        with patch("factory.state.subprocess.run", side_effect=fake_run):
+            assert detect_state(tmp_project) == ProjectState.NO_FACTORY


### PR DESCRIPTION
Closes #382

## Changes
- **`factory/state.py:15` (functional fix):** `for label in ("plan", "implementation"):` → `for label in ("plan",):` (single-element tuple — trailing comma is load-bearing). Only the external `plan` scaffold convention now signals a genuinely unbuilt repo.
- Added a guard comment above the loop explaining that `implementation` is the factory's OWN backlog label (emitted by the CEO on already-built repos), so a future contributor doesn't re-add it.
- Updated the `_has_open_plan_issues` docstring (line 14) and the `detect_state` step-4 docstring (line 63) to drop the `implementation` reference.
- **Regression test (`tests/test_state.py`):** `side_effect`-based test in `TestDetectStateWithIssues` that returns an open-issue list only for `--label implementation` (and `[]` for `--label plan`), asserting an `implementation`-only repo resolves to `ProjectState.NO_FACTORY`, not `REPO_INCOMPLETE`.

## Why
`implementation` is the factory's own backlog label, created by the CEO during Improve-mode experiments on already-built repos. Treating it as evidence of an *unbuilt* repo misrouted mature factory-managed projects to Build mode and rejected `--focus`. `plan` still catches genuinely unbuilt scaffolds.

## Out of scope
Per the owner's CHANGES_REQUESTED review on PR #380, this is a clean main-based forward edit. It does NOT touch `_is_built_project`, `_has_substantial_source`, or `_ensure_factory_config` (the rejected heavyweight approach).

## Verification
- `pytest tests/test_state.py -v` — 16 passed
- `ruff check factory/state.py tests/test_state.py` — clean
- `mypy factory/state.py` — clean