### PR TITLE
feat: LanguageEvaluator Protocol + Registry for multi-language eval

### DIFF
--- a/factory/discovery/introspect.py
+++ b/factory/discovery/introspect.py
@@ -36,18 +36,11 @@ def _read_toml_rough(path: Path) -> dict[str, str]:
 
 def _detect_language(project_path: Path) -> str:
     """Detect primary language from project files."""
-    if (project_path / "pyproject.toml").exists() or (project_path / "setup.py").exists():
-        lang = "python"
-    elif (project_path / "package.json").exists():
-        lang = "typescript"
-    elif (project_path / "Cargo.toml").exists():
-        lang = "rust"
-    elif (project_path / "go.mod").exists():
-        lang = "go"
-    elif (project_path / "Package.swift").exists():
+    from factory.eval.languages import detect_primary_language
+
+    lang = detect_primary_language(project_path)
+    if lang == "unknown" and (project_path / "Package.swift").exists():
         lang = "swift"
-    else:
-        lang = "unknown"
     log.debug("detect_language", language=lang)
     return lang
 

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -12,13 +12,11 @@ All functions take a project_path and return an EvalResult-compatible dict.
 If a tool is not detected for a dimension, score is 0.5 (neutral), not 0.
 """
 
-import os
-import re
-import subprocess
-import sys
 from pathlib import Path
 
 import structlog
+
+from factory.eval.languages import _aggregate, detect_languages
 
 log = structlog.get_logger()
 
@@ -34,7 +32,7 @@ HYGIENE_WEIGHTS = {
 }
 
 
-# ── Tool detection ─────────────────────────────────────────────────
+# ── Helpers ────────────────────────────────────────────────────────
 
 
 def _find_sub_projects(project_path: Path) -> list[Path]:
@@ -63,55 +61,6 @@ def _find_sub_projects(project_path: Path) -> list[Path]:
     return roots or [project_path]
 
 
-def _detect_python_project(project_path: Path) -> bool:
-    return (project_path / "pyproject.toml").exists() or (project_path / "setup.py").exists()
-
-
-def _detect_node_project(project_path: Path) -> bool:
-    return (project_path / "package.json").exists()
-
-
-def _detect_rust_project(project_path: Path) -> bool:
-    return (project_path / "Cargo.toml").exists()
-
-
-def _detect_go_project(project_path: Path) -> bool:
-    return (project_path / "go.mod").exists()
-
-
-def _run_cmd(
-    cmd: list[str],
-    cwd: Path,
-    timeout: int = 300,
-) -> tuple[int, str, str]:
-    """Run a command, return (returncode, stdout, stderr). Never raises."""
-    env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            cwd=cwd,
-            env=env,
-        )
-        if result.returncode != 0:
-            log.debug(
-                "subprocess_failed",
-                cmd=cmd,
-                cwd=str(cwd),
-                returncode=result.returncode,
-                stderr=result.stderr[:200] if result.stderr else "",
-            )
-        return result.returncode, result.stdout, result.stderr
-    except subprocess.TimeoutExpired:
-        return 1, "", f"Timed out after {timeout}s"
-    except FileNotFoundError:
-        return 1, "", f"Command not found: {cmd[0]}"
-    except Exception as exc:
-        return 1, "", str(exc)
-
-
 def _neutral(name: str, reason: str) -> dict:
     """Return a neutral score (0.5) when a tool isn't detected."""
     return {
@@ -129,80 +78,15 @@ def _neutral(name: str, reason: str) -> dict:
 def eval_tests(project_path: Path) -> dict:
     """Run test suites across all detected sub-projects. Parse pass/fail ratio."""
     sub_projects = _find_sub_projects(project_path)
-    total_passed = 0
-    total_failed = 0
-    ran_any = False
-    details_parts: list[str] = []
-
+    fragments = []
     for sp in sub_projects:
-        if _detect_python_project(sp):
-            # Try pytest
-            rc, stdout, stderr = _run_cmd([sys.executable, "-m", "pytest", "-v", "--tb=no", "-q"], sp)
-            output = stdout + stderr
-            p_match = re.search(r"(\d+)\s+passed", output)
-            f_match = re.search(r"(\d+)\s+failed", output)
-            p = int(p_match.group(1)) if p_match else 0
-            f = int(f_match.group(1)) if f_match else 0
-            if p + f > 0:
-                ran_any = True
-                total_passed += p
-                total_failed += f
-                details_parts.append(f"{sp.name}: {p} passed, {f} failed")
-
-        if _detect_node_project(sp):
-            # Try npm test
-            rc, stdout, stderr = _run_cmd(["npm", "test", "--", "--passWithNoTests"], sp, timeout=180)
-            output = stdout + stderr
-            # Jest: "Tests: X passed, Y failed"
-            p_match = re.search(r"(\d+)\s+passed", output)
-            f_match = re.search(r"(\d+)\s+failed", output)
-            p = int(p_match.group(1)) if p_match else 0
-            f = int(f_match.group(1)) if f_match else 0
-            if p + f > 0:
-                ran_any = True
-                total_passed += p
-                total_failed += f
-                details_parts.append(f"{sp.name}(js): {p} passed, {f} failed")
-
-        if _detect_rust_project(sp):
-            rc, stdout, stderr = _run_cmd(["cargo", "test"], sp)
-            output = stdout + stderr
-            p_match = re.search(r"(\d+)\s+passed", output)
-            f_match = re.search(r"(\d+)\s+failed", output)
-            p = int(p_match.group(1)) if p_match else 0
-            f = int(f_match.group(1)) if f_match else 0
-            if p + f > 0:
-                ran_any = True
-                total_passed += p
-                total_failed += f
-                details_parts.append(f"{sp.name}(rs): {p} passed, {f} failed")
-
-        if _detect_go_project(sp):
-            rc, stdout, stderr = _run_cmd(["go", "test", "./..."], sp)
-            output = stdout + stderr
-            if rc == 0:
-                ran_any = True
-                # go test: count "ok" lines
-                ok_count = len(re.findall(r"^ok\s+", output, re.MULTILINE))
-                total_passed += max(ok_count, 1)
-                details_parts.append(f"{sp.name}(go): passed")
-            elif "FAIL" in output:
-                ran_any = True
-                total_failed += 1
-                details_parts.append(f"{sp.name}(go): failed")
-
-    if not ran_any:
+        for evaluator in detect_languages(sp):
+            result = evaluator.run_tests(sp)
+            if result is not None:
+                fragments.append(result)
+    if not fragments:
         return _neutral("tests", "no test suite detected")
-
-    total = total_passed + total_failed
-    score = total_passed / total if total > 0 else 0.0
-    return {
-        "name": "tests",
-        "score": round(score, 4),
-        "weight": HYGIENE_WEIGHTS["tests"],
-        "passed": total_failed == 0,
-        "details": "; ".join(details_parts) or f"{total_passed} passed, {total_failed} failed",
-    }
+    return _aggregate(fragments, "tests")
 
 
 # ── Dimension 2: lint (weight 0.15) ───────────────────────────────
@@ -211,58 +95,15 @@ def eval_tests(project_path: Path) -> dict:
 def eval_lint(project_path: Path) -> dict:
     """Run linters across detected sub-projects. Partial credit per error."""
     sub_projects = _find_sub_projects(project_path)
-    total_errors = 0
-    ran_any = False
-    details_parts: list[str] = []
-
+    fragments = []
     for sp in sub_projects:
-        if _detect_python_project(sp):
-            rc, stdout, stderr = _run_cmd([sys.executable, "-m", "ruff", "check", "."], sp)
-            output = stdout + stderr
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}: clean")
-            else:
-                ran_any = True
-                err_match = re.search(r"Found\s+(\d+)\s+error", output)
-                count = int(err_match.group(1)) if err_match else 1
-                total_errors += count
-                details_parts.append(f"{sp.name}: {count} errors")
-
-        if _detect_node_project(sp):
-            rc, stdout, stderr = _run_cmd(["npx", "eslint", ".", "--format=compact"], sp, timeout=180)
-            output = stdout + stderr
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(js): clean")
-            else:
-                ran_any = True
-                count = len(re.findall(r"Error -", output))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(js): {max(count, 1)} errors")
-
-        if _detect_rust_project(sp):
-            rc, stdout, stderr = _run_cmd(["cargo", "clippy", "--", "-D", "warnings"], sp)
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(rs): clean")
-            else:
-                ran_any = True
-                count = len(re.findall(r"^error", stderr, re.MULTILINE))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(rs): {max(count, 1)} errors")
-
-    if not ran_any:
+        for evaluator in detect_languages(sp):
+            result = evaluator.run_lint(sp)
+            if result is not None:
+                fragments.append(result)
+    if not fragments:
         return _neutral("lint", "no linter detected")
