### PR TITLE
feat: rename --budget-conscious to --lite with v2 5-agent pipeline design

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -2769,6 +2769,69 @@ For hypotheses with non-overlapping file scopes, execute them in parallel:
 
 ---
 
+## Lite Mode
+
+When your task includes a `## Lite Mode` section, apply these 7 optimizations to reduce agent invocations while preserving correctness. The target is 5 agents per single-hypothesis cycle (Researcher, Strategist, Builder, Evaluator, Archivist) with a cap of 7 total invocations.
+
+### 1. Lite Researcher (archive-only, no web search)
+
+Skip web search. Invoke the Researcher with an explicit directive:
+
+```bash
+factory agent researcher --task "Mode 2 research for $PROJECT_PATH. Do NOT perform web searches. Read only from .factory/archive/ and .factory/strategy/observations.md. Write research report to .factory/strategy/research.md" --project "$PROJECT_PATH" --timeout 180
+```
+
+### 2. Skip baseline eval
+
+Read `.factory/last_eval.json` as `score_before` instead of spawning an Evaluator agent for step 2a. Parse the `total` field from the JSON. Fall back to spawning the Evaluator if the file is missing, unreadable, or older than the current experiment branch's base commit.
+
+### 3. Review pipeline reduction
+
+Skip the Reviewer agent (step 2e) and the headless final review (step 2h-final). Replace the Reviewer invocation with a bare CLI guard check:
+
+```bash
+BASELINE_SHA=$(cd "$PROJECT_PATH" && git log --format=%H -1 main)
+factory guard "$PROJECT_PATH" --baseline $BASELINE_SHA --check-scope
+```
+
+The CEO structured review (step 2d-review) still runs in full. The precheck gate (step 2g) remains mandatory and unchanged.
+
+### 4. Archivist consolidation
+
+Replace all per-phase Archivist invocations (steps 0c, 1-arch, 2d-arch, 2h) with a single batch Archivist at cycle end (Step 3). The batch Archivist receives all phase outputs:
+
+```bash
+factory agent archivist --task "Batch archival for $PROJECT_PATH.
+Read all phase outputs:
+- .factory/reviews/researcher-latest.md
+- .factory/reviews/strategist-latest.md
+- .factory/reviews/builder-latest.md
+- .factory/reviews/ceo-verdict-*.md
+Write consolidated notes to .factory/archive/. Then run: factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
+```
+
+### 5. Strategist context compression
+
+Use `$(factory brief $PROJECT_PATH)` instead of catting full observation/research/strategy files when building the Strategist's task string. This provides the same key signals (current score, threshold, weakest dimensions, recent verdicts, backlog count) in a compact format.
+
+### 6. Single hypothesis per cycle
+
+The invocation budget naturally constrains to 1 hypothesis per cycle. After the single experiment completes (keep or revert), proceed directly to Step 3 (Final Archive). Do not loop back for additional hypotheses.
+
+### 7. Invocation budget
+
+Cap at 7 agent invocations per cycle. Track invocations as you spawn agents. When 2 invocations remain before the ceiling, log a warning:
+
+```bash
+factory log "$PROJECT_PATH" "lite.ceiling_warning" --data '{"remaining": 2}'
+```
+
+If the ceiling would be exceeded, skip the remaining agent and proceed to finalization.
+
+**Invariant:** These optimizations are additive to all other rules. Sacred Rules, guard checks, and eval requirements still apply in full. The precheck gate (step 2g) remains mandatory and unchanged.
+
+---
+
 ## Error Recovery
 
 ### Builder Failure

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2334,6 +2334,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         else:
             clean_pr_resolved = False
 
