### PR TITLE
feat: multi-language eval engine (Rust/TS/Go/Java)

### DIFF
--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -111,7 +111,11 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
             try:
                 toml_text = (project_path / "pyproject.toml").read_text().lower()
             except (OSError, UnicodeDecodeError) as exc:
-                log.debug("framework_file_read_failed", path=str(project_path / "pyproject.toml"), exc=str(exc))
+                log.debug(
+                    "framework_file_read_failed",
+                    path=str(project_path / "pyproject.toml"),
+                    exc=str(exc),
+                )
         if "fastapi" in toml_text:
             return "fastapi"
         if "django" in toml_text:
@@ -133,7 +137,11 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
             try:
                 cargo_text = (project_path / "Cargo.toml").read_text().lower()
             except (OSError, UnicodeDecodeError) as exc:
-                log.debug("framework_file_read_failed", path=str(project_path / "Cargo.toml"), exc=str(exc))
+                log.debug(
+                    "framework_file_read_failed",
+                    path=str(project_path / "Cargo.toml"),
+                    exc=str(exc),
+                )
         if "actix-web" in cargo_text:
             return "actix-web"
         if "axum" in cargo_text:
@@ -146,12 +154,20 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
             try:
                 go_deps = (project_path / "go.mod").read_text().lower()
             except (OSError, UnicodeDecodeError) as exc:
-                log.debug("framework_file_read_failed", path=str(project_path / "go.mod"), exc=str(exc))
+                log.debug(
+                    "framework_file_read_failed",
+                    path=str(project_path / "go.mod"),
+                    exc=str(exc),
+                )
         elif (project_path / "go.sum").exists():
             try:
                 go_deps = (project_path / "go.sum").read_text().lower()
             except (OSError, UnicodeDecodeError) as exc:
-                log.debug("framework_file_read_failed", path=str(project_path / "go.sum"), exc=str(exc))
+                log.debug(
+                    "framework_file_read_failed",
+                    path=str(project_path / "go.sum"),
+                    exc=str(exc),
+                )
         if "gin-gonic/gin" in go_deps:
             return "gin"
         if "labstack/echo" in go_deps:
@@ -164,17 +180,29 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
             try:
                 java_deps = (project_path / "pom.xml").read_text().lower()
             except (OSError, UnicodeDecodeError) as exc:
-                log.debug("framework_file_read_failed", path=str(project_path / "pom.xml"), exc=str(exc))
+                log.debug(
+                    "framework_file_read_failed",
+                    path=str(project_path / "pom.xml"),
+                    exc=str(exc),
+                )
         if (project_path / "build.gradle").exists():
             try:
-                java_deps += (project_path / "build.gradle").read_text().lower()
+                java_deps += "\n" + (project_path / "build.gradle").read_text().lower()
             except (OSError, UnicodeDecodeError) as exc:
-                log.debug("framework_file_read_failed", path=str(project_path / "build.gradle"), exc=str(exc))
+                log.debug(
+                    "framework_file_read_failed",
+                    path=str(project_path / "build.gradle"),
+                    exc=str(exc),
+                )
         if (project_path / "build.gradle.kts").exists():
             try:
-                java_deps += (project_path / "build.gradle.kts").read_text().lower()
+                java_deps += "\n" + (project_path / "build.gradle.kts").read_text().lower()
             except (OSError, UnicodeDecodeError) as exc:
-                log.debug("framework_file_read_failed", path=str(project_path / "build.gradle.kts"), exc=str(exc))
+                log.debug(
+                    "framework_file_read_failed",
+                    path=str(project_path / "build.gradle.kts"),
+                    exc=str(exc),
+                )
         if "spring-boot" in java_deps:
             return "spring-boot"
         if "quarkus" in java_deps:

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import structlog
@@ -109,8 +110,8 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if (project_path / "pyproject.toml").exists():
             try:
                 toml_text = (project_path / "pyproject.toml").read_text().lower()
-            except (OSError, UnicodeDecodeError):
-                pass
+            except (OSError, UnicodeDecodeError) as exc:
+                log.debug("framework_file_read_failed", path=str(project_path / "pyproject.toml"), exc=str(exc))
         if "fastapi" in toml_text:
             return "fastapi"
         if "django" in toml_text:
@@ -131,8 +132,8 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if (project_path / "Cargo.toml").exists():
             try:
                 cargo_text = (project_path / "Cargo.toml").read_text().lower()
-            except (OSError, UnicodeDecodeError):
-                pass
+            except (OSError, UnicodeDecodeError) as exc:
+                log.debug("framework_file_read_failed", path=str(project_path / "Cargo.toml"), exc=str(exc))
         if "actix-web" in cargo_text:
             return "actix-web"
         if "axum" in cargo_text:
@@ -144,13 +145,13 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if (project_path / "go.mod").exists():
             try:
                 go_deps = (project_path / "go.mod").read_text().lower()
-            except (OSError, UnicodeDecodeError):
-                pass
+            except (OSError, UnicodeDecodeError) as exc:
+                log.debug("framework_file_read_failed", path=str(project_path / "go.mod"), exc=str(exc))
         elif (project_path / "go.sum").exists():
             try:
                 go_deps = (project_path / "go.sum").read_text().lower()
-            except (OSError, UnicodeDecodeError):
-                pass
+            except (OSError, UnicodeDecodeError) as exc:
+                log.debug("framework_file_read_failed", path=str(project_path / "go.sum"), exc=str(exc))
         if "gin-gonic/gin" in go_deps:
             return "gin"
         if "labstack/echo" in go_deps:
@@ -162,18 +163,18 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if (project_path / "pom.xml").exists():
             try:
                 java_deps = (project_path / "pom.xml").read_text().lower()
-            except (OSError, UnicodeDecodeError):
-                pass
+            except (OSError, UnicodeDecodeError) as exc:
+                log.debug("framework_file_read_failed", path=str(project_path / "pom.xml"), exc=str(exc))
         if (project_path / "build.gradle").exists():
             try:
                 java_deps += (project_path / "build.gradle").read_text().lower()
-            except (OSError, UnicodeDecodeError):
-                pass
+            except (OSError, UnicodeDecodeError) as exc:
+                log.debug("framework_file_read_failed", path=str(project_path / "build.gradle"), exc=str(exc))
         if (project_path / "build.gradle.kts").exists():
             try:
                 java_deps += (project_path / "build.gradle.kts").read_text().lower()
-            except (OSError, UnicodeDecodeError):
-                pass
+            except (OSError, UnicodeDecodeError) as exc:
+                log.debug("framework_file_read_failed", path=str(project_path / "build.gradle.kts"), exc=str(exc))
         if "spring-boot" in java_deps:
             return "spring-boot"
         if "quarkus" in java_deps:
@@ -235,6 +236,10 @@ def _detect_lint_command(project_path: Path, language: str) -> str | None:
     elif language == "java":
         if (project_path / "pom.xml").exists():
             return "mvn checkstyle:check"
+        if (project_path / "gradlew").exists():
+            return "./gradlew checkstyleMain"
+        if (project_path / "build.gradle").exists() or (project_path / "build.gradle.kts").exists():
+            return "gradle checkstyleMain"
         return None
     return None
 
@@ -268,7 +273,7 @@ def _detect_type_check_command(project_path: Path, language: str) -> str | None:
             return "cargo check"
     elif language == "go":
         if (project_path / "go.mod").exists():
-            return "go build -o /dev/null ./..."
+            return f"go build -o {os.devnull} ./..."
     return None
 
 

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -107,7 +107,10 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
     if language == "python":
         toml_text = ""
         if (project_path / "pyproject.toml").exists():
-            toml_text = (project_path / "pyproject.toml").read_text().lower()
+            try:
+                toml_text = (project_path / "pyproject.toml").read_text().lower()
+            except (OSError, UnicodeDecodeError):
+                pass
         if "fastapi" in toml_text:
             return "fastapi"
         if "django" in toml_text:
@@ -126,7 +129,10 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
     elif language == "rust":
         cargo_text = ""
         if (project_path / "Cargo.toml").exists():
-            cargo_text = (project_path / "Cargo.toml").read_text().lower()
+            try:
+                cargo_text = (project_path / "Cargo.toml").read_text().lower()
+            except (OSError, UnicodeDecodeError):
+                pass
         if "actix-web" in cargo_text:
             return "actix-web"
         if "axum" in cargo_text:
@@ -136,9 +142,15 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
     elif language == "go":
         go_deps = ""
         if (project_path / "go.mod").exists():
-            go_deps = (project_path / "go.mod").read_text().lower()
+            try:
+                go_deps = (project_path / "go.mod").read_text().lower()
+            except (OSError, UnicodeDecodeError):
+                pass
         elif (project_path / "go.sum").exists():
-            go_deps = (project_path / "go.sum").read_text().lower()
+            try:
+                go_deps = (project_path / "go.sum").read_text().lower()
+            except (OSError, UnicodeDecodeError):
+                pass
         if "gin-gonic/gin" in go_deps:
             return "gin"
         if "labstack/echo" in go_deps:
@@ -148,11 +160,20 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
     elif language == "java":
         java_deps = ""
         if (project_path / "pom.xml").exists():
-            java_deps = (project_path / "pom.xml").read_text().lower()
+            try:
+                java_deps = (project_path / "pom.xml").read_text().lower()
+            except (OSError, UnicodeDecodeError):
+                pass
         if (project_path / "build.gradle").exists():
-            java_deps += (project_path / "build.gradle").read_text().lower()
+            try:
+                java_deps += (project_path / "build.gradle").read_text().lower()
+            except (OSError, UnicodeDecodeError):
+                pass
         if (project_path / "build.gradle.kts").exists():
-            java_deps += (project_path / "build.gradle.kts").read_text().lower()
+            try:
+                java_deps += (project_path / "build.gradle.kts").read_text().lower()
+            except (OSError, UnicodeDecodeError):
+                pass
         if "spring-boot" in java_deps:
             return "spring-boot"
         if "quarkus" in java_deps:

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -121,6 +121,28 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
             return "next.js"
         if "express" in deps:
             return "express"
+    elif language == "rust":
+        cargo_text = ""
+        if (project_path / "Cargo.toml").exists():
+            cargo_text = (project_path / "Cargo.toml").read_text().lower()
+        if "actix-web" in cargo_text:
+            return "actix-web"
+        if "axum" in cargo_text:
+            return "axum"
+        if "rocket" in cargo_text:
+            return "rocket"
+    elif language == "go":
+        go_sum = ""
+        if (project_path / "go.sum").exists():
+            go_sum = (project_path / "go.sum").read_text().lower()
+        elif (project_path / "go.mod").exists():
+            go_sum = (project_path / "go.mod").read_text().lower()
+        if "gin-gonic/gin" in go_sum:
+            return "gin"
+        if "labstack/echo" in go_sum:
+            return "echo"
+        if "gofiber/fiber" in go_sum:
+            return "fiber"
     return None
 
 
@@ -216,12 +238,26 @@ def _detect_project_evals(project_path: Path) -> list[dict[str, str]]:
                 "command": f"python {dir_name}/{script.name}",
                 "source": "discovered",
             })
+        for script in eval_dir.glob("*.sh"):
+            evals.append({
+                "name": script.stem,
+                "command": f"bash {dir_name}/{script.name}",
+                "source": "discovered",
+            })
 
     for name in ("evaluate.py", "benchmark.py", "bench.py"):
         if (project_path / name).exists():
             evals.append({
                 "name": Path(name).stem,
                 "command": f"python {name}",
+                "source": "discovered",
+            })
+
+    for name in ("evaluate.sh", "benchmark.sh", "bench.sh"):
+        if (project_path / name).exists():
+            evals.append({
+                "name": Path(name).stem,
+                "command": f"bash {name}",
                 "source": "discovered",
             })
 

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -39,7 +39,7 @@ def _detect_language(project_path: Path) -> str:
     if (project_path / "pyproject.toml").exists() or (project_path / "setup.py").exists():
         lang = "python"
     elif (project_path / "package.json").exists():
-        lang = "typescript"
+        lang = "typescript" if (project_path / "tsconfig.json").exists() else "javascript"
     elif (project_path / "Cargo.toml").exists():
         lang = "rust"
     elif (project_path / "go.mod").exists():

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -263,6 +263,12 @@ def _detect_type_check_command(project_path: Path, language: str) -> str | None:
             return "./gradlew compileJava"
         if (project_path / "build.gradle").exists() or (project_path / "build.gradle.kts").exists():
             return "gradle compileJava"
+    elif language == "rust":
+        if (project_path / "Cargo.toml").exists():
+            return "cargo check"
+    elif language == "go":
+        if (project_path / "go.mod").exists():
+            return "go build -o /dev/null ./..."
     return None
 
 

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -132,16 +132,16 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if "rocket" in cargo_text:
             return "rocket"
     elif language == "go":
-        go_sum = ""
-        if (project_path / "go.sum").exists():
-            go_sum = (project_path / "go.sum").read_text().lower()
-        elif (project_path / "go.mod").exists():
-            go_sum = (project_path / "go.mod").read_text().lower()
-        if "gin-gonic/gin" in go_sum:
+        go_deps = ""
+        if (project_path / "go.mod").exists():
+            go_deps = (project_path / "go.mod").read_text().lower()
+        elif (project_path / "go.sum").exists():
+            go_deps = (project_path / "go.sum").read_text().lower()
+        if "gin-gonic/gin" in go_deps:
             return "gin"
-        if "labstack/echo" in go_sum:
+        if "labstack/echo" in go_deps:
             return "echo"
-        if "gofiber/fiber" in go_sum:
+        if "gofiber/fiber" in go_deps:
             return "fiber"
     return None
 

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -151,6 +151,8 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
             java_deps = (project_path / "pom.xml").read_text().lower()
         if (project_path / "build.gradle").exists():
             java_deps += (project_path / "build.gradle").read_text().lower()
+        if (project_path / "build.gradle.kts").exists():
+            java_deps += (project_path / "build.gradle.kts").read_text().lower()
         if "spring-boot" in java_deps:
             return "spring-boot"
         if "quarkus" in java_deps:

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -44,6 +44,8 @@ def _detect_language(project_path: Path) -> str:
         lang = "rust"
     elif (project_path / "go.mod").exists():
         lang = "go"
+    elif any((project_path / f).exists() for f in ("pom.xml", "build.gradle", "build.gradle.kts")):
+        lang = "java"
     elif (project_path / "Package.swift").exists():
         lang = "swift"
     else:
@@ -143,6 +145,18 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
             return "echo"
         if "gofiber/fiber" in go_deps:
             return "fiber"
+    elif language == "java":
+        java_deps = ""
+        if (project_path / "pom.xml").exists():
+            java_deps = (project_path / "pom.xml").read_text().lower()
+        if (project_path / "build.gradle").exists():
+            java_deps += (project_path / "build.gradle").read_text().lower()
+        if "spring-boot" in java_deps:
+            return "spring-boot"
+        if "quarkus" in java_deps:
+            return "quarkus"
+        if "micronaut" in java_deps:
+            return "micronaut"
     return None
 
 
@@ -166,6 +180,13 @@ def _detect_test_command(project_path: Path, language: str) -> str | None:
         return "cargo test"
     elif language == "go":
         return "go test ./..."
+    elif language == "java":
+        if (project_path / "pom.xml").exists():
+            return "mvn test"
+        if (project_path / "gradlew").exists():
+            return "./gradlew test"
+        if (project_path / "build.gradle").exists() or (project_path / "build.gradle.kts").exists():
+            return "gradle test"
     return None
 
 
@@ -188,6 +209,10 @@ def _detect_lint_command(project_path: Path, language: str) -> str | None:
         return "cargo clippy"
     elif language == "go":
         return "golangci-lint run"
+    elif language == "java":
+        if (project_path / "pom.xml").exists():
+            return "mvn checkstyle:check"
+        return None
     return None
 
 
@@ -208,6 +233,13 @@ def _detect_type_check_command(project_path: Path, language: str) -> str | None:
         pkg = _read_json(project_path / "package.json")
         if "typescript" in pkg.get("devDependencies", {}):
             return "npx tsc --noEmit"
+    elif language == "java":
+        if (project_path / "pom.xml").exists():
+            return "mvn compile -q"
+        if (project_path / "gradlew").exists():
+            return "./gradlew compileJava"
+        if (project_path / "build.gradle").exists() or (project_path / "build.gradle.kts").exists():
+            return "gradle compileJava"
     return None
 
 

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -141,13 +141,15 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if "rocket" in cargo_text:
             return "rocket"
     elif language == "go":
-        go_deps = (_safe_read(project_path / "go.mod") or _safe_read(project_path / "go.sum")).lower()
+        go_deps = f'{_safe_read(project_path / "go.mod")} {_safe_read(project_path / "go.sum")}'.lower()
         if "gin-gonic/gin" in go_deps:
             return "gin"
         if "labstack/echo" in go_deps:
             return "echo"
         if "gofiber/fiber" in go_deps:
             return "fiber"
