### PR TITLE
fix: ceo-review falls back to PR comment when formal review fails

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -83,7 +83,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ steps.pr.outputs.number }},
-              per_page: 5,
+              per_page: 100,
             });
             const latest = comments.data.reverse().find(c =>
               c.user.login === 'github-actions[bot]' &&
@@ -97,6 +97,9 @@ jobs:
                 event: 'APPROVE',
                 body: '✅ Factory CEO approved this PR.',
               });
+              core.info('PR approved — KEEP verdict found');
+            } else {
+              core.info(`No approval — latest matching comment: ${latest ? 'found but no KEEP' : 'not found'}`);
             }
 
       - name: Post failure comment

--- a/factory/review.py
+++ b/factory/review.py
@@ -96,16 +96,33 @@ def format_review(payload: ReviewPayload) -> str:
     return "\n".join(lines)
 
 
+def _post_comment(
+    pr_number: int,
+    body: str,
+    repo: str | None = None,
+) -> bool:
+    """Post a plain comment on a PR using gh CLI."""
+    cmd = ["gh", "pr", "comment", str(pr_number), "--body", body]
+    if repo:
+        cmd.extend(["--repo", repo])
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+    return result.returncode == 0
+
+
 def post_review(
     pr_number: int,
     review_body: str,
     verdict: str,
     repo: str | None = None,
 ) -> bool:
-    """Post a review comment on a GitHub PR using gh CLI.
+    """Post a review on a GitHub PR using gh CLI.
 
-    Uses `gh pr review` with --approve for KEEP and --request-changes for REVERT.
-    Returns True on success.
+    Tries ``gh pr review`` first (formal approval/request-changes). If that
+    fails (common in CI where GITHUB_TOKEN lacks review permissions), falls
+    back to posting a plain PR comment so the review is still visible.
     """
     if verdict == "KEEP":
         review_flag = "--approve"
@@ -132,14 +149,18 @@ def post_review(
         log.error("post_review_gh_not_found")
         return False
 
-    if result.returncode != 0:
-        log.error(
-            "post_review_failed",
-            pr=pr_number,
-            stderr=result.stderr[:200],
-            returncode=result.returncode,
-        )
-        return False
+    if result.returncode == 0:
+        log.info("post_review_success", pr=pr_number)
+        return True
 
-    log.info("post_review_success", pr=pr_number)
-    return True
+    log.warning(
+        "post_review_fallback_to_comment",
+        pr=pr_number,
+        stderr=result.stderr[:200],
+    )
+    if _post_comment(pr_number, review_body, repo=repo):
+        log.info("post_review_comment_success", pr=pr_number)
+        return True
+
+    log.error("post_review_comment_failed", pr=pr_number)
+    return False

--- a/tests/test_precheck.py
+++ b/tests/test_precheck.py
@@ -516,9 +516,21 @@ class TestPostReview:
         assert "owner/repo" in call_args
 
     @patch("factory.review.subprocess.run")
-    def test_failure(self, mock_run):
+    def test_review_fails_falls_back_to_comment(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=1, stderr="auth error"),
+            MagicMock(returncode=0),
+        ]
+        assert post_review(42, "body", "KEEP") is True
+        assert mock_run.call_count == 2
+        fallback_cmd = mock_run.call_args_list[1][0][0]
+        assert fallback_cmd[:3] == ["gh", "pr", "comment"]
+
+    @patch("factory.review.subprocess.run")
+    def test_review_and_comment_both_fail(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stderr="auth error")
         assert post_review(42, "body", "KEEP") is False
+        assert mock_run.call_count == 2
 
     @patch("factory.review.subprocess.run")
     def test_timeout(self, mock_run):


### PR DESCRIPTION
## Summary

- `post_review()` now falls back to `gh pr comment` when `gh pr review --approve` fails (common in CI where `GITHUB_TOKEN` can't create formal reviews from subprocesses)
- Fixed `per_page: 5` → `per_page: 100` in the auto-approve workflow step — was only fetching the first 5 comments, missing the CEO review on busy PRs
- Added logging to the auto-approve step so failures are no longer silent

## Context

The CEO review workflow (`@ceo-review`) was silently failing to post reviews. `post_review()` used `gh pr review --approve` which fails in CI, and when it failed, nothing was posted — the review was just dumped to stdout. The workflow's auto-approve step then couldn't find any matching comment.

## Test plan

- [x] Existing `TestPostReview` tests updated — fallback to comment tested
- [x] `pytest tests/test_precheck.py::TestPostReview -v` — all 7 tests pass
- [ ] Trigger `@ceo-review` on a PR to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)