### PR TITLE
fix: fetch origin before creating worktree to prevent stale branches

### DIFF
--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -17,12 +17,17 @@ def _fetch_and_resolve_base(project_path: Path, base_branch: str) -> str:
     ``origin/<base_branch>`` so the worktree starts from the remote tip.
     Falls back to the local ``<base_branch>`` for repos without a remote.
     """
-    fetch = subprocess.run(
-        ["git", "fetch", "origin", base_branch],
-        cwd=project_path,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        fetch = subprocess.run(
+            ["git", "fetch", "origin", base_branch],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        log.warning("worktree_fetch_skipped", reason="timeout", base=base_branch)
+        return base_branch
     if fetch.returncode != 0:
         log.info("worktree_fetch_skipped", reason="no_remote", base=base_branch)
         return base_branch

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -10,8 +10,60 @@ import structlog
 log = structlog.get_logger()
 
 
+def _fetch_and_resolve_base(project_path: Path, base_branch: str) -> str:
+    """Fetch the latest remote state and return the best start point for a worktree.
+
+    Tries ``git fetch origin <base_branch>``. On success, returns
+    ``origin/<base_branch>`` so the worktree starts from the remote tip.
+    Falls back to the local ``<base_branch>`` for repos without a remote.
+    """
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", base_branch],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    if fetch.returncode != 0:
+        log.info("worktree_fetch_skipped", reason="no_remote", base=base_branch)
+        return base_branch
+
+    remote_ref = f"origin/{base_branch}"
+    local_rev = subprocess.run(
+        ["git", "rev-parse", base_branch],
+        cwd=project_path, capture_output=True, text=True,
+    )
+    remote_rev = subprocess.run(
+        ["git", "rev-parse", remote_ref],
+        cwd=project_path, capture_output=True, text=True,
+    )
+    if (
+        local_rev.returncode == 0
+        and remote_rev.returncode == 0
+        and local_rev.stdout.strip() != remote_rev.stdout.strip()
+    ):
+        behind = subprocess.run(
+            ["git", "rev-list", "--count", f"{base_branch}..{remote_ref}"],
+            cwd=project_path, capture_output=True, text=True,
+        )
+        count = behind.stdout.strip() if behind.returncode == 0 else "?"
+        log.warning(
+            "worktree_local_behind",
+            base=base_branch, behind_by=count,
+            local=local_rev.stdout.strip()[:8],
+            remote=remote_rev.stdout.strip()[:8],
+        )
+
+    log.info("worktree_fetch_ok", base=base_branch, start_point=remote_ref)
+    return remote_ref
+
+
 def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
     """Create an isolated worktree for a factory run.
