### PR TITLE
fix: Bob RunnerMeta.check_auth() supports file-based auth

### DIFF
--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -102,6 +102,17 @@ def _check_auth(start_path: Path | None = None) -> None:
     raise BobAuthError()
 
 
+def _has_bob_auth() -> bool:
+    """Check if Bob auth is available via any supported method."""
+    if os.environ.get("BOBSHELL_API_KEY"):
+        return True
+    auth_file = _find_auth_file(Path.cwd())
+    if auth_file and auth_file.is_file():
+        return True
+    bob_config = Path.home() / ".bob" / "settings.json"
+    return bob_config.is_file()
+
+
 def is_dry_run() -> bool:
     """Return True if dry-run mode is enabled."""
     from factory.user_config import resolve
@@ -150,6 +161,7 @@ class BobRunner:
             supports_model_override=False,
             supports_usage_telemetry=False,
             supports_session_name=False,
+            custom_auth_check=_has_bob_auth,
         )
 
     def __init__(

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -107,8 +107,12 @@ def _has_bob_auth() -> bool:
     if os.environ.get("BOBSHELL_API_KEY"):
         return True
     auth_file = _find_auth_file(Path.cwd())
-    if auth_file and auth_file.is_file():
-        return True
+    if auth_file is not None:
+        try:
+            if auth_file.read_text().strip():
+                return True
+        except OSError:
+            pass
     bob_config = Path.home() / ".bob" / "settings.json"
     return bob_config.is_file()
 

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Callable, Protocol
 
 if TYPE_CHECKING:
     from factory.models import AgentRunRequest, AgentRunResult
@@ -25,13 +25,20 @@ class RunnerMeta:
     supports_streaming: bool = True
     supports_usage_telemetry: bool = False
     supports_session_name: bool = False
+    custom_auth_check: Callable[[], bool] | None = None
 
     def is_available(self) -> bool:
         """Check if the runner binary is on PATH."""
         return shutil.which(self.binary) is not None
 
     def check_auth(self) -> bool:
-        """Check if required env vars are set."""
+        """Check if authentication is available.
+
+        Uses ``custom_auth_check`` when provided (e.g. Bob's file-based auth),
+        otherwise falls back to checking ``required_env_vars``.
+        """
+        if self.custom_auth_check is not None:
+            return self.custom_auth_check()
         import os
         return all(os.environ.get(v) for v in self.required_env_vars)
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1465,3 +1465,70 @@ class TestBobInteractivePrompt:
             assert "Start session" in full_prompt
 
         bob_module._auth_checked = False
+
+
+class TestBobMetaAuthCheck:
+    """Tests for BobRunner.metadata().check_auth() — file-based auth support."""
+
+    def test_check_auth_true_with_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BOBSHELL_API_KEY", "test-key")
+        meta = BobRunner.metadata()
+        assert meta.check_auth() is True
+
+    def test_check_auth_true_with_bob_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+        bob_dir = tmp_path / ".bob"
+        bob_dir.mkdir()
+        (bob_dir / "settings.json").write_text("{}")
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        meta = BobRunner.metadata()
+        assert meta.check_auth() is True
+
+    def test_check_auth_true_with_factory_auth_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".factory").mkdir()
+        (tmp_path / ".factory" / ".bob_auth").write_text("file-key")
+
+        meta = BobRunner.metadata()
+        assert meta.check_auth() is True
+
+    def test_check_auth_false_when_nothing_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        meta = BobRunner.metadata()
+        assert meta.check_auth() is False
+
+
+class TestRunnerMetaCustomAuthCheck:
+    """Tests for RunnerMeta.custom_auth_check support."""
+
+    def test_custom_auth_check_used_when_provided(self) -> None:
+        from factory.runners.protocol import RunnerMeta
+
+        meta = RunnerMeta(
+            name="test", display_name="Test", binary="test",
+            install_hint="test", custom_auth_check=lambda: True,
+        )
+        assert meta.check_auth() is True
+
+    def test_falls_back_to_env_var_check_without_custom(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from factory.runners.protocol import RunnerMeta
+
+        monkeypatch.delenv("SOME_KEY", raising=False)
+        meta = RunnerMeta(
+            name="test", display_name="Test", binary="test",
+            install_hint="test", required_env_vars=["SOME_KEY"],
+        )
+        assert meta.check_auth() is False

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1508,6 +1508,18 @@ class TestBobMetaAuthCheck:
         meta = BobRunner.metadata()
         assert meta.check_auth() is False
 
+    def test_check_auth_false_with_empty_auth_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BOBSHELL_API_KEY", raising=False)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        (tmp_path / ".factory").mkdir()
+        (tmp_path / ".factory" / ".bob_auth").write_text("   \n  ")
+
+        meta = BobRunner.metadata()
+        assert meta.check_auth() is False
+
 
 class TestRunnerMetaCustomAuthCheck:
     """Tests for RunnerMeta.custom_auth_check support."""


### PR DESCRIPTION
## Summary

Fixes #475 — `RunnerMeta.check_auth()` returns false negative for Bob file-based auth.

- Added optional `custom_auth_check` callable to `RunnerMeta` dataclass
- When provided, `check_auth()` uses the custom callback instead of the default env var check
- Bob's `metadata()` provides `_has_bob_auth()` which checks env var, `.factory/.bob_auth`, and `~/.bob/settings.json`
- `factory runners list` now correctly shows "auth: ok" when Bob is authenticated via file-based credentials

## Test plan

- [x] New tests for Bob meta auth check (4 tests: env var, ~/.bob/settings.json, .factory/.bob_auth, nothing configured)
- [x] New tests for RunnerMeta custom_auth_check (2 tests: custom callback, env var fallback)
- [x] `uv run ruff check` — all checks passed

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)