### PR TITLE
fix: skip test_available_runners_detected in CI

### DIFF
--- a/tests/test_runner_e2e.py
+++ b/tests/test_runner_e2e.py
@@ -350,6 +350,10 @@ def test_capability_matrix() -> None:
                 )
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="No runners authenticated in CI",
+)
 def test_available_runners_detected() -> None:
     """At least one runner is detected as available and authenticated."""
     assert len(AVAILABLE_RUNNERS) > 0, (


### PR DESCRIPTION
## Summary

- Skip `test_available_runners_detected` when `CI=true` — no runners are authenticated in GitHub Actions, so the test always fails
- Test still runs locally where runners are installed
- Closes #479

## Test plan

- [x] Test passes locally (no `CI` env var)
- [x] Test skips with `CI=true`
- [ ] CI should go green once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)