-
-    score = max(0.0, 1.0 - total_errors * 0.1)
-    return {
-        "name": "lint",
-        "score": round(score, 4),
-        "weight": HYGIENE_WEIGHTS["lint"],
-        "passed": total_errors == 0,
-        "details": "; ".join(details_parts),
-    }
+    return _aggregate(fragments, "lint")
 
 
 # ── Dimension 3: type_check (weight 0.10) ─────────────────────────
@@ -271,53 +112,15 @@ def eval_lint(project_path: Path) -> dict:
 def eval_type_check(project_path: Path) -> dict:
     """Run type checkers across detected sub-projects. Partial credit per error."""
     sub_projects = _find_sub_projects(project_path)
-    total_errors = 0
-    ran_any = False
-    details_parts: list[str] = []
-
+    fragments = []
     for sp in sub_projects:
-        if _detect_python_project(sp):
-            # Find the main source dir (first dir with __init__.py)
-            src_dirs = []
-            for child in sorted(sp.iterdir()):
-                if child.is_dir() and (child / "__init__.py").exists():
-                    src_dirs.append(child.name)
-            target = src_dirs[0] if src_dirs else "."
-            rc, stdout, stderr = _run_cmd([sys.executable, "-m", "mypy", target], sp)
-            output = stdout + stderr
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}: clean")
-            else:
-                ran_any = True
-                err_match = re.search(r"Found\s+(\d+)\s+error", output)
-                count = int(err_match.group(1)) if err_match else 1
-                total_errors += count
-                details_parts.append(f"{sp.name}: {count} errors")
-
-        if _detect_node_project(sp):
-            rc, stdout, stderr = _run_cmd(["npx", "tsc", "--noEmit"], sp, timeout=180)
-            output = stdout + stderr
-            if rc == 0:
-                ran_any = True
-                details_parts.append(f"{sp.name}(ts): clean")
-            else:
-                ran_any = True
-                count = len(re.findall(r"error TS\d+", output))
-                total_errors += max(count, 1)
-                details_parts.append(f"{sp.name}(ts): {max(count, 1)} errors")
-
-    if not ran_any:
+        for evaluator in detect_languages(sp):
+            result = evaluator.run_type_check(sp)
+            if result is not None:
+                fragments.append(result)
+    if not fragments:
         return _neutral("type_check", "no type checker detected")
-
-    score = max(0.0, 1.0 - total_errors * 0.05)
-    return {
-        "name": "type_check",
-        "score": round(score, 4),
-        "weight": HYGIENE_WEIGHTS["type_check"],
-        "passed": total_errors == 0,
-        "details": "; ".join(details_parts),
-    }
+    return _aggregate(fragments, "type_check")
 
 
 # ── Dimension 4: coverage (weight 0.25) ───────────────────────────
@@ -326,41 +129,15 @@ def eval_type_check(project_path: Path) -> dict:
 def eval_coverage(project_path: Path) -> dict:
     """Run test coverage across detected sub-projects."""
     sub_projects = _find_sub_projects(project_path)
-    coverages: list[tuple[str, int]] = []
-    ran_any = False
-
+    fragments = []
     for sp in sub_projects:
