### PR TITLE
feat: add 3-pass adversarial review protocol to CEO prompt

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -2679,15 +2679,19 @@ factory log "$PROJECT_PATH" "refine.completed" --data "{\"exp_id\": $EXP_ID, \"v
 
 ## Mode: PR Review (`--mode review --pr <N>`)
 
-A 3-pass adversarial review of a GitHub PR. Three independent reviewers, three rounds. Each round, reviewers see the others' findings from the prior round — cross-pollination forces them to challenge each other, catch what others missed, and go deeper than any single reviewer would alone.
+A 3-pass adversarial review of a GitHub PR. Three independent reviewers, three rounds. In each subsequent round, a reviewer sees its own full prior trajectory but only **summaries** of the other reviewers' findings — this preserves each reviewer's depth while cross-pollinating awareness without anchoring or context bloat.
 
 ```
-Round 1: A, B, C review independently (blind to each other)
-              ↓ collect findings
-Round 2: A sees B+C findings, B sees A+C, C sees A+B
-              ↓ collect findings
-Round 3: Same cross-pollination with rounds 1+2 findings (adversarial)
-              ↓ collect findings
+Round 1: A1, B1, C1 review independently (blind)
+              ↓ CEO writes a summary of each reviewer's findings
+Round 2: A2 sees A1 (full) + summaries of B1, C1
+         B2 sees B1 (full) + summaries of A1, C1
+         C2 sees C1 (full) + summaries of A1, B1
+              ↓ CEO writes a summary of each reviewer's round 2 findings
+Round 3: A3 sees A1+A2 (full) + summaries of B1, B2, C1, C2
+         B3 sees B1+B2 (full) + summaries of A1, A2, C1, C2
+         C3 sees C1+C2 (full) + summaries of A1, A2, B1, B2
+              ↓ collect final findings
 Final:   CEO consolidates all 3 rounds into KEEP/REVERT verdict
 ```
 
@@ -2757,11 +2761,15 @@ Do NOT modify any files. This is a read-only review.
 End with a one-line verdict: APPROVE, REQUEST_CHANGES, or COMMENT." --project $PROJECT_PATH --timeout 300
 ```
 
-After each reviewer completes, read `.factory/reviews/reviewer-latest.md` and save the output labeled as `Reviewer $LETTER — Round 1`.
+After each reviewer completes, read `.factory/reviews/reviewer-latest.md` and save the full output as `Reviewer $LETTER — Round 1 (full)`.
+
+**CEO summarization step (MANDATORY after Round 1):** For each reviewer's full output, write a concise summary (3-8 bullet points) capturing: the verdict, each finding with its severity and file:line reference, and the reviewer's key concern. These summaries are what get cross-pollinated to the OTHER reviewers in subsequent rounds. Label each as `Reviewer $LETTER — Round 1 (summary)`.
 
 ### PR4: Round 2 — Cross-Pollinated Deep Review
 
-Spawn all 3 reviewers again. Each receives the OTHER two reviewers' round 1 findings.
+Spawn all 3 reviewers again. Each receives:
+- Its OWN round 1 output in **full** (preserves the reviewer's depth and reasoning chain)
+- The OTHER two reviewers' round 1 findings as **summaries only** (provides awareness without anchoring)
 
 For each reviewer:
 
@@ -2773,13 +2781,18 @@ You are Reviewer $LETTER ($LENS_NAME) reviewing PR #$PR_NUMBER.
 **Full diff:**
 $DIFF
 
-Here are the findings from the other two reviewers in round 1. You have NOT seen these before.
+## Your Round 1 Review (full)
+$OWN_ROUND1_FULL
 
-### Reviewer $OTHER1 ($OTHER1_LENS) found:
-$OTHER1_ROUND1_FINDINGS
+## Other Reviewers' Round 1 Findings (summaries)
 
-### Reviewer $OTHER2 ($OTHER2_LENS) found:
-$OTHER2_ROUND1_FINDINGS
+You have NOT seen these before. These are condensed summaries — not the full reviews.
+
+### Reviewer $OTHER1 ($OTHER1_LENS) — Round 1 summary:
+$OTHER1_ROUND1_SUMMARY
+
+### Reviewer $OTHER2 ($OTHER2_LENS) — Round 1 summary:
+$OTHER2_ROUND1_SUMMARY
 
 Now review the PR again with this additional context:
 1. Do you agree or disagree with their findings? Challenge anything you think is wrong.
@@ -2790,11 +2803,15 @@ Provide NEW findings only (do not repeat your round 1 findings). Use severity ra
 End with an updated verdict." --project $PROJECT_PATH --timeout 300
 ```
 
