### PR TITLE
fix: align Strategist ideation output with phased build-plan format

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -468,9 +468,9 @@ Raw idea: <RAW_IDEA>
 
 MANDATORY: Read ALL tagged research files FIRST (.factory/strategy/research-similar.md, research-techstack.md, research-pitfalls.md). Extract specific findings before writing any spec content.
 
-Every Core Feature MUST have at least 3 sentences covering What (user-visible behavior), How (implementation approach), and Why (research-grounded rationale). A bulleted list of one-liners is NOT a spec.
+Every Phase hypothesis MUST have a substantive What field (specific changes), Why field (research-grounded rationale), and Expected impact field. A one-line What field is NOT enough.
 
-Produce a complete idea.md specification." --project "$PROJECT_PATH" --timeout 300
+Produce a complete build plan. Phase 1 must be project scaffold + eval harness." --project "$PROJECT_PATH" --timeout 300
 ```
 
 **For existing projects** (`## Interactive Ideation Mode` with `existing_project: true`):
@@ -483,7 +483,7 @@ Project: $PROJECT_PATH
 
 MANDATORY: Read ALL tagged research files FIRST (.factory/strategy/research-health.md, research-practices.md, research-backlog.md). Extract specific findings before writing any spec content.
 
-Every Core Feature or Proposed Change MUST have at least 3 sentences covering What (user-visible behavior), How (implementation approach), and Why (research-grounded rationale). A bulleted list of one-liners is NOT a spec.
+Every Proposed Change MUST have a substantive What field (specific changes), Why field (research-grounded rationale), and Expected impact field. A one-line What field is NOT enough.
 
 This is an EXISTING project, not a new idea. Produce an improvement spec with these sections:
 
@@ -520,9 +520,9 @@ the Surface Scoping section.
 
 MANDATORY: Read ALL tagged research files FIRST (.factory/strategy/research-similar.md, research-techstack.md, research-pitfalls.md). Extract specific findings before writing any spec content.
 
-Every Core Feature MUST have at least 3 sentences covering What (user-visible behavior), How (implementation approach), and Why (research-grounded rationale). A bulleted list of one-liners is NOT a spec.
+Every Phase hypothesis MUST have a substantive What field (specific changes), Why field (research-grounded rationale), and Expected impact field. A one-line What field is NOT enough.
 
-Produce a complete idea.md specification with research configuration." --project "$PROJECT_PATH" --timeout 300
+Produce a complete build plan with research configuration. Phase 1 must be project scaffold + eval harness." --project "$PROJECT_PATH" --timeout 300
 ```
 
 ### I1r: CEO Review — Draft Spec
@@ -531,15 +531,19 @@ Read `.factory/reviews/strategist-latest.md` and assess the draft:
 - Does it capture the user's intent?
 - Are the technology choices well-justified by research?
 - Is the scope achievable?
-- Are features specific enough for a Builder agent?
+- Are phases specific enough for a Builder agent?
 
 **Quantitative depth checks (MANDATORY — REDIRECT if any fail):**
 
-1. **Depth check:** Read each Core Feature entry. Every feature MUST have 3+ sentences across its What/How/Why sub-fields. If any feature is a one-liner without the structured sub-fields, REDIRECT with: "Feature '<name>' is a one-liner — expand to What/How/Why with 3+ sentences total."
+1. **Depth check:** Read each Phase/Hypothesis entry. Every hypothesis MUST have Category, What, Why, and Expected impact fields. The What field must be specific enough to implement without clarification. A one-line What field is too vague — REDIRECT with: "Phase N hypothesis has a one-line What field — expand with specific changes (files, dependencies, entry points)."
 
-2. **Research grounding check:** Architecture decisions and feature rationale must reference specific findings from the tagged research files (`.factory/strategy/research-*.md`). If the spec contains no citations or rationale grounded in research, REDIRECT with: "No research grounding found — architecture decisions must cite findings from research files."
+2. **Research grounding check:** The Architecture section and hypothesis rationale must reference specific findings from the tagged research files (`.factory/strategy/research-*.md`). If the plan contains no citations or rationale grounded in research, REDIRECT with: "No research grounding found — Architecture section and hypothesis rationale must cite findings from research files."
 
-3. **Buildability check:** For each Core Feature, ask: could a Builder agent implement this feature from the spec alone, without asking clarifying questions? If any feature is too vague to implement (missing key details like data format, API shape, error handling approach), REDIRECT with: "Feature '<name>' is not buildable — a Builder would need to ask clarifying questions. Add implementation details."
+3. **Buildability check:** For each Phase/Hypothesis, ask: could a Builder agent implement this phase from the plan alone, without asking clarifying questions? If any phase is too vague to implement (missing key details like data format, API shape, error handling approach), REDIRECT with: "Phase N is not buildable — a Builder would need to ask clarifying questions. Add implementation details to the What field."
+
+4. **Phase 1 check:** Phase 1 must be 'Project scaffold + eval harness'. If Phase 1 is something else, REDIRECT with: "Phase 1 must always be project scaffold + eval harness — reorder phases."
+
+5. **Deferred section check:** If a Deferred section exists, verify it only contains items requiring human intervention (API keys, external accounts, manual provisioning). If it contains features or integrations that could be built without a human, REDIRECT with: "Deferred section contains buildable items — move them to build phases."
 
 Write your review to `.factory/reviews/ceo-verdict-strategist.md`.
 
@@ -638,7 +642,7 @@ When the user approves the spec:
    ```
 4. **Transition — route by project type:**
 
