### PR TITLE
fix: auto-approve checks formal reviews, not stale comments

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -79,27 +79,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const comments = await github.rest.issues.listComments({
+            const reviews = await github.rest.pulls.listReviews({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.pr.outputs.number }},
-              per_page: 100,
+              pull_number: ${{ steps.pr.outputs.number }},
             });
-            const latest = comments.data.reverse().find(c =>
-              c.user.login === 'github-actions[bot]' &&
-              c.body.includes('Factory') && c.body.includes('Review:')
+            const latestBot = reviews.data.reverse().find(r =>
+              r.user.login === 'github-actions[bot]'
             );
-            if (latest && latest.body.includes('KEEP')) {
-              await github.rest.pulls.createReview({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: ${{ steps.pr.outputs.number }},
-                event: 'APPROVE',
-                body: '✅ Factory CEO approved this PR.',
-              });
-              core.info('PR approved — KEEP verdict found');
+            if (!latestBot) {
+              core.info('No formal review from github-actions[bot] found');
+              return;
+            }
+            if (latestBot.state === 'APPROVED') {
+              core.info('PR already approved by factory review');
+            } else if (latestBot.state === 'CHANGES_REQUESTED') {
+              core.info('Factory review requested changes — not approving');
             } else {
-              core.info(`No approval — latest matching comment: ${latest ? 'found but no KEEP' : 'not found'}`);
+              core.info(`Unexpected review state: ${latestBot.state}`);
             }
 
       - name: Post failure comment


### PR DESCRIPTION
## Summary

- The auto-approve step was searching PR **comments** for a KEEP verdict, but `factory review` posts **formal PR reviews** (APPROVED/CHANGES_REQUESTED), not comments
- On PRs with previous CEO reviews, the step found old KEEP comments from earlier runs and approved even when the current review was REVERT
- Now checks the latest formal PR review from `github-actions[bot]` — the authoritative source that can't be confused by stale comments

## What happened on PR #445

1. CEO posted a REVERT review (CHANGES_REQUESTED) at 02:08:22
2. Auto-approve step found an **old** `github-actions` comment from a previous run containing "Factory CEO Review: KEEP"
3. Approved the PR at 02:08:40 despite the current REVERT verdict

## Test plan

- [ ] Trigger `@ceo-review` on a PR likely to get KEEP — verify it approves correctly
- [ ] Trigger `@ceo-review` on a PR likely to get REVERT — verify no false approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)