### PR TITLE
ci: debug ceo-review workflow for CI testing

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -1,16 +1,8 @@
 name: CEO PR Review
 
 on:
-  pull_request:
-    types: [labeled]
   issue_comment:
     types: [created]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to review"
-        required: true
-        type: number
 
 permissions:
   contents: read
@@ -20,19 +12,14 @@ permissions:
 jobs:
   review:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      github.event.label.name == 'ceo-review' &&
-      contains(fromJSON('["akashgit", "xukai92"]'), github.actor)) ||
-      (github.event.issue.pull_request &&
+      github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
-      contains(fromJSON('["akashgit", "xukai92"]'), github.event.comment.user.login))
+      contains(fromJSON('["akashgit", "xukai92"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
       - name: React with eyes
-        if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
         with:
           script: |
@@ -45,14 +32,7 @@ jobs:
 
       - name: Get PR number
         id: pr
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR merge ref
         uses: actions/checkout@v4

--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -1,6 +1,8 @@
 name: CEO PR Review
 
 on:
+  pull_request:
+    types: [labeled]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -19,6 +21,9 @@ jobs:
   review:
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      github.event.label.name == 'ceo-review' &&
+      contains(fromJSON('["akashgit", "xukai92"]'), github.actor)) ||
       (github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
       contains(fromJSON('["akashgit", "xukai92"]'), github.event.comment.user.login))
@@ -43,6 +48,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           fi
@@ -72,11 +79,18 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Verify Claude Code on PATH
+        run: |
+          export PATH="$(npm prefix -g)/bin:$PATH"
+          echo "PATH=$(npm prefix -g)/bin:$PATH" >> "$GITHUB_ENV"
+          claude --version
+
       - name: Run CEO review
         env:
           CLAUDE_CODE_USE_VERTEX: "1"
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
           CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv run factory ceo . --mode review --pr ${{ steps.pr.outputs.number }} --headless
 


### PR DESCRIPTION
## Summary

- Add `pull_request: labeled` trigger so the workflow can be tested from this PR (since `issue_comment` only fires for workflows already on `main`)
- Add `pull_request` event handling in the job `if` condition (authorized users + `ceo-review` label) and PR number extraction
- Add Claude Code PATH verification step after `npm install -g` to ensure `claude` is discoverable by the factory subprocess
- Pass `GITHUB_TOKEN` explicitly to the review step so `gh pr diff` / `gh pr view` work inside the spawned CEO agent

## Test plan

- [ ] Apply the `ceo-review` label to this PR to trigger the workflow
- [ ] Verify the workflow starts and passes the "Verify Claude Code on PATH" step
- [ ] Verify GCP auth succeeds
- [ ] Verify the full CEO review completes and posts a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)