### PR TITLE
fix: write agent prompts to temp files to avoid ARG_MAX limit

### DIFF
--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -83,7 +83,10 @@ async def run_in_tmux(
     exitcode_file = tmpdir / "exitcode"
     wrapper_script = tmpdir / "wrapper.sh"
 
-    cmd = ["claude", "--append-system-prompt", prompt]
+    prompt_file = tmpdir / "prompt.md"
+    prompt_file.write_text(prompt)
+
+    cmd = ["claude", "--append-system-prompt-file", str(prompt_file)]
     if dangerously_skip_permissions:
         cmd.append("--dangerously-skip-permissions")
     if model:

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -79,67 +80,76 @@ class ClaudeRunner:
                 )
             logger.warning("tmux not available; falling back to headless")
 
-        cmd = [
-            "claude", "--append-system-prompt", prompt,
-            "-p", task,
-            "--output-format", "json",
-        ]
-        if dangerously_skip_permissions:
-            cmd.append("--dangerously-skip-permissions")
-        if model:
-            cmd.extend(["--model", model])
-        if session_name:
-            cmd.extend(["--name", session_name])
-
-        logger.info("ClaudeRunner headless: cwd=%s, model=%s", cwd, model)
-
-        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-        if model:
-            env["FACTORY_MODEL"] = model
-
-        stream = should_stream()
-        prefix = f"[claude:{role}]" if stream else None
-
+        prompt_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", prefix="factory-prompt-", delete=False,
+        )
         try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-            )
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                stream_subprocess(proc, stream=stream, prefix=prefix),
-                timeout=timeout,
-            )
-        except asyncio.TimeoutError:
-            proc.kill()  # type: ignore[union-attr]
-            await proc.wait()  # type: ignore[union-attr]
-            logger.error("ClaudeRunner timed out after %ss", timeout)
-            return f"Agent timed out after {timeout}s", 1, None
-        except FileNotFoundError:
-            logger.error("'claude' CLI not found on PATH")
-            return "Error: 'claude' CLI not found on PATH", 1, None
+            prompt_file.write(prompt)
+            prompt_file.close()
 
-        raw_stdout = stdout_bytes.decode()
-        stderr = stderr_bytes.decode()
-        return_code = proc.returncode or 0
+            cmd = [
+                "claude", "--append-system-prompt-file", prompt_file.name,
+                "-p", task,
+                "--output-format", "json",
+            ]
+            if dangerously_skip_permissions:
+                cmd.append("--dangerously-skip-permissions")
+            if model:
+                cmd.extend(["--model", model])
+            if session_name:
+                cmd.extend(["--name", session_name])
 
-        if return_code != 0:
-            logger.warning("ClaudeRunner exited with code %d: %s", return_code, stderr[:200])
+            logger.info("ClaudeRunner headless: cwd=%s, model=%s", cwd, model)
 
-        usage = None
-        result_text = raw_stdout
-        try:
-            data = json.loads(raw_stdout)
-            if isinstance(data, dict):
-                result_value = data.get("result", raw_stdout)
-                result_text = result_value if isinstance(result_value, str) else raw_stdout
-                usage = _parse_usage(data)
-        except (json.JSONDecodeError, ValueError):
-            logger.debug("Could not parse JSON output, returning raw stdout")
+            env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+            if model:
+                env["FACTORY_MODEL"] = model
 
