### PR TITLE
fix: --force must not bypass hard constraints

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -937,7 +937,8 @@ def cmd_finalize(args: argparse.Namespace) -> int:
                 _emit_cli_event(project_path, "verdict.force_kept", {
                     "exp_id": args.id,
                 })
-                print("Finalize gate: precheck SKIPPED (--force), hard constraints PASSED")
+                hc_msg = ", hard constraints PASSED" if config.hard_constraints else ""
+                print(f"Finalize gate: precheck SKIPPED (--force){hc_msg}")
 
     cost = args.cost
     if cost is None:

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -885,41 +885,59 @@ def cmd_finalize(args: argparse.Namespace) -> int:
 
     force = getattr(args, "force", False)
 
-    if verdict == "keep" and not force:
+    if verdict == "keep":
         config_path = project_path / ".factory" / "config.json"
         if config_path.exists():
             config = FactoryConfig(**json.loads(config_path.read_text()))
-            history = _run(store.load_history())
-            history_dicts = [r.model_dump() for r in history]
 
-            precheck_result = run_precheck(
-                score_before=score_before,
-                score_after=score_after,
-                threshold=config.eval_threshold,
-                hypothesis=args.hypothesis or "",
-                history=history_dicts,
-                project_path=project_path,
-                smoke_test_command=config.smoke_test,
-                hard_constraints=config.hard_constraints,
-            )
+            if config.hard_constraints:
+                from factory.precheck import check_hard_constraints
+                hc_results = check_hard_constraints(config.hard_constraints, project_path)
+                hc_failures = [c.name for c in hc_results if not c.passed]
+                if hc_failures:
+                    verdict = "revert"
+                    failure_detail = "; ".join(hc_failures)
+                    notes = f"[OVERRIDDEN by finalize gate] hard constraint failed: {failure_detail}. {notes}"
+                    _emit_cli_event(project_path, "verdict.overridden", {
+                        "exp_id": args.id,
+                        "original_verdict": "keep",
+                        "new_verdict": "revert",
+                        "reason": failure_detail,
+                    })
+                    print(f"Finalize gate: hard constraint FAILED — overriding keep to revert ({failure_detail})")
 