-After each reviewer completes, read and save as `Reviewer $LETTER — Round 2`.
+After each reviewer completes, read and save the full output as `Reviewer $LETTER — Round 2 (full)`.
+
+**CEO summarization step (MANDATORY after Round 2):** Same as after Round 1 — write a concise summary for each reviewer's round 2 output. Label as `Reviewer $LETTER — Round 2 (summary)`.
 
 ### PR5: Round 3 — Adversarial Stress Test
 
-Spawn all 3 reviewers one final time. Each gets ALL findings from rounds 1 and 2 from the other reviewers.
+Spawn all 3 reviewers one final time. Each receives:
+- Its OWN rounds 1+2 output in **full** (complete reasoning trajectory)
+- ALL other reviewers' rounds 1+2 findings as **summaries only**
 
 For each reviewer:
 
@@ -2806,19 +2823,27 @@ You are Reviewer $LETTER ($LENS_NAME) reviewing PR #$PR_NUMBER.
 **Full diff:**
 $DIFF
 
-Here are ALL findings from the other reviewers across rounds 1 and 2:
+## Your Prior Reviews (full trajectory)
 
-### Reviewer $OTHER1 ($OTHER1_LENS) — Round 1:
-$OTHER1_R1
+### Your Round 1:
+$OWN_ROUND1_FULL
 
-### Reviewer $OTHER1 ($OTHER1_LENS) — Round 2:
-$OTHER1_R2
+### Your Round 2:
+$OWN_ROUND2_FULL
 
-### Reviewer $OTHER2 ($OTHER2_LENS) — Round 1:
-$OTHER2_R1
+## Other Reviewers' Findings (summaries only)
 
-### Reviewer $OTHER2 ($OTHER2_LENS) — Round 2:
-$OTHER2_R2
+### Reviewer $OTHER1 ($OTHER1_LENS) — Round 1 summary:
+$OTHER1_R1_SUMMARY
+
+### Reviewer $OTHER1 ($OTHER1_LENS) — Round 2 summary:
+$OTHER1_R2_SUMMARY
+
+### Reviewer $OTHER2 ($OTHER2_LENS) — Round 1 summary:
+$OTHER2_R1_SUMMARY
+
+### Reviewer $OTHER2 ($OTHER2_LENS) — Round 2 summary:
+$OTHER2_R2_SUMMARY
 
 Final round. Try to BREAK the PR:
 1. What assumptions does this code make that might not hold?

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -2677,6 +2677,220 @@ factory log "$PROJECT_PATH" "refine.completed" --data "{\"exp_id\": $EXP_ID, \"v
 
 ---
 