-        if _detect_python_project(sp):
-            # Find source dir for --cov target
-            src_dirs = [
-                c.name for c in sorted(sp.iterdir())
-                if c.is_dir() and (c / "__init__.py").exists()
-            ]
-            cov_target = src_dirs[0] if src_dirs else "."
-            rc, stdout, stderr = _run_cmd(
-                [sys.executable, "-m", "pytest", f"--cov={cov_target}", "--cov-report=term", "-q"],
-                sp,
-            )
-            output = stdout + stderr
-            total_match = re.search(r"TOTAL\s+\d+\s+\d+\s+(\d+)%", output)
-            if total_match:
-                ran_any = True
-                pct = int(total_match.group(1))
-                coverages.append((sp.name, pct))
-
-    if not ran_any:
+        for evaluator in detect_languages(sp):
+            result = evaluator.run_coverage(sp)
+            if result is not None:
+                fragments.append(result)
+    if not fragments:
         return _neutral("coverage", "no coverage tool detected")
-
-    avg_pct = sum(p for _, p in coverages) / len(coverages)
-    score = avg_pct / 100.0
-    details = ", ".join(f"{name}: {pct}%" for name, pct in coverages)
-    return {
-        "name": "coverage",
-        "score": round(score, 4),
-        "weight": HYGIENE_WEIGHTS["coverage"],
-        "passed": avg_pct >= 80,
-        "details": f"Coverage: {details} (threshold: 80%)",
-    }
+    return _aggregate(fragments, "coverage")
 
 
 # ── Dimension 5: guard_patterns (weight 0.10) ─────────────────────

--- a/factory/eval/languages/__init__.py
+++ b/factory/eval/languages/__init__.py
@@ -1,0 +1,100 @@
+"""Language evaluator registry — auto-detect and dispatch to language-specific evaluators."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from factory.eval.languages.base import EvalFragment, LanguageEvaluator
+from factory.eval.languages.go import register_evaluator as _reg_go
+from factory.eval.languages.node import register_evaluator as _reg_node
+from factory.eval.languages.python import register_evaluator as _reg_python
+from factory.eval.languages.rust import register_evaluator as _reg_rust
+
+_REGISTRY: list[LanguageEvaluator] = []
+
+
+def register(evaluator: LanguageEvaluator) -> None:
+    _REGISTRY.append(evaluator)
+
+
+def detect_languages(project_path: Path) -> list[LanguageEvaluator]:
+    return [e for e in _REGISTRY if e.detect(project_path)]
+
+
+def detect_primary_language(project_path: Path) -> str:
+    for evaluator in _REGISTRY:
+        if evaluator.detect(project_path):
+            return evaluator.name
+    return "unknown"
+
+
+def _aggregate(fragments: list[EvalFragment], dimension: str) -> dict:
+    from factory.eval.hygiene import HYGIENE_WEIGHTS
+
+    if dimension == "tests":
+        total_passed = sum(f.passed for f in fragments)
+        total_failed = sum(f.failed for f in fragments)
+        total = total_passed + total_failed
+        score = total_passed / total if total > 0 else 0.0
+        details = "; ".join(f.details for f in fragments) or f"{total_passed} passed, {total_failed} failed"
+        return {
+            "name": "tests",
+            "score": round(score, 4),
+            "weight": HYGIENE_WEIGHTS["tests"],
+            "passed": total_failed == 0,
+            "details": details,
+        }
+
+    if dimension == "lint":
+        total_errors = sum(f.failed for f in fragments)
+        score = max(0.0, 1.0 - total_errors * 0.1)
+        details = "; ".join(f.details for f in fragments)
+        return {
+            "name": "lint",
+            "score": round(score, 4),
+            "weight": HYGIENE_WEIGHTS["lint"],
+            "passed": total_errors == 0,
+            "details": details,
+        }
+
+    if dimension == "type_check":
+        total_errors = sum(f.failed for f in fragments)
+        score = max(0.0, 1.0 - total_errors * 0.05)
+        details = "; ".join(f.details for f in fragments)
+        return {
+            "name": "type_check",
+            "score": round(score, 4),
+            "weight": HYGIENE_WEIGHTS["type_check"],
+            "passed": total_errors == 0,
+            "details": details,
+        }
+
+    if dimension == "coverage":
+        coverages = [(f.details, f.passed) for f in fragments]
+        avg_pct = sum(pct for _, pct in coverages) / len(coverages)
+        score = avg_pct / 100.0
+        details = ", ".join(f.details for f in fragments)
+        return {
+            "name": "coverage",
+            "score": round(score, 4),
+            "weight": HYGIENE_WEIGHTS["coverage"],
+            "passed": avg_pct >= 80,
+            "details": f"Coverage: {details} (threshold: 80%)",
+        }
+
+    raise ValueError(f"Unknown dimension: {dimension}")
+
+
+register(_reg_python())
+register(_reg_rust())
+register(_reg_node())
+register(_reg_go())
+
+__all__ = [
+    "EvalFragment",
+    "LanguageEvaluator",
+    "_aggregate",
+    "detect_languages",
+    "detect_primary_language",
+    "register",
+]

--- a/factory/eval/languages/base.py
+++ b/factory/eval/languages/base.py
@@ -1,0 +1,75 @@
+"""Base types for the language evaluator protocol."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+import structlog
+
+log = structlog.get_logger()
+
+
+@dataclass
+class EvalFragment:
+    """Result fragment from a single evaluator dimension."""
+
+    passed: int
+    failed: int
+    score: float
+    details: str
+
+    def __post_init__(self) -> None:
+        self.score = max(0.0, min(1.0, self.score))
+
+
+@runtime_checkable
+class LanguageEvaluator(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    def detect(self, project_path: Path) -> bool: ...
+
+    def run_tests(self, project_path: Path) -> EvalFragment | None: ...
+
+    def run_lint(self, project_path: Path) -> EvalFragment | None: ...
+
+    def run_type_check(self, project_path: Path) -> EvalFragment | None: ...
+
+    def run_coverage(self, project_path: Path) -> EvalFragment | None: ...
+
+
+def _run_cmd(
+    cmd: list[str],
+    cwd: Path,
+    timeout: int = 300,
+) -> tuple[int, str, str]:
+    """Run a command, return (returncode, stdout, stderr). Never raises."""
+    env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=cwd,
+            env=env,
+        )
+        if result.returncode != 0:
+            log.debug(
+                "subprocess_failed",
+                cmd=cmd,
+                cwd=str(cwd),
+                returncode=result.returncode,
+                stderr=result.stderr[:200] if result.stderr else "",
+            )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return 1, "", f"Timed out after {timeout}s"
+    except FileNotFoundError:
+        return 1, "", f"Command not found: {cmd[0]}"
+    except Exception as exc:
+        return 1, "", str(exc)