+
+    Fetches the latest remote state before creating the worktree so the
+    branch starts from ``origin/<base_branch>`` rather than the (possibly
+    stale) local branch.  Falls back to the local branch for repos without
+    a remote.
 
     Returns (worktree_path, branch_name).
     """
@@ -21,10 +73,11 @@ def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path
     factory_dir = project_path / ".factory"
     wt_dir = factory_dir / "worktrees" / f"run-{run_id}"
 
-    log.info("worktree_create", branch=branch, path=str(wt_dir))
+    start_point = _fetch_and_resolve_base(project_path, base_branch)
+    log.info("worktree_create", branch=branch, path=str(wt_dir), start_point=start_point)
 
     subprocess.run(
-        ["git", "worktree", "add", str(wt_dir), "-b", branch, base_branch],
+        ["git", "worktree", "add", str(wt_dir), "-b", branch, start_point],
         cwd=project_path,
         check=True,
         capture_output=True,

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -353,6 +353,21 @@ class TestFetchAndResolveBase:
         result = _fetch_and_resolve_base(git_project, "main")
         assert result == "main"
 
+    def test_falls_back_to_local_on_fetch_timeout(
+        self, git_project_with_remote: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        original_run = subprocess.run
+
+        def slow_fetch(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "fetch" in cmd:
+                raise subprocess.TimeoutExpired(cmd, 30)
+            return original_run(*args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "run", slow_fetch)
+        result = _fetch_and_resolve_base(git_project_with_remote, "main")
+        assert result == "main"
+
 
 class TestCreateWorktreeWithRemote:
     def test_worktree_includes_remote_changes(self, git_project_with_remote: Path) -> None:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -15,6 +15,13 @@ from factory.worktree import (
 
 pytestmark = pytest.mark.real_worktree
 
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "test@test.com",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "test@test.com",
+}
+
 
 @pytest.fixture
 def git_project(tmp_path: Path) -> Path:
@@ -22,14 +29,7 @@ def git_project(tmp_path: Path) -> Path:
     project = tmp_path / "project"
     project.mkdir()
 
-    env = {
-        "GIT_AUTHOR_NAME": "test",
-        "GIT_AUTHOR_EMAIL": "test@test.com",
-        "GIT_COMMITTER_NAME": "test",
-        "GIT_COMMITTER_EMAIL": "test@test.com",
-        "HOME": str(tmp_path),
-        "PATH": "/usr/bin:/bin:/usr/local/bin",
-    }
+    env = {**GIT_ENV, "HOME": str(tmp_path), "PATH": "/usr/bin:/bin:/usr/local/bin"}
 
     subprocess.run(["git", "init", "-b", "main"], cwd=project, capture_output=True, check=True)
     (project / ".gitignore").write_text(".factory/\n")
@@ -80,14 +80,7 @@ class TestCreateWorktree:
         assert result.stdout.strip() == branch
 
     def test_worktree_uses_custom_base_branch(self, git_project: Path) -> None:
-        env = {
-            "GIT_AUTHOR_NAME": "test",
-            "GIT_AUTHOR_EMAIL": "test@test.com",
-            "GIT_COMMITTER_NAME": "test",
-            "GIT_COMMITTER_EMAIL": "test@test.com",
-            "HOME": str(git_project.parent),
-            "PATH": "/usr/bin:/bin:/usr/local/bin",
-        }
+        env = {**GIT_ENV, "HOME": str(git_project.parent), "PATH": "/usr/bin:/bin:/usr/local/bin"}
         subprocess.run(
             ["git", "checkout", "-b", "develop"],
             cwd=git_project, capture_output=True, check=True,
@@ -197,14 +190,7 @@ def git_project_master(tmp_path: Path) -> Path:
     project = tmp_path / "project"
     project.mkdir()
 
-    env = {
-        "GIT_AUTHOR_NAME": "test",
-        "GIT_AUTHOR_EMAIL": "test@test.com",
-        "GIT_COMMITTER_NAME": "test",
-        "GIT_COMMITTER_EMAIL": "test@test.com",
-        "HOME": str(tmp_path),
-        "PATH": "/usr/bin:/bin:/usr/local/bin",
-    }
+    env = {**GIT_ENV, "HOME": str(tmp_path), "PATH": "/usr/bin:/bin:/usr/local/bin"}
 
     subprocess.run(["git", "init", "-b", "master"], cwd=project, capture_output=True, check=True)
     (project / ".gitignore").write_text(".factory/\n")
@@ -239,14 +225,7 @@ class TestDetectDefaultBranch:
         project = tmp_path / "project"
         project.mkdir()
 
-        env = {
-            "GIT_AUTHOR_NAME": "test",
-            "GIT_AUTHOR_EMAIL": "test@test.com",
-            "GIT_COMMITTER_NAME": "test",
-            "GIT_COMMITTER_EMAIL": "test@test.com",
-            "HOME": str(tmp_path),
-            "PATH": "/usr/bin:/bin:/usr/local/bin",
-        }
+        env = {**GIT_ENV, "HOME": str(tmp_path), "PATH": "/usr/bin:/bin:/usr/local/bin"}
 
         subprocess.run(
             ["git", "init", "-b", "develop"],
@@ -289,14 +268,6 @@ class TestSymlinkResolution:
         config_via_symlink = (wt_path / ".factory" / "config.json").read_text()
         config_direct = (git_project / ".factory" / "config.json").read_text()
         assert config_via_symlink == config_direct
-
-
-GIT_ENV = {
-    "GIT_AUTHOR_NAME": "test",
-    "GIT_AUTHOR_EMAIL": "test@test.com",
-    "GIT_COMMITTER_NAME": "test",
-    "GIT_COMMITTER_EMAIL": "test@test.com",
-}
 
 
 @pytest.fixture

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from factory.worktree import create_worktree, detect_default_branch, prune_stale, remove_worktree
+from factory.worktree import (
+    _fetch_and_resolve_base,
+    create_worktree,
+    detect_default_branch,
+    prune_stale,
+    remove_worktree,
+)
 
 pytestmark = pytest.mark.real_worktree
 
@@ -283,6 +289,91 @@ class TestSymlinkResolution:
         config_via_symlink = (wt_path / ".factory" / "config.json").read_text()
         config_direct = (git_project / ".factory" / "config.json").read_text()
         assert config_via_symlink == config_direct
+
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "test@test.com",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "test@test.com",
+}
+
+
+@pytest.fixture
+def git_project_with_remote(tmp_path: Path) -> Path:
+    """Create a project with a bare remote where origin/main is ahead of local main."""
+    env = {**GIT_ENV, "HOME": str(tmp_path), "PATH": "/usr/bin:/bin:/usr/local/bin"}
+
+    bare = tmp_path / "bare.git"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(bare)],
+                    capture_output=True, check=True)
+
+    project = tmp_path / "project"
+    subprocess.run(["git", "clone", str(bare), str(project)],
+                    capture_output=True, check=True)
+    (project / "README.md").write_text("v1")
+    (project / ".gitignore").write_text(".factory/\n")
+    subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=project,
+                    capture_output=True, check=True, env=env)
+    subprocess.run(["git", "push"], cwd=project, capture_output=True, check=True)
+
+    # Simulate a PR merge: push a new commit directly to the bare remote via a
+    # temporary clone, so the project's local main is behind origin/main.
+    pusher = tmp_path / "pusher"
+    subprocess.run(["git", "clone", str(bare), str(pusher)],
+                    capture_output=True, check=True)
+    (pusher / "new_feature.py").write_text("print('merged PR')")
+    subprocess.run(["git", "add", "."], cwd=pusher, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "merged PR"], cwd=pusher,
+                    capture_output=True, check=True, env=env)
+    subprocess.run(["git", "push"], cwd=pusher, capture_output=True, check=True)
+
+    # project's local main is now 1 commit behind origin/main
+    factory_dir = project / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "config.json").write_text("{}")
+    (factory_dir / "results.tsv").write_text("id\n")
+
+    return project
+
+
+class TestFetchAndResolveBase:
+    def test_returns_remote_ref_when_behind(self, git_project_with_remote: Path) -> None:
+        result = _fetch_and_resolve_base(git_project_with_remote, "main")
+        assert result == "origin/main"
+
+    def test_returns_remote_ref_when_up_to_date(self, git_project_with_remote: Path) -> None:
+        subprocess.run(["git", "pull"], cwd=git_project_with_remote,
+                        capture_output=True, check=True)
+        result = _fetch_and_resolve_base(git_project_with_remote, "main")
+        assert result == "origin/main"
+
+    def test_falls_back_to_local_without_remote(self, git_project: Path) -> None:
+        result = _fetch_and_resolve_base(git_project, "main")
+        assert result == "main"
+
+
+class TestCreateWorktreeWithRemote:
+    def test_worktree_includes_remote_changes(self, git_project_with_remote: Path) -> None:
+        """Worktree should contain the file from the 'merged PR' that only exists on origin."""
+        wt_path, branch = create_worktree(git_project_with_remote)
+        try:
+            assert (wt_path / "new_feature.py").exists(), (
+                "Worktree should include commits from origin/main, not stale local main"
+            )
+            assert (wt_path / "new_feature.py").read_text() == "print('merged PR')"
+        finally:
+            remove_worktree(git_project_with_remote, wt_path, branch)
+
+    def test_local_only_repo_still_works(self, git_project: Path) -> None:
+        """Repos without a remote should still create worktrees normally."""
+        wt_path, branch = create_worktree(git_project)
+        try:
+            assert wt_path.exists()
+            assert (wt_path / "README.md").exists()
+        finally:
+            remove_worktree(git_project, wt_path, branch)
 
 
 class TestFilelockConcurrency:


### PR DESCRIPTION
## Summary

- `create_worktree()` now runs `git fetch origin <base_branch>` before creating the worktree, branching from `origin/<base_branch>` instead of the (possibly stale) local branch
- Falls back gracefully to the local branch for repos without a remote
- Logs a warning with the commit delta when the local branch is behind origin

## Problem

When a PR is merged to `origin/main` but the user hasn't pulled locally, the factory creates a worktree from the stale local `main`. The CEO then researches outdated code, distills an improvement spec, and proposes re-doing work that was already completed in the merged PR. The failure mode is silent and expensive: the entire research/distill/strategy cycle is wasted.

Closes #487

## Test plan

- [x] 26/26 worktree tests pass (5 new)
- [x] `TestFetchAndResolveBase`: verifies `origin/main` is returned when behind, when up-to-date, and that local branch is returned when there's no remote
- [x] `TestCreateWorktreeWithRemote`: end-to-end test confirming the worktree contains commits from origin that the local branch doesn't have
- [x] `ruff check` and `mypy` clean