+        if "go-chi/chi" in go_deps:
+            return "chi"
     elif language == "java":
         parts = [
             _safe_read(project_path / "pom.xml"),

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -35,6 +35,16 @@ def _read_toml_rough(path: Path) -> dict[str, str]:
     return result
 
 
+def _safe_read(path: Path) -> str:
+    if not path.exists():
+        return ""
+    try:
+        return path.read_text()
+    except (OSError, UnicodeDecodeError) as exc:
+        log.debug("framework_file_read_failed", path=str(path), exc=str(exc))
+        return ""
+
+
 def _detect_language(project_path: Path) -> str:
     """Detect primary language from project files."""
     if (project_path / "pyproject.toml").exists() or (project_path / "setup.py").exists():
@@ -106,16 +116,7 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
     """Detect framework from dependencies."""
     log.debug("detect_framework_start", language=language)
     if language == "python":
-        toml_text = ""
-        if (project_path / "pyproject.toml").exists():
-            try:
-                toml_text = (project_path / "pyproject.toml").read_text().lower()
-            except (OSError, UnicodeDecodeError) as exc:
-                log.debug(
-                    "framework_file_read_failed",
-                    path=str(project_path / "pyproject.toml"),
-                    exc=str(exc),
-                )
+        toml_text = _safe_read(project_path / "pyproject.toml").lower()
         if "fastapi" in toml_text:
             return "fastapi"
         if "django" in toml_text:
@@ -132,16 +133,7 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if "express" in deps:
             return "express"
     elif language == "rust":
-        cargo_text = ""
-        if (project_path / "Cargo.toml").exists():
-            try:
-                cargo_text = (project_path / "Cargo.toml").read_text().lower()
-            except (OSError, UnicodeDecodeError) as exc:
-                log.debug(
-                    "framework_file_read_failed",
-                    path=str(project_path / "Cargo.toml"),
-                    exc=str(exc),
-                )
+        cargo_text = _safe_read(project_path / "Cargo.toml").lower()
         if "actix-web" in cargo_text:
             return "actix-web"
         if "axum" in cargo_text:
@@ -149,25 +141,7 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if "rocket" in cargo_text:
             return "rocket"
     elif language == "go":
-        go_deps = ""
-        if (project_path / "go.mod").exists():
-            try:
-                go_deps = (project_path / "go.mod").read_text().lower()
-            except (OSError, UnicodeDecodeError) as exc:
-                log.debug(
-                    "framework_file_read_failed",
-                    path=str(project_path / "go.mod"),
-                    exc=str(exc),
-                )
-        elif (project_path / "go.sum").exists():
-            try:
-                go_deps = (project_path / "go.sum").read_text().lower()
-            except (OSError, UnicodeDecodeError) as exc:
-                log.debug(
-                    "framework_file_read_failed",
-                    path=str(project_path / "go.sum"),
-                    exc=str(exc),
-                )
+        go_deps = (_safe_read(project_path / "go.mod") or _safe_read(project_path / "go.sum")).lower()
         if "gin-gonic/gin" in go_deps:
             return "gin"
         if "labstack/echo" in go_deps:
@@ -175,34 +149,12 @@ def _detect_framework(project_path: Path, language: str) -> str | None:
         if "gofiber/fiber" in go_deps:
             return "fiber"
     elif language == "java":
-        java_deps = ""
-        if (project_path / "pom.xml").exists():
-            try:
-                java_deps = (project_path / "pom.xml").read_text().lower()
-            except (OSError, UnicodeDecodeError) as exc:
-                log.debug(
-                    "framework_file_read_failed",
-                    path=str(project_path / "pom.xml"),
-                    exc=str(exc),
-                )
-        if (project_path / "build.gradle").exists():
-            try:
-                java_deps += "\n" + (project_path / "build.gradle").read_text().lower()
-            except (OSError, UnicodeDecodeError) as exc:
-                log.debug(
-                    "framework_file_read_failed",
-                    path=str(project_path / "build.gradle"),
-                    exc=str(exc),
-                )
-        if (project_path / "build.gradle.kts").exists():
-            try:
-                java_deps += "\n" + (project_path / "build.gradle.kts").read_text().lower()
-            except (OSError, UnicodeDecodeError) as exc:
-                log.debug(
-                    "framework_file_read_failed",
-                    path=str(project_path / "build.gradle.kts"),
-                    exc=str(exc),
-                )
+        parts = [
+            _safe_read(project_path / "pom.xml"),
+            _safe_read(project_path / "build.gradle"),
+            _safe_read(project_path / "build.gradle.kts"),
+        ]
+        java_deps = "\n".join(parts).lower()
         if "spring-boot" in java_deps:
             return "spring-boot"
         if "quarkus" in java_deps:

--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -236,7 +236,8 @@ def _detect_lint_command(project_path: Path, language: str) -> str | None:
     elif language == "java":
         if (project_path / "pom.xml").exists():
             return "mvn checkstyle:check"
-        if (project_path / "gradlew").exists():
+        gradlew = project_path / "gradlew"
+        if gradlew.exists() and os.access(gradlew, os.X_OK):
             return "./gradlew checkstyleMain"
         if (project_path / "build.gradle").exists() or (project_path / "build.gradle.kts").exists():
             return "gradle checkstyleMain"

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -172,7 +172,7 @@ def _coverage_command(project: ProjectProfile) -> str | None:
     if project.language == "go":
         return "go test -cover ./..."
     if project.language in ("typescript", "javascript"):
-        return "npx jest --coverage --passWithNoTests"
+        return "npx jest --coverage"
     if project.language == "java":
         tc = project.test_command or ""
         if "gradlew" in tc:

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -163,7 +163,7 @@ def _coverage_command(project: ProjectProfile) -> str | None:
         pm = "uv run" if project.package_manager == "uv" else "python -m"
         return f"{pm} pytest --cov={coverage_target} --cov-report=term -q"
     if project.language == "rust":
-        return "cargo tarpaulin --out stdout --skip-clean"
+        return "cargo llvm-cov --summary-only"
     if project.language == "go":
         return "go test -cover ./..."
     if project.language == "typescript":

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -163,6 +163,7 @@ def _coverage_command(project: ProjectProfile) -> str | None:
         pm = "uv run" if project.package_manager == "uv" else "python -m"
         return f"{pm} pytest --cov={coverage_target} --cov-report=term -q"
     if project.language == "rust":
+        # hygiene.py falls back to cargo tarpaulin if this fails
         return "cargo llvm-cov --summary-only"
     if project.language == "go":
         return "go test -cover ./..."

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -152,7 +152,7 @@ def _syntax_check_command(project: ProjectProfile) -> str:
             return "./gradlew compileJava"
         if "gradle" in tc:
             return "gradle compileJava"
-        return "javac -version"
+        return "true"
     return "true"  # no-op fallback
 
 

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -145,6 +145,13 @@ def _syntax_check_command(project: ProjectProfile) -> str:
     if project.language == "go":
         return "go vet ./..."
     if project.language == "java":
+        tc = project.test_command or ""
+        if "mvn" in tc:
+            return "mvn compile -q"
+        if "gradlew" in tc:
+            return "./gradlew compileJava"
+        if "gradle" in tc:
+            return "gradle compileJava"
         return "javac -version"
     return "true"  # no-op fallback
 
@@ -162,5 +169,10 @@ def _coverage_command(project: ProjectProfile) -> str | None:
     if project.language == "typescript":
         return "npx jest --coverage --passWithNoTests"
     if project.language == "java":
+        tc = project.test_command or ""
+        if "gradlew" in tc:
+            return "./gradlew jacocoTestReport"
+        if "gradle" in tc:
+            return "gradle jacocoTestReport"
         return "mvn jacoco:report"
     return None

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -166,7 +166,7 @@ def _coverage_command(project: ProjectProfile) -> str | None:
         return "cargo llvm-cov --summary-only"
     if project.language == "go":
         return "go test -cover ./..."
-    if project.language == "typescript":
+    if project.language in ("typescript", "javascript"):
         return "npx jest --coverage --passWithNoTests"
     if project.language == "java":
         tc = project.test_command or ""

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -144,6 +144,8 @@ def _syntax_check_command(project: ProjectProfile) -> str:
         return "cargo check"
     if project.language == "go":
         return "go vet ./..."
+    if project.language == "java":
+        return "javac -version"
     return "true"  # no-op fallback
 
 
@@ -159,4 +161,6 @@ def _coverage_command(project: ProjectProfile) -> str | None:
         return "go test -cover ./..."
     if project.language == "typescript":
         return "npx jest --coverage --passWithNoTests"
+    if project.language == "java":
+        return "mvn jacoco:report"
     return None

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -1,4 +1,7 @@
-"""Build an EvalProfile from a ProjectProfile — the bridge between introspection and eval generation."""
+"""Build an EvalProfile from a ProjectProfile.
+
+The bridge between introspection and eval generation.
+"""
 
 from __future__ import annotations
 
@@ -163,7 +166,8 @@ def _coverage_command(project: ProjectProfile) -> str | None:
         pm = "uv run" if project.package_manager == "uv" else "python -m"
         return f"{pm} pytest --cov={coverage_target} --cov-report=term -q"
     if project.language == "rust":
-        # hygiene.py falls back to cargo tarpaulin if this fails
+        # Primary: llvm-cov. hygiene.py auto-falls back to
+        # `cargo tarpaulin --out stdout --skip-clean` if llvm-cov fails.
         return "cargo llvm-cov --summary-only"
     if project.language == "go":
         return "go test -cover ./..."

--- a/factory/discovery/profile.py
+++ b/factory/discovery/profile.py
@@ -61,19 +61,17 @@ def build_eval_profile(project: ProjectProfile) -> EvalProfile:
         if tier == "fallback":
             tier = "researched"
 
-    # Add coverage eval if tests exist but coverage isn't tracked
-    if project.has_tests and project.language == "python":
-        # Find the main package for coverage target
-        coverage_target = project.name.replace("-", "_")
-        pm = "uv run" if project.package_manager == "uv" else "python -m"
-        dimensions.append(EvalDimension(
-            name="coverage",
-            command=f"{pm} pytest --cov={coverage_target} --cov-report=term -q",
-            weight=0.15,
-            parser="exit_code",
-            description="Measure test coverage",
-            source="researched",
-        ))
+    if project.has_tests:
+        cov_cmd = _coverage_command(project)
+        if cov_cmd:
+            dimensions.append(EvalDimension(
+                name="coverage",
+                command=cov_cmd,
+                weight=0.15,
+                parser="exit_code",
+                description="Measure test coverage",
+                source="researched",
+            ))
 
     # Tier 0: Fallback — minimal checks
     if not dimensions:
@@ -147,3 +145,18 @@ def _syntax_check_command(project: ProjectProfile) -> str:
     if project.language == "go":
         return "go vet ./..."
     return "true"  # no-op fallback
+
+
+def _coverage_command(project: ProjectProfile) -> str | None:
+    """Return a coverage command appropriate for the project language."""
+    if project.language == "python":
+        coverage_target = project.name.replace("-", "_")
+        pm = "uv run" if project.package_manager == "uv" else "python -m"
+        return f"{pm} pytest --cov={coverage_target} --cov-report=term -q"
+    if project.language == "rust":
+        return "cargo tarpaulin --out stdout --skip-clean"
+    if project.language == "go":
+        return "go test -cover ./..."
+    if project.language == "typescript":
+        return "npx jest --coverage --passWithNoTests"
+    return None

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -14,6 +14,7 @@ import re
 import time
 from collections import Counter
 from pathlib import Path
+from typing import Any
 
 # Relative weights within the growth category (sum to 1.0).
 # The runner normalizes these so that growth gets 50% of the composite.
@@ -26,47 +27,140 @@ GROWTH_WEIGHTS = {
     "spec_compliance": 0.10,
 }
 
+LANG_CONFIG: dict[str, dict[str, Any]] = {
+    "python": {
+        "extensions": ["*.py"],
+        "skip_dirs": {
+            "tests", "test", "node_modules", ".venv", "venv",
+            "__pycache__", "build", "dist", "docs", "doc",
+            "examples", "scripts", "eval",
+        },
+        "function_regex": None,
+        "entry_point_patterns": [
+            r'add_parser\("(\w[\w-]*)"',
+            r"@\w+\.command\(",
+        ],
+    },
+    "rust": {
+        "extensions": ["*.rs"],
+        "skip_dirs": {
+            "target", "tests", "test", "examples", "benches", "docs",
+        },
+        "function_regex": re.compile(r"^\s*pub\s+(?:async\s+)?fn\s+(\w+)", re.MULTILINE),
+        "entry_point_patterns": [
+            r"fn\s+main\s*\(",
+            r'#\[(?:tokio::main|actix_web::main)\]',
+        ],
+    },
+    "go": {
+        "extensions": ["*.go"],
+        "skip_dirs": {
+            "vendor", "testdata", "test", "docs", "examples",
+        },
+        "function_regex": re.compile(r"^func\s+(?:\(\w+\s+\*?\w+\)\s+)?([A-Z]\w*)\s*\(", re.MULTILINE),
+        "entry_point_patterns": [
+            r"func\s+main\s*\(",
+            r'\.HandleFunc\(',
+            r'\.Handle\(',
+        ],
+    },
+    "typescript": {
+        "extensions": ["*.ts", "*.tsx"],
+        "skip_dirs": {
+            "node_modules", "dist", "build", ".next", "coverage",
+            "test", "tests", "__tests__", "docs",
+        },
+        "function_regex": re.compile(
+            r"^(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(",
+            re.MULTILINE,
+        ),
+        "entry_point_patterns": [
+            r"\.command\(",
+            r'app\.(?:get|post|put|delete|use)\(',
+        ],
+    },
+}
+
+
+def _detect_project_language(project_path: Path) -> str:
+    """Detect project language, reusing introspect logic when available."""
+    try:
+        from factory.discovery.introspect import _detect_language
+        return _detect_language(project_path)
+    except ImportError:
+        if (project_path / "pyproject.toml").exists() or (project_path / "setup.py").exists():
+            return "python"
+        if (project_path / "package.json").exists():
+            return "typescript"
+        if (project_path / "Cargo.toml").exists():
+            return "rust"
+        if (project_path / "go.mod").exists():
+            return "go"
+        return "unknown"
+
+
+def _count_functions_python(modules: list[Path]) -> int:
+    """Count public functions in Python files via AST."""
+    public_fns = 0
+    for mod in modules:
+        try:
+            tree = ast.parse(mod.read_text())
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if not node.name.startswith("_"):
+                    public_fns += 1
+    return public_fns
+
+
+def _count_functions_regex(modules: list[Path], pattern: re.Pattern[str]) -> int:
+    """Count public functions in non-Python files via regex."""
+    count = 0
+    for mod in modules:
+        try:
+            text = mod.read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        count += len(pattern.findall(text))
+    return count
+
 
 def eval_capability_surface(project_path: Path) -> dict:
     """Measure breadth of capabilities: modules, public functions, entry points."""
     try:
-        # Find Python source directories (skip tests, venvs, hidden dirs)
-        src_dirs = _find_src_dirs(project_path)
+        language = _detect_project_language(project_path)
+        src_dirs = _find_src_dirs(project_path, language)
+        lang_cfg = LANG_CONFIG.get(language, LANG_CONFIG["python"])
+        skip_dirs = lang_cfg["skip_dirs"]
 
         modules: list[Path] = []
         for src_dir in src_dirs:
-            modules.extend(
-                f for f in src_dir.rglob("*.py")
-                if f.name != "__init__.py"
-                and ".venv" not in f.parts
-                and "node_modules" not in f.parts
-            )
+            for ext in lang_cfg["extensions"]:
+                for f in src_dir.rglob(ext):
+                    if f.name == "__init__.py":
+                        continue
+                    if any(part in skip_dirs or part.startswith(".") for part in f.relative_to(project_path).parts):
+                        continue
+                    modules.append(f)
 
-        # Count public functions via AST
-        public_fns = 0
-        for mod in modules:
-            try:
-                tree = ast.parse(mod.read_text())
-            except (SyntaxError, UnicodeDecodeError):
-                continue
-            for node in ast.walk(tree):
-                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    if not node.name.startswith("_"):
-                        public_fns += 1
+        if language == "python":
+            public_fns = _count_functions_python(modules)
+        elif lang_cfg["function_regex"] is not None:
+            public_fns = _count_functions_regex(modules, lang_cfg["function_regex"])
+        else:
+            public_fns = 0
 
-        # Count CLI entry points (argparse add_parser, click commands, etc.)
         entry_points = 0
         for mod in modules:
             try:
                 text = mod.read_text()
             except (OSError, UnicodeDecodeError):
                 continue
-            entry_points += len(re.findall(r'add_parser\("(\w[\w-]*)"', text))
-            entry_points += len(re.findall(r"@\w+\.command\(", text))
+            for pattern in lang_cfg["entry_point_patterns"]:
+                entry_points += len(re.findall(pattern, text))
 
         surface = len(modules) + public_fns + entry_points
-        # Target scales with project size but stays ambitious:
-        # modules * 10 means you need ~9 public functions per module to max out
         target = max(100, len(modules) * 10)
         score = min(1.0, surface / target)
         details = (
@@ -164,7 +258,8 @@ def eval_observability(project_path: Path) -> dict:
     try:
         from factory.study import _analyze_observability
 
-        result = _analyze_observability(project_path, "python")
+        language = _detect_project_language(project_path)
+        result = _analyze_observability(project_path, language)
         score = result.get("observability_score", 0.0)
         fn_cov = result.get("function_coverage", 0.0)
         structured = result.get("structured_logging", False)
@@ -486,26 +581,28 @@ def compute_growth_results(project_path: Path) -> list[dict]:
     ]
 
 
-def _find_src_dirs(project_path: Path) -> list[Path]:
-    """Find Python source directories in a project (not tests, venvs, etc.)."""
+def _find_src_dirs(project_path: Path, language: str = "python") -> list[Path]:
+    """Find source directories in a project for the given language."""
+    lang_cfg = LANG_CONFIG.get(language, LANG_CONFIG["python"])
+    skip_dirs = lang_cfg["skip_dirs"]
+    extensions = lang_cfg["extensions"]
+
+    def _has_source_files(directory: Path) -> bool:
+        return any(any(directory.rglob(ext)) for ext in extensions)
+
     candidates = []
-    # Check for common patterns: src/<name>/, <name>/, app/, lib/
     for child in project_path.iterdir():
         if not child.is_dir():
             continue
-        if child.name.startswith(".") or child.name in {
-            "tests", "test", "node_modules", ".venv", "venv", "__pycache__",
-            "build", "dist", "docs", "doc", "examples", "scripts", "eval",
-        }:
+        if child.name.startswith(".") or child.name in skip_dirs:
             continue
-        if any(child.rglob("*.py")):
+        if _has_source_files(child):
             candidates.append(child)
 
-    # Also check src/ subdirectory
     src_dir = project_path / "src"
     if src_dir.is_dir():
         for child in src_dir.iterdir():
-            if child.is_dir() and any(child.rglob("*.py")):
+            if child.is_dir() and _has_source_files(child):
                 candidates.append(child)
 
     return candidates or [project_path]

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -646,7 +646,7 @@ def _find_src_dirs(project_path: Path, language: str = "python") -> list[Path]:
     src_dir = project_path / "src"
     if src_dir.is_dir():
         for child in src_dir.iterdir():
-            if child.is_dir() and _has_source_files(child):
+            if child.is_dir() and child not in candidates and _has_source_files(child):
                 candidates.append(child)
 
     return candidates or [project_path]

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -79,6 +79,22 @@ LANG_CONFIG: dict[str, dict[str, Any]] = {
             r'app\.(?:get|post|put|delete|use)\(',
         ],
     },
+    "java": {
+        "extensions": ["*.java"],
+        "skip_dirs": {
+            "target", "build", "test", "tests", ".gradle", "docs", "examples",
+        },
+        "function_regex": re.compile(
+            r"^\s*(?:public|protected)\s+(?:static\s+)?(?:final\s+)?(?:synchronized\s+)?\w+\s+(\w+)\s*\(",
+            re.MULTILINE,
+        ),
+        "entry_point_patterns": [
+            r"public\s+static\s+void\s+main\s*\(",
+            r"@SpringBootApplication",
+            r"@RestController",
+            r"@QuarkusMain",
+        ],
+    },
 }
 
 
@@ -96,6 +112,8 @@ def _detect_project_language(project_path: Path) -> str:
             return "rust"
         if (project_path / "go.mod").exists():
             return "go"
+        if any((project_path / f).exists() for f in ("pom.xml", "build.gradle", "build.gradle.kts")):
+            return "java"
         return "unknown"
 
 

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -16,6 +16,10 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+import structlog
+
+log = structlog.get_logger()
+
 # Relative weights within the growth category (sum to 1.0).
 # The runner normalizes these so that growth gets 50% of the composite.
 GROWTH_WEIGHTS = {
@@ -95,6 +99,21 @@ LANG_CONFIG: dict[str, dict[str, Any]] = {
             r"@QuarkusMain",
         ],
     },
+    "javascript": {
+        "extensions": ["*.js", "*.jsx", "*.mjs"],
+        "skip_dirs": {
+            "node_modules", "dist", "build", ".next", "coverage",
+            "test", "tests", "__tests__", "docs",
+        },
+        "function_regex": re.compile(
+            r"^(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(",
+            re.MULTILINE,
+        ),
+        "entry_point_patterns": [
+            r"\.command\(",
+            r'app\.(?:get|post|put|delete|use)\(',
+        ],
+    },
 }
 
 
@@ -103,11 +122,12 @@ def _detect_project_language(project_path: Path) -> str:
     try:
         from factory.discovery.introspect import _detect_language
         return _detect_language(project_path)
-    except ImportError:
+    except ImportError as exc:
+        log.warning("introspect_import_failed", exc=str(exc))
         if (project_path / "pyproject.toml").exists() or (project_path / "setup.py").exists():
             return "python"
         if (project_path / "package.json").exists():
-            return "typescript"
+            return "typescript" if (project_path / "tsconfig.json").exists() else "javascript"
         if (project_path / "Cargo.toml").exists():
             return "rust"
         if (project_path / "go.mod").exists():

--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -143,7 +143,7 @@ def _count_functions_python(modules: list[Path]) -> int:
     for mod in modules:
         try:
             tree = ast.parse(mod.read_text())
-        except (SyntaxError, UnicodeDecodeError):
+        except (SyntaxError, UnicodeDecodeError, OSError):
             continue
         for node in ast.walk(tree):
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -214,6 +214,7 @@ def eval_capability_surface(project_path: Path) -> dict:
             "details": details,
         }
     except Exception as exc:
+        log.error("growth_eval_failed", dimension="capability_surface", exc=str(exc))
         return {
             "name": "capability_surface",
             "score": 0.0,
@@ -282,6 +283,7 @@ def eval_experiment_diversity(project_path: Path) -> dict:
             "details": details,
         }
     except Exception as exc:
+        log.error("growth_eval_failed", dimension="experiment_diversity", exc=str(exc))
         return {
             "name": "experiment_diversity",
             "score": 0.0,
@@ -314,6 +316,7 @@ def eval_observability(project_path: Path) -> dict:
             "details": details,
         }
     except Exception as exc:
+        log.error("growth_eval_failed", dimension="observability", exc=str(exc))
         return {
             "name": "observability",
             "score": 0.0,
@@ -429,6 +432,7 @@ def eval_research_grounding(project_path: Path) -> dict:
             "details": details,
         }
     except Exception as exc:
+        log.error("growth_eval_failed", dimension="research_grounding", exc=str(exc))
         return {
             "name": "research_grounding",
             "score": 0.0,
@@ -539,6 +543,7 @@ def eval_factory_effectiveness(project_path: Path) -> dict:
             "details": details,
         }
     except Exception as exc:
+        log.error("growth_eval_failed", dimension="factory_effectiveness", exc=str(exc))
         return {
             "name": "factory_effectiveness",
             "score": 0.0,
@@ -598,6 +603,7 @@ def eval_spec_compliance(project_path: Path) -> dict:
             "details": f"{passed}/{total} spec checks passed",
         }
     except Exception as exc:
+        log.error("growth_eval_failed", dimension="spec_compliance", exc=str(exc))
         return {
             "name": "spec_compliance",
             "score": 0.5,

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -14,6 +14,7 @@ If a tool is not detected for a dimension, score is 0.5 (neutral), not 0.
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -153,11 +154,11 @@ def eval_tests(project_path: Path) -> dict:
             # Try npm test
             rc, stdout, stderr = _run_cmd(["npm", "test", "--", "--passWithNoTests"], sp, timeout=180)
             output = stdout + stderr
-            # Jest: "Tests: X passed, Y failed"
-            p_match = re.search(r"(\d+)\s+passed", output)
-            f_match = re.search(r"(\d+)\s+failed", output)
-            p = int(p_match.group(1)) if p_match else 0
-            f = int(f_match.group(1)) if f_match else 0
+            # Jest: "Tests: X passed, Y failed" — use findall to aggregate monorepo output
+            p_matches = re.findall(r"(\d+)\s+passed", output)
+            f_matches = re.findall(r"(\d+)\s+failed", output)
+            p = sum(int(x) for x in p_matches)
+            f = sum(int(x) for x in f_matches)
             if p + f > 0:
                 ran_any = True
                 total_passed += p
@@ -165,12 +166,15 @@ def eval_tests(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}(js): {p} passed, {f} failed")
 
         if _detect_rust_project(sp):
-            rc, stdout, stderr = _run_cmd(["cargo", "test"], sp)
+            if not shutil.which("cargo"):
+                log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust tests")
+                continue
+            rc, stdout, stderr = _run_cmd(["cargo", "test", "--workspace"], sp)
             output = stdout + stderr
-            p_match = re.search(r"(\d+)\s+passed", output)
-            f_match = re.search(r"(\d+)\s+failed", output)
-            p = int(p_match.group(1)) if p_match else 0
-            f = int(f_match.group(1)) if f_match else 0
+            p_matches = re.findall(r"(\d+)\s+passed", output)
+            f_matches = re.findall(r"(\d+)\s+failed", output)
+            p = sum(int(x) for x in p_matches)
+            f = sum(int(x) for x in f_matches)
             if p + f > 0:
                 ran_any = True
                 total_passed += p

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -335,7 +335,7 @@ def eval_type_check(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
 
         if _detect_go_project(sp):
-            rc, stdout, stderr = _run_cmd(["go", "vet", "./..."], sp)
+            rc, stdout, stderr = _run_cmd(["go", "build", "-o", "/dev/null", "./..."], sp)
             if rc == 0:
                 ran_any = True
                 details_parts.append(f"{sp.name}(go): clean")

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -135,6 +135,9 @@ def _run_cmd(
 ) -> tuple[int, str, str]:
     """Run a command, return (returncode, stdout, stderr). Never raises."""
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    cargo_bin = Path.home() / ".cargo" / "bin"
+    if cargo_bin.is_dir() and str(cargo_bin) not in env.get("PATH", ""):
+        env["PATH"] = f"{cargo_bin}:{env.get('PATH', '')}"
     try:
         result = subprocess.run(
             cmd,
@@ -517,7 +520,11 @@ def eval_coverage(project_path: Path) -> dict:
                 timeout=600,
             )
             output = stdout + stderr
-            if "no such command" in stderr.lower() or "no such subcommand" in stderr.lower():
+            pct_match = None
+            if rc == 0:
+                pct_match = re.search(r"TOTAL\s+[\d.]+\s+[\d.]+\s+([\d.]+)%", output)
+            else:
+                llvm_cov_stderr = stderr
                 rc, stdout, stderr = _run_cmd(
                     ["cargo", "tarpaulin", "--out", "stdout", "--skip-clean"],
                     sp,
@@ -525,8 +532,8 @@ def eval_coverage(project_path: Path) -> dict:
                 )
                 output = stdout + stderr
                 pct_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
-            else:
-                pct_match = re.search(r"TOTAL\s+[\d.]+\s+[\d.]+\s+([\d.]+)%", output)
+                if not pct_match:
+                    stderr = llvm_cov_stderr
             if pct_match:
                 ran_any = True
                 pct = int(float(pct_match.group(1)))

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -596,10 +596,11 @@ def eval_coverage(project_path: Path) -> dict:
                 if rc == 0 and jacoco_xml.exists():
                     try:
                         xml_text = jacoco_xml.read_text()
-                        line_counter = re.search(r'<counter[^>]+type="LINE"[^>]*/>', xml_text)
-                        if line_counter:
-                            missed_m = re.search(r'missed="(\d+)"', line_counter.group(0))
-                            covered_m = re.search(r'covered="(\d+)"', line_counter.group(0))
+                        line_counters = re.findall(r'<counter[^>]+type="LINE"[^>]*/>', xml_text)
+                        line_counter_text = line_counters[-1] if line_counters else None
+                        if line_counter_text:
+                            missed_m = re.search(r'missed="(\d+)"', line_counter_text)
+                            covered_m = re.search(r'covered="(\d+)"', line_counter_text)
                         else:
                             missed_m = covered_m = None
                         if missed_m and covered_m:

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -457,7 +457,7 @@ def eval_lint(project_path: Path) -> dict:
                     msg="mvn/gradle not installed, skipping Java lint",
                 )
             else:
-                if tool[-1] == "mvn":
+                if tool[-1].endswith("mvn"):
                     cmd = [*tool, "checkstyle:check", "-q"]
                 else:
                     cmd = [*tool, "checkstyleMain", "-q"]
@@ -590,7 +590,7 @@ def eval_type_check(project_path: Path) -> dict:
                     msg="mvn/gradle not installed, skipping Java type check",
                 )
             else:
-                if tool[-1] == "mvn":
+                if tool[-1].endswith("mvn"):
                     cmd = [*tool, "compile", "-q"]
                 else:
                     cmd = [*tool, "compileJava", "-q"]
@@ -755,7 +755,7 @@ def eval_coverage(project_path: Path) -> dict:
                     msg="mvn/gradle not installed, skipping Java coverage",
                 )
             else:
-                if tool[-1] == "mvn":
+                if tool[-1].endswith("mvn"):
                     cmd = [*tool, "verify", "-q", "-Djacoco.skip=false"]
                     jacoco_xml = sp / "target" / "site" / "jacoco" / "jacoco.xml"
                 else:

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -252,6 +252,18 @@ def eval_lint(project_path: Path) -> dict:
                 total_errors += max(count, 1)
                 details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
 
+        if _detect_go_project(sp):
+            rc, stdout, stderr = _run_cmd(["go", "vet", "./..."], sp)
+            if rc == 0:
+                ran_any = True
+                details_parts.append(f"{sp.name}(go): clean")
+            else:
+                ran_any = True
+                output = stdout + stderr
+                count = len(re.findall(r"^.*\.go:\d+:\d+:", output, re.MULTILINE))
+                total_errors += max(count, 1)
+                details_parts.append(f"{sp.name}(go): {max(count, 1)} errors")
+
     if not ran_any:
         return _neutral("lint", "no linter detected")
 
@@ -307,6 +319,29 @@ def eval_type_check(project_path: Path) -> dict:
                 total_errors += max(count, 1)
                 details_parts.append(f"{sp.name}(ts): {max(count, 1)} errors")
 
+        if _detect_rust_project(sp):
+            rc, stdout, stderr = _run_cmd(["cargo", "check"], sp)
+            if rc == 0:
+                ran_any = True
+                details_parts.append(f"{sp.name}(rs): clean")
+            else:
+                ran_any = True
+                count = len(re.findall(r"^error", stderr, re.MULTILINE))
+                total_errors += max(count, 1)
+                details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
+
+        if _detect_go_project(sp):
+            rc, stdout, stderr = _run_cmd(["go", "build", "./..."], sp)
+            if rc == 0:
+                ran_any = True
+                details_parts.append(f"{sp.name}(go): clean")
+            else:
+                ran_any = True
+                output = stdout + stderr
+                count = len(re.findall(r"^.*\.go:\d+:\d+:", output, re.MULTILINE))
+                total_errors += max(count, 1)
+                details_parts.append(f"{sp.name}(go): {max(count, 1)} errors")
+
     if not ran_any:
         return _neutral("type_check", "no type checker detected")
 
