### PR TITLE
fix: add codex to --runner argparse choices on agent/ceo/run/tmux

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3756,7 +3756,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Timeout in seconds (default: 600)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocess (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -3812,7 +3812,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Target branch for PRs (default: from factory.md, fallback: main)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -3878,7 +3878,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Target branch for PRs (default: from factory.md, fallback: main)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -3911,7 +3911,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
 
     # tmux-ls — list factory tmux sessions

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2000,3 +2000,23 @@ class TestDeferredCreationFlow:
         project_path, context = _resolve_input(str(tmp_path))
         assert project_path == tmp_path
         assert context is None
+
+
+RUNTIME_SUBCOMMANDS = ["agent", "ceo", "run", "tmux"]
+RUNNER_NAMES = ["claude", "bob", "codex"]
+
+
+@pytest.mark.parametrize("subcommand", RUNTIME_SUBCOMMANDS)
+@pytest.mark.parametrize("runner", RUNNER_NAMES)
+def test_runner_flag_accepted(subcommand, runner, tmp_path):
+    """build_parser() accepts --runner <name> for all runners on all runtime subcommands."""
+    parser = build_parser()
+    base_args = {
+        "agent": ["agent", "researcher", "--task", "x", "--project", str(tmp_path)],
+        "ceo": ["ceo", str(tmp_path)],
+        "run": ["run", str(tmp_path)],
+        "tmux": ["tmux", str(tmp_path)],
+    }
+    argv = base_args[subcommand] + ["--runner", runner]
+    args = parser.parse_args(argv)
+    assert args.runner == runner


### PR DESCRIPTION
Closes #401

## Changes

- Added `codex` to the `--runner` argparse `choices` list on 4 subcommands: `agent`, `ceo`, `run`, `tmux` (the `build` subcommand already had it)
- Added a parametrized test (`test_runner_flag_accepted`) that verifies `build_parser()` accepts `--runner <name>` for all three runner names (`claude`, `bob`, `codex`) on all 4 runtime subcommands (12 test cases)