### PR TITLE
feat: Agent-Runner Abstraction (Phases H1-H5)

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 from factory.ace.injector import inject_playbook, load_playbook
 from factory.runners import get_runner
+from factory.runners.abstraction import AgentRunner, Request
 
 logger = logging.getLogger(__name__)
 
@@ -175,17 +176,33 @@ async def invoke_agent(
     agent_session_name = session_name or f"factory: {project_path.resolve().name}/{role}"
 
     try:
-        stdout, return_code, usage = await runner.headless(
-            prompt=prompt,
-            task=task,
-            cwd=project_path,
-            timeout=timeout,
-            model=model,
-            dangerously_skip_permissions=dangerously_skip_permissions,
-            role=role,
-            session_name=agent_session_name,
-            tmux_persist=tmux_persist,
-        )
+        if isinstance(runner, AgentRunner):
+            request = Request(
+                system_prompt=prompt,
+                task=task,
+                cwd=project_path,
+                timeout=timeout,
+                model=model,
+                skip_permissions=dangerously_skip_permissions,
+                session_name=agent_session_name,
+                tmux_persist=tmux_persist,
+                role=role,
+            )
+            response = await runner.run(request)
+            stdout, return_code, usage = response.output, response.exit_code, response.usage
+        else:
+            # Legacy runners (Bob, Codex) — will be migrated in Phase 3
+            stdout, return_code, usage = await runner.headless(
+                prompt=prompt,
+                task=task,
+                cwd=project_path,
+                timeout=timeout,
+                model=model,
+                dangerously_skip_permissions=dangerously_skip_permissions,
+                role=role,
+                session_name=agent_session_name,
+                tmux_persist=tmux_persist,
+            )
     except Exception as e:
         logger.error("%s agent failed: %s", role, e)
         _emit_safe(project_path, "agent.failed", agent=role, data={"error": str(e)[:200]})

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 from factory.ace.injector import inject_playbook, load_playbook
 from factory.runners import get_runner
-from factory.runners.abstraction import AgentRunner, Request
+from factory.runners.abstraction import Request
 
 logger = logging.getLogger(__name__)
 
@@ -176,33 +176,19 @@ async def invoke_agent(
     agent_session_name = session_name or f"factory: {project_path.resolve().name}/{role}"
 
     try:
-        if isinstance(runner, AgentRunner):
-            request = Request(
-                system_prompt=prompt,
-                task=task,
-                cwd=project_path,
-                timeout=timeout,
-                model=model,
-                skip_permissions=dangerously_skip_permissions,
-                session_name=agent_session_name,
-                tmux_persist=tmux_persist,
-                role=role,
-            )
-            response = await runner.run(request)
-            stdout, return_code, usage = response.output, response.exit_code, response.usage
-        else:
-            # Legacy runners (Bob, Codex) — will be migrated in Phase 3
-            stdout, return_code, usage = await runner.headless(
-                prompt=prompt,
-                task=task,
-                cwd=project_path,
-                timeout=timeout,
-                model=model,
-                dangerously_skip_permissions=dangerously_skip_permissions,
-                role=role,
-                session_name=agent_session_name,
-                tmux_persist=tmux_persist,
-            )
+        request = Request(
+            system_prompt=prompt,
+            task=task,
+            cwd=project_path,
+            timeout=timeout,
+            model=model,
+            skip_permissions=dangerously_skip_permissions,
+            session_name=agent_session_name,
+            tmux_persist=tmux_persist,
+            role=role,
+        )
+        response = await runner.run(request)
+        stdout, return_code, usage = response.output, response.exit_code, response.usage
     except Exception as e:
         logger.error("%s agent failed: %s", role, e)
         _emit_safe(project_path, "agent.failed", agent=role, data={"error": str(e)[:200]})

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -331,12 +331,27 @@ def _classify_with_llm(
         old_quiet = os.environ.get("FACTORY_RUNNER_QUIET")
         os.environ["FACTORY_RUNNER_QUIET"] = "1"
         try:
-            result, code, _usage = _run(runner.headless(
-                prompt, task, Path.cwd(),
-                timeout=60.0,
-                dangerously_skip_permissions=True,
-                role="wizard",
-            ))
+            from factory.runners.abstraction import AgentRunner as _AgentRunner
+            from factory.runners.abstraction import Request as _Request
+
+            if isinstance(runner, _AgentRunner):
+                _req = _Request(
+                    system_prompt=prompt,
+                    task=task,
+                    cwd=str(Path.cwd()),
+                    timeout=60.0,
+                    skip_permissions=True,
+                    role="wizard",
+                )
+                _resp = _run(runner.run(_req))
+                result, code = _resp.output, _resp.exit_code
+            else:
+                result, code, _usage = _run(runner.headless(
+                    prompt, task, Path.cwd(),
+                    timeout=60.0,
+                    dangerously_skip_permissions=True,
+                    role="wizard",
+                ))
         finally:
             if old_quiet is None:
                 os.environ.pop("FACTORY_RUNNER_QUIET", None)
@@ -2515,13 +2530,28 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             mark_read(project_path, pending_ids)
+        from factory.runners.abstraction import AgentRunner as _AgentRunner
+        from factory.runners.abstraction import Request as _Request
+
         prompt = resolve_prompt("ceo", wt_path, use_profile=use_profile)
         runner = get_runner(runner_name)
-        return runner.interactive_run(
-            prompt, task, wt_path,
-            model=model, role="ceo", dangerously_skip_permissions=True,
-            session_name=session_name,
-        )
+        if isinstance(runner, _AgentRunner):
+            _req = _Request(
+                system_prompt=prompt,
+                task=task,
+                cwd=wt_path,
+                model=model,
+                skip_permissions=True,
+                session_name=session_name,
+                role="ceo",
+            )
+            return runner.run_interactive(_req)
+        else:
+            return runner.interactive_run(
+                prompt, task, wt_path,
+                model=model, role="ceo", dangerously_skip_permissions=True,
+                session_name=session_name,
+            )
     finally:
         remove_worktree(project_path, wt_path, wt_branch)
         if needs_materialize and _is_scaffold_only(project_path):

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -723,6 +723,38 @@ def cmd_home(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_health(args: argparse.Namespace) -> int:
+    """Check health of all registered runners and print status table."""
+    from factory.runners import _RUNNERS, BobRunner
+
+    from factory.user_config import resolve
+
+    default_runner = resolve("runner", env_var="FACTORY_RUNNER", default="claude") or "claude"
+
+    default_ok = False
+
+    for name, cls in _RUNNERS.items():
+        try:
+            if cls is BobRunner:
+                runner = cls()
+            else:
+                runner = cls()
+            ok, msg = _run(runner.check_health())
+        except Exception as e:
+            ok, msg = False, str(e)
+
+        if name == default_runner:
+            default_ok = ok
+
+        if ok:
+            status = "\033[32mOK\033[0m"
+        else:
+            status = "\033[31mFAIL\033[0m"
+        print(f"  {name:<12} {status}    {msg}")
+
+    return 0 if default_ok else 1
+
+
 def cmd_detect(args: argparse.Namespace) -> int:
     from factory.state import detect_state
 
@@ -3601,6 +3633,9 @@ def build_parser() -> argparse.ArgumentParser:
     # home
     sub.add_parser("home", help="Print factory installation root directory")
 
+    # health
+    sub.add_parser("health", help="Check health of all registered runners")
+
     # detect
     p = sub.add_parser("detect", help="Print project state")
     p.add_argument("path", help="Path to the project")
@@ -4120,6 +4155,7 @@ def main(argv: list[str] | None = None) -> int:
 
     handlers = {
         "home": cmd_home,
+        "health": cmd_health,
         "detect": cmd_detect,
         "discover": cmd_discover,
         "init": cmd_init,

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3910,7 +3910,7 @@ def build_parser() -> argparse.ArgumentParser:
                          help="Project paths to collect evidence from (default: all registered)")
     p_build.add_argument("--dry-run", action="store_true", default=False,
                          help="Print collected evidence without running LLM synthesis")
-    p_build.add_argument("--runner", choices=["claude", "bob", "codex"], default=None,
+    p_build.add_argument("--runner", choices=["claude", "bob", "codex", "opencode", "aider"], default=None,
                          help="CLI backend to use for synthesis")
     profile_sub.add_parser("show", help="Print the current user profile")
 
@@ -3933,7 +3933,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Timeout in seconds (default: 600)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocess (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex", "opencode", "aider"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -3991,7 +3991,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Target branch for PRs (default: from factory.md, fallback: main)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex", "opencode", "aider"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -4059,7 +4059,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Target branch for PRs (default: from factory.md, fallback: main)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex", "opencode", "aider"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -4094,7 +4094,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex", "opencode", "aider"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
 
     # tmux-ls — list factory tmux sessions

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -6,20 +6,24 @@ from pathlib import Path
 from typing import Literal
 
 from factory.runners._stream import should_stream, stream_subprocess
+from factory.runners.abstraction import AgentRunner, Request, Response
 from factory.runners.bob import BobRunner, is_dry_run
 from factory.runners.claude import ClaudeRunner
 from factory.runners.codex import CodexRunner, is_codex_dry_run
 from factory.runners.protocol import Runner
 
 __all__ = [
-    "Runner",
-    "ClaudeRunner",
+    "AgentRunner",
     "BobRunner",
+    "ClaudeRunner",
     "CodexRunner",
-    "get_runner",
+    "Request",
+    "Response",
+    "Runner",
     "RunnerName",
-    "is_dry_run",
+    "get_runner",
     "is_codex_dry_run",
+    "is_dry_run",
     "should_stream",
     "stream_subprocess",
 ]
@@ -58,7 +62,7 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
         raise ValueError(f"Unknown runner '{resolved}'. Available: {available}")
 
     if resolved == "bob":
-        return BobRunner(project_path=project_path)
+        return BobRunner(project_path=project_path)  # type: ignore[return-value]
     return _RUNNERS[resolved]()
 
 

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -7,16 +7,20 @@ from typing import Literal
 
 from factory.runners._stream import should_stream, stream_subprocess
 from factory.runners.abstraction import AgentRunner, Request, Response
+from factory.runners.aider import AiderRunner
 from factory.runners.bob import BobRunner, is_dry_run
 from factory.runners.claude import ClaudeRunner
 from factory.runners.codex import CodexRunner, is_codex_dry_run
+from factory.runners.opencode import OpenCodeRunner
 from factory.runners.protocol import Runner
 
 __all__ = [
     "AgentRunner",
+    "AiderRunner",
     "BobRunner",
     "ClaudeRunner",
     "CodexRunner",
+    "OpenCodeRunner",
     "Request",
     "Response",
     "Runner",
@@ -28,16 +32,18 @@ __all__ = [
     "stream_subprocess",
 ]
 
-RunnerName = Literal["claude", "bob", "codex"]
+RunnerName = Literal["claude", "bob", "codex", "opencode", "aider"]
 
-_RUNNERS: dict[str, type[Runner]] = {
-    "claude": ClaudeRunner,  # type: ignore[dict-item]
-    "bob": BobRunner,  # type: ignore[dict-item]
-    "codex": CodexRunner,  # type: ignore[dict-item]
+_RUNNERS: dict[str, type[AgentRunner]] = {
+    "claude": ClaudeRunner,
+    "bob": BobRunner,
+    "codex": CodexRunner,
+    "opencode": OpenCodeRunner,
+    "aider": AiderRunner,
 }
 
 
-def get_runner(name: str | None = None, project_path: Path | None = None) -> Runner:
+def get_runner(name: str | None = None, project_path: Path | None = None) -> AgentRunner:
     """Get a runner by name.
 
     Resolution order:
@@ -46,7 +52,7 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
     3. Default to "claude"
 
     Args:
-        name: Runner name ("claude", "bob", or "codex").
+        name: Runner name ("claude", "bob", "codex", "opencode", or "aider").
         project_path: Path to the project. Passed to BobRunner for cycle state lookup.
 
     Raises:
@@ -62,10 +68,10 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
         raise ValueError(f"Unknown runner '{resolved}'. Available: {available}")
 
     if resolved == "bob":
-        return BobRunner(project_path=project_path)  # type: ignore[return-value]
+        return BobRunner(project_path=project_path)
     return _RUNNERS[resolved]()
 
 
-def register_runner(name: str, runner_class: type[Runner]) -> None:
-    """Register a runner implementation (used by bob module on import)."""
+def register_runner(name: str, runner_class: type[AgentRunner]) -> None:
+    """Register a runner implementation."""
     _RUNNERS[name] = runner_class

--- a/factory/runners/abstraction.py
+++ b/factory/runners/abstraction.py
@@ -122,6 +122,14 @@ class AgentRunner(ABC):
         """Parse raw subprocess output into a Response."""
         ...
 
+    @property
+    def _sanitize_output(self) -> bool:
+        """Whether to sanitize ANSI escape sequences from streamed output.
+
+        Override in subclasses (e.g. BobRunner) that emit raw terminal sequences.
+        """
+        return False
+
     def _build_env(self, request: Request) -> dict[str, str]:
         """Build the subprocess environment.
 
@@ -183,7 +191,10 @@ class AgentRunner(ABC):
                     env=env,
                 )
                 stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                    stream_subprocess(proc, stream=stream, prefix=prefix),
+                    stream_subprocess(
+                        proc, stream=stream, prefix=prefix,
+                        sanitize=self._sanitize_output,
+                    ),
                     timeout=request.timeout,
                 )
             except asyncio.TimeoutError:

--- a/factory/runners/abstraction.py
+++ b/factory/runners/abstraction.py
@@ -245,3 +245,56 @@ class AgentRunner(ABC):
             return result.returncode
         finally:
             Path(prompt_file.name).unlink(missing_ok=True)
+
+    # ── Backward-compat shims (Phase 2 migration) ────────────────
+
+    async def headless(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        timeout: float = 600.0,
+        model: str | None = None,
+        dangerously_skip_permissions: bool = True,
+        role: str = "unknown",
+        session_name: str | None = None,
+        tmux_persist: bool = False,
+    ) -> tuple[str, int, AgentUsage | None]:
+        """Backward-compat shim — delegates to run()."""
+        request = Request(
+            system_prompt=prompt,
+            task=task,
+            cwd=cwd,
+            timeout=timeout,
+            model=model,
+            skip_permissions=dangerously_skip_permissions,
+            session_name=session_name,
+            tmux_persist=tmux_persist,
+            role=role,
+        )
+        response = await self.run(request)
+        return response.output, response.exit_code, response.usage
+
+    def interactive_run(
+        self,
+        prompt: str,
+        task: str,
+        cwd: Path,
+        *,
+        model: str | None = None,
+        role: str = "ceo",
+        dangerously_skip_permissions: bool = False,
+        session_name: str | None = None,
+    ) -> int:
+        """Backward-compat shim — delegates to run_interactive()."""
+        request = Request(
+            system_prompt=prompt,
+            task=task,
+            cwd=cwd,
+            model=model,
+            skip_permissions=dangerously_skip_permissions,
+            session_name=session_name,
+            role=role,
+        )
+        return self.run_interactive(request)

--- a/factory/runners/abstraction.py
+++ b/factory/runners/abstraction.py
@@ -1,12 +1,43 @@
 """Agent-Runner abstraction — base class and core types for CLI backends.
 
+The 3-method contract
+---------------------
 Concrete runners implement three methods:
-  - identity (property): declares name, display_name, binary, capabilities
-  - _build_command(request, *, prompt_file): maps Request fields to CLI args
-  - _parse_response(stdout, stderr, exit_code): extracts Response from raw output
+
+  - ``identity`` (property) → ``RunnerIdentity``
+        Declares name, display_name, binary, and capabilities for registry
+        and health-check purposes.
+
+  - ``_build_command(request, *, prompt_file)`` → ``list[str]``
+        Maps ``Request`` fields to CLI args for the specific backend.
+        ``prompt_file`` is a temp file containing ``request.system_prompt``.
+
+  - ``_parse_response(stdout, stderr, exit_code)`` → ``Response``
+        Extracts structured output from raw subprocess results. Runners with
+        JSON output (e.g. Claude) parse it here; others return raw stdout.
 
 The base class handles the shared subprocess lifecycle (temp file management,
-env isolation, streaming, timeout enforcement) via run() and run_interactive().
+env isolation, streaming, timeout enforcement) via ``run()`` and
+``run_interactive()``.  Override ``_build_env()`` for custom environment setup
+(e.g. API key mapping, PATH manipulation).
+
+Adding a new runner
+-------------------
+1. Create ``factory/runners/<name>.py`` with a class extending ``AgentRunner``.
+2. Implement ``identity``, ``_build_command``, and ``_parse_response``.
+3. Register it in ``factory/runners/__init__.py`` → ``_RUNNERS`` dict.
+4. Update the ``RunnerName`` Literal type in ``__init__.py``.
+5. Add tests in ``tests/test_runner_integration.py``.
+
+Request.prompt vs Request.system_prompt / Request.task
+------------------------------------------------------
+``Request.system_prompt`` is WHO the agent is (role prompt + playbook).
+``Request.task`` is WHAT to do (the work request).
+``Request.prompt`` is a convenience property that combines both, separated by a
+``---`` divider.  Runners that support native system-prompt separation (e.g.
+Claude's ``--append-system-prompt-file``) use ``system_prompt`` and ``task``
+independently.  Runners without that feature (e.g. Aider, Bob) use the combined
+``prompt`` property.
 """
 
 from __future__ import annotations

--- a/factory/runners/abstraction.py
+++ b/factory/runners/abstraction.py
@@ -1,0 +1,247 @@
+"""Agent-Runner abstraction — base class and core types for CLI backends.
+
+Concrete runners implement three methods:
+  - identity (property): declares name, display_name, binary, capabilities
+  - _build_command(request, *, prompt_file): maps Request fields to CLI args
+  - _parse_response(stdout, stderr, exit_code): extracts Response from raw output
+
+The base class handles the shared subprocess lifecycle (temp file management,
+env isolation, streaming, timeout enforcement) via run() and run_interactive().
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from factory.runners._stream import should_stream, stream_subprocess
+
+if TYPE_CHECKING:
+    from factory.models import AgentUsage
+
+logger = logging.getLogger(__name__)
+
+
+# ── Core types ────────────────────────────────────────────────────
+
+
+@dataclass
+class Request:
+    """Describes what to run and how."""
+
+    system_prompt: str
+    task: str
+    cwd: str | Path
+    timeout: float = 600.0
+    model: str | None = None
+    skip_permissions: bool = True
+    session_name: str | None = None
+    env: dict[str, str] | None = None
+    tmux_persist: bool = False
+    role: str = "unknown"
+
+    @property
+    def prompt(self) -> str:
+        """Combined system_prompt + task for agents that don't separate them."""
+        return f"{self.system_prompt}\n\n---\n\n## Current Task\n\n{self.task}"
+
+
+@dataclass
+class Response:
+    """Result from an agent invocation."""
+
+    output: str
+    exit_code: int
+    usage: AgentUsage | None = None
+    error: str | None = None
+
+
+class Capability(Enum):
+    """Optional features a runner may support."""
+
+    MODEL_OVERRIDE = "model_override"
+    SESSION_RESUME = "session_resume"
+    SYSTEM_PROMPT_FILE = "system_prompt_file"
+    STREAMING = "streaming"
+    INTERACTIVE = "interactive"
+    SANDBOXING = "sandboxing"
+    STRUCTURED_OUTPUT = "structured_output"
+
+
+@dataclass
+class RunnerIdentity:
+    """Static metadata about a runner implementation."""
+
+    name: str
+    display_name: str
+    binary: str = ""
+    capabilities: set[Capability] = field(default_factory=set)
+
+    def __post_init__(self) -> None:
+        if not self.binary:
+            self.binary = self.name
+
+
+# ── Base class ────────────────────────────────────────────────────
+
+
+class AgentRunner(ABC):
+    """Abstract base class for CLI agent backends."""
+
+    @property
+    @abstractmethod
+    def identity(self) -> RunnerIdentity:
+        """Return static metadata about this runner."""
+        ...
+
+    @abstractmethod
+    def _build_command(
+        self, request: Request, *, prompt_file: str | None = None
+    ) -> list[str]:
+        """Build the CLI command list for the given request.
+
+        Args:
+            request: The agent request.
+            prompt_file: Path to a temp file containing the system prompt.
+        """
+        ...
+
+    @abstractmethod
+    def _parse_response(
+        self, stdout: str, stderr: str, exit_code: int
+    ) -> Response:
+        """Parse raw subprocess output into a Response."""
+        ...
+
+    def _build_env(self, request: Request) -> dict[str, str]:
+        """Build the subprocess environment.
+
+        Base implementation copies os.environ, strips VIRTUAL_ENV,
+        and merges any extra env vars from the request.
+        """
+        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        if request.env:
+            env.update(request.env)
+        return env
+
+    async def check_health(self) -> tuple[bool, str]:
+        """Check whether this runner's binary is available on PATH."""
+        binary = self.identity.binary
+        path = shutil.which(binary)
+        if path:
+            return True, f"{self.identity.display_name} found at {path}"
+        return False, f"'{binary}' not found in PATH"
+
+    async def run(self, request: Request) -> Response:
+        """Run a headless agent invocation.
+
+        Lifecycle:
+        1. Write system_prompt to a temp file
+        2. Build env via _build_env()
+        3. Build command via _build_command()
+        4. Spawn subprocess, stream output via stream_subprocess()
+        5. Enforce timeout (kill on TimeoutError)
+        6. Parse output via _parse_response()
+        7. Clean up temp file
+        """
+        cwd = Path(request.cwd)
+        ident = self.identity
+
+        prompt_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", prefix="factory-prompt-", delete=False,
+        )
+        try:
+            prompt_file.write(request.system_prompt)
+            prompt_file.close()
+
+            env = self._build_env(request)
+            cmd = self._build_command(request, prompt_file=prompt_file.name)
+
+            logger.info(
+                "%s run: cwd=%s, model=%s, role=%s",
+                ident.display_name, cwd, request.model, request.role,
+            )
+
+            stream = should_stream()
+            prefix = f"[{ident.name}:{request.role}]" if stream else None
+
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=cwd,
+                    env=env,
+                )
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    stream_subprocess(proc, stream=stream, prefix=prefix),
+                    timeout=request.timeout,
+                )
+            except asyncio.TimeoutError:
+                proc.kill()  # type: ignore[union-attr]
+                await proc.wait()  # type: ignore[union-attr]
+                logger.error(
+                    "%s timed out after %ss", ident.display_name, request.timeout,
+                )
+                return Response(
+                    output=f"Agent timed out after {request.timeout}s",
+                    exit_code=1,
+                    error=f"Timeout after {request.timeout}s",
+                )
+            except FileNotFoundError:
+                logger.error("'%s' CLI not found on PATH", ident.binary)
+                return Response(
+                    output=f"Error: '{ident.binary}' CLI not found on PATH",
+                    exit_code=1,
+                    error=f"'{ident.binary}' not found on PATH",
+                )
+
+            raw_stdout = stdout_bytes.decode()
+            raw_stderr = stderr_bytes.decode()
+            return_code = proc.returncode or 0
+
+            if return_code != 0:
+                logger.warning(
+                    "%s exited with code %d: %s",
+                    ident.display_name, return_code, raw_stderr[:200],
+                )
+
+            return self._parse_response(raw_stdout, raw_stderr, return_code)
+        finally:
+            Path(prompt_file.name).unlink(missing_ok=True)
+
+    def run_interactive(self, request: Request) -> int:
+        """Run an interactive session with inherited stdio.
+
+        Returns the subprocess exit code.
+        """
+        cwd = Path(request.cwd)
+        ident = self.identity
+
+        prompt_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", prefix="factory-prompt-", delete=False,
+        )
+        try:
+            prompt_file.write(request.system_prompt)
+            prompt_file.close()
+
+            cmd = self._build_command(request, prompt_file=prompt_file.name)
+
+            logger.info(
+                "%s interactive: cwd=%s, role=%s",
+                ident.display_name, cwd, request.role,
+            )
+
+            result = subprocess.run(cmd, cwd=cwd)
+            return result.returncode
+        finally:
+            Path(prompt_file.name).unlink(missing_ok=True)

--- a/factory/runners/aider.py
+++ b/factory/runners/aider.py
@@ -1,0 +1,37 @@
+"""AiderRunner — Aider CLI backend implementation."""
+
+from __future__ import annotations
+
+from factory.runners.abstraction import (
+    AgentRunner,
+    Request,
+    Response,
+    RunnerIdentity,
+)
+
+_IDENTITY = RunnerIdentity(
+    name="aider",
+    display_name="Aider",
+    binary="aider",
+    capabilities=set(),
+)
+
+
+class AiderRunner(AgentRunner):
+    """Runner implementation for Aider CLI."""
+
+    name: str = "aider"
+
+    @property
+    def identity(self) -> RunnerIdentity:
+        return _IDENTITY
+
+    def _build_command(
+        self, request: Request, *, prompt_file: str | None = None
+    ) -> list[str]:
+        return ["aider", "--message", request.prompt, "--yes"]
+
+    def _parse_response(
+        self, stdout: str, stderr: str, exit_code: int
+    ) -> Response:
+        return Response(output=stdout, exit_code=exit_code)

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import shutil
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-import subprocess as _subprocess
 
-from factory.runners._stream import should_stream, stream_subprocess
+from factory.runners.abstraction import (
+    AgentRunner,
+    Request,
+    Response,
+    RunnerIdentity,
+)
 from factory.runners.usage import (
     CeilingExceededError,
     check_ceilings,
@@ -24,6 +27,17 @@ _auth_checked = False
 
 # File where we persist the API key for nested subagent spawns
 _AUTH_FILE_NAME = ".bob_auth"
+
+_IDENTITY = RunnerIdentity(
+    name="bob",
+    display_name="Bob Shell",
+    binary="bob",
+    capabilities=set(),
+)
+
+# Bob Shell only supports built-in modes: plan, code, advanced, ask.
+# We use 'code' mode for agent work; the role is injected via the prompt.
+_BOB_CHAT_MODE = "code"
 
 
 class BobAuthError(Exception):
@@ -154,12 +168,14 @@ def _make_env_with_bob_path() -> dict[str, str]:
     return env
 
 
-# Bob Shell only supports built-in modes: plan, code, advanced, ask.
-# We use 'code' mode for agent work; the role is injected via the prompt.
-_BOB_CHAT_MODE = "code"
+def _sanitize_ansi(text: str) -> str:
+    """Strip ANSI escape sequences from text."""
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", text)
 
 
-class BobRunner:
+class BobRunner(AgentRunner):
     """Runner implementation for Bob Shell CLI."""
 
     name: str = "bob"
@@ -179,137 +195,98 @@ class BobRunner:
         if cycle_start is not None:
             self.cycle_start = cycle_start
         elif project_path is not None:
-            # Lazy import: ceo_completion imports runners, so module-level import would cycle
             from factory.ceo_completion import read_cycle_state
 
             state = read_cycle_state(project_path)
             self.cycle_start = state.started_at if state else datetime.now(timezone.utc)
         else:
             self.cycle_start = datetime.now(timezone.utc)
-        self._role: str = "unknown"
 
-    async def headless(
-        self,
-        prompt: str,
-        task: str,
-        cwd: Path,
-        *,
-        timeout: float = 600.0,
-        model: str | None = None,
-        dangerously_skip_permissions: bool = True,
-        role: str = "unknown",
-        session_name: str | None = None,
-        tmux_persist: bool = False,
-    ) -> tuple[str, int, None]:
-        """Run a headless Bob Shell invocation.
+    @property
+    def identity(self) -> RunnerIdentity:
+        return _IDENTITY
 
-        Returns (stdout, return_code, None). Bob has no token telemetry.
-        """
-        _ = session_name
-        if tmux_persist:
-            logger.warning("tmux_persist not supported with bob runner")
-        self._role = role
-        project_path = self._find_project_path(cwd)
+    def _build_command(
+        self, request: Request, *, prompt_file: str | None = None
+    ) -> list[str]:
+        cmd = ["bob", "-p", request.prompt, f"--chat-mode={_BOB_CHAT_MODE}"]
+        if request.skip_permissions:
+            cmd.append("--yolo")
+        return cmd
 
-        # Persist key for nested subagent spawns (before dry-run check so file exists)
+    def _build_env(self, request: Request) -> dict[str, str]:
+        env = _make_env_with_bob_path()
+        # Strip VIRTUAL_ENV like the base class
+        env.pop("VIRTUAL_ENV", None)
+        if request.env:
+            env.update(request.env)
+        # Persist key for nested subagent spawns
+        project_path = self._find_project_path(Path(request.cwd))
+        _persist_key(project_path)
+        return env
+
+    def _parse_response(
+        self, stdout: str, stderr: str, exit_code: int
+    ) -> Response:
+        return Response(output=_sanitize_ansi(stdout), exit_code=exit_code)
+
+    async def check_health(self) -> tuple[bool, str]:
+        """Check bob binary and BOBSHELL_API_KEY."""
+        ok, msg = await super().check_health()
+        if not ok:
+            return ok, msg
+        if os.environ.get("BOBSHELL_API_KEY"):
+            return True, f"{self.identity.display_name} found and API key set"
+        try:
+            _check_auth()
+            return True, f"{self.identity.display_name} found and API key set"
+        except BobAuthError:
+            return False, "BOBSHELL_API_KEY not set"
+
+    async def run(self, request: Request) -> Response:
+        """Override to add dry-run detection, ceiling enforcement, usage logging."""
+        project_path = self._find_project_path(Path(request.cwd))
+
+        # Persist key before dry-run check so file exists for nested spawns
         _persist_key(project_path)
 
         if is_dry_run():
-            stdout, code = self._dry_run_response(role, cwd, task)
-            return stdout, code, None
+            stdout, code = self._dry_run_response(request.role, Path(request.cwd), request.task)
+            return Response(output=stdout, exit_code=code)
 
-        _check_auth(cwd)
+        _check_auth(Path(request.cwd))
 
         try:
             check_ceilings(project_path, self.cycle_start)
         except CeilingExceededError as e:
             self._emit_ceiling_event(project_path, e)
-            return str(e), 1, None
+            return Response(output=str(e), exit_code=1, error=str(e))
 
-        # NOTE: Custom modes are not supported in Bob Shell (unlike Claude Code).
-        # The agent role definition is injected via the prompt instead.
-
-        chat_mode = _BOB_CHAT_MODE
-        full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
-
-        cmd = ["bob", "-p", full_task, f"--chat-mode={chat_mode}"]
-        if dangerously_skip_permissions:
-            cmd.append("--yolo")
-
-        logger.info("BobRunner headless: cwd=%s, role=%s, chat_mode=%s", cwd, role, chat_mode)
-
-        env = _make_env_with_bob_path()
         start_time = time.monotonic()
-
-        stream = should_stream()
-        prefix = f"[bob:{role}]" if stream else None
-
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-            )
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                # sanitize=True: Bob is a TUI emitting cursor/clear/alt-screen
-                # escapes — strip them from the live terminal write (the captured
-                # buffer stays raw). See issue #379.
-                stream_subprocess(proc, stream=stream, prefix=prefix, sanitize=True),
-                timeout=timeout,
-            )
-        except asyncio.TimeoutError:
-            proc.kill()  # type: ignore[union-attr]
-            await proc.wait()  # type: ignore[union-attr]
-            duration = time.monotonic() - start_time
-            log_usage(project_path, role, cwd, duration, 1, dry_run=False)
-            logger.error("BobRunner timed out after %ss", timeout)
-            return f"Agent timed out after {timeout}s", 1, None
-        except FileNotFoundError:
-            logger.error("'bob' CLI not found on PATH")
-            return "Error: 'bob' CLI not found on PATH", 1, None
-
+        response = await super().run(request)
         duration = time.monotonic() - start_time
-        return_code = proc.returncode or 0
 
-        log_usage(project_path, role, cwd, duration, return_code, dry_run=False)
+        log_usage(
+            project_path, request.role, Path(request.cwd),
+            duration, response.exit_code, dry_run=False,
+        )
 
-        stdout = stdout_bytes.decode()
-        stderr = stderr_bytes.decode()
+        return response
 
-        if return_code != 0:
-            logger.warning("BobRunner exited with code %d: %s", return_code, stderr[:200])
+    def run_interactive(self, request: Request) -> int:
+        """Override for interactive Bob Shell session."""
+        import subprocess as _subprocess
 
-        return stdout, return_code, None
-
-    def interactive_run(
-        self,
-        prompt: str,
-        task: str,
-        cwd: Path,
-        *,
-        model: str | None = None,
-        role: str = "ceo",
-        dangerously_skip_permissions: bool = False,
-        session_name: str | None = None,
-    ) -> int:
-        """Run an interactive Bob Shell session as a subprocess.
-
-        Returns the exit code so the caller can clean up in a finally block.
-        """
-        _ = session_name
-        project_path = self._find_project_path(cwd)
-
+        project_path = self._find_project_path(Path(request.cwd))
         _persist_key(project_path)
 
         if is_dry_run():
-            yolo_flag = " --yolo" if dangerously_skip_permissions else ""
-            print(f"[DRY-RUN] Would run: bob --chat-mode=factory-{role}{yolo_flag}")
-            print(f"[DRY-RUN] Task: {task[:200]}...")
+            yolo_flag = " --yolo" if request.skip_permissions else ""
+            print(f"[DRY-RUN] Would run: bob --chat-mode={_BOB_CHAT_MODE}{yolo_flag}")
+            print(f"[DRY-RUN] Task: {request.task[:200]}...")
             return 0
 
-        _check_auth(cwd)
+        _check_auth(Path(request.cwd))
 
         try:
             check_ceilings(project_path, self.cycle_start)
@@ -317,24 +294,21 @@ class BobRunner:
             print(f"ERROR: {e}")
             return 1
 
-        chat_mode = _BOB_CHAT_MODE
-        full_task = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
-
         cmd = [
             "bob",
-            f"--chat-mode={chat_mode}",
-            "-i", full_task,
+            f"--chat-mode={_BOB_CHAT_MODE}",
+            "-i", request.prompt,
         ]
-        if dangerously_skip_permissions:
+        if request.skip_permissions:
             cmd.append("--yolo")
 
-        logger.info("BobRunner interactive_run: cwd=%s, chat_mode=%s", cwd, chat_mode)
+        logger.info("BobRunner interactive: cwd=%s", request.cwd)
 
         bob_bin_dir = _get_bob_bin_dir()
         if bob_bin_dir and not os.environ.get("PATH", "").startswith(bob_bin_dir):
             os.environ["PATH"] = f"{bob_bin_dir}:{os.environ.get('PATH', '')}"
 
-        result = _subprocess.run(cmd, cwd=cwd)
+        result = _subprocess.run(cmd, cwd=request.cwd)
         return result.returncode
 
     def _find_project_path(self, cwd: Path) -> Path:
@@ -380,5 +354,3 @@ class BobRunner:
             )
         except Exception:
             logger.debug("Failed to emit ceiling event", exc_info=True)