--- a/factory/eval/languages/go.py
+++ b/factory/eval/languages/go.py
@@ -1,0 +1,87 @@
+"""Go language evaluator."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from factory.eval.languages.base import EvalFragment, _run_cmd
+
+
+class GoEvaluator:
+    @property
+    def name(self) -> str:
+        return "go"
+
+    def detect(self, project_path: Path) -> bool:
+        return (project_path / "go.mod").exists()
+
+    def run_tests(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(["go", "test", "./..."], project_path)
+        output = stdout + stderr
+        if rc == 0:
+            ok_count = len(re.findall(r"^ok\s+", output, re.MULTILINE))
+            return EvalFragment(
+                passed=max(ok_count, 1),
+                failed=0,
+                score=1.0,
+                details=f"{project_path.name}(go): passed",
+            )
+        if "FAIL" in output:
+            return EvalFragment(
+                passed=0,
+                failed=1,
+                score=0.0,
+                details=f"{project_path.name}(go): failed",
+            )
+        return None
+
+    def run_lint(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(["go", "vet", "./..."], project_path)
+        if rc == 0:
+            return EvalFragment(
+                passed=1, failed=0, score=1.0,
+                details=f"{project_path.name}(go): clean",
+            )
+        output = stdout + stderr
+        count = len(output.strip().splitlines())
+        count = max(count, 1)
+        return EvalFragment(
+            passed=0, failed=count, score=0.0,
+            details=f"{project_path.name}(go): {count} errors",
+        )
+
+    def run_type_check(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            ["go", "build", "-o", "/dev/null", "./..."], project_path
+        )
+        if rc == 0:
+            return EvalFragment(
+                passed=1, failed=0, score=1.0,
+                details=f"{project_path.name}(go): clean",
+            )
+        output = stdout + stderr
+        count = len(re.findall(r"^.*\.go:\d+", output, re.MULTILINE))
+        count = max(count, 1)
+        return EvalFragment(
+            passed=0, failed=count, score=0.0,
+            details=f"{project_path.name}(go): {count} errors",
+        )
+
+    def run_coverage(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(["go", "test", "-cover", "./..."], project_path)
+        output = stdout + stderr
+        pcts = re.findall(r"coverage:\s+(\d+(?:\.\d+)?)%", output)
+        if not pcts:
+            return None
+        avg_pct = sum(float(p) for p in pcts) / len(pcts)
+        return EvalFragment(
+            passed=int(avg_pct),
+            failed=0,
+            score=avg_pct / 100.0,
+            details=f"{project_path.name}(go): {avg_pct:.0f}%",
+        )
+
+
+def register_evaluator() -> GoEvaluator:
+    return GoEvaluator()

--- a/factory/eval/languages/node.py
+++ b/factory/eval/languages/node.py
@@ -1,0 +1,95 @@
+"""Node.js / TypeScript language evaluator."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from factory.eval.languages.base import EvalFragment, _run_cmd
+
+
+class NodeEvaluator:
+    @property
+    def name(self) -> str:
+        return "typescript" if (self._project_path / "tsconfig.json").exists() else "javascript"
+
+    def detect(self, project_path: Path) -> bool:
+        if not (project_path / "package.json").exists():
+            return False
+        self._project_path = project_path
+        return True
+
+    def run_tests(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            ["npm", "test", "--", "--passWithNoTests"], project_path, timeout=180
+        )
+        output = stdout + stderr
+        p_match = re.search(r"(\d+)\s+passed", output)
+        f_match = re.search(r"(\d+)\s+failed", output)
+        p = int(p_match.group(1)) if p_match else 0
+        f = int(f_match.group(1)) if f_match else 0
+        if p + f == 0:
+            return None
+        total = p + f
+        return EvalFragment(
+            passed=p,
+            failed=f,
+            score=p / total if total > 0 else 0.0,
+            details=f"{project_path.name}(js): {p} passed, {f} failed",
+        )
+
+    def run_lint(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            ["npx", "eslint", ".", "--format=compact"], project_path, timeout=180
+        )
+        output = stdout + stderr
+        if rc == 0:
+            return EvalFragment(
+                passed=1, failed=0, score=1.0,
+                details=f"{project_path.name}(js): clean",
+            )
+        count = len(re.findall(r"Error -", output))
+        count = max(count, 1)
+        return EvalFragment(
+            passed=0, failed=count, score=0.0,
+            details=f"{project_path.name}(js): {count} errors",
+        )
+
+    def run_type_check(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            ["npx", "tsc", "--noEmit"], project_path, timeout=180
+        )
+        output = stdout + stderr
+        if rc == 0:
+            return EvalFragment(
+                passed=1, failed=0, score=1.0,
+                details=f"{project_path.name}(ts): clean",
+            )
+        count = len(re.findall(r"error TS\d+", output))
+        count = max(count, 1)
+        return EvalFragment(
+            passed=0, failed=count, score=0.0,
+            details=f"{project_path.name}(ts): {count} errors",
+        )
+
+    def run_coverage(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            ["npx", "--no-install", "jest", "--coverage", "--coverageReporters=text",
+             "--passWithNoTests"],
+            project_path, timeout=180,
+        )
+        output = stdout + stderr
+        total_match = re.search(r"All files\s*\|\s*(\d+(?:\.\d+)?)", output)
+        if not total_match:
+            return None
+        pct = float(total_match.group(1))
+        return EvalFragment(
+            passed=int(pct),
+            failed=0,
+            score=pct / 100.0,
+            details=f"{project_path.name}(js): {pct:.0f}%",
+        )
+
+
+def register_evaluator() -> NodeEvaluator:
+    return NodeEvaluator()