-   **For new ideas** (no `existing_project: true` flag): Transition to **Build mode**. The spec is now persisted. **Skip steps B0 (Research) and B1 (Strategist)** — the approved spec already contains research-grounded architecture decisions and a concrete feature plan. Jump directly to B2 (Builder) using the approved spec from `.factory/strategy/current.md` as the implementation brief.
+   **For new ideas** (no `existing_project: true` flag): Transition to **Build mode**. The spec is now persisted. **Skip steps B0 (Research) and B1 (Strategist build plan generation)** — the approved build plan already contains research-grounded architecture decisions and phased hypotheses. Proceed from B2 (Archivist records the approved plan) then B3 (Builder implements each phase) using the approved plan from `.factory/strategy/current.md`.
 
    **For existing projects** (`existing_project: true`): Transition to **Improve mode** with the approved spec as the focus:
    1. Persist the improvement spec to `.factory/strategy/current.md`

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -331,7 +331,7 @@ This phase activates when your task includes a `## Interactive Ideation Mode (Ph
 
 ### Purpose
 
-- **New ideas:** Transform a vague idea into a research-grounded, buildable project specification (idea.md) through iterative refinement with the user.
+- **New ideas:** Transform a vague idea into a research-grounded, buildable phased build plan through iterative refinement with the user.
 - **Existing projects:** Study the project and collaboratively decide what to improve next, producing an improvement spec through research and user feedback.
 
 ### I0: Research the Space (Researcher Agent)
@@ -628,7 +628,7 @@ Read the Strategist's output and return to **I1v** (re-validate the research con
 
 When the user approves the spec:
 
-1. **Persist the spec**: Write the final idea.md content to `.factory/strategy/current.md` (prepend `## Project Specification\n\n` before the content)
+1. **Persist the build plan**: Write the final build plan content to `.factory/strategy/current.md` (prepend `## Build Plan\n\n` before the content)
 2. **If this is research ideation** (task included `## Research Ideation Mode`):
    - The approved spec should contain a `## Research Configuration` section with Research Target, Mutable Surfaces, Fixed Surfaces, etc.
    - Verify it's present. If the Strategist omitted it, REDIRECT with: "This is a research project — the spec MUST include a Research Configuration section."

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -447,12 +447,12 @@ Before writing any spec content, you MUST ground your decisions in research:
 
 1. **Read `.factory/strategy/research.md`** and extract at least 3 specific findings (technology recommendations, architecture patterns, pitfalls, prior art). These findings must appear as citations in your spec — not as vague references but as concrete decisions grounded in evidence.
 
-2. **Write a minimum of 3 sentences per Core Feature** covering:
-   - **What:** The user-visible behavior — what the feature does from the user's perspective
-   - **How:** The implementation approach — libraries, data flow, key functions
-   - **Why:** The research-grounded rationale — why this approach over alternatives
+2. **Write a substantive hypothesis for each Phase** with:
+   - **What:** Specific changes — project layout, deps, entry points, or feature implementation (detailed enough to implement without clarification)
+   - **Why:** Research-grounded rationale — why this approach over alternatives
+   - **Expected impact:** Which eval dimensions improve and why
 
-3. **Self-check before outputting:** Review each Core Feature and verify it meets the 3-sentence minimum across What/How/Why. A feature description under 3 sentences is too thin. If you can't write 3+ sentences about a feature, it's either too vague (break it down) or too trivial (merge it into another feature).
+3. **Self-check before outputting:** Review each Phase hypothesis and verify it has a substantive What field (specific changes, not a one-liner), a Why field (research-grounded rationale), and an Expected impact field. If you can't write specific changes for a phase, it's either too vague (break it down) or too trivial (merge it into another phase).
 
 ### Refinement Mode
 
@@ -467,54 +467,70 @@ When your task includes a `## Prior Draft` and `## User Feedback` section, you a
 ### Ideation Constraints
 
 - Be specific and concrete — avoid weasel words like "flexible", "scalable", "robust" unless you define what you mean
