### PR TITLE
feat: code-level issue dedup via factory issue-resolve

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -857,6 +857,17 @@ def cmd_guard(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_issue_resolve(args: argparse.Namespace) -> int:
+    """Check if a hypothesis references a reusable open GitHub issue."""
+    from factory.issue import resolve_reusable_issue
+
+    project_path = Path(args.path)
+    number = resolve_reusable_issue(args.hypothesis, project_path)
+    if number is not None:
+        print(number)
+    return 0
+
+
 def cmd_begin(args: argparse.Namespace) -> int:
     from factory.store import ExperimentStore
 
@@ -3702,6 +3713,12 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Also check fixed surface constraints (research mode)")
 
     # begin
+    p = sub.add_parser("issue-resolve",
+                        help="Check if hypothesis references a reusable open issue")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--hypothesis", required=True, help="Hypothesis text to scan for issue refs")
+
+    # begin
     p = sub.add_parser("begin", help="Start experiment, print ID")
     p.add_argument("path", help="Path to the project")
     p.add_argument("--hypothesis", required=True, help="Experiment hypothesis text")
@@ -4209,6 +4226,7 @@ def main(argv: list[str] | None = None) -> int:
         "init": cmd_init,
         "eval": cmd_eval,
         "guard": cmd_guard,
+        "issue-resolve": cmd_issue_resolve,
         "begin": cmd_begin,
         "finalize": cmd_finalize,
         "history": cmd_history,

--- a/factory/issue.py
+++ b/factory/issue.py
@@ -175,6 +175,78 @@ def is_issue_ref(ref: str) -> bool:
     return False
 
 
+_ISSUE_REF_PATTERNS = [
+    re.compile(r"[Aa]ddresses:?\s*#(\d+)"),
+    re.compile(r"\*\*Backlog item:\*\*\s*#(\d+)"),
+    re.compile(r"[Ii]ssue\s+#(\d+)"),
+]
+_BARE_REF = re.compile(r"(?<![/\w])#(\d+)\b")
+
+
+def extract_issue_refs(text: str) -> list[int]:
+    """Extract issue numbers from hypothesis or backlog text.
+
+    Priority order:
+    1. Explicit references: ``Addresses #NNN``, ``**Backlog item:** #NNN``, ``issue #NNN``
+    2. Bare ``#NNN`` only if exactly one match and no explicit match found
+    """
+    explicit: list[int] = []
+    for pattern in _ISSUE_REF_PATTERNS:
+        explicit.extend(int(m.group(1)) for m in pattern.finditer(text))
+    if explicit:
+        return sorted(set(explicit))
+
+    bare = sorted({int(m.group(1)) for m in _BARE_REF.finditer(text)})
+    if len(bare) == 1:
+        return bare
+    return []
+
+
+def resolve_reusable_issue(
+    hypothesis: str,
+    project_path: Path,
+) -> int | None:
+    """Check if *hypothesis* references an existing open issue that can be reused.
+
+    Returns the issue number if a single, open, relevant issue is found.
+    Returns ``None`` when a new issue should be created instead.
+    """
+    refs = extract_issue_refs(hypothesis)
+    if not refs:
+        return None
+
+    for number in refs:
+        try:
+            spec = fetch_issue(str(number), project_path)
+        except (RuntimeError, ValueError):
+            log.info("issue_resolve_skip", number=number, reason="fetch_failed")
+            continue
+
+        # Verify the issue is open
+        result = subprocess.run(
+            ["gh", "issue", "view", str(number), "--json", "state", "--jq", ".state"],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0 or result.stdout.strip() != "OPEN":
+            log.info("issue_resolve_skip", number=number, reason="not_open")
+            continue
+
+        # Verify relevance: at least one hypothesis keyword appears in the title
+        title_lower = spec.title.lower()
+        words = re.findall(r"[a-z]{4,}", hypothesis.lower())
+        if not any(w in title_lower for w in words):
+            log.info("issue_resolve_skip", number=number, reason="not_relevant",
+                     title=spec.title)
+            continue
+
+        log.info("issue_resolve_reuse", number=number, title=spec.title)
+        return number
+
+    return None
+
+
 def format_issue_as_spec(spec: IssueSpec) -> str:
     """Format an ``IssueSpec`` as a markdown build specification."""
     lines = [f"# {spec.title}", ""]

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -271,6 +271,125 @@ class TestFetchIssue:
 # ── CLI focus-as-issue integration ─────────────────────────
 
 
+# ── extract_issue_refs ──────────────────────────────────────
+
+
+class TestExtractIssueRefs:
+    def test_addresses_pattern(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("Addresses #42: fix the login bug") == [42]
+
+    def test_addresses_without_colon(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("Addresses #42") == [42]
+
+    def test_backlog_item_tag(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("**Backlog item:** #352 implement handoff") == [352]
+
+    def test_issue_keyword(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("This is related to issue #99") == [99]
+
+    def test_bare_single_ref(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("Fix the chain bug from #18") == [18]
+
+    def test_bare_multiple_refs_ambiguous(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("Related to #18 and #42") == []
+
+    def test_explicit_takes_priority_over_bare(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("Addresses #42, also see #99") == [42]
+
+    def test_no_refs(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("Add structured logging to the API layer") == []
+
+    def test_multiple_explicit_refs(self) -> None:
+        from factory.issue import extract_issue_refs
+        result = extract_issue_refs("Addresses #42, also addresses #99")
+        assert result == [42, 99]
+
+    def test_does_not_match_path_fragments(self) -> None:
+        from factory.issue import extract_issue_refs
+        assert extract_issue_refs("See file path/to/#42/config") == []
+
+
+# ── resolve_reusable_issue ──────────────────────────────────
+
+
+class TestResolveReusableIssue:
+    def test_returns_number_for_open_relevant_issue(self, tmp_project: Path) -> None:
+        from factory.issue import resolve_reusable_issue
+        gh_response = json.dumps({
+            "number": 42, "title": "Add widget support",
+            "body": "Details.", "labels": [], "url": "",
+        })
+        state_response = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="OPEN\n", stderr="",
+        )
+        with (
+            patch("factory.issue.infer_remote", return_value=("github", "org/repo")),
+            patch("factory.issue.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=gh_response, stderr=""),
+                state_response,
+            ]
+            result = resolve_reusable_issue("Addresses #42: add widget support", tmp_project)
+        assert result == 42
+
+    def test_returns_none_for_closed_issue(self, tmp_project: Path) -> None:
+        from factory.issue import resolve_reusable_issue
+        gh_response = json.dumps({
+            "number": 42, "title": "Add widgets",
+            "body": "Done.", "labels": [], "url": "",
+        })
+        state_response = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="CLOSED\n", stderr="",
+        )
+        with (
+            patch("factory.issue.infer_remote", return_value=("github", "org/repo")),
+            patch("factory.issue.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=gh_response, stderr=""),
+                state_response,
+            ]
+            result = resolve_reusable_issue("Addresses #42: add widgets", tmp_project)
+        assert result is None
+
+    def test_returns_none_when_title_irrelevant(self, tmp_project: Path) -> None:
+        from factory.issue import resolve_reusable_issue
+        gh_response = json.dumps({
+            "number": 42, "title": "Fix login page CSS",
+            "body": "Details.", "labels": [], "url": "",
+        })
+        state_response = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="OPEN\n", stderr="",
+        )
+        with (
+            patch("factory.issue.infer_remote", return_value=("github", "org/repo")),
+            patch("factory.issue.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=gh_response, stderr=""),
+                state_response,
+            ]
+            result = resolve_reusable_issue("Add structured logging to API", tmp_project)
+        assert result is None
+
+    def test_returns_none_when_no_refs(self, tmp_project: Path) -> None:
+        from factory.issue import resolve_reusable_issue
+        result = resolve_reusable_issue("Add structured logging", tmp_project)
+        assert result is None
+
+
+# ── CLI focus-as-issue integration ─────────────────────────
+
+
 class TestFocusIssueIntegration:
     """Test that --focus with issue refs works correctly via _resolve_focus_issue."""
 


### PR DESCRIPTION
## Summary

Alternative approach to #375 for fixing #372 (CEO creates duplicate GitHub issues). Moves the dedup logic from the CEO prompt into tested Python code.

- Add `extract_issue_refs()` to parse hypothesis text for issue references with priority ordering (explicit `Addresses #N` > `**Backlog item:** #N` > `issue #N` > single bare `#N`)
- Add `resolve_reusable_issue()` to verify the referenced issue is open and relevant (keyword match against title)
- Add `factory issue-resolve` CLI command the CEO can call before `gh issue create`
- 14 new tests covering parsing, resolution, and edge cases (ambiguous refs, closed issues, irrelevant titles)

## How the CEO uses it

The 37-line Issue Reuse Protocol in PR #375's `ceo.md` shrinks to:

```
EXISTING_ISSUE=$(factory issue-resolve "$PROJECT_PATH" --hypothesis "<hypothesis text>")
if [ -n "$EXISTING_ISSUE" ]; then
  ISSUE_NUM=$EXISTING_ISSUE
else
  ISSUE_NUM=$(gh issue create ...)
fi
```

## Why code over prompt

- All regex parsing, open-state checks, and relevance validation are unit-tested
- Works identically across all modes (Improve step 2c, Research R3a, Refine R3) without duplicating instructions
- Less likely to regress when the prompt is edited for unrelated reasons
- Edge cases (ambiguous bare refs, closed issues, poisoned references) are handled deterministically

## Test plan

- [x] 54/54 issue tests pass (14 new)
- [x] `TestExtractIssueRefs`: explicit refs, bare refs, ambiguous multi-ref, path fragments
- [x] `TestResolveReusableIssue`: open+relevant, closed, irrelevant title, no refs
- [x] `ruff check` and `mypy` clean