### PR TITLE
feat: --bg flag to dispatch agents via claude agent view

### DIFF
--- a/.factory.bak
+++ b/.factory.bak
@@ -1,0 +1,1 @@
+/Users/akash/cursor-projects/remote-factory/.factory

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -138,6 +138,7 @@ async def invoke_agent(
     session_name: str | None = None,
     use_profile: bool = False,
     tmux_persist: bool = False,
+    background: bool = False,
 ) -> tuple[str, int]:
     """Invoke a Claude Code agent with the resolved prompt + task.
 
@@ -155,6 +156,7 @@ async def invoke_agent(
             If not provided, defaults to "factory: {project_name}/{role}".
         use_profile: If True, inject user profile into the agent prompt.
         tmux_persist: If True, run the agent interactively in a tmux window.
+        background: If True, dispatch via claude --bg (agent view).
 
     Returns (stdout, return_code).
 
@@ -185,6 +187,7 @@ async def invoke_agent(
             role=role,
             session_name=agent_session_name,
             tmux_persist=tmux_persist,
+            background=background,
         )
     except Exception as e:
         logger.error("%s agent failed: %s", role, e)
@@ -286,6 +289,7 @@ async def invoke_agents_parallel(
     model: str | None = None,
     runner_name: str | None = None,
     tmux_persist: bool = False,
+    background: bool = False,
 ) -> list[tuple[str, int]]:
     """Invoke multiple agents concurrently. Returns list of (output, return_code).
 
@@ -304,6 +308,7 @@ async def invoke_agents_parallel(
             runner_name=runner_name,
             _track_failures=False,  # Avoid race condition; track locally below
             tmux_persist=tmux_persist,
+            background=background,
         )
         for role, task in tasks
     ]

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -388,6 +388,7 @@ async def run_ceo_with_completion_guard(
     session_name: str | None = None,
     use_profile: bool = False,
     tmux_persist: bool = False,
+    background: bool = False,
 ) -> tuple[str, int]:
     """Spawn CEO; if it exits with planned work undone, re-spawn until done or cap hit.
 
@@ -405,11 +406,20 @@ async def run_ceo_with_completion_guard(
         session_name: Optional session name for /resume identification.
         use_profile: If True, inject user profile into the CEO prompt.
         tmux_persist: If True, run agents in tmux windows.
+        background: If True, dispatch via claude --bg (single dispatch, no respawn).
 
     Returns:
         (final_output, exit_code)
     """
     from factory.agents.runner import invoke_agent
+
+    if background:
+        log.info("ceo_background_dispatch", reason="--bg: single dispatch, no respawn loop")
+        return await invoke_agent(
+            "ceo", initial_task, project_path,
+            timeout=timeout, model=model, runner_name=runner_name,
+            background=True,
+        )
 
     # Check escape hatch
     from factory.user_config import resolve

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2179,6 +2179,8 @@ def cmd_agent(args: argparse.Namespace) -> int:
     use_profile = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
 
+    background = _resolve_background(args)
+
     result, code = _run(invoke_agent(
         role,
         task,
@@ -2189,6 +2191,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
         runner_name=runner,
         use_profile=use_profile,
         tmux_persist=tmux_persist,
+        background=background,
     ))
     print(result)
     return code
@@ -2238,7 +2241,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     raw_path = getattr(args, "path", None)
     mode = getattr(args, "mode", "auto")
-    headless = getattr(args, "headless", False)
+    headless = getattr(args, "headless", False) or getattr(args, "bg", False)
     prompt_file = getattr(args, "prompt", None)
     focus = getattr(args, "focus", None)
     dir_name = getattr(args, "dir", None)
@@ -2372,6 +2375,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     runner_name = _resolve_runner(args)
     use_profile = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
+    background = _resolve_background(args)
     clean_pr_flag = getattr(args, "clean_pr", None)
 
     if mode == "research" and not research_ideation and not _has_research_target(project_path):
@@ -2476,6 +2480,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 session_name=session_name,
                 use_profile=use_profile,
                 tmux_persist=tmux_persist,
+                background=background,
             ))
             print(result)
             if code == 0:
@@ -2489,6 +2494,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 already_improved=mode in ("improve", "meta") or discover_only,
                 model=model, no_github=no_github, use_profile=use_profile,
                 tmux_persist=tmux_persist,
+                background=background,
             )
         finally:
             remove_worktree(project_path, wt_path, wt_branch)