-        return result_text, return_code, usage
+            stream = should_stream()
+            prefix = f"[claude:{role}]" if stream else None
+
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=cwd,
+                    env=env,
+                )
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    stream_subprocess(proc, stream=stream, prefix=prefix),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                proc.kill()  # type: ignore[union-attr]
+                await proc.wait()  # type: ignore[union-attr]
+                logger.error("ClaudeRunner timed out after %ss", timeout)
+                return f"Agent timed out after {timeout}s", 1, None
+            except FileNotFoundError:
+                logger.error("'claude' CLI not found on PATH")
+                return "Error: 'claude' CLI not found on PATH", 1, None
+
+            raw_stdout = stdout_bytes.decode()
+            stderr = stderr_bytes.decode()
+            return_code = proc.returncode or 0
+
+            if return_code != 0:
+                logger.warning("ClaudeRunner exited with code %d: %s", return_code, stderr[:200])
+
+            usage = None
+            result_text = raw_stdout
+            try:
+                data = json.loads(raw_stdout)
+                if isinstance(data, dict):
+                    result_value = data.get("result", raw_stdout)
+                    result_text = result_value if isinstance(result_value, str) else raw_stdout
+                    usage = _parse_usage(data)
+            except (json.JSONDecodeError, ValueError):
+                logger.debug("Could not parse JSON output, returning raw stdout")
+
+            return result_text, return_code, usage
+        finally:
+            Path(prompt_file.name).unlink(missing_ok=True)
 
     def interactive_run(
         self,
@@ -157,20 +167,29 @@ class ClaudeRunner:
         Returns the exit code so the caller can clean up in a finally block.
         """
         _ = role
-        cmd = [
-            "claude",
-            "--append-system-prompt", prompt,
-        ]
-        if dangerously_skip_permissions:
-            cmd.append("--dangerously-skip-permissions")
-        cmd.append(task)
-        if model:
-            cmd.extend(["--model", model])
-            os.environ["FACTORY_MODEL"] = model
-        if session_name:
-            cmd.extend(["--name", session_name])
+        prompt_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", prefix="factory-prompt-", delete=False,
+        )
+        try:
+            prompt_file.write(prompt)
+            prompt_file.close()
 
-        logger.info("ClaudeRunner interactive_run: cwd=%s", cwd)
+            cmd = [
+                "claude",
+                "--append-system-prompt-file", prompt_file.name,
+            ]
+            if dangerously_skip_permissions:
+                cmd.append("--dangerously-skip-permissions")
+            cmd.append(task)
+            if model:
+                cmd.extend(["--model", model])
+                os.environ["FACTORY_MODEL"] = model
+            if session_name:
+                cmd.extend(["--name", session_name])
 
-        result = subprocess.run(cmd, cwd=cwd)
-        return result.returncode
+            logger.info("ClaudeRunner interactive_run: cwd=%s", cwd)
+
+            result = subprocess.run(cmd, cwd=cwd)
+            return result.returncode
+        finally:
+            Path(prompt_file.name).unlink(missing_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1019,7 +1019,7 @@ class TestCmdCeo:
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == "claude"
-        assert "--append-system-prompt" in cmd
+        assert "--append-system-prompt-file" in cmd
         assert "--dangerously-skip-permissions" in cmd
 
     def test_ceo_foreground_passes_task_as_prompt(self, tmp_path):

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -108,9 +108,8 @@ class TestClaudeRunner:
                 )
 
                 cmd = mock_exec.call_args[0]
-                asp_idx = cmd.index("--append-system-prompt-file")
+                assert "--append-system-prompt-file" in cmd
                 p_idx = cmd.index("-p")
-                # The prompt file is cleaned up after execution, so just check task arg
                 assert cmd[p_idx + 1] == "Run the experiment"
 
     async def test_interactive_run_uses_append_system_prompt_file(self, tmp_path: Path) -> None:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -77,7 +77,7 @@ class TestClaudeRunner:
                 call_args = mock_exec.call_args
                 cmd = call_args[0]
                 assert cmd[0] == "claude"
-                assert "--append-system-prompt" in cmd
+                assert "--append-system-prompt-file" in cmd
                 assert "-p" in cmd
                 assert "--dangerously-skip-permissions" in cmd
                 assert "--model" in cmd
@@ -86,7 +86,7 @@ class TestClaudeRunner:
                 assert "json" in cmd
 
     async def test_headless_separates_prompt_and_task(self, tmp_path: Path) -> None:
-        """headless() passes prompt via --append-system-prompt and task via -p as separate args."""
+        """headless() writes prompt to a temp file via --append-system-prompt-file and task via -p."""
         runner = ClaudeRunner()
 
         with patch(
@@ -108,13 +108,13 @@ class TestClaudeRunner:
                 )
 
                 cmd = mock_exec.call_args[0]
-                asp_idx = cmd.index("--append-system-prompt")
+                asp_idx = cmd.index("--append-system-prompt-file")
                 p_idx = cmd.index("-p")
-                assert cmd[asp_idx + 1] == "You are the CEO."
+                # The prompt file is cleaned up after execution, so just check task arg
                 assert cmd[p_idx + 1] == "Run the experiment"
 
-    async def test_interactive_run_uses_append_system_prompt(self, tmp_path: Path) -> None:
-        """interactive_run() uses --append-system-prompt (not --system-prompt)."""
+    async def test_interactive_run_uses_append_system_prompt_file(self, tmp_path: Path) -> None:
+        """interactive_run() uses --append-system-prompt-file (not inline --append-system-prompt)."""
         runner = ClaudeRunner()
 
         with patch("subprocess.run") as mock_run:
@@ -126,8 +126,8 @@ class TestClaudeRunner:
             )
 
             cmd = mock_run.call_args[0][0]
-            assert "--append-system-prompt" in cmd
-            assert "--system-prompt" not in cmd
+            assert "--append-system-prompt-file" in cmd
+            assert "--append-system-prompt" not in [c for c in cmd if c != "--append-system-prompt-file"]
 
 
 class TestBobRunner:


### PR DESCRIPTION
## Summary
- The CEO agent prompt (~153KB) was passed inline as a `--append-system-prompt` CLI argument, exceeding Linux's `ARG_MAX` per-argument limit and causing `[Errno 7] Argument list too long: 'claude'`
- Switched all three invocation sites (`headless`, `interactive_run`, `run_in_tmux`) to write the prompt to a temporary file and use `--append-system-prompt-file` instead
- Temp files are cleaned up in `finally` blocks after execution completes

## Test plan
- [x] All 2179 tests pass (`pytest -v`)
- [x] Verified `--append-system-prompt-file` flag works with `claude` CLI
- [x] Updated tests in `test_runners.py` and `test_cli.py` to match new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)