+## Mode: PR Review (`--mode review --pr <N>`)
+
+A 3-pass adversarial review of a GitHub PR. Three independent reviewers, three rounds. Each round, reviewers see the others' findings from the prior round — cross-pollination forces them to challenge each other, catch what others missed, and go deeper than any single reviewer would alone.
+
+```
+Round 1: A, B, C review independently (blind to each other)
+              ↓ collect findings
+Round 2: A sees B+C findings, B sees A+C, C sees A+B
+              ↓ collect findings
+Round 3: Same cross-pollination with rounds 1+2 findings (adversarial)
+              ↓ collect findings
+Final:   CEO consolidates all 3 rounds into KEEP/REVERT verdict
+```
+
+You receive the PR number and optional repo from the task string. Read them from your task context.
+
+### PR1: Read PR Context
+
+Fetch the PR metadata and full diff:
+
+```bash
+gh pr view $PR_NUMBER --json title,body,additions,deletions,changedFiles
+gh pr diff $PR_NUMBER
+```
+
+If `--repo` was provided, append `--repo $REPO` to both commands.
+
+Save the diff and metadata — you will pass them to all reviewers.
+
+### PR2: Detect Language and Select Review Lenses
+
+Determine the dominant language from the changed file extensions:
+
+```bash
+gh pr diff $PR_NUMBER --name-only
+```
+
+Map extensions to review lenses for Reviewer B:
+- `.py` → Python patterns (type hints, PEP 8, async correctness, Django/FastAPI idioms)
+- `.ts`, `.tsx`, `.js`, `.jsx` → TypeScript/JavaScript patterns (type safety, async, Node/web security)
+- `.rs` → Rust patterns (ownership, lifetimes, error handling, unsafe usage)
+- `.go` → Go patterns (goroutine safety, error handling, interface design)
+- `.java` → Java patterns (Spring Boot, JPA, concurrency, layered architecture)
+- `.md`, `.txt`, `.yaml`, `.toml` → Documentation/config patterns (clarity, completeness, consistency)
+- Mixed → pick the dominant language by file count
+
+Reviewer A always reviews for **code quality** (bugs, logic errors, DRY, edge cases, error handling).
+Reviewer B reviews for **language-specific patterns** (selected above).
+Reviewer C always reviews for **security** (injection, auth, path traversal, secrets, unsafe operations).
+
+### PR3: Round 1 — Independent Blind Review
+
+Spawn all 3 reviewers sequentially (per the CEO synchronous-only constraint). Each reviewer MUST receive the full PR diff and lens-specific instructions.
+
+For each reviewer (A, B, C):
+
+```bash
+factory agent reviewer --task "You are reviewing PR #$PR_NUMBER.
+
+**Title:** $TITLE
+**Description:** $DESCRIPTION
+**Changed files:** $FILE_COUNT (+$ADDITIONS, -$DELETIONS)
+
+**Full diff:**
+$DIFF
+
+## Instructions
+
+This is ROUND 1 of 3 of an adversarial review. You are Reviewer $LETTER ($LENS_NAME). You CANNOT see the other reviewers' findings yet.
+
+Review the PR through your lens:
+$LENS_SPECIFIC_INSTRUCTIONS
+
+Provide findings as a numbered list with severity ratings: [CRITICAL], [HIGH], [MEDIUM], [LOW], [INFO].
+Include file:line references where applicable.
+
+Do NOT modify any files. This is a read-only review.
+End with a one-line verdict: APPROVE, REQUEST_CHANGES, or COMMENT." --project $PROJECT_PATH --timeout 300
+```
+
+After each reviewer completes, read `.factory/reviews/reviewer-latest.md` and save the output labeled as `Reviewer $LETTER — Round 1`.
+
+### PR4: Round 2 — Cross-Pollinated Deep Review
+
+Spawn all 3 reviewers again. Each receives the OTHER two reviewers' round 1 findings.
+
+For each reviewer:
+
+```bash
+factory agent reviewer --task "## Round 2 of 3 — Cross-Pollinated Deep Review
+
+You are Reviewer $LETTER ($LENS_NAME) reviewing PR #$PR_NUMBER.
+
+**Full diff:**
+$DIFF
+
+Here are the findings from the other two reviewers in round 1. You have NOT seen these before.
+
+### Reviewer $OTHER1 ($OTHER1_LENS) found:
+$OTHER1_ROUND1_FINDINGS
+
+### Reviewer $OTHER2 ($OTHER2_LENS) found:
+$OTHER2_ROUND1_FINDINGS
+
+Now review the PR again with this additional context:
+1. Do you agree or disagree with their findings? Challenge anything you think is wrong.
+2. Did their findings make you notice something YOU missed in round 1?
+3. Go deeper on your area of expertise — what did you gloss over the first time?
+
+Provide NEW findings only (do not repeat your round 1 findings). Use severity ratings.
+End with an updated verdict." --project $PROJECT_PATH --timeout 300
+```
+
+After each reviewer completes, read and save as `Reviewer $LETTER — Round 2`.
+
+### PR5: Round 3 — Adversarial Stress Test
+
+Spawn all 3 reviewers one final time. Each gets ALL findings from rounds 1 and 2 from the other reviewers.
+
+For each reviewer:
+
+```bash
+factory agent reviewer --task "## Round 3 of 3 — Adversarial Stress Test
+
+You are Reviewer $LETTER ($LENS_NAME) reviewing PR #$PR_NUMBER.
+
+**Full diff:**
+$DIFF
+
+Here are ALL findings from the other reviewers across rounds 1 and 2:
+
+### Reviewer $OTHER1 ($OTHER1_LENS) — Round 1:
+$OTHER1_R1
+
+### Reviewer $OTHER1 ($OTHER1_LENS) — Round 2:
+$OTHER1_R2
+
+### Reviewer $OTHER2 ($OTHER2_LENS) — Round 1:
+$OTHER2_R1
+
+### Reviewer $OTHER2 ($OTHER2_LENS) — Round 2:
+$OTHER2_R2
+
+Final round. Try to BREAK the PR:
+1. What assumptions does this code make that might not hold?
+2. What are the boundary conditions nobody tested?
+3. Race conditions, concurrency issues, TOCTOU?
+4. What if dependencies are unavailable or behave differently?
+5. Can a malicious actor exploit any of these changes?
+6. Look at every finding marked [LOW] or [INFO] across all reviewers — should any be escalated?
+
+Provide NEW findings only. Use severity ratings.
+End with your FINAL verdict: APPROVE, REQUEST_CHANGES, or COMMENT." --project $PROJECT_PATH --timeout 300
+```
+
+After each reviewer completes, read and save as `Reviewer $LETTER — Round 3`.
+
+### PR6: Consolidate and Post Verdict
+
+Collect all findings across 3 rounds and 3 reviewers. Produce a consolidated report:
+
+```markdown
+## 3-Pass Adversarial Review: PR #$PR_NUMBER
+
+### Reviewer Verdicts
+| Reviewer | Round 1 | Round 2 | Round 3 (Final) |
+|----------|---------|---------|-----------------|
+| A (code quality) | ... | ... | ... |
+| B ($language) | ... | ... | ... |
+| C (security) | ... | ... | ... |
+
+### All Findings by Severity
+**CRITICAL:**
+- ...
+
+**HIGH:**
+- ...
+
+**MEDIUM:**
+- ...
+
+**LOW / INFO:**
+- ...
+
+### Consensus
+<what all 3 reviewers agreed on>
+
+### Disagreements
+<where reviewers challenged each other's findings>
+
+### Overall Recommendation
+<KEEP or REVERT based on majority + severity>
+```
+
+**Verdict mapping to factory's KEEP/REVERT framework:**
+- ANY finding rated [CRITICAL] → **REVERT** (non-negotiable)
+- Majority of final verdicts are REQUEST_CHANGES with [HIGH] findings → **REVERT**
+- Majority of final verdicts are APPROVE with no [CRITICAL] → **KEEP**
+- Mixed verdicts with no [CRITICAL] → **KEEP** with code review notes listing [HIGH] items
+
+Post the verdict using `factory review`:
+
+```bash
+factory review \
+    --verdict $VERDICT \
+    --reason "$ONE_SENTENCE_SUMMARY" \
+    --code-notes "finding1|finding2|finding3" \
+    --pr $PR_NUMBER
+```
+
+If `--repo` was provided, add `--repo $REPO` to the command.
+
+---
+
 ## CEO Self-Learning Protocol
 
 You learn from your own decisions. Every keep/revert decision and every agent failure is data that feeds your own playbook evolution.

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2346,16 +2346,12 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         task = (
             f"Project: {project_path}\nMode: review\n\n"
             f"## PR Review Directive\n\n"
-            f"Review PR #{pr_number}{repo_clause}.\n\n"
-            f"1. Read the PR diff: `gh pr diff {pr_number}"
-            f"{' --repo ' + repo if repo else ''}`\n"
-            f"2. Read the PR description: `gh pr view {pr_number}"
-            f"{' --repo ' + repo if repo else ''}`\n"
-            f"3. Run the project's test suite and lint checks\n"
-            f"4. Spawn the Reviewer agent for a structured code review\n"
-            f"5. Post your review verdict on the PR using "
-            f"`factory review --verdict <KEEP|REVERT> --pr {pr_number}"
-            f"{' --repo ' + repo if repo else ''}`\n"
+            f"Review PR #{pr_number}{repo_clause} using the "
+            f"3-pass adversarial review protocol.\n\n"
+            f"Follow the `## Mode: PR Review` section in your prompt.\n\n"
+            f"PR number: {pr_number}\n"
+            f"{'Repo: ' + repo + chr(10) if repo else ''}"
+            f"Project path: {project_path}\n"
         )
 
         if not headless:

--- a/skills/3-pass-review/SKILL.md
+++ b/skills/3-pass-review/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: 3-pass-review
+description: Run a 3-round adversarial review on a GitHub PR with 3 independent reviewers. Each round spawns all reviewers in parallel. In rounds 2 and 3, each reviewer gets the other reviewers' prior findings cross-pollinated into their context, so they can challenge, validate, and go deeper. Use when the user asks for a "3-pass review", "deep review", "iterative review", or wants a thorough multi-pass review of a PR.
+disable-model-invocation: true
+argument-hint: "<PR number or URL>"
+---
+
+# 3-Pass Adversarial PR Review
+
+Three independent reviewers, three rounds. Each round, reviewers see the others' findings from the prior round — cross-pollination forces them to challenge each other, catch what others missed, and go deeper than any single reviewer would alone.
+
+```
+Round 1: A, B, C review independently (blind to each other)
+              ↓ collect findings
+Round 2: A sees B+C's findings, B sees A+C's, C sees A+B's
+              ↓ collect findings  
+Round 3: Same cross-pollination with rounds 1+2 findings
+              ↓ collect findings
+Final:   Parent consolidates all 3 rounds into verdict
+```
+
+## When to Use
+
+- User asks for "3-pass review", "deep review", "iterative review", "thorough review"
+- Any PR where a single pass isn't enough
+- When you want independent perspectives that converge through cross-challenge
+
+## How to Run
+
+### Step 1: Gather PR Context
+
+Parse the PR number from `$ARGUMENTS`. If a URL was given, extract the number from it.
+
+Fetch the PR metadata and full diff:
+```bash
+gh pr view <number> --json title,body,additions,deletions,changedFiles
+gh pr diff <number>
+```
+
+### Step 2: Detect Language and Select Reviewers
+
+Determine the dominant language from file extensions:
+```bash
+gh pr diff <number> --name-only
+```
+
+Pick 3 reviewers based on the diff content:
+- **Reviewer A** (code quality): bugs, logic errors, DRY, edge cases, error handling
+- **Reviewer B** (language-specific): selected by dominant language
+  - Python → type hints, PEP 8, async correctness, Django/FastAPI idioms
+  - TypeScript/JS → type safety, async patterns, Node/web security
+  - Rust → ownership, lifetimes, error handling, unsafe usage
+  - Go → goroutine safety, error handling, interface design
+  - Java → Spring Boot, JPA, concurrency, layered architecture
+  - Markdown/docs/prompts → clarity, completeness, consistency
+  - Mixed → pick the dominant language by file count
+- **Reviewer C** (security): injection, auth, path traversal, secrets, unsafe operations
+
+### Step 3: Round 1 — Independent Blind Review
+
+Spawn all 3 reviewers in a **single message** (so they run in parallel). Each reviewer MUST:
+- Have a unique `name` (e.g., `reviewer-a`, `reviewer-b`, `reviewer-c`)
+- Set `run_in_background: true`
+- Receive the full PR metadata and diff
+- Be told: **"This is round 1 of 3. You are one of 3 independent reviewers. You cannot see the others' findings. Review independently."**
+
+Each reviewer's prompt should include:
+
+```
+You are reviewing PR #<number>.
+
+**Title:** <title>
+**Description:** <description>
+**Changed files:** <count> (+<additions>, -<deletions>)
+
+**Full diff:**
+<paste complete diff here>
+
+## Instructions
+
+This is ROUND 1 of 3 of an adversarial review. You are one of 3 independent reviewers. You CANNOT see the others' findings yet.
+
+Review the PR through your lens:
+<lens-specific instructions>
+
+Provide findings as a numbered list with severity ratings: [CRITICAL], [HIGH], [MEDIUM], [LOW], [INFO].
+Include file:line references where applicable.
+
+Do NOT modify any files. This is a read-only review.
+End with a one-line verdict: APPROVE, REQUEST_CHANGES, or COMMENT.
+```
+
+Wait for all 3 to complete. Collect and label each reviewer's findings.
+
+### Step 4: Round 2 — Cross-Pollinated Deep Review
+
+Use `SendMessage` to **continue** each reviewer (preserving their full context). Each reviewer receives the OTHER two reviewers' round 1 findings.
+
+Send to reviewer-a:
+```
+## Round 2 of 3 — Cross-Pollinated Deep Review
+
+Here are the findings from the other two reviewers in round 1. You have NOT seen these before.
+
+### Reviewer B (language specialist) found:
+<paste reviewer B's round 1 findings>
+
+### Reviewer C (security) found:
+<paste reviewer C's round 1 findings>
+
+Now review the PR again with this additional context:
+1. Do you agree or disagree with their findings? Challenge anything you think is wrong.
+2. Did their findings make you notice something YOU missed in round 1?
+3. Go deeper on your area of expertise — what did you gloss over the first time?
+
+Provide NEW findings only (don't repeat your round 1). Use severity ratings.
+End with an updated verdict.
+```
+
+Send equivalent messages to reviewer-b (with A+C's findings) and reviewer-c (with A+B's findings).
+
+Wait for all 3 to complete. Collect round 2 findings.
+
+### Step 5: Round 3 — Adversarial Stress Test
+
+Use `SendMessage` again to continue each reviewer. Each gets ALL findings from rounds 1 and 2 from the other reviewers.
+
+Send to each reviewer:
+```
+## Round 3 of 3 — Adversarial Stress Test
+
+Here are ALL findings from the other reviewers across rounds 1 and 2:
+
+### Reviewer [X] — Round 1:
+<findings>
+### Reviewer [X] — Round 2:
+<findings>
+
+### Reviewer [Y] — Round 1:
+<findings>
+### Reviewer [Y] — Round 2:
+<findings>
+
+Final round. Try to BREAK the PR:
+1. What assumptions does this code make that might not hold?
+2. What are the boundary conditions nobody tested?
+3. Race conditions, concurrency issues, TOCTOU?
+4. What if dependencies are unavailable or behave differently?
+5. Can a malicious actor exploit any of these changes?
+6. Look at every finding marked [LOW] or [INFO] across all reviewers — should any be escalated?
+
+Provide NEW findings only. Use severity ratings.
+End with your FINAL verdict: APPROVE, REQUEST_CHANGES, or COMMENT.
+```
+
+Wait for all 3 to complete.
+
+### Step 6: Consolidate and Report
+
+Present a unified report to the user:
+
+```
+## 3-Pass Adversarial Review: PR #<number>
+
+### Reviewer Verdicts
+| Reviewer | Round 1 | Round 2 | Round 3 (Final) |
+|----------|---------|---------|-----------------|
+| A (code quality) | ... | ... | ... |
+| B (language) | ... | ... | ... |
+| C (security) | ... | ... | ... |
+
+### All Findings by Severity
+**CRITICAL:**
+- ...
+
+**HIGH:**
+- ...
+
+**MEDIUM:**
+- ...
+
+**LOW / INFO:**
+- ...
+
+### Consensus
+<what all 3 reviewers agreed on>
+
+### Disagreements
+<where reviewers challenged each other's findings>
+
+### Overall Recommendation
+<APPROVE / REQUEST_CHANGES / COMMENT based on majority + severity>
+
+### Summary
+<one paragraph: most important thing the author should address>
+```
+
+Offer to post the review as a comment on the PR.
+
+## Notes
+
+- The cross-pollination is what makes this powerful. Round 1 is independent (no anchoring). Round 2 forces each reviewer to engage with perspectives they didn't consider. Round 3 is adversarial — trying to break what survived two rounds.
+- Use `SendMessage` with the reviewer's `name` to continue them — this preserves their full context. Do NOT spawn new agents for rounds 2 and 3.
+- Each reviewer accumulates context across all 3 rounds, so by round 3 they have deep familiarity with the PR AND all other reviewers' findings.
+- For very large PRs (>1000 lines), consider splitting the diff into logical chunks and reviewing each chunk separately, or just spawning more reviewers per round.