+    lite_flag = getattr(args, "lite", False)
+
     task = _build_ceo_task(
         wt_path, ceo_mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
@@ -2346,6 +2348,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         issue_url=issue_url,
         refine_request=refine_request,
         clean_pr=clean_pr_resolved,
+        lite=lite_flag,
     )
 
     session_name = _derive_session_name(
@@ -2941,6 +2944,7 @@ def _build_ceo_task(
     issue_url: str | None = None,
     refine_request: str | None = None,
     clean_pr: bool = False,
+    lite: bool = False,
 ) -> str:
     """Build the CEO agent task string from mode and optional context."""
     task = f"Project: {project_path}\nMode: {mode}"
@@ -3137,6 +3141,32 @@ def _build_ceo_task(
             "If stripping breaks tests, fall back to the full diff.\n"
         )
 
+    if lite:
+        task += (
+            "\n\n## Lite Mode\n\n"
+            "Lite Mode is ACTIVE. Apply these 7 optimizations to reduce agent invocations "
+            "while preserving correctness:\n\n"
+            "1. **Lite Researcher (archive-only, no web search):** Skip web search. Invoke "
+            "Researcher with explicit directive: \"Do NOT perform web searches. Read only from "
+            ".factory/archive/ and observations.\"\n"
+            "2. **Skip baseline eval:** Read `.factory/last_eval.json` as score_before instead "
+            "of spawning an Evaluator agent. Fall back to spawning Evaluator if file is missing "
+            "or stale.\n"
+            "3. **Review pipeline reduction:** Skip Reviewer agent (step 2e) and headless final "
+            "review (step 2h-final). Run `factory guard` as CLI instead. CEO structured review "
+            "(step 2d-review) still runs.\n"
+            "4. **Archivist consolidation:** Replace per-cycle Archivist invocations with 1 batch "
+            "at cycle end (Step 3).\n"
+            "5. **Strategist context compression:** Use `$(factory brief $PROJECT_PATH)` instead "
+            "of catting full observation/research/strategy files.\n"
+            "6. **Single hypothesis per cycle:** The invocation budget naturally constrains to "
+            "1 hypothesis.\n"
+            "7. **Invocation budget:** Cap at 7 agent invocations. Warn at 2 remaining.\n\n"
+            "These optimizations are additive to all other rules. Sacred Rules, guard checks, "
+            "and eval requirements still apply in full. The precheck gate (step 2g) remains "
+            "mandatory and unchanged.\n"
+        )
+
     return task
 
 
@@ -3200,6 +3230,7 @@ def _run_single_cycle(
     issue_url: str | None = None,
     use_profile: bool = False,
     clean_pr: bool = False,
+    lite: bool = False,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
     from factory.agents.runner import invoke_agent
@@ -3226,6 +3257,7 @@ def _run_single_cycle(
             issue_number=issue_number,
             issue_url=issue_url,
             clean_pr=clean_pr,
+            lite=lite,
         )
 
         result, code = _run(invoke_agent(
@@ -3266,6 +3298,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     branch = getattr(args, "branch", None)
     model = _resolve_model(args)
     use_profile_flag = getattr(args, "use_profile", False)
+    lite_flag = getattr(args, "lite", False)
 
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
@@ -3339,6 +3372,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             issue_url=issue_url,
             use_profile=use_profile_flag,
             clean_pr=clean_pr_resolved,
+            lite=lite_flag,
             **budget_kwargs,
         )
         if code != 0:
@@ -3377,6 +3411,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 issue_url=issue_url,
                 use_profile=use_profile_flag,
                 clean_pr=clean_pr_resolved,
+                lite=lite_flag,
                 **budget_kwargs,
             )
             _chain_modes(
@@ -3804,6 +3839,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-github", action="store_true", default=False,
         help="Disable GitHub operations (issue creation, PR posting, cloning)",
     )
+    p.add_argument(
+        "--lite", action="store_true", default=False,
+        help="Enable lite mode: reduced agent invocations for subscription users",
+    )
     p.add_argument("--min-growth", type=int, default=None,
                     help="Minimum guaranteed growth hypotheses (default: 2)")
     p.add_argument("--max-new", type=int, default=None,
@@ -3857,6 +3896,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--no-github", action="store_true", default=False,
         help="Disable GitHub operations (issue creation, PR posting, cloning)",
+    )
+    p.add_argument(
+        "--lite", action="store_true", default=False,
+        help="Enable lite mode: reduced agent invocations for subscription users",
     )
     p.add_argument(
         "--loop", action="store_true", default=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2000,3 +2000,67 @@ class TestDeferredCreationFlow:
         project_path, context = _resolve_input(str(tmp_path))
         assert project_path == tmp_path
         assert context is None
+
+
+class TestLiteMode:
+    """Tests for --lite flag: parsing, default, task injection, propagation."""
+
+    def test_parser_ceo_accepts_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path", "--lite"])
+        assert args.lite is True
+
+    def test_parser_ceo_default_false(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path"])
+        assert args.lite is False
+
+    def test_parser_run_accepts_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--lite"])
+        assert args.lite is True
+
+    def test_parser_run_default_false(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path"])
+        assert args.lite is False
+
+    def test_build_ceo_task_injects_section(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "improve", lite=True)
+        assert "## Lite Mode" in task
+        assert "archive-only, no web search" in task
+        assert "Skip baseline eval" in task
+        assert "Review pipeline reduction" in task
+        assert "Archivist consolidation" in task
+        assert "Strategist context compression" in task
+        assert "Single hypothesis per cycle" in task
+        assert "Invocation budget" in task
+        assert "Sacred Rules" in task
+
+    def test_build_ceo_task_omits_section_when_false(self, tmp_path):
+        task = _build_ceo_task(tmp_path, "improve", lite=False)
+        assert "## Lite Mode" not in task
+
+    def test_ceo_headless_passes_flag(self, tmp_path):
+        """--lite flag propagates through cmd_ceo --headless."""
+        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
+             patch("factory.cli._chain_modes", return_value=0):
+            result = main(["ceo", str(tmp_path), "--headless", "--lite"])
+        assert result == 0
+        task = mock_agent.call_args[0][1]
+        assert "## Lite Mode" in task
+
+    def test_run_passes_flag(self, tmp_path):
+        """--lite flag propagates through cmd_run."""
+        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
+             patch("factory.cli._chain_modes", return_value=0), \
+             patch("factory.worktree.create_worktree",
+                   side_effect=lambda p, b="main": (p, "factory/run-test")), \
+             patch("factory.worktree.remove_worktree"), \
+             patch("factory.worktree.prune_stale", return_value=[]), \
+             patch("factory.cli._read_target_branch", return_value="main"), \
+             patch("factory.cli._ensure_dashboard"):
+            result = main(["run", str(tmp_path), "--lite"])
+        assert result == 0
+        task = mock_agent.call_args[0][1]
+        assert "## Lite Mode" in task


### PR DESCRIPTION
Closes #398

## Changes

- Add `--lite` boolean flag to both `ceo` and `run` subcommand parsers in `build_parser()`, following the same pattern as `--no-github`
- Thread the `lite` bool through `cmd_ceo()`, `cmd_run()`, `_build_ceo_task()`, and `_run_single_cycle()`
- When `lite=True`, `_build_ceo_task()` appends a `## Lite Mode` section to the CEO task string describing 7 optimizations:
  1. Lite Researcher (archive-only, no web search)
  2. Skip baseline eval (read last_eval.json)
  3. Review pipeline reduction (skip Reviewer agent + headless review, use CLI guard)
  4. Archivist consolidation (1 batch at cycle end)
  5. Strategist context compression (factory brief)
  6. Single hypothesis per cycle
  7. Invocation budget (cap at 7)
- Add `## Lite Mode` section to `ceo.md` with full v2 protocol for each optimization, including concrete bash examples
- Verify Builder Failure Recovery Protocol is present in ceo.md (confirmed present in Error Recovery section)
- Add `TestLiteMode` class with 8 unit tests covering parser acceptance, defaults, task injection, and flag propagation
- No handoff command code, no structlog imports in plugin/runner/mcp files