-
-

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -206,6 +206,10 @@ class BobRunner(AgentRunner):
     def identity(self) -> RunnerIdentity:
         return _IDENTITY
 
+    @property
+    def _sanitize_output(self) -> bool:
+        return True
+
     def _build_command(
         self, request: Request, *, prompt_file: str | None = None
     ) -> list[str]:

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -2,24 +2,40 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
-import os
-import subprocess
-import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from factory.runners._stream import should_stream, stream_subprocess
+from factory.runners.abstraction import (
+    AgentRunner,
+    Capability,
+    Request,
+    Response,
+    RunnerIdentity,
+)
 
 if TYPE_CHECKING:
     from factory.models import AgentUsage
 
 logger = logging.getLogger(__name__)
 
+_IDENTITY = RunnerIdentity(
+    name="claude",
+    display_name="Claude Code",
+    binary="claude",
+    capabilities={
+        Capability.MODEL_OVERRIDE,
+        Capability.SESSION_RESUME,
+        Capability.SYSTEM_PROMPT_FILE,
+        Capability.STRUCTURED_OUTPUT,
+        Capability.STREAMING,
+        Capability.INTERACTIVE,
+    },
+)
 
-def _parse_usage(data: dict) -> "AgentUsage":
+
+def _parse_usage(data: dict) -> AgentUsage:
     """Extract AgentUsage from Claude Code JSON output."""
     from factory.models import AgentUsage
 