--- a/skills/3-pass-review/SKILL.md
+++ b/skills/3-pass-review/SKILL.md
@@ -7,15 +7,19 @@ argument-hint: "<PR number or URL>"
 
 # 3-Pass Adversarial PR Review
 
-Three independent reviewers, three rounds. Each round, reviewers see the others' findings from the prior round — cross-pollination forces them to challenge each other, catch what others missed, and go deeper than any single reviewer would alone.
+Three independent reviewers, three rounds. In each subsequent round, a reviewer sees its own full prior trajectory but only **summaries** of the other reviewers' findings — this preserves each reviewer's depth while cross-pollinating awareness without anchoring or context bloat.
 
 ```
-Round 1: A, B, C review independently (blind to each other)
-              ↓ collect findings
-Round 2: A sees B+C's findings, B sees A+C's, C sees A+B's
-              ↓ collect findings  
-Round 3: Same cross-pollination with rounds 1+2 findings
-              ↓ collect findings
+Round 1: A1, B1, C1 review independently (blind)
+              ↓ parent writes a summary of each reviewer's findings
+Round 2: A2 sees A1 (full) + summaries of B1, C1
+         B2 sees B1 (full) + summaries of A1, C1
+         C2 sees C1 (full) + summaries of A1, B1
+              ↓ parent writes a summary of each reviewer's round 2 findings
+Round 3: A3 sees A1+A2 (full) + summaries of B1, B2, C1, C2
+         B3 sees B1+B2 (full) + summaries of A1, A2, C1, C2
+         C3 sees C1+C2 (full) + summaries of A1, A2, B1, B2
+              ↓ collect final findings
 Final:   Parent consolidates all 3 rounds into verdict
 ```
 