@@ -2541,6 +2547,16 @@ def _resolve_tmux_persist(args: argparse.Namespace) -> bool:
     cli_flag = getattr(args, "tmux_persist", False)
     cli_value = "true" if cli_flag else None
     val = resolve("tmux_persist", cli_value=cli_value, env_var="FACTORY_TMUX_PERSIST", default="false")
+    return bool(val and val.lower() in ("1", "true", "yes"))
+
+
+def _resolve_background(args: argparse.Namespace) -> bool:
+    """Resolve background: CLI flag > FACTORY_BG env var > config.toml > False."""
+    from factory.user_config import resolve
+
+    cli_flag = getattr(args, "bg", False)
+    cli_value = "true" if cli_flag else None
+    val = resolve("bg", cli_value=cli_value, env_var="FACTORY_BG", default="false")
     return bool(val and val.lower() in ("1", "true", "yes"))
 
 
@@ -3267,6 +3283,7 @@ def _chain_modes(
     no_github: bool = False,
     use_profile: bool = False,
     tmux_persist: bool = False,
+    background: bool = False,
 ) -> int:
     """After a cycle completes, re-detect state and chain into the next mode.
 
@@ -3294,7 +3311,7 @@ def _chain_modes(
             project_path, next_mode, focus=focus,
             min_growth=min_growth, max_new=max_new, branch=branch,
             no_github=no_github, model=model, use_profile=use_profile,
-            tmux_persist=tmux_persist,
+            tmux_persist=tmux_persist, background=background,
         )
         if code != 0:
             return code
@@ -3318,6 +3335,7 @@ def _run_single_cycle(
     use_profile: bool = False,
     clean_pr: bool = False,
     tmux_persist: bool = False,
+    background: bool = False,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
     from factory.agents.runner import invoke_agent
@@ -3355,6 +3373,7 @@ def _run_single_cycle(
             model=model,
             use_profile=use_profile,
             tmux_persist=tmux_persist,
+            background=background,
         ))
 
         if code == 0:
@@ -3386,6 +3405,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     model = _resolve_model(args)
     use_profile_flag = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
+    background = _resolve_background(args)
 
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
@@ -3460,6 +3480,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             use_profile=use_profile_flag,
             clean_pr=clean_pr_resolved,
             tmux_persist=tmux_persist,
+            background=background,
             **budget_kwargs,
         )
         if code != 0:
@@ -3469,6 +3490,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             min_growth=min_growth, max_new=max_new, branch=branch,
             model=model, no_github=no_github, use_profile=use_profile_flag,
             tmux_persist=tmux_persist,
+            background=background,
         )
 
     # Heartbeat loop mode
@@ -3500,6 +3522,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 use_profile=use_profile_flag,
                 clean_pr=clean_pr_resolved,
                 tmux_persist=tmux_persist,
+                background=background,
                 **budget_kwargs,
             )
             _chain_modes(
@@ -3507,6 +3530,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 min_growth=min_growth, max_new=max_new, branch=branch,
                 model=model, no_github=no_github, use_profile=use_profile_flag,
                 tmux_persist=tmux_persist,
+                background=background,
             )
             _emit_cli_event(project_path, "cycle.completed", {"cycle": cycle, "mode": mode})
 
@@ -3900,6 +3924,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Inject user profile (~/.factory/profile.md) into the agent prompt")
     p.add_argument("--tmux-persist", action="store_true", default=False,
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
+    p.add_argument("--bg", action="store_true", default=False,
+                    help="Dispatch agent as a background session via claude agent view (claude only)")
 
     # ceo — launch the Factory CEO agent directly
     p = sub.add_parser("ceo", help="Launch the Factory CEO agent (interactive by default)")
@@ -3968,6 +3994,8 @@ def build_parser() -> argparse.ArgumentParser:
                                 help="Disable clean PR mode")
     p.add_argument("--tmux-persist", action="store_true", default=False,
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
+    p.add_argument("--bg", action="store_true", default=False,
+                    help="Dispatch agent as a background session via claude agent view (claude only)")
 
     # run
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
@@ -4031,6 +4059,8 @@ def build_parser() -> argparse.ArgumentParser:
                                     help="Disable clean PR mode")
     p.add_argument("--tmux-persist", action="store_true", default=False,
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
+    p.add_argument("--bg", action="store_true", default=False,
+                    help="Dispatch agent as a background session via claude agent view (claude only)")
 
     # tmux — launch factory run in a detached tmux session
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -1,10 +1,11 @@
-"""Tmux persist — launch agents interactively in tmux with output capture."""
+"""Alternative agent execution modes — tmux windows and background sessions."""
 
 from __future__ import annotations
 
 import asyncio
 import hashlib
 import logging
+import os
 import platform
 import re
 import shlex
@@ -170,3 +171,111 @@ def _cleanup(tmpdir: Path) -> None:
         tmpdir.rmdir()
     except OSError:
         pass
+
+
+# ── Background (agent view) mode ─────────────────────────────
+
+_BG_POLL_INTERVAL = 5.0
+_BG_TERMINAL_STATES = {"done", "completed", "failed", "stopped"}
+_CLAUDE_JOBS_DIR = Path("~/.claude/jobs").expanduser()
+
+
+def _parse_bg_session_id(output: str) -> str | None:
+    """Parse session ID from `claude --bg` output.
+
+    Expected format: 'backgrounded · <hex_id> [· <name>]'
+    """
+    for line in output.splitlines():
+        if line.startswith("backgrounded"):
+            parts = line.split("·")
+            if len(parts) >= 2:
+                return parts[1].strip()
+    return None
+
+
+def _read_session_state(session_id: str) -> dict | None:
+    state_file = _CLAUDE_JOBS_DIR / session_id / "state.json"
+    if not state_file.exists():
+        return None
+    try:
+        import json
+        return json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+async def run_in_background(
+    prompt: str,
+    task: str,
+    cwd: Path,
+    role: str,
+    *,
+    timeout: float = _DEFAULT_TMUX_TIMEOUT,
+    model: str | None = None,
+    dangerously_skip_permissions: bool = True,
+) -> tuple[str, int, None]:
+    """Launch claude as a background session via --bg (agent view).
+
+    The session is visible in `claude agents`. The factory polls for
+    completion and returns the output when the session finishes.
+
+    Returns (stdout, return_code, None). Usage is always None for bg mode.
+    """
+    session_name = f"factory-{role}"
+
+    cmd = ["claude", "--bg", "--name", session_name, "--append-system-prompt", prompt, task]
+    if dangerously_skip_permissions:
+        cmd.append("--dangerously-skip-permissions")
+    if model:
+        cmd.extend(["--model", model])
+
+    logger.info("Launching background agent: role=%s, cwd=%s", role, cwd)
+
+    env = dict(os.environ)
+    env["FACTORY_BG"] = "1"
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+    except FileNotFoundError:
+        logger.error("'claude' CLI not found on PATH")
+        return "Error: 'claude' CLI not found on PATH", 1, None
+    except subprocess.TimeoutExpired:
+        logger.error("claude --bg timed out during launch")
+        return "Error: claude --bg timed out during launch", 1, None
+
+    output = result.stdout + result.stderr
+    session_id = _parse_bg_session_id(output)
+
+    if result.returncode != 0 or not session_id:
+        logger.warning("Failed to launch background agent: %s", output[:200])
+        return f"Failed to launch background agent for {role}: {output[:200]}", 1, None
+
+    print(f"Agent '{role}' launched in background: {session_id}", file=sys.stderr)
+    print(f"  claude attach {session_id}    # attach to interact", file=sys.stderr)
+
+    elapsed = 0.0
+    while elapsed < timeout:
+        await asyncio.sleep(_BG_POLL_INTERVAL)
+        elapsed += _BG_POLL_INTERVAL
+
+        state = _read_session_state(session_id)
+        if state and state.get("state") in _BG_TERMINAL_STATES:
+            session_output = ""
+            if isinstance(state.get("output"), dict):
+                session_output = state["output"].get("result", "")
+            elif isinstance(state.get("output"), str):
+                session_output = state["output"]
+
+            is_success = state["state"] in ("done", "completed")
+            return session_output, 0 if is_success else 1, None
+
+    logger.error("Background agent timed out after %ss: role=%s", timeout, role)
+    subprocess.run(["claude", "stop", session_id], capture_output=True)
+    return f"Agent timed out after {timeout}s", 1, None

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -200,6 +200,7 @@ class BobRunner:
         role: str = "unknown",
         session_name: str | None = None,
         tmux_persist: bool = False,
+        background: bool = False,
     ) -> tuple[str, int, None]:
         """Run a headless Bob Shell invocation.
 