@@ -36,160 +52,106 @@ def _parse_usage(data: dict) -> "AgentUsage":
     )
 
 
-class ClaudeRunner:
+class ClaudeRunner(AgentRunner):
     """Runner implementation for Claude Code CLI."""
 
     name: str = "claude"
 
-    async def headless(
-        self,
-        prompt: str,
-        task: str,
-        cwd: Path,
-        *,
-        timeout: float = 600.0,
-        model: str | None = None,
-        dangerously_skip_permissions: bool = True,
-        role: str = "unknown",
-        session_name: str | None = None,
-        tmux_persist: bool = False,
-    ) -> tuple[str, int, "AgentUsage | None"]:
-        """Run a headless Claude Code invocation.
+    @property
+    def identity(self) -> RunnerIdentity:
+        return _IDENTITY
 
-        Args:
-            prompt: The system prompt / agent role definition.
-            task: The task to execute.
-            cwd: Working directory for the subprocess.
-            timeout: Maximum execution time in seconds.
-            model: Optional model override.
-            dangerously_skip_permissions: If True, skip permission prompts.
-            role: Agent role (used for streaming prefix).
-            session_name: Optional session name for identification in /resume.
-            tmux_persist: If True, run the agent interactively in a tmux window.
+    def _build_command(
+        self, request: Request, *, prompt_file: str | None = None
+    ) -> list[str]:
+        cmd = ["claude"]
+        if prompt_file:
+            cmd.extend(["--append-system-prompt-file", prompt_file])
+        cmd.extend(["-p", request.task])
+        cmd.extend(["--output-format", "json"])
+        if request.skip_permissions:
+            cmd.append("--dangerously-skip-permissions")
+        if request.model:
+            cmd.extend(["--model", request.model])
+        if request.session_name:
+            cmd.extend(["--name", request.session_name])
+        return cmd
 
-        Returns (stdout, return_code, usage).
-        """
-        if tmux_persist:
-            from factory.runners._tmux_persist import find_project_path, run_in_tmux, tmux_available
+    def _parse_response(
+        self, stdout: str, stderr: str, exit_code: int
+    ) -> Response:
+        usage = None
+        result_text = stdout
+        try:
+            data = json.loads(stdout)
+            if isinstance(data, dict):
+                result_value = data.get("result", stdout)
+                result_text = result_value if isinstance(result_value, str) else stdout
+                usage = _parse_usage(data)
+        except (json.JSONDecodeError, ValueError):
+            logger.debug("Could not parse JSON output, returning raw stdout")
 
