### PR TITLE
Fix PR URL handling in factory ceo input resolution

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2585,6 +2585,19 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             shutil.rmtree(project_path, ignore_errors=True)
 
 
+_PR_URL_RE = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)(?:/(?:files|commits))?/?$"
+)
+
+
+def _parse_pr_url(url: str) -> tuple[str, int] | None:
+    """Extract (owner/repo, pr_number) from a GitHub PR URL, or None."""
+    m = _PR_URL_RE.match(url)
+    if not m:
+        return None
+    return f"{m.group('owner')}/{m.group('repo')}", int(m.group("number"))
+
+
 def _is_github_url(path: str) -> bool:
     """Return True if path looks like a GitHub URL."""
     return path.startswith("https://github.com/") or path.startswith("git@github.com:")
@@ -2652,7 +2665,18 @@ def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | N
         print(f"Project directory: {project_path}")
         return project_path, idea_content
 
-    # 3. GitHub URL
+    # 3a. GitHub PR URL — clone base repo, then checkout the PR branch
+    pr_match = _parse_pr_url(raw)
+    if pr_match:
+        owner_repo, pr_number = pr_match
+        repo_url = f"https://github.com/{owner_repo}"
+        tmp_dir = tempfile.mkdtemp(prefix="factory-")
+        subprocess.run(["git", "clone", repo_url, tmp_dir], check=True)
+        subprocess.run(["gh", "pr", "checkout", str(pr_number)], check=True, cwd=tmp_dir)
+        print(f"Cloned {owner_repo} and checked out PR #{pr_number} → {tmp_dir}")
+        return Path(tmp_dir).resolve(), None
+
+    # 3b. GitHub URL
     if _is_github_url(raw):
         tmp_dir = tempfile.mkdtemp(prefix="factory-")
         subprocess.run(["git", "clone", raw, tmp_dir], check=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
-from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo, _materialize_project, _is_scaffold_only, _quick_classify, _welcome_wizard
+from factory.cli import main, build_parser, _is_github_url, _parse_pr_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo, _materialize_project, _is_scaffold_only, _quick_classify, _welcome_wizard
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -2077,3 +2077,38 @@ class TestDeferredCreationFlow:
         project_path, context = _resolve_input(str(tmp_path))
         assert project_path == tmp_path
         assert context is None
+
+
+class TestParsePrUrl:
+    """Tests for _parse_pr_url() helper."""
+
+    def test_parse_pr_url_basic(self):
+        result = _parse_pr_url("https://github.com/acme/widgets/pull/42")
+        assert result == ("acme/widgets", 42)
+
+    def test_parse_pr_url_with_suffix(self):
+        assert _parse_pr_url("https://github.com/acme/widgets/pull/99/files") == ("acme/widgets", 99)
+        assert _parse_pr_url("https://github.com/acme/widgets/pull/7/commits") == ("acme/widgets", 7)
+
+    def test_parse_pr_url_not_pr(self):
+        assert _parse_pr_url("https://github.com/acme/widgets") is None
+        assert _parse_pr_url("https://github.com/acme/widgets/issues/5") is None
+        assert _parse_pr_url("https://example.com/acme/widgets/pull/1") is None
+
+    def test_resolve_input_pr_url(self, tmp_path):
+        """_resolve_input clones the base repo and checks out the PR."""
+        mock_run = MagicMock(return_value=MagicMock(returncode=0))
+        with patch("factory.cli.subprocess.run", mock_run), \
+             patch("factory.cli.tempfile.mkdtemp", return_value=str(tmp_path)):
+            project_path, context = _resolve_input("https://github.com/acme/widgets/pull/42")
+
+        assert project_path == tmp_path
+        assert context is None
+        assert mock_run.call_count == 2
+        # First call: git clone
+        clone_call = mock_run.call_args_list[0]
+        assert clone_call[0][0] == ["git", "clone", "https://github.com/acme/widgets", str(tmp_path)]
+        # Second call: gh pr checkout
+        checkout_call = mock_run.call_args_list[1]
+        assert checkout_call[0][0] == ["gh", "pr", "checkout", "42"]
+        assert checkout_call[1]["cwd"] == str(tmp_path)


### PR DESCRIPTION
Closes #456

## Changes

- Added `_parse_pr_url()` regex helper in `factory/cli.py` to extract `owner/repo` and PR number from GitHub PR URLs (supports `/files` and `/commits` suffixes)
- Modified `_resolve_input()` to detect PR URLs before generic GitHub URLs, clone the base repo, and run `gh pr checkout <number>` to land on the PR branch
- Added 4 unit tests in `tests/test_cli.py`:
  - `test_parse_pr_url_basic` — basic owner/repo + number extraction
  - `test_parse_pr_url_with_suffix` — handles `/files` and `/commits` suffixes
  - `test_parse_pr_url_not_pr` — regular repo URLs return None
  - `test_resolve_input_pr_url` — full clone+checkout flow with mocked subprocess.run