-            if not precheck_result.passed:
-                verdict = "revert"
-                failure_detail = "; ".join(precheck_result.blocking_failures)
-                notes = f"[OVERRIDDEN by finalize gate] precheck failed: {failure_detail}. {notes}"
-                _emit_cli_event(project_path, "verdict.overridden", {
+            if verdict == "keep" and not force:
+                history = _run(store.load_history())
+                history_dicts = [r.model_dump() for r in history]
+
+                precheck_result = run_precheck(
+                    score_before=score_before,
+                    score_after=score_after,
+                    threshold=config.eval_threshold,
+                    hypothesis=args.hypothesis or "",
+                    history=history_dicts,
+                    project_path=project_path,
+                    smoke_test_command=config.smoke_test,
+                    hard_constraints=None,
+                )
+
+                if not precheck_result.passed:
+                    verdict = "revert"
+                    failure_detail = "; ".join(precheck_result.blocking_failures)
+                    notes = f"[OVERRIDDEN by finalize gate] precheck failed: {failure_detail}. {notes}"
+                    _emit_cli_event(project_path, "verdict.overridden", {
+                        "exp_id": args.id,
+                        "original_verdict": "keep",
+                        "new_verdict": "revert",
+                        "reason": failure_detail,
+                    })
+                    print(f"Finalize gate: precheck FAILED — overriding keep to revert ({failure_detail})")
+
+            if verdict == "keep" and force:
+                _emit_cli_event(project_path, "verdict.force_kept", {
                     "exp_id": args.id,
-                    "original_verdict": "keep",
-                    "new_verdict": "revert",
-                    "reason": failure_detail,
                 })
-                print(f"Finalize gate: precheck FAILED — overriding keep to revert ({failure_detail})")
-
-    if verdict == "keep" and force:
-        _emit_cli_event(project_path, "verdict.force_kept", {
-            "exp_id": args.id,
-        })
-        print("Finalize gate: precheck SKIPPED (--force)")
+                print("Finalize gate: precheck SKIPPED (--force), hard constraints PASSED")
 
     cost = args.cost
     if cost is None:
@@ -3721,7 +3739,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--score-before", type=float, default=None, help="Eval score before change")
     p.add_argument("--score-after", type=float, default=None, help="Eval score after change")
     p.add_argument("--force", action="store_true", default=False,
-                    help="Bypass precheck gate (for pre-existing failures)")
+                    help="Bypass precheck gate (for pre-existing failures). Hard constraints are always enforced.")
 
     # history
     p = sub.add_parser("history", help="Print formatted experiment history table")

--- a/tests/test_hard_constraints.py
+++ b/tests/test_hard_constraints.py
@@ -190,7 +190,7 @@ def _make_project_with_config(tmp_path: Path, hard_constraints: list[dict] | Non
 
 
 class TestForceFlag:
-    def test_force_flag_bypasses_precheck(self, tmp_path: Path) -> None:
+    def test_force_flag_does_not_bypass_hard_constraints(self, tmp_path: Path) -> None:
         from factory.cli import cmd_finalize
 
         project = _make_project_with_config(tmp_path, [
@@ -201,6 +201,24 @@ class TestForceFlag:
             hypothesis="test hyp", summary="test", notes="",
             issue=None, pr=None, cost=None,
             score_before=0.5, score_after=0.9,
+            force=True,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "revert" in tsv
+        assert "hard constraint failed" in tsv
+
+    def test_force_flag_bypasses_non_constraint_precheck(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [
+            {"name": "always_pass", "check": "true", "description": ""},
+        ])
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=None, score_after=None,
             force=True,
         )
         cmd_finalize(args)

--- a/tests/test_hard_constraints.py
+++ b/tests/test_hard_constraints.py
@@ -280,6 +280,23 @@ class TestFinalizeGate:
         assert "keep" in tsv
         assert "OVERRIDDEN" not in tsv
 
+    def test_keep_overridden_by_soft_precheck_without_force(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [
+            {"name": "always_pass", "check": "true", "description": ""},
+        ])
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=0.9, score_after=0.1,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "revert" in tsv
+        assert "precheck failed" in tsv
+
     def test_revert_verdict_skips_precheck(self, tmp_path: Path) -> None:
         from factory.cli import cmd_finalize
 

--- a/tests/test_hard_constraints.py
+++ b/tests/test_hard_constraints.py
@@ -226,6 +226,23 @@ class TestForceFlag:
         assert "keep" in tsv
         assert "OVERRIDDEN" not in tsv
 
+    def test_force_flag_no_constraints_configured(self, tmp_path: Path, capsys) -> None:
+        from factory.cli import cmd_finalize
+
+        project = _make_project_with_config(tmp_path, [])
+        args = Namespace(
+            path=str(project), id=1, verdict="keep",
+            hypothesis="test hyp", summary="test", notes="",
+            issue=None, pr=None, cost=None,
+            score_before=None, score_after=None,
+            force=True,
+        )
+        cmd_finalize(args)
+        tsv = (project / ".factory" / "results.tsv").read_text()
+        assert "keep" in tsv
+        captured = capsys.readouterr()
+        assert "hard constraints PASSED" not in captured.out
+
     def test_force_flag_with_revert_is_noop(self, tmp_path: Path) -> None:
         from factory.cli import cmd_finalize
 


### PR DESCRIPTION
## Summary

- `--force` on `factory finalize` now only bypasses soft prechecks (smoke test, score direction, anti-pattern detection)
- Hard constraints from `factory.md` are **always enforced** regardless of `--force`
- Hard constraints run first, before any other precheck — if they fail, the verdict is overridden to revert even with `--force`

## Motivation

Hard constraints are user-defined invariants (e.g. GPU memory caps, quality gates) that the CEO should never circumvent. Since #232 added `--force` and the CEO prompt templates include it by default, hard constraints were effectively disabled — the CEO could `--force` past any constraint violation.

This was observed in practice: a factory running with a 24GB GPU memory constraint (`--gpu-memory-utilization 0.29`) had the CEO "fix" the value to 0.95 and keep the experiment using `--force`, completely bypassing the user's hardware constraint.

## What changed

`cmd_finalize` in `factory/cli.py`:
- Hard constraints are checked **outside** the `if not force` block — they always run
- Soft prechecks remain inside `if not force` — `--force` still bypasses them (preserving the fix for #222)
- `hard_constraints=None` is passed to `run_precheck` to avoid double-checking constraints

## Test plan

- [x] `test_force_flag_does_not_bypass_hard_constraints` — `--force` with failing hard constraint still reverts
- [x] `test_force_flag_bypasses_non_constraint_precheck` — `--force` with passing constraints skips soft precheck
- [x] `test_force_flag_with_revert_is_noop` — unchanged
- [x] All 23 hard constraint tests pass
- [x] Full test suite: 309 passed, 1 pre-existing failure (unrelated `test_interactive_task_contains_idea_text`)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)