### PR TITLE
feat: replace wall-clock timeout with inactivity-based timeout (issue #525)

### DIFF
--- a/factory/runners/_stream.py
+++ b/factory/runners/_stream.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import re
 import sys
 import time
@@ -114,6 +115,7 @@ async def _watchdog(
     proc: asyncio.subprocess.Process,
     last_activity: list[float],
     inactivity_timeout: float,
+    killed_by_watchdog: list[bool] | None = None,
 ) -> None:
     """Kill the subprocess if no output is produced for ``inactivity_timeout`` seconds."""
     poll_interval = min(inactivity_timeout / 4, 30.0)
@@ -122,6 +124,8 @@ async def _watchdog(
         idle = time.monotonic() - last_activity[0]
         if idle >= inactivity_timeout and proc.returncode is None:
             log.warning("watchdog_killing_process", idle_seconds=round(idle, 1), threshold=inactivity_timeout)
+            if killed_by_watchdog is not None:
+                killed_by_watchdog[0] = True
             proc.kill()
             return
 
@@ -133,6 +137,7 @@ async def stream_subprocess(
     prefix: str | None = None,
     sanitize: bool = False,
     inactivity_timeout: float | None = None,
+    killed_by_watchdog: list[bool] | None = None,
 ) -> tuple[bytes, bytes]:
     """Stream subprocess stdout/stderr to the terminal while collecting output.
 
@@ -144,6 +149,9 @@ async def stream_subprocess(
             the terminal (both stdout and stderr). The returned buffers stay raw.
         inactivity_timeout: If set, kill the subprocess after this many seconds
             without any output on stdout or stderr.
+        killed_by_watchdog: Single-element mutable flag set by the watchdog when it
+            kills the process. Lets callers distinguish watchdog kills from external
+            SIGKILL (OOM killer, manual kill -9).
 
     Returns:
         (stdout_bytes, stderr_bytes) tuple with all collected output.
@@ -160,31 +168,38 @@ async def stream_subprocess(
     assert proc.stdout is not None
     assert proc.stderr is not None
 
-    coros = [
-        tee_stream(
-            proc.stdout,
-            sys.stdout.buffer,
-            stdout_buf,
-            stream=stream,
-            prefix=prefix_bytes,
-            sanitize=sanitize,
-            last_activity=last_activity,
-        ),
-        tee_stream(
-            proc.stderr,
-            sys.stderr.buffer,
-            stderr_buf,
-            stream=stream,
-            prefix=prefix_bytes,
-            sanitize=sanitize,
-            last_activity=last_activity,
-        ),
-    ]
+    tee_stdout = tee_stream(
+        proc.stdout,
+        sys.stdout.buffer,
+        stdout_buf,
+        stream=stream,
+        prefix=prefix_bytes,
+        sanitize=sanitize,
+        last_activity=last_activity,
+    )
+    tee_stderr = tee_stream(
+        proc.stderr,
+        sys.stderr.buffer,
+        stderr_buf,
+        stream=stream,
+        prefix=prefix_bytes,
+        sanitize=sanitize,
+        last_activity=last_activity,
+    )
 
+    watchdog_task: asyncio.Task[None] | None = None
     if inactivity_timeout is not None and last_activity is not None:
-        coros.append(_watchdog(proc, last_activity, inactivity_timeout))
+        watchdog_task = asyncio.create_task(
+            _watchdog(proc, last_activity, inactivity_timeout, killed_by_watchdog)
+        )
 
-    await asyncio.gather(*coros)
+    try:
+        await asyncio.gather(tee_stdout, tee_stderr)
+    finally:
+        if watchdog_task is not None:
+            watchdog_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await watchdog_task
 
     await proc.wait()
 

--- a/factory/runners/_stream.py
+++ b/factory/runners/_stream.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import asyncio
 import re
 import sys
+import time
 from typing import BinaryIO
+
+import structlog
+
+log = structlog.get_logger()
 
 # Robust multi-branch matcher for ANSI/VT escape sequences. Deliberately
 # preserves \r and \n (they are not ANSI escapes). Covers five classes:
@@ -69,6 +74,7 @@ async def tee_stream(
     stream: bool = True,
     prefix: bytes | None = None,
     sanitize: bool = False,
+    last_activity: list[float] | None = None,
 ) -> None:
     """Read from an async stream, optionally tee to a destination, and collect in buffer.
 
@@ -84,11 +90,15 @@ async def tee_stream(
             \\r/\\n) are skipped entirely, including the prefix, so redraw-only TUI
             frames do not flood the terminal with bare prefixes. Genuine blank
             lines (no escapes) are preserved.
+        last_activity: Single-element list holding a monotonic timestamp. Updated on
+            each successful readline() so the watchdog can detect inactivity.
     """
     while True:
         line = await src.readline()
         if not line:
             break
+        if last_activity is not None:
+            last_activity[0] = time.monotonic()
         buffer.append(line)  # ALWAYS raw — the captured buffer is never sanitized
         if stream:
             out = strip_ansi(line) if sanitize else line
@@ -100,12 +110,29 @@ async def tee_stream(
             dest.flush()
 
 
+async def _watchdog(
+    proc: asyncio.subprocess.Process,
+    last_activity: list[float],
+    inactivity_timeout: float,
+) -> None:
+    """Kill the subprocess if no output is produced for ``inactivity_timeout`` seconds."""
+    poll_interval = min(inactivity_timeout / 4, 30.0)
+    while proc.returncode is None:
+        await asyncio.sleep(poll_interval)
+        idle = time.monotonic() - last_activity[0]
+        if idle >= inactivity_timeout and proc.returncode is None:
+            log.warning("watchdog_killing_process", idle_seconds=round(idle, 1), threshold=inactivity_timeout)
+            proc.kill()
+            return
+
+
 async def stream_subprocess(
     proc: asyncio.subprocess.Process,
     *,
     stream: bool = True,
     prefix: str | None = None,
     sanitize: bool = False,
+    inactivity_timeout: float | None = None,
 ) -> tuple[bytes, bytes]:
     """Stream subprocess stdout/stderr to the terminal while collecting output.
 
@@ -115,6 +142,8 @@ async def stream_subprocess(
         prefix: Optional prefix for each line (e.g., "[bob:researcher]").
         sanitize: If True, strip ANSI/VT escape sequences from the bytes written to
             the terminal (both stdout and stderr). The returned buffers stay raw.
+        inactivity_timeout: If set, kill the subprocess after this many seconds
+            without any output on stdout or stderr.
 
     Returns:
         (stdout_bytes, stderr_bytes) tuple with all collected output.
@@ -124,10 +153,14 @@ async def stream_subprocess(
 
     prefix_bytes = f"{prefix} ".encode() if prefix else None
 
+    last_activity: list[float] | None = None
+    if inactivity_timeout is not None:
+        last_activity = [time.monotonic()]
+
     assert proc.stdout is not None
     assert proc.stderr is not None
 
-    await asyncio.gather(
+    coros = [
         tee_stream(
             proc.stdout,
             sys.stdout.buffer,
@@ -135,6 +168,7 @@ async def stream_subprocess(
             stream=stream,
             prefix=prefix_bytes,
             sanitize=sanitize,
+            last_activity=last_activity,
         ),
         tee_stream(
             proc.stderr,
@@ -143,8 +177,14 @@ async def stream_subprocess(
             stream=stream,
             prefix=prefix_bytes,
             sanitize=sanitize,
+            last_activity=last_activity,
         ),
-    )
+    ]
+
+    if inactivity_timeout is not None and last_activity is not None:
+        coros.append(_watchdog(proc, last_activity, inactivity_timeout))
+
+    await asyncio.gather(*coros)
 
     await proc.wait()
 

--- a/factory/runners/_stream.py
+++ b/factory/runners/_stream.py
@@ -124,9 +124,12 @@ async def _watchdog(
         idle = time.monotonic() - last_activity[0]
         if idle >= inactivity_timeout and proc.returncode is None:
             log.warning("watchdog_killing_process", idle_seconds=round(idle, 1), threshold=inactivity_timeout)
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                return
             if killed_by_watchdog is not None:
                 killed_by_watchdog[0] = True
-            proc.kill()
             return
 
 

--- a/factory/runners/_subprocess.py
+++ b/factory/runners/_subprocess.py
@@ -36,14 +36,29 @@ async def run_subprocess(
     runner_name: str,
     role: str,
     sanitize: bool = False,
+    max_timeout: float = 3600.0,
 ) -> AgentRunResult:
     """Run a subprocess with streaming, timeout, and error handling.
 
     This is the shared execution path for all runners, eliminating
     ~30 lines of duplicated subprocess code per runner.
+
+    Args:
+        timeout: Inactivity timeout — kills the subprocess if no output is
+            produced for this many seconds.
+        max_timeout: Hard wall-clock backstop via ``asyncio.wait_for``.
+            Catches pathological trickle-output that keeps the inactivity
+            watchdog alive indefinitely. Defaults to 3600s (1 hour).
     """
     stream = should_stream()
     prefix = f"[{runner_name}:{role}]" if stream else None
+
+    log.info(
+        f"{runner_name}_subprocess_start",
+        role=role,
+        inactivity_timeout=timeout,
+        max_timeout=max_timeout,
+    )
 
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -55,15 +70,25 @@ async def run_subprocess(
             env=env,
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            stream_subprocess(proc, stream=stream, prefix=prefix, sanitize=sanitize),
-            timeout=timeout,
+            stream_subprocess(
+                proc,
+                stream=stream,
+                prefix=prefix,
+                sanitize=sanitize,
+                inactivity_timeout=timeout,
+            ),
+            timeout=max_timeout,
         )
     except asyncio.TimeoutError:
         proc.kill()  # type: ignore[union-attr]
         await proc.wait()  # type: ignore[union-attr]
-        log.error(f"{runner_name}_timed_out", timeout=timeout)
+        log.error(
+            f"{runner_name}_max_timeout",
+            max_timeout=max_timeout,
+            inactivity_timeout=timeout,
+        )
         return AgentRunResult(
-            stdout=f"Agent timed out after {timeout}s",
+            stdout=f"Agent exceeded max wall-clock timeout ({max_timeout}s)",
             return_code=1,
         )
     except FileNotFoundError:
@@ -79,6 +104,18 @@ async def run_subprocess(
     return_code = proc.returncode or 0
 
     if return_code != 0:
+        # Distinguish inactivity kill (SIGKILL → -9) from other failures
+        if proc.returncode == -9:
+            log.warning(
+                f"{runner_name}_inactivity_timeout",
+                inactivity_timeout=timeout,
+                role=role,
+            )
+            return AgentRunResult(
+                stdout=f"Agent killed after {timeout}s of inactivity",
+                return_code=1,
+                metadata={"stderr": stderr},
+            )
         log.warning(f"{runner_name}_nonzero_exit", code=return_code, stderr=stderr[:200])
 
     return AgentRunResult(

--- a/factory/runners/_subprocess.py
+++ b/factory/runners/_subprocess.py
@@ -60,6 +60,8 @@ async def run_subprocess(
         max_timeout=max_timeout,
     )
 
+    killed_by_watchdog: list[bool] = [False]
+
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -76,6 +78,7 @@ async def run_subprocess(
                 prefix=prefix,
                 sanitize=sanitize,
                 inactivity_timeout=timeout,
+                killed_by_watchdog=killed_by_watchdog,
             ),
             timeout=max_timeout,
         )
@@ -104,8 +107,7 @@ async def run_subprocess(
     return_code = proc.returncode or 0
 
     if return_code != 0:
-        # Distinguish inactivity kill (SIGKILL → -9) from other failures
-        if proc.returncode == -9:
+        if killed_by_watchdog[0]:
             log.warning(
                 f"{runner_name}_inactivity_timeout",
                 inactivity_timeout=timeout,

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1,5 +1,6 @@
 """Tests for factory/runners/ — Runner protocol and implementations."""
 
+import asyncio
 import json
 import os
 from pathlib import Path
@@ -173,12 +174,12 @@ class TestBobRunner:
 
         (tmp_path / ".factory").mkdir()
 
-        # Mock run_subprocess to return a timeout result
+        # Mock run_subprocess to return an inactivity timeout result
         with patch(
             "factory.runners.bob.run_subprocess", new_callable=AsyncMock
         ) as mock_run:
             mock_run.return_value = AgentRunResult(
-                stdout="Agent timed out after 0.1s",
+                stdout="Agent killed after 0.1s of inactivity",
                 return_code=1,
             )
 
@@ -192,7 +193,7 @@ class TestBobRunner:
             ))
 
         assert result.return_code == 1
-        assert "timed out" in result.stdout.lower()
+        assert "inactivity" in result.stdout.lower()
         assert result.usage is None
         bob_module._auth_checked = False
 
@@ -1234,6 +1235,62 @@ class TestAnsiSanitization:
 
             mock_run.assert_called_once()
             assert mock_run.call_args.kwargs.get("sanitize", False) is False
+
+
+class TestInactivityTimeout:
+    """Tests for the inactivity-based timeout watchdog."""
+
+    async def test_inactivity_timeout_kills_silent_process(self) -> None:
+        """A subprocess that stops producing output is killed after the inactivity timeout."""
+        proc = await asyncio.create_subprocess_exec(
+            "python3", "-c",
+            "import time; print('hello', flush=True); time.sleep(60)",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        from factory.runners._stream import stream_subprocess
+
+        stdout, stderr = await stream_subprocess(
+            proc, stream=False, inactivity_timeout=0.5,
+        )
+
+        assert proc.returncode == -9
+        assert b"hello" in stdout
+
+    async def test_active_output_prevents_timeout(self) -> None:
+        """A subprocess that keeps producing output is NOT killed even past old wall-clock limit."""
+        proc = await asyncio.create_subprocess_exec(
+            "python3", "-c",
+            "import time\nfor i in range(6):\n    print(f'tick {i}', flush=True)\n    time.sleep(0.2)\n",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        from factory.runners._stream import stream_subprocess
+
+        stdout, stderr = await stream_subprocess(
+            proc, stream=False, inactivity_timeout=0.8,
+        )
+
+        assert proc.returncode == 0
+        assert b"tick 5" in stdout
+
+    async def test_max_timeout_backstop(self) -> None:
+        """Hard wall-clock max_timeout catches trickle-output that keeps the watchdog alive."""
+        from factory.runners._subprocess import run_subprocess
+
+        result = await run_subprocess(
+            ["python3", "-c",
+             "import time\nwhile True:\n    print('.', flush=True)\n    time.sleep(0.1)\n"],
+            cwd=".",
+            env=dict(os.environ),
+            timeout=999.0,
+            runner_name="test",
+            role="test",
+            max_timeout=1.0,
+        )
+
+        assert result.return_code == 1
+        assert "max wall-clock timeout" in result.stdout.lower()
 
 
 class TestCeilingAccumulationAcrossInvocations:


### PR DESCRIPTION
Closes #529

## Changes

- **`factory/runners/_stream.py`**: Added `last_activity` parameter to `tee_stream()` that updates a monotonic timestamp on each readline(). Added `_watchdog()` async task and `inactivity_timeout` parameter to `stream_subprocess()` — the watchdog polls activity and kills the process if idle too long.
- **`factory/runners/_subprocess.py`**: Repurposed `timeout` as inactivity timeout (passed to the watchdog via `stream_subprocess()`). Added `max_timeout=3600.0` as a hard wall-clock backstop via `asyncio.wait_for`. Updated error messages and structured logging to distinguish inactivity kills from max-wall-clock timeouts.
- **`tests/test_runners.py`**: Updated `test_headless_timeout` for new message format. Added 3 new tests:
  - `test_inactivity_timeout_kills_silent_process` — verifies silent subprocess is killed
  - `test_active_output_prevents_timeout` — verifies active output keeps process alive
  - `test_max_timeout_backstop` — verifies wall-clock limit catches trickle-output