### PR TITLE
ci: allow osilkin98 and gx-ai-architect to trigger @ceo-review

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
-      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander"]'), github.event.comment.user.login)
+      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary

- Added `osilkin98` and `gx-ai-architect` to the `@ceo-review` trigger allow list

🤖 Generated with [Claude Code](https://claude.com/claude-code)