### PR TITLE
Fix 6 CI test failures: review_tag mocks, prompt assertion updates

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -112,7 +112,7 @@ class TestInvokeAgentsParallel:
 
         call_count = 0
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, review_tag=None):
             nonlocal call_count
             call_count += 1
             return (f"output-{role}", 0)
@@ -132,7 +132,7 @@ class TestInvokeAgentsParallel:
         """invoke_agents_parallel returns results from all agents."""
         from factory.agents.runner import invoke_agents_parallel
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, review_tag=None):
             return (f"output-{role}", 0)
 
         monkeypatch.setattr("factory.agents.runner.invoke_agent", mock_invoke)
@@ -153,7 +153,7 @@ class TestInvokeAgentsParallel:
 
         captured_models: list[str | None] = []
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, review_tag=None):
             captured_models.append(model)
             return (f"output-{role}", 0)
 
@@ -450,15 +450,12 @@ class TestCeoPromptNoBackgroundSpawning:
     def test_no_background_ampersand_after_factory_agent(self):
         """CEO prompt must not show `factory agent ... &` pattern."""
         prompt = resolve_prompt("ceo")
-        # Look for patterns like: factory agent ... &
-        # We want to ensure no code block shows backgrounding via &
         import re
-        # Match lines that start factory agent and end with &
         pattern = r"factory\s+agent\s+[^`\n]+\s+&\s*$"
         matches = re.findall(pattern, prompt, re.MULTILINE)
-        # The only & should be in the "Forbidden pattern" example showing what NOT to do
-        # That example has a comment after it: "# Background spawn"
         for match in matches:
+            if "--review-tag" in match:
+                continue
             assert "WRONG" in prompt[prompt.find(match) - 50:prompt.find(match)], \
                 f"Found `factory agent ... &` without 'WRONG' context: {match}"
 

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -1100,7 +1100,8 @@ class TestCeoPromptResearchMode:
 
         r15_section = research_section[r15_idx:r2_idx]
         assert "failure_analysis.md" in r15_section
-        assert "research.md" in r15_section
+        assert "research-failures.md" in r15_section
+        assert "research-priorart.md" in r15_section
         assert "archivist after research" in r15_section
 
     def test_references_research_infrastructure(self, ceo_prompt: str) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -388,9 +388,8 @@ class TestStrategistIdeationMode:
         assert "## Interactive / Ideation Mode" in strategist_prompt
 
     def test_has_output_format(self, strategist_prompt: str) -> None:
-        assert "## Vision" in strategist_prompt
-        assert "## Core Features" in strategist_prompt
-        assert "## Architecture" in strategist_prompt
+        assert "### Vision" in strategist_prompt
+        assert "### Architecture" in strategist_prompt
 
     def test_has_refinement_mode(self, strategist_prompt: str) -> None:
         assert "### Refinement Mode" in strategist_prompt


### PR DESCRIPTION
Closes #540

## Changes

- **test_agents.py (TestInvokeAgentsParallel):** Added `review_tag=None` to 3 `mock_invoke` function signatures to match the updated `invoke_agent()` call site from PR #528
- **test_agents.py (TestCeoPromptNoBackgroundSpawning):** Whitelisted `factory agent ... &` lines containing `--review-tag` — these are legitimate parallel researcher spawns with `wait`; lines without `--review-tag` still require "WRONG" context
- **test_ceo_completion.py (TestCeoPromptResearchMode):** Replaced `assert "research.md" in r15_section` with assertions for `research-failures.md` and `research-priorart.md` to match the split research output files from PR #528
- **test_prompts.py (TestStrategistIdeationMode):** Removed `assert "## Core Features"` (heading removed in PR #534) and updated `## Vision` / `## Architecture` to `### Vision` / `### Architecture` to match the new heading levels