### PR TITLE
ci: rename plugin branch to plugins and document plugin install

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,4 +1,4 @@
-name: Build plugin branch
+name: Build plugins branch
 
 on:
   push:
@@ -30,12 +30,12 @@ jobs:
       - name: Copy skills to .agents/skills
         run: cp -r skills/ .agents/skills/
 
-      - name: Push to plugin branch
+      - name: Push to plugins branch
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -B plugin
+          git checkout -B plugins
           git add -f agents/ codex-agents/ .agents/skills/
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "build: generate plugin agent files from $(git rev-parse --short main)"
-          git push --force origin plugin
+          git push --force origin plugins

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Copy skills to .agents/skills
         run: cp -r skills/ .agents/skills/
 
-      - name: Push to plugins branch
+      - name: Push to plugins branch (and legacy plugin branch)
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -39,3 +39,6 @@ jobs:
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "build: generate plugin agent files from $(git rev-parse --short main)"
           git push --force origin plugins
+          # Backward compatibility: mirror to the legacy 'plugin' branch.
+          # Remove once downstream marketplace installs have migrated to 'plugins'.
+          git push --force origin plugins:plugin

--- a/README.md
+++ b/README.md
@@ -353,15 +353,42 @@ Run `uv run factory config show` to see resolved config, or `uv run factory conf
 
 ---
 
+## Install as a Claude Code Plugin
+
+re:factory is also distributed as a fully-bundled [Claude Code plugin](https://docs.claude.com/en/docs/claude-code/plugins) — agents, skills, and slash commands packaged together. A GitHub Actions workflow rebuilds the `plugins` branch of this repo on every push to `main`, so it always tracks the latest generated artifacts.
+
+From inside Claude Code:
+
+```text
+/plugin marketplace add akashgit/remote-factory#plugins
+/plugin install factory@remote-factory
+/reload-plugins
+```
+
+Once installed, the plugin exposes:
+
+- The `/factory:implement` slash command (entry point for the multi-agent pipeline).
+- Namespaced subagents — invoke with `factory:ceo`, `factory:researcher`, `factory:builder`, etc.
+- The bundled skills under `.agents/skills/` (e.g. `pipeline-subagents`, `implement`).
+
+The plugin still shells out to the `factory` CLI for the heavy lifting, so you'll need `uv` and the `factory` package installed locally as described in [Quick Start](#quick-start).
+
+To update later: `/plugin marketplace update remote-factory`. To remove: `/plugin uninstall factory@remote-factory`.
+
+---
+
 ## Plugin Agents
 
-Every factory agent is available as a standalone Claude Code subagent:
+If you'd rather skip the marketplace and just register the specialist agents as standalone Claude Code (or Codex) subagents, use the built-in installer:
 
 ```bash
 uv run factory install                   # Install all 9 agents to ~/.claude/agents/
+uv run factory install --runner codex    # Or install Codex TOML agents to ~/.codex/agents/
 claude --agent factory-ceo "improve this project"
 claude --agent factory-researcher "study the auth system"
 ```
+
+This path only ships the agent prompts (no skills, no slash commands) and is independent of the plugin marketplace install above.
 
 ---
 


### PR DESCRIPTION
## What
- rename the bundled Claude Code plugin workflow from `plugin` to `plugins`
- update README instructions for installing re:factory from the `plugins` branch
- keep publishing a legacy `plugin` branch mirror for backward compatibility

## Why
The branch and workflow name now match the user-facing `/plugin marketplace add akashgit/remote-factory#plugins` command while preserving existing installs that still reference `#plugin`.

## Split
This PR intentionally contains only the plugin branch/workflow/README changes. The phase 0 harness abstraction work is split into a separate PR.