@@ -90,23 +94,27 @@ Do NOT modify any files. This is a read-only review.
 End with a one-line verdict: APPROVE, REQUEST_CHANGES, or COMMENT.
 ```
 
-Wait for all 3 to complete. Collect and label each reviewer's findings.
+Wait for all 3 to complete. Collect and label each reviewer's full output.
+
+**Summarization step (MANDATORY after Round 1):** For each reviewer's full output, write a concise summary (3-8 bullet points) capturing: the verdict, each finding with its severity and file:line reference, and the reviewer's key concern. These summaries are what get cross-pollinated to the OTHER reviewers. The full outputs are only sent back to the reviewer who wrote them.
 
 ### Step 4: Round 2 — Cross-Pollinated Deep Review
 
-Use `SendMessage` to **continue** each reviewer (preserving their full context). Each reviewer receives the OTHER two reviewers' round 1 findings.
+Use `SendMessage` to **continue** each reviewer (preserving their full context). Each reviewer receives:
+- Its OWN round 1 findings are already in its context (via SendMessage continuation)
+- The OTHER two reviewers' round 1 findings as **summaries only**
 
 Send to reviewer-a:
 ```
 ## Round 2 of 3 — Cross-Pollinated Deep Review
 
-Here are the findings from the other two reviewers in round 1. You have NOT seen these before.
+Here are condensed summaries of the other two reviewers' round 1 findings. You have NOT seen these before.
 