@@ -208,6 +209,8 @@ class BobRunner:
         _ = session_name
         if tmux_persist:
             logger.warning("tmux_persist not supported with bob runner")
+        if background:
+            logger.warning("--bg not supported with bob runner (claude-only feature)")
         self._role = role
         project_path = self._find_project_path(cwd)
 

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -52,6 +52,7 @@ class ClaudeRunner:
         role: str = "unknown",
         session_name: str | None = None,
         tmux_persist: bool = False,
+        background: bool = False,
     ) -> tuple[str, int, "AgentUsage | None"]:
         """Run a headless Claude Code invocation.
 
@@ -65,9 +66,19 @@ class ClaudeRunner:
             role: Agent role (used for streaming prefix).
             session_name: Optional session name for identification in /resume.
             tmux_persist: If True, run the agent interactively in a tmux window.
+            background: If True, dispatch via claude --bg (agent view).
 
         Returns (stdout, return_code, usage).
         """
+        if background:
+            from factory.runners._tmux_persist import run_in_background
+
+            return await run_in_background(
+                prompt, task, cwd, role,
+                model=model,
+                dangerously_skip_permissions=dangerously_skip_permissions,
+            )
+
         if tmux_persist:
             from factory.runners._tmux_persist import find_project_path, run_in_tmux, tmux_available
 

