### PR TITLE
ci: auto-approve PR when CEO review verdict is KEEP

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -86,6 +86,7 @@ jobs:
               per_page: 5,
             });
             const latest = comments.data.reverse().find(c =>
+              c.user.login === 'github-actions[bot]' &&
               c.body.includes('Factory') && c.body.includes('Review:')
             );
             if (latest && latest.body.includes('KEEP')) {

--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -74,6 +74,30 @@ jobs:
         run: |
           uv run factory ceo . --mode review --pr ${{ steps.pr.outputs.number }} --headless
 
+      - name: Approve PR if verdict is KEEP
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.number }},
+              per_page: 5,
+            });
+            const latest = comments.data.reverse().find(c =>
+              c.body.includes('Factory') && c.body.includes('Review:')
+            );
+            if (latest && latest.body.includes('KEEP')) {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: ${{ steps.pr.outputs.number }},
+                event: 'APPROVE',
+                body: '✅ Factory CEO approved this PR.',
+              });
+            }
+
       - name: Post failure comment
         if: failure()
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

- After the CEO review step completes successfully, check the posted review comment for a KEEP verdict
- If KEEP, submit a formal GitHub PR approval via `pulls.createReview` with `event: 'APPROVE'`
- This satisfies the 1-reviewer branch protection requirement, allowing the PR to be merged without manual approval

The CEO agent already tries `gh pr review --approve` itself, but the default `GITHUB_TOKEN` can't approve from within a subprocess (GitHub security restriction). Moving the approval to a top-level workflow step using `actions/github-script` works because the token has `pull-requests: write` permission.

**Note:** You may need to enable "Allow GitHub Actions reviews to count toward required approval" in repo Settings → Rules → (your ruleset) for this to satisfy the branch protection requirement.

## Test plan

- [ ] Merge this PR
- [ ] Comment `@ceo-review` on a test PR
- [ ] Verify the CEO posts a KEEP comment and the workflow submits a formal approval
- [ ] Verify the PR shows as approved and mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)