-- Every feature must be implementable by an AI coding agent without human intervention (except items in Open Questions)
+- Every phase must be implementable by a Builder agent in one PR without human intervention (except items in Open Questions)
 - Prefer proven, well-documented technologies over cutting-edge ones
 - Architecture decisions must be grounded in the research findings — cite the reasoning
 - The spec must be complete enough to build from without further clarification (except Open Questions)
 - Do not include timelines or effort estimates — the factory uses AI agents
 - Do not include deployment or CI/CD setup — the factory handles that separately
-- If the user's idea is too broad for a single project, narrow it to an achievable MVP and note what was deferred in Non-Goals
+- If the user's idea is too broad, narrow to achievable phases and note what was deferred in the Deferred section
 - When your task explicitly states "This is a research project", the Research Configuration section is MANDATORY
 
 ### Ideation Output
 
-Write the idea.md content to stdout using this exact structure:
+Write the build plan content to stdout using this exact structure. Each phase = one Builder invocation = one PR. The CEO iterates over phases to create GitHub issues for the Builder, so the format must match the B1 build-plan structure:
 
 ```markdown
-# <Project Name>
+## Build Plan — <Project Name>
 
-## Vision
+### Vision
 <1-2 sentences: what this project does and why it matters>
 
-## Core Features
-<Bulleted list of concrete, buildable features. Each feature should be
-specific enough that a Builder agent can implement it in one PR.>
-
-- **<Feature Name>**
-  - **What:** <user-visible behavior — 1-2 sentences>
-  - **How:** <implementation approach — libraries, data flow, key functions — 1-2 sentences>
-  - **Why:** <rationale citing research or engineering tradeoffs — 1 sentence>
-- ...
-
-## Architecture
+### Architecture
 - **Language/Runtime**: <choice + one-line rationale>
 - **Framework**: <choice + one-line rationale>
 - **Data Storage**: <choice + one-line rationale, if applicable>
 - **Key Libraries**: <list with rationale>
 
-## User Interface
-<How users interact with this: CLI commands, API endpoints, web UI
-pages, etc. Be specific about the primary user flow.>
+### Phase 1: Project scaffold + eval harness
+#### H1: <title>
+- **Category:** EXPLORE
+- **Growth dimension:** capability_surface
+- **What:** <specific changes — project layout, deps, entry points, eval scaffolding>
+- **Why:** <rationale citing research>
+- **Expected impact:** <which eval dimensions improve>
+- **Priority:** high
 
-## Non-Goals (v1)
-<What this project explicitly does NOT do in the first version.
-Important for scoping.>
+### Phase 2: <feature title>
+#### H2: <title>
+- **Category:** EXPLORE
+- **Growth dimension:** capability_surface
+- **What:** <specific, scoped change — one PR's worth>
+- **Why:** <rationale citing research>
+- **Expected impact:** <which eval dimensions improve>
+- **Priority:** high
 
-## Open Questions
+... (one phase per feature, in dependency order)
+
+### Anti-patterns to Avoid
+- <potential pitfalls from research>
+
+### Open Questions
 <Anything that genuinely requires user input: API keys needed,
 deployment target, specific business logic choices. Keep this short —
 most decisions should be made by the Strategist based on research.>
+
+## Deferred
+- <items requiring human intervention — explain what's needed>
 ```
+
+**Key rules for ideation output:**
+- Phase 1 MUST always be 'Project scaffold + eval harness'
+- Each phase has exactly one hypothesis (HN) with Category, Growth dimension, What, Why, Expected impact, Priority
+- The Deferred section replaces Non-Goals — only list items requiring human intervention (API keys, external accounts, manual provisioning), NOT features that could be built
+- Do NOT include an Observations section (this is a new project — no prior state)
+- Do NOT include a Design Space table (no experiment history)
+- Do NOT include a New Backlog Items section (this IS the initial plan)
 
 ### Research Configuration (append when project is research/benchmarking)
 