--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -70,6 +70,7 @@ class CodexRunner:
         role: str = "unknown",
         session_name: str | None = None,
         tmux_persist: bool = False,
+        background: bool = False,
     ) -> tuple[str, int, None]:
         """Run a headless Codex CLI invocation via ``codex exec``.
 
@@ -81,6 +82,8 @@ class CodexRunner:
         _ = session_name
         if tmux_persist:
             logger.warning("tmux_persist not supported with codex runner")
+        if background:
+            logger.warning("--bg not supported with codex runner (claude-only feature)")
         if is_codex_dry_run():
             stdout, code = self._dry_run_response(role, cwd, task)
             return stdout, code, None

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -26,6 +26,7 @@ class Runner(Protocol):
         role: str = "unknown",
         session_name: str | None = None,
         tmux_persist: bool = False,
+        background: bool = False,
     ) -> tuple[str, int, AgentUsage | None]:
         """Run a headless (non-interactive) agent invocation.
 

--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -35,6 +35,7 @@ _CONFIG_TEMPLATE = """\
 # model = ""                           # Claude model for agent subprocesses
 # projects_dir = "~/factory-projects"  # Root for factory-managed projects
 # tmux_persist = false                 # Launch agents in tmux windows
+# bg = false                           # Dispatch agents via claude --bg (agent view)
 
 # [credentials.vertex]
 # FACTORY_RUNNER = "claude"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -112,7 +112,7 @@ class TestInvokeAgentsParallel:
 
         call_count = 0
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, background=False):
             nonlocal call_count
             call_count += 1
             return (f"output-{role}", 0)
@@ -132,7 +132,7 @@ class TestInvokeAgentsParallel:
         """invoke_agents_parallel returns results from all agents."""
         from factory.agents.runner import invoke_agents_parallel
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, background=False):
             return (f"output-{role}", 0)
 
         monkeypatch.setattr("factory.agents.runner.invoke_agent", mock_invoke)
@@ -153,7 +153,7 @@ class TestInvokeAgentsParallel:
 
         captured_models: list[str | None] = []
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, background=False):
             captured_models.append(model)
             return (f"output-{role}", 0)
 


### PR DESCRIPTION
## Summary

- Add `--bg` flag that dispatches agents as background sessions via `claude --bg`, visible in `claude agents`
- Factory polls `~/.claude/jobs/<id>/state.json` for completion and returns output — CEO orchestration loop works as before
- `--bg` implies headless for `factory ceo`, skips completion guard respawn loop (single dispatch)
- Propagates `FACTORY_BG=1` to sub-agent environment so the full fleet appears in agent view
- Configurable via `--bg` CLI flag, `FACTORY_BG` env var, or `bg = true` in `~/.factory/config.toml`
- Bob/Codex runners log a warning (claude-only feature)
- Builds on top of PR #285 (tmux persist mode)

## Test plan

- [x] All 2175 tests pass
- [x] Lint clean
- [ ] Manual: `factory agent researcher --task "list files" --project /tmp/test --bg`
- [ ] Manual: `factory ceo /path --bg --mode discover` — single session in `claude agents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)