-            if tmux_available():
-                return await run_in_tmux(
-                    prompt, task, cwd, role, find_project_path(cwd),
-                    model=model,
-                    dangerously_skip_permissions=dangerously_skip_permissions,
-                )
-            logger.warning("tmux not available; falling back to headless")
+        return Response(output=result_text, exit_code=exit_code, usage=usage)
 
+    def _build_env(self, request: Request) -> dict[str, str]:
+        env = super()._build_env(request)
+        if request.model:
+            env["FACTORY_MODEL"] = request.model
+        return env
+
+    def run_interactive(self, request: Request) -> int:
+        """Override to use Claude's interactive command format (no -p, no --output-format)."""
+        import subprocess
+        import tempfile
+
+        cwd = Path(request.cwd)
         prompt_file = tempfile.NamedTemporaryFile(
             mode="w", suffix=".md", prefix="factory-prompt-", delete=False,
         )
         try:
-            prompt_file.write(prompt)
-            prompt_file.close()
-
-            cmd = [
-                "claude", "--append-system-prompt-file", prompt_file.name,
-                "-p", task,
-                "--output-format", "json",
-            ]
-            if dangerously_skip_permissions:
-                cmd.append("--dangerously-skip-permissions")
-            if model:
-                cmd.extend(["--model", model])
-            if session_name:
-                cmd.extend(["--name", session_name])
-
-            logger.info("ClaudeRunner headless: cwd=%s, model=%s", cwd, model)
-
-            env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-            if model:
-                env["FACTORY_MODEL"] = model
-
-            stream = should_stream()
-            prefix = f"[claude:{role}]" if stream else None
-
-            try:
-                proc = await asyncio.create_subprocess_exec(
-                    *cmd,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=cwd,
-                    env=env,
-                )
-                stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                    stream_subprocess(proc, stream=stream, prefix=prefix),
-                    timeout=timeout,
-                )
-            except asyncio.TimeoutError:
-                proc.kill()  # type: ignore[union-attr]
-                await proc.wait()  # type: ignore[union-attr]
-                logger.error("ClaudeRunner timed out after %ss", timeout)
-                return f"Agent timed out after {timeout}s", 1, None
-            except FileNotFoundError:
-                logger.error("'claude' CLI not found on PATH")
-                return "Error: 'claude' CLI not found on PATH", 1, None
-
-            raw_stdout = stdout_bytes.decode()
-            stderr = stderr_bytes.decode()
-            return_code = proc.returncode or 0
-
-            if return_code != 0:
-                logger.warning("ClaudeRunner exited with code %d: %s", return_code, stderr[:200])
-
-            usage = None
-            result_text = raw_stdout
-            try:
-                data = json.loads(raw_stdout)
-                if isinstance(data, dict):
-                    result_value = data.get("result", raw_stdout)
-                    result_text = result_value if isinstance(result_value, str) else raw_stdout
-                    usage = _parse_usage(data)
-            except (json.JSONDecodeError, ValueError):
-                logger.debug("Could not parse JSON output, returning raw stdout")
-
-            return result_text, return_code, usage
-        finally:
-            Path(prompt_file.name).unlink(missing_ok=True)
-
-    def interactive_run(
-        self,
-        prompt: str,
-        task: str,
-        cwd: Path,
-        *,
-        model: str | None = None,
-        role: str = "ceo",
-        dangerously_skip_permissions: bool = False,
-        session_name: str | None = None,
-    ) -> int:
-        """Run an interactive Claude Code session as a subprocess.
-
-        Returns the exit code so the caller can clean up in a finally block.
-        """
-        _ = role
-        prompt_file = tempfile.NamedTemporaryFile(
-            mode="w", suffix=".md", prefix="factory-prompt-", delete=False,
-        )
-        try:
-            prompt_file.write(prompt)
+            prompt_file.write(request.system_prompt)
             prompt_file.close()
 
             cmd = [
                 "claude",
                 "--append-system-prompt-file", prompt_file.name,
             ]
-            if dangerously_skip_permissions:
+            if request.skip_permissions:
                 cmd.append("--dangerously-skip-permissions")
-            cmd.append(task)
-            if model:
-                cmd.extend(["--model", model])
-                os.environ["FACTORY_MODEL"] = model
-            if session_name:
-                cmd.extend(["--name", session_name])
+            cmd.append(request.task)
+            if request.model:
+                cmd.extend(["--model", request.model])
+            if request.session_name:
+                cmd.extend(["--name", request.session_name])
 
-            logger.info("ClaudeRunner interactive_run: cwd=%s", cwd)
+            logger.info("ClaudeRunner interactive: cwd=%s", cwd)
 
             result = subprocess.run(cmd, cwd=cwd)
             return result.returncode
         finally:
             Path(prompt_file.name).unlink(missing_ok=True)
+
+    async def run(self, request: Request) -> Response:
+        """Override to handle tmux_persist before delegating to base."""
+        if request.tmux_persist:
+            from factory.runners._tmux_persist import (
+                find_project_path,
+                run_in_tmux,
+                tmux_available,
+            )
+
+            if tmux_available():
+                cwd = Path(request.cwd)
+                stdout, return_code, usage = await run_in_tmux(
+                    request.system_prompt,
+                    request.task,
+                    cwd,
+                    request.role,
+                    find_project_path(cwd),
+                    model=request.model,
+                    dangerously_skip_permissions=request.skip_permissions,
+                )
+                return Response(output=stdout, exit_code=return_code, usage=usage)
+            logger.warning("tmux not available; falling back to headless")
+
+        return await super().run(request)

--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -2,17 +2,27 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
-import subprocess
-from pathlib import Path
 
-from factory.runners._stream import should_stream, stream_subprocess
+from factory.runners.abstraction import (
+    AgentRunner,
+    Capability,
+    Request,
+    Response,
+    RunnerIdentity,
+)
 
 logger = logging.getLogger(__name__)
 
 _auth_checked = False
+
+_IDENTITY = RunnerIdentity(
+    name="codex",
+    display_name="OpenAI Codex",
+    binary="codex",
+    capabilities={Capability.MODEL_OVERRIDE, Capability.SANDBOXING},
+)
 
 
 class CodexAuthError(Exception):
@@ -37,14 +47,6 @@ def _check_auth() -> None:
     raise CodexAuthError()
 
 
-def _make_codex_env() -> dict[str, str]:
-    """Build subprocess env: strip VIRTUAL_ENV, ensure OPENAI_API_KEY is set."""
-    env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-    if "OPENAI_API_KEY" not in env and "CODEX_API_KEY" in env:
-        env["OPENAI_API_KEY"] = env["CODEX_API_KEY"]
-    return env
-
-
 def is_codex_dry_run() -> bool:
     """Return True if Codex dry-run mode is enabled."""
     from factory.user_config import resolve
@@ -53,127 +55,78 @@ def is_codex_dry_run() -> bool:
     return val.lower() in ("1", "true", "yes")
 
 
-class CodexRunner:
+class CodexRunner(AgentRunner):
     """Runner implementation for OpenAI Codex CLI."""
 
     name: str = "codex"
 
-    async def headless(
-        self,
-        prompt: str,
-        task: str,
-        cwd: Path,
-        *,
-        timeout: float = 600.0,
-        model: str | None = None,
-        dangerously_skip_permissions: bool = True,
-        role: str = "unknown",
-        session_name: str | None = None,
-        tmux_persist: bool = False,
-    ) -> tuple[str, int, None]:
-        """Run a headless Codex CLI invocation via ``codex exec``.
+    @property
+    def identity(self) -> RunnerIdentity:
+        return _IDENTITY
 
-        Codex exec streams progress to stderr and writes only the final
-        agent message to stdout, which aligns with the factory's capture model.
+    def _build_command(
+        self, request: Request, *, prompt_file: str | None = None
+    ) -> list[str]:
+        cmd = ["codex", "exec", request.prompt]
+        if request.skip_permissions:
+            cmd.extend(["--sandbox", "workspace-write", "--ask-for-approval", "never"])
+        if request.model:
+            cmd.extend(["--model", request.model])
+        return cmd
 
-        Returns (stdout, return_code, None). Codex has no token telemetry.
-        """
-        _ = session_name
-        if tmux_persist:
-            logger.warning("tmux_persist not supported with codex runner")
+    def _build_env(self, request: Request) -> dict[str, str]:
+        env = super()._build_env(request)
+        if "OPENAI_API_KEY" not in env and "CODEX_API_KEY" in env:
+            env["OPENAI_API_KEY"] = env["CODEX_API_KEY"]
+        return env
+
+    def _parse_response(
+        self, stdout: str, stderr: str, exit_code: int
+    ) -> Response:
+        return Response(output=stdout, exit_code=exit_code)
+
+    async def check_health(self) -> tuple[bool, str]:
+        """Check codex binary and API key."""
+        ok, msg = await super().check_health()
+        if not ok:
+            return ok, msg
+        if os.environ.get("CODEX_API_KEY") or os.environ.get("OPENAI_API_KEY"):
+            return True, f"{self.identity.display_name} found and API key set"
+        return False, "CODEX_API_KEY (or OPENAI_API_KEY) not set"
+
+    async def run(self, request: Request) -> Response:
+        """Override for dry-run detection."""
         if is_codex_dry_run():
