### PR TITLE
fix: address PR #443 review — interactive mode + Codex auth

### DIFF
--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -45,15 +45,15 @@ def _using_api_key() -> bool:
 
 
 def _check_auth() -> None:
-    """Check that Codex auth is available (API key or OAuth, once per process)."""
+    """Check that Codex auth is available (OAuth preferred, then API key)."""
     global _auth_checked  # noqa: PLW0603
     if _auth_checked:
         return
-    if _using_api_key():
-        _auth_checked = True
-        return
     if _has_codex_oauth():
         log.info("codex_oauth_detected")
+        _auth_checked = True
+        return
+    if _using_api_key():
         _auth_checked = True
         return
     raise CodexAuthError()
@@ -62,13 +62,22 @@ def _check_auth() -> None:
 def _make_codex_env() -> tuple[dict[str, str], tempfile.TemporaryDirectory[str] | None]:
     """Build subprocess env with auth isolation.
 
+    OAuth is preferred when ~/.codex/auth.json exists — OPENAI_API_KEY is
+    stripped from the env so Codex doesn't switch to API key mode (which
+    can cause 401 errors when the key lacks Responses API scopes).
+
     In API key mode, sets CODEX_HOME to a temp dir to avoid stale OAuth.
-    In OAuth mode, leaves CODEX_HOME unset so Codex uses ~/.codex/.
 
     Returns (env_dict, tmpdir_handle_or_None) — caller must keep tmpdir_handle
     alive until the subprocess exits, then call .cleanup() if not None.
     """
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+
+    if _has_codex_oauth():
+        env.pop("OPENAI_API_KEY", None)
+        env.pop("CODEX_API_KEY", None)
+        return env, None
+
     if "OPENAI_API_KEY" not in env and "CODEX_API_KEY" in env:
         env["OPENAI_API_KEY"] = env["CODEX_API_KEY"]
 
@@ -180,7 +189,7 @@ class CodexRunner:
             cmd.append("--ignore-user-config")
 
         if request.skip_permissions:
-            cmd.extend(["--sandbox", "workspace-write"])
+            cmd.append("--full-auto")
 
         if request.model:
             cmd.extend(["--model", request.model])

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -171,7 +171,8 @@ class OpenCodeRunner:
             print(f"[DRY-RUN] Task: {request.task[:200]}...")
             return 0
 
-        cmd = ["opencode", "-c", str(request.cwd)]
+        full_prompt = f"{request.prompt}\n\n---\n\n## Current Task\n\n{request.task}"
+        cmd = ["opencode", "-p", full_prompt, "-c", str(request.cwd)]
 
         log.info("opencode_interactive", cwd=str(request.cwd))
 

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -105,8 +105,16 @@ class TestCodexAuth:
         monkeypatch.delenv("CODEX_API_KEY", raising=False)
         monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
 
