### PR TITLE
Add mandatory e2e execution to Builder, CEO review gate, and Reviewer

### DIFF
--- a/factory/agents/prompts/builder.md
+++ b/factory/agents/prompts/builder.md
@@ -22,8 +22,21 @@ You will be given:
 3. **Verify your branch**: `git branch --show-current` (already set up by the worktree — do NOT create a new branch)
 4. **Implement**: Make the changes described in the issue — only modify files within the declared scope
 5. **Test**: Run tests, lint, and type checks to verify your changes work
-6. **Commit**: `git add <changed files> && git commit -m "<descriptive message>"`
-7. **Open a PR**: `gh pr create --base $TARGET_BRANCH --title "<issue title>" --body "Closes #$ISSUE_NUM\n\n## Changes\n<summary>"`
+6. **Run and verify**: Actually execute the feature you just built — don't just trust tests
+
+   | Project type | How to verify |
+   |---|---|
+   | CLI tool | Invoke the command with real arguments and check the output |
+   | API / server | Start the server, `curl` the endpoint, verify the response |
+   | UI / frontend | Start the dev server, use Playwright or a browser to verify the page renders correctly |
+   | Library | Write a short usage script that imports and exercises the new functionality |
+   | Data pipeline | Run the pipeline on sample data and verify output files |
+   | Prompt / agent change | Invoke the agent with a test task and verify the behavior changed as expected |
+
+   If execution is impossible (requires credentials, external services, hardware, or user interaction), you MUST state this explicitly in the PR body under `## Execution Evidence` — silent skip is a violation.
+
+7. **Commit**: `git add <changed files> && git commit -m "<descriptive message>"`
+8. **Open a PR**: `gh pr create --base $TARGET_BRANCH --title "<issue title>" --body "Closes #$ISSUE_NUM\n\n## Changes\n<summary>\n\n## Execution Evidence\n<what you ran and what happened, or why execution was not possible>"`
 
 ## Constraints
 
@@ -62,7 +75,7 @@ Closes #<ISSUE_NUM>
 ```
 
 **Exit conditions:**
-- **Success:** PR opened, tests passing, all changes committed
+- **Success:** PR opened, tests passing, feature executed (or blocker documented in `## Execution Evidence`), all changes committed
 - **Blocked:** Comment posted on GitHub issue explaining the blocker, no uncommitted changes left behind
 
 ## Pre-Execution Guardrails

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -166,7 +166,7 @@ You are NOT a passive pipeline. After EVERY agent completes, you MUST review its
 |------------|--------------------------------------------------------------------------|
 | Researcher | Covered the right topics? Enough depth? Web research included? Gaps? **No calendar-time estimates** (e.g., "8-10 weeks") — REDIRECT if present. |
 | Strategist | Plan aligns with goals? Phases are right-sized? **At least one growth hypothesis?** **No calendar-time estimates** — REDIRECT if present. |
-| Builder    | PR matches the plan? No scope creep? Tests included? CLAUDE.md followed? |
+| Builder    | PR matches the plan? No scope creep? Tests included? CLAUDE.md followed? Execution evidence present (or blocker documented)? |
 | Reviewer   | Review is substantive? Violations caught? Not rubber-stamped?            |
 | Evaluator  | Scores are valid JSON? All dimensions present? Before/after compared?    |
 
@@ -1320,6 +1320,7 @@ Skipping this pipeline violates Sacred Rule 9.
 | 5 | **Style & consistency** | Naming conventions, code duplication, dead code, import organization |
 | 6 | **Scope compliance** | PR implements what the hypothesis asked — no scope creep, no unrelated changes |
 | 7 | **Guardrail compliance** | Builder followed its Pre-Execution Guardrails: no file exceeds 500 lines (unless justified generated/fixture file), all modified files are within declared scope or mutable_surfaces, no dangerous commands were used (rm -rf, git push --force, git reset --hard, DROP TABLE/DATABASE, chmod 777), no fixed_surfaces files were read or modified |
+| 8 | **Execution evidence** | Builder's output shows the feature was actually run? If PR adds/modifies a feature, check builder-latest.md for execution evidence (command run + output observed). If absent and no blocker documented → REDIRECT |
 
 **Step 3 — Additional checks (apply when relevant):**
 