-            stdout, code = self._dry_run_response(role, cwd, task)
-            return stdout, code, None
+            stdout, code = self._dry_run_response(request.role, request.cwd, request.task)
+            return Response(output=stdout, exit_code=code)
 
         _check_auth()
+        return await super().run(request)
 
-        full_prompt = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
-
-        cmd = ["codex", "exec", full_prompt]
-
-        if dangerously_skip_permissions:
-            cmd.extend(["--sandbox", "workspace-write", "--ask-for-approval", "never"])
-
-        if model:
-            cmd.extend(["--model", model])
-
-        logger.info("CodexRunner headless: cwd=%s, model=%s, role=%s", cwd, model, role)
-
-        env = _make_codex_env()
-
-        stream = should_stream()
-        prefix = f"[codex:{role}]" if stream else None
-
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-            )
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                stream_subprocess(proc, stream=stream, prefix=prefix),
-                timeout=timeout,
-            )
-        except asyncio.TimeoutError:
-            proc.kill()  # type: ignore[union-attr]
-            await proc.wait()  # type: ignore[union-attr]
-            logger.error("CodexRunner timed out after %ss", timeout)
-            return f"Agent timed out after {timeout}s", 1, None
-        except FileNotFoundError:
-            logger.error("'codex' CLI not found on PATH")
-            return "Error: 'codex' CLI not found on PATH", 1, None
-
-        stdout = stdout_bytes.decode()
-        stderr = stderr_bytes.decode()
-
-        if proc.returncode != 0:
-            logger.warning("CodexRunner exited with code %d: %s", proc.returncode, stderr[:200])
-
-        return stdout, proc.returncode or 0, None
-
-    def interactive_run(
-        self,
-        prompt: str,
-        task: str,
-        cwd: Path,
-        *,
-        model: str | None = None,
-        role: str = "ceo",
-        dangerously_skip_permissions: bool = False,
-        session_name: str | None = None,
-    ) -> int:
-        """Run an interactive Codex CLI session as a subprocess.
-
-        Returns the exit code so the caller can clean up in a finally block.
-        """
-        _ = role, session_name
+    def run_interactive(self, request: Request) -> int:
+        """Override for interactive Codex session."""
+        import subprocess
 
         if is_codex_dry_run():
             print("[DRY-RUN] Would exec: codex (interactive)")
-            print(f"[DRY-RUN] Task: {task[:200]}...")
+            print(f"[DRY-RUN] Task: {request.task[:200]}...")
             return 0
 
         _check_auth()
 
-        full_prompt = f"{prompt}\n\n---\n\n## Current Task\n\n{task}"
-
-        cmd = ["codex", full_prompt]
-
-        if dangerously_skip_permissions:
+        cmd = ["codex", request.prompt]
+        if request.skip_permissions:
             cmd.extend(["--sandbox", "workspace-write", "--ask-for-approval", "never"])
+        if request.model:
+            cmd.extend(["--model", request.model])
 
-        if model:
-            cmd.extend(["--model", model])
+        logger.info("CodexRunner interactive: cwd=%s", request.cwd)
 
-        logger.info("CodexRunner interactive_run: cwd=%s", cwd)
-
-        env = _make_codex_env()
-        result = subprocess.run(cmd, cwd=cwd, env=env)
+        env = self._build_env(request)
+        result = subprocess.run(cmd, cwd=request.cwd, env=env)
         return result.returncode
 
