### PR TITLE
fix: detect OpenCode npm vs Go binary incompatibility at runtime

### DIFF
--- a/docs/runner-v2-spec.md
+++ b/docs/runner-v2-spec.md
@@ -164,11 +164,13 @@ The concatenation approach works — all 22 e2e tests pass, and agents produce u
 
 3. **OpenCode binary PATH**: Installed via `go install` to `~/go/bin/opencode`. Not on system PATH by default. The runner auto-detects common locations.
 
-4. **System prompt degradation**: Non-Claude runners concatenate system + task prompts. Works but less effective than proper system prompt slot.
+4. **OpenCode Go vs npm incompatibility**: The OpenCode runner requires the **Go binary** (`go install github.com/opencode-ai/opencode@latest`). The npm package (`opencode-ai`) exposes a different CLI that does not support the `-p`, `-c`, or `-q` flags used by the runner, and will fail silently. The runner performs a runtime compatibility check on first invocation by running `opencode version` and looking for Go-style semver output (e.g. `opencode version v0.0.55`). A warning is logged if the binary appears to be the npm version.
 
-5. **No fallback chains**: If a runner fails, the factory aborts. No automatic failover to another runner.
+5. **System prompt degradation**: Non-Claude runners concatenate system + task prompts. Works but less effective than proper system prompt slot.
 
-6. **Bob invocation ceilings**: Bob Shell has no token telemetry, so the factory self-enforces invocation ceilings via `FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE` (default: 8). All invocations logged to `.factory/bob_usage.jsonl`. Ceiling violations abort with an actionable error.
+6. **No fallback chains**: If a runner fails, the factory aborts. No automatic failover to another runner.
+
+7. **Bob invocation ceilings**: Bob Shell has no token telemetry, so the factory self-enforces invocation ceilings via `FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE` (default: 8). All invocations logged to `.factory/bob_usage.jsonl`. Ceiling violations abort with an actionable error.
 
 ## Dry-Run Mode
 

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 log = structlog.get_logger()
 
 _auth_checked = False
+_compat_checked = False
 
 
 class OpenCodeAuthError(Exception):
@@ -48,6 +49,7 @@ def _check_auth() -> None:
     global _auth_checked  # noqa: PLW0603
     if _auth_checked:
         return
+    _check_binary_compat()
     if os.environ.get("OPENAI_API_KEY"):
         _auth_checked = True
         return
@@ -55,6 +57,56 @@ def _check_auth() -> None:
         _auth_checked = True
         return
     raise OpenCodeAuthError()
+
+
+def _check_binary_compat() -> None:
+    """Warn if the opencode binary is the npm version instead of the Go version.
+
+    The OpenCode runner relies on CLI flags (-p, -c, -q) that only exist in the
+    Go binary (go install github.com/opencode-ai/opencode@latest).  The npm
+    package (opencode-ai) exposes a different CLI that silently ignores these
+    flags.  We detect the Go binary by running ``opencode version`` and checking
+    for output matching ``opencode version v<semver>``.
+    """
+    global _compat_checked  # noqa: PLW0603
+    if _compat_checked:
+        return
+    _compat_checked = True
+
+    import re
+    import shutil
+
+    if not shutil.which("opencode"):
+        # Binary not on PATH at all — _find_opencode_bin_dir will handle later.
+        return
+
+    try:
+        result = subprocess.run(
+            ["opencode", "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        output = (result.stdout or "").strip() + (result.stderr or "").strip()
+        # Go binary outputs e.g. "opencode version v0.0.55" or "v0.1.0"
+        if re.search(r"v\d+\.\d+\.\d+", output):
+            log.debug("opencode_binary_compat_ok", output=output)
+            return
+        log.warning(
+            "opencode_binary_compat_mismatch",
+            output=output,
+            hint=(
+                "The opencode binary does not appear to be the Go version. "
+                "The factory OpenCode runner requires the Go binary "
+                "(go install github.com/opencode-ai/opencode@latest). "
+                "The npm package 'opencode-ai' has a different CLI and will "
+                "fail silently. Please install the Go version."
+            ),
+        )
+    except FileNotFoundError:
+        pass
+    except subprocess.TimeoutExpired:
+        log.debug("opencode_version_check_timeout")
 
 
 def _find_opencode_bin_dir() -> str | None:


### PR DESCRIPTION
## Summary

- Add `_check_binary_compat()` to the OpenCode runner that runs `opencode version` on first invocation and logs a structured warning if the binary doesn't appear to be the Go version (i.e., output lacks semver pattern like `v0.0.55`)
- Call the check from `_check_auth()` so it executes once per process, before any CLI invocation
- Document the Go vs npm incompatibility as Known Limitation #4 in `docs/runner-v2-spec.md`

The OpenCode runner uses `-p`, `-c`, `-q` flags that only exist in the Go binary (`go install github.com/opencode-ai/opencode@latest`). The npm package (`opencode-ai`) has a different CLI and fails silently. This change surfaces the problem early with a clear warning message.

Closes #472

## Test plan

- [x] Existing tests pass: `uv run pytest tests/test_runners.py -v --tb=short -x -k "opencode or OpenCode or GetRunner"` (9/9 pass)
- [x] Lint clean: `uv run ruff check factory/runners/opencode.py docs/runner-v2-spec.md`
- [ ] Manual: install npm `opencode-ai`, run factory with opencode runner, verify warning is logged
- [ ] Manual: install Go `opencode`, run factory with opencode runner, verify no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)