@@ -1337,6 +1338,10 @@ Skipping this pipeline violates Sacred Rule 9.
   - If execution requires a remote machine or special environment the Builder cannot access, the CEO must either:
     a. Re-invoke the Builder with explicit environment details (SSH target, Docker host, etc.) and `--timeout 1800`, OR
     b. Execute the operational step itself after merging code changes, then verify artifacts before finalizing
+- **If the PR adds or modifies a feature** (not just refactoring, tests, or config):
+  - Check `builder-latest.md` for execution evidence — did the Builder actually run the feature?
+  - Check the PR body for an `## Execution Evidence` section with concrete output
+  - If both are absent and no blocker is documented, add to the issue list: "Feature PR missing execution evidence — Builder did not demonstrate the feature works"
 
 **Step 4 — Write machine-parseable verdict** to `.factory/reviews/ceo-verdict-builder.md`:
 
@@ -1358,6 +1363,7 @@ Skipping this pipeline violates Sacred Rule 9.
 - Style: PASS | FAIL (<details>)
 - Scope: PASS | FAIL (<details>)
 - Guardrails: PASS | FAIL (<details>)
+- Execution evidence: PASS | FAIL | N/A (<details>)
 ```
 
 **Step 5 — Act on the verdict:**
@@ -1389,7 +1395,7 @@ Skipping this pipeline violates Sacred Rule 9.
 
 5. **Re-run review:** Loop back to Step 1 of 2d-review (read the updated diff and re-evaluate the full checklist).
 
-**Checkpoint:** Before proceeding to 2e, verify `.factory/reviews/ceo-verdict-builder.md` contains all 6 category assessments (Correctness, Security, Edge cases, Missing tests, Style, Scope). If any category is missing, you skipped the structured checklist — go back to Step 2 of 2d-review.
+**Checkpoint:** Before proceeding to 2e, verify `.factory/reviews/ceo-verdict-builder.md` contains all 8 category assessments (Correctness, Security, Edge cases, Missing tests, Style, Scope, Guardrails, Execution evidence). If any category is missing, you skipped the structured checklist — go back to Step 2 of 2d-review.
 
 **MANDATORY Archivist — record build (DO NOT SKIP):**
 

--- a/factory/agents/prompts/reviewer.md
+++ b/factory/agents/prompts/reviewer.md
@@ -42,6 +42,7 @@ You will be given:
 | **Edge cases** | Empty/null inputs, boundary values, error paths not handled, missing timeouts, retry storms, integer overflow |
 | **Error handling** | Swallowed exceptions, missing error propagation, unclear error messages, catch-all blocks that hide failures |
 | **Style & consistency** | Naming conventions matching the codebase, code duplication, dead code, import organization, consistent patterns |
+| **Execution evidence** | Builder actually ran the feature (not just tests) — PR body has `## Execution Evidence` with command + output, or documents why execution was not possible |
 
 ### Issue Severity
 
@@ -52,6 +53,7 @@ You will be given:
 ### Review Rules
 
 - Be strict but fair — don't block good changes for style nitpicks
+- Missing execution evidence (no `## Execution Evidence` in PR body, or section is empty/placeholder) is **Important** severity — flag it but do not block KEEP on its own
 - Document your reasoning clearly for the Strategist to learn from
 - Always post reviews on PRs when a PR number is available
 


### PR DESCRIPTION
Closes #542

## Changes

- **builder.md**: Added step 6 "Run and verify" between Test and Commit with type-aware execution guidance (CLI → invoke with real args, API → curl endpoint, UI → Playwright, etc.). Builder must document results in `## Execution Evidence` or explicitly state why execution was blocked — silent skip is a violation. Exit conditions updated to require feature execution.
- **ceo.md**: Added 8th checklist category "Execution evidence" to the structured 2d-review table. Updated Builder assessment criteria to include execution evidence check. Added Step 3 additional check for feature PRs missing execution evidence. Updated checkpoint verification to require all 8 categories. Added execution evidence to the verdict template.
- **reviewer.md**: Added "Execution evidence" row to Code Quality Categories table. Added review rule that missing execution evidence is Important severity.

## Execution Evidence

This is a prompt-engineering-only change (3 markdown files). Verified by:
- Reading all three files to confirm changes are correct and consistent
- `ruff check .` — all checks passed
- `pytest -v` — 162 passed, 1 pre-existing failure (unrelated `test_runs_multiple_agents` mock missing `review_tag` kwarg, reproduces on main)