-    def _dry_run_response(self, role: str, cwd: Path, task: str) -> tuple[str, int]:
+    def _dry_run_response(self, role: str, cwd: str | os.PathLike[str], task: str) -> tuple[str, int]:
         """Return a stub response for dry-run mode."""
         response = (
             f"[DRY-RUN] CodexRunner would have executed:\n"

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -1,0 +1,46 @@
+"""OpenCodeRunner — OpenCode CLI backend implementation."""
+
+from __future__ import annotations
+
+from factory.runners.abstraction import (
+    AgentRunner,
+    Capability,
+    Request,
+    Response,
+    RunnerIdentity,
+)
+
+_IDENTITY = RunnerIdentity(
+    name="opencode",
+    display_name="OpenCode",
+    binary="opencode",
+    capabilities={Capability.MODEL_OVERRIDE},
+)
+
+
+class OpenCodeRunner(AgentRunner):
+    """Runner implementation for OpenCode CLI."""
+
+    name: str = "opencode"
+
+    @property
+    def identity(self) -> RunnerIdentity:
+        return _IDENTITY
+
+    def _build_command(
+        self, request: Request, *, prompt_file: str | None = None
+    ) -> list[str]:
+        cmd = ["opencode", "run", request.prompt, "--format", "json"]
+        if request.skip_permissions:
+            cmd.append("--dangerously-skip-permissions")
+        if request.model:
+            model = request.model
+            if "/" not in model:
+                model = f"anthropic/{model}"
+            cmd.extend(["--model", model])
+        return cmd
+
+    def _parse_response(
+        self, stdout: str, stderr: str, exit_code: int
+    ) -> Response:
+        return Response(output=stdout, exit_code=exit_code)

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -1,63 +1,10 @@
-"""Runner protocol — interface for CLI backend implementations.
+"""Runner protocol — re-exports AgentRunner as the canonical interface.
 
-Defines both the new Request/Response interface (run, run_interactive)
-and the legacy interface (headless, interactive_run) for backward compat
-during the Phase 2-3 migration.
+All runners now extend AgentRunner (factory/runners/abstraction.py).
+This module exists for backward compatibility — import AgentRunner directly
+from factory.runners.abstraction instead.
 """
 
-from __future__ import annotations
+from factory.runners.abstraction import AgentRunner as Runner
 
-from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
-
-if TYPE_CHECKING:
-    from factory.models import AgentUsage
-    from factory.runners.abstraction import Request, Response
-
-
-class Runner(Protocol):
-    """Protocol for CLI backend implementations (claude, bob, etc.)."""
-
-    name: str
-
-    # ── New interface (Phase 2+) ──────────────────────────────────
-
-    async def run(self, request: Request) -> Response:
-        """Run a headless agent invocation via Request/Response types."""
-        ...
-
-    def run_interactive(self, request: Request) -> int:
-        """Run an interactive session with inherited stdio. Returns exit code."""
-        ...
-
-    # ── Legacy interface (backward compat, removed in Phase 4) ───
-
-    async def headless(
-        self,
-        prompt: str,
-        task: str,
-        cwd: Path,
-        *,
-        timeout: float = 600.0,
-        model: str | None = None,
-        dangerously_skip_permissions: bool = True,
-        role: str = "unknown",
-        session_name: str | None = None,
-        tmux_persist: bool = False,
-    ) -> tuple[str, int, AgentUsage | None]:
-        """Run a headless invocation (legacy — use run() instead)."""
-        ...
-
-    def interactive_run(
-        self,
-        prompt: str,
-        task: str,
-        cwd: Path,
-        *,
-        model: str | None = None,
-        role: str = "ceo",
-        dangerously_skip_permissions: bool = False,
-        session_name: str | None = None,
-    ) -> int:
-        """Run an interactive session (legacy — use run_interactive() instead)."""
-        ...
+__all__ = ["Runner"]

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -1,4 +1,9 @@
-"""Runner protocol — interface for CLI backend implementations."""
+"""Runner protocol — interface for CLI backend implementations.
+
+Defines both the new Request/Response interface (run, run_interactive)
+and the legacy interface (headless, interactive_run) for backward compat
+during the Phase 2-3 migration.
+"""
 
 from __future__ import annotations
 
@@ -7,12 +12,25 @@ from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from factory.models import AgentUsage
+    from factory.runners.abstraction import Request, Response
 
 
 class Runner(Protocol):
     """Protocol for CLI backend implementations (claude, bob, etc.)."""
 
     name: str
+
+    # ── New interface (Phase 2+) ──────────────────────────────────
+
+    async def run(self, request: Request) -> Response:
+        """Run a headless agent invocation via Request/Response types."""
+        ...
+
+    def run_interactive(self, request: Request) -> int:
+        """Run an interactive session with inherited stdio. Returns exit code."""
+        ...
+
+    # ── Legacy interface (backward compat, removed in Phase 4) ───
 
     async def headless(
         self,
@@ -27,23 +45,7 @@ class Runner(Protocol):
         session_name: str | None = None,
         tmux_persist: bool = False,
     ) -> tuple[str, int, AgentUsage | None]:
-        """Run a headless (non-interactive) agent invocation.
-
-        Args:
-            prompt: The system prompt / agent role definition.
-            task: The task to execute.
-            cwd: Working directory for the subprocess.
-            timeout: Maximum execution time in seconds.
-            model: Optional model override.
-            dangerously_skip_permissions: If True, skip permission prompts.
-            role: Agent role name (used for logging and output prefixing).
-            session_name: Optional session name for identification in /resume.
-            tmux_persist: If True, run the agent interactively in a tmux window.
-
-        Returns:
-            (stdout, return_code, usage) tuple. usage is None for runners
-            without token telemetry (bob, codex).
-        """
+        """Run a headless invocation (legacy — use run() instead)."""
         ...
 
     def interactive_run(
@@ -57,21 +59,5 @@ class Runner(Protocol):
         dangerously_skip_permissions: bool = False,
         session_name: str | None = None,
     ) -> int:
-        """Run an interactive CLI session as a subprocess (returns on exit).
-
-        Unlike interactive_exec, this uses subprocess.run so the caller regains
-        control after the session finishes — enabling cleanup in finally blocks.
-
-        Args:
-            prompt: The system prompt to append.
-            task: The initial user message.
-            cwd: Working directory for the subprocess.
-            model: Optional model override.
-            role: Agent role name (used for logging and output prefixing).
-            dangerously_skip_permissions: If True, skip permission prompts (--yolo for bob).
-            session_name: Optional session name for identification in /resume.
-
-        Returns:
-            The subprocess exit code.
-        """
+        """Run an interactive session (legacy — use run_interactive() instead)."""
         ...

--- a/tests/test_abstraction.py
+++ b/tests/test_abstraction.py
@@ -1,0 +1,297 @@
+"""Tests for factory/runners/abstraction.py — AgentRunner base class and core types."""
+
+import asyncio
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from factory.runners.abstraction import (
+    AgentRunner,
+    Capability,
+    Request,
+    Response,
+    RunnerIdentity,
+)
+
+
+# ── Minimal concrete subclass for testing ──────────────────────
+
+
+class StubRunner(AgentRunner):
+    """Minimal concrete runner for testing the ABC."""
+
+    @property
+    def identity(self) -> RunnerIdentity:
+        return RunnerIdentity(name="stub", display_name="Stub Runner")
+
+    def _build_command(
+        self, request: Request, *, prompt_file: str | None = None
+    ) -> list[str]:
+        return ["echo", "hello"]
+
+    def _parse_response(self, stdout: str, stderr: str, exit_code: int) -> Response:
+        return Response(output=stdout.strip(), exit_code=exit_code)
+
+
+# ── Request tests ──────────────────────────────────────────────
+
+
+class TestRequest:
+    def test_prompt_combines_system_and_task(self) -> None:
+        req = Request(system_prompt="You are a reviewer.", task="Review PR #42", cwd="/tmp")
+        assert "You are a reviewer." in req.prompt
+        assert "Review PR #42" in req.prompt
+        assert "---" in req.prompt
+        assert "## Current Task" in req.prompt
+
+    def test_default_values(self) -> None:
+        req = Request(system_prompt="sp", task="t", cwd="/tmp")
+        assert req.timeout == 600.0
+        assert req.model is None
+        assert req.skip_permissions is True
+        assert req.session_name is None
+        assert req.env is None
+        assert req.tmux_persist is False
+        assert req.role == "unknown"
+
+    def test_custom_values(self) -> None:
+        req = Request(
+            system_prompt="sp", task="t", cwd="/tmp",
+            timeout=120.0, model="claude-sonnet-4-6", skip_permissions=False,
+            session_name="sess1", env={"FOO": "bar"}, tmux_persist=True, role="builder",
+        )
+        assert req.timeout == 120.0
+        assert req.model == "claude-sonnet-4-6"
+        assert req.skip_permissions is False
+        assert req.session_name == "sess1"
+        assert req.env == {"FOO": "bar"}
+        assert req.tmux_persist is True
+        assert req.role == "builder"
+
+
+# ── Response tests ─────────────────────────────────────────────
+
+
+class TestResponse:
+    def test_construction(self) -> None:
+        resp = Response(output="hello", exit_code=0)
+        assert resp.output == "hello"
+        assert resp.exit_code == 0
+        assert resp.usage is None
+        assert resp.error is None
+
+    def test_with_error(self) -> None:
+        resp = Response(output="", exit_code=1, error="timeout")
+        assert resp.exit_code == 1
+        assert resp.error == "timeout"
+
+
+# ── Capability tests ───────────────────────────────────────────
+
+
+class TestCapability:
+    def test_enum_values(self) -> None:
+        assert Capability.MODEL_OVERRIDE.value == "model_override"
+        assert Capability.SESSION_RESUME.value == "session_resume"
+        assert Capability.SYSTEM_PROMPT_FILE.value == "system_prompt_file"
+        assert Capability.STREAMING.value == "streaming"
+        assert Capability.INTERACTIVE.value == "interactive"
+        assert Capability.SANDBOXING.value == "sandboxing"
+        assert Capability.STRUCTURED_OUTPUT.value == "structured_output"
+
+    def test_all_capabilities_count(self) -> None:
+        assert len(Capability) == 7
+
+
+# ── RunnerIdentity tests ──────────────────────────────────────
+
+
+class TestRunnerIdentity:
+    def test_binary_defaults_to_name(self) -> None:
+        ident = RunnerIdentity(name="claude", display_name="Claude Code")
+        assert ident.binary == "claude"
+
+    def test_explicit_binary(self) -> None:
+        ident = RunnerIdentity(name="claude", display_name="Claude Code", binary="claude-cli")
+        assert ident.binary == "claude-cli"
+
+    def test_capabilities_default_empty(self) -> None:
+        ident = RunnerIdentity(name="test", display_name="Test")
+        assert ident.capabilities == set()
+
+
+# ── AgentRunner tests ──────────────────────────────────────────
+
+
+class TestAgentRunnerCheckHealth:
+    async def test_health_found(self) -> None:
+        runner = StubRunner()
+        with patch("shutil.which", return_value="/usr/bin/stub"):
+            ok, msg = await runner.check_health()
+        assert ok is True
+        assert "/usr/bin/stub" in msg
+
+    async def test_health_not_found(self) -> None:
+        runner = StubRunner()
+        with patch("shutil.which", return_value=None):
+            ok, msg = await runner.check_health()
+        assert ok is False
+        assert "not found" in msg
+
+
+class TestAgentRunnerBuildEnv:
+    def test_strips_virtual_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
+        monkeypatch.setenv("HOME", "/home/test")
+        runner = StubRunner()
+        req = Request(system_prompt="sp", task="t", cwd="/tmp")
+        env = runner._build_env(req)
+        assert "VIRTUAL_ENV" not in env
+        assert env["HOME"] == "/home/test"
+
+    def test_merges_request_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MY_CUSTOM_VAR", raising=False)
+        runner = StubRunner()
+        req = Request(system_prompt="sp", task="t", cwd="/tmp", env={"MY_CUSTOM_VAR": "val"})
+        env = runner._build_env(req)
+        assert env["MY_CUSTOM_VAR"] == "val"
+
+    def test_request_env_overrides_os_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("EXISTING", "old")
+        runner = StubRunner()
+        req = Request(system_prompt="sp", task="t", cwd="/tmp", env={"EXISTING": "new"})
+        env = runner._build_env(req)
+        assert env["EXISTING"] == "new"
+
+
+class TestAgentRunnerRun:
+    async def test_run_success(self, tmp_path: Path) -> None:
+        runner = StubRunner()
+        req = Request(system_prompt="sys prompt", task="do stuff", cwd=str(tmp_path))
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+
+        with patch("factory.runners.abstraction.asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec, \
+             patch("factory.runners.abstraction.stream_subprocess", return_value=(b"output text", b"")), \
+             patch("factory.runners.abstraction.should_stream", return_value=False):
+            resp = await runner.run(req)
+
+        assert resp.output == "output text"
+        assert resp.exit_code == 0
+        # Verify _build_command was called (via create_subprocess_exec receiving the command)
+        call_args = mock_exec.call_args
+        cmd = call_args[0]
+        assert cmd == ("echo", "hello")
+
+    async def test_run_cleans_up_temp_file(self, tmp_path: Path) -> None:
+        runner = StubRunner()
+        req = Request(system_prompt="sys prompt", task="do stuff", cwd=str(tmp_path))
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+
+        temp_files_created: list[str] = []
+        original_ntf = __import__("tempfile").NamedTemporaryFile
+
+        def track_tempfile(**kwargs):
+            f = original_ntf(**kwargs)
+            temp_files_created.append(f.name)
+            return f
+
+        with patch("factory.runners.abstraction.tempfile.NamedTemporaryFile", side_effect=track_tempfile), \
+             patch("factory.runners.abstraction.asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch("factory.runners.abstraction.stream_subprocess", return_value=(b"ok", b"")), \
+             patch("factory.runners.abstraction.should_stream", return_value=False):
+            await runner.run(req)
+
+        # Temp file should have been cleaned up
+        assert len(temp_files_created) == 1
+        assert not Path(temp_files_created[0]).exists()
+
+    async def test_run_timeout(self, tmp_path: Path) -> None:
+        runner = StubRunner()
+        req = Request(system_prompt="sp", task="t", cwd=str(tmp_path), timeout=1.0)
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = -9
+
+        with patch("factory.runners.abstraction.asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch("factory.runners.abstraction.stream_subprocess", side_effect=asyncio.TimeoutError), \
+             patch("factory.runners.abstraction.should_stream", return_value=False):
+            resp = await runner.run(req)
+
+        assert resp.exit_code == 1
+        assert "timed out" in resp.output.lower()
+        assert resp.error is not None
+
+    async def test_run_file_not_found(self, tmp_path: Path) -> None:
+        runner = StubRunner()
+        req = Request(system_prompt="sp", task="t", cwd=str(tmp_path))
+
+        with patch("factory.runners.abstraction.asyncio.create_subprocess_exec", side_effect=FileNotFoundError), \
+             patch("factory.runners.abstraction.should_stream", return_value=False):
+            resp = await runner.run(req)
+
+        assert resp.exit_code == 1
+        assert "not found" in resp.output.lower()
+
+
+class TestAgentRunnerInteractive:
+    def test_run_interactive(self, tmp_path: Path) -> None:
+        runner = StubRunner()
+        req = Request(system_prompt="sp", task="t", cwd=str(tmp_path))
+
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_result.returncode = 0
+
+        with patch("factory.runners.abstraction.subprocess.run", return_value=mock_result) as mock_run:
+            code = runner.run_interactive(req)
+
+        assert code == 0
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert call_args[0][0] == ["echo", "hello"]
+
+
+# ── Concrete runner instantiation tests ────────────────────────
+
+
+class TestConcreteRunners:
+    def test_claude_runner(self) -> None:
+        from factory.runners.claude import ClaudeRunner
+        r = ClaudeRunner()
+        assert r.identity.name == "claude"
+        assert r.identity.binary == "claude"
+        assert r.identity.display_name
+
+    def test_bob_runner(self) -> None:
+        from factory.runners.bob import BobRunner
+        r = BobRunner()
+        assert r.identity.name == "bob"
+        assert r.identity.display_name
+
+    def test_codex_runner(self) -> None:
+        from factory.runners.codex import CodexRunner
+        r = CodexRunner()
+        assert r.identity.name == "codex"
+        assert r.identity.display_name
+
+    def test_opencode_runner(self) -> None:
+        from factory.runners.opencode import OpenCodeRunner
+        r = OpenCodeRunner()
+        assert r.identity.name == "opencode"
+        assert r.identity.display_name
+
+    def test_aider_runner(self) -> None:
+        from factory.runners.aider import AiderRunner
+        r = AiderRunner()
+        assert r.identity.name == "aider"
+        assert r.identity.display_name
+
+    def test_all_runners_are_agent_runners(self) -> None:
+        from factory.runners import _RUNNERS
+        for name, cls in _RUNNERS.items():
+            assert issubclass(cls, AgentRunner), f"{name} does not extend AgentRunner"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -181,7 +181,7 @@ class TestInvokeAgentModel:
             return proc
 
         with patch(
-            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"ok", b"")
 
@@ -208,7 +208,7 @@ class TestInvokeAgentModel:
             return proc
 
         with patch(
-            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"ok", b"")
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -12,6 +12,7 @@ from factory.agents.runner import (
     ConsecutiveAgentFailureError,
     reset_failure_counter,
 )
+from factory.runners.abstraction import Response
 
 
 # Path to the project root (parent of factory/)
@@ -296,8 +297,8 @@ class TestConsecutiveFailureAbort:
         # Mock the runner at the point where it's imported in runner.py
         class MockRunner:
             name = "claude"
-            async def headless(self, *args, **kwargs):
-                return ("success", 0, None)
+            async def run(self, request):
+                return Response(output="success", exit_code=0)
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
 
@@ -319,8 +320,8 @@ class TestConsecutiveFailureAbort:
 
         class MockRunner:
             name = "claude"
-            async def headless(self, *args, **kwargs):
-                return ("error output", 1, None)  # non-zero exit code
+            async def run(self, request):
+                return Response(output="error output", exit_code=1)
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
 
@@ -342,8 +343,8 @@ class TestConsecutiveFailureAbort:
 
         class MockRunner:
             name = "claude"
-            async def headless(self, *args, **kwargs):
-                return ("error", 1, None)
+            async def run(self, request):
+                return Response(output="error", exit_code=1)
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
 
@@ -370,8 +371,8 @@ class TestConsecutiveFailureAbort:
 
         class MockRunner:
             name = "claude"
-            async def headless(self, *args, **kwargs):
-                return ("error", 1, None)
+            async def run(self, request):
+                return Response(output="error", exit_code=1)
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
 
@@ -405,7 +406,7 @@ class TestConsecutiveFailureAbort:
 
         class MockRunner:
             name = "claude"
-            async def headless(self, *args, **kwargs):
+            async def run(self, request):
                 raise RuntimeError("Connection failed")
 
         monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,7 +31,7 @@ def _mock_foreground():
     """Mock the interactive foreground path: subprocess.run inside ClaudeRunner,
     worktree lifecycle, and dashboard.  Yields the subprocess.run mock."""
     mock_run = MagicMock(return_value=MagicMock(returncode=0))
-    with patch("factory.runners.claude.subprocess.run", mock_run), \
+    with patch("factory.runners.abstraction.subprocess.run", mock_run), \
          patch("factory.worktree.create_worktree",
                side_effect=lambda p, b="main": (p, "factory/run-test")), \
          patch("factory.worktree.remove_worktree"), \

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -120,13 +120,18 @@ class TestCodexAuth:
 
 
 class TestCodexEnvMapping:
+    def _build_env(self, **overrides: str) -> dict[str, str]:
+        """Helper: build env via CodexRunner._build_env with a dummy Request."""
+        from factory.runners.abstraction import Request
+
+        request = Request(system_prompt="test", task="test", cwd="/tmp", **overrides)
+        return CodexRunner()._build_env(request)
+
     def test_codex_key_mapped_to_openai(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "my-codex-key")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
-        from factory.runners.codex import _make_codex_env
-
-        env = _make_codex_env()
+        env = self._build_env()
         assert env["OPENAI_API_KEY"] == "my-codex-key"
         assert "VIRTUAL_ENV" not in env
 
@@ -134,17 +139,13 @@ class TestCodexEnvMapping:
         monkeypatch.setenv("CODEX_API_KEY", "codex-key")
         monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
 
-        from factory.runners.codex import _make_codex_env
-
-        env = _make_codex_env()
+        env = self._build_env()
         assert env["OPENAI_API_KEY"] == "openai-key"
 
     def test_virtual_env_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
 
-        from factory.runners.codex import _make_codex_env
-
-        env = _make_codex_env()
+        env = self._build_env()
         assert "VIRTUAL_ENV" not in env
 
 
@@ -158,7 +159,7 @@ class TestCodexHeadless:
         runner = CodexRunner()
 
         with patch(
-            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"output", b"")
 
@@ -200,7 +201,7 @@ class TestCodexHeadless:
         runner = CodexRunner()
 
         with patch(
-            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"ok", b"")
 
@@ -232,7 +233,7 @@ class TestCodexHeadless:
         runner = CodexRunner()
 
         with patch(
-            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"ok", b"")
 
@@ -263,7 +264,7 @@ class TestCodexHeadless:
         runner = CodexRunner()
 
         with patch(
-            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"ok", b"")
 
@@ -292,7 +293,7 @@ class TestCodexHeadless:
         monkeypatch.setenv("CODEX_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_CODEX_DRY_RUN", raising=False)
 
-        with patch("factory.runners.codex.asyncio.wait_for", side_effect=aio.TimeoutError):
+        with patch("factory.runners.abstraction.asyncio.wait_for", side_effect=aio.TimeoutError):
             with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
                 mock_proc = AsyncMock()
                 mock_proc.kill = AsyncMock()
@@ -345,7 +346,7 @@ class TestCodexHeadless:
         runner = CodexRunner()
 
         with patch(
-            "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"ok", b"")
 
@@ -377,9 +378,9 @@ class TestCodexStreaming:
 
         runner = CodexRunner()
 
-        with patch("factory.runners.codex.should_stream", return_value=True):
+        with patch("factory.runners.abstraction.should_stream", return_value=True):
             with patch(
-                "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+                "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
             ) as mock_stream:
                 mock_stream.return_value = (b"output\n", b"")
 
@@ -412,9 +413,9 @@ class TestCodexStreaming:
 
         runner = CodexRunner()
 
-        with patch("factory.runners.codex.should_stream", return_value=True):
+        with patch("factory.runners.abstraction.should_stream", return_value=True):
             with patch(
-                "factory.runners.codex.stream_subprocess", new_callable=AsyncMock
+                "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
             ) as mock_stream:
                 mock_stream.return_value = (b"output\n", b"")
 

--- a/tests/test_runner_integration.py
+++ b/tests/test_runner_integration.py
@@ -1,0 +1,373 @@
+"""Integration tests for the agent-runner abstraction.
+
+Tests the full path: invoke_agent() -> get_runner() -> runner.run(Request) -> Response -> event emission.
+Also tests runner registry, identity uniqueness, and edge cases.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from factory.runners import _RUNNERS, get_runner
+from factory.runners.abstraction import (
+    AgentRunner,
+    Request,
+    Response,
+)
+
+
+# ── Runner registry tests ─────────────────────────────────────
+
+
+class TestRunnerRegistry:
+    def test_all_runners_resolve(self) -> None:
+        """get_runner() resolves all registered runner names."""
+        for name in _RUNNERS:
+            if name == "bob":
+                runner = get_runner(name, project_path=None)
+            else:
+                runner = get_runner(name)
+            assert isinstance(runner, AgentRunner)
+
+    def test_unique_identity_names(self) -> None:
+        """All 5 runners have unique identity names."""
+        names: set[str] = set()
+        for key, cls in _RUNNERS.items():
+            if key == "bob":
+                runner = cls()
+            else:
+                runner = cls()
+            name = runner.identity.name
+            assert name not in names, f"Duplicate identity name: {name}"
+            names.add(name)
+        assert len(names) == 5
+
+    def test_valid_binary_names(self) -> None:
+        """All 5 runners have non-empty binary names."""
+        for key, cls in _RUNNERS.items():
+            runner = cls()
+            assert runner.identity.binary, f"{key} has empty binary"
+            assert isinstance(runner.identity.binary, str)
+
+    def test_unknown_runner_raises(self) -> None:
+        """Runner not found -> ValueError."""
+        with pytest.raises(ValueError, match="Unknown runner"):
+            get_runner("nonexistent")
+
+
+# ── ClaudeRunner integration ──────────────────────────────────
+
+
+class TestClaudeRunnerIntegration:
+    async def test_invoke_agent_constructs_request(self, tmp_path: Path) -> None:
+        """invoke_agent() -> get_runner() -> runner.run(Request) -> Response."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+
+        captured_request: list[Request] = []
+
+        async def capture_run(self: AgentRunner, request: Request) -> Response:
+            captured_request.append(request)
+            return Response(output="test output", exit_code=0)
+
+        with patch("factory.runners.abstraction.AgentRunner.run", capture_run), \
+             patch("factory.agents.runner.get_runner") as mock_get_runner, \
+             patch("factory.agents.runner.resolve_prompt", return_value="You are a builder."):
+            from factory.runners.claude import ClaudeRunner
+            runner = ClaudeRunner()
+            mock_get_runner.return_value = runner
+
+            from factory.agents.runner import invoke_agent
+            stdout, return_code = await invoke_agent(
+                "builder", "Build feature X", project,
+                timeout=120.0, model="claude-sonnet-4-6",
+                _track_failures=False,
+            )
+
+        assert return_code == 0
+        assert stdout == "test output"
+        assert len(captured_request) == 1
+        req = captured_request[0]
+        assert req.system_prompt == "You are a builder."
+        assert req.task == "Build feature X"
+        assert req.timeout == 120.0
+        assert req.model == "claude-sonnet-4-6"
+        assert req.role == "builder"
+
+    async def test_claude_request_constructed_correctly(self, tmp_path: Path) -> None:
+        """ClaudeRunner._build_command() maps Request fields to CLI args."""
+        from factory.runners.claude import ClaudeRunner
+
+        runner = ClaudeRunner()
+        req = Request(
+            system_prompt="sys", task="do stuff", cwd=str(tmp_path),
+            model="claude-sonnet-4-6", session_name="sess1",
+        )
+        cmd = runner._build_command(req, prompt_file="/tmp/prompt.md")
+        assert cmd[0] == "claude"
+        assert "--append-system-prompt-file" in cmd
+        assert "/tmp/prompt.md" in cmd
+        assert "-p" in cmd
+        assert "do stuff" in cmd
+        assert "--model" in cmd
+        assert "claude-sonnet-4-6" in cmd
+        assert "--name" in cmd
+        assert "sess1" in cmd
+        assert "--output-format" in cmd
+        assert "json" in cmd
+
+    async def test_claude_response_unpacked(self, tmp_path: Path) -> None:
+        """Response from ClaudeRunner is unpacked to (stdout, return_code) by invoke_agent."""
+        import json
+
+        from factory.runners.claude import ClaudeRunner
+
+        runner = ClaudeRunner()
+        raw_json = json.dumps({"result": "review complete", "cost_usd": 0.01})
+        resp = runner._parse_response(raw_json, "", 0)
+        assert resp.output == "review complete"
+        assert resp.exit_code == 0
+        assert resp.usage is not None
+        assert resp.usage.total_cost_usd == 0.01
+
+
+# ── CodexRunner integration ──────────────────────────────────
+
+
+class TestCodexRunnerIntegration:
+    def test_codex_env_maps_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CodexRunner._build_env() maps CODEX_API_KEY -> OPENAI_API_KEY."""
+        monkeypatch.setenv("CODEX_API_KEY", "sk-test-123")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        from factory.runners.codex import CodexRunner
+        runner = CodexRunner()
+        req = Request(system_prompt="sp", task="t", cwd="/tmp")
+        env = runner._build_env(req)
+        assert env["OPENAI_API_KEY"] == "sk-test-123"
+
+    def test_codex_command_uses_prompt_property(self) -> None:
+        """CodexRunner._build_command() uses request.prompt (combined)."""
+        from factory.runners.codex import CodexRunner
+
+        runner = CodexRunner()
+        req = Request(system_prompt="You are a reviewer.", task="Review PR", cwd="/tmp")
+        cmd = runner._build_command(req)
+        assert cmd[0] == "codex"
+        assert cmd[1] == "exec"
+        # The prompt should contain both system_prompt and task
+        assert "You are a reviewer." in cmd[2]
+        assert "Review PR" in cmd[2]
+
+
+# ── OpenCodeRunner integration ────────────────────────────────
+
+
+class TestOpenCodeRunnerIntegration:
+    def test_model_with_provider_prefix(self) -> None:
+        """OpenCodeRunner passes through model with provider/ prefix."""
+        from factory.runners.opencode import OpenCodeRunner
+
+        runner = OpenCodeRunner()
+        req = Request(
+            system_prompt="sp", task="t", cwd="/tmp",
+            model="openai/gpt-4o",
+        )
+        cmd = runner._build_command(req)
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "openai/gpt-4o"
+
+    def test_model_without_provider_gets_anthropic_prefix(self) -> None:
+        """OpenCodeRunner adds anthropic/ prefix when model has no /."""
+        from factory.runners.opencode import OpenCodeRunner
+
+        runner = OpenCodeRunner()
+        req = Request(
+            system_prompt="sp", task="t", cwd="/tmp",
+            model="claude-sonnet-4-6",
+        )
+        cmd = runner._build_command(req)
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "anthropic/claude-sonnet-4-6"
+
+
+# ── AiderRunner integration ──────────────────────────────────
+
+
+class TestAiderRunnerIntegration:
+    def test_minimal_command(self) -> None:
+        """AiderRunner builds minimal command with --message and --yes."""
+        from factory.runners.aider import AiderRunner
+
+        runner = AiderRunner()
+        req = Request(system_prompt="sp", task="t", cwd="/tmp")
+        cmd = runner._build_command(req)
+        assert cmd[0] == "aider"
+        assert "--message" in cmd
+        assert "--yes" in cmd
+
+
+# ── invoke_agent event emission ───────────────────────────────
+
+
+class TestInvokeAgentEvents:
+    async def test_events_emitted_on_success(self, tmp_path: Path) -> None:
+        """invoke_agent() emits agent.started and agent.completed events."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        emitted: list[str] = []
+
+        def track_emit(path: Path, event_type: str, **kwargs: object) -> None:
+            emitted.append(event_type)
+
+        async def mock_run(self: AgentRunner, request: Request) -> Response:
+            return Response(output="done", exit_code=0)
+
+        with patch("factory.runners.abstraction.AgentRunner.run", mock_run), \
+             patch("factory.agents.runner.get_runner") as mock_get_runner, \
+             patch("factory.agents.runner.resolve_prompt", return_value="prompt"), \
+             patch("factory.agents.runner._emit_safe", side_effect=track_emit):
+            from factory.runners.claude import ClaudeRunner
+            mock_get_runner.return_value = ClaudeRunner()
+
+            from factory.agents.runner import invoke_agent
+            await invoke_agent("researcher", "research X", project, _track_failures=False)
+
+        assert "agent.started" in emitted
+        assert "agent.completed" in emitted
+
+    async def test_events_emitted_on_failure(self, tmp_path: Path) -> None:
+        """invoke_agent() emits agent.started and agent.failed on non-zero exit."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        emitted: list[str] = []
+
+        def track_emit(path: Path, event_type: str, **kwargs: object) -> None:
+            emitted.append(event_type)
+
+        async def mock_run(self: AgentRunner, request: Request) -> Response:
+            return Response(output="error", exit_code=1)
+
+        with patch("factory.runners.abstraction.AgentRunner.run", mock_run), \
+             patch("factory.agents.runner.get_runner") as mock_get_runner, \
+             patch("factory.agents.runner.resolve_prompt", return_value="prompt"), \
+             patch("factory.agents.runner._emit_safe", side_effect=track_emit):
+            from factory.runners.claude import ClaudeRunner
+            mock_get_runner.return_value = ClaudeRunner()
+
+            from factory.agents.runner import invoke_agent
+            await invoke_agent("builder", "build X", project, _track_failures=False)
+
+        assert "agent.started" in emitted
+        assert "agent.failed" in emitted
+
+
+# ── Edge cases ────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    async def test_timeout_returns_error_response(self, tmp_path: Path) -> None:
+        """Timeout -> process killed, error Response returned."""
+        from factory.runners.claude import ClaudeRunner
+
+        runner = ClaudeRunner()
+        req = Request(system_prompt="sp", task="t", cwd=str(tmp_path), timeout=0.001)
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = -9
+
+        with patch("factory.runners.abstraction.asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch("factory.runners.abstraction.stream_subprocess", side_effect=asyncio.TimeoutError), \
+             patch("factory.runners.abstraction.should_stream", return_value=False):
+            resp = await runner.run(req)
+
+        assert resp.exit_code == 1
+        assert "timed out" in resp.output.lower()
+        assert resp.error is not None
+        mock_proc.kill.assert_called_once()
+
+    async def test_binary_not_found_handled(self, tmp_path: Path) -> None:
+        """Binary not found -> FileNotFoundError handled gracefully."""
+        from factory.runners.claude import ClaudeRunner
+
+        runner = ClaudeRunner()
+        req = Request(system_prompt="sp", task="t", cwd=str(tmp_path))
+
+        with patch("factory.runners.abstraction.asyncio.create_subprocess_exec", side_effect=FileNotFoundError), \
+             patch("factory.runners.abstraction.should_stream", return_value=False):
+            resp = await runner.run(req)
+
+        assert resp.exit_code == 1
+        assert "not found" in resp.output.lower()
+        assert resp.error is not None
+
+    async def test_review_saved_on_success(self, tmp_path: Path) -> None:
+        """Agent output is saved to .factory/reviews/<role>-latest.md."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        async def mock_run(self: AgentRunner, request: Request) -> Response:
+            return Response(output="analysis complete", exit_code=0)
+
+        with patch("factory.runners.abstraction.AgentRunner.run", mock_run), \
+             patch("factory.agents.runner.get_runner") as mock_get_runner, \
+             patch("factory.agents.runner.resolve_prompt", return_value="prompt"):
+            from factory.runners.claude import ClaudeRunner
+            mock_get_runner.return_value = ClaudeRunner()
+
+            from factory.agents.runner import invoke_agent
+            await invoke_agent("researcher", "analyze", project, _track_failures=False)
+
+        review_file = project / ".factory" / "reviews" / "researcher-latest.md"
+        assert review_file.exists()
+        content = review_file.read_text()
+        assert "analysis complete" in content
+        assert "Researcher" in content
+
+
+# ── _classify_with_llm integration ────────────────────────────
+
+
+class TestClassifyWithLlm:
+    def test_uses_request_response_interface(self) -> None:
+        """_classify_with_llm() uses Request/Response when runner is AgentRunner."""
+        import json
+
+        from factory.runners.claude import ClaudeRunner
+
+        response_json = json.dumps({
+            "follow_ups": [],
+            "suggestions": [{"label": "test", "command": "factory ceo /tmp"}],
+        })
+        mock_response = Response(output=response_json, exit_code=0)
+
+        async def mock_run(self: AgentRunner, request: Request) -> Response:
+            assert request.role == "wizard"
+            assert request.timeout == 60.0
+            assert request.skip_permissions is True
+            return mock_response
+
+        with patch("factory.runners.abstraction.AgentRunner.run", mock_run), \
+             patch("factory.runners.get_runner", return_value=ClaudeRunner()), \
+             patch("factory.cli._show_spinner"):
+            from factory.cli import _classify_with_llm
+            result = _classify_with_llm("build a weather app")
+
+        assert result is not None
+        follow_ups, suggestions = result
+        assert len(suggestions) == 1
+        assert suggestions[0]["label"] == "test"

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -173,7 +173,7 @@ class TestBobRunner:
 
         (tmp_path / ".factory").mkdir()
 
-        with patch("factory.runners.bob.asyncio.wait_for", side_effect=asyncio.TimeoutError):
+        with patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
             with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
                 mock_proc = AsyncMock()
                 mock_proc.kill = AsyncMock()
@@ -484,7 +484,7 @@ class TestBobAuthPreflight:
 
         # Mock the streaming subprocess to avoid actual bob invocation
         with patch(
-            "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"output", b"")
 
@@ -634,7 +634,7 @@ class TestKeyPersistence:
         monkeypatch.chdir(tmp_path)
 
         with patch(
-            "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"output", b"")
 
@@ -865,9 +865,9 @@ class TestStreamingOutput:
         import factory.runners.bob as bob_module
         bob_module._auth_checked = False
 
-        with patch("factory.runners.bob.should_stream", return_value=True):
+        with patch("factory.runners.abstraction.should_stream", return_value=True):
             with patch(
-                "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+                "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
             ) as mock_stream:
                 mock_stream.return_value = (b"output\n", b"")
 
@@ -1189,9 +1189,9 @@ class TestAnsiSanitization:
 
         runner = BobRunner()
 
-        with patch("factory.runners.bob.should_stream", return_value=True):
+        with patch("factory.runners.abstraction.should_stream", return_value=True):
             with patch(
-                "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+                "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
             ) as mock_stream:
                 mock_stream.return_value = (b"output\n", b"")
 
@@ -1292,7 +1292,7 @@ class TestCeilingAccumulationAcrossInvocations:
 
         # Mock subprocess to avoid actually calling bob
         with patch(
-            "factory.runners.bob.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b"output", b"")
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -51,7 +51,7 @@ class TestClaudeRunner:
         runner = ClaudeRunner()
 
         with patch(
-            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b'{"result":"output","usage":{},"cost_usd":0,"duration_ms":0,"num_turns":1,"model":"claude-opus-4-7"}', b"")
 
@@ -90,7 +90,7 @@ class TestClaudeRunner:
         runner = ClaudeRunner()
 
         with patch(
-            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b'{"result":"ok"}', b"")
 
@@ -821,9 +821,9 @@ class TestStreamingOutput:
         runner = ClaudeRunner()
 
         # Mock should_stream to return True
-        with patch("factory.runners.claude.should_stream", return_value=True):
+        with patch("factory.runners.abstraction.should_stream", return_value=True):
             with patch(
-                "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+                "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
             ) as mock_stream:
                 mock_stream.return_value = (b'{"result":"output"}', b"")
 
@@ -903,7 +903,7 @@ class TestStreamingOutput:
         runner = ClaudeRunner()
 
         with patch(
-            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (b'{"result":"output"}', b"")
 
@@ -940,7 +940,7 @@ class TestStreamingOutput:
         json_output = json.dumps({"result": "Line 1\nLine 2\nLine 3\n", "usage": {}, "cost_usd": 0.01})
 
         with patch(
-            "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+            "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
         ) as mock_stream:
             mock_stream.return_value = (json_output.encode(), b"")
 
@@ -1224,9 +1224,9 @@ class TestAnsiSanitization:
 
         runner = ClaudeRunner()
 
-        with patch("factory.runners.claude.should_stream", return_value=True):
+        with patch("factory.runners.abstraction.should_stream", return_value=True):
             with patch(
-                "factory.runners.claude.stream_subprocess", new_callable=AsyncMock
+                "factory.runners.abstraction.stream_subprocess", new_callable=AsyncMock
             ) as mock_stream:
                 mock_stream.return_value = (b'{"result":"output"}', b"")
 

--- a/tests/test_tmux_persist.py
+++ b/tests/test_tmux_persist.py
@@ -260,9 +260,9 @@ class TestClaudeRunnerTmuxPersist:
 
         with (
             patch("factory.runners._tmux_persist.tmux_available", return_value=False),
-            patch("factory.runners.claude.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("factory.runners.claude.stream_subprocess", return_value=(b"headless output", b"")),
-            patch("factory.runners.claude.should_stream", return_value=False),
+            patch("factory.runners.abstraction.asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("factory.runners.abstraction.stream_subprocess", return_value=(b"headless output", b"")),
+            patch("factory.runners.abstraction.should_stream", return_value=False),
         ):
             stdout, code, _usage = await runner.headless(
                 prompt="test prompt", task="test task", cwd=tmp_path,
@@ -276,9 +276,9 @@ class TestClaudeRunnerTmuxPersist:
         mock_proc.returncode = 0
 
         with (
-            patch("factory.runners.claude.asyncio.create_subprocess_exec", return_value=mock_proc),
-            patch("factory.runners.claude.stream_subprocess", return_value=(b"normal", b"")),
-            patch("factory.runners.claude.should_stream", return_value=False),
+            patch("factory.runners.abstraction.asyncio.create_subprocess_exec", return_value=mock_proc),
+            patch("factory.runners.abstraction.stream_subprocess", return_value=(b"normal", b"")),
+            patch("factory.runners.abstraction.should_stream", return_value=False),
         ):
             stdout, code, _usage = await runner.headless(
                 prompt="test prompt", task="test task", cwd=tmp_path,


### PR DESCRIPTION
## Summary

Complete Agent-Runner Abstraction — phases H1 through H5. Introduces the `AgentRunner` base class, migrates all existing runners to extend it, adds two new runner backends, removes the legacy dispatch path, updates tests, and adds integration testing.

### Phase H1: Base class and core types
- `AgentRunner` ABC with `Request`/`Response` types, `RunnerIdentity`, `Capability` enum
- Shared subprocess lifecycle in `run()` and `run_interactive()`

### Phase H2: Migrate ClaudeRunner
- `ClaudeRunner` extends `AgentRunner` with JSON output parsing, tmux support, session resume

### Phase H3: Migrate remaining runners + add new
- **Migrated BobRunner** — ceiling enforcement, auth, dry-run, ANSI sanitization, PATH manipulation preserved via method overrides
- **Migrated CodexRunner** — API key mapping (`CODEX_API_KEY` → `OPENAI_API_KEY`) via `_build_env`, dry-run via `run` override
- **Created OpenCodeRunner** — supports `--dangerously-skip-permissions`, `--model provider/model` format
- **Created AiderRunner** — minimal runner using `--message` and `--yes` flags
- **Updated `RunnerName`** to include all 5 backends: claude, bob, codex, opencode, aider
- **Removed legacy isinstance check** in `factory/agents/runner.py` — all runners use unified `Request`/`Response` interface
- **Updated `--runner` argparse choices** across all CLI subcommands

### Phase H4: Update tests + health CLI
- Updated test mocks from tuple returns to `Response` objects
- Added `tests/test_abstraction.py` — unit tests for base class and core types
- Added `factory health` CLI command

### Phase H5: Integration testing and documentation
- **Created `tests/test_runner_integration.py`** (18 tests) covering:
  - Full path: `invoke_agent()` → `get_runner()` → `runner.run(Request)` → `Response` → event emission
  - Per-runner verification: ClaudeRunner, CodexRunner, OpenCodeRunner, AiderRunner
  - `_classify_with_llm()` Request/Response interface
  - Registry: all 5 runners resolve, unique identities, valid binaries
  - Edge cases: unknown runner ValueError, timeout, binary not found
  - Event emission and review file saving
- **Expanded `abstraction.py` docstring**: 3-method contract, how to add a runner, Request.prompt vs system_prompt/task

## Verification

- `pytest tests/ -x -q` — 2223 passed, 0 failures
- `ruff check .` — all checks passed
- All 5 runners resolve via `get_runner()`

## Test plan

- [x] `pytest tests/test_runner_integration.py -v` — 18/18 passed
- [x] `pytest tests/ -x -q` — 2223 passed, 0 failures
- [x] `ruff check .` passes