### PR TITLE
fix: wizard _quick_classify bypasses LLM for long inputs

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -180,10 +180,7 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
 
     if _safe_is_file(expanded):
         if expanded == _WIZARD_INPUT_PATH.expanduser():
-            return [
-                {"label": "Build from this idea", "explanation": "Build the project directly.", "command": f'factory ceo {shlex.quote(stripped)} --mode build'},
-                {"label": "Brainstorm and refine first", "explanation": "Discuss and refine the idea interactively.", "command": f'factory ceo {shlex.quote(stripped)} --mode interactive'},
-            ]
+            return None
         return [
             {"label": "Build from this spec file", "explanation": "Use the file as a project specification.", "command": f'factory ceo {shlex.quote(stripped)} --mode build'},
         ]
@@ -309,7 +306,21 @@ def _classify_with_llm(
     except Exception:
         return None
 
-    prompt = _WIZARD_PROMPT + json.dumps(user_input)
+    wizard_path = _WIZARD_INPUT_PATH.expanduser()
+    input_path = Path(user_input.strip()).expanduser()
+    if input_path == wizard_path:
+        try:
+            file_content = wizard_path.read_text()
+        except OSError:
+            file_content = user_input
+        prompt = (
+            _WIZARD_PROMPT
+            + json.dumps(file_content)
+            + f"\n\nNote: The user's input was saved to the file {user_input}. "
+            "Use this file path (not the raw text) in all generated factory commands."
+        )
+    else:
+        prompt = _WIZARD_PROMPT + json.dumps(user_input)
     task = "Respond with ONLY a JSON object. No markdown, no explanation."
 
     try:

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -316,7 +316,7 @@ def _classify_with_llm(
         prompt = (
             _WIZARD_PROMPT
             + json.dumps(file_content)
-            + f"\n\nNote: The user's input was saved to the file {user_input}. "
+            + f"\n\nNote: The user's input was saved to the file {wizard_path}. "
             "Use this file path (not the raw text) in all generated factory commands."
         )
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1849,10 +1849,10 @@ class TestWizardLongInputRedirect:
 
 
 class TestQuickClassifyWizardFile:
-    """Tests for _quick_classify returning two options for wizard-generated files."""
+    """Tests for _quick_classify returning None for wizard-generated files (LLM fallthrough)."""
 
-    def test_wizard_file_returns_two_options(self, tmp_path, monkeypatch):
-        """_quick_classify returns build and interactive options for wizard_input.md."""
+    def test_wizard_file_returns_none(self, tmp_path, monkeypatch):
+        """_quick_classify returns None for wizard_input.md so LLM classifies the content."""
         fake_home = tmp_path / "home"
         fake_home.mkdir()
         monkeypatch.setenv("HOME", str(fake_home))
@@ -1861,12 +1861,7 @@ class TestQuickClassifyWizardFile:
         wizard_file.write_text("some long idea text")
 
         result = _quick_classify(str(wizard_file))
-        assert result is not None
-        assert len(result) == 2
-        assert result[0]["label"] == "Build from this idea"
-        assert "--mode build" in result[0]["command"]
-        assert result[1]["label"] == "Brainstorm and refine first"
-        assert "--mode interactive" in result[1]["command"]
+        assert result is None
 
     def test_regular_file_returns_one_option(self, tmp_path):
         """_quick_classify returns one option for a regular spec file."""
@@ -1878,8 +1873,8 @@ class TestQuickClassifyWizardFile:
         assert len(result) == 1
         assert result[0]["label"] == "Build from this spec file"
 
-    def test_wizard_file_with_tilde_path(self, tmp_path, monkeypatch):
-        """_quick_classify handles ~/. factory/wizard_input.md with tilde expansion."""
+    def test_wizard_file_with_tilde_path_returns_none(self, tmp_path, monkeypatch):
+        """_quick_classify returns None for ~/.factory/wizard_input.md with tilde expansion."""
         fake_home = tmp_path / "home"
         fake_home.mkdir()
         monkeypatch.setenv("HOME", str(fake_home))
@@ -1888,8 +1883,7 @@ class TestQuickClassifyWizardFile:
         wizard_file.write_text("idea content")
 
         result = _quick_classify("~/.factory/wizard_input.md")
-        assert result is not None
-        assert len(result) == 2
+        assert result is None
 
 
 class TestMaterializeProject:

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -874,3 +874,115 @@ class TestBannerUpdate:
 
         # The no-color branch prints the tagline without mode for welcome
         mock_stderr.write.assert_any_call("The Factory — Self-Evolving Meta-Harness")
+
+
+# -- wizard file LLM classification ----------------------------------------
+
+
+class TestClassifyWithLLMWizardFile:
+    """_classify_with_llm reads wizard file content instead of passing the path."""
+
+    def test_wizard_file_prompt_contains_file_content(self, tmp_path, monkeypatch):
+        """When input is wizard_input.md, the LLM prompt contains the file's content."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+        wizard_file.parent.mkdir(parents=True)
+        idea_text = "Build a distributed key-value store with Raft consensus"
+        wizard_file.write_text(idea_text)
+
+        captured_prompt = {}
+        response = {
+            "follow_ups": [],
+            "suggestions": [
+                {"label": "Build it", "explanation": "Go.", "command": f'factory ceo {str(wizard_file)} --mode build'},
+            ],
+        }
+        mock_runner = MagicMock()
+
+        async def capture_headless(prompt, task, cwd, **kwargs):
+            captured_prompt["value"] = prompt
+            return (json.dumps(response), 0)
+
+        mock_runner.headless = capture_headless
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm(str(wizard_file))
+
+        assert result is not None
+        assert idea_text in captured_prompt["value"]
+        assert "wizard_input.md" not in captured_prompt["value"].split("Note:")[0]
+
+    def test_wizard_file_prompt_injects_path_note(self, tmp_path, monkeypatch):
+        """The LLM prompt tells it to use the file path in generated commands."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        wizard_file = fake_home / ".factory" / "wizard_input.md"
+        wizard_file.parent.mkdir(parents=True)
+        wizard_file.write_text("some idea")
+
+        captured_prompt = {}
+        response = {
+            "follow_ups": [],
+            "suggestions": [
+                {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+            ],
+        }
+        mock_runner = MagicMock()
+
+        async def capture_headless(prompt, task, cwd, **kwargs):
+            captured_prompt["value"] = prompt
+            return (json.dumps(response), 0)
+
+        mock_runner.headless = capture_headless
+
+        wizard_path_str = str(wizard_file)
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            _classify_with_llm(wizard_path_str)
+
+        assert "Use this file path" in captured_prompt["value"]
+
+    def test_wizard_file_missing_falls_back_gracefully(self, tmp_path, monkeypatch):
+        """If wizard_input.md doesn't exist when _classify_with_llm reads it, falls back."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        response = {
+            "follow_ups": [],
+            "suggestions": [
+                {"label": "Build", "explanation": "Go.", "command": 'factory ceo "test"'},
+            ],
+        }
+        mock_runner = MagicMock()
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            result = _classify_with_llm("~/.factory/wizard_input.md")
+
+        assert result is not None
+
+    def test_non_wizard_file_uses_input_directly(self):
+        """For non-wizard inputs, the prompt just contains the user input string."""
+        captured_prompt = {}
+        response = {
+            "follow_ups": [],
+            "suggestions": [
+                {"label": "Build", "explanation": "Go.", "command": 'factory ceo "weather CLI"'},
+            ],
+        }
+        mock_runner = MagicMock()
+
+        async def capture_headless(prompt, task, cwd, **kwargs):
+            captured_prompt["value"] = prompt
+            return (json.dumps(response), 0)
+
+        mock_runner.headless = capture_headless
+
+        with patch("factory.runners.get_runner", return_value=mock_runner):
+            _classify_with_llm("build a weather CLI")
+
+        assert "build a weather CLI" in captured_prompt["value"]
+        assert "Use this file path" not in captured_prompt["value"]

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -903,7 +903,7 @@ class TestClassifyWithLLMWizardFile:
 
         async def capture_headless(prompt, task, cwd, **kwargs):
             captured_prompt["value"] = prompt
-            return (json.dumps(response), 0)
+            return (json.dumps(response), 0, None)
 
         mock_runner.headless = capture_headless
 
@@ -934,7 +934,7 @@ class TestClassifyWithLLMWizardFile:
 
         async def capture_headless(prompt, task, cwd, **kwargs):
             captured_prompt["value"] = prompt
-            return (json.dumps(response), 0)
+            return (json.dumps(response), 0, None)
 
         mock_runner.headless = capture_headless
 
@@ -957,7 +957,7 @@ class TestClassifyWithLLMWizardFile:
             ],
         }
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("~/.factory/wizard_input.md")
@@ -977,7 +977,7 @@ class TestClassifyWithLLMWizardFile:
 
         async def capture_headless(prompt, task, cwd, **kwargs):
             captured_prompt["value"] = prompt
-            return (json.dumps(response), 0)
+            return (json.dumps(response), 0, None)
 
         mock_runner.headless = capture_headless
 


### PR DESCRIPTION
Closes #409

## Changes

- **`_quick_classify` returns `None` for `wizard_input.md`**: Instead of returning 2 hardcoded options ("Build from this idea" / "Brainstorm and refine first"), the wizard file now falls through to LLM classification so long user inputs get semantically classified
- **`_classify_with_llm` reads wizard file content**: When the input path matches `wizard_input.md`, the function reads the file's actual content and sends it to the LLM instead of the file path string
- **Prompt injection for correct commands**: Injects a note telling the LLM to use the wizard file path in generated commands, not the raw text
- **Graceful fallback**: If `wizard_input.md` doesn't exist when `_classify_with_llm` tries to read it, falls back to using the input string directly
- **2 existing tests updated**: `test_wizard_file_returns_two_options` → `test_wizard_file_returns_none`, `test_wizard_file_with_tilde_path` → `test_wizard_file_with_tilde_path_returns_none`
- **4 new tests added**: LLM prompt contains file content, prompt injects path note, missing file graceful fallback, non-wizard input passes through directly

## Test plan

- [x] All 2160 tests pass (0 failures)
- [x] Ruff lint passes
- [x] Updated tests assert `None` return from `_quick_classify` for wizard paths
- [x] New tests verify LLM receives file content not file path
- [x] New tests verify path injection note in prompt
- [x] New tests verify graceful fallback when wizard file missing