### PR TITLE
feat: token usage auditing and profiling across factory workflow

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -173,7 +173,7 @@ async def invoke_agent(
     agent_session_name = session_name or f"factory: {project_path.resolve().name}/{role}"
 
     try:
-        stdout, return_code = await runner.headless(
+        stdout, return_code, usage = await runner.headless(
             prompt=prompt,
             task=task,
             cwd=project_path,
@@ -201,12 +201,21 @@ async def invoke_agent(
             _consecutive_failures += 1
             _check_failure_threshold(project_path, role)
     else:
+        completed_data: dict[str, object] = {"return_code": 0}
+        if usage is not None:
+            completed_data.update({
+                "input_tokens": usage.input_tokens,
+                "output_tokens": usage.output_tokens,
+                "cache_read_tokens": usage.cache_read_tokens,
+                "total_cost_usd": usage.total_cost_usd,
+                "duration_ms": usage.duration_ms,
+                "num_turns": usage.num_turns,
+            })
         _emit_safe(
             project_path, "agent.completed", agent=role,
-            data={"return_code": 0},
+            data=completed_data,
         )
         if _track_failures:
-            # Reset counter on success
             _consecutive_failures = 0
 
     _save_review(project_path, role, stdout, return_code)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -910,8 +910,14 @@ def cmd_finalize(args: argparse.Namespace) -> int:
 
     cost = args.cost
     if cost is None:
-        from factory.events import sum_agent_costs
-        cost = sum_agent_costs(project_path) or None
+        from factory.events import load_events, sum_agent_costs
+        exp_events = load_events(project_path)
+        exp_start = None
+        for ev in reversed(exp_events):
+            if ev.get("type") == "experiment.begin":
+                exp_start = datetime.fromisoformat(ev["timestamp"])
+                break
+        cost = sum_agent_costs(project_path, since=exp_start) or None
 
     record = ExperimentRecord(
         id=args.id,
@@ -2113,7 +2119,7 @@ def cmd_usage(args: argparse.Namespace) -> int:
         if s["calls"] > 0:
             s["avg_cost"] = s["total_cost_usd"] / s["calls"]
 
-    use_json = getattr(args, "json", False)
+    use_json = args.json
 
     if use_json:
         print(json.dumps(agent_stats, indent=2))

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -320,7 +320,7 @@ def _classify_with_llm(
         old_quiet = os.environ.get("FACTORY_RUNNER_QUIET")
         os.environ["FACTORY_RUNNER_QUIET"] = "1"
         try:
-            result, code = _run(runner.headless(
+            result, code, _usage = _run(runner.headless(
                 prompt, task, Path.cwd(),
                 timeout=60.0,
                 dangerously_skip_permissions=True,
@@ -908,6 +908,11 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         })
         print("Finalize gate: precheck SKIPPED (--force)")
 
+    cost = args.cost
+    if cost is None:
+        from factory.events import sum_agent_costs
+        cost = sum_agent_costs(project_path) or None
+
     record = ExperimentRecord(
         id=args.id,
         timestamp=datetime.now(),
@@ -919,7 +924,7 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         score_after=score_after,
         delta=None,
         verdict=verdict,
-        cost_usd=args.cost,
+        cost_usd=cost,
         notes=notes,
     )
     _run(store.finalize(args.id, record))
@@ -2074,6 +2079,79 @@ def cmd_profile(args: argparse.Namespace) -> int:
 
     print(f"Unknown profile subcommand: {sub}", file=sys.stderr)
     return 1
+
+
+def cmd_usage(args: argparse.Namespace) -> int:
+    """Print per-agent token usage breakdown from events.jsonl."""
+    from factory.events import load_events
+
+    project_path = Path(args.path).resolve()
+    events = load_events(project_path)
+
+    agent_stats: dict[str, dict[str, float]] = {}
+    for ev in events:
+        if ev.get("type") != "agent.completed":
+            continue
+        data = ev.get("data", {})
+        if "input_tokens" not in data:
+            continue
+        agent = ev.get("agent", "unknown") or "unknown"
+        if agent not in agent_stats:
+            agent_stats[agent] = {
+                "input_tokens": 0, "output_tokens": 0,
+                "cache_read_tokens": 0, "total_cost_usd": 0.0,
+                "calls": 0, "avg_cost": 0.0,
+            }
+        s = agent_stats[agent]
+        s["input_tokens"] += data.get("input_tokens", 0)
+        s["output_tokens"] += data.get("output_tokens", 0)
+        s["cache_read_tokens"] += data.get("cache_read_tokens", 0)
+        s["total_cost_usd"] += data.get("total_cost_usd", 0.0)
+        s["calls"] += 1
+
+    for s in agent_stats.values():
+        if s["calls"] > 0:
+            s["avg_cost"] = s["total_cost_usd"] / s["calls"]
+
+    use_json = getattr(args, "json", False)
+
+    if use_json:
+        print(json.dumps(agent_stats, indent=2))
+        return 0
+
+    if not agent_stats:
+        print("No agent usage data found.")
+        return 0
+
+    header = f"{'Agent':<16} {'Input':>10} {'Output':>10} {'Cache Read':>12} {'Cost':>10} {'Calls':>6} {'Avg Cost':>10}"
+    print(header)
+    print("-" * len(header))
+
+    total_input = 0
+    total_output = 0
+    total_cache = 0
+    total_cost = 0.0
+    total_calls = 0
+
+    for agent, s in sorted(agent_stats.items()):
+        inp = int(s["input_tokens"])
+        out = int(s["output_tokens"])
+        cache = int(s["cache_read_tokens"])
+        cost = s["total_cost_usd"]
+        calls = int(s["calls"])
+        avg = s["avg_cost"]
+        print(f"{agent:<16} {inp:>10,} {out:>10,} {cache:>12,} ${cost:>9.4f} {calls:>6} ${avg:>9.4f}")
+        total_input += inp
+        total_output += out
+        total_cache += cache
+        total_cost += cost
+        total_calls += calls
+
+    print("-" * len(header))
+    total_avg = total_cost / total_calls if total_calls > 0 else 0.0
+    print(f"{'TOTAL':<16} {total_input:>10,} {total_output:>10,} {total_cache:>12,} ${total_cost:>9.4f} {total_calls:>6} ${total_avg:>9.4f}")
+
+    return 0
 
 
 def cmd_agent(args: argparse.Namespace) -> int:
@@ -3724,6 +3802,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Target CLI: claude writes Markdown to ~/.claude/agents/, codex writes TOML to ~/.codex/agents/ (default: claude)",
     )
 
+    # usage — token usage breakdown
+    p = sub.add_parser("usage", help="Show per-agent token usage and cost breakdown")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--json", action="store_true", default=False,
+                    help="Output as JSON instead of table")
+
     # serve-mcp — MCP stdio server
     sub.add_parser("serve-mcp", help="Start the Factory MCP stdio server")
 
@@ -4007,6 +4091,7 @@ def main(argv: list[str] | None = None) -> int:
         "config": cmd_config,
         "profile": cmd_profile,
         "emit": cmd_emit,
+        "usage": cmd_usage,
         "agent": cmd_agent,
         "ceo": cmd_ceo,
         "run": cmd_run,

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -915,8 +915,10 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         exp_start = None
         for ev in reversed(exp_events):
             if ev.get("type") == "experiment.begin":
-                exp_start = datetime.fromisoformat(ev["timestamp"])
-                break
+                ts_str = ev.get("timestamp")
+                if ts_str:
+                    exp_start = datetime.fromisoformat(ts_str)
+                    break
         cost = sum_agent_costs(project_path, since=exp_start) or None
 
     record = ExperimentRecord(

--- a/factory/events.py
+++ b/factory/events.py
@@ -66,6 +66,21 @@ def load_events(
     return events
 
 
+def sum_agent_costs(
+    project_path: Path,
+    *,
+    since: datetime | None = None,
+) -> float:
+    """Sum total_cost_usd from agent.completed events, optionally since a timestamp."""
+    events = load_events(project_path, since=since)
+    total = 0.0
+    for ev in events:
+        if ev.get("type") != "agent.completed":
+            continue
+        total += ev.get("data", {}).get("total_cost_usd", 0.0)
+    return total
+
+
 def discover_factory_projects(projects_dir: Path, *, max_depth: int = 3) -> list[Path]:
     """Find all subdirectories with .factory/ directories, up to max_depth levels."""
     if not projects_dir.exists():

--- a/factory/models.py
+++ b/factory/models.py
@@ -385,6 +385,24 @@ class CrossProjectInsights(BaseModel):
     generated_at: datetime
 
 
+# ── agent usage / token profiling ─────────────────────────────────
+
+
+class AgentUsage(BaseModel):
+    """Token usage data from a single agent invocation."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    total_cost_usd: float = 0.0
+    duration_ms: float = 0.0
+    num_turns: int = 0
+    model: str = ""
+
+
 # ── cost tracking ─────────────────────────────────────────────────
 
 

--- a/factory/profile.py
+++ b/factory/profile.py
@@ -188,7 +188,7 @@ async def synthesize_profile(
     task = _build_synthesis_task(evidence)
 
     runner = get_runner(runner_name)
-    result, code = await runner.headless(
+    result, code, _usage = await runner.headless(
         prompt=prompt,
         task=task,
         cwd=Path.cwd(),

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -199,15 +199,10 @@ class BobRunner:
         dangerously_skip_permissions: bool = True,
         role: str = "unknown",
         session_name: str | None = None,
-    ) -> tuple[str, int]:
+    ) -> tuple[str, int, None]:
         """Run a headless Bob Shell invocation.
 
-        Returns (stdout, return_code).
-
-        Note: The prompt+task are passed as a CLI argument via `-p`. Very large prompts
-        may hit the OS ARG_MAX limit (typically 128-256KB on Linux). If you encounter
-        "Argument list too long" errors, consider reducing prompt size or using a
-        file-based approach for prompt injection.
+        Returns (stdout, return_code, None). Bob has no token telemetry.
         """
         _ = session_name
         self._role = role
@@ -217,7 +212,8 @@ class BobRunner:
         _persist_key(project_path)
 
         if is_dry_run():
-            return self._dry_run_response(role, cwd, task)
+            stdout, code = self._dry_run_response(role, cwd, task)
+            return stdout, code, None
 
         _check_auth(cwd)
 
@@ -225,7 +221,7 @@ class BobRunner:
             check_ceilings(project_path, self.cycle_start)
         except CeilingExceededError as e:
             self._emit_ceiling_event(project_path, e)
-            return str(e), 1
+            return str(e), 1, None
 
         # NOTE: Custom modes are not supported in Bob Shell (unlike Claude Code).
         # The agent role definition is injected via the prompt instead.
@@ -266,10 +262,10 @@ class BobRunner:
             duration = time.monotonic() - start_time
             log_usage(project_path, role, cwd, duration, 1, dry_run=False)
             logger.error("BobRunner timed out after %ss", timeout)
-            return f"Agent timed out after {timeout}s", 1
+            return f"Agent timed out after {timeout}s", 1, None
         except FileNotFoundError:
             logger.error("'bob' CLI not found on PATH")
-            return "Error: 'bob' CLI not found on PATH", 1
+            return "Error: 'bob' CLI not found on PATH", 1, None
 
         duration = time.monotonic() - start_time
         return_code = proc.returncode or 0
@@ -282,7 +278,7 @@ class BobRunner:
         if return_code != 0:
             logger.warning("BobRunner exited with code %d: %s", return_code, stderr[:200])
 
-        return stdout, return_code
+        return stdout, return_code, None
 
     def interactive_run(
         self,

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -3,14 +3,36 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from factory.runners._stream import should_stream, stream_subprocess
 
+if TYPE_CHECKING:
+    from factory.models import AgentUsage
+
 logger = logging.getLogger(__name__)
+
+
+def _parse_usage(data: dict) -> "AgentUsage":
+    """Extract AgentUsage from Claude Code JSON output."""
+    from factory.models import AgentUsage
+
+    usage_block = data.get("usage", {})
+    return AgentUsage(
+        input_tokens=usage_block.get("input_tokens", 0),
+        output_tokens=usage_block.get("output_tokens", 0),
+        cache_read_tokens=usage_block.get("cache_read_input_tokens", 0),
+        cache_creation_tokens=usage_block.get("cache_creation_input_tokens", 0),
+        total_cost_usd=data.get("cost_usd", 0.0) or 0.0,
+        duration_ms=data.get("duration_ms", 0.0) or 0.0,
+        num_turns=data.get("num_turns", 0) or 0,
+        model=data.get("model", ""),
+    )
 
 
 class ClaudeRunner:
@@ -29,7 +51,7 @@ class ClaudeRunner:
         dangerously_skip_permissions: bool = True,
         role: str = "unknown",
         session_name: str | None = None,
-    ) -> tuple[str, int]:
+    ) -> tuple[str, int, "AgentUsage | None"]:
         """Run a headless Claude Code invocation.
 
         Args:
@@ -42,9 +64,13 @@ class ClaudeRunner:
             role: Agent role (used for streaming prefix).
             session_name: Optional session name for identification in /resume.
 
-        Returns (stdout, return_code).
+        Returns (stdout, return_code, usage).
         """
-        cmd = ["claude", "--append-system-prompt", prompt, "-p", task]
+        cmd = [
+            "claude", "--append-system-prompt", prompt,
+            "-p", task,
+            "--output-format", "json",
+        ]
         if dangerously_skip_permissions:
             cmd.append("--dangerously-skip-permissions")
         if model:
@@ -77,18 +103,29 @@ class ClaudeRunner:
             proc.kill()  # type: ignore[union-attr]
             await proc.wait()  # type: ignore[union-attr]
             logger.error("ClaudeRunner timed out after %ss", timeout)
-            return f"Agent timed out after {timeout}s", 1
+            return f"Agent timed out after {timeout}s", 1, None
         except FileNotFoundError:
             logger.error("'claude' CLI not found on PATH")
-            return "Error: 'claude' CLI not found on PATH", 1
+            return "Error: 'claude' CLI not found on PATH", 1, None
 
-        stdout = stdout_bytes.decode()
+        raw_stdout = stdout_bytes.decode()
         stderr = stderr_bytes.decode()
+        return_code = proc.returncode or 0
 
-        if proc.returncode != 0:
-            logger.warning("ClaudeRunner exited with code %d: %s", proc.returncode, stderr[:200])
+        if return_code != 0:
+            logger.warning("ClaudeRunner exited with code %d: %s", return_code, stderr[:200])
 
-        return stdout, proc.returncode or 0
+        usage = None
+        result_text = raw_stdout
+        try:
+            data = json.loads(raw_stdout)
+            if isinstance(data, dict):
+                result_text = data.get("result", raw_stdout)
+                usage = _parse_usage(data)
+        except (json.JSONDecodeError, ValueError):
+            logger.debug("Could not parse JSON output, returning raw stdout")
+
+        return result_text, return_code, usage
 
     def interactive_run(
         self,

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -120,7 +120,8 @@ class ClaudeRunner:
         try:
             data = json.loads(raw_stdout)
             if isinstance(data, dict):
-                result_text = data.get("result", raw_stdout)
+                result_value = data.get("result", raw_stdout)
+                result_text = result_value if isinstance(result_value, str) else raw_stdout
                 usage = _parse_usage(data)
         except (json.JSONDecodeError, ValueError):
             logger.debug("Could not parse JSON output, returning raw stdout")

--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -69,17 +69,18 @@ class CodexRunner:
         dangerously_skip_permissions: bool = True,
         role: str = "unknown",
         session_name: str | None = None,
-    ) -> tuple[str, int]:
+    ) -> tuple[str, int, None]:
         """Run a headless Codex CLI invocation via ``codex exec``.
 
         Codex exec streams progress to stderr and writes only the final
         agent message to stdout, which aligns with the factory's capture model.
 
-        Returns (stdout, return_code).
+        Returns (stdout, return_code, None). Codex has no token telemetry.
         """
         _ = session_name
         if is_codex_dry_run():
-            return self._dry_run_response(role, cwd, task)
+            stdout, code = self._dry_run_response(role, cwd, task)
+            return stdout, code, None
 
         _check_auth()
 
@@ -116,10 +117,10 @@ class CodexRunner:
             proc.kill()  # type: ignore[union-attr]
             await proc.wait()  # type: ignore[union-attr]
             logger.error("CodexRunner timed out after %ss", timeout)
-            return f"Agent timed out after {timeout}s", 1
+            return f"Agent timed out after {timeout}s", 1, None
         except FileNotFoundError:
             logger.error("'codex' CLI not found on PATH")
-            return "Error: 'codex' CLI not found on PATH", 1
+            return "Error: 'codex' CLI not found on PATH", 1, None
 
         stdout = stdout_bytes.decode()
         stderr = stderr_bytes.decode()
@@ -127,7 +128,7 @@ class CodexRunner:
         if proc.returncode != 0:
             logger.warning("CodexRunner exited with code %d: %s", proc.returncode, stderr[:200])
 
-        return stdout, proc.returncode or 0
+        return stdout, proc.returncode or 0, None
 
     def interactive_run(
         self,

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from factory.models import AgentUsage
 
 
 class Runner(Protocol):
@@ -22,7 +25,7 @@ class Runner(Protocol):
         dangerously_skip_permissions: bool = True,
         role: str = "unknown",
         session_name: str | None = None,
-    ) -> tuple[str, int]:
+    ) -> tuple[str, int, AgentUsage | None]:
         """Run a headless (non-interactive) agent invocation.
 
         Args:
@@ -36,7 +39,8 @@ class Runner(Protocol):
             session_name: Optional session name for identification in /resume.
 
         Returns:
-            (stdout, return_code) tuple.
+            (stdout, return_code, usage) tuple. usage is None for runners
+            without token telemetry (bob, codex).
         """
         ...
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -297,7 +297,7 @@ class TestConsecutiveFailureAbort:
         class MockRunner:
             name = "claude"
             async def headless(self, *args, **kwargs):
-                return ("success", 0)
+                return ("success", 0, None)
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
 
@@ -320,7 +320,7 @@ class TestConsecutiveFailureAbort:
         class MockRunner:
             name = "claude"
             async def headless(self, *args, **kwargs):
-                return ("error output", 1)  # non-zero exit code
+                return ("error output", 1, None)  # non-zero exit code
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
 
@@ -343,7 +343,7 @@ class TestConsecutiveFailureAbort:
         class MockRunner:
             name = "claude"
             async def headless(self, *args, **kwargs):
-                return ("error", 1)
+                return ("error", 1, None)
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
 
@@ -371,7 +371,7 @@ class TestConsecutiveFailureAbort:
         class MockRunner:
             name = "claude"
             async def headless(self, *args, **kwargs):
-                return ("error", 1)
+                return ("error", 1, None)
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
 

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -147,7 +147,7 @@ class TestClassifyWithLLM:
             ],
         }
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("fix a bug in my project")
@@ -168,7 +168,7 @@ class TestClassifyWithLLM:
             ],
         }
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
@@ -186,7 +186,7 @@ class TestClassifyWithLLM:
             {"label": "Build directly", "explanation": "Start building.", "command": 'factory ceo "weather CLI"'},
         ]
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(suggestions), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(suggestions), 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
@@ -199,7 +199,7 @@ class TestClassifyWithLLM:
     def test_json_with_markdown_wrapper(self) -> None:
         raw = '```json\n{"follow_ups": [], "suggestions": [{"label": "Build it", "explanation": "Go.", "command": "factory ceo \\"test\\""}]}\n```'
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(raw, 0))
+        mock_runner.headless = AsyncMock(return_value=(raw, 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test")
@@ -211,7 +211,7 @@ class TestClassifyWithLLM:
 
     def test_invalid_json_returns_none(self) -> None:
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=("not valid json at all", 0))
+        mock_runner.headless = AsyncMock(return_value=("not valid json at all", 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
@@ -220,7 +220,7 @@ class TestClassifyWithLLM:
 
     def test_runner_failure_returns_none(self) -> None:
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=("Error", 1))
+        mock_runner.headless = AsyncMock(return_value=("Error", 1, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("weather CLI")
@@ -236,7 +236,7 @@ class TestClassifyWithLLM:
     def test_empty_suggestions_returns_none(self) -> None:
         response = {"follow_ups": [], "suggestions": []}
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test idea")
@@ -246,7 +246,7 @@ class TestClassifyWithLLM:
     def test_missing_required_fields_returns_none(self) -> None:
         response = {"follow_ups": [], "suggestions": [{"label": "Test"}]}  # missing command
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test idea")
@@ -262,7 +262,7 @@ class TestClassifyWithLLM:
             ],
         }
         mock_runner = MagicMock()
-        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0))
+        mock_runner.headless = AsyncMock(return_value=(json.dumps(response), 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner):
             result = _classify_with_llm("test")

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -50,7 +50,7 @@ class TestCodexDryRun:
         monkeypatch.setenv("FACTORY_CODEX_DRY_RUN", "1")
 
         runner = CodexRunner()
-        stdout, code = await runner.headless(
+        stdout, code, usage = await runner.headless(
             prompt="You are a test agent.",
             task="Say hello",
             cwd=tmp_path,
@@ -60,6 +60,7 @@ class TestCodexDryRun:
         assert code == 0
         assert "[DRY-RUN]" in stdout
         assert "researcher" in stdout
+        assert usage is None
 
     def test_interactive_run_dry_run(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -168,7 +169,7 @@ class TestCodexHeadless:
                 mock_proc.returncode = 0
                 mock_exec.return_value = mock_proc
 
-                stdout, code = await runner.headless(
+                stdout, code, usage = await runner.headless(
                     prompt="You are a test agent.",
                     task="Say hello",
                     cwd=tmp_path,
@@ -178,6 +179,7 @@ class TestCodexHeadless:
 
                 assert code == 0
                 assert stdout == "output"
+                assert usage is None
 
                 call_args = mock_exec.call_args[0]
                 assert call_args[0] == "codex"
@@ -298,7 +300,7 @@ class TestCodexHeadless:
                 mock_exec.return_value = mock_proc
 
                 runner = CodexRunner()
-                stdout, code = await runner.headless(
+                stdout, code, usage = await runner.headless(
                     prompt="Test",
                     task="Test",
                     cwd=tmp_path,
@@ -308,6 +310,7 @@ class TestCodexHeadless:
 
         assert code == 1
         assert "timed out" in stdout.lower()
+        assert usage is None
 
     async def test_handles_missing_binary(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -321,7 +324,7 @@ class TestCodexHeadless:
             side_effect=FileNotFoundError,
         ):
             runner = CodexRunner()
-            stdout, code = await runner.headless(
+            stdout, code, usage = await runner.headless(
                 prompt="Test",
                 task="Test",
                 cwd=tmp_path,
@@ -329,6 +332,7 @@ class TestCodexHeadless:
 
         assert code == 1
         assert "not found" in stdout.lower()
+        assert usage is None
 
     async def test_passes_env_with_openai_key(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -272,7 +272,7 @@ class TestSynthesizeProfile:
         from factory.profile import synthesize_profile
 
         mock_runner = AsyncMock()
-        mock_runner.headless = AsyncMock(return_value=("Synthesized profile text", 0))
+        mock_runner.headless = AsyncMock(return_value=("Synthesized profile text", 0, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner), \
              patch("factory.agents.runner.resolve_prompt", return_value="profiler prompt"):
@@ -284,7 +284,7 @@ class TestSynthesizeProfile:
         from factory.profile import synthesize_profile
 
         mock_runner = AsyncMock()
-        mock_runner.headless = AsyncMock(return_value=("Error output", 1))
+        mock_runner.headless = AsyncMock(return_value=("Error output", 1, None))
 
         with patch("factory.runners.get_runner", return_value=mock_runner), \
              patch("factory.agents.runner.resolve_prompt", return_value="prompt"):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -53,7 +53,7 @@ class TestClaudeRunner:
         with patch(
             "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
-            mock_stream.return_value = (b"output", b"")
+            mock_stream.return_value = (b'{"result":"output","usage":{},"cost_usd":0,"duration_ms":0,"num_turns":1,"model":"claude-opus-4-7"}', b"")
 
             with patch(
                 "asyncio.create_subprocess_exec", new_callable=AsyncMock
@@ -62,7 +62,7 @@ class TestClaudeRunner:
                 mock_proc.returncode = 0
                 mock_exec.return_value = mock_proc
 
-                stdout, code = await runner.headless(
+                stdout, code, usage = await runner.headless(
                     prompt="You are a test agent.",
                     task="Say hello",
                     cwd=tmp_path,
@@ -72,6 +72,7 @@ class TestClaudeRunner:
 
                 assert code == 0
                 assert stdout == "output"
+                assert usage is not None
 
                 call_args = mock_exec.call_args
                 cmd = call_args[0]
@@ -81,6 +82,8 @@ class TestClaudeRunner:
                 assert "--dangerously-skip-permissions" in cmd
                 assert "--model" in cmd
                 assert "claude-opus-4-7" in cmd
+                assert "--output-format" in cmd
+                assert "json" in cmd
 
     async def test_headless_separates_prompt_and_task(self, tmp_path: Path) -> None:
         """headless() passes prompt via --append-system-prompt and task via -p as separate args."""
@@ -89,7 +92,7 @@ class TestClaudeRunner:
         with patch(
             "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
-            mock_stream.return_value = (b"ok", b"")
+            mock_stream.return_value = (b'{"result":"ok"}', b"")
 
             with patch(
                 "asyncio.create_subprocess_exec", new_callable=AsyncMock
@@ -179,7 +182,7 @@ class TestBobRunner:
                 mock_exec.return_value = mock_proc
 
                 runner = BobRunner()
-                stdout, code = await runner.headless(
+                stdout, code, usage = await runner.headless(
                     prompt="Test",
                     task="Test",
                     cwd=tmp_path,
@@ -189,6 +192,7 @@ class TestBobRunner:
 
         assert code == 1
         assert "timed out" in stdout.lower()
+        assert usage is None
         bob_module._auth_checked = False
 
     def test_count_cycle_invocations_with_datetime(self, tmp_path: Path) -> None:
@@ -242,7 +246,7 @@ class TestBobRunner:
         # Log entry AFTER cycle_start so it counts
         log_usage(tmp_path, "a", tmp_path, 1.0, 0, dry_run=False)
 
-        stdout, code = await runner.headless(
+        stdout, code, usage = await runner.headless(
             prompt="Test",
             task="Test",
             cwd=tmp_path,
@@ -251,6 +255,7 @@ class TestBobRunner:
 
         assert code == 1
         assert "ceiling" in stdout.lower() or "exceeded" in stdout.lower()
+        assert usage is None
         bob_module._auth_checked = False
 
     async def test_dry_run_returns_stub(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -260,7 +265,7 @@ class TestBobRunner:
         (tmp_path / ".factory").mkdir()
 
         runner = BobRunner()
-        stdout, code = await runner.headless(
+        stdout, code, usage = await runner.headless(
             prompt="You are a test agent.",
             task="Say hello",
             cwd=tmp_path,
@@ -270,6 +275,7 @@ class TestBobRunner:
         assert code == 0
         assert "[DRY-RUN]" in stdout
         assert "researcher" in stdout
+        assert usage is None
 
     async def test_dry_run_logs_usage(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
@@ -278,7 +284,7 @@ class TestBobRunner:
         (tmp_path / ".factory").mkdir()
 
         runner = BobRunner()
-        await runner.headless(
+        _stdout, _code, _usage = await runner.headless(
             prompt="Test prompt",
             task="Test task",
             cwd=tmp_path,
@@ -491,7 +497,7 @@ class TestBobAuthPreflight:
                 mock_exec.return_value = mock_proc
 
                 runner = BobRunner()
-                stdout, code = await runner.headless(
+                stdout, code, usage = await runner.headless(
                     prompt="Test",
                     task="Test",
                     cwd=tmp_path,
@@ -499,6 +505,7 @@ class TestBobAuthPreflight:
                 )
 
                 assert code == 0
+                assert usage is None
 
 
 class TestKeyPersistence:
@@ -640,7 +647,7 @@ class TestKeyPersistence:
                 mock_exec.return_value = mock_proc
 
                 runner = BobRunner()
-                await runner.headless(
+                stdout, code, usage = await runner.headless(
                     prompt="Test",
                     task="Test",
                     cwd=tmp_path,
@@ -651,6 +658,7 @@ class TestKeyPersistence:
                 call_kwargs = mock_exec.call_args.kwargs
                 assert "env" in call_kwargs
                 assert call_kwargs["env"].get("BOBSHELL_API_KEY") == "subprocess-test-key"
+                assert usage is None
 
         monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
         bob_module._auth_checked = False
@@ -818,7 +826,7 @@ class TestStreamingOutput:
             with patch(
                 "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
             ) as mock_stream:
-                mock_stream.return_value = (b"output\n", b"")
+                mock_stream.return_value = (b'{"result":"output"}', b"")
 
                 with patch(
                     "asyncio.create_subprocess_exec", new_callable=AsyncMock
@@ -827,7 +835,7 @@ class TestStreamingOutput:
                     mock_proc.returncode = 0
                     mock_exec.return_value = mock_proc
 
-                    stdout, code = await runner.headless(
+                    stdout, code, usage = await runner.headless(
                         prompt="Test",
                         task="Test",
                         cwd=tmp_path,
@@ -871,7 +879,7 @@ class TestStreamingOutput:
                     mock_proc.returncode = 0
                     mock_exec.return_value = mock_proc
 
-                    stdout, code = await runner.headless(
+                    stdout, code, usage = await runner.headless(
                         prompt="Test",
                         task="Test",
                         cwd=tmp_path,
@@ -883,6 +891,7 @@ class TestStreamingOutput:
                     call_kwargs = mock_stream.call_args.kwargs
                     assert call_kwargs["stream"] is True
                     assert call_kwargs["prefix"] == "[bob:builder]"
+                    assert usage is None
 
         bob_module._auth_checked = False
 
@@ -897,7 +906,7 @@ class TestStreamingOutput:
         with patch(
             "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
-            mock_stream.return_value = (b"output\n", b"")
+            mock_stream.return_value = (b'{"result":"output"}', b"")
 
             with patch(
                 "asyncio.create_subprocess_exec", new_callable=AsyncMock
@@ -929,12 +938,12 @@ class TestStreamingOutput:
         # Import invoke_agent which saves the review
         from factory.agents.runner import invoke_agent
 
-        expected_output = "Line 1\nLine 2\nLine 3\n"
+        json_output = json.dumps({"result": "Line 1\nLine 2\nLine 3\n", "usage": {}, "cost_usd": 0.01})
 
         with patch(
             "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
-            mock_stream.return_value = (expected_output.encode(), b"")
+            mock_stream.return_value = (json_output.encode(), b"")
 
             with patch(
                 "asyncio.create_subprocess_exec", new_callable=AsyncMock
@@ -950,7 +959,7 @@ class TestStreamingOutput:
                     runner_name="claude",
                 )
 
-                assert expected_output in stdout
+                assert "Line 1" in stdout
 
                 # Check the saved review file
                 review_file = tmp_path / ".factory" / "reviews" / "researcher-latest.md"
@@ -1206,6 +1215,8 @@ class TestAnsiSanitization:
 
         bob_module._auth_checked = False
 
+
+
     async def test_claude_runner_does_not_sanitize(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1218,7 +1229,7 @@ class TestAnsiSanitization:
             with patch(
                 "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
             ) as mock_stream:
-                mock_stream.return_value = (b"output\n", b"")
+                mock_stream.return_value = (b'{"result":"output"}', b"")
 
                 with patch(
                     "asyncio.create_subprocess_exec", new_callable=AsyncMock


### PR DESCRIPTION
Closes #411

## Changes

- Added `AgentUsage` Pydantic model to `factory/models.py` with fields for input/output/cache tokens, cost, duration, turns, and model
- Updated `ClaudeRunner.headless()` to use `--output-format json`, parsing the JSON response for both text result and usage data
- Updated `Runner` protocol to return `tuple[str, int, AgentUsage | None]` — Bob and Codex runners return `None` for usage
- Propagated token data through `agent.completed` events in `factory/agents/runner.py`
- Added `factory usage <path>` CLI command that reads `events.jsonl` and displays per-agent token breakdown table with `--json` support
- Populated `ExperimentRecord.cost_usd` from aggregated agent costs to activate dormant ACE cost analysis
- All 2156 tests pass, lint clean, mypy clean