-        _check_auth()
-        assert codex_module._auth_checked is True
+        with patch("factory.runners.codex._has_codex_oauth", return_value=False):
+            _check_auth()
+            assert codex_module._auth_checked is True
+
+    def test_auth_prefers_oauth_over_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with patch("factory.runners.codex._has_codex_oauth", return_value=True):
+            _check_auth()
+            assert codex_module._auth_checked is True
 
     async def test_headless_fails_without_key(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -135,30 +143,45 @@ class TestCodexEnvMapping:
 
         from factory.runners.codex import _make_codex_env
 
-        env, tmpdir = _make_codex_env()
-        tmpdir.cleanup()
-        assert env["OPENAI_API_KEY"] == "my-codex-key"
-        assert "VIRTUAL_ENV" not in env
+        with patch("factory.runners.codex._has_codex_oauth", return_value=False):
+            env, tmpdir = _make_codex_env()
+            tmpdir.cleanup()
+            assert env["OPENAI_API_KEY"] == "my-codex-key"
+            assert "VIRTUAL_ENV" not in env
 
-    def test_openai_key_not_overridden(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_openai_key_not_overridden_without_oauth(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CODEX_API_KEY", "codex-key")
         monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
 
         from factory.runners.codex import _make_codex_env
 
-        env, tmpdir = _make_codex_env()
-        tmpdir.cleanup()
-        assert env["OPENAI_API_KEY"] == "openai-key"
+        with patch("factory.runners.codex._has_codex_oauth", return_value=False):
+            env, tmpdir = _make_codex_env()
+            tmpdir.cleanup()
+            assert env["OPENAI_API_KEY"] == "openai-key"
+
+    def test_oauth_strips_api_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+        monkeypatch.setenv("CODEX_API_KEY", "codex-key")
+
+        from factory.runners.codex import _make_codex_env
+
+        with patch("factory.runners.codex._has_codex_oauth", return_value=True):
+            env, tmpdir = _make_codex_env()
+            assert tmpdir is None
+            assert "OPENAI_API_KEY" not in env
+            assert "CODEX_API_KEY" not in env
 
     def test_virtual_env_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
 
         from factory.runners.codex import _make_codex_env
 
-        env, tmpdir = _make_codex_env()
-        if tmpdir is not None:
-            tmpdir.cleanup()
-        assert "VIRTUAL_ENV" not in env
+        with patch("factory.runners.codex._has_codex_oauth", return_value=False):
+            env, tmpdir = _make_codex_env()
+            if tmpdir is not None:
+                tmpdir.cleanup()
+            assert "VIRTUAL_ENV" not in env
 
 
 class TestCodexHeadless:
@@ -346,22 +369,23 @@ class TestCodexHeadless:
 
         runner = CodexRunner()
 
-        with patch(
-            "factory.runners.codex.run_subprocess", new_callable=AsyncMock
-        ) as mock_run:
-            mock_run.return_value = AgentRunResult(stdout="ok", return_code=0)
+        with patch("factory.runners.codex._has_codex_oauth", return_value=False):
+            with patch(
+                "factory.runners.codex.run_subprocess", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = AgentRunResult(stdout="ok", return_code=0)
 
-            await runner.headless(
-                AgentRunRequest(
-                    prompt="Test",
-                    task="Test",
-                    cwd=tmp_path,
+                await runner.headless(
+                    AgentRunRequest(
+                        prompt="Test",
+                        task="Test",
+                        cwd=tmp_path,
+                    )
                 )
-            )
 
-            call_kwargs = mock_run.call_args.kwargs
-            assert "VIRTUAL_ENV" not in call_kwargs["env"]
-            assert call_kwargs["env"]["OPENAI_API_KEY"] == "test-key"
+                call_kwargs = mock_run.call_args.kwargs
+                assert "VIRTUAL_ENV" not in call_kwargs["env"]
+                assert call_kwargs["env"]["OPENAI_API_KEY"] == "test-key"
 
 
 class TestCodexStreaming:
@@ -447,8 +471,7 @@ class TestCodexInteractive:
             cmd = mock_run.call_args[0][0]
             assert cmd[0] == "codex"
             assert "--ignore-user-config" in cmd
-            assert "--sandbox" in cmd
-            assert "workspace-write" in cmd
+            assert "--full-auto" in cmd
             assert "--model" in cmd
             assert "gpt-5.4" in cmd
 
@@ -472,7 +495,7 @@ class TestCodexInteractive:
             )
 
             cmd = mock_run.call_args[0][0]
-            assert "--sandbox" not in cmd
+            assert "--full-auto" not in cmd
 
     def test_interactive_run_passes_env(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -484,16 +507,17 @@ class TestCodexInteractive:
 
         runner = CodexRunner()
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = type("Result", (), {"returncode": 0})()
-            runner.interactive_run(
-                AgentRunRequest(
-                    prompt="Test",
-                    task="Test",
-                    cwd=tmp_path,
+        with patch("factory.runners.codex._has_codex_oauth", return_value=False):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = type("Result", (), {"returncode": 0})()
+                runner.interactive_run(
+                    AgentRunRequest(
+                        prompt="Test",
+                        task="Test",
+                        cwd=tmp_path,
+                    )
                 )
-            )
 
-            call_kwargs = mock_run.call_args.kwargs
-            assert "VIRTUAL_ENV" not in call_kwargs["env"]
-            assert call_kwargs["env"]["OPENAI_API_KEY"] == "test-key"
+                call_kwargs = mock_run.call_args.kwargs
+                assert "VIRTUAL_ENV" not in call_kwargs["env"]
+                assert call_kwargs["env"]["OPENAI_API_KEY"] == "test-key"

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -9,6 +9,7 @@ import pytest
 
 from factory.models import AgentRunRequest, AgentRunResult
 from factory.runners import ClaudeRunner, BobRunner, get_runner, is_dry_run
+from factory.runners.opencode import OpenCodeRunner
 from factory.runners.usage import (
     CeilingExceededError,
     CeilingWarning,
@@ -1364,3 +1365,103 @@ class TestCeilingAccumulationAcrossInvocations:
 
         # Runner's cycle_start should be between now_before and now_after
         assert now_before <= runner.cycle_start <= now_after
+
+
+class TestOpenCodeInteractive:
+    """Tests for OpenCodeRunner.interactive_run() — prompt delivery."""
+
+    def test_interactive_run_passes_prompt(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """interactive_run() passes -p with the prompt to OpenCode."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
+        runner = OpenCodeRunner()
+
+        with patch("factory.runners.opencode.subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            code = runner.interactive_run(AgentRunRequest(
+                prompt="You are the CEO.",
+                task="Start session",
+                cwd=tmp_path,
+            ))
+
+            assert code == 0
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == "opencode"
+            assert "-p" in cmd
+            p_idx = cmd.index("-p")
+            full_prompt = cmd[p_idx + 1]
+            assert "You are the CEO." in full_prompt
+            assert "Start session" in full_prompt
+            assert "## Current Task" in full_prompt
+
+    def test_interactive_run_passes_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """interactive_run() passes -c with the cwd."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
+        runner = OpenCodeRunner()
+
+        with patch("factory.runners.opencode.subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+            ))
+
+            cmd = mock_run.call_args[0][0]
+            assert "-c" in cmd
+            c_idx = cmd.index("-c")
+            assert cmd[c_idx + 1] == str(tmp_path)
+
+    def test_interactive_run_dry_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """interactive_run() prints dry-run message and returns 0."""
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
+        runner = OpenCodeRunner()
+
+        code = runner.interactive_run(AgentRunRequest(
+            prompt="Test prompt",
+            task="Test task",
+            cwd=tmp_path,
+        ))
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "[DRY-RUN]" in captured.out
+
+
+class TestBobInteractivePrompt:
+    """Tests for BobRunner.interactive_run() — prompt delivery."""
+
+    def test_interactive_run_passes_prompt_via_i_flag(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """interactive_run() passes the prompt via -i flag."""
+        monkeypatch.setenv("BOBSHELL_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_BOB_DRY_RUN", raising=False)
+
+        import factory.runners.bob as bob_module
+        bob_module._auth_checked = False
+
+        (tmp_path / ".factory").mkdir()
+        runner = BobRunner()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            code = runner.interactive_run(AgentRunRequest(
+                prompt="You are the CEO.",
+                task="Start session",
+                cwd=tmp_path,
+            ))
+
+            assert code == 0
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == "bob"
+            assert "-i" in cmd
+            i_idx = cmd.index("-i")
+            full_prompt = cmd[i_idx + 1]
+            assert "You are the CEO." in full_prompt
+            assert "Start session" in full_prompt
+
+        bob_module._auth_checked = False


### PR DESCRIPTION
## Summary

Addresses the review feedback from PR #443 (consolidated review by @gx-ai-architect):

- **P0 — OpenCode `interactive_run()` drops prompt**: Fixed to pass `-p` with full prompt (prompt + task), matching headless behavior
- **P1 — Codex auth priority**: OAuth (`~/.codex/auth.json`) is now preferred over API key. `OPENAI_API_KEY` and `CODEX_API_KEY` are stripped from subprocess env in OAuth mode to prevent Codex from switching to API key mode (which causes 401 errors)
- **Codex bypass-permission mode**: Interactive mode now uses `--full-auto` (correct flag for interactive `codex`) instead of `--sandbox workspace-write` (which is only for `codex exec`)
- **Test coverage**: Added `interactive_run()` unit tests for OpenCode (3 tests) and Bob (1 test), plus Codex OAuth priority and env-stripping tests (2 tests)

All 2205 tests pass, ruff clean.

## Test plan

- [x] `uv run pytest tests/test_codex_runner.py tests/test_runners.py -v` — 94 passed
- [x] `uv run pytest tests/ -x -q --tb=short -m "not slow"` — 2205 passed, 3 skipped
- [x] `uv run ruff check` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)