### PR TITLE
fix: add opencode to --runner argparse choices on all subcommands

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3733,7 +3733,7 @@ def build_parser() -> argparse.ArgumentParser:
                          help="Project paths to collect evidence from (default: all registered)")
     p_build.add_argument("--dry-run", action="store_true", default=False,
                          help="Print collected evidence without running LLM synthesis")
-    p_build.add_argument("--runner", choices=["claude", "bob", "codex"], default=None,
+    p_build.add_argument("--runner", choices=["claude", "bob", "codex", "opencode"], default=None,
                          help="CLI backend to use for synthesis")
     profile_sub.add_parser("show", help="Print the current user profile")
 
@@ -3756,7 +3756,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Timeout in seconds (default: 600)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocess (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex", "opencode"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -3812,7 +3812,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Target branch for PRs (default: from factory.md, fallback: main)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex", "opencode"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -3878,7 +3878,7 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Target branch for PRs (default: from factory.md, fallback: main)")
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex", "opencode"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
     p.add_argument("--profile", default=None,
                     help="Credential profile from ~/.factory/config.toml")
@@ -3911,7 +3911,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--model", default=None,
                     help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", choices=["claude", "bob"], default=None,
+    p.add_argument("--runner", choices=["claude", "bob", "codex", "opencode"], default=None,
                     help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
 
     # tmux-ls — list factory tmux sessions

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2000,3 +2000,22 @@ class TestDeferredCreationFlow:
         project_path, context = _resolve_input(str(tmp_path))
         assert project_path == tmp_path
         assert context is None
+
+
+RUNTIME_SUBCOMMANDS = ["agent", "ceo", "run", "tmux"]
+RUNNER_NAMES = ["claude", "bob", "codex", "opencode"]
+
+
+@pytest.mark.parametrize("subcommand", RUNTIME_SUBCOMMANDS)
+@pytest.mark.parametrize("runner", RUNNER_NAMES)
+def test_runner_choices_accepted(subcommand, runner):
+    """build_parser() accepts --runner <name> for all runners on all runtime subcommands."""
+    parser = build_parser()
+    base_args = {
+        "agent": ["agent", "researcher", "--task", "x", "--project", "/tmp", "--runner", runner],
+        "ceo": ["ceo", "/tmp", "--runner", runner],
+        "run": ["run", "/tmp", "--runner", runner],
+        "tmux": ["tmux", "/tmp", "--runner", runner],
+    }
+    args = parser.parse_args(base_args[subcommand])
+    assert args.runner == runner


### PR DESCRIPTION
Closes #463

## Changes
- Updated `--runner` argparse choices on agent, ceo, run, and tmux subcommands from `["claude", "bob"]` to `["claude", "bob", "codex", "opencode"]`
- Updated profile build subcommand choices from `["claude", "bob", "codex"]` to `["claude", "bob", "codex", "opencode"]` for consistency
- Added parametrized test (`test_runner_choices_accepted`) covering all 4 runner names x 4 runtime subcommands (16 test cases)