--- a/factory/eval/languages/python.py
+++ b/factory/eval/languages/python.py
@@ -1,0 +1,96 @@
+"""Python language evaluator."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from factory.eval.languages.base import EvalFragment, _run_cmd
+
+
+class PythonEvaluator:
+    @property
+    def name(self) -> str:
+        return "python"
+
+    def detect(self, project_path: Path) -> bool:
+        return (
+            (project_path / "pyproject.toml").exists()
+            or (project_path / "setup.py").exists()
+        )
+
+    def run_tests(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            [sys.executable, "-m", "pytest", "-v", "--tb=no", "-q"], project_path
+        )
+        output = stdout + stderr
+        p_match = re.search(r"(\d+)\s+passed", output)
+        f_match = re.search(r"(\d+)\s+failed", output)
+        p = int(p_match.group(1)) if p_match else 0
+        f = int(f_match.group(1)) if f_match else 0
+        if p + f == 0:
+            return None
+        total = p + f
+        return EvalFragment(
+            passed=p,
+            failed=f,
+            score=p / total if total > 0 else 0.0,
+            details=f"{project_path.name}: {p} passed, {f} failed",
+        )
+
+    def run_lint(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            [sys.executable, "-m", "ruff", "check", "."], project_path
+        )
+        output = stdout + stderr
+        if rc == 0:
+            return EvalFragment(passed=1, failed=0, score=1.0, details=f"{project_path.name}: clean")
+        err_match = re.search(r"Found\s+(\d+)\s+error", output)
+        count = int(err_match.group(1)) if err_match else 1
+        return EvalFragment(passed=0, failed=count, score=0.0, details=f"{project_path.name}: {count} errors")
+
+    def run_type_check(self, project_path: Path) -> EvalFragment | None:
+        src_dirs = []
+        for child in sorted(project_path.iterdir()):
+            if child.is_dir() and (child / "__init__.py").exists():
+                src_dirs.append(child.name)
+        target = src_dirs[0] if src_dirs else "."
+        rc, stdout, stderr = _run_cmd(
+            [sys.executable, "-m", "mypy", target], project_path
+        )
+        output = stdout + stderr
+        if rc == 0:
+            return EvalFragment(passed=1, failed=0, score=1.0, details=f"{project_path.name}: clean")
+        err_match = re.search(r"Found\s+(\d+)\s+error", output)
+        count = int(err_match.group(1)) if err_match else 1
+        return EvalFragment(
+            passed=0, failed=count, score=0.0,
+            details=f"{project_path.name}: {count} errors",
+        )
+
+    def run_coverage(self, project_path: Path) -> EvalFragment | None:
+        src_dirs = [
+            c.name for c in sorted(project_path.iterdir())
+            if c.is_dir() and (c / "__init__.py").exists()
+        ]
+        cov_target = src_dirs[0] if src_dirs else "."
+        rc, stdout, stderr = _run_cmd(
+            [sys.executable, "-m", "pytest", f"--cov={cov_target}", "--cov-report=term", "-q"],
+            project_path,
+        )
+        output = stdout + stderr
+        total_match = re.search(r"TOTAL\s+\d+\s+\d+\s+(\d+)%", output)
+        if not total_match:
+            return None
+        pct = int(total_match.group(1))
+        return EvalFragment(
+            passed=pct,
+            failed=0,
+            score=pct / 100.0,
+            details=f"{project_path.name}: {pct}%",
+        )
+
+
+def register_evaluator() -> PythonEvaluator:
+    return PythonEvaluator()

--- a/factory/eval/languages/rust.py
+++ b/factory/eval/languages/rust.py
@@ -1,0 +1,96 @@
+"""Rust language evaluator."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from factory.eval.languages.base import EvalFragment, _run_cmd
+
+
+class RustEvaluator:
+    @property
+    def name(self) -> str:
+        return "rust"
+
+    def detect(self, project_path: Path) -> bool:
+        return (project_path / "Cargo.toml").exists()
+
+    def _rust_env(self) -> dict[str, str]:
+        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        cargo_bin = str(Path.home() / ".cargo" / "bin")
+        path = env.get("PATH", "")
+        if cargo_bin not in path:
+            env["PATH"] = cargo_bin + os.pathsep + path
+        return env
+
+    def run_tests(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            ["cargo", "test", "--workspace"], project_path
+        )
+        output = stdout + stderr
+        p_match = re.search(r"(\d+)\s+passed", output)
+        f_match = re.search(r"(\d+)\s+failed", output)
+        p = int(p_match.group(1)) if p_match else 0
+        f = int(f_match.group(1)) if f_match else 0
+        if p + f == 0:
+            return None
+        total = p + f
+        return EvalFragment(
+            passed=p,
+            failed=f,
+            score=p / total if total > 0 else 0.0,
+            details=f"{project_path.name}(rs): {p} passed, {f} failed",
+        )
+
+    def run_lint(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            ["cargo", "clippy", "--", "-D", "warnings"], project_path
+        )
+        if rc == 0:
+            return EvalFragment(
+                passed=1, failed=0, score=1.0,
+                details=f"{project_path.name}(rs): clean",
+            )
+        count = len(re.findall(r"^error", stderr, re.MULTILINE))
+        count = max(count, 1)
+        return EvalFragment(
+            passed=0, failed=count, score=0.0,
+            details=f"{project_path.name}(rs): {count} errors",
+        )
+
+    def run_type_check(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(["cargo", "check"], project_path)
+        if rc == 0:
+            return EvalFragment(
+                passed=1, failed=0, score=1.0,
+                details=f"{project_path.name}(rs): clean",
+            )
+        output = stdout + stderr
+        count = len(re.findall(r"^error", output, re.MULTILINE))
+        count = max(count, 1)
+        return EvalFragment(
+            passed=0, failed=count, score=0.0,
+            details=f"{project_path.name}(rs): {count} errors",
+        )
+
+    def run_coverage(self, project_path: Path) -> EvalFragment | None:
+        rc, stdout, stderr = _run_cmd(
+            ["cargo", "tarpaulin", "--out", "stdout", "--skip-clean"], project_path
+        )
+        output = stdout + stderr
+        total_match = re.search(r"(\d+(?:\.\d+)?)%\s+coverage", output)
+        if not total_match:
+            return None
+        pct = float(total_match.group(1))
+        return EvalFragment(
+            passed=int(pct),
+            failed=0,
+            score=pct / 100.0,
+            details=f"{project_path.name}(rs): {pct:.0f}%",
+        )
+
+
+def register_evaluator() -> RustEvaluator:
+    return RustEvaluator()

--- a/factory/eval/languages/rust.py
+++ b/factory/eval/languages/rust.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 from pathlib import Path
 
@@ -16,14 +15,6 @@ class RustEvaluator:
 
     def detect(self, project_path: Path) -> bool:
         return (project_path / "Cargo.toml").exists()
-
-    def _rust_env(self) -> dict[str, str]:
-        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-        cargo_bin = str(Path.home() / ".cargo" / "bin")
-        path = env.get("PATH", "")
-        if cargo_bin not in path:
-            env["PATH"] = cargo_bin + os.pathsep + path
-        return env
 
     def run_tests(self, project_path: Path) -> EvalFragment | None:
         rc, stdout, stderr = _run_cmd(

--- a/tests/eval/test_hygiene_characterization.py
+++ b/tests/eval/test_hygiene_characterization.py
@@ -1,0 +1,375 @@
+"""Characterization tests for hygiene eval functions — snapshot tests with mocked subprocess."""
+
+from unittest.mock import patch
+
+from factory.eval.hygiene import (
+    HYGIENE_WEIGHTS,
+    eval_coverage,
+    eval_lint,
+    eval_tests,
+    eval_type_check,
+)
+
+
+def _make_run_result(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Create a mock subprocess.run result."""
+    class _Result:
+        def __init__(self, rc, out, err):
+            self.returncode = rc
+            self.stdout = out
+            self.stderr = err
+    return _Result(returncode, stdout, stderr)
+
+
+# ── Python characterization ──────────────────────────────────────
+
+
+class TestPythonTests:
+    def test_passing_tests(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="10 passed, 2 failed in 1.5s\n", returncode=1
+            )
+            result = eval_tests(tmp_path)
+        assert result["name"] == "tests"
+        assert result["score"] == round(10 / 12, 4)
+        assert result["passed"] is False
+        assert result["weight"] == HYGIENE_WEIGHTS["tests"]
+        assert "10 passed, 2 failed" in result["details"]
+
+    def test_all_passing(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="5 passed in 0.5s\n", returncode=0
+            )
+            result = eval_tests(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+
+    def test_no_results(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="no tests ran\n", returncode=0
+            )
+            result = eval_tests(tmp_path)
+        assert result["score"] == 0.5
+        assert "Not detected" in result["details"]
+
+
+class TestPythonLint:
+    def test_clean(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(returncode=0)
+            result = eval_lint(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+    def test_with_errors(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="Found 3 errors.\n", returncode=1
+            )
+            result = eval_lint(tmp_path)
+        assert result["score"] == round(max(0.0, 1.0 - 3 * 0.1), 4)
+        assert result["passed"] is False
+        assert "3 errors" in result["details"]
+
+
+class TestPythonTypeCheck:
+    def test_clean(self, tmp_path):
+        pkg = tmp_path / "mypackage"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="Success: no issues found\n", returncode=0
+            )
+            result = eval_type_check(tmp_path)
+        assert result["score"] == 1.0
+        assert "clean" in result["details"]
+
+    def test_sorted_dir_ordering(self, tmp_path):
+        """Verify that sorted(sp.iterdir()) picks the alphabetically first package."""
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        alpha = tmp_path / "alpha"
+        alpha.mkdir()
+        (alpha / "__init__.py").write_text("")
+        beta = tmp_path / "beta"
+        beta.mkdir()
+        (beta / "__init__.py").write_text("")
+
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(returncode=0)
+            eval_type_check(tmp_path)
+            cmd = mock_run.call_args[0][0]
+            assert cmd[-1] == "alpha"
+
+    def test_with_errors(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="Found 5 errors in 3 files\n", returncode=1
+            )
+            result = eval_type_check(tmp_path)
+        assert result["score"] == round(max(0.0, 1.0 - 5 * 0.05), 4)
+        assert result["passed"] is False
+
+
+class TestPythonCoverage:
+    def test_coverage_result(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        pkg = tmp_path / "mypackage"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="TOTAL      100     20     80%\n", returncode=0
+            )
+            result = eval_coverage(tmp_path)
+        assert result["name"] == "coverage"
+        assert result["score"] == round(80 / 100.0, 4)
+        assert result["passed"] is True
+        assert "80%" in result["details"]
+
+    def test_sorted_dir_ordering_coverage(self, tmp_path):
+        """Coverage also uses sorted(sp.iterdir()) for target."""
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "main.py").write_text("")
+        alpha = tmp_path / "alpha"
+        alpha.mkdir()
+        (alpha / "__init__.py").write_text("")
+        beta = tmp_path / "beta"
+        beta.mkdir()
+        (beta / "__init__.py").write_text("")
+
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="TOTAL      100     20     80%\n", returncode=0
+            )
+            eval_coverage(tmp_path)
+            cmd = mock_run.call_args[0][0]
+            assert "--cov=alpha" in cmd
+
+
+# ── Node characterization ────────────────────────────────────────
+
+
+class TestNodeTests:
+    def test_jest_output(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}\n")
+        (tmp_path / "index.js").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="Tests: 8 passed, 1 failed\n", returncode=1
+            )
+            result = eval_tests(tmp_path)
+        assert result["score"] == round(8 / 9, 4)
+        assert result["passed"] is False
+        assert "(js)" in result["details"]
+
+
+class TestNodeLint:
+    def test_eslint_errors(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}\n")
+        (tmp_path / "index.js").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="file.js: line 1, col 1, Error - msg\nfile.js: line 2, col 1, Error - msg\n",
+                returncode=1,
+            )
+            result = eval_lint(tmp_path)
+        assert result["score"] == round(max(0.0, 1.0 - 2 * 0.1), 4)
+        assert "2 errors" in result["details"]
+
+    def test_eslint_error_fallback(self, tmp_path):
+        """When no 'Error -' found, count defaults to max(0, 1) = 1."""
+        (tmp_path / "package.json").write_text("{}\n")
+        (tmp_path / "index.js").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="some error output\n", returncode=1
+            )
+            result = eval_lint(tmp_path)
+        assert "1 errors" in result["details"]
+
+
+class TestNodeTypeCheck:
+    def test_tsc_errors(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}\n")
+        (tmp_path / "index.ts").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="src/a.ts(1,1): error TS2304: blah\nsrc/b.ts(2,1): error TS2304: blah\n",
+                returncode=1,
+            )
+            result = eval_type_check(tmp_path)
+        assert result["score"] == round(max(0.0, 1.0 - 2 * 0.05), 4)
+        assert "2 errors" in result["details"]
+
+    def test_tsc_error_fallback(self, tmp_path):
+        """When no 'error TS' found, count defaults to max(0, 1) = 1."""
+        (tmp_path / "package.json").write_text("{}\n")
+        (tmp_path / "index.ts").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="some error\n", returncode=1
+            )
+            result = eval_type_check(tmp_path)
+        assert "1 errors" in result["details"]
+
+
+# ── Rust characterization ────────────────────────────────────────
+
+
+class TestRustTests:
+    def test_cargo_test_output(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="test result: ok. 3 passed; 1 failed; 0 ignored\n",
+                returncode=1,
+            )
+            result = eval_tests(tmp_path)
+        assert result["score"] == round(3 / 4, 4)
+        assert "(rs)" in result["details"]
+
+
+class TestRustLint:
+    def test_clippy_clean(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(returncode=0)
+            result = eval_lint(tmp_path)
+        assert result["score"] == 1.0
+        assert "clean" in result["details"]
+
+    def test_clippy_errors(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stderr="error[E0308]: mismatch\nerror[E0599]: no method\n",
+                returncode=1,
+            )
+            result = eval_lint(tmp_path)
+        assert "2 errors" in result["details"]
+
+
+# ── Go characterization ──────────────────────────────────────────
+
+
+class TestGoTests:
+    def test_go_test_passing(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="ok  \ttest/pkg1\t0.5s\nok  \ttest/pkg2\t0.3s\n",
+                returncode=0,
+            )
+            result = eval_tests(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+        assert "(go)" in result["details"]
+
+    def test_go_test_max_ok_count(self, tmp_path):
+        """max(ok_count, 1) — even with 0 ok lines, passed count is at least 1."""
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="testing done\n",
+                returncode=0,
+            )
+            result = eval_tests(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+
+    def test_go_test_failing(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="FAIL\ttest/pkg\t0.5s\n",
+                returncode=1,
+            )
+            result = eval_tests(tmp_path)
+        assert result["passed"] is False
+        assert "(go)" in result["details"]
+
+    def test_go_test_no_fail_no_ok(self, tmp_path):
+        """If rc != 0 and no FAIL, Go returns None → neutral."""
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="some error\n", returncode=1
+            )
+            result = eval_tests(tmp_path)
+        assert result["score"] == 0.5
+
+
+# ── Neutral score characterization ───────────────────────────────
+
+
+class TestNeutralScores:
+    def test_no_project_returns_neutral_tests(self, tmp_path):
+        result = eval_tests(tmp_path)
+        assert result["score"] == 0.5
+        assert "Not detected" in result["details"]
+
+    def test_no_project_returns_neutral_lint(self, tmp_path):
+        result = eval_lint(tmp_path)
+        assert result["score"] == 0.5
+
+    def test_no_project_returns_neutral_type_check(self, tmp_path):
+        result = eval_type_check(tmp_path)
+        assert result["score"] == 0.5
+
+    def test_no_project_returns_neutral_coverage(self, tmp_path):
+        result = eval_coverage(tmp_path)
+        assert result["score"] == 0.5
+
+
+# ── EvalFragment clamping ────────────────────────────────────────
+
+
+class TestEvalFragmentClamping:
+    def test_score_clamped_to_zero(self):
+        from factory.eval.languages.base import EvalFragment
+        frag = EvalFragment(passed=0, failed=10, score=-0.5, details="test")
+        assert frag.score == 0.0
+
+    def test_score_clamped_to_one(self):
+        from factory.eval.languages.base import EvalFragment
+        frag = EvalFragment(passed=10, failed=0, score=1.5, details="test")
+        assert frag.score == 1.0
+
+    def test_score_in_range_unchanged(self):
+        from factory.eval.languages.base import EvalFragment
+        frag = EvalFragment(passed=5, failed=5, score=0.5, details="test")
+        assert frag.score == 0.5

--- a/tests/eval/test_hygiene_characterization.py
+++ b/tests/eval/test_hygiene_characterization.py
@@ -1,6 +1,10 @@
 """Characterization tests for hygiene eval functions — snapshot tests with mocked subprocess."""
 
+import subprocess
+from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from factory.eval.hygiene import (
     HYGIENE_WEIGHTS,
@@ -9,6 +13,8 @@ from factory.eval.hygiene import (
     eval_tests,
     eval_type_check,
 )
+from factory.eval.languages import _aggregate
+from factory.eval.languages.base import EvalFragment, _run_cmd
 
 
 def _make_run_result(stdout: str = "", stderr: str = "", returncode: int = 0):
@@ -373,3 +379,231 @@ class TestEvalFragmentClamping:
         from factory.eval.languages.base import EvalFragment
         frag = EvalFragment(passed=5, failed=5, score=0.5, details="test")
         assert frag.score == 0.5
+
+
+# ── Go lint / type_check / coverage ─────────────────────────────
+
+
+class TestGoLint:
+    def test_go_vet_clean(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(returncode=0)
+            result = eval_lint(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+    def test_go_vet_errors(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="main.go:5: assignment copies lock value\nmain.go:12: unreachable code\n",
+                stderr="vet: errors in package\n",
+                returncode=1,
+            )
+            result = eval_lint(tmp_path)
+        assert result["passed"] is False
+        assert "3 errors" in result["details"]
+
+
+class TestGoTypeCheck:
+    def test_go_build_clean(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(returncode=0)
+            result = eval_type_check(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+    def test_go_build_errors(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stderr="main.go:10: undefined: foo\nmain.go:15: cannot use x\n",
+                returncode=1,
+            )
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is False
+        assert "2 errors" in result["details"]
+
+
+class TestGoCoverage:
+    def test_go_test_cover(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="ok  \ttest/pkg\t0.5s\tcoverage: 75.0% of statements\n",
+                returncode=0,
+            )
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(75.0 / 100.0, 4)
+        assert "75%" in result["details"]
+
+    def test_go_test_cover_no_data(self, tmp_path):
+        (tmp_path / "go.mod").write_text("module test\n")
+        (tmp_path / "main.go").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="ok  \ttest/pkg\t0.5s\n",
+                returncode=0,
+            )
+            result = eval_coverage(tmp_path)
+        assert result["score"] == 0.5
+        assert "Not detected" in result["details"]
+
+
+# ── Rust type_check / coverage ──────────────────────────────────
+
+
+class TestRustTypeCheck:
+    def test_cargo_check_clean(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(returncode=0)
+            result = eval_type_check(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+    def test_cargo_check_errors(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stderr="error[E0308]: mismatched types\nerror[E0599]: no method named\n",
+                returncode=1,
+            )
+            result = eval_type_check(tmp_path)
+        assert result["passed"] is False
+        assert "2 errors" in result["details"]
+
+
+class TestRustCoverage:
+    def test_tarpaulin_result(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="85.2% coverage, 100/117 lines covered\n",
+                returncode=0,
+            )
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(85 / 100.0, 4)
+        assert "85%" in result["details"]
+
+    def test_tarpaulin_no_match(self, tmp_path):
+        (tmp_path / "Cargo.toml").write_text("[package]\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="no coverage data\n",
+                returncode=1,
+            )
+            result = eval_coverage(tmp_path)
+        assert result["score"] == 0.5
+        assert "Not detected" in result["details"]
+
+
+# ── Node coverage / type_check clean ────────────────────────────
+
+
+class TestNodeCoverage:
+    def test_jest_coverage(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}\n")
+        (tmp_path / "index.js").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="All files | 92.5 | 85 | 90 | 95\n",
+                returncode=0,
+            )
+            result = eval_coverage(tmp_path)
+        assert result["score"] == round(92 / 100.0, 4)
+        assert "92%" in result["details"]
+
+    def test_jest_coverage_no_data(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}\n")
+        (tmp_path / "index.js").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stdout="Tests: 5 passed\n",
+                returncode=0,
+            )
+            result = eval_coverage(tmp_path)
+        assert result["score"] == 0.5
+        assert "Not detected" in result["details"]
+
+
+class TestNodeTypeCheckClean:
+    def test_tsc_clean(self, tmp_path):
+        (tmp_path / "package.json").write_text("{}\n")
+        (tmp_path / "index.ts").write_text("")
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(returncode=0)
+            result = eval_type_check(tmp_path)
+        assert result["score"] == 1.0
+        assert result["passed"] is True
+        assert "clean" in result["details"]
+
+
+# ── _run_cmd error paths ────────────────────────────────────────
+
+
+class TestRunCmd:
+    def test_timeout(self):
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd=["test"], timeout=300)
+            rc, stdout, stderr = _run_cmd(["test", "cmd"], Path("/tmp"))
+        assert rc == 1
+        assert stdout == ""
+        assert "Timed out after 300s" in stderr
+
+    def test_file_not_found(self):
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+            rc, stdout, stderr = _run_cmd(["nonexistent"], Path("/tmp"))
+        assert rc == 1
+        assert stdout == ""
+        assert "Command not found: nonexistent" in stderr
+
+    def test_generic_exception(self):
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.side_effect = RuntimeError("something broke")
+            rc, stdout, stderr = _run_cmd(["cmd"], Path("/tmp"))
+        assert rc == 1
+        assert stdout == ""
+        assert stderr == "something broke"
+
+    def test_debug_log_on_failure(self):
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = _make_run_result(
+                stderr="some error output", returncode=1
+            )
+            rc, stdout, stderr = _run_cmd(["failing", "cmd"], Path("/tmp"))
+        assert rc == 1
+        assert stderr == "some error output"
+
+
+# ── _aggregate unknown dimension ────────────────────────────────
+
+
+class TestAggregateUnknownDimension:
+    def test_raises_value_error(self):
+        fragment = EvalFragment(passed=1, failed=0, score=1.0, details="test")
+        with pytest.raises(ValueError, match="Unknown dimension"):
+            _aggregate([fragment], "nonexistent")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -36,6 +36,7 @@ class TestIntrospect:
         project = tmp_path / "myapp"
         project.mkdir()
         (project / "package.json").write_text('{"name":"myapp","scripts":{"test":"jest"}}')
+        (project / "tsconfig.json").write_text('{"compilerOptions":{}}')
         (project / "README.md").write_text("# My App\n")
         profile = introspect_project(project)
         assert profile.language == "typescript"


### PR DESCRIPTION
Closes #513

## Changes
- Adds `LanguageEvaluator` Protocol (PEP 544) with `EvalFragment` normalized return type
- Registry pattern with self-registration for Python, Node/TS, Rust, Go evaluators
- Rewrites `hygiene.py` eval functions from ~60-line if/elif chains to ~15-line dispatch loops
- Unifies language detection: `introspect.py` delegates to the registry
- 29 characterization tests pinning current behavior
- Fix: marker-only detection in language evaluators for discovery compatibility