-### Reviewer B (language specialist) found:
-<paste reviewer B's round 1 findings>
+### Reviewer B (language specialist) — Round 1 summary:
+<paste reviewer B's round 1 SUMMARY>
 
-### Reviewer C (security) found:
-<paste reviewer C's round 1 findings>
+### Reviewer C (security) — Round 1 summary:
+<paste reviewer C's round 1 SUMMARY>
 
 Now review the PR again with this additional context:
 1. Do you agree or disagree with their findings? Challenge anything you think is wrong.
@@ -117,29 +125,31 @@ Provide NEW findings only (don't repeat your round 1). Use severity ratings.
 End with an updated verdict.
 ```
 
-Send equivalent messages to reviewer-b (with A+C's findings) and reviewer-c (with A+B's findings).
+Send equivalent messages to reviewer-b (with A+C summaries) and reviewer-c (with A+B summaries).
 
 Wait for all 3 to complete. Collect round 2 findings.
 
+**Summarization step (MANDATORY after Round 2):** Same as after Round 1 — write a concise summary for each reviewer's round 2 output.
+
 ### Step 5: Round 3 — Adversarial Stress Test
 
-Use `SendMessage` again to continue each reviewer. Each gets ALL findings from rounds 1 and 2 from the other reviewers.
+Use `SendMessage` again to continue each reviewer. Each reviewer's own full trajectory is already in its context. Each receives **summaries only** from all other reviewers' rounds 1 and 2.
 
 Send to each reviewer:
 ```
 ## Round 3 of 3 — Adversarial Stress Test
 
-Here are ALL findings from the other reviewers across rounds 1 and 2:
+Here are summaries of ALL findings from the other reviewers across rounds 1 and 2:
 
-### Reviewer [X] — Round 1:
-<findings>
-### Reviewer [X] — Round 2:
-<findings>
+### Reviewer [X] — Round 1 summary:
+<summary>
+### Reviewer [X] — Round 2 summary:
+<summary>
 
-### Reviewer [Y] — Round 1:
-<findings>
-### Reviewer [Y] — Round 2:
-<findings>
+### Reviewer [Y] — Round 1 summary:
+<summary>
+### Reviewer [Y] — Round 2 summary:
+<summary>
 
 Final round. Try to BREAK the PR:
 1. What assumptions does this code make that might not hold?

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1010,8 +1010,8 @@ class TestCmdCeoReview:
         task = mock_agent.call_args[0][1]
         assert "Mode: review" in task
         assert "PR #42" in task
-        assert "gh pr diff 42" in task
-        assert "gh pr view 42" in task
+        assert "3-pass adversarial review protocol" in task
+        assert "PR number: 42" in task
 
     def test_review_mode_headless_with_repo(self, tmp_path, capsys):
         """--mode review --pr 42 --repo owner/repo includes repo in task."""
@@ -1021,7 +1021,7 @@ class TestCmdCeoReview:
         assert result == 0
         task = mock_agent.call_args[0][1]
         assert "owner/repo" in task
-        assert "--repo owner/repo" in task
+        assert "Repo: owner/repo" in task
 
     def test_review_mode_skips_worktree(self, tmp_path):
         """Review mode does not create worktrees or touch experiment store."""


### PR DESCRIPTION
Closes #1

## Changes

- Added new `## Mode: PR Review (--mode review --pr <N>)` section to the CEO agent prompt
- Defines a 6-step protocol (PR1–PR6) for 3-pass adversarial PR review:
  - **PR1:** Read PR context (metadata + diff)
  - **PR2:** Detect language and select review lenses (code quality, language-specific, security)
  - **PR3:** Round 1 — independent blind review by 3 reviewers
  - **PR4:** Round 2 — cross-pollinated deep review (each reviewer sees others' round 1 findings)
  - **PR5:** Round 3 — adversarial stress test (each reviewer sees all prior findings)
  - **PR6:** Consolidate findings and post KEEP/REVERT verdict
- Inserted between the existing "Mode: Refine" section and "CEO Self-Learning Protocol" section
- No other parts of the file were modified