@@ -574,4 +590,4 @@ When in refinement mode, append at the very end:
 - <what changed and why, one bullet per change>
 ```
 
-**Exit condition (Ideation):** Complete idea.md printed to stdout with all required sections populated. Every Core Feature is specific enough for a single PR. Architecture decisions cite research findings.
+**Exit condition (Ideation):** Complete build plan printed to stdout with Vision, Architecture, at least one Phase with a hypothesis, and Anti-patterns. Every phase is scoped to one PR. Architecture decisions cite research findings. Phase 1 is always project scaffold + eval harness.

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -423,7 +423,7 @@ When the CEO's task includes `loop_level: "outer"`, the research metric has plat
 
 ## Interactive / Ideation Mode
 
-When invoked during the factory's Interactive or Research Ideation mode (Phase 0), you switch from hypothesis generation to **specification authoring**. Instead of producing `current.md` with hypotheses, you produce a complete, buildable project specification (idea.md).
+When invoked during the factory's Interactive or Research Ideation mode (Phase 0), you switch from hypothesis generation to **build plan authoring**. Instead of producing `current.md` with hypotheses, you produce a complete, buildable phased build plan.
 
 ### Context (Ideation)
 
@@ -436,16 +436,16 @@ You are invoked after the Researcher has completed domain analysis. You have acc
 
 1. **Read the raw idea**: Understand the user's intent, even if underspecified
 2. **Read the research**: Study the Researcher's findings at `.factory/strategy/research.md` for domain context, prior art, technology recommendations, and pitfalls
-3. **Synthesize**: Combine the user's intent with research-grounded recommendations into a structured specification
+3. **Synthesize**: Combine the user's intent with research-grounded recommendations into a phased build plan
 4. **Be opinionated**: Make concrete technology and architecture decisions based on research. Do not list alternatives — pick the best one and justify it
 5. **Evaluate research mode**: Determine whether this project is a research/benchmarking project (iteratively improving a measurable metric against a dataset) and include the Research Configuration section if so
-6. **Write the spec**: Produce a complete idea.md in the format specified below
+6. **Write the build plan**: Produce a complete phased build plan in the format specified below
 
 ### Grounding Protocol (MANDATORY)
 
-Before writing any spec content, you MUST ground your decisions in research:
+Before writing any build plan content, you MUST ground your decisions in research:
 
-1. **Read `.factory/strategy/research.md`** and extract at least 3 specific findings (technology recommendations, architecture patterns, pitfalls, prior art). These findings must appear as citations in your spec — not as vague references but as concrete decisions grounded in evidence.
+1. **Read `.factory/strategy/research.md`** and extract at least 3 specific findings (technology recommendations, architecture patterns, pitfalls, prior art). These findings must appear as citations in your build plan — not as vague references but as concrete decisions grounded in evidence.
 
 2. **Write a substantive hypothesis for each Phase** with:
    - **What:** Specific changes — project layout, deps, entry points, or feature implementation (detailed enough to implement without clarification)
@@ -470,7 +470,7 @@ When your task includes a `## Prior Draft` and `## User Feedback` section, you a
 - Every phase must be implementable by a Builder agent in one PR without human intervention (except items in Open Questions)
 - Prefer proven, well-documented technologies over cutting-edge ones
 - Architecture decisions must be grounded in the research findings — cite the reasoning
-- The spec must be complete enough to build from without further clarification (except Open Questions)
+- The build plan must be complete enough to build from without further clarification (except Open Questions)
 - Do not include timelines or effort estimates — the factory uses AI agents
 - Do not include deployment or CI/CD setup — the factory handles that separately
 - If the user's idea is too broad, narrow to achievable phases and note what was deferred in the Deferred section


### PR DESCRIPTION
Closes #531

## Summary

The Distiller-to-Strategist merge (PR #523) copied the old Distiller's spec format verbatim into ideation mode. This produced a `Vision/Core Features/Architecture/Non-Goals` output that the CEO can't iterate over in B3 (it expects phased hypotheses for creating GitHub issues). This PR aligns the ideation output format with the B1 build-plan format.

## Changes

**strategist.md:**
- Replaced ideation output template: old spec format (`# Project / ## Vision / ## Core Features / ## Architecture / ## Non-Goals / ## Open Questions`) → phased build plan (`## Build Plan / ### Vision / ### Architecture / ### Phase N: ... / #### HN: ... / ### Anti-patterns / ### Open Questions / ## Deferred`)
- Updated Grounding Protocol: `Core Feature` references → `Phase/Hypothesis`; `What/How/Why` sub-fields → `What/Why/Expected impact`
- Updated Ideation Constraints: `Every feature must be implementable by an AI coding agent` → `Every phase must be implementable by a Builder agent in one PR`; `Non-Goals` → `Deferred section`
- Updated exit condition to require Vision, Architecture, at least one Phase with hypothesis, Anti-patterns, and Phase 1 = scaffold + eval harness

**ceo.md:**
- Updated I1r review checks: `Core Feature` → `Phase/Hypothesis`; added Phase 1 ordering check and Deferred section validation
- Fixed I4 transition: `Jump directly to B2 (Builder)` → `Proceed from B2 (Archivist records the approved plan) then B3 (Builder implements each phase)` (B2 is the Archivist, not the Builder)
- Updated Strategist task strings in I1 to reference phased format instead of Core Features

## Test plan

- [ ] Verify no Python source files were modified
- [ ] Verify `eval/score.py` and `.factory/` contents unchanged
- [ ] Verify Research Configuration section (lines 519-566) unchanged
- [ ] Verify Refinement Output section (lines 568-575) unchanged
- [ ] Run `factory ceo "test idea" --mode interactive` and confirm Strategist produces phased output
- [ ] Verify CEO I1r review correctly validates phases and Phase 1 ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)