### PR TITLE
Add Miro CLI subcommands: miro-init, miro-link, miro-sync

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3237,6 +3237,55 @@ def _emit_cli_event(project_path: Path, event_type: str, data: dict) -> None:
         pass
 
 
+def cmd_miro_init(args: argparse.Namespace) -> int:
+    """Create a Miro board for a project."""
+    from factory.user_config import resolve
+
+    token = resolve("miro_token", env_var="FACTORY_MIRO_TOKEN")
+    if not token:
+        print("Miro token not found. To set up:", file=sys.stderr)
+        print("  1. Go to https://miro.com/app/settings/user-profile/apps", file=sys.stderr)
+        print("  2. Create a new app and generate an access token", file=sys.stderr)
+        print("  3. export FACTORY_MIRO_TOKEN=<your-token>", file=sys.stderr)
+        print('     Or add to ~/.factory/config.toml:', file=sys.stderr)
+        print("     [defaults]", file=sys.stderr)
+        print('     miro_token = "<your-token>"', file=sys.stderr)
+        return 1
+    from factory.miro.sync import sync_board
+
+    result = _run(sync_board(Path(args.path)))
+    if result:
+        print(f'Board synced: {result.get("item_count", 0)} items, {result.get("drift_count", 0)} drift findings')
+    return 0
+
+
+def cmd_miro_link(args: argparse.Namespace) -> int:
+    """Link an existing Miro board to a project."""
+    project_path = Path(args.path)
+    config_path = project_path / ".factory" / "config.json"
+    if not config_path.exists():
+        print("Error: No .factory/config.json found. Run factory init first.", file=sys.stderr)
+        return 1
+    data = json.loads(config_path.read_text())
+    data["miro_board_id"] = args.board_id
+    config_path.write_text(json.dumps(data, indent=2) + "\n")
+    print(f"Linked Miro board {args.board_id} to {project_path}")
+    return 0
+
+
+def cmd_miro_sync(args: argparse.Namespace) -> int:
+    """Sync project state to Miro board."""
+    from factory.miro.sync import sync_board
+
+    result = _run(sync_board(Path(args.path)))
+    if result:
+        print(f'Synced: {result.get("item_count", 0)} items, {result.get("connector_count", 0)} connectors,'
+              f' {result.get("drift_count", 0)} drift')
+    else:
+        print("Sync skipped (no board configured or no token)", file=sys.stderr)
+    return 0
+
+
 # ── parser construction ────────────────────────────────────────
 
 
@@ -3721,6 +3770,19 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--session", default=None, help="Session name to stop")
     p.add_argument("--path", default=None, help="Project path (derives session name)")
 
+    # miro-init — create a Miro board for a project
+    p = sub.add_parser("miro-init", help="Create a Miro board for a project")
+    p.add_argument("path", help="Path to the project")
+
+    # miro-link — link an existing Miro board
+    p = sub.add_parser("miro-link", help="Link an existing Miro board")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--board-id", required=True, help="Miro board ID")
+
+    # miro-sync — sync project state to Miro board
+    p = sub.add_parser("miro-sync", help="Sync project state to Miro board")
+    p.add_argument("path", help="Path to the project")
+
     return parser
 
 
@@ -3791,6 +3853,9 @@ def main(argv: list[str] | None = None) -> int:
         "tmux": cmd_tmux,
         "tmux-ls": cmd_tmux_ls,
         "tmux-stop": cmd_tmux_stop,
+        "miro-init": cmd_miro_init,
+        "miro-link": cmd_miro_link,
+        "miro-sync": cmd_miro_sync,
     }
 
     try:

--- a/factory/miro/analyzer.py
+++ b/factory/miro/analyzer.py
@@ -1,0 +1,186 @@
+"""AST-based codebase parser — extracts project structure for Miro board generation."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+# Directories to skip during source file discovery (mirrors factory/study.py)
+_SKIP_DIRS = {
+    "tests", "test", ".venv", "venv", "node_modules", "__pycache__",
+    ".git", ".factory", "eval", "dist", "build", ".mypy_cache",
+    ".tox", ".eggs", ".ruff_cache",
+}
+
+
+@dataclass
+class FunctionInfo:
+    """A function or method extracted from source."""
+
+    name: str
+    lineno: int
+    is_async: bool = False
+    is_method: bool = False
+
+
+@dataclass
+class ClassInfo:
+    """A class extracted from source."""
+
+    name: str
+    lineno: int
+    bases: list[str] = field(default_factory=list)
+    methods: list[FunctionInfo] = field(default_factory=list)
+
+
+@dataclass
+class Dependency:
+    """An import dependency between modules."""
+
+    source: str
+    target: str
+    is_relative: bool = False
+
+
+@dataclass
+class ModuleInfo:
+    """Parsed information about a single Python module."""
+
+    path: str
+    classes: list[ClassInfo] = field(default_factory=list)
+    functions: list[FunctionInfo] = field(default_factory=list)
+    imports: list[Dependency] = field(default_factory=list)
+
+
+@dataclass
+class ProjectStructure:
+    """Full parsed project structure."""
+
+    root: str
+    modules: list[ModuleInfo] = field(default_factory=list)
+    dependencies: list[Dependency] = field(default_factory=list)
+
+
+def _find_source_files(project_path: Path) -> list[Path]:
+    """Find Python source files, skipping tests, venvs, and generated code."""
+    sources: list[Path] = []
+    for f in project_path.rglob("*.py"):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project_path).parts):
+            continue
+        sources.append(f)
+    return sorted(sources)
+
+
+def _parse_module(path: Path, project_root: Path) -> ModuleInfo:
+    """Parse a single Python file into a ModuleInfo."""
+    rel_path = str(path.relative_to(project_root))
+    module = ModuleInfo(path=rel_path)
+
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        log.debug("ast_parse_failed", path=rel_path)
+        return module
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            bases = []
+            for base in node.bases:
+                if isinstance(base, ast.Name):
+                    bases.append(base.id)
+                elif isinstance(base, ast.Attribute):
+                    bases.append(ast.unparse(base))
+
+            methods: list[FunctionInfo] = []
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    methods.append(FunctionInfo(
+                        name=item.name,
+                        lineno=item.lineno,
+                        is_async=isinstance(item, ast.AsyncFunctionDef),
+                        is_method=True,
+                    ))
+
+            module.classes.append(ClassInfo(
+                name=node.name,
+                lineno=node.lineno,
+                bases=bases,
+                methods=methods,
+            ))
+
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # Skip methods — they're captured under their class
+            if isinstance(getattr(node, '_parent', None), ast.ClassDef):
+                continue
+            # Top-level check: parent is Module
+            module.functions.append(FunctionInfo(
+                name=node.name,
+                lineno=node.lineno,
+                is_async=isinstance(node, ast.AsyncFunctionDef),
+            ))
+
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                module.imports.append(Dependency(
+                    source=rel_path,
+                    target=alias.name,
+                ))
+
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                module.imports.append(Dependency(
+                    source=rel_path,
+                    target=node.module,
+                    is_relative=node.level > 0,
+                ))
+
+    return module
+
+
+def _list_non_python_files(project_path: Path) -> list[ModuleInfo]:
+    """Fallback: list directory structure for non-Python projects."""
+    modules: list[ModuleInfo] = []
+    for f in sorted(project_path.rglob("*")):
+        if not f.is_file():
+            continue
+        if any(part in _SKIP_DIRS for part in f.relative_to(project_path).parts):
+            continue
+        if f.suffix in {".pyc", ".pyo", ".so", ".o", ".class"}:
+            continue
+        rel_path = str(f.relative_to(project_path))
+        modules.append(ModuleInfo(path=rel_path))
+    return modules
+
+
+def analyze(project_path: Path) -> ProjectStructure:
+    """Analyze a project directory and return its parsed structure.
+
+    Uses AST parsing for Python projects. Falls back to directory listing
+    for non-Python projects.
+    """
+    project_path = project_path.resolve()
+    structure = ProjectStructure(root=str(project_path))
+
+    python_files = _find_source_files(project_path)
+
+    if not python_files:
+        log.info("no_python_files", path=str(project_path), fallback="directory_listing")
+        structure.modules = _list_non_python_files(project_path)
+        return structure
+
+    log.info("analyzing_project", path=str(project_path), file_count=len(python_files))
+
+    all_deps: list[Dependency] = []
+    for py_file in python_files:
+        module = _parse_module(py_file, project_path)
+        structure.modules.append(module)
+        all_deps.extend(module.imports)
+
+    structure.dependencies = all_deps
+    return structure

--- a/factory/miro/board.py
+++ b/factory/miro/board.py
@@ -1,0 +1,403 @@
+"""Board renderer — transforms analyzed project data into Miro board elements."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from factory.miro.analyzer import ProjectStructure
+from factory.miro.client import MiroClient
+from factory.miro.drift import DriftItem
+from factory.miro.layout import compute_frame_positions, layout_items_in_frame
+from factory.miro.templates import (
+    AGENT_COLORS,
+    COMPONENT_COLORS,
+    CONNECTOR_COLOR,
+    CONNECTOR_STROKE_WIDTH,
+    CONNECTOR_STYLE,
+    DRIFT_COLORS,
+    SHAPE_HEIGHT,
+    SHAPE_WIDTH,
+    VERDICT_COLORS,
+)
+
+log = structlog.get_logger()
+
+# The six board frames in display order
+_FRAME_NAMES = [
+    "Project Overview",
+    "Agent Pipeline",
+    "Architecture Map",
+    "Drift Report",
+    "Experiment Timeline",
+    "Strategy State",
+]
+
+# Agent pipeline display order
+_AGENT_ORDER = [
+    "researcher", "strategist", "builder", "reviewer", "evaluator", "archivist",
+]
+
+
+def _classify_module(path: str) -> str:
+    """Classify a module path into a component category for coloring."""
+    if "agent" in path:
+        return "agent"
+    if "eval" in path:
+        return "eval"
+    if "cli" in path or path.endswith("cli.py"):
+        return "cli"
+    if "config" in path or "model" in path:
+        return "config"
+    if "test" in path:
+        return "test"
+    return "data"
+
+
+class BoardRenderer:
+    """Renders project analysis data onto a Miro board.
+
+    Creates six frames in a 3x2 grid layout, then populates each with
+    shapes and connectors representing the project structure.
+    """
+
+    def __init__(self, client: MiroClient, board_id: str) -> None:
+        self._client = client
+        self._board_id = board_id
+
+    async def render(
+        self,
+        structure: ProjectStructure,
+        drift_items: list[DriftItem],
+        history: list[dict[str, Any]],
+        config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Render the full board with all six frames.
+
+        Args:
+            structure: Analyzed project structure from analyzer.
+            drift_items: Architecture drift findings.
+            history: List of experiment records (dicts with 'id', 'verdict', etc.).
+            config: Project config dict (used for overview and strategy).
+
+        Returns:
+            Summary dict with frame_ids, item_count, and connector_count.
+        """
+        # Phase 1: Create all frames FIRST (April 2025 Miro bug —
+        # items created before their parent frame are orphaned)
+        frame_positions = compute_frame_positions(len(_FRAME_NAMES))
+        frame_ids: dict[str, str] = {}
+
+        for i, name in enumerate(_FRAME_NAMES):
+            x, y, w, h = frame_positions[i]
+            result = await self._client.create_frame_item(
+                self._board_id,
+                title=name,
+                x=x,
+                y=y,
+                width=w,
+                height=h,
+            )
+            frame_id = _extract_id(result)
+            frame_ids[name] = frame_id
+            log.debug("board_frame_created", name=name, frame_id=frame_id)
+
+        # Phase 2: Populate each frame with items
+        item_count = 0
+        connector_count = 0
+
+        item_count += await self._render_overview(
+            frame_ids["Project Overview"], frame_positions[0], structure, config,
+        )
+        agent_ids = await self._render_agent_pipeline(
+            frame_ids["Agent Pipeline"], frame_positions[1],
+        )
+        item_count += len(agent_ids)
+        arch_ids = await self._render_architecture_map(
+            frame_ids["Architecture Map"], frame_positions[2], structure,
+        )
+        item_count += len(arch_ids)
+        item_count += await self._render_drift_report(
+            frame_ids["Drift Report"], frame_positions[3], drift_items,
+        )
+        item_count += await self._render_experiment_timeline(
+            frame_ids["Experiment Timeline"], frame_positions[4], history,
+        )
+        item_count += await self._render_strategy_state(
+            frame_ids["Strategy State"], frame_positions[5], config,
+        )
+
+        # Phase 3: Draw connectors
+        connector_count += await self._draw_agent_connectors(agent_ids)
+        connector_count += await self._draw_dependency_connectors(
+            arch_ids, structure,
+        )
+
+        summary = {
+            "frame_ids": frame_ids,
+            "item_count": item_count,
+            "connector_count": connector_count,
+        }
+        log.info(
+            "board_render_complete",
+            items=item_count,
+            connectors=connector_count,
+            frames=len(frame_ids),
+        )
+        return summary
+
+    async def _render_overview(
+        self,
+        frame_id: str,
+        frame_pos: tuple[int, int, int, int],
+        structure: ProjectStructure,
+        config: dict[str, Any],
+    ) -> int:
+        """Render project overview: name, module count, goal."""
+        fx, fy, fw, fh = frame_pos
+        items = [
+            config.get("goal", "Software project"),
+            f"Modules: {len(structure.modules)}",
+            f"Dependencies: {len(structure.dependencies)}",
+        ]
+        positions = layout_items_in_frame(items, fx, fy, fw, fh)
+        for pos, text in zip(positions, items):
+            await self._client.create_shape_item(
+                self._board_id,
+                content=text,
+                x=pos.x,
+                y=pos.y,
+                width=pos.width,
+                height=pos.height,
+                parent=frame_id,
+            )
+        return len(items)
+
+    async def _render_agent_pipeline(
+        self,
+        frame_id: str,
+        frame_pos: tuple[int, int, int, int],
+    ) -> dict[str, str]:
+        """Render agent pipeline: one shape per agent role, returns {role: item_id}."""
+        fx, fy, fw, fh = frame_pos
+        positions = layout_items_in_frame(_AGENT_ORDER, fx, fy, fw, fh)
+        agent_ids: dict[str, str] = {}
+
+        for pos, role in zip(positions, _AGENT_ORDER):
+            color = AGENT_COLORS.get(role, "#888888")
+            result = await self._client.create_shape_item(
+                self._board_id,
+                content=role.capitalize(),
+                x=pos.x,
+                y=pos.y,
+                width=pos.width,
+                height=pos.height,
+                parent=frame_id,
+                fill_color=color,
+            )
+            agent_ids[role] = _extract_id(result)
+
+        return agent_ids
+
+    async def _render_architecture_map(
+        self,
+        frame_id: str,
+        frame_pos: tuple[int, int, int, int],
+        structure: ProjectStructure,
+    ) -> dict[str, str]:
+        """Render architecture map: one shape per module, colored by type."""
+        fx, fy, fw, fh = frame_pos
+        module_names = [m.path for m in structure.modules]
+        positions = layout_items_in_frame(module_names, fx, fy, fw, fh)
+        module_ids: dict[str, str] = {}
+
+        for pos, module in zip(positions, structure.modules):
+            category = _classify_module(module.path)
+            color = COMPONENT_COLORS.get(category, "#95A5A6")
+            label = module.path.rsplit("/", 1)[-1]  # show filename only
+
+            result = await self._client.create_shape_item(
+                self._board_id,
+                content=label,
+                x=pos.x,
+                y=pos.y,
+                width=pos.width,
+                height=pos.height,
+                parent=frame_id,
+                fill_color=color,
+            )
+            module_ids[module.path] = _extract_id(result)
+
+        return module_ids
+
+    async def _render_drift_report(
+        self,
+        frame_id: str,
+        frame_pos: tuple[int, int, int, int],
+        drift_items: list[DriftItem],
+    ) -> int:
+        """Render drift report: color-coded drift items."""
+        if not drift_items:
+            # Show an "All clear" shape when no drift
+            fx, fy, fw, fh = frame_pos
+            await self._client.create_shape_item(
+                self._board_id,
+                content="No architecture drift detected",
+                x=fx + fw // 2 - SHAPE_WIDTH // 2,
+                y=fy + fh // 2 - SHAPE_HEIGHT // 2,
+                width=SHAPE_WIDTH,
+                height=SHAPE_HEIGHT,
+                parent=frame_id,
+                fill_color="#27AE60",
+            )
+            return 1
+
+        fx, fy, fw, fh = frame_pos
+        labels = [f"[{d.category}] {d.name}" for d in drift_items]
+        positions = layout_items_in_frame(labels, fx, fy, fw, fh)
+
+        for pos, drift in zip(positions, drift_items):
+            color = DRIFT_COLORS.get(drift.category, "#CCCCCC")
+            await self._client.create_shape_item(
+                self._board_id,
+                content=f"[{drift.category}] {drift.name}\n{drift.description}",
+                x=pos.x,
+                y=pos.y,
+                width=pos.width,
+                height=pos.height,
+                parent=frame_id,
+                fill_color=color,
+            )
+
+        return len(drift_items)
+
+    async def _render_experiment_timeline(
+        self,
+        frame_id: str,
+        frame_pos: tuple[int, int, int, int],
+        history: list[dict[str, Any]],
+    ) -> int:
+        """Render experiment timeline: cards from experiment records."""
+        if not history:
+            fx, fy, fw, fh = frame_pos
+            await self._client.create_shape_item(
+                self._board_id,
+                content="No experiments yet",
+                x=fx + fw // 2 - SHAPE_WIDTH // 2,
+                y=fy + fh // 2 - SHAPE_HEIGHT // 2,
+                width=SHAPE_WIDTH,
+                height=SHAPE_HEIGHT,
+                parent=frame_id,
+            )
+            return 1
+
+        fx, fy, fw, fh = frame_pos
+        labels = [f"Exp {e.get('id', '?')}" for e in history]
+        positions = layout_items_in_frame(labels, fx, fy, fw, fh)
+
+        for pos, exp in zip(positions, history):
+            verdict = str(exp.get("verdict", "error")).lower()
+            color = VERDICT_COLORS.get(verdict, "#95A5A6")
+            exp_id = exp.get("id", "?")
+            label = f"#{exp_id}: {verdict}"
+
+            await self._client.create_shape_item(
+                self._board_id,
+                content=label,
+                x=pos.x,
+                y=pos.y,
+                width=pos.width,
+                height=pos.height,
+                parent=frame_id,
+                fill_color=color,
+            )
+
+        return len(history)
+
+    async def _render_strategy_state(
+        self,
+        frame_id: str,
+        frame_pos: tuple[int, int, int, int],
+        config: dict[str, Any],
+    ) -> int:
+        """Render strategy state: current focus, threshold, constraints."""
+        fx, fy, fw, fh = frame_pos
+        items = [
+            f"Threshold: {config.get('threshold', 0.8)}",
+            f"Focus: {config.get('focus', 'general improvement')}",
+            f"Mode: {config.get('mode', 'improve')}",
+        ]
+        positions = layout_items_in_frame(items, fx, fy, fw, fh)
+
+        for pos, text in zip(positions, items):
+            await self._client.create_shape_item(
+                self._board_id,
+                content=text,
+                x=pos.x,
+                y=pos.y,
+                width=pos.width,
+                height=pos.height,
+                parent=frame_id,
+            )
+
+        return len(items)
+
+    async def _draw_agent_connectors(
+        self, agent_ids: dict[str, str],
+    ) -> int:
+        """Draw connectors between agents in pipeline order."""
+        count = 0
+        for i in range(len(_AGENT_ORDER) - 1):
+            from_role = _AGENT_ORDER[i]
+            to_role = _AGENT_ORDER[i + 1]
+            from_id = agent_ids.get(from_role)
+            to_id = agent_ids.get(to_role)
+            if from_id and to_id:
+                await self._client.create_connector(
+                    self._board_id,
+                    start_item=from_id,
+                    end_item=to_id,
+                    style=CONNECTOR_STYLE,
+                    stroke_width=CONNECTOR_STROKE_WIDTH,
+                    stroke_color=CONNECTOR_COLOR,
+                )
+                count += 1
+        return count
+
+    async def _draw_dependency_connectors(
+        self,
+        module_ids: dict[str, str],
+        structure: ProjectStructure,
+    ) -> int:
+        """Draw connectors for import dependencies between modules."""
+        count = 0
+        for dep in structure.dependencies:
+            from_id = module_ids.get(dep.source)
+            # Try to resolve the target to an actual module path
+            target_path = dep.target.replace(".", "/") + ".py"
+            to_id = module_ids.get(target_path)
+            # Also try direct match
+            if not to_id:
+                to_id = module_ids.get(dep.target)
+
+            if from_id and to_id and from_id != to_id:
+                await self._client.create_connector(
+                    self._board_id,
+                    start_item=from_id,
+                    end_item=to_id,
+                    style=CONNECTOR_STYLE,
+                    stroke_width=CONNECTOR_STROKE_WIDTH,
+                    stroke_color=CONNECTOR_COLOR,
+                )
+                count += 1
+        return count
+
+
+def _extract_id(result: Any) -> str:
+    """Extract an ID from a Miro API response (dict or object)."""
+    if result is None:
+        return ""
+    if isinstance(result, dict):
+        return str(result.get("id", ""))
+    return str(getattr(result, "id", ""))

--- a/factory/miro/client.py
+++ b/factory/miro/client.py
@@ -1,0 +1,172 @@
+"""Async Miro API client with rate limiting, dry-run support, and event emission."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.events import emit_event
+from factory.user_config import resolve
+
+log = structlog.get_logger()
+
+_DRY_RUN_COUNTER = 0
+
+
+def _next_dry_run_id() -> str:
+    """Generate a sequential dry-run ID."""
+    global _DRY_RUN_COUNTER  # noqa: PLW0603
+    _DRY_RUN_COUNTER += 1
+    return f"dry-run-{_DRY_RUN_COUNTER}"
+
+
+class MiroClient:
+    """Wrapper around miro_api.MiroApi with rate limiting and observability.
+
+    Token resolution uses the factory config system:
+      resolve("miro_token", env_var="FACTORY_MIRO_TOKEN")
+
+    Set FACTORY_MIRO_DRY_RUN=1 to skip actual API calls (returns stub data).
+    """
+
+    def __init__(self, *, project_path: Path | None = None) -> None:
+        self._token = resolve("miro_token", env_var="FACTORY_MIRO_TOKEN")
+        self._project_path = project_path or Path.cwd()
+        self._dry_run = os.environ.get("FACTORY_MIRO_DRY_RUN", "").strip() == "1"
+        self._api: Any = None
+
+        if not self._token:
+            log.debug("miro_no_token", hint="Set FACTORY_MIRO_TOKEN or miro_token in config.toml")
+            return
+
+        if self._dry_run:
+            log.info("miro_dry_run_enabled")
+            return
+
+        try:
+            from miro_api import MiroApi
+            self._api = MiroApi(self._token)
+        except ImportError:
+            log.warning("miro_api_not_installed", hint="pip install miro-api")
+        except Exception as exc:
+            log.warning("miro_init_failed", error=str(exc))
+
+    @property
+    def available(self) -> bool:
+        """True if the client can make API calls (or is in dry-run mode)."""
+        return self._dry_run or self._api is not None
+
+    async def _call_with_backoff(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        """Call an API method with exponential backoff on HTTP 429."""
+        if not self.available:
+            log.debug("miro_unavailable", method=method_name)
+            return None
+
+        if self._dry_run:
+            stub_id = _next_dry_run_id()
+            log.info("miro_dry_run", method=method_name, stub_id=stub_id)
+            emit_event(
+                self._project_path,
+                f"miro.api.{method_name}",
+                data={"dry_run": True, "stub_id": stub_id},
+            )
+            return {"id": stub_id, "type": "dry_run"}
+
+        max_retries = 5
+        base_delay = 1.0
+
+        for attempt in range(max_retries):
+            try:
+                method = getattr(self._api, method_name)
+                result = method(*args, **kwargs)
+                emit_event(
+                    self._project_path,
+                    f"miro.api.{method_name}",
+                    data={"success": True},
+                )
+                return result
+            except Exception as exc:
+                status = getattr(exc, "status", None) or getattr(exc, "status_code", None)
+                if status == 429:
+                    reset_after = _parse_reset_header(exc)
+                    delay = reset_after if reset_after else base_delay * (2 ** attempt)
+                    log.warning(
+                        "miro_rate_limited",
+                        method=method_name,
+                        attempt=attempt + 1,
+                        delay=delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
+                log.error("miro_api_error", method=method_name, error=str(exc))
+                emit_event(
+                    self._project_path,
+                    f"miro.api.{method_name}",
+                    data={"success": False, "error": str(exc)},
+                )
+                return None
+
+        log.error("miro_rate_limit_exhausted", method=method_name, max_retries=max_retries)
+        return None
+
+    async def create_board(self, name: str, description: str = "") -> Any:
+        """Create a new Miro board."""
+        return await self._call_with_backoff(
+            "create_board",
+            {"name": name, "description": description},
+        )
+
+    async def create_frame_item(self, board_id: str, **kwargs: Any) -> Any:
+        """Create a frame on a board."""
+        return await self._call_with_backoff("create_frame_item", board_id, **kwargs)
+
+    async def create_shape_item(self, board_id: str, **kwargs: Any) -> Any:
+        """Create a shape on a board."""
+        return await self._call_with_backoff("create_shape_item", board_id, **kwargs)
+
+    async def create_connector(self, board_id: str, **kwargs: Any) -> Any:
+        """Create a connector between items on a board."""
+        return await self._call_with_backoff("create_connector", board_id, **kwargs)
+
+    async def get_board(self, board_id: str) -> Any:
+        """Get board details."""
+        return await self._call_with_backoff("get_board", board_id)
+
+    async def get_items(self, board_id: str, **kwargs: Any) -> Any:
+        """Get all items on a board."""
+        return await self._call_with_backoff("get_items_on_board", board_id, **kwargs)
+
+    async def update_shape_item(self, board_id: str, item_id: str, **kwargs: Any) -> Any:
+        """Update an existing shape item."""
+        return await self._call_with_backoff(
+            "update_shape_item", board_id, item_id, **kwargs,
+        )
+
+    async def delete_item(self, board_id: str, item_id: str) -> Any:
+        """Delete an item from a board."""
+        return await self._call_with_backoff("delete_item", board_id, item_id)
+
+
+def _parse_reset_header(exc: Exception) -> float | None:
+    """Extract retry delay from X-RateLimit-Reset header if available."""
+    headers = getattr(exc, "headers", None)
+    if not headers:
+        return None
+    reset = headers.get("X-RateLimit-Reset")
+    if reset is None:
+        return None
+    try:
+        reset_time = float(reset)
+        # If it looks like a Unix timestamp, compute delay
+        if reset_time > 1_000_000_000:
+            return max(0.1, reset_time - time.time())
+        # Otherwise treat as seconds to wait
+        return max(0.1, reset_time)
+    except (ValueError, TypeError):
+        return None

--- a/factory/miro/drift.py
+++ b/factory/miro/drift.py
@@ -1,0 +1,276 @@
+"""Architecture drift detector — compares documented structure against actual code."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import structlog
+
+from factory.miro.analyzer import ProjectStructure
+
+log = structlog.get_logger()
+
+
+@dataclass
+class DocumentedComponent:
+    """A module, file, or class referenced in architecture documentation."""
+
+    name: str
+    source_file: str  # which doc file referenced it
+    kind: str = "module"  # module | class | file
+
+
+@dataclass
+class DocumentedStructure:
+    """Aggregated architecture expectations parsed from project docs."""
+
+    components: list[DocumentedComponent] = field(default_factory=list)
+
+
+@dataclass
+class DriftItem:
+    """A single architecture drift finding."""
+
+    category: str  # 'undocumented' | 'phantom' | 'drifted'
+    name: str
+    description: str
+    source: str = ""  # file that evidences the drift
+
+
+# ── regex patterns for extracting references from docs ──────────
+
+# Matches Python-style module paths: factory/foo.py, factory/bar/baz.py
+_FILE_REF = re.compile(r"`([\w/]+\.py)`")
+# Matches module dotted paths: factory.foo, factory.bar.baz
+_MODULE_REF = re.compile(r"`((?:[\w]+\.)+[\w]+)`")
+# Matches class-like references: `FooBar`, `MyClass`
+_CLASS_REF = re.compile(r"`([A-Z][a-zA-Z0-9]+)`")
+
+
+def _extract_refs_from_text(
+    text: str, source_file: str,
+) -> list[DocumentedComponent]:
+    """Extract module/file/class references from markdown text."""
+    components: list[DocumentedComponent] = []
+    seen: set[str] = set()
+
+    for match in _FILE_REF.finditer(text):
+        name = match.group(1)
+        if name not in seen:
+            seen.add(name)
+            components.append(DocumentedComponent(
+                name=name, source_file=source_file, kind="file",
+            ))
+
+    for match in _MODULE_REF.finditer(text):
+        name = match.group(1)
+        if name not in seen:
+            seen.add(name)
+            components.append(DocumentedComponent(
+                name=name, source_file=source_file, kind="module",
+            ))
+
+    for match in _CLASS_REF.finditer(text):
+        name = match.group(1)
+        if name not in seen:
+            seen.add(name)
+            components.append(DocumentedComponent(
+                name=name, source_file=source_file, kind="class",
+            ))
+
+    return components
+
+
+def _extract_architecture_section(text: str) -> str:
+    """Extract the '## Architecture' section from markdown text."""
+    lines = text.split("\n")
+    in_section = False
+    section_lines: list[str] = []
+
+    for line in lines:
+        if re.match(r"^##\s+Architecture", line, re.IGNORECASE):
+            in_section = True
+            continue
+        if in_section and re.match(r"^##\s+", line):
+            break
+        if in_section:
+            section_lines.append(line)
+
+    return "\n".join(section_lines)
+
+
+def parse_architecture_docs(project_path: Path) -> DocumentedStructure:
+    """Parse architecture documentation from CLAUDE.md, README.md, and .factory/archive/."""
+    structure = DocumentedStructure()
+
+    # Parse CLAUDE.md architecture section
+    claude_md = project_path / "CLAUDE.md"
+    if claude_md.exists():
+        try:
+            text = claude_md.read_text(encoding="utf-8", errors="replace")
+            arch_section = _extract_architecture_section(text)
+            if arch_section:
+                structure.components.extend(
+                    _extract_refs_from_text(arch_section, "CLAUDE.md"),
+                )
+                log.debug("drift_parsed_claude_md", refs=len(structure.components))
+        except OSError:
+            log.debug("drift_claude_md_read_failed")
+
+    # Parse README.md for architecture info
+    readme = project_path / "README.md"
+    if readme.exists():
+        try:
+            text = readme.read_text(encoding="utf-8", errors="replace")
+            arch_section = _extract_architecture_section(text)
+            if arch_section:
+                structure.components.extend(
+                    _extract_refs_from_text(arch_section, "README.md"),
+                )
+        except OSError:
+            log.debug("drift_readme_read_failed")
+
+    # Parse .factory/archive/decisions/ and patterns/
+    for subdir in ("decisions", "patterns"):
+        archive_dir = project_path / ".factory" / "archive" / subdir
+        if not archive_dir.is_dir():
+            continue
+        for md_file in sorted(archive_dir.glob("*.md")):
+            try:
+                text = md_file.read_text(encoding="utf-8", errors="replace")
+                rel = str(md_file.relative_to(project_path))
+                structure.components.extend(_extract_refs_from_text(text, rel))
+            except OSError:
+                continue
+
+    log.info("drift_docs_parsed", total_refs=len(structure.components))
+    return structure
+
+
+def _normalize_path(name: str) -> str:
+    """Normalize a dotted module path to a file path for comparison."""
+    return name.replace(".", "/")
+
+
+def detect(structure: ProjectStructure, project_path: Path) -> list[DriftItem]:
+    """Compare analyzer's ProjectStructure against documented architecture.
+
+    Returns a list of DriftItem findings in three categories:
+      - undocumented: exists in code but not in docs
+      - phantom: exists in docs but not in code
+      - drifted: structural mismatch (wrong location, renamed)
+    """
+    documented = parse_architecture_docs(project_path)
+    items: list[DriftItem] = []
+
+    # Build sets of actual code artifacts
+    actual_files: set[str] = {m.path for m in structure.modules}
+    actual_classes: set[str] = set()
+    for mod in structure.modules:
+        for cls in mod.classes:
+            actual_classes.add(cls.name)
+
+    # Build sets of documented references by kind
+    doc_files: set[str] = set()
+    doc_modules: set[str] = set()
+    doc_classes: set[str] = set()
+    doc_sources: dict[str, str] = {}  # name -> source_file
+
+    for comp in documented.components:
+        doc_sources[comp.name] = comp.source_file
+        if comp.kind == "file":
+            doc_files.add(comp.name)
+        elif comp.kind == "module":
+            doc_modules.add(comp.name)
+        elif comp.kind == "class":
+            doc_classes.add(comp.name)
+
+    # Combine file and module refs for path-based comparison
+    doc_paths: set[str] = set(doc_files)
+    for mod_name in doc_modules:
+        doc_paths.add(_normalize_path(mod_name) + ".py")
+        doc_paths.add(_normalize_path(mod_name))
+
+    # Undocumented: in code but not in docs
+    for file_path in sorted(actual_files):
+        found = False
+        for dp in doc_paths:
+            if file_path == dp or file_path.endswith("/" + dp) or dp.endswith("/" + file_path):
+                found = True
+                break
+        if not found and not any(
+            file_path == dp or dp in file_path or file_path in dp
+            for dp in doc_paths
+        ):
+            items.append(DriftItem(
+                category="undocumented",
+                name=file_path,
+                description=f"Module {file_path} exists in code but is not referenced in architecture docs",
+                source=file_path,
+            ))
+
+    for cls_name in sorted(actual_classes):
+        if cls_name not in doc_classes:
+            items.append(DriftItem(
+                category="undocumented",
+                name=cls_name,
+                description=f"Class {cls_name} exists in code but is not referenced in architecture docs",
+                source=cls_name,
+            ))
+
+    # Phantom: in docs but not in code
+    for file_ref in sorted(doc_files):
+        if file_ref not in actual_files and not any(
+            f.endswith("/" + file_ref) or f == file_ref for f in actual_files
+        ):
+            items.append(DriftItem(
+                category="phantom",
+                name=file_ref,
+                description=f"File {file_ref} referenced in {doc_sources[file_ref]} but not found in code",
+                source=doc_sources[file_ref],
+            ))
+
+    for cls_ref in sorted(doc_classes):
+        if cls_ref not in actual_classes:
+            # Check if it's a drifted class (similar name exists)
+            similar = [c for c in actual_classes if c.lower() == cls_ref.lower()]
+            if similar:
+                items.append(DriftItem(
+                    category="drifted",
+                    name=cls_ref,
+                    description=(
+                        f"Class {cls_ref} in {doc_sources[cls_ref]} may have been "
+                        f"renamed to {similar[0]} (case mismatch)"
+                    ),
+                    source=doc_sources[cls_ref],
+                ))
+            else:
+                items.append(DriftItem(
+                    category="phantom",
+                    name=cls_ref,
+                    description=f"Class {cls_ref} referenced in {doc_sources[cls_ref]} but not found in code",
+                    source=doc_sources[cls_ref],
+                ))
+
+    # Drifted: module path mismatches (documented in one location, found in another)
+    for mod_name in sorted(doc_modules):
+        expected_path = _normalize_path(mod_name) + ".py"
+        if expected_path not in actual_files:
+            # Check if the module exists under a different path
+            base = expected_path.rsplit("/", 1)[-1]
+            matches = [f for f in actual_files if f.endswith("/" + base) or f == base]
+            if matches:
+                items.append(DriftItem(
+                    category="drifted",
+                    name=mod_name,
+                    description=(
+                        f"Module {mod_name} documented as {expected_path} "
+                        f"but found at {matches[0]}"
+                    ),
+                    source=doc_sources[mod_name],
+                ))
+
+    log.info("drift_detection_complete", total_items=len(items))
+    return items

--- a/factory/miro/layout.py
+++ b/factory/miro/layout.py
@@ -1,0 +1,119 @@
+"""Pure coordinate math engine for Miro board layout — no API calls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from factory.miro.templates import (
+    FRAME_HEIGHT,
+    FRAME_WIDTH,
+    GRID_GAP,
+    GRID_PADDING,
+    SHAPE_HEIGHT,
+    SHAPE_WIDTH,
+)
+
+# Grid configuration: 3 columns x 2 rows
+_GRID_COLS = 3
+_GRID_ROWS = 2
+
+
+@dataclass
+class FramePosition:
+    """Computed position and size for a frame."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass
+class ItemPosition:
+    """Computed position for an item within a frame."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+    index: int  # original item index
+
+
+@dataclass
+class ConnectorRoute:
+    """Computed coordinates for a connector between two items."""
+
+    start_x: int
+    start_y: int
+    end_x: int
+    end_y: int
+
+
+def compute_frame_positions(section_count: int) -> list[tuple[int, int, int, int]]:
+    """Compute (x, y, width, height) for each frame in a 3x2 grid layout.
+
+    Frames are arranged left-to-right, top-to-bottom.
+    """
+    positions: list[tuple[int, int, int, int]] = []
+    for i in range(section_count):
+        col = i % _GRID_COLS
+        row = i // _GRID_COLS
+        x = col * (FRAME_WIDTH + GRID_GAP)
+        y = row * (FRAME_HEIGHT + GRID_GAP)
+        positions.append((x, y, FRAME_WIDTH, FRAME_HEIGHT))
+    return positions
+
+
+def layout_items_in_frame(
+    items: list[str],
+    frame_x: int,
+    frame_y: int,
+    frame_w: int,
+    frame_h: int,
+) -> list[ItemPosition]:
+    """Position items top-down within a frame with padding.
+
+    Each item is placed below the previous one with GRID_PADDING spacing.
+    Items are horizontally centered within the frame.
+    """
+    positioned: list[ItemPosition] = []
+    item_x = frame_x + GRID_PADDING
+    available_width = frame_w - 2 * GRID_PADDING
+    item_width = min(SHAPE_WIDTH, available_width)
+
+    # Center items horizontally
+    item_x = frame_x + (frame_w - item_width) // 2
+
+    current_y = frame_y + GRID_PADDING
+
+    for i, _item in enumerate(items):
+        positioned.append(ItemPosition(
+            x=item_x,
+            y=current_y,
+            width=item_width,
+            height=SHAPE_HEIGHT,
+            index=i,
+        ))
+        current_y += SHAPE_HEIGHT + GRID_PADDING
+
+    return positioned
+
+
+def route_connector(
+    from_pos: tuple[int, int, int, int],
+    to_pos: tuple[int, int, int, int],
+) -> ConnectorRoute:
+    """Compute connector coordinates between two positioned items.
+
+    Each position is (x, y, width, height). The connector goes from the
+    center-bottom of the source to the center-top of the target.
+    """
+    from_x, from_y, from_w, from_h = from_pos
+    to_x, to_y, to_w, _to_h = to_pos
+
+    return ConnectorRoute(
+        start_x=from_x + from_w // 2,
+        start_y=from_y + from_h,
+        end_x=to_x + to_w // 2,
+        end_y=to_y,
+    )

--- a/factory/miro/sync.py
+++ b/factory/miro/sync.py
@@ -1,0 +1,128 @@
+"""Sync orchestrator — full and incremental Miro board synchronization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.events import emit_event
+from factory.miro.analyzer import analyze
+from factory.miro.board import BoardRenderer
+from factory.miro.client import MiroClient
+from factory.miro.drift import detect
+from factory.store import ExperimentStore
+
+log = structlog.get_logger()
+
+
+async def sync_board(project_path: Path) -> dict[str, Any]:
+    """Full board sync: analyze code, detect drift, render board.
+
+    Non-blocking: Miro API failures are logged but never propagated.
+    Returns a summary dict on success, empty dict on skip/failure.
+    """
+    project_path = project_path.resolve()
+    store = ExperimentStore(project_path)
+
+    try:
+        config = await store.read_config()
+    except (FileNotFoundError, ValueError):
+        log.debug("miro_sync_skipped", reason="no valid config")
+        return {}
+
+    if not config.miro_board_id:
+        log.debug("miro_sync_skipped", reason="no board_id configured")
+        return {}
+
+    client = MiroClient(project_path=project_path)
+    if not client.available:
+        log.debug("miro_sync_skipped", reason="client not available")
+        return {}
+
+    emit_event(project_path, "miro.sync.started", data={"sync_type": "full"})
+
+    try:
+        structure = analyze(project_path)
+        drift_items = detect(structure, project_path)
+        history_records = await store.load_history()
+        history: list[dict[str, Any]] = [
+            {
+                "id": r.id,
+                "hypothesis": r.hypothesis,
+                "verdict": r.verdict,
+                "delta": r.delta,
+            }
+            for r in history_records
+        ]
+
+        renderer = BoardRenderer(client, config.miro_board_id)
+        summary = await renderer.render(
+            structure,
+            drift_items,
+            history,
+            {"goal": config.goal, "threshold": config.eval_threshold},
+        )
+        summary["drift_count"] = len(drift_items)
+
+        emit_event(
+            project_path,
+            "miro.sync.completed",
+            data={
+                "items_created": summary.get("item_count", 0),
+                "drift_count": len(drift_items),
+            },
+        )
+        return summary
+    except Exception as exc:
+        log.error("miro_sync_failed", error=str(exc))
+        emit_event(project_path, "miro.sync.failed", data={"error": str(exc)})
+        return {}
+
+
+async def update_experiment(project_path: Path, experiment_id: int) -> None:
+    """Incremental update: refresh the board after a new experiment.
+
+    Falls back to a full re-render via sync_board. Miro API failures
+    are logged but never propagated.
+    """
+    project_path = project_path.resolve()
+    store = ExperimentStore(project_path)
+
+    try:
+        config = await store.read_config()
+    except (FileNotFoundError, ValueError):
+        log.debug("miro_update_skipped", reason="no valid config")
+        return
+
+    if not config.miro_board_id:
+        log.debug("miro_update_skipped", reason="no board_id")
+        return
+
+    client = MiroClient(project_path=project_path)
+    if not client.available:
+        return
+
+    emit_event(
+        project_path,
+        "miro.sync.started",
+        data={"sync_type": "incremental", "experiment_id": experiment_id},
+    )
+
+    try:
+        history_records = await store.load_history()
+        record = next((r for r in history_records if r.id == experiment_id), None)
+        if not record:
+            log.debug("miro_update_no_record", experiment_id=experiment_id)
+            return
+
+        await sync_board(project_path)
+        emit_event(
+            project_path,
+            "miro.sync.completed",
+            data={"sync_type": "incremental", "experiment_id": experiment_id},
+        )
+    except Exception as exc:
+        log.error("miro_update_failed", error=str(exc))
+        emit_event(project_path, "miro.sync.failed", data={"error": str(exc)})

--- a/factory/miro/templates.py
+++ b/factory/miro/templates.py
@@ -1,0 +1,63 @@
+"""Pure-data module: colors, dimensions, spacing, and connector style constants for Miro boards."""
+
+# ── agent role colors ────────────────────────────────────────────
+
+AGENT_COLORS: dict[str, str] = {
+    "researcher": "#4A90D9",
+    "strategist": "#2ECC71",
+    "builder": "#7B68EE",
+    "reviewer": "#E74C3C",
+    "evaluator": "#F39C12",
+    "archivist": "#9B59B6",
+    "distiller": "#1ABC9C",
+    "ceo": "#34495E",
+}
+
+# ── drift analysis colors ────────────────────────────────────────
+
+DRIFT_COLORS: dict[str, str] = {
+    "undocumented": "#FF4444",
+    "phantom": "#CCCCCC",
+    "drifted": "#FF8C00",
+}
+
+# ── component category colors ────────────────────────────────────
+
+COMPONENT_COLORS: dict[str, str] = {
+    "agent": "#4A90D9",
+    "data": "#27AE60",
+    "eval": "#F39C12",
+    "cli": "#8E44AD",
+    "config": "#95A5A6",
+    "test": "#E67E22",
+}
+
+# ── experiment verdict colors ────────────────────────────────────
+
+VERDICT_COLORS: dict[str, str] = {
+    "keep": "#27AE60",
+    "revert": "#E74C3C",
+    "error": "#95A5A6",
+}
+
+# ── frame and shape dimensions ───────────────────────────────────
+
+FRAME_WIDTH = 800
+FRAME_HEIGHT = 600
+
+SHAPE_WIDTH = 200
+SHAPE_HEIGHT = 80
+
+SHAPE_SMALL_WIDTH = 150
+SHAPE_SMALL_HEIGHT = 60
+
+# ── grid layout constants ────────────────────────────────────────
+
+GRID_GAP = 40
+GRID_PADDING = 20
+
+# ── connector style constants ────────────────────────────────────
+
+CONNECTOR_STYLE = "straight"
+CONNECTOR_STROKE_WIDTH = 2
+CONNECTOR_COLOR = "#333333"

--- a/factory/models.py
+++ b/factory/models.py
@@ -207,6 +207,7 @@ class FactoryConfig(BaseModel):
     eval_spec: list[str] = []
     hygiene_weights: TierWeights | None = None
     growth_weights: TierWeights | None = None
+    miro_board_id: str = ""
 
 
 # ── eval ──────────────────────────────────────────────────────────

--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -35,6 +35,9 @@ _CONFIG_TEMPLATE = """\
 # model = ""                           # Claude model for agent subprocesses
 # projects_dir = "~/factory-projects"  # Root for factory-managed projects
 
+# miro_token = ""                     # Miro API token (or set FACTORY_MIRO_TOKEN)
+# miro_team_id = ""                   # Miro team ID for board creation
+
 # [credentials.vertex]
 # FACTORY_RUNNER = "claude"
 # ANTHROPIC_API_KEY = "sk-ant-..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "mcp>=1.27.0",
     "pyyaml>=6.0",
     "filelock>=3.0",
+    "miro-api>=2.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Changes

- Added `cmd_miro_init` — creates a Miro board for a project, with token setup guidance if `FACTORY_MIRO_TOKEN` is not configured
- Added `cmd_miro_link` — links an existing Miro board ID to a project by writing to `.factory/config.json`
- Added `cmd_miro_sync` — syncs project state to a linked Miro board via `factory.miro.sync.sync_board`
- Registered all three subcommands (`miro-init`, `miro-link`, `miro-sync`) in `build_parser()` and the handlers dict
- Follows existing cli.py conventions: type annotations, docstrings, `_run()` for async, `Path(args.path)` conversion