@@ -331,7 +366,6 @@ def eval_coverage(project_path: Path) -> dict:
 
     for sp in sub_projects:
         if _detect_python_project(sp):
-            # Find source dir for --cov target
             src_dirs = [
                 c.name for c in sorted(sp.iterdir())
                 if c.is_dir() and (c / "__init__.py").exists()
@@ -347,6 +381,43 @@ def eval_coverage(project_path: Path) -> dict:
                 ran_any = True
                 pct = int(total_match.group(1))
                 coverages.append((sp.name, pct))
+
+        if _detect_rust_project(sp):
+            rc, stdout, stderr = _run_cmd(
+                ["cargo", "tarpaulin", "--out", "stdout", "--skip-clean"],
+                sp,
+            )
+            output = stdout + stderr
+            pct_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
+            if pct_match:
+                ran_any = True
+                pct = int(float(pct_match.group(1)))
+                coverages.append((f"{sp.name}(rs)", pct))
+
+        if _detect_go_project(sp):
+            rc, stdout, stderr = _run_cmd(
+                ["go", "test", "-cover", "./..."],
+                sp,
+            )
+            output = stdout + stderr
+            pcts = [float(m) for m in re.findall(r"coverage:\s+(\d+(?:\.\d+)?)%", output)]
+            if pcts:
+                ran_any = True
+                avg = int(sum(pcts) / len(pcts))
+                coverages.append((f"{sp.name}(go)", avg))
+
+        if _detect_node_project(sp):
+            rc, stdout, stderr = _run_cmd(
+                ["npx", "jest", "--coverage", "--coverageReporters=text", "--passWithNoTests"],
+                sp,
+                timeout=180,
+            )
+            output = stdout + stderr
+            pct_match = re.search(r"All files\s*\|\s*(\d+(?:\.\d+)?)", output)
+            if pct_match:
+                ran_any = True
+                pct = int(float(pct_match.group(1)))
+                coverages.append((f"{sp.name}(js)", pct))
 
     if not ran_any:
         return _neutral("coverage", "no coverage tool detected")

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -69,8 +69,8 @@ def _find_sub_projects(project_path: Path) -> list[Path]:
             try:
                 if "[workspace]" in cargo.read_text():
                     workspace_roots.append(r.resolve())
-            except OSError:
-                pass
+            except OSError as exc:
+                log.debug("cargo_toml_read_failed", path=str(cargo), exc=str(exc))
     if workspace_roots:
         roots = [
             r for r in roots
@@ -116,7 +116,7 @@ def _java_build_tool(project_path: Path) -> list[str] | None:
         (project_path / "build.gradle").exists() or (project_path / "build.gradle.kts").exists()
     ):
         return ["gradle"]
-    if shutil.which("mvn"):
+    if shutil.which("mvn") and (project_path / "pom.xml").exists():
         return ["mvn"]
     return None
 
@@ -219,56 +219,56 @@ def eval_tests(project_path: Path) -> dict:
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
                 log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust tests")
-                continue
-            rc, stdout, stderr = _run_cmd(["cargo", "test", "--workspace"], sp)
-            output = stdout + stderr
-            p_matches = re.findall(r"(\d+)\s+passed", output)
-            f_matches = re.findall(r"(\d+)\s+failed", output)
-            p = sum(int(x) for x in p_matches)
-            f = sum(int(x) for x in f_matches)
-            if p + f > 0:
-                ran_any = True
-                total_passed += p
-                total_failed += f
-                details_parts.append(f"{sp.name}(rs): {p} passed, {f} failed")
+            else:
+                rc, stdout, stderr = _run_cmd(["cargo", "test", "--workspace"], sp)
+                output = stdout + stderr
+                p_matches = re.findall(r"(\d+)\s+passed", output)
+                f_matches = re.findall(r"(\d+)\s+failed", output)
+                p = sum(int(x) for x in p_matches)
+                f = sum(int(x) for x in f_matches)
+                if p + f > 0:
+                    ran_any = True
+                    total_passed += p
+                    total_failed += f
+                    details_parts.append(f"{sp.name}(rs): {p} passed, {f} failed")
 
         if _detect_go_project(sp):
-            rc, stdout, stderr = _run_cmd(["go", "test", "./..."], sp)
-            output = stdout + stderr
-            if rc == 0:
-                ran_any = True
-                # go test: count "ok" lines
-                ok_count = len(re.findall(r"^ok\s+", output, re.MULTILINE))
-                total_passed += max(ok_count, 1)
-                details_parts.append(f"{sp.name}(go): passed")
-            elif "FAIL" in output:
-                ran_any = True
-                total_failed += 1
-                details_parts.append(f"{sp.name}(go): failed")
+            if not shutil.which("go"):
+                log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go tests")
+            else:
+                rc, stdout, stderr = _run_cmd(["go", "test", "./..."], sp)
+                output = stdout + stderr
+                if rc == 0:
+                    ran_any = True
+                    ok_count = len(re.findall(r"^ok\s+", output, re.MULTILINE))
+                    total_passed += max(ok_count, 1)
+                    details_parts.append(f"{sp.name}(go): passed")
+                elif "FAIL" in output:
+                    ran_any = True
+                    total_failed += 1
+                    details_parts.append(f"{sp.name}(go): failed")
 
         if _detect_java_project(sp):
             java_cmd = _java_test_cmd(sp)
             if not java_cmd:
                 log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java tests")
-                continue
-            rc, stdout, stderr = _run_cmd(java_cmd, sp)
-            output = stdout + stderr
-            t_matches = re.findall(r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)", output)
-            if t_matches:
-                ran_any = True
-                java_passed = 0
-                java_failed = 0
-                for total_run_s, fail_s, err_s in t_matches:
-                    p = int(total_run_s) - int(fail_s) - int(err_s)
-                    java_passed += p
-                    java_failed += int(fail_s) + int(err_s)
-                total_passed += java_passed
-                total_failed += java_failed
-                details_parts.append(f"{sp.name}(java): {java_passed} passed, {java_failed} failed")
-            elif rc == 0:
-                ran_any = True
-                total_passed += 1
-                details_parts.append(f"{sp.name}(java): passed")
+            else:
+                rc, stdout, stderr = _run_cmd(java_cmd, sp)
+                output = stdout + stderr
+                t_matches = re.findall(r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)", output)
+                if t_matches:
+                    ran_any = True
+                    java_passed = 0
+                    java_failed = 0
+                    for total_run_s, fail_s, err_s in t_matches:
+                        p = int(total_run_s) - int(fail_s) - int(err_s)
+                        java_passed += p
+                        java_failed += int(fail_s) + int(err_s)
+                    total_passed += java_passed
+                    total_failed += java_failed
+                    details_parts.append(f"{sp.name}(java): {java_passed} passed, {java_failed} failed")
+                elif rc == 0:
+                    log.warning("java_tests_unparsed", project=str(sp), msg="Tests passed but output format unrecognized")
 
     if not ran_any:
         return _neutral("tests", "no test suite detected")
@@ -321,50 +321,53 @@ def eval_lint(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}(js): {max(count, 1)} errors")
 
         if _detect_rust_project(sp):
-            rc, stdout, stderr = _run_cmd(["cargo", "clippy", "--", "-D", "warnings"], sp)
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(rs): clean")
+            if not shutil.which("cargo"):
+                log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust lint")
             else:
-                ran_any = True
-                count = len(re.findall(r"^error", stderr, re.MULTILINE))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
+                rc, stdout, stderr = _run_cmd(["cargo", "clippy", "--", "-D", "warnings"], sp)
+                if rc == 0:
+                    ran_any = True
+                    details_parts.append(f"{sp.name}(rs): clean")
+                else:
+                    ran_any = True
+                    count = len(re.findall(r"^error", stderr, re.MULTILINE))
+                    total_errors += max(count, 1)
+                    details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
 
         if _detect_go_project(sp):
             if not shutil.which("go"):
                 log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go lint")
-                continue
-            rc, stdout, stderr = _run_cmd(["go", "vet", "./..."], sp)
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(go): clean")
             else:
-                ran_any = True
-                output = stdout + stderr
-                count = len(re.findall(r"^.*\.go:\d+:\d+:", output, re.MULTILINE))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(go): {max(count, 1)} errors")
+                rc, stdout, stderr = _run_cmd(["go", "vet", "./..."], sp)
+                if rc == 0:
+                    ran_any = True
+                    details_parts.append(f"{sp.name}(go): clean")
+                else:
+                    ran_any = True
+                    output = stdout + stderr
+                    count = len(re.findall(r"^.*\.go:\d+:\d+:", output, re.MULTILINE))
+                    total_errors += max(count, 1)
+                    details_parts.append(f"{sp.name}(go): {max(count, 1)} errors")
 
         if _detect_java_project(sp):
             tool = _java_build_tool(sp)
             if not tool:
                 log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java lint")
-                continue
-            if tool[-1] == "mvn":
-                cmd = [*tool, "checkstyle:check", "-q"]
             else:
-                cmd = [*tool, "checkstyleMain", "-q"]
-            rc, stdout, stderr = _run_cmd(cmd, sp)
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(java): clean")
-            else:
-                ran_any = True
-                output = stdout + stderr
-                count = len(re.findall(r"\[ERROR\]", output))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(java): {max(count, 1)} errors")
+                if tool[-1] == "mvn":
+                    cmd = [*tool, "checkstyle:check", "-q"]
+                else:
+                    cmd = [*tool, "checkstyleMain", "-q"]
+                rc, stdout, stderr = _run_cmd(cmd, sp)
+                if rc == 0:
+                    ran_any = True
+                    details_parts.append(f"{sp.name}(java): clean")
+                else:
+                    ran_any = True
+                    output = stdout + stderr
+                    count = len(re.findall(r"\[ERROR\]", output))
+                    total_errors += max(count, 1)
+                    details_parts.append(f"{sp.name}(java): {max(count, 1)} errors")
 
     if not ran_any:
         return _neutral("lint", "no linter detected")
@@ -424,51 +427,51 @@ def eval_type_check(project_path: Path) -> dict:
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
                 log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust type check")
-                continue
-            rc, stdout, stderr = _run_cmd(["cargo", "check"], sp)
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(rs): clean")
             else:
-                ran_any = True
-                count = len(re.findall(r"^error", stderr, re.MULTILINE))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
+                rc, stdout, stderr = _run_cmd(["cargo", "check"], sp)
+                if rc == 0:
+                    ran_any = True
+                    details_parts.append(f"{sp.name}(rs): clean")
+                else:
+                    ran_any = True
+                    count = len(re.findall(r"^error", stderr, re.MULTILINE))
+                    total_errors += max(count, 1)
+                    details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
 
         if _detect_go_project(sp):
             if not shutil.which("go"):
                 log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go type check")
-                continue
-            rc, stdout, stderr = _run_cmd(["go", "build", "-o", os.devnull, "./..."], sp)
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(go): clean")
             else:
-                ran_any = True
-                output = stdout + stderr
-                count = len(re.findall(r"^.*\.go:\d+:\d+:", output, re.MULTILINE))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(go): {max(count, 1)} errors")
+                rc, stdout, stderr = _run_cmd(["go", "build", "-o", os.devnull, "./..."], sp)
+                if rc == 0:
+                    ran_any = True
+                    details_parts.append(f"{sp.name}(go): clean")
+                else:
+                    ran_any = True
+                    output = stdout + stderr
+                    count = len(re.findall(r"^.*\.go:\d+:\d+:", output, re.MULTILINE))
+                    total_errors += max(count, 1)
+                    details_parts.append(f"{sp.name}(go): {max(count, 1)} errors")
 
         if _detect_java_project(sp):
             tool = _java_build_tool(sp)
             if not tool:
                 log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java type check")
-                continue
-            if tool[-1] == "mvn":
-                cmd = [*tool, "compile", "-q"]
             else:
-                cmd = [*tool, "compileJava", "-q"]
-            rc, stdout, stderr = _run_cmd(cmd, sp)
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(java): clean")
-            else:
-                ran_any = True
-                output = stdout + stderr
-                count = len(re.findall(r"\[ERROR\]", output))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(java): {max(count, 1)} errors")
+                if tool[-1] == "mvn":
+                    cmd = [*tool, "compile", "-q"]
+                else:
+                    cmd = [*tool, "compileJava", "-q"]
+                rc, stdout, stderr = _run_cmd(cmd, sp)
+                if rc == 0:
+                    ran_any = True
+                    details_parts.append(f"{sp.name}(java): clean")
+                else:
+                    ran_any = True
+                    output = stdout + stderr
+                    count = len(re.findall(r"\[ERROR\]", output))
+                    total_errors += max(count, 1)
+                    details_parts.append(f"{sp.name}(java): {max(count, 1)} errors")
 
     if not ran_any:
         return _neutral("type_check", "no type checker detected")
@@ -513,86 +516,103 @@ def eval_coverage(project_path: Path) -> dict:
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
                 log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust coverage")
-                continue
-            rc, stdout, stderr = _run_cmd(
-                ["cargo", "llvm-cov", "--summary-only"],
-                sp,
-                timeout=600,
-            )
-            output = stdout + stderr
-            pct_match = None
-            if rc == 0:
-                pct_match = re.search(r"TOTAL\s+[\d.]+\s+[\d.]+\s+([\d.]+)%", output)
             else:
-                llvm_cov_stderr = stderr
                 rc, stdout, stderr = _run_cmd(
-                    ["cargo", "tarpaulin", "--out", "stdout", "--skip-clean"],
+                    ["cargo", "llvm-cov", "--summary-only"],
                     sp,
                     timeout=600,
                 )
                 output = stdout + stderr
-                pct_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
-                if not pct_match:
-                    stderr = llvm_cov_stderr
-            if pct_match:
-                ran_any = True
-                pct = int(float(pct_match.group(1)))
-                coverages.append((f"{sp.name}(rs)", pct))
-            elif "Timed out" in stderr:
-                log.warning("coverage_timeout", project=str(sp), lang="rust", timeout=600)
-            elif rc != 0:
-                log.warning("coverage_tool_failed", project=str(sp), lang="rust", rc=rc, stderr=stderr[:200])
+                pct_match = None
+                if rc == 0:
+                    pct_match = re.search(r"TOTAL\s+[\d.]+\s+[\d.]+\s+([\d.]+)%", output)
+                else:
+                    llvm_cov_stderr = stderr
+                    rc, stdout, stderr = _run_cmd(
+                        ["cargo", "tarpaulin", "--out", "stdout", "--skip-clean"],
+                        sp,
+                        timeout=600,
+                    )
+                    output = stdout + stderr
+                    pct_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
+                    if not pct_match:
+                        stderr = llvm_cov_stderr
+                if pct_match:
+                    ran_any = True
+                    pct = int(float(pct_match.group(1)))
+                    coverages.append((f"{sp.name}(rs)", pct))
+                elif "Timed out" in stderr:
+                    log.warning("coverage_timeout", project=str(sp), lang="rust", timeout=600)
+                elif rc != 0:
+                    log.warning("coverage_tool_failed", project=str(sp), lang="rust", rc=rc, stderr=stderr[:200])
 
         if _detect_go_project(sp):
             if not shutil.which("go"):
                 log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go coverage")
-                continue
-            rc, stdout, stderr = _run_cmd(
-                ["go", "test", "-cover", "./..."],
-                sp,
-            )
-            output = stdout + stderr
-            pcts = [float(m) for m in re.findall(r"coverage:\s+(\d+(?:\.\d+)?)%", output)]
-            if pcts:
-                ran_any = True
-                avg = int(sum(pcts) / len(pcts))
-                coverages.append((f"{sp.name}(go)", avg))
+            else:
+                rc, stdout, stderr = _run_cmd(
+                    ["go", "test", "-cover", "./..."],
+                    sp,
+                )
+                output = stdout + stderr
+                pcts = [float(m) for m in re.findall(r"coverage:\s+(\d+(?:\.\d+)?)%", output)]
+                if pcts:
+                    ran_any = True
+                    avg = int(sum(pcts) / len(pcts))
+                    coverages.append((f"{sp.name}(go)", avg))
+                else:
+                    log.warning("coverage_output_unrecognized", project=str(sp), lang="go")
 
         if _detect_node_project(sp):
             if not shutil.which("npx"):
                 log.warning("npx_not_found", project=str(sp), msg="npx not on PATH, skipping Node coverage")
-                continue
-            rc, stdout, stderr = _run_cmd(
-                ["npx", "--no-install", "jest", "--coverage", "--coverageReporters=text", "--passWithNoTests"],
-                sp,
-                timeout=180,
-            )
-            output = stdout + stderr
-            pct_match = re.search(r"All files\s*\|\s*(\d+(?:\.\d+)?)", output)
-            if pct_match:
-                ran_any = True
-                pct = int(float(pct_match.group(1)))
-                coverages.append((f"{sp.name}(js)", pct))
+            else:
+                rc, stdout, stderr = _run_cmd(
+                    ["npx", "--no-install", "jest", "--coverage", "--coverageReporters=text", "--passWithNoTests"],
+                    sp,
+                    timeout=180,
+                )
+                output = stdout + stderr
+                pct_match = re.search(r"All files\s*\|\s*(\d+(?:\.\d+)?)", output)
+                if pct_match:
+                    ran_any = True
+                    pct = int(float(pct_match.group(1)))
+                    coverages.append((f"{sp.name}(js)", pct))
+                else:
+                    log.warning("coverage_output_unrecognized", project=str(sp), lang="node")
 
         if _detect_java_project(sp):
             tool = _java_build_tool(sp)
             if not tool:
                 log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java coverage")
-                continue
-            if tool[-1] == "mvn":
-                cmd = [*tool, "verify", "-q", "-Djacoco.skip=false"]
             else:
-                cmd = [*tool, "jacocoTestReport", "-q"]
-            rc, stdout, stderr = _run_cmd(cmd, sp)
-            output = stdout + stderr
-            pct_match = re.search(r"Total.*?(\d+)%", output)
-            if pct_match:
-                ran_any = True
-                pct = int(pct_match.group(1))
-                coverages.append((f"{sp.name}(java)", pct))
-            elif rc == 0:
-                ran_any = True
-                coverages.append((f"{sp.name}(java)", 0))
+                if tool[-1] == "mvn":
+                    cmd = [*tool, "verify", "-q", "-Djacoco.skip=false"]
+                    jacoco_xml = sp / "target" / "site" / "jacoco" / "jacoco.xml"
+                else:
+                    cmd = [*tool, "jacocoTestReport", "-q"]
+                    jacoco_xml = sp / "build" / "reports" / "jacoco" / "test" / "jacocoTestReport.xml"
+                rc, stdout, stderr = _run_cmd(cmd, sp)
+                if rc == 0 and jacoco_xml.exists():
+                    try:
+                        xml_text = jacoco_xml.read_text()
+                        line_match = re.search(
+                            r'<counter\s+type="LINE"\s+missed="(\d+)"\s+covered="(\d+)"',
+                            xml_text,
+                        )
+                        if line_match:
+                            missed = int(line_match.group(1))
+                            covered = int(line_match.group(2))
+                            total_lines = missed + covered
+                            pct = int(covered * 100 / total_lines) if total_lines > 0 else 0
+                            ran_any = True
+                            coverages.append((f"{sp.name}(java)", pct))
+                        else:
+                            log.warning("jacoco_xml_no_line_counter", project=str(sp))
+                    except OSError:
+                        log.warning("jacoco_xml_read_failed", project=str(sp))
+                elif rc == 0:
+                    log.warning("jacoco_xml_not_found", project=str(sp), path=str(jacoco_xml))
 
     if not ran_any:
         return _neutral("coverage", "no coverage tool detected")

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -110,7 +110,7 @@ def _detect_java_project(project_path: Path) -> bool:
 def _java_build_tool(project_path: Path) -> list[str] | None:
     """Return the Java build tool command prefix, or None if not available."""
     gradlew = project_path / "gradlew"
-    if gradlew.exists():
+    if gradlew.exists() and os.access(gradlew, os.X_OK):
         return [str(gradlew)]
     if shutil.which("gradle") and (
         (project_path / "build.gradle").exists() or (project_path / "build.gradle.kts").exists()
@@ -139,8 +139,8 @@ def _run_cmd(
         cargo_bin = Path.home() / ".cargo" / "bin"
         if cargo_bin.is_dir() and str(cargo_bin) not in env.get("PATH", ""):
             env["PATH"] = f"{cargo_bin}:{env.get('PATH', '')}"
-    except RuntimeError:
-        pass
+    except (RuntimeError, KeyError, OSError) as exc:
+        log.debug("cargo_bin_path_injection_failed", exc=str(exc))
     try:
         result = subprocess.run(
             cmd,
@@ -281,6 +281,9 @@ def eval_tests(project_path: Path) -> dict:
                     total_failed += java_failed
                     details_parts.append(f"{sp.name}(java): {java_passed} passed, {java_failed} failed")
                 elif rc == 0:
+                    ran_any = True
+                    total_passed += 1
+                    details_parts.append(f"{sp.name}(java): passed (output unparsed)")
                     log.warning("java_tests_unparsed", project=str(sp), msg="Tests passed but output format unrecognized")
                 elif rc != 0:
                     log.warning("java_tests_unparsed_failure", project=str(sp), rc=rc, msg="Tests failed but output format unrecognized")
@@ -562,6 +565,9 @@ def eval_coverage(project_path: Path) -> dict:
                     ran_any = True
                     pct = int(float(pct_match.group(1)))
                     coverages.append((f"{sp.name}(rs)", pct))
+                elif rc == 0:
+                    log.warning("coverage_output_unrecognized", project=str(sp), lang="rust",
+                                msg="llvm-cov succeeded but output not parseable")
                 elif "Timed out" in stderr:
                     log.warning("coverage_timeout", project=str(sp), lang="rust", timeout=600)
                 elif rc != 0:
@@ -633,8 +639,10 @@ def eval_coverage(project_path: Path) -> dict:
                             coverages.append((f"{sp.name}(java)", pct))
                         else:
                             log.warning("jacoco_xml_no_line_counter", project=str(sp))
-                    except (OSError, ValueError):
-                        log.warning("jacoco_xml_read_failed", project=str(sp))
+                    except OSError as exc:
+                        log.warning("jacoco_xml_read_failed", project=str(sp), exc=str(exc))
+                    except ValueError as exc:
+                        log.warning("jacoco_xml_parse_failed", project=str(sp), exc=str(exc))
                 elif rc == 0:
                     log.warning("jacoco_xml_not_found", project=str(sp), path=str(jacoco_xml))
 

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -512,15 +512,29 @@ def eval_coverage(project_path: Path) -> dict:
                 log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust coverage")
                 continue
             rc, stdout, stderr = _run_cmd(
-                ["cargo", "tarpaulin", "--out", "stdout", "--skip-clean"],
+                ["cargo", "llvm-cov", "--summary-only"],
                 sp,
+                timeout=600,
             )
             output = stdout + stderr
-            pct_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
+            if "no such command" in stderr.lower() or "no such subcommand" in stderr.lower():
+                rc, stdout, stderr = _run_cmd(
+                    ["cargo", "tarpaulin", "--out", "stdout", "--skip-clean"],
+                    sp,
+                    timeout=600,
+                )
+                output = stdout + stderr
+                pct_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
+            else:
+                pct_match = re.search(r"TOTAL\s+[\d.]+\s+[\d.]+\s+([\d.]+)%", output)
             if pct_match:
                 ran_any = True
                 pct = int(float(pct_match.group(1)))
                 coverages.append((f"{sp.name}(rs)", pct))
+            elif "Timed out" in stderr:
+                log.warning("coverage_timeout", project=str(sp), lang="rust", timeout=600)
+            elif rc != 0:
+                log.warning("coverage_tool_failed", project=str(sp), lang="rust", rc=rc, stderr=stderr[:200])
 
         if _detect_go_project(sp):
             if not shutil.which("go"):

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -282,7 +282,7 @@ def eval_tests(project_path: Path) -> dict:
                     ran_any = True
                     total_failed += 1
                     details_parts.append(f"{sp.name}(go): failed")
-                else:
+                elif rc != 0:
                     log.warning(
                         "go_test_nonzero_no_fail",
                         project=str(sp),

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -44,7 +44,7 @@ def _find_sub_projects(project_path: Path) -> list[Path]:
     Checks the project root and immediate subdirectories. Returns the project
     root itself if it has project markers, plus any sub-project dirs.
     """
-    markers = ["pyproject.toml", "package.json", "Cargo.toml", "go.mod"]
+    markers = ["pyproject.toml", "package.json", "Cargo.toml", "go.mod", "pom.xml", "build.gradle", "build.gradle.kts"]
     skip = {".git", ".factory", "node_modules", ".venv", "venv", "__pycache__"}
     roots: list[Path] = []
 
@@ -60,6 +60,25 @@ def _find_sub_projects(project_path: Path) -> list[Path]:
         resolved = child.resolve()
         if any((resolved / m).exists() for m in markers):
             roots.append(child)
+
+    # Rust workspace dedup: if a root has a workspace Cargo.toml, remove member sub-crates
+    workspace_roots: list[Path] = []
+    for r in roots:
+        cargo = r / "Cargo.toml"
+        if cargo.exists():
+            try:
+                if "[workspace]" in cargo.read_text():
+                    workspace_roots.append(r.resolve())
+            except OSError:
+                pass
+    if workspace_roots:
+        roots = [
+            r for r in roots
+            if not any(
+                r.resolve() != ws and str(r.resolve()).startswith(str(ws) + os.sep)
+                for ws in workspace_roots
+            )
+        ]
 
     return roots or [project_path]
 
@@ -78,6 +97,37 @@ def _detect_rust_project(project_path: Path) -> bool:
 
 def _detect_go_project(project_path: Path) -> bool:
     return (project_path / "go.mod").exists()
+
+
+def _detect_java_project(project_path: Path) -> bool:
+    return (
+        (project_path / "pom.xml").exists()
+        or (project_path / "build.gradle").exists()
+        or (project_path / "build.gradle.kts").exists()
+    )
+
+
+def _java_build_tool(project_path: Path) -> list[str] | None:
+    """Return the Java build tool command prefix, or None if not available."""
+    gradlew = project_path / "gradlew"
+    if gradlew.exists():
+        return [str(gradlew)]
+    if shutil.which("gradle") and (
+        (project_path / "build.gradle").exists() or (project_path / "build.gradle.kts").exists()
+    ):
+        return ["gradle"]
+    if shutil.which("mvn"):
+        return ["mvn"]
+    return None
+
+
+def _java_test_cmd(project_path: Path) -> list[str] | None:
+    tool = _java_build_tool(project_path)
+    if not tool:
+        return None
+    if tool[-1] in ("mvn",):
+        return [*tool, "test", "-q"]
+    return [*tool, "test", "-q"]
 
 
 def _run_cmd(
@@ -154,9 +204,9 @@ def eval_tests(project_path: Path) -> dict:
             # Try npm test
             rc, stdout, stderr = _run_cmd(["npm", "test", "--", "--passWithNoTests"], sp, timeout=180)
             output = stdout + stderr
-            # Jest: "Tests: X passed, Y failed" — use findall to aggregate monorepo output
-            p_matches = re.findall(r"(\d+)\s+passed", output)
-            f_matches = re.findall(r"(\d+)\s+failed", output)
+            # Jest: match only "Tests:" lines, not "Test Suites:" lines
+            p_matches = re.findall(r"^Tests:.*?(\d+)\s+passed", output, re.MULTILINE)
+            f_matches = re.findall(r"^Tests:.*?(\d+)\s+failed", output, re.MULTILINE)
             p = sum(int(x) for x in p_matches)
             f = sum(int(x) for x in f_matches)
             if p + f > 0:
@@ -194,6 +244,27 @@ def eval_tests(project_path: Path) -> dict:
                 ran_any = True
                 total_failed += 1
                 details_parts.append(f"{sp.name}(go): failed")
+
+        if _detect_java_project(sp):
+            java_cmd = _java_test_cmd(sp)
+            if not java_cmd:
+                log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java tests")
+                continue
+            rc, stdout, stderr = _run_cmd(java_cmd, sp)
+            output = stdout + stderr
+            t_match = re.search(r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)", output)
+            if t_match:
+                ran_any = True
+                total_run = int(t_match.group(1))
+                failures = int(t_match.group(2)) + int(t_match.group(3))
+                p = total_run - failures
+                total_passed += p
+                total_failed += failures
+                details_parts.append(f"{sp.name}(java): {p} passed, {failures} failed")
+            elif rc == 0:
+                ran_any = True
+                total_passed += 1
+                details_parts.append(f"{sp.name}(java): passed")
 
     if not ran_any:
         return _neutral("tests", "no test suite detected")
@@ -267,6 +338,26 @@ def eval_lint(project_path: Path) -> dict:
                 count = len(re.findall(r"^.*\.go:\d+:\d+:", output, re.MULTILINE))
                 total_errors += max(count, 1)
                 details_parts.append(f"{sp.name}(go): {max(count, 1)} errors")
+
+        if _detect_java_project(sp):
+            tool = _java_build_tool(sp)
+            if not tool:
+                log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java lint")
+                continue
+            if tool[-1] == "mvn":
+                cmd = [*tool, "checkstyle:check", "-q"]
+            else:
+                cmd = [*tool, "checkstyleMain", "-q"]
+            rc, stdout, stderr = _run_cmd(cmd, sp)
+            if rc == 0:
+                ran_any = True
+                details_parts.append(f"{sp.name}(java): clean")
+            else:
+                ran_any = True
+                output = stdout + stderr
+                count = len(re.findall(r"\[ERROR\]", output))
+                total_errors += max(count, 1)
+                details_parts.append(f"{sp.name}(java): {max(count, 1)} errors")
 
     if not ran_any:
         return _neutral("lint", "no linter detected")
@@ -351,6 +442,22 @@ def eval_type_check(project_path: Path) -> dict:
                 count = len(re.findall(r"^.*\.go:\d+:\d+:", output, re.MULTILINE))
                 total_errors += max(count, 1)
                 details_parts.append(f"{sp.name}(go): {max(count, 1)} errors")
+
+        if _detect_java_project(sp):
+            tool = _java_build_tool(sp)
+            if not tool:
+                log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java type check")
+                continue
+            rc, stdout, stderr = _run_cmd([*tool, "compile", "-q"], sp)
+            if rc == 0:
+                ran_any = True
+                details_parts.append(f"{sp.name}(java): clean")
+            else:
+                ran_any = True
+                output = stdout + stderr
+                count = len(re.findall(r"\[ERROR\]", output))
+                total_errors += max(count, 1)
+                details_parts.append(f"{sp.name}(java): {max(count, 1)} errors")
 
     if not ran_any:
         return _neutral("type_check", "no type checker detected")
@@ -437,6 +544,26 @@ def eval_coverage(project_path: Path) -> dict:
                 ran_any = True
                 pct = int(float(pct_match.group(1)))
                 coverages.append((f"{sp.name}(js)", pct))
+
+        if _detect_java_project(sp):
+            tool = _java_build_tool(sp)
+            if not tool:
+                log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java coverage")
+                continue
+            if tool[-1] == "mvn":
+                cmd = [*tool, "verify", "-q", "-Djacoco.skip=false"]
+            else:
+                cmd = [*tool, "jacocoTestReport", "-q"]
+            rc, stdout, stderr = _run_cmd(cmd, sp)
+            output = stdout + stderr
+            pct_match = re.search(r"Total.*?(\d+)%", output)
+            if pct_match:
+                ran_any = True
+                pct = int(pct_match.group(1))
+                coverages.append((f"{sp.name}(java)", pct))
+            elif rc == 0:
+                ran_any = True
+                coverages.append((f"{sp.name}(java)", 0))
 
     if not ran_any:
         return _neutral("coverage", "no coverage tool detected")

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -135,9 +135,12 @@ def _run_cmd(
 ) -> tuple[int, str, str]:
     """Run a command, return (returncode, stdout, stderr). Never raises."""
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-    cargo_bin = Path.home() / ".cargo" / "bin"
-    if cargo_bin.is_dir() and str(cargo_bin) not in env.get("PATH", ""):
-        env["PATH"] = f"{cargo_bin}:{env.get('PATH', '')}"
+    try:
+        cargo_bin = Path.home() / ".cargo" / "bin"
+        if cargo_bin.is_dir() and str(cargo_bin) not in env.get("PATH", ""):
+            env["PATH"] = f"{cargo_bin}:{env.get('PATH', '')}"
+    except RuntimeError:
+        pass
     try:
         result = subprocess.run(
             cmd,
@@ -202,19 +205,22 @@ def eval_tests(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}: {p} passed, {f} failed")
 
         if _detect_node_project(sp):
-            # Try npm test
-            rc, stdout, stderr = _run_cmd(["npm", "test", "--", "--passWithNoTests"], sp, timeout=180)
-            output = stdout + stderr
-            # Jest: match only "Tests:" lines, not "Test Suites:" lines
-            p_matches = re.findall(r"^Tests:.*?(\d+)\s+passed", output, re.MULTILINE)
-            f_matches = re.findall(r"^Tests:.*?(\d+)\s+failed", output, re.MULTILINE)
-            p = sum(int(x) for x in p_matches)
-            f = sum(int(x) for x in f_matches)
-            if p + f > 0:
-                ran_any = True
-                total_passed += p
-                total_failed += f
-                details_parts.append(f"{sp.name}(js): {p} passed, {f} failed")
+            if not shutil.which("npm"):
+                log.warning("npm_not_found", project=str(sp), msg="npm not on PATH, skipping Node tests")
+            else:
+                # Try npm test
+                rc, stdout, stderr = _run_cmd(["npm", "test", "--", "--passWithNoTests"], sp, timeout=180)
+                output = stdout + stderr
+                # Jest: match only "Tests:" lines, not "Test Suites:" lines
+                p_matches = re.findall(r"^Tests:.*?(\d+)\s+passed", output, re.MULTILINE)
+                f_matches = re.findall(r"^Tests:.*?(\d+)\s+failed", output, re.MULTILINE)
+                p = sum(int(x) for x in p_matches)
+                f = sum(int(x) for x in f_matches)
+                if p + f > 0:
+                    ran_any = True
+                    total_passed += p
+                    total_failed += f
+                    details_parts.append(f"{sp.name}(js): {p} passed, {f} failed")
 
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
@@ -256,6 +262,10 @@ def eval_tests(project_path: Path) -> dict:
                 rc, stdout, stderr = _run_cmd(java_cmd, sp)
                 output = stdout + stderr
                 t_matches = re.findall(r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)", output)
+                if not t_matches:
+                    t_matches_gradle = re.findall(r"(\d+)\s+tests?\s+completed,\s*(\d+)\s+failed", output)
+                    if t_matches_gradle:
+                        t_matches = [(c, f_s, "0") for c, f_s in t_matches_gradle]
                 if t_matches:
                     ran_any = True
                     java_passed = 0
@@ -269,6 +279,8 @@ def eval_tests(project_path: Path) -> dict:
                     details_parts.append(f"{sp.name}(java): {java_passed} passed, {java_failed} failed")
                 elif rc == 0:
                     log.warning("java_tests_unparsed", project=str(sp), msg="Tests passed but output format unrecognized")
+                elif rc != 0:
+                    log.warning("java_tests_unparsed_failure", project=str(sp), rc=rc, msg="Tests failed but output format unrecognized")
 
     if not ran_any:
         return _neutral("tests", "no test suite detected")
@@ -309,16 +321,19 @@ def eval_lint(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}: {count} errors")
 
         if _detect_node_project(sp):
-            rc, stdout, stderr = _run_cmd(["npx", "eslint", ".", "--format=compact"], sp, timeout=180)
-            output = stdout + stderr
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(js): clean")
+            if not shutil.which("npx"):
+                log.warning("npx_not_found", project=str(sp), msg="npx not on PATH, skipping Node lint")
             else:
-                ran_any = True
-                count = len(re.findall(r"Error -", output))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(js): {max(count, 1)} errors")
+                rc, stdout, stderr = _run_cmd(["npx", "eslint", ".", "--format=compact"], sp, timeout=180)
+                output = stdout + stderr
+                if rc == 0:
+                    ran_any = True
+                    details_parts.append(f"{sp.name}(js): clean")
+                else:
+                    ran_any = True
+                    count = len(re.findall(r"Error -", output))
+                    total_errors += max(count, 1)
+                    details_parts.append(f"{sp.name}(js): {max(count, 1)} errors")
 
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
@@ -413,16 +428,19 @@ def eval_type_check(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}: {count} errors")
 
         if _detect_node_project(sp):
-            rc, stdout, stderr = _run_cmd(["npx", "tsc", "--noEmit"], sp, timeout=180)
-            output = stdout + stderr
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(ts): clean")
+            if not shutil.which("npx"):
+                log.warning("npx_not_found", project=str(sp), msg="npx not on PATH, skipping Node type check")
             else:
-                ran_any = True
-                count = len(re.findall(r"error TS\d+", output))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(ts): {max(count, 1)} errors")
+                rc, stdout, stderr = _run_cmd(["npx", "tsc", "--noEmit"], sp, timeout=180)
+                output = stdout + stderr
+                if rc == 0:
+                    ran_any = True
+                    details_parts.append(f"{sp.name}(ts): clean")
+                else:
+                    ran_any = True
+                    count = len(re.findall(r"error TS\d+", output))
+                    total_errors += max(count, 1)
+                    details_parts.append(f"{sp.name}(ts): {max(count, 1)} errors")
 
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
@@ -536,7 +554,7 @@ def eval_coverage(project_path: Path) -> dict:
                     output = stdout + stderr
                     pct_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
                     if not pct_match:
-                        stderr = llvm_cov_stderr
+                        stderr = f"{llvm_cov_stderr}\n--- tarpaulin stderr ---\n{stderr}"
                 if pct_match:
                     ran_any = True
                     pct = int(float(pct_match.group(1)))
@@ -612,7 +630,7 @@ def eval_coverage(project_path: Path) -> dict:
                             coverages.append((f"{sp.name}(java)", pct))
                         else:
                             log.warning("jacoco_xml_no_line_counter", project=str(sp))
-                    except OSError:
+                    except (OSError, ValueError):
                         log.warning("jacoco_xml_read_failed", project=str(sp))
                 elif rc == 0:
                     log.warning("jacoco_xml_not_found", project=str(sp), path=str(jacoco_xml))

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -596,13 +596,15 @@ def eval_coverage(project_path: Path) -> dict:
                 if rc == 0 and jacoco_xml.exists():
                     try:
                         xml_text = jacoco_xml.read_text()
-                        line_match = re.search(
-                            r'<counter\s+type="LINE"\s+missed="(\d+)"\s+covered="(\d+)"',
-                            xml_text,
-                        )
-                        if line_match:
-                            missed = int(line_match.group(1))
-                            covered = int(line_match.group(2))
+                        line_counter = re.search(r'<counter[^>]+type="LINE"[^>]*/>', xml_text)
+                        if line_counter:
+                            missed_m = re.search(r'missed="(\d+)"', line_counter.group(0))
+                            covered_m = re.search(r'covered="(\d+)"', line_counter.group(0))
+                        else:
+                            missed_m = covered_m = None
+                        if missed_m and covered_m:
+                            missed = int(missed_m.group(1))
+                            covered = int(covered_m.group(1))
                             total_lines = missed + covered
                             pct = int(covered * 100 / total_lines) if total_lines > 0 else 0
                             ran_any = True

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -408,7 +408,7 @@ def eval_coverage(project_path: Path) -> dict:
 
         if _detect_node_project(sp):
             rc, stdout, stderr = _run_cmd(
-                ["npx", "jest", "--coverage", "--coverageReporters=text", "--passWithNoTests"],
+                ["npx", "--no-install", "jest", "--coverage", "--coverageReporters=text", "--passWithNoTests"],
                 sp,
                 timeout=180,
             )

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -44,7 +44,10 @@ def _find_sub_projects(project_path: Path) -> list[Path]:
     Checks the project root and immediate subdirectories. Returns the project
     root itself if it has project markers, plus any sub-project dirs.
     """
-    markers = ["pyproject.toml", "package.json", "Cargo.toml", "go.mod", "pom.xml", "build.gradle", "build.gradle.kts"]
+    markers = [
+        "pyproject.toml", "package.json", "Cargo.toml", "go.mod",
+        "pom.xml", "build.gradle", "build.gradle.kts",
+    ]
     skip = {".git", ".factory", "node_modules", ".venv", "venv", "__pycache__"}
     roots: list[Path] = []
 
@@ -187,12 +190,16 @@ def eval_tests(project_path: Path) -> dict:
     total_passed = 0
     total_failed = 0
     ran_any = False
+    tool_missing = False
     details_parts: list[str] = []
 
     for sp in sub_projects:
         if _detect_python_project(sp):
             # Try pytest
-            rc, stdout, stderr = _run_cmd([sys.executable, "-m", "pytest", "-v", "--tb=no", "-q"], sp)
+            rc, stdout, stderr = _run_cmd(
+                [sys.executable, "-m", "pytest", "-v", "--tb=no", "-q"],
+                sp,
+            )
             output = stdout + stderr
             p_match = re.search(r"(\d+)\s+passed", output)
             f_match = re.search(r"(\d+)\s+failed", output)
@@ -206,10 +213,19 @@ def eval_tests(project_path: Path) -> dict:
 
         if _detect_node_project(sp):
             if not shutil.which("npm"):
-                log.warning("npm_not_found", project=str(sp), msg="npm not on PATH, skipping Node tests")
+                tool_missing = True
+                log.warning(
+                    "npm_not_found",
+                    project=str(sp),
+                    msg="npm not installed, skipping Node tests",
+                )
             else:
                 # Try npm test
-                rc, stdout, stderr = _run_cmd(["npm", "test", "--", "--passWithNoTests"], sp, timeout=180)
+                rc, stdout, stderr = _run_cmd(
+                    ["npm", "test", "--", "--passWithNoTests"],
+                    sp,
+                    timeout=180,
+                )
                 output = stdout + stderr
                 # Jest: match only "Tests:" lines, not "Test Suites:" lines
                 p_matches = re.findall(r"^Tests:.*?(\d+)\s+passed", output, re.MULTILINE)
@@ -224,12 +240,17 @@ def eval_tests(project_path: Path) -> dict:
 
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
-                log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust tests")
+                tool_missing = True
+                log.warning(
+                    "cargo_not_found",
+                    project=str(sp),
+                    msg="cargo not installed, skipping Rust tests",
+                )
             else:
                 rc, stdout, stderr = _run_cmd(["cargo", "test", "--workspace"], sp)
                 output = stdout + stderr
-                p_matches = re.findall(r"(\d+)\s+passed", output)
-                f_matches = re.findall(r"(\d+)\s+failed", output)
+                p_matches = re.findall(r"test result:.*?(\d+)\s+passed", output)
+                f_matches = re.findall(r"test result:.*?(\d+)\s+failed", output)
                 p = sum(int(x) for x in p_matches)
                 f = sum(int(x) for x in f_matches)
                 if p + f > 0:
@@ -240,7 +261,12 @@ def eval_tests(project_path: Path) -> dict:
 
         if _detect_go_project(sp):
             if not shutil.which("go"):
-                log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go tests")
+                tool_missing = True
+                log.warning(
+                    "go_not_found",
+                    project=str(sp),
+                    msg="go not installed, skipping Go tests",
+                )
             else:
                 rc, stdout, stderr = _run_cmd(["go", "test", "./..."], sp)
                 output = stdout + stderr
@@ -256,17 +282,35 @@ def eval_tests(project_path: Path) -> dict:
                     ran_any = True
                     total_failed += 1
                     details_parts.append(f"{sp.name}(go): failed")
+                else:
+                    log.warning(
+                        "go_test_nonzero_no_fail",
+                        project=str(sp),
+                        rc=rc,
+                        msg="go test returned non-zero but no FAIL in output",
+                    )
 
         if _detect_java_project(sp):
             java_cmd = _java_test_cmd(sp)
             if not java_cmd:
-                log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java tests")
+                tool_missing = True
+                log.warning(
+                    "java_build_tool_not_found",
+                    project=str(sp),
+                    msg="mvn/gradle not installed, skipping Java tests",
+                )
             else:
                 rc, stdout, stderr = _run_cmd(java_cmd, sp)
                 output = stdout + stderr
-                t_matches = re.findall(r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)", output)
+                t_matches = re.findall(
+                    r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)",
+                    output,
+                )
                 if not t_matches:
-                    t_matches_gradle = re.findall(r"(\d+)\s+tests?\s+completed,\s*(\d+)\s+failed", output)
+                    t_matches_gradle = re.findall(
+                        r"(\d+)\s+tests?\s+completed,\s*(\d+)\s+failed",
+                        output,
+                    )
                     if t_matches_gradle:
                         t_matches = [(c, f_s, "0") for c, f_s in t_matches_gradle]
                 if t_matches:
@@ -279,17 +323,26 @@ def eval_tests(project_path: Path) -> dict:
                         java_failed += int(fail_s) + int(err_s)
                     total_passed += java_passed
                     total_failed += java_failed
-                    details_parts.append(f"{sp.name}(java): {java_passed} passed, {java_failed} failed")
+                    details_parts.append(
+                        f"{sp.name}(java): {java_passed} passed, {java_failed} failed"
+                    )
                 elif rc == 0:
-                    ran_any = True
-                    total_passed += 1
-                    details_parts.append(f"{sp.name}(java): passed (output unparsed)")
-                    log.warning("java_tests_unparsed", project=str(sp), msg="Tests passed but output format unrecognized")
+                    log.warning(
+                        "java_tests_unparsed",
+                        project=str(sp),
+                        msg="rc=0 but test output unrecognized, not counting as pass",
+                    )
                 elif rc != 0:
-                    log.warning("java_tests_unparsed_failure", project=str(sp), rc=rc, msg="Tests failed but output format unrecognized")
+                    log.warning(
+                        "java_tests_unparsed_failure",
+                        project=str(sp),
+                        rc=rc,
+                        msg="Tests failed but output format unrecognized",
+                    )
 
     if not ran_any:
-        return _neutral("tests", "no test suite detected")
+        reason = "tool not on PATH" if tool_missing else "no test suite detected"
+        return _neutral("tests", reason)
 
     total = total_passed + total_failed
     score = total_passed / total if total > 0 else 0.0
@@ -310,11 +363,14 @@ def eval_lint(project_path: Path) -> dict:
     sub_projects = _find_sub_projects(project_path)
     total_errors = 0
     ran_any = False
+    tool_missing = False
     details_parts: list[str] = []
 
     for sp in sub_projects:
         if _detect_python_project(sp):
-            rc, stdout, stderr = _run_cmd([sys.executable, "-m", "ruff", "check", "."], sp)
+            rc, stdout, stderr = _run_cmd(
+                [sys.executable, "-m", "ruff", "check", "."], sp,
+            )
             output = stdout + stderr
             if rc == 0:
                 ran_any = True
@@ -328,9 +384,18 @@ def eval_lint(project_path: Path) -> dict:
 
         if _detect_node_project(sp):
             if not shutil.which("npx"):
-                log.warning("npx_not_found", project=str(sp), msg="npx not on PATH, skipping Node lint")
+                tool_missing = True
+                log.warning(
+                    "npx_not_found",
+                    project=str(sp),
+                    msg="npx not installed, skipping Node lint",
+                )
             else:
-                rc, stdout, stderr = _run_cmd(["npx", "eslint", ".", "--format=compact"], sp, timeout=180)
+                rc, stdout, stderr = _run_cmd(
+                    ["npx", "eslint", ".", "--format=compact"],
+                    sp,
+                    timeout=180,
+                )
                 output = stdout + stderr
                 if rc == 0:
                     ran_any = True
@@ -343,9 +408,16 @@ def eval_lint(project_path: Path) -> dict:
 
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
-                log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust lint")
+                tool_missing = True
+                log.warning(
+                    "cargo_not_found",
+                    project=str(sp),
+                    msg="cargo not installed, skipping Rust lint",
+                )
             else:
-                rc, stdout, stderr = _run_cmd(["cargo", "clippy", "--", "-D", "warnings"], sp)
+                rc, stdout, stderr = _run_cmd(
+                    ["cargo", "clippy", "--", "-D", "warnings"], sp,
+                )
                 if rc == 0:
                     ran_any = True
                     details_parts.append(f"{sp.name}(rs): clean")
@@ -357,7 +429,12 @@ def eval_lint(project_path: Path) -> dict:
 
         if _detect_go_project(sp):
             if not shutil.which("go"):
-                log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go lint")
+                tool_missing = True
+                log.warning(
+                    "go_not_found",
+                    project=str(sp),
+                    msg="go not installed, skipping Go lint",
+                )
             else:
                 rc, stdout, stderr = _run_cmd(["go", "vet", "./..."], sp)
                 if rc == 0:
@@ -373,7 +450,12 @@ def eval_lint(project_path: Path) -> dict:
         if _detect_java_project(sp):
             tool = _java_build_tool(sp)
             if not tool:
-                log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java lint")
+                tool_missing = True
+                log.warning(
+                    "java_build_tool_not_found",
+                    project=str(sp),
+                    msg="mvn/gradle not installed, skipping Java lint",
+                )
             else:
                 if tool[-1] == "mvn":
                     cmd = [*tool, "checkstyle:check", "-q"]
@@ -391,7 +473,8 @@ def eval_lint(project_path: Path) -> dict:
                     details_parts.append(f"{sp.name}(java): {max(count, 1)} errors")
 
     if not ran_any:
-        return _neutral("lint", "no linter detected")
+        reason = "tool not on PATH" if tool_missing else "no linter detected"
+        return _neutral("lint", reason)
 
     score = max(0.0, 1.0 - total_errors * 0.1)
     return {
@@ -411,6 +494,7 @@ def eval_type_check(project_path: Path) -> dict:
     sub_projects = _find_sub_projects(project_path)
     total_errors = 0
     ran_any = False
+    tool_missing = False
     details_parts: list[str] = []
 
     for sp in sub_projects:
@@ -435,9 +519,16 @@ def eval_type_check(project_path: Path) -> dict:
 
         if _detect_node_project(sp):
             if not shutil.which("npx"):
-                log.warning("npx_not_found", project=str(sp), msg="npx not on PATH, skipping Node type check")
+                tool_missing = True
+                log.warning(
+                    "npx_not_found",
+                    project=str(sp),
+                    msg="npx not installed, skipping Node type check",
+                )
             else:
-                rc, stdout, stderr = _run_cmd(["npx", "tsc", "--noEmit"], sp, timeout=180)
+                rc, stdout, stderr = _run_cmd(
+                    ["npx", "tsc", "--noEmit"], sp, timeout=180,
+                )
                 output = stdout + stderr
                 if rc == 0:
                     ran_any = True
@@ -450,7 +541,12 @@ def eval_type_check(project_path: Path) -> dict:
 
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
-                log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust type check")
+                tool_missing = True
+                log.warning(
+                    "cargo_not_found",
+                    project=str(sp),
+                    msg="cargo not installed, skipping Rust type check",
+                )
             else:
                 rc, stdout, stderr = _run_cmd(["cargo", "check"], sp)
                 if rc == 0:
@@ -464,9 +560,16 @@ def eval_type_check(project_path: Path) -> dict:
 
         if _detect_go_project(sp):
             if not shutil.which("go"):
-                log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go type check")
+                tool_missing = True
+                log.warning(
+                    "go_not_found",
+                    project=str(sp),
+                    msg="go not installed, skipping Go type check",
+                )
             else:
-                rc, stdout, stderr = _run_cmd(["go", "build", "-o", os.devnull, "./..."], sp)
+                rc, stdout, stderr = _run_cmd(
+                    ["go", "build", "-o", os.devnull, "./..."], sp,
+                )
                 if rc == 0:
                     ran_any = True
                     details_parts.append(f"{sp.name}(go): clean")
@@ -480,7 +583,12 @@ def eval_type_check(project_path: Path) -> dict:
         if _detect_java_project(sp):
             tool = _java_build_tool(sp)
             if not tool:
-                log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java type check")
+                tool_missing = True
+                log.warning(
+                    "java_build_tool_not_found",
+                    project=str(sp),
+                    msg="mvn/gradle not installed, skipping Java type check",
+                )
             else:
                 if tool[-1] == "mvn":
                     cmd = [*tool, "compile", "-q"]
@@ -498,7 +606,8 @@ def eval_type_check(project_path: Path) -> dict:
                     details_parts.append(f"{sp.name}(java): {max(count, 1)} errors")
 
     if not ran_any:
-        return _neutral("type_check", "no type checker detected")
+        reason = "tool not on PATH" if tool_missing else "no type checker detected"
+        return _neutral("type_check", reason)
 
     score = max(0.0, 1.0 - total_errors * 0.05)
     return {
@@ -518,6 +627,7 @@ def eval_coverage(project_path: Path) -> dict:
     sub_projects = _find_sub_projects(project_path)
     coverages: list[tuple[str, int]] = []
     ran_any = False
+    tool_missing = False
 
     for sp in sub_projects:
         if _detect_python_project(sp):
@@ -539,7 +649,12 @@ def eval_coverage(project_path: Path) -> dict:
 
         if _detect_rust_project(sp):
             if not shutil.which("cargo"):
-                log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust coverage")
+                tool_missing = True
+                log.warning(
+                    "cargo_not_found",
+                    project=str(sp),
+                    msg="cargo not installed, skipping Rust coverage",
+                )
             else:
                 rc, stdout, stderr = _run_cmd(
                     ["cargo", "llvm-cov", "--summary-only"],
@@ -548,6 +663,7 @@ def eval_coverage(project_path: Path) -> dict:
                 )
                 output = stdout + stderr
                 pct_match = None
+                cov_tool = "llvm-cov"
                 if rc == 0:
                     pct_match = re.search(r"TOTAL\s+[\d.]+\s+[\d.]+\s+([\d.]+)%", output)
                 else:
@@ -558,6 +674,7 @@ def eval_coverage(project_path: Path) -> dict:
                         timeout=600,
                     )
                     output = stdout + stderr
+                    cov_tool = "tarpaulin"
                     pct_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
                     if not pct_match:
                         stderr = f"{llvm_cov_stderr}\n--- tarpaulin stderr ---\n{stderr}"
@@ -566,16 +683,31 @@ def eval_coverage(project_path: Path) -> dict:
                     pct = int(float(pct_match.group(1)))
                     coverages.append((f"{sp.name}(rs)", pct))
                 elif rc == 0:
-                    log.warning("coverage_output_unrecognized", project=str(sp), lang="rust",
-                                msg="llvm-cov succeeded but output not parseable")
+                    log.warning(
+                        "coverage_output_unrecognized",
+                        project=str(sp),
+                        lang="rust",
+                        msg=f"{cov_tool} succeeded but output not parseable",
+                    )
                 elif "Timed out" in stderr:
                     log.warning("coverage_timeout", project=str(sp), lang="rust", timeout=600)
                 elif rc != 0:
-                    log.warning("coverage_tool_failed", project=str(sp), lang="rust", rc=rc, stderr=stderr[:200])
+                    log.warning(
+                        "coverage_tool_failed",
+                        project=str(sp),
+                        lang="rust",
+                        rc=rc,
+                        stderr=stderr[:200],
+                    )
 
         if _detect_go_project(sp):
             if not shutil.which("go"):
-                log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go coverage")
+                tool_missing = True
+                log.warning(
+                    "go_not_found",
+                    project=str(sp),
+                    msg="go not installed, skipping Go coverage",
+                )
             else:
                 rc, stdout, stderr = _run_cmd(
                     ["go", "test", "-cover", "./..."],
@@ -592,7 +724,12 @@ def eval_coverage(project_path: Path) -> dict:
 
         if _detect_node_project(sp):
             if not shutil.which("npx"):
-                log.warning("npx_not_found", project=str(sp), msg="npx not on PATH, skipping Node coverage")
+                tool_missing = True
+                log.warning(
+                    "npx_not_found",
+                    project=str(sp),
+                    msg="npx not installed, skipping Node coverage",
+                )
             else:
                 rc, stdout, stderr = _run_cmd(
                     ["npx", "--no-install", "jest", "--coverage", "--coverageReporters=text"],
@@ -611,14 +748,21 @@ def eval_coverage(project_path: Path) -> dict:
         if _detect_java_project(sp):
             tool = _java_build_tool(sp)
             if not tool:
-                log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java coverage")
+                tool_missing = True
+                log.warning(
+                    "java_build_tool_not_found",
+                    project=str(sp),
+                    msg="mvn/gradle not installed, skipping Java coverage",
+                )
             else:
                 if tool[-1] == "mvn":
                     cmd = [*tool, "verify", "-q", "-Djacoco.skip=false"]
                     jacoco_xml = sp / "target" / "site" / "jacoco" / "jacoco.xml"
                 else:
                     cmd = [*tool, "jacocoTestReport", "-q"]
-                    jacoco_xml = sp / "build" / "reports" / "jacoco" / "test" / "jacocoTestReport.xml"
+                    jacoco_xml = (
+                        sp / "build" / "reports" / "jacoco" / "test" / "jacocoTestReport.xml"
+                    )
                 rc, stdout, stderr = _run_cmd(cmd, sp)
                 if rc == 0 and jacoco_xml.exists():
                     try:
@@ -647,7 +791,8 @@ def eval_coverage(project_path: Path) -> dict:
                     log.warning("jacoco_xml_not_found", project=str(sp), path=str(jacoco_xml))
 
     if not ran_any:
-        return _neutral("coverage", "no coverage tool detected")
+        reason = "tool not on PATH" if tool_missing else "no coverage tool detected"
+        return _neutral("coverage", reason)
 
     avg_pct = sum(p for _, p in coverages) / len(coverages)
     score = avg_pct / 100.0

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -125,8 +125,6 @@ def _java_test_cmd(project_path: Path) -> list[str] | None:
     tool = _java_build_tool(project_path)
     if not tool:
         return None
-    if tool[-1] in ("mvn",):
-        return [*tool, "test", "-q"]
     return [*tool, "test", "-q"]
 
 
@@ -328,6 +326,9 @@ def eval_lint(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
 
         if _detect_go_project(sp):
+            if not shutil.which("go"):
+                log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go lint")
+                continue
             rc, stdout, stderr = _run_cmd(["go", "vet", "./..."], sp)
             if rc == 0:
                 ran_any = True
@@ -432,7 +433,7 @@ def eval_type_check(project_path: Path) -> dict:
             if not shutil.which("go"):
                 log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go type check")
                 continue
-            rc, stdout, stderr = _run_cmd(["go", "build", "-o", "/dev/null", "./..."], sp)
+            rc, stdout, stderr = _run_cmd(["go", "build", "-o", os.devnull, "./..."], sp)
             if rc == 0:
                 ran_any = True
                 details_parts.append(f"{sp.name}(go): clean")

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -250,15 +250,18 @@ def eval_tests(project_path: Path) -> dict:
                 continue
             rc, stdout, stderr = _run_cmd(java_cmd, sp)
             output = stdout + stderr
-            t_match = re.search(r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)", output)
-            if t_match:
+            t_matches = re.findall(r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+)", output)
+            if t_matches:
                 ran_any = True
-                total_run = int(t_match.group(1))
-                failures = int(t_match.group(2)) + int(t_match.group(3))
-                p = total_run - failures
-                total_passed += p
-                total_failed += failures
-                details_parts.append(f"{sp.name}(java): {p} passed, {failures} failed")
+                java_passed = 0
+                java_failed = 0
+                for total_run_s, fail_s, err_s in t_matches:
+                    p = int(total_run_s) - int(fail_s) - int(err_s)
+                    java_passed += p
+                    java_failed += int(fail_s) + int(err_s)
+                total_passed += java_passed
+                total_failed += java_failed
+                details_parts.append(f"{sp.name}(java): {java_passed} passed, {java_failed} failed")
             elif rc == 0:
                 ran_any = True
                 total_passed += 1
@@ -449,7 +452,11 @@ def eval_type_check(project_path: Path) -> dict:
             if not tool:
                 log.warning("java_build_tool_not_found", project=str(sp), msg="mvn/gradle not on PATH, skipping Java type check")
                 continue
-            rc, stdout, stderr = _run_cmd([*tool, "compile", "-q"], sp)
+            if tool[-1] == "mvn":
+                cmd = [*tool, "compile", "-q"]
+            else:
+                cmd = [*tool, "compileJava", "-q"]
+            rc, stdout, stderr = _run_cmd(cmd, sp)
             if rc == 0:
                 ran_any = True
                 details_parts.append(f"{sp.name}(java): clean")

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -331,7 +331,7 @@ def eval_type_check(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
 
         if _detect_go_project(sp):
-            rc, stdout, stderr = _run_cmd(["go", "build", "./..."], sp)
+            rc, stdout, stderr = _run_cmd(["go", "vet", "./..."], sp)
             if rc == 0:
                 ran_any = True
                 details_parts.append(f"{sp.name}(go): clean")

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -247,6 +247,9 @@ def eval_tests(project_path: Path) -> dict:
                 if rc == 0:
                     ran_any = True
                     ok_count = len(re.findall(r"^ok\s+", output, re.MULTILINE))
+                    if ok_count == 0:
+                        log.warning("go_test_pass_count_fallback", project=str(sp),
+                                    msg="go test passed but no 'ok' lines found, counting as 1")
                     total_passed += max(ok_count, 1)
                     details_parts.append(f"{sp.name}(go): passed")
                 elif "FAIL" in output:
@@ -586,7 +589,7 @@ def eval_coverage(project_path: Path) -> dict:
                 log.warning("npx_not_found", project=str(sp), msg="npx not on PATH, skipping Node coverage")
             else:
                 rc, stdout, stderr = _run_cmd(
-                    ["npx", "--no-install", "jest", "--coverage", "--coverageReporters=text", "--passWithNoTests"],
+                    ["npx", "--no-install", "jest", "--coverage", "--coverageReporters=text"],
                     sp,
                     timeout=180,
                 )

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -324,6 +324,9 @@ def eval_type_check(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}(ts): {max(count, 1)} errors")
 
         if _detect_rust_project(sp):
+            if not shutil.which("cargo"):
+                log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust type check")
+                continue
             rc, stdout, stderr = _run_cmd(["cargo", "check"], sp)
             if rc == 0:
                 ran_any = True
@@ -335,6 +338,9 @@ def eval_type_check(project_path: Path) -> dict:
                 details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
 
         if _detect_go_project(sp):
+            if not shutil.which("go"):
+                log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go type check")
+                continue
             rc, stdout, stderr = _run_cmd(["go", "build", "-o", "/dev/null", "./..."], sp)
             if rc == 0:
                 ran_any = True
@@ -387,6 +393,9 @@ def eval_coverage(project_path: Path) -> dict:
                 coverages.append((sp.name, pct))
 
         if _detect_rust_project(sp):
+            if not shutil.which("cargo"):
+                log.warning("cargo_not_found", project=str(sp), msg="cargo not on PATH, skipping Rust coverage")
+                continue
             rc, stdout, stderr = _run_cmd(
                 ["cargo", "tarpaulin", "--out", "stdout", "--skip-clean"],
                 sp,
@@ -399,6 +408,9 @@ def eval_coverage(project_path: Path) -> dict:
                 coverages.append((f"{sp.name}(rs)", pct))
 
         if _detect_go_project(sp):
+            if not shutil.which("go"):
+                log.warning("go_not_found", project=str(sp), msg="go not on PATH, skipping Go coverage")
+                continue
             rc, stdout, stderr = _run_cmd(
                 ["go", "test", "-cover", "./..."],
                 sp,
@@ -411,6 +423,9 @@ def eval_coverage(project_path: Path) -> dict:
                 coverages.append((f"{sp.name}(go)", avg))
 
         if _detect_node_project(sp):
+            if not shutil.which("npx"):
+                log.warning("npx_not_found", project=str(sp), msg="npx not on PATH, skipping Node coverage")
+                continue
             rc, stdout, stderr = _run_cmd(
                 ["npx", "--no-install", "jest", "--coverage", "--coverageReporters=text", "--passWithNoTests"],
                 sp,

--- a/factory/study.py
+++ b/factory/study.py
@@ -26,6 +26,7 @@ def _find_source_files(project_path: Path, language: str) -> list[Path]:
         "typescript": ".ts",
         "go": ".go",
         "rust": ".rs",
+        "java": ".java",
     }.get(language, ".py")
 
     sources: list[Path] = []

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -222,7 +222,10 @@ class TestNodeMonorepoAggregation:
 
     def test_aggregates_multiple_suites(self, tmp_path):
         (tmp_path / "package.json").write_text('{"name": "monorepo"}\n')
-        with patch("factory.eval.hygiene._run_cmd", return_value=(1, self.MONOREPO_OUTPUT, "")):
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, self.MONOREPO_OUTPUT, "")),
+            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: "/usr/bin/npm" if cmd == "npm" else None),
+        ):
             result = eval_tests(tmp_path)
         assert result["name"] == "tests"
         # 12 + 8 = 20 passed, 0 + 2 = 2 failed
@@ -232,7 +235,10 @@ class TestNodeMonorepoAggregation:
     def test_single_suite_still_works(self, tmp_path):
         output = "Tests: 5 passed, 0 failed\n"
         (tmp_path / "package.json").write_text('{"name": "app"}\n')
-        with patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")):
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: "/usr/bin/npm" if cmd == "npm" else None),
+        ):
             result = eval_tests(tmp_path)
         assert result["score"] == 1.0
         assert result["passed"] is True
@@ -322,7 +328,10 @@ class TestJestDoesNotDoubleCount:
             "Time:        1.5 s\n"
         )
         (tmp_path / "package.json").write_text('{"name": "app"}\n')
-        with patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")):
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: "/usr/bin/npm" if cmd == "npm" else None),
+        ):
             result = eval_tests(tmp_path)
         assert result["score"] == 1.0
         assert "10 passed" in result["details"]
@@ -333,7 +342,10 @@ class TestJestDoesNotDoubleCount:
             "Tests:       2 failed, 8 passed, 10 total\n"
         )
         (tmp_path / "package.json").write_text('{"name": "app"}\n')
-        with patch("factory.eval.hygiene._run_cmd", return_value=(1, output, "")):
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, output, "")),
+            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: "/usr/bin/npm" if cmd == "npm" else None),
+        ):
             result = eval_tests(tmp_path)
         assert result["score"] == round(8 / 10, 4)
         assert result["passed"] is False

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -6,6 +6,8 @@ from factory.eval.hygiene import (
     HYGIENE_WEIGHTS,
     _detect_java_project,
     _find_sub_projects,
+    _java_build_tool,
+    _java_test_cmd,
     compute_hygiene_results,
     eval_config_parser,
     eval_coverage,
@@ -333,3 +335,311 @@ class TestJestDoesNotDoubleCount:
             result = eval_tests(tmp_path)
         assert result["score"] == round(8 / 10, 4)
         assert result["passed"] is False
+
+
+class TestJavaBuildTool:
+    """Tests for _java_build_tool() — gradlew > gradle > mvn priority."""
+
+    def test_gradlew_preferred(self, tmp_path):
+        (tmp_path / "gradlew").write_text("#!/bin/sh\n")
+        (tmp_path / "build.gradle").write_text("")
+        with patch("shutil.which", return_value="/usr/bin/mvn"):
+            result = _java_build_tool(tmp_path)
+        assert result == [str(tmp_path / "gradlew")]
+
+    def test_gradle_with_build_gradle(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("")
+        with patch("shutil.which", side_effect=lambda t: "/usr/bin/gradle" if t == "gradle" else None):
+            result = _java_build_tool(tmp_path)
+        assert result == ["gradle"]
+
+    def test_gradle_with_build_gradle_kts(self, tmp_path):
+        (tmp_path / "build.gradle.kts").write_text("")
+        with patch("shutil.which", side_effect=lambda t: "/usr/bin/gradle" if t == "gradle" else None):
+            result = _java_build_tool(tmp_path)
+        assert result == ["gradle"]
+
+    def test_mvn_fallback(self, tmp_path):
+        with patch("shutil.which", side_effect=lambda t: "/usr/bin/mvn" if t == "mvn" else None):
+            result = _java_build_tool(tmp_path)
+        assert result == ["mvn"]
+
+    def test_no_tool_returns_none(self, tmp_path):
+        with patch("shutil.which", return_value=None):
+            result = _java_build_tool(tmp_path)
+        assert result is None
+
+
+class TestJavaTestCmd:
+    """Tests for _java_test_cmd() — delegates to _java_build_tool."""
+
+    def test_returns_cmd_when_tool_available(self, tmp_path):
+        with patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]):
+            result = _java_test_cmd(tmp_path)
+        assert result == ["mvn", "test", "-q"]
+
+    def test_returns_none_when_no_tool(self, tmp_path):
+        with patch("factory.eval.hygiene._java_build_tool", return_value=None):
+            result = _java_test_cmd(tmp_path)
+        assert result is None
+
+
+class TestEvalLintLanguages:
+    """Tests for eval_lint() Go and Java branches."""
+
+    def test_go_pass(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("shutil.which", return_value="/usr/bin/go"),
+        ):
+            result = eval_lint(tmp_path)
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+    def test_go_fail_counts_errors(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        stderr = "main.go:10:5: unreachable code\nmain.go:20:3: unused variable\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, "", stderr)),
+            patch("shutil.which", return_value="/usr/bin/go"),
+        ):
+            result = eval_lint(tmp_path)
+        assert result["passed"] is False
+        assert "2 errors" in result["details"]
+
+    def test_go_no_go_on_path(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        with patch("shutil.which", return_value=None):
+            result = eval_lint(tmp_path)
+        assert result["score"] == 0.5
+
+    def test_java_mvn_pass(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+        ):
+            result = eval_lint(tmp_path)
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+    def test_java_mvn_fail(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        output = "[ERROR] src/Main.java:1\n[ERROR] src/Main.java:5\n[ERROR] src/Main.java:10\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, output, "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+        ):
+            result = eval_lint(tmp_path)
+        assert result["passed"] is False
+        assert "3 errors" in result["details"]
+
+    def test_java_gradle_pass(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["gradle"]),
+        ):
+            result = eval_lint(tmp_path)
+        assert result["passed"] is True
+
+    def test_java_no_tool(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with patch("factory.eval.hygiene._java_build_tool", return_value=None):
+            result = eval_lint(tmp_path)
+        assert result["score"] == 0.5
+
+
+class TestEvalTypeCheckLanguages:
+    """Tests for eval_type_check() Rust, Go, and Java branches."""
+
+    def test_rust_pass(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+    def test_rust_fail(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        stderr = "error[E0308]: mismatched types\nerror[E0425]: cannot find value\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, "", stderr)),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is False
+        assert "2 errors" in result["details"]
+
+    def test_rust_no_cargo(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        with patch("shutil.which", return_value=None):
+            result = eval_type_check(tmp_path)
+        assert result["score"] == 0.5
+
+    def test_go_pass(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("shutil.which", return_value="/usr/bin/go"),
+        ):
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+    def test_go_fail(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        output = "main.go:10:5: cannot use x\nmain.go:20:3: undefined: y\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, output, "")),
+            patch("shutil.which", return_value="/usr/bin/go"),
+        ):
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is False
+        assert "2 errors" in result["details"]
+
+    def test_go_no_go(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        with patch("shutil.which", return_value=None):
+            result = eval_type_check(tmp_path)
+        assert result["score"] == 0.5
+
+    def test_java_mvn_pass(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+        ):
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is True
+
+    def test_java_mvn_fail(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        output = "[ERROR] src/Main.java:1\n[ERROR] src/Main.java:5\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, output, "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+        ):
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is False
+        assert "2 errors" in result["details"]
+
+    def test_java_gradle_pass(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["gradle"]),
+        ):
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is True
+
+    def test_java_no_tool(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with patch("factory.eval.hygiene._java_build_tool", return_value=None):
+            result = eval_type_check(tmp_path)
+        assert result["score"] == 0.5
+
+
+class TestEvalCoverageLanguages:
+    """Tests for eval_coverage() Rust, Go, Node, and Java branches."""
+
+    def test_rust_coverage_parse(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        output = "85.5% coverage, 100/117 lines covered\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(85 / 100, 4)
+        assert "85%" in result["details"]
+
+    def test_rust_no_cargo(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        with patch("shutil.which", return_value=None):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == 0.5
+
+    def test_go_multi_package_coverage(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        output = (
+            "ok  \ttest/pkg1\t0.5s\tcoverage: 80.0% of statements\n"
+            "ok  \ttest/pkg2\t0.3s\tcoverage: 60.0% of statements\n"
+        )
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("shutil.which", return_value="/usr/bin/go"),
+        ):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(70 / 100, 4)
+        assert "70%" in result["details"]
+
+    def test_go_no_go(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        with patch("shutil.which", return_value=None):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == 0.5
+
+    def test_node_jest_coverage_parse(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+        output = (
+            "----------|---------|----------|---------|---------|---\n"
+            "File      | % Stmts | % Branch | % Funcs | % Lines |\n"
+            "----------|---------|----------|---------|---------|---\n"
+            "All files |   72.5  |   60.0   |   80.0  |   72.5  |\n"
+            "----------|---------|----------|---------|---------|---\n"
+        )
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("shutil.which", return_value="/usr/bin/npx"),
+        ):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(72 / 100, 4)
+        assert "72%" in result["details"]
+
+    def test_node_no_npx(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+        with patch("shutil.which", return_value=None):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == 0.5
+
+    def test_java_mvn_with_percentage(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        output = "Total line coverage: 78%\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+        ):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(78 / 100, 4)
+        assert "78%" in result["details"]
+
+    def test_java_gradle_coverage(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("")
+        output = "Total instruction coverage: 90%\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["gradle"]),
+        ):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(90 / 100, 4)
+
+    def test_java_rc0_no_pct_fallback(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "BUILD SUCCESS\n", "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+        ):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == 0.0
+        assert "0%" in result["details"]
+
+    def test_java_no_tool(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with patch("factory.eval.hygiene._java_build_tool", return_value=None):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == 0.5

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -1,5 +1,7 @@
 """Tests for factory.eval.hygiene — universal hygiene dimensions."""
 
+from unittest.mock import patch
+
 from factory.eval.hygiene import (
     HYGIENE_WEIGHTS,
     _find_sub_projects,
@@ -139,3 +141,93 @@ class TestComputeHygieneResults:
             assert "weight" in r
             assert "passed" in r
             assert "details" in r
+
+
+class TestRustWorkspaceAggregation:
+    """Tests for multi-crate cargo workspace test result aggregation."""
+
+    WORKSPACE_OUTPUT = (
+        "running 5 tests\n"
+        "test tests::test_a ... ok\n"
+        "test tests::test_b ... ok\n"
+        "test tests::test_c ... ok\n"
+        "test tests::test_d ... ok\n"
+        "test tests::test_e ... ok\n"
+        "\n"
+        "test result: ok. 5 passed; 0 failed; 0 ignored\n"
+        "\n"
+        "running 10 tests\n"
+        "test tests::test_f ... ok\n"
+        "test result: ok. 10 passed; 0 failed; 0 ignored\n"
+        "\n"
+        "running 3 tests\n"
+        "test tests::test_g ... FAILED\n"
+        "test result: FAILED. 2 passed; 1 failed; 0 ignored\n"
+    )
+
+    def test_aggregates_multiple_crates(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[workspace]\nmembers = ['a', 'b', 'c']\n")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, self.WORKSPACE_OUTPUT, "")),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_tests(tmp_path)
+        assert result["name"] == "tests"
+        # 5 + 10 + 2 = 17 passed, 1 failed
+        assert result["score"] == round(17 / 18, 4)
+        assert result["passed"] is False
+        assert "17 passed" in result["details"]
+        assert "1 failed" in result["details"]
+
+    def test_all_passing_workspace(self, tmp_path):
+        output = (
+            "test result: ok. 15 passed; 0 failed; 0 ignored\n"
+            "test result: ok. 20 passed; 0 failed; 0 ignored\n"
+        )
+        (tmp_path / "Cargo.toml").write_text("[workspace]\n")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_tests(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+
+    def test_cargo_not_on_path_warns_and_skips(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        with (
+            patch("shutil.which", return_value=None),
+            patch("factory.eval.hygiene.log") as mock_log,
+        ):
+            result = eval_tests(tmp_path)
+        mock_log.warning.assert_called_once()
+        call_kwargs = mock_log.warning.call_args
+        assert "cargo_not_found" in call_kwargs.args or "cargo_not_found" == call_kwargs.args[0]
+        # No tests ran, should be neutral
+        assert result["score"] == 0.5
+
+
+class TestNodeMonorepoAggregation:
+    """Tests for Node/Jest monorepo test result aggregation."""
+
+    MONOREPO_OUTPUT = (
+        "Tests: 12 passed, 0 failed, 12 total\n"
+        "Tests: 8 passed, 2 failed, 10 total\n"
+    )
+
+    def test_aggregates_multiple_suites(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name": "monorepo"}\n')
+        with patch("factory.eval.hygiene._run_cmd", return_value=(1, self.MONOREPO_OUTPUT, "")):
+            result = eval_tests(tmp_path)
+        assert result["name"] == "tests"
+        # 12 + 8 = 20 passed, 0 + 2 = 2 failed
+        assert result["score"] == round(20 / 22, 4)
+        assert result["passed"] is False
+
+    def test_single_suite_still_works(self, tmp_path):
+        output = "Tests: 5 passed, 0 failed\n"
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+        with patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")):
+            result = eval_tests(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -234,6 +234,44 @@ class TestNodeMonorepoAggregation:
         assert result["passed"] is True
 
 
+class TestJavaMavenMultiModuleAggregation:
+    """Multi-module Maven builds report multiple 'Tests run:' lines — all must be summed."""
+
+    MULTI_MODULE_OUTPUT = (
+        "[INFO] --- maven-surefire-plugin:3.0.0:test (default-test) @ module-a ---\n"
+        "Tests run: 10, Failures: 1, Errors: 0, Skipped: 0\n"
+        "[INFO] --- maven-surefire-plugin:3.0.0:test (default-test) @ module-b ---\n"
+        "Tests run: 20, Failures: 0, Errors: 2, Skipped: 0\n"
+    )
+
+    def test_aggregates_multiple_modules(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, self.MULTI_MODULE_OUTPUT, "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+        ):
+            result = eval_tests(tmp_path)
+        assert result["name"] == "tests"
+        # module-a: 10 - 1 - 0 = 9 passed, 1 failed
+        # module-b: 20 - 0 - 2 = 18 passed, 2 failed
+        # total: 27 passed, 3 failed
+        assert result["score"] == round(27 / 30, 4)
+        assert result["passed"] is False
+        assert "27 passed" in result["details"]
+        assert "3 failed" in result["details"]
+
+    def test_single_module_still_works(self, tmp_path):
+        output = "Tests run: 5, Failures: 0, Errors: 0, Skipped: 0\n"
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+        ):
+            result = eval_tests(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+
+
 class TestRustWorkspaceDedup:
     """Bug 1: Rust workspace triple-counting — member crates should be deduplicated."""
 

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -282,6 +282,24 @@ class TestJavaMavenMultiModuleAggregation:
         assert result["passed"] is True
 
 
+class TestJavaGradleTestOutputParsing:
+    """Gradle-style test output ('N tests completed, M failed') is parsed correctly."""
+
+    def test_gradle_test_output_parsed(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("")
+        output = "3 tests completed, 1 failed\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, output, "")),
+            patch("factory.eval.hygiene._java_build_tool", return_value=["gradle"]),
+        ):
+            result = eval_tests(tmp_path)
+        assert result["name"] == "tests"
+        assert result["score"] == round(2 / 3, 4)
+        assert result["passed"] is False
+        assert "2 passed" in result["details"]
+        assert "1 failed" in result["details"]
+
+
 class TestRustWorkspaceDedup:
     """Bug 1: Rust workspace triple-counting — member crates should be deduplicated."""
 
@@ -355,11 +373,13 @@ class TestJavaBuildTool:
     """Tests for _java_build_tool() — gradlew > gradle > mvn priority."""
 
     def test_gradlew_preferred(self, tmp_path):
-        (tmp_path / "gradlew").write_text("#!/bin/sh\n")
+        gradlew = tmp_path / "gradlew"
+        gradlew.write_text("#!/bin/sh\n")
+        gradlew.chmod(0o755)
         (tmp_path / "build.gradle").write_text("")
         with patch("shutil.which", return_value="/usr/bin/mvn"):
             result = _java_build_tool(tmp_path)
-        assert result == [str(tmp_path / "gradlew")]
+        assert result == [str(gradlew)]
 
     def test_gradle_with_build_gradle(self, tmp_path):
         (tmp_path / "build.gradle").write_text("")

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -737,6 +737,7 @@ class TestRunCmdCargoPath:
             assert str(cargo_dir) in env.get("PATH", "")
 
     def test_cargo_bin_not_added_when_missing(self, tmp_path):
+        cargo_dir = tmp_path / ".cargo" / "bin"
         with (
             patch("factory.eval.hygiene.Path.home", return_value=tmp_path),
             patch("factory.eval.hygiene.subprocess.run") as mock_run,
@@ -746,4 +747,4 @@ class TestRunCmdCargoPath:
             )
             _run_cmd(["echo", "test"], tmp_path)
             env = mock_run.call_args.kwargs["env"]
-            assert ".cargo/bin" not in env.get("PATH", "")
+            assert str(cargo_dir) not in env.get("PATH", "")

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -174,7 +174,7 @@ class TestRustWorkspaceAggregation:
         (tmp_path / "Cargo.toml").write_text("[workspace]\nmembers = ['a', 'b', 'c']\n")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(1, self.WORKSPACE_OUTPUT, "")),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_tests(tmp_path)
         assert result["name"] == "tests"
@@ -192,7 +192,7 @@ class TestRustWorkspaceAggregation:
         (tmp_path / "Cargo.toml").write_text("[workspace]\n")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_tests(tmp_path)
         assert result["score"] == 1.0
@@ -201,7 +201,7 @@ class TestRustWorkspaceAggregation:
     def test_cargo_not_on_path_warns_and_skips(self, tmp_path):
         (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
         with (
-            patch("shutil.which", return_value=None),
+            patch("factory.eval.hygiene.shutil.which", return_value=None),
             patch("factory.eval.hygiene.log") as mock_log,
         ):
             result = eval_tests(tmp_path)
@@ -377,35 +377,35 @@ class TestJavaBuildTool:
         gradlew.write_text("#!/bin/sh\n")
         gradlew.chmod(0o755)
         (tmp_path / "build.gradle").write_text("")
-        with patch("shutil.which", return_value="/usr/bin/mvn"):
+        with patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/mvn"):
             result = _java_build_tool(tmp_path)
         assert result == [str(gradlew)]
 
     def test_gradle_with_build_gradle(self, tmp_path):
         (tmp_path / "build.gradle").write_text("")
-        with patch("shutil.which", side_effect=lambda t: "/usr/bin/gradle" if t == "gradle" else None):
+        with patch("factory.eval.hygiene.shutil.which", side_effect=lambda t: "/usr/bin/gradle" if t == "gradle" else None):
             result = _java_build_tool(tmp_path)
         assert result == ["gradle"]
 
     def test_gradle_with_build_gradle_kts(self, tmp_path):
         (tmp_path / "build.gradle.kts").write_text("")
-        with patch("shutil.which", side_effect=lambda t: "/usr/bin/gradle" if t == "gradle" else None):
+        with patch("factory.eval.hygiene.shutil.which", side_effect=lambda t: "/usr/bin/gradle" if t == "gradle" else None):
             result = _java_build_tool(tmp_path)
         assert result == ["gradle"]
 
     def test_mvn_fallback(self, tmp_path):
         (tmp_path / "pom.xml").write_text("<project></project>")
-        with patch("shutil.which", side_effect=lambda t: "/usr/bin/mvn" if t == "mvn" else None):
+        with patch("factory.eval.hygiene.shutil.which", side_effect=lambda t: "/usr/bin/mvn" if t == "mvn" else None):
             result = _java_build_tool(tmp_path)
         assert result == ["mvn"]
 
     def test_mvn_without_pom_returns_none(self, tmp_path):
-        with patch("shutil.which", side_effect=lambda t: "/usr/bin/mvn" if t == "mvn" else None):
+        with patch("factory.eval.hygiene.shutil.which", side_effect=lambda t: "/usr/bin/mvn" if t == "mvn" else None):
             result = _java_build_tool(tmp_path)
         assert result is None
 
     def test_no_tool_returns_none(self, tmp_path):
-        with patch("shutil.which", return_value=None):
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
             result = _java_build_tool(tmp_path)
         assert result is None
 
@@ -431,7 +431,7 @@ class TestEvalLintLanguages:
         (tmp_path / "go.mod").write_text("module test\n")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
-            patch("shutil.which", return_value="/usr/bin/go"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/go"),
         ):
             result = eval_lint(tmp_path)
         assert result["passed"] is True
@@ -442,7 +442,7 @@ class TestEvalLintLanguages:
         stderr = "main.go:10:5: unreachable code\nmain.go:20:3: unused variable\n"
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(1, "", stderr)),
-            patch("shutil.which", return_value="/usr/bin/go"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/go"),
         ):
             result = eval_lint(tmp_path)
         assert result["passed"] is False
@@ -450,7 +450,7 @@ class TestEvalLintLanguages:
 
     def test_go_no_go_on_path(self, tmp_path):
         (tmp_path / "go.mod").write_text("module test\n")
-        with patch("shutil.which", return_value=None):
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
             result = eval_lint(tmp_path)
         assert result["score"] == 0.5
 
@@ -498,7 +498,7 @@ class TestEvalTypeCheckLanguages:
         (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_type_check(tmp_path)
         assert result["passed"] is True
@@ -509,7 +509,7 @@ class TestEvalTypeCheckLanguages:
         stderr = "error[E0308]: mismatched types\nerror[E0425]: cannot find value\n"
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(1, "", stderr)),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_type_check(tmp_path)
         assert result["passed"] is False
@@ -517,7 +517,7 @@ class TestEvalTypeCheckLanguages:
 
     def test_rust_no_cargo(self, tmp_path):
         (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
-        with patch("shutil.which", return_value=None):
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
             result = eval_type_check(tmp_path)
         assert result["score"] == 0.5
 
@@ -525,7 +525,7 @@ class TestEvalTypeCheckLanguages:
         (tmp_path / "go.mod").write_text("module test\n")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
-            patch("shutil.which", return_value="/usr/bin/go"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/go"),
         ):
             result = eval_type_check(tmp_path)
         assert result["passed"] is True
@@ -536,7 +536,7 @@ class TestEvalTypeCheckLanguages:
         output = "main.go:10:5: cannot use x\nmain.go:20:3: undefined: y\n"
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(1, output, "")),
-            patch("shutil.which", return_value="/usr/bin/go"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/go"),
         ):
             result = eval_type_check(tmp_path)
         assert result["passed"] is False
@@ -544,7 +544,7 @@ class TestEvalTypeCheckLanguages:
 
     def test_go_no_go(self, tmp_path):
         (tmp_path / "go.mod").write_text("module test\n")
-        with patch("shutil.which", return_value=None):
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
             result = eval_type_check(tmp_path)
         assert result["score"] == 0.5
 
@@ -595,7 +595,7 @@ class TestEvalCoverageLanguages:
         )
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_coverage(tmp_path)
         assert result["score"] == round(85 / 100, 4)
@@ -613,7 +613,7 @@ class TestEvalCoverageLanguages:
 
         with (
             patch("factory.eval.hygiene._run_cmd", side_effect=fake_run_cmd),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_coverage(tmp_path)
         assert result["score"] == round(85 / 100, 4)
@@ -623,7 +623,7 @@ class TestEvalCoverageLanguages:
         (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(1, "", "Timed out after 600s")),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
             patch("factory.eval.hygiene.log") as mock_log,
         ):
             eval_coverage(tmp_path)
@@ -633,7 +633,7 @@ class TestEvalCoverageLanguages:
         (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(1, "", "some error")),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
             patch("factory.eval.hygiene.log") as mock_log,
         ):
             eval_coverage(tmp_path)
@@ -646,7 +646,7 @@ class TestEvalCoverageLanguages:
         (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")) as mock_run,
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             eval_coverage(tmp_path)
         mock_run.assert_called_once()
@@ -655,7 +655,7 @@ class TestEvalCoverageLanguages:
 
     def test_rust_no_cargo(self, tmp_path):
         (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
-        with patch("shutil.which", return_value=None):
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
             result = eval_coverage(tmp_path)
         assert result["score"] == 0.5
 
@@ -667,7 +667,7 @@ class TestEvalCoverageLanguages:
         )
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
-            patch("shutil.which", return_value="/usr/bin/go"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/go"),
         ):
             result = eval_coverage(tmp_path)
         assert result["score"] == round(70 / 100, 4)
@@ -675,7 +675,7 @@ class TestEvalCoverageLanguages:
 
     def test_go_no_go(self, tmp_path):
         (tmp_path / "go.mod").write_text("module test\n")
-        with patch("shutil.which", return_value=None):
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
             result = eval_coverage(tmp_path)
         assert result["score"] == 0.5
 
@@ -690,7 +690,7 @@ class TestEvalCoverageLanguages:
         )
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
-            patch("shutil.which", return_value="/usr/bin/npx"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/npx"),
         ):
             result = eval_coverage(tmp_path)
         assert result["score"] == round(72 / 100, 4)
@@ -698,7 +698,7 @@ class TestEvalCoverageLanguages:
 
     def test_node_no_npx(self, tmp_path):
         (tmp_path / "package.json").write_text('{"name": "app"}\n')
-        with patch("shutil.which", return_value=None):
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
             result = eval_coverage(tmp_path)
         assert result["score"] == 0.5
 
@@ -761,7 +761,7 @@ class TestEvalCoverageLanguages:
 
         with (
             patch("factory.eval.hygiene._run_cmd", side_effect=fake_run_cmd),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_coverage(tmp_path)
         assert result["score"] == round(72 / 100, 4)
@@ -786,7 +786,7 @@ class TestPolyglotSubProject:
 
         with (
             patch("factory.eval.hygiene._run_cmd", side_effect=fake_run),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_tests(tmp_path)
         assert result["passed"] is True
@@ -799,7 +799,7 @@ class TestPolyglotSubProject:
 
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_lint(tmp_path)
         assert "(rs): clean" in result["details"]
@@ -811,7 +811,7 @@ class TestPolyglotSubProject:
 
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_type_check(tmp_path)
         assert "(rs): clean" in result["details"]
@@ -832,7 +832,7 @@ class TestPolyglotSubProject:
 
         with (
             patch("factory.eval.hygiene._run_cmd", side_effect=fake_run),
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             result = eval_coverage(tmp_path)
         assert "85%" in result["details"]
@@ -847,7 +847,7 @@ class TestCargoWorkspaceFlag:
         output = "test result: ok. 5 passed; 0 failed; 0 ignored\n"
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")) as mock_run,
-            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/cargo"),
         ):
             eval_tests(tmp_path)
         mock_run.assert_called_once()

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -1,5 +1,6 @@
 """Tests for factory.eval.hygiene — universal hygiene dimensions."""
 
+import subprocess
 from unittest.mock import patch
 
 from factory.eval.hygiene import (
@@ -8,6 +9,7 @@ from factory.eval.hygiene import (
     _find_sub_projects,
     _java_build_tool,
     _java_test_cmd,
+    _run_cmd,
     compute_hygiene_results,
     eval_config_parser,
     eval_coverage,
@@ -562,12 +564,13 @@ class TestEvalCoverageLanguages:
         assert "85%" in result["details"]
 
     def test_rust_coverage_tarpaulin_fallback(self, tmp_path):
+        """Any non-zero rc from llvm-cov triggers the tarpaulin fallback."""
         (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
         tarpaulin_output = "85.5% coverage, 100/117 lines covered\n"
 
         def fake_run_cmd(cmd, *args, **kwargs):
             if "llvm-cov" in cmd:
-                return (1, "", "error: no such subcommand: `llvm-cov`")
+                return (1, "", "error: failed to run llvm-cov")
             return (0, tarpaulin_output, "")
 
         with (
@@ -696,3 +699,51 @@ class TestEvalCoverageLanguages:
         with patch("factory.eval.hygiene._java_build_tool", return_value=None):
             result = eval_coverage(tmp_path)
         assert result["score"] == 0.5
+
+    def test_rust_coverage_llvm_tools_preview_fallback(self, tmp_path):
+        """llvm-cov fails with 'llvm-tools-preview not found' — should fall back to tarpaulin."""
+        (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
+        tarpaulin_output = "72.0% coverage, 80/111 lines covered\n"
+
+        def fake_run_cmd(cmd, *args, **kwargs):
+            if "llvm-cov" in cmd:
+                return (1, "", "error: failed to find llvm-tools-preview")
+            return (0, tarpaulin_output, "")
+
+        with (
+            patch("factory.eval.hygiene._run_cmd", side_effect=fake_run_cmd),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(72 / 100, 4)
+        assert "72%" in result["details"]
+
+
+class TestRunCmdCargoPath:
+    """Test that _run_cmd adds ~/.cargo/bin to PATH."""
+
+    def test_cargo_bin_added_to_path(self, tmp_path):
+        cargo_dir = tmp_path / ".cargo" / "bin"
+        cargo_dir.mkdir(parents=True)
+        with (
+            patch("factory.eval.hygiene.Path.home", return_value=tmp_path),
+            patch("factory.eval.hygiene.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["echo"], returncode=0, stdout="", stderr="",
+            )
+            _run_cmd(["echo", "test"], tmp_path)
+            env = mock_run.call_args.kwargs["env"]
+            assert str(cargo_dir) in env.get("PATH", "")
+
+    def test_cargo_bin_not_added_when_missing(self, tmp_path):
+        with (
+            patch("factory.eval.hygiene.Path.home", return_value=tmp_path),
+            patch("factory.eval.hygiene.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["echo"], returncode=0, stdout="", stderr="",
+            )
+            _run_cmd(["echo", "test"], tmp_path)
+            env = mock_run.call_args.kwargs["env"]
+            assert ".cargo/bin" not in env.get("PATH", "")

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -548,8 +548,11 @@ class TestEvalCoverageLanguages:
     """Tests for eval_coverage() Rust, Go, Node, and Java branches."""
 
     def test_rust_coverage_parse(self, tmp_path):
-        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
-        output = "85.5% coverage, 100/117 lines covered\n"
+        (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
+        output = (
+            "Filename  Regions  Missed  Cover  Lines  Missed  Cover\n"
+            "TOTAL     100      15      85.0%  200    30      85.0%\n"
+        )
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
             patch("shutil.which", return_value="/usr/bin/cargo"),
@@ -557,6 +560,56 @@ class TestEvalCoverageLanguages:
             result = eval_coverage(tmp_path)
         assert result["score"] == round(85 / 100, 4)
         assert "85%" in result["details"]
+
+    def test_rust_coverage_tarpaulin_fallback(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
+        tarpaulin_output = "85.5% coverage, 100/117 lines covered\n"
+
+        def fake_run_cmd(cmd, *args, **kwargs):
+            if "llvm-cov" in cmd:
+                return (1, "", "error: no such subcommand: `llvm-cov`")
+            return (0, tarpaulin_output, "")
+
+        with (
+            patch("factory.eval.hygiene._run_cmd", side_effect=fake_run_cmd),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(85 / 100, 4)
+        assert "85%" in result["details"]
+
+    def test_rust_coverage_timeout_warns(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, "", "Timed out after 600s")),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.log") as mock_log,
+        ):
+            eval_coverage(tmp_path)
+        mock_log.warning.assert_any_call("coverage_timeout", project=str(tmp_path), lang="rust", timeout=600)
+
+    def test_rust_coverage_tool_failed_warns(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(1, "", "some error")),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+            patch("factory.eval.hygiene.log") as mock_log,
+        ):
+            eval_coverage(tmp_path)
+        mock_log.warning.assert_any_call(
+            "coverage_tool_failed", project=str(tmp_path), lang="rust", rc=1, stderr="some error"
+        )
+
+    def test_rust_coverage_timeout_600s(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname=\"test\"\n")
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")) as mock_run,
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            eval_coverage(tmp_path)
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("timeout") == 600
 
     def test_rust_no_cargo(self, tmp_path):
         (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -362,9 +362,15 @@ class TestJavaBuildTool:
         assert result == ["gradle"]
 
     def test_mvn_fallback(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
         with patch("shutil.which", side_effect=lambda t: "/usr/bin/mvn" if t == "mvn" else None):
             result = _java_build_tool(tmp_path)
         assert result == ["mvn"]
+
+    def test_mvn_without_pom_returns_none(self, tmp_path):
+        with patch("shutil.which", side_effect=lambda t: "/usr/bin/mvn" if t == "mvn" else None):
+            result = _java_build_tool(tmp_path)
+        assert result is None
 
     def test_no_tool_returns_none(self, tmp_path):
         with patch("shutil.which", return_value=None):
@@ -663,36 +669,46 @@ class TestEvalCoverageLanguages:
             result = eval_coverage(tmp_path)
         assert result["score"] == 0.5
 
-    def test_java_mvn_with_percentage(self, tmp_path):
+    def test_java_mvn_jacoco_xml(self, tmp_path):
         (tmp_path / "pom.xml").write_text("<project></project>")
-        output = "Total line coverage: 78%\n"
+        jacoco_dir = tmp_path / "target" / "site" / "jacoco"
+        jacoco_dir.mkdir(parents=True)
+        (jacoco_dir / "jacoco.xml").write_text(
+            '<report><counter type="LINE" missed="22" covered="78"/></report>'
+        )
         with (
-            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
             patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
         ):
             result = eval_coverage(tmp_path)
         assert result["score"] == round(78 / 100, 4)
         assert "78%" in result["details"]
 
-    def test_java_gradle_coverage(self, tmp_path):
+    def test_java_gradle_jacoco_xml(self, tmp_path):
         (tmp_path / "build.gradle").write_text("")
-        output = "Total instruction coverage: 90%\n"
+        jacoco_dir = tmp_path / "build" / "reports" / "jacoco" / "test"
+        jacoco_dir.mkdir(parents=True)
+        (jacoco_dir / "jacocoTestReport.xml").write_text(
+            '<report><counter type="LINE" missed="10" covered="90"/></report>'
+        )
         with (
-            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")),
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
             patch("factory.eval.hygiene._java_build_tool", return_value=["gradle"]),
         ):
             result = eval_coverage(tmp_path)
         assert result["score"] == round(90 / 100, 4)
 
-    def test_java_rc0_no_pct_fallback(self, tmp_path):
+    def test_java_rc0_no_jacoco_xml_logs_warning(self, tmp_path):
         (tmp_path / "pom.xml").write_text("<project></project>")
         with (
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "BUILD SUCCESS\n", "")),
             patch("factory.eval.hygiene._java_build_tool", return_value=["mvn"]),
+            patch("factory.eval.hygiene.log") as mock_log,
         ):
             result = eval_coverage(tmp_path)
-        assert result["score"] == 0.0
-        assert "0%" in result["details"]
+        mock_log.warning.assert_called_once()
+        assert mock_log.warning.call_args[0][0] == "jacoco_xml_not_found"
+        assert result["score"] == 0.5
 
     def test_java_no_tool(self, tmp_path):
         (tmp_path / "pom.xml").write_text("<project></project>")
@@ -717,6 +733,108 @@ class TestEvalCoverageLanguages:
             result = eval_coverage(tmp_path)
         assert result["score"] == round(72 / 100, 4)
         assert "72%" in result["details"]
+
+
+class TestPolyglotSubProject:
+    """T1: Polyglot sub-project — both languages detected in all 4 hygiene functions."""
+
+    def test_rust_and_node_both_evaluated_in_eval_tests(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+        rust_output = "test result: ok. 3 passed; 0 failed; 0 ignored\n"
+        node_output = "Tests: 5 passed, 0 failed\n"
+
+        def fake_run(cmd, *args, **kwargs):
+            if "cargo" in cmd:
+                return (0, rust_output, "")
+            if "npm" in cmd:
+                return (0, node_output, "")
+            return (1, "", "")
+
+        with (
+            patch("factory.eval.hygiene._run_cmd", side_effect=fake_run),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_tests(tmp_path)
+        assert result["passed"] is True
+        assert "3 passed" in result["details"]
+        assert "5 passed" in result["details"]
+
+    def test_rust_and_node_both_evaluated_in_eval_lint(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_lint(tmp_path)
+        assert "(rs): clean" in result["details"]
+        assert "(js): clean" in result["details"]
+
+    def test_rust_and_node_both_evaluated_in_eval_type_check(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_type_check(tmp_path)
+        assert "(rs): clean" in result["details"]
+        assert "(ts): clean" in result["details"]
+
+    def test_rust_and_node_both_evaluated_in_eval_coverage(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+        rust_cov = "TOTAL     100      15      85.0%  200    30      85.0%\n"
+        node_cov = "All files |   72.5  |   60.0   |   80.0  |   72.5  |\n"
+
+        def fake_run(cmd, *args, **kwargs):
+            if "llvm-cov" in cmd:
+                return (0, rust_cov, "")
+            if "jest" in cmd:
+                return (0, node_cov, "")
+            return (1, "", "")
+
+        with (
+            patch("factory.eval.hygiene._run_cmd", side_effect=fake_run),
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            result = eval_coverage(tmp_path)
+        assert "85%" in result["details"]
+        assert "72%" in result["details"]
+
+
+class TestCargoWorkspaceFlag:
+    """T2: Assert command list includes --workspace."""
+
+    def test_cargo_test_uses_workspace_flag(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='test'\n")
+        output = "test result: ok. 5 passed; 0 failed; 0 ignored\n"
+        with (
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")) as mock_run,
+            patch("shutil.which", return_value="/usr/bin/cargo"),
+        ):
+            eval_tests(tmp_path)
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["cargo", "test", "--workspace"]
+
+
+class TestJavaNoBuildToolIntegration:
+    """T3: eval_tests() handles _java_test_cmd returning None."""
+
+    def test_eval_tests_java_no_build_tool_logs_warning(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        with (
+            patch("factory.eval.hygiene._java_build_tool", return_value=None),
+            patch("factory.eval.hygiene.log") as mock_log,
+        ):
+            result = eval_tests(tmp_path)
+        mock_log.warning.assert_called_once()
+        assert mock_log.warning.call_args[0][0] == "java_build_tool_not_found"
+        assert result["score"] == 0.5
 
 
 class TestRunCmdCargoPath:

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from factory.eval.hygiene import (
     HYGIENE_WEIGHTS,
+    _detect_java_project,
     _find_sub_projects,
     compute_hygiene_results,
     eval_config_parser,
@@ -231,3 +232,66 @@ class TestNodeMonorepoAggregation:
             result = eval_tests(tmp_path)
         assert result["score"] == 1.0
         assert result["passed"] is True
+
+
+class TestRustWorkspaceDedup:
+    """Bug 1: Rust workspace triple-counting — member crates should be deduplicated."""
+
+    def test_rust_workspace_deduplicates_members(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[workspace]\nmembers = ['crate_a', 'crate_b']\n")
+        (tmp_path / "crate_a").mkdir()
+        (tmp_path / "crate_a" / "Cargo.toml").write_text("[package]\nname = 'crate_a'\n")
+        (tmp_path / "crate_b").mkdir()
+        (tmp_path / "crate_b" / "Cargo.toml").write_text("[package]\nname = 'crate_b'\n")
+        roots = _find_sub_projects(tmp_path)
+        assert len(roots) == 1
+        assert roots[0] == tmp_path
+
+
+class TestJavaProjectDetected:
+    """Bug 2: Java missing from hygiene eval — pom.xml should be detected."""
+
+    def test_java_project_detected(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        roots = _find_sub_projects(tmp_path)
+        assert tmp_path in roots
+
+    def test_java_gradle_detected(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("apply plugin: 'java'")
+        assert _detect_java_project(tmp_path) is True
+
+    def test_java_gradle_kts_detected(self, tmp_path):
+        (tmp_path / "build.gradle.kts").write_text("plugins { java }")
+        assert _detect_java_project(tmp_path) is True
+
+    def test_non_java_not_detected(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]")
+        assert _detect_java_project(tmp_path) is False
+
+
+class TestJestDoesNotDoubleCount:
+    """Bug 3: Jest over-counting — regex should match Tests: line only, not Test Suites:."""
+
+    def test_jest_does_not_double_count_suites(self, tmp_path):
+        output = (
+            "Test Suites: 2 passed, 2 total\n"
+            "Tests:       10 passed, 10 total\n"
+            "Snapshots:   0 total\n"
+            "Time:        1.5 s\n"
+        )
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+        with patch("factory.eval.hygiene._run_cmd", return_value=(0, output, "")):
+            result = eval_tests(tmp_path)
+        assert result["score"] == 1.0
+        assert "10 passed" in result["details"]
+
+    def test_jest_with_failures_counts_correctly(self, tmp_path):
+        output = (
+            "Test Suites: 1 failed, 2 passed, 3 total\n"
+            "Tests:       2 failed, 8 passed, 10 total\n"
+        )
+        (tmp_path / "package.json").write_text('{"name": "app"}\n')
+        with patch("factory.eval.hygiene._run_cmd", return_value=(1, output, "")):
+            result = eval_tests(tmp_path)
+        assert result["score"] == round(8 / 10, 4)
+        assert result["passed"] is False

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -606,7 +606,8 @@ class TestEvalCoverageLanguages:
         ):
             eval_coverage(tmp_path)
         mock_log.warning.assert_any_call(
-            "coverage_tool_failed", project=str(tmp_path), lang="rust", rc=1, stderr="some error"
+            "coverage_tool_failed", project=str(tmp_path), lang="rust", rc=1,
+            stderr="some error\n--- tarpaulin stderr ---\nsome error"
         )
 
     def test_rust_coverage_timeout_600s(self, tmp_path):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -36,9 +36,18 @@ class TestIntrospect:
         project = tmp_path / "myapp"
         project.mkdir()
         (project / "package.json").write_text('{"name":"myapp","scripts":{"test":"jest"}}')
+        (project / "tsconfig.json").write_text('{"compilerOptions":{}}')
         (project / "README.md").write_text("# My App\n")
         profile = introspect_project(project)
         assert profile.language == "typescript"
+
+    def test_detects_javascript(self, tmp_path):
+        project = tmp_path / "myapp"
+        project.mkdir()
+        (project / "package.json").write_text('{"name":"myapp","scripts":{"test":"jest"}}')
+        (project / "README.md").write_text("# My App\n")
+        profile = introspect_project(project)
+        assert profile.language == "javascript"
 
     def test_unknown_language(self, tmp_path):
         project = tmp_path / "mystery"

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -727,16 +727,18 @@ class TestGoTestsGoNotOnPath:
 
 class TestJavaTestsUnparsed:
     def test_java_tests_unparsed(self, tmp_path):
-        """rc==0 with unparsed output credits 1 pass instead of dropping to neutral."""
+        """rc==0 with unparsed output drops to neutral — not credited as pass."""
         (tmp_path / "pom.xml").write_text("<project/>")
         with (
-            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: "/usr/bin/mvn" if cmd == "mvn" else None),
+            patch(
+                "factory.eval.hygiene.shutil.which",
+                side_effect=lambda cmd: "/usr/bin/mvn" if cmd == "mvn" else None,
+            ),
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "BUILD SUCCESS", "")),
         ):
             result = eval_tests(tmp_path)
-        assert result["score"] == 1.0
-        assert result["passed"] is True
-        assert "output unparsed" in result["details"]
+        assert result["score"] == 0.5
+        assert "Not detected" in result["details"]
 
 
 # ── Hygiene: Rust eval_lint missing cargo ────────────────────────

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -416,6 +416,11 @@ class TestCoverageCommand:
         assert cmd is not None
         assert "jacoco" in cmd
 
+    def test_javascript_coverage(self):
+        cmd = _coverage_command(self._make_profile("javascript"))
+        assert cmd is not None
+        assert "jest --coverage" in cmd
+
     def test_unknown_returns_none(self):
         assert _coverage_command(self._make_profile("unknown")) is None
 
@@ -479,8 +484,15 @@ class TestDetectLintCommandJava:
         (tmp_path / "pom.xml").write_text("<project/>")
         assert _detect_lint_command(tmp_path, "java") == "mvn checkstyle:check"
 
-    def test_no_pom_xml_returns_none(self, tmp_path):
+    def test_gradle_returns_checkstyle(self, tmp_path):
         (tmp_path / "build.gradle").write_text("")
+        assert _detect_lint_command(tmp_path, "java") == "gradle checkstyleMain"
+
+    def test_gradlew_returns_checkstyle(self, tmp_path):
+        (tmp_path / "gradlew").write_text("#!/bin/sh")
+        assert _detect_lint_command(tmp_path, "java") == "./gradlew checkstyleMain"
+
+    def test_no_build_file_returns_none(self, tmp_path):
         assert _detect_lint_command(tmp_path, "java") is None
 
 
@@ -714,13 +726,16 @@ class TestGoTestsGoNotOnPath:
 
 class TestJavaTestsUnparsed:
     def test_java_tests_unparsed(self, tmp_path):
+        """rc==0 with unparsed output credits 1 pass instead of dropping to neutral."""
         (tmp_path / "pom.xml").write_text("<project/>")
         with (
             patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: "/usr/bin/mvn" if cmd == "mvn" else None),
             patch("factory.eval.hygiene._run_cmd", return_value=(0, "BUILD SUCCESS", "")),
         ):
             result = eval_tests(tmp_path)
-        assert result["score"] == 0.5
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+        assert "output unparsed" in result["details"]
 
 
 # ── Hygiene: Rust eval_lint missing cargo ────────────────────────

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -723,7 +723,7 @@ class TestPolyglotShutilWhichSideEffect:
             patch("factory.eval.hygiene._run_cmd") as mock_run,
         ):
             mock_run.return_value = (0, "test result: 5 passed; 0 failed", "")
-            result = eval_tests(tmp_path)
+            eval_tests(tmp_path)
         called_cmds = [call[0][0] for call in mock_run.call_args_list]
         assert any(cmd[0] == "cargo" for cmd in called_cmds)
         assert not any(cmd[0] == "go" for cmd in called_cmds)

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -13,10 +13,13 @@ from factory.eval.growth import (
 )
 from factory.discovery.introspect import (
     _detect_framework,
+    _detect_lint_command,
     _detect_project_evals,
+    _detect_test_command,
+    _detect_type_check_command,
     introspect_project,
 )
-from factory.discovery.profile import build_eval_profile, _coverage_command
+from factory.discovery.profile import build_eval_profile, _coverage_command, _syntax_check_command
 from factory.models import ProjectProfile
 
 
@@ -434,3 +437,206 @@ class TestProfileCoverageNotPythonGated:
         profile = build_eval_profile(proj)
         dim_names = [d.name for d in profile.dimensions]
         assert "coverage" in dim_names
+
+
+# ── _detect_test_command for Java ─────────────────────────────────
+
+
+class TestDetectTestCommandJava:
+    def test_pom_xml_returns_mvn_test(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project/>")
+        assert _detect_test_command(tmp_path, "java") == "mvn test"
+
+    def test_gradlew_returns_gradlew_test(self, tmp_path):
+        (tmp_path / "gradlew").write_text("#!/bin/sh")
+        assert _detect_test_command(tmp_path, "java") == "./gradlew test"
+
+    def test_build_gradle_returns_gradle_test(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("")
+        assert _detect_test_command(tmp_path, "java") == "gradle test"
+
+    def test_build_gradle_kts_returns_gradle_test(self, tmp_path):
+        (tmp_path / "build.gradle.kts").write_text("")
+        assert _detect_test_command(tmp_path, "java") == "gradle test"
+
+    def test_no_build_file_returns_none(self, tmp_path):
+        assert _detect_test_command(tmp_path, "java") is None
+
+
+# ── _detect_lint_command for Java ─────────────────────────────────
+
+
+class TestDetectLintCommandJava:
+    def test_pom_xml_returns_checkstyle(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project/>")
+        assert _detect_lint_command(tmp_path, "java") == "mvn checkstyle:check"
+
+    def test_no_pom_xml_returns_none(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("")
+        assert _detect_lint_command(tmp_path, "java") is None
+
+
+# ── _detect_type_check_command for Java ───────────────────────────
+
+
+class TestDetectTypeCheckCommandJava:
+    def test_pom_xml_returns_mvn_compile(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project/>")
+        assert _detect_type_check_command(tmp_path, "java") == "mvn compile -q"
+
+    def test_gradlew_returns_gradlew_compile(self, tmp_path):
+        (tmp_path / "gradlew").write_text("#!/bin/sh")
+        assert _detect_type_check_command(tmp_path, "java") == "./gradlew compileJava"
+
+    def test_build_gradle_returns_gradle_compile(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("")
+        assert _detect_type_check_command(tmp_path, "java") == "gradle compileJava"
+
+    def test_build_gradle_kts_returns_gradle_compile(self, tmp_path):
+        (tmp_path / "build.gradle.kts").write_text("")
+        assert _detect_type_check_command(tmp_path, "java") == "gradle compileJava"
+
+    def test_no_build_file_returns_none(self, tmp_path):
+        assert _detect_type_check_command(tmp_path, "java") is None
+
+
+# ── _detect_project_evals top-level .sh scripts ──────────────────
+
+
+class TestDetectProjectEvalsTopLevelSh:
+    def test_evaluate_sh_discovered(self, tmp_path):
+        (tmp_path / "evaluate.sh").write_text("#!/bin/bash\necho done")
+        evals = _detect_project_evals(tmp_path)
+        match = [e for e in evals if e["name"] == "evaluate"]
+        assert len(match) == 1
+        assert match[0]["command"] == "bash evaluate.sh"
+
+    def test_benchmark_sh_discovered(self, tmp_path):
+        (tmp_path / "benchmark.sh").write_text("#!/bin/bash\necho done")
+        evals = _detect_project_evals(tmp_path)
+        match = [e for e in evals if e["name"] == "benchmark"]
+        assert len(match) == 1
+        assert match[0]["command"] == "bash benchmark.sh"
+
+    def test_bench_sh_discovered(self, tmp_path):
+        (tmp_path / "bench.sh").write_text("#!/bin/bash\necho done")
+        evals = _detect_project_evals(tmp_path)
+        match = [e for e in evals if e["name"] == "bench"]
+        assert len(match) == 1
+        assert match[0]["command"] == "bash bench.sh"
+
+
+# ── _syntax_check_command for Java ────────────────────────────────
+
+
+class TestSyntaxCheckCommandJava:
+    def _make_java_profile(self, test_command: str | None = None) -> ProjectProfile:
+        return ProjectProfile(
+            name="test-project",
+            language="java",
+            framework=None,
+            project_type="cli_tool",
+            has_tests=test_command is not None,
+            has_linter=False,
+            has_type_checker=False,
+            has_ci=False,
+            test_command=test_command,
+            lint_command=None,
+            type_check_command=None,
+            package_manager=None,
+            discovered_evals=[],
+        )
+
+    def test_mvn_test_returns_mvn_compile(self):
+        profile = self._make_java_profile("mvn test")
+        assert _syntax_check_command(profile) == "mvn compile -q"
+
+    def test_gradlew_test_returns_gradlew_compile(self):
+        profile = self._make_java_profile("./gradlew test")
+        assert _syntax_check_command(profile) == "./gradlew compileJava"
+
+    def test_gradle_test_returns_gradle_compile(self):
+        profile = self._make_java_profile("gradle test")
+        assert _syntax_check_command(profile) == "gradle compileJava"
+
+    def test_no_test_command_returns_true(self):
+        profile = self._make_java_profile(None)
+        assert _syntax_check_command(profile) == "true"
+
+
+# ── _coverage_command for Java with gradlew/gradle ────────────────
+
+
+class TestCoverageCommandJavaGradlew:
+    def _make_java_profile(self, test_command: str) -> ProjectProfile:
+        return ProjectProfile(
+            name="test-project",
+            language="java",
+            framework=None,
+            project_type="cli_tool",
+            has_tests=True,
+            has_linter=False,
+            has_type_checker=False,
+            has_ci=False,
+            test_command=test_command,
+            lint_command=None,
+            type_check_command=None,
+            package_manager=None,
+            discovered_evals=[],
+        )
+
+    def test_gradlew_returns_gradlew_jacoco(self):
+        profile = self._make_java_profile("./gradlew test")
+        assert _coverage_command(profile) == "./gradlew jacocoTestReport"
+
+    def test_gradle_returns_gradle_jacoco(self):
+        profile = self._make_java_profile("gradle test")
+        assert _coverage_command(profile) == "gradle jacocoTestReport"
+
+    def test_mvn_returns_mvn_jacoco(self):
+        profile = self._make_java_profile("mvn test")
+        assert _coverage_command(profile) == "mvn jacoco:report"
+
+
+# ── _detect_project_language ImportError fallback ─────────────────
+
+
+class TestDetectProjectLanguageImportErrorFallback:
+    """Test the ImportError fallback path in _detect_project_language.
+
+    Setting sys.modules["factory.discovery.introspect"] to None makes
+    ``from factory.discovery.introspect import _detect_language`` raise
+    ImportError, triggering the fallback detection logic.
+    """
+
+    def _run_with_import_error(self, tmp_path):
+        import sys
+        with patch.dict(sys.modules, {"factory.discovery.introspect": None}):
+            return _detect_project_language(tmp_path)
+
+    def test_python_fallback(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+        assert self._run_with_import_error(tmp_path) == "python"
+
+    def test_python_setup_py_fallback(self, tmp_path):
+        (tmp_path / "setup.py").write_text("from setuptools import setup\n")
+        assert self._run_with_import_error(tmp_path) == "python"
+
+    def test_typescript_fallback(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name":"x"}')
+        assert self._run_with_import_error(tmp_path) == "typescript"
+
+    def test_rust_fallback(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname='x'\n")
+        assert self._run_with_import_error(tmp_path) == "rust"
+
+    def test_go_fallback(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com/x\n")
+        assert self._run_with_import_error(tmp_path) == "go"
+
+    def test_java_fallback(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project/>")
+        assert self._run_with_import_error(tmp_path) == "java"
+
+    def test_unknown_fallback(self, tmp_path):
+        assert self._run_with_import_error(tmp_path) == "unknown"

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -24,8 +24,8 @@ from factory.models import ProjectProfile
 
 
 class TestLangConfig:
-    def test_four_languages_configured(self):
-        assert set(LANG_CONFIG.keys()) == {"python", "rust", "go", "typescript"}
+    def test_five_languages_configured(self):
+        assert set(LANG_CONFIG.keys()) == {"python", "rust", "go", "typescript", "java"}
 
     def test_each_has_required_keys(self):
         for lang, cfg in LANG_CONFIG.items():
@@ -57,6 +57,14 @@ class TestDetectProjectLanguage:
     def test_typescript_project(self, tmp_path):
         (tmp_path / "package.json").write_text('{"name":"x"}')
         assert _detect_project_language(tmp_path) == "typescript"
+
+    def test_java_project(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        assert _detect_project_language(tmp_path) == "java"
+
+    def test_java_gradle_project(self, tmp_path):
+        (tmp_path / "build.gradle").write_text("apply plugin: 'java'")
+        assert _detect_project_language(tmp_path) == "java"
 
     def test_unknown_project(self, tmp_path):
         assert _detect_project_language(tmp_path) == "unknown"
@@ -96,6 +104,13 @@ class TestFindSrcDirsMultiLang:
         (src / "lib.rs").write_text("pub fn y() {}")
         dirs = _find_src_dirs(tmp_path, "rust")
         assert not any("target" in str(d) for d in dirs)
+
+    def test_finds_java_src(self, tmp_path):
+        src = tmp_path / "src" / "main" / "java" / "com"
+        src.mkdir(parents=True)
+        (src / "App.java").write_text("public class App {}")
+        dirs = _find_src_dirs(tmp_path, "java")
+        assert any("src" in str(d) for d in dirs)
 
     def test_fallback_to_project_root(self, tmp_path):
         dirs = _find_src_dirs(tmp_path, "go")
@@ -143,6 +158,21 @@ class TestMultiLangFunctionCounting:
         count = _count_functions_regex([src / "app.ts"], pattern)
         assert count == 3
 
+    def test_java_public_methods(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "App.java").write_text(
+            "public class App {\n"
+            "    public String getName() { return null; }\n"
+            "    protected int getAge() { return 0; }\n"
+            "    private void helper() {}\n"
+            "    public App() {}\n"  # constructor — no return type, should NOT match
+            "}\n"
+        )
+        pattern = LANG_CONFIG["java"]["function_regex"]
+        count = _count_functions_regex([src / "App.java"], pattern)
+        assert count == 2
+
     def test_unreadable_file_skipped(self, tmp_path):
         fake = tmp_path / "bad.rs"
         fake.write_bytes(b"\xff\xfe invalid utf-8 \x80\x81")
@@ -187,6 +217,20 @@ class TestCapabilitySurfaceMultiLang:
         )
         result = eval_capability_surface(tmp_path)
         assert result["score"] > 0.0
+
+    def test_java_project(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project></project>")
+        src = tmp_path / "src" / "main" / "java" / "com"
+        src.mkdir(parents=True)
+        (src / "App.java").write_text(
+            "public class App {\n"
+            "    public String greet() { return \"hi\"; }\n"
+            "    public static void main(String[] args) {}\n"
+            "}\n"
+        )
+        result = eval_capability_surface(tmp_path)
+        assert result["score"] > 0.0
+        assert "public_fns=" in result["details"]
 
     def test_nonexistent_path_handled(self):
         result = eval_capability_surface(Path("/nonexistent/path"))
@@ -259,6 +303,24 @@ class TestFrameworkDetectionRustGo:
             "module example.com/x\nrequire github.com/gofiber/fiber/v2 v2.50.0\n"
         )
         assert _detect_framework(tmp_path, "go") == "fiber"
+
+    def test_java_spring_boot(self, tmp_path):
+        (tmp_path / "pom.xml").write_text(
+            "<project><dependency>spring-boot-starter</dependency></project>"
+        )
+        assert _detect_framework(tmp_path, "java") == "spring-boot"
+
+    def test_java_quarkus(self, tmp_path):
+        (tmp_path / "build.gradle").write_text(
+            "dependencies { implementation 'io.quarkus:quarkus-core' }"
+        )
+        assert _detect_framework(tmp_path, "java") == "quarkus"
+
+    def test_java_micronaut(self, tmp_path):
+        (tmp_path / "pom.xml").write_text(
+            "<project><dependency>micronaut-core</dependency></project>"
+        )
+        assert _detect_framework(tmp_path, "java") == "micronaut"
 
     def test_no_framework(self, tmp_path):
         (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
@@ -338,6 +400,11 @@ class TestCoverageCommand:
         cmd = _coverage_command(self._make_profile("typescript"))
         assert cmd is not None
         assert "jest --coverage" in cmd
+
+    def test_java_coverage(self):
+        cmd = _coverage_command(self._make_profile("java"))
+        assert cmd is not None
+        assert "jacoco" in cmd
 
     def test_unknown_returns_none(self):
         assert _coverage_command(self._make_profile("unknown")) is None

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -1,0 +1,369 @@
+"""Tests for multi-language eval support in growth, hygiene, profile, and introspect."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from factory.eval.growth import (
+    LANG_CONFIG,
+    _count_functions_regex,
+    _detect_project_language,
+    _find_src_dirs,
+    eval_capability_surface,
+    eval_observability,
+)
+from factory.discovery.introspect import (
+    _detect_framework,
+    _detect_project_evals,
+    introspect_project,
+)
+from factory.discovery.profile import build_eval_profile, _coverage_command
+from factory.models import ProjectProfile
+
+
+# ── LANG_CONFIG structure ──────────────────────────────────────────
+
+
+class TestLangConfig:
+    def test_four_languages_configured(self):
+        assert set(LANG_CONFIG.keys()) == {"python", "rust", "go", "typescript"}
+
+    def test_each_has_required_keys(self):
+        for lang, cfg in LANG_CONFIG.items():
+            assert "extensions" in cfg, f"{lang} missing extensions"
+            assert "skip_dirs" in cfg, f"{lang} missing skip_dirs"
+            assert "function_regex" in cfg, f"{lang} missing function_regex"
+            assert "entry_point_patterns" in cfg, f"{lang} missing entry_point_patterns"
+
+    def test_python_has_no_function_regex(self):
+        assert LANG_CONFIG["python"]["function_regex"] is None
+
+
+# ── _detect_project_language ───────────────────────────────────────
+
+
+class TestDetectProjectLanguage:
+    def test_python_project(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        assert _detect_project_language(tmp_path) == "python"
+
+    def test_rust_project(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        assert _detect_project_language(tmp_path) == "rust"
+
+    def test_go_project(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com/x\n")
+        assert _detect_project_language(tmp_path) == "go"
+
+    def test_typescript_project(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name":"x"}')
+        assert _detect_project_language(tmp_path) == "typescript"
+
+    def test_unknown_project(self, tmp_path):
+        assert _detect_project_language(tmp_path) == "unknown"
+
+
+# ── _find_src_dirs multi-language ──────────────────────────────────
+
+
+class TestFindSrcDirsMultiLang:
+    def test_finds_rust_src(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "main.rs").write_text("fn main() {}")
+        dirs = _find_src_dirs(tmp_path, "rust")
+        assert any("src" in str(d) for d in dirs)
+
+    def test_finds_go_src(self, tmp_path):
+        pkg = tmp_path / "cmd"
+        pkg.mkdir()
+        (pkg / "main.go").write_text("package main")
+        dirs = _find_src_dirs(tmp_path, "go")
+        assert any("cmd" in str(d) for d in dirs)
+
+    def test_finds_typescript_src(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "index.ts").write_text("export function hello() {}")
+        dirs = _find_src_dirs(tmp_path, "typescript")
+        assert any("src" in str(d) for d in dirs)
+
+    def test_skips_language_specific_dirs(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "debug.rs").write_text("fn x() {}")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text("pub fn y() {}")
+        dirs = _find_src_dirs(tmp_path, "rust")
+        assert not any("target" in str(d) for d in dirs)
+
+    def test_fallback_to_project_root(self, tmp_path):
+        dirs = _find_src_dirs(tmp_path, "go")
+        assert dirs == [tmp_path]
+
+
+# ── Multi-language function counting ──────────────────────────────
+
+
+class TestMultiLangFunctionCounting:
+    def test_rust_public_functions(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text(
+            "pub fn hello() {}\n"
+            "pub async fn async_hello() {}\n"
+            "fn private_fn() {}\n"
+        )
+        pattern = LANG_CONFIG["rust"]["function_regex"]
+        count = _count_functions_regex([src / "lib.rs"], pattern)
+        assert count == 2
+
+    def test_go_exported_functions(self, tmp_path):
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "handler.go").write_text(
+            "package handler\n\n"
+            "func HandleRequest(w http.ResponseWriter, r *http.Request) {}\n"
+            "func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {}\n"
+            "func privateHelper() {}\n"
+        )
+        pattern = LANG_CONFIG["go"]["function_regex"]
+        count = _count_functions_regex([pkg / "handler.go"], pattern)
+        assert count == 2
+
+    def test_typescript_functions(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "app.ts").write_text(
+            "export function handleRequest() {}\n"
+            "export async function fetchData() {}\n"
+            "function privateHelper() {}\n"
+        )
+        pattern = LANG_CONFIG["typescript"]["function_regex"]
+        count = _count_functions_regex([src / "app.ts"], pattern)
+        assert count == 3
+
+    def test_unreadable_file_skipped(self, tmp_path):
+        fake = tmp_path / "bad.rs"
+        fake.write_bytes(b"\xff\xfe invalid utf-8 \x80\x81")
+        pattern = LANG_CONFIG["rust"]["function_regex"]
+        count = _count_functions_regex([fake], pattern)
+        assert count == 0
+
+
+# ── eval_capability_surface multi-language ─────────────────────────
+
+
+class TestCapabilitySurfaceMultiLang:
+    def test_rust_project(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "main.rs").write_text(
+            "pub fn greet() {}\npub fn serve() {}\nfn main() {}\n"
+        )
+        result = eval_capability_surface(tmp_path)
+        assert result["score"] > 0.0
+        assert "public_fns=2" in result["details"]
+
+    def test_go_project(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com/x\n")
+        pkg = tmp_path / "cmd"
+        pkg.mkdir()
+        (pkg / "main.go").write_text(
+            "package main\n\nfunc Main() {}\nfunc main() {}\n"
+        )
+        result = eval_capability_surface(tmp_path)
+        assert result["score"] > 0.0
+        assert "public_fns=1" in result["details"]
+
+    def test_typescript_project(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name":"x"}')
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "index.ts").write_text(
+            "export function hello() {}\n"
+            "export async function world() {}\n"
+        )
+        result = eval_capability_surface(tmp_path)
+        assert result["score"] > 0.0
+
+    def test_nonexistent_path_handled(self):
+        result = eval_capability_surface(Path("/nonexistent/path"))
+        assert result["score"] == 0.0
+
+
+# ── eval_observability language detection ──────────────────────────
+
+
+class TestObservabilityLanguageDetection:
+    def test_passes_detected_language(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        with patch("factory.study._analyze_observability") as mock_obs:
+            mock_obs.return_value = {
+                "observability_score": 0.5,
+                "function_coverage": 0.3,
+                "structured_logging": False,
+            }
+            eval_observability(tmp_path)
+            mock_obs.assert_called_once_with(tmp_path, "rust")
+
+    def test_python_project_passes_python(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        with patch("factory.study._analyze_observability") as mock_obs:
+            mock_obs.return_value = {
+                "observability_score": 0.5,
+                "function_coverage": 0.3,
+                "structured_logging": False,
+            }
+            eval_observability(tmp_path)
+            mock_obs.assert_called_once_with(tmp_path, "python")
+
+
+# ── Framework detection (Rust/Go) ─────────────────────────────────
+
+
+class TestFrameworkDetectionRustGo:
+    def test_rust_actix_web(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text(
+            '[dependencies]\nactix-web = "4"\n'
+        )
+        assert _detect_framework(tmp_path, "rust") == "actix-web"
+
+    def test_rust_axum(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text(
+            '[dependencies]\naxum = "0.7"\n'
+        )
+        assert _detect_framework(tmp_path, "rust") == "axum"
+
+    def test_rust_rocket(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text(
+            '[dependencies]\nrocket = "0.5"\n'
+        )
+        assert _detect_framework(tmp_path, "rust") == "rocket"
+
+    def test_go_gin(self, tmp_path):
+        (tmp_path / "go.mod").write_text(
+            "module example.com/x\nrequire github.com/gin-gonic/gin v1.9.0\n"
+        )
+        assert _detect_framework(tmp_path, "go") == "gin"
+
+    def test_go_echo(self, tmp_path):
+        (tmp_path / "go.sum").write_text(
+            "github.com/labstack/echo/v4 v4.11.0 h1:abc\n"
+        )
+        assert _detect_framework(tmp_path, "go") == "echo"
+
+    def test_go_fiber(self, tmp_path):
+        (tmp_path / "go.mod").write_text(
+            "module example.com/x\nrequire github.com/gofiber/fiber/v2 v2.50.0\n"
+        )
+        assert _detect_framework(tmp_path, "go") == "fiber"
+
+    def test_no_framework(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        assert _detect_framework(tmp_path, "rust") is None
+
+
+# ── Eval discovery (.sh scripts) ──────────────────────────────────
+
+
+class TestEvalDiscoverySh:
+    def test_discovers_sh_in_eval_dir(self, tmp_path):
+        eval_dir = tmp_path / "eval"
+        eval_dir.mkdir()
+        (eval_dir / "run_bench.sh").write_text("#!/bin/bash\necho done")
+        evals = _detect_project_evals(tmp_path)
+        names = [e["name"] for e in evals]
+        assert "run_bench" in names
+        cmd = next(e for e in evals if e["name"] == "run_bench")
+        assert cmd["command"] == "bash eval/run_bench.sh"
+
+    def test_discovers_top_level_sh(self, tmp_path):
+        (tmp_path / "benchmark.sh").write_text("#!/bin/bash\necho done")
+        evals = _detect_project_evals(tmp_path)
+        names = [e["name"] for e in evals]
+        assert "benchmark" in names
+
+    def test_py_and_sh_coexist(self, tmp_path):
+        eval_dir = tmp_path / "eval"
+        eval_dir.mkdir()
+        (eval_dir / "accuracy.py").write_text("print('ok')")
+        (eval_dir / "speed.sh").write_text("#!/bin/bash\necho fast")
+        evals = _detect_project_evals(tmp_path)
+        names = [e["name"] for e in evals]
+        assert "accuracy" in names
+        assert "speed" in names
+
+
+# ── Profile coverage command ───────────────────────────────────────
+
+
+class TestCoverageCommand:
+    def _make_profile(self, language: str, **kwargs) -> ProjectProfile:
+        return ProjectProfile(
+            name="test-project",
+            language=language,
+            framework=None,
+            project_type="cli_tool",
+            has_tests=True,
+            has_linter=False,
+            has_type_checker=False,
+            has_ci=False,
+            test_command="test",
+            lint_command=None,
+            type_check_command=None,
+            package_manager=kwargs.get("package_manager"),
+            discovered_evals=[],
+        )
+
+    def test_python_coverage(self):
+        profile = self._make_profile("python", package_manager="uv")
+        cmd = _coverage_command(profile)
+        assert cmd is not None
+        assert "pytest --cov=" in cmd
+        assert cmd.startswith("uv run")
+
+    def test_rust_coverage(self):
+        cmd = _coverage_command(self._make_profile("rust"))
+        assert cmd is not None
+        assert "cargo tarpaulin" in cmd
+
+    def test_go_coverage(self):
+        cmd = _coverage_command(self._make_profile("go"))
+        assert cmd is not None
+        assert "go test -cover" in cmd
+
+    def test_typescript_coverage(self):
+        cmd = _coverage_command(self._make_profile("typescript"))
+        assert cmd is not None
+        assert "jest --coverage" in cmd
+
+    def test_unknown_returns_none(self):
+        assert _coverage_command(self._make_profile("unknown")) is None
+
+
+# ── Profile coverage not gated to Python ───────────────────────────
+
+
+class TestProfileCoverageNotPythonGated:
+    def test_rust_project_gets_coverage_dimension(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        proj = introspect_project(tmp_path)
+        profile = build_eval_profile(proj)
+        dim_names = [d.name for d in profile.dimensions]
+        assert "coverage" in dim_names
+
+    def test_go_project_gets_coverage_dimension(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com/x\n")
+        proj = introspect_project(tmp_path)
+        profile = build_eval_profile(proj)
+        dim_names = [d.name for d in profile.dimensions]
+        assert "coverage" in dim_names
+
+    def test_typescript_project_gets_coverage_dimension(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name":"x","scripts":{"test":"jest"}}')
+        proj = introspect_project(tmp_path)
+        profile = build_eval_profile(proj)
+        dim_names = [d.name for d in profile.dimensions]
+        assert "coverage" in dim_names

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -392,7 +392,7 @@ class TestCoverageCommand:
     def test_rust_coverage(self):
         cmd = _coverage_command(self._make_profile("rust"))
         assert cmd is not None
-        assert "cargo tarpaulin" in cmd
+        assert "cargo llvm-cov --summary-only" in cmd
 
     def test_go_coverage(self):
         cmd = _coverage_command(self._make_profile("go"))

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -508,6 +508,30 @@ class TestDetectTypeCheckCommandJava:
         assert _detect_type_check_command(tmp_path, "java") is None
 
 
+# ── _detect_type_check_command for Rust ─────────────────────────
+
+
+class TestDetectTypeCheckCommandRust:
+    def test_rust_with_cargo_toml(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]")
+        assert _detect_type_check_command(tmp_path, "rust") == "cargo check"
+
+    def test_rust_without_cargo_toml(self, tmp_path):
+        assert _detect_type_check_command(tmp_path, "rust") is None
+
+
+# ── _detect_type_check_command for Go ───────────────────────────
+
+
+class TestDetectTypeCheckCommandGo:
+    def test_go_with_go_mod(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com/foo")
+        assert _detect_type_check_command(tmp_path, "go") == "go build -o /dev/null ./..."
+
+    def test_go_without_go_mod(self, tmp_path):
+        assert _detect_type_check_command(tmp_path, "go") is None
+
+
 # ── _detect_project_evals top-level .sh scripts ──────────────────
 
 

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -27,8 +27,8 @@ from factory.models import ProjectProfile
 
 
 class TestLangConfig:
-    def test_five_languages_configured(self):
-        assert set(LANG_CONFIG.keys()) == {"python", "rust", "go", "typescript", "java"}
+    def test_six_languages_configured(self):
+        assert set(LANG_CONFIG.keys()) == {"python", "rust", "go", "typescript", "javascript", "java"}
 
     def test_each_has_required_keys(self):
         for lang, cfg in LANG_CONFIG.items():
@@ -59,7 +59,12 @@ class TestDetectProjectLanguage:
 
     def test_typescript_project(self, tmp_path):
         (tmp_path / "package.json").write_text('{"name":"x"}')
+        (tmp_path / "tsconfig.json").write_text('{"compilerOptions":{}}')
         assert _detect_project_language(tmp_path) == "typescript"
+
+    def test_javascript_project(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name":"x"}')
+        assert _detect_project_language(tmp_path) == "javascript"
 
     def test_java_project(self, tmp_path):
         (tmp_path / "pom.xml").write_text("<project></project>")
@@ -212,6 +217,7 @@ class TestCapabilitySurfaceMultiLang:
 
     def test_typescript_project(self, tmp_path):
         (tmp_path / "package.json").write_text('{"name":"x"}')
+        (tmp_path / "tsconfig.json").write_text('{"compilerOptions":{}}')
         src = tmp_path / "src"
         src.mkdir()
         (src / "index.ts").write_text(
@@ -433,6 +439,7 @@ class TestProfileCoverageNotPythonGated:
 
     def test_typescript_project_gets_coverage_dimension(self, tmp_path):
         (tmp_path / "package.json").write_text('{"name":"x","scripts":{"test":"jest"}}')
+        (tmp_path / "tsconfig.json").write_text('{"compilerOptions":{}}')
         proj = introspect_project(tmp_path)
         profile = build_eval_profile(proj)
         dim_names = [d.name for d in profile.dimensions]
@@ -624,7 +631,12 @@ class TestDetectProjectLanguageImportErrorFallback:
 
     def test_typescript_fallback(self, tmp_path):
         (tmp_path / "package.json").write_text('{"name":"x"}')
+        (tmp_path / "tsconfig.json").write_text('{"compilerOptions":{}}')
         assert self._run_with_import_error(tmp_path) == "typescript"
+
+    def test_javascript_fallback(self, tmp_path):
+        (tmp_path / "package.json").write_text('{"name":"x"}')
+        assert self._run_with_import_error(tmp_path) == "javascript"
 
     def test_rust_fallback(self, tmp_path):
         (tmp_path / "Cargo.toml").write_text("[package]\nname='x'\n")

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -490,6 +490,7 @@ class TestDetectLintCommandJava:
 
     def test_gradlew_returns_checkstyle(self, tmp_path):
         (tmp_path / "gradlew").write_text("#!/bin/sh")
+        (tmp_path / "gradlew").chmod(0o755)
         assert _detect_lint_command(tmp_path, "java") == "./gradlew checkstyleMain"
 
     def test_no_build_file_returns_none(self, tmp_path):

--- a/tests/test_multilang_eval.py
+++ b/tests/test_multilang_eval.py
@@ -11,6 +11,7 @@ from factory.eval.growth import (
     eval_capability_surface,
     eval_observability,
 )
+from factory.eval.hygiene import eval_tests, eval_lint, eval_type_check
 from factory.discovery.introspect import (
     _detect_framework,
     _detect_lint_command,
@@ -652,3 +653,95 @@ class TestDetectProjectLanguageImportErrorFallback:
 
     def test_unknown_fallback(self, tmp_path):
         assert self._run_with_import_error(tmp_path) == "unknown"
+
+
+# ── Hygiene: polyglot independence ───────────────────────────────
+
+
+class TestPolyglotIndependence:
+    def test_cargo_missing_go_present(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        (tmp_path / "go.mod").write_text("module example.com/x\n")
+        with (
+            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: {
+                "cargo": None, "go": "/usr/bin/go",
+            }.get(cmd)),
+            patch("factory.eval.hygiene._run_cmd") as mock_run,
+        ):
+            mock_run.return_value = (0, "ok\texample.com/x\t0.5s", "")
+            result = eval_tests(tmp_path)
+        assert result["score"] > 0
+        assert result["name"] == "tests"
+
+
+# ── Hygiene: Go eval_tests with go not on PATH ──────────────────
+
+
+class TestGoTestsGoNotOnPath:
+    def test_go_tests_go_not_on_path(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com/x\n")
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
+            result = eval_tests(tmp_path)
+        assert result["score"] == 0.5
+
+
+# ── Hygiene: Java tests unparsed output ──────────────────────────
+
+
+class TestJavaTestsUnparsed:
+    def test_java_tests_unparsed(self, tmp_path):
+        (tmp_path / "pom.xml").write_text("<project/>")
+        with (
+            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: "/usr/bin/mvn" if cmd == "mvn" else None),
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "BUILD SUCCESS", "")),
+        ):
+            result = eval_tests(tmp_path)
+        assert result["score"] == 0.5
+
+
+# ── Hygiene: Rust eval_lint missing cargo ────────────────────────
+
+
+class TestRustLintCargoMissing:
+    def test_rust_lint_cargo_missing(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        with patch("factory.eval.hygiene.shutil.which", return_value=None):
+            result = eval_lint(tmp_path)
+        assert result["score"] == 0.5
+
+
+# ── Hygiene: polyglot shutil.which with side_effect ──────────────
+
+
+class TestPolyglotShutilWhichSideEffect:
+    def test_which_side_effect_routes_correctly(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        (tmp_path / "go.mod").write_text("module example.com/x\n")
+        which_map = {"cargo": "/usr/bin/cargo", "go": None}
+        with (
+            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: which_map.get(cmd)),
+            patch("factory.eval.hygiene._run_cmd") as mock_run,
+        ):
+            mock_run.return_value = (0, "test result: 5 passed; 0 failed", "")
+            result = eval_tests(tmp_path)
+        called_cmds = [call[0][0] for call in mock_run.call_args_list]
+        assert any(cmd[0] == "cargo" for cmd in called_cmds)
+        assert not any(cmd[0] == "go" for cmd in called_cmds)
+
+
+# ── Hygiene: eval_type_check Go command assertion ────────────────
+
+
+class TestGoTypeCheckCommand:
+    def test_go_type_check_uses_go_build(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module example.com/x\n")
+        with (
+            patch("factory.eval.hygiene.shutil.which", side_effect=lambda cmd: "/usr/bin/go" if cmd == "go" else None),
+            patch("factory.eval.hygiene._run_cmd", return_value=(0, "", "")) as mock_run,
+        ):
+            eval_type_check(tmp_path)
+        assert mock_run.called
+        cmd_arg = mock_run.call_args[0][0]
+        assert cmd_arg[0] == "go"
+        assert cmd_arg[1] == "build"
+        assert "-o" in cmd_arg


### PR DESCRIPTION
Closes #33

## Summary

Makes the factory eval engine stack-agnostic, adding first-class support for **Rust**, **TypeScript/Node**, **Go**, and **Java** projects alongside the existing Python support. All six hygiene dimensions (tests, lint, type_check, coverage, guard_patterns, config_parser) now work across all five languages.

## Changes

### Multi-language eval support
- **Rust**: `cargo test`, `cargo clippy`, `cargo check`, `cargo llvm-cov` (with tarpaulin fallback), workspace-aware test aggregation and dedup
- **TypeScript/Node**: Jest test detection and counting, `npx eslint`, `npx tsc --noEmit`, Jest coverage, monorepo support
- **Go**: `go test ./...`, `golangci-lint`, `go vet`, `go test -cover`, framework detection (Gin, Echo, Fiber, Chi, stdlib)
- **Java**: Maven and Gradle support, `mvn test`/`gradle test`, checkstyle/spotbugs lint, `mvn compile`/`gradle compileJava` type check, JaCoCo coverage, `build.gradle.kts` detection

### Rust coverage improvements (addresses review feedback)
- Switched from `cargo tarpaulin` to `cargo llvm-cov --summary-only` as primary tool (faster, better workspace support)
- Falls back to tarpaulin on any llvm-cov failure (not just "command not found")
- Increased coverage timeout to 600s for large workspaces
- Added `~/.cargo/bin` to subprocess PATH in `_run_cmd` so Rust tools are discoverable
- Distinguished failure modes: timeout vs tool failure vs no tool (with structured logging)

### Other fixes
- Go framework detection precedence (specific frameworks before stdlib)
- Read-only Jest eval (no `--passWithNoTests` side effects)
- `go build -o /dev/null` for type_check (catches type errors without producing binaries)
- `shutil.which` guards for all external tools (Go, Node, Rust, Java)
- Multi-crate Rust and monorepo Node test result aggregation
- Java syntax check fallback to no-op `true` when no build tool detected

### Tests
- 38 new tests covering multi-lang eval branches (introspect, profile, growth, hygiene)
- Tests for llvm-cov parsing, tarpaulin fallback, timeout handling, PATH injection
- Total: 2325 tests passing

## Test plan
- [x] All 2325 tests pass locally
- [x] Verified `cargo llvm-cov --summary-only` works on real Rust workspace (factory-board)
- [x] Verified PATH injection resolves "no coverage tool detected" on real projects
- [x] CI passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
