### PR TITLE
refactor: rename interactive mode to design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,13 +47,13 @@ Pure tools that don't make decisions. Entry point is `factory/cli.py` → `facto
 
 ### Layer 2: CEO Agent (`factory/agents/prompts/ceo.md`)
 
-A dedicated Claude Code agent that owns the full factory workflow. Spawned via `factory ceo /path` or `factory run /path`. The CEO detects project state, routes to modes (Build/Discover/Review/Improve/Research/Interactive/Meta), spawns specialist agents, makes keep/revert decisions, and ensures mandatory archival. SKILL.md is a thin launcher shim that spawns the CEO.
+A dedicated Claude Code agent that owns the full factory workflow. Spawned via `factory ceo /path` or `factory run /path`. The CEO detects project state, routes to modes (Build/Discover/Review/Improve/Research/Design/Meta), spawns specialist agents, makes keep/revert decisions, and ensures mandatory archival. SKILL.md is a thin launcher shim that spawns the CEO.
 
 ### Layer 3: Specialist Agents (`factory/agents/`)
 
 Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent <role>`. Agent prompts are resolved via `factory/agents/runner.py` with a two-tier lookup: project-specific override (`.factory/agents/<role>.md`) then factory default (`factory/agents/prompts/<role>.md`). Evolved playbooks from `~/.factory/playbooks/<role>.md` (user-local, ACE-generated) are auto-injected, falling back to factory defaults in `factory/agents/playbooks/<role>.md`.
 
-**Roles:** Researcher (observe), Strategist (hypothesize), Builder (implement), Reviewer (guard), Evaluator (measure), Archivist (record), Distiller (refine ideas), Refiner (scope refinements), CEO (orchestrate).
+**Roles:** Researcher (observe), Strategist (hypothesize and refine ideas), Builder (implement), Reviewer (guard), Evaluator (measure), Archivist (record), Refiner (scope refinements), CEO (orchestrate).
 
 ### Key data flow
 
@@ -173,9 +173,9 @@ factory ceo "Build a weather CLI"               # Raw idea → ~/factory-project
 factory ceo "Build a weather CLI" --dir my-app  # Explicit dir name override
 factory ceo ~/ideas/spec.md                     # Spec file → new project
 factory ceo https://github.com/user/repo        # Clone and improve
-factory ceo "distributed eval runner" --mode interactive  # Brainstorm → build
-factory ceo /path/to/project --mode interactive           # Discuss what to work on → improve
-factory ceo /path/to/project --mode interactive --focus "auth"  # Discuss a specific topic
+factory ceo "distributed eval runner" --mode design  # Brainstorm → build
+factory ceo /path/to/project --mode design           # Discuss what to work on → improve
+factory ceo /path/to/project --mode design --focus "auth"  # Discuss a specific topic
 factory ceo "SWE-bench solver" --mode research            # Research ideation → build
 
 # Improve — point at existing codebase
@@ -211,7 +211,7 @@ factory precheck /path --score-before 0.7 --score-after 0.85  # Hard precheck ga
 factory review --verdict KEEP --pr 42           # Post structured review on GitHub PR
 ```
 
-`factory run` / `factory ceo` spawn the CEO agent as a subprocess using the selected runner (`claude` by default, or `bob` with `--runner bob`). The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all agent roles. `--focus` activates targeted mode: builds exactly one item and exits. Accepts backlog names (`--focus "eval reliability"`), issue numbers (`--focus 42`), issue URLs, or `owner/repo#N` shorthand. Issue refs are auto-detected and fetched via `gh`/`glab` CLI. Works in improve and research modes; mutually exclusive with `--loop`. `--mode interactive` enters ideation mode. For new ideas (e.g. `factory ceo "distributed eval runner" --mode interactive`), the CEO researches the space via the Researcher, then iteratively refines the idea with the Distiller agent through user feedback, producing an idea.md spec before building. For existing projects (e.g. `factory ceo /path/to/project --mode interactive`), the CEO studies the project (backlog, eval scores, open issues, history), presents findings, and discusses what to work on before transitioning to Improve mode. `--focus` is allowed on existing projects to seed the discussion topic. Incompatible with `--headless`. `--mode research` enters research ideation for new projects (e.g. `factory ceo "SWE-bench solver" --mode research`) — the Distiller collects research config (target metric, mutable/fixed surfaces, constraints) before building. For existing projects with `research_target` configured, runs the research improvement loop directly. Incompatible with `--headless` (for new projects) and `--prompt`. `--refine "<request>"` enters refinement mode — routes a single change request through the Refiner → Builder → full review pipeline. Mutually exclusive with `--mode`, `--prompt`, and `--focus`. Requires an existing project directory. In foreground mode, the CEO also enters the refinement loop automatically after completing a build/improve cycle, staying active for follow-up requests without `--refine`.
+`factory run` / `factory ceo` spawn the CEO agent as a subprocess using the selected runner (`claude` by default, or `bob` with `--runner bob`). The CEO owns the full workflow: state detection, agent spawning, experiment lifecycle, and mandatory archival. The `--loop` flag adds a heartbeat wrapper with configurable interval and max cycles. `--mode meta` runs the full Improve loop on the factory itself, then ACE playbook evolution for all agent roles. `--focus` activates targeted mode: builds exactly one item and exits. Accepts backlog names (`--focus "eval reliability"`), issue numbers (`--focus 42`), issue URLs, or `owner/repo#N` shorthand. Issue refs are auto-detected and fetched via `gh`/`glab` CLI. Works in improve and research modes; mutually exclusive with `--loop`. `--mode design` enters ideation mode. For new ideas (e.g. `factory ceo "distributed eval runner" --mode design`), the CEO researches the space via the Researcher, then iteratively refines the idea with the Strategist through user feedback, producing a phased build plan before building. For existing projects (e.g. `factory ceo /path/to/project --mode design`), the CEO studies the project (backlog, eval scores, open issues, history), presents findings, and discusses what to work on before transitioning to Improve mode. `--mode interactive` is accepted as a backward-compatible alias for `--mode design`. `--focus` is allowed on existing projects to seed the discussion topic. Incompatible with `--headless`. `--mode research` enters research ideation for new projects (e.g. `factory ceo "SWE-bench solver" --mode research`) — the Strategist collects research config (target metric, mutable/fixed surfaces, constraints) before building. For existing projects with `research_target` configured, runs the research improvement loop directly. Incompatible with `--headless` (for new projects) and `--prompt`. `--refine "<request>"` enters refinement mode — routes a single change request through the Refiner → Builder → full review pipeline. Mutually exclusive with `--mode`, `--prompt`, and `--focus`. Requires an existing project directory. In foreground mode, the CEO also enters the refinement loop automatically after completing a build/improve cycle, staying active for follow-up requests without `--refine`.
 
 ## Observability
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The **welcome wizard** launches automatically — a conversational agent that as
 You can also skip the wizard and call commands directly:
 
 ```bash
-uv run factory ceo "Build a personal homepage with a blog" --mode interactive
+uv run factory ceo "Build a personal homepage with a blog" --mode design
 ```
 
 See the [full setup guide](docs/setup.md) for authentication and environment variables.
@@ -49,7 +49,7 @@ See the [full setup guide](docs/setup.md) for authentication and environment var
 
 | I want to… | Command |
 |---|---|
-| **Start from a raw idea** | `uv run factory ceo "my idea" --mode interactive` |
+| **Start from a raw idea** | `uv run factory ceo "my idea" --mode design` |
 | **Build from a spec or repo** | `uv run factory ceo spec.md` |
 | **Improve an existing project** | `uv run factory ceo /path/to/project` |
 | **Fix or add one thing** | `uv run factory ceo /path --focus "add dark mode"` |
@@ -59,32 +59,32 @@ See the [full setup guide](docs/setup.md) for authentication and environment var
 
 ---
 
-## Interactive Workflow
+## Design Workflow
 
-Use interactive mode when you want to brainstorm before building. Start a conversation with the CEO to refine an idea, then build:
+Use design mode when you want to brainstorm before building. Start a conversation with the CEO to refine an idea, then build:
 
 ```bash
 # From a raw idea — discuss and refine into a buildable spec
-uv run factory ceo "distributed task runner" --mode interactive
+uv run factory ceo "distributed task runner" --mode design
 
 # From a spec file — read and discuss before building
-uv run factory ceo ~/ideas/my-app-spec.md --mode interactive
+uv run factory ceo ~/ideas/my-app-spec.md --mode design
 ```
 
-Interactive mode also works on existing projects. The CEO studies the backlog, eval scores, open issues, and experiment history, then discusses what to work on before executing:
+Design mode also works on existing projects. The CEO studies the backlog, eval scores, open issues, and experiment history, then discusses what to work on before executing:
 
 ```bash
-uv run factory ceo ~/factory-projects/my-app --mode interactive
+uv run factory ceo ~/factory-projects/my-app --mode design
 
 # Seed the conversation with a topic
-uv run factory ceo ~/factory-projects/my-app --mode interactive --focus "auth layer"
+uv run factory ceo ~/factory-projects/my-app --mode design --focus "auth layer"
 ```
 
 ---
 
 ## Build Workflow
 
-When you already have a spec file, a GitHub repo, or a clear description, re:factory builds directly — no interactive step needed:
+When you already have a spec file, a GitHub repo, or a clear description, re:factory builds directly — no design step needed:
 
 ```bash
 uv run factory ceo ~/ideas/spec.md
@@ -92,7 +92,7 @@ uv run factory ceo https://github.com/user/repo
 uv run factory ceo "Build a personal homepage with a blog"
 ```
 
-The pipeline: **Researcher** surveys best practices → **Strategist** creates a plan → **Builder** implements and commits → **E2E gate** confirms it runs. Override the output directory with `--dir my-site`. (If you start with a raw idea via `--mode interactive`, the CEO refines it into a spec first, then transitions into this same build pipeline automatically.)
+The pipeline: **Researcher** surveys best practices → **Strategist** creates a plan → **Builder** implements and commits → **E2E gate** confirms it runs. Override the output directory with `--dir my-site`. (If you start with a raw idea via `--mode design`, the CEO refines it into a spec first, then transitions into this same build pipeline automatically. `--mode interactive` remains accepted as an alias.)
 
 After the first build, a backlog appears at `.factory/strategy/backlog.md` — deferred features that feed future improvement cycles. Manage it with `uv run factory backlog-list`, `uv run factory backlog-add`, and `uv run factory backlog-remove`.
 
@@ -275,7 +275,7 @@ re:factory improves itself. Every keep/revert decision becomes training data —
 | **HLS design space explorer** | Per-function AI agents + ILP solver for HLS optimization — 92% execution time reduction | Build |
 | **Pluck** | iOS app that extracts structured data from screenshots using on-device AI | Build + Improve |
 | **[SDG Hub](https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub)** | Agent-maintained open-source framework for synthetic data generation | Build + Improve |
-| **[OpenSkies Airline Corpus](https://github.com/lukeinglis/OpenSkiesAirline)** | 85-document fictional airline corpus for RAG/fine-tuning evaluation with cross-document consistency validation | Interactive + Improve |
+| **[OpenSkies Airline Corpus](https://github.com/lukeinglis/OpenSkiesAirline)** | 85-document fictional airline corpus for RAG/fine-tuning evaluation with cross-document consistency validation | Design + Improve |
 | **re:factory itself** | Runs on itself in meta mode — agent playbooks are evolved from its own experiment outcomes | Meta |
 
 Built something with re:factory? Open a PR to add it here.
@@ -287,7 +287,7 @@ Built something with re:factory? Open a PR to add it here.
 ```bash
 # Core workflow
 uv run factory ceo <path|url|idea>              # Build or improve
-uv run factory ceo <path> --mode interactive    # Discuss, then execute
+uv run factory ceo <path> --mode design         # Discuss, then execute
 uv run factory ceo <path> --focus "..."         # One target, one experiment
 uv run factory ceo <path> --refine "..."        # Single targeted refinement
 uv run factory ceo <path> --loop                # Continuous loop (research projects)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ Nine specialist Claude Code subprocesses, each with a narrow responsibility:
 | **Reviewer** | Guard rules + structured code review | `factory agent reviewer --task "..."` |
 | **Evaluator** | Run evals, compare before/after scores | `factory agent evaluator --task "..."` |
 | **Archivist** | Write learnings to `.factory/archive/`, update performance reports | `factory agent archivist --task "..."` |
-| **Distiller** | Synthesize research + raw idea into a buildable project spec | `factory agent distiller --task "..."` |
+| **Strategist (Design mode)** | Synthesize research + raw idea into a buildable project plan during ideation | `factory agent strategist --task "..."` |
 | **Refiner** | Classify and scope post-cycle refinement requests (T1/T2/T3 tiers) | `factory agent refiner --task "..."` |
 | **Failure Analyst** | Classify run failures by root cause (research mode only) | `factory agent failure_analyst --task "..."` |
 
@@ -61,7 +61,7 @@ The CEO detects project state and routes to the appropriate mode:
 | Flag | Mode | What it does |
 |------|------|-------------|
 | `--focus "item"` | **Targeted** | Pins one backlog item, one hypothesis, one experiment, then exits |
-| `--mode interactive` | **Interactive** | Research → Distiller spec → user feedback loop → build |
+| `--mode design` | **Design** | Research → Strategist plan → user feedback loop → build |
 | `--mode research` | **Research** | Failure analysis → targeted research → hypothesis → build → metric evaluation with leakage guards and monotonic improvement |
 | `--mode meta` | **Meta** | Full Improve loop on re:factory itself, then ACE playbook evolution |
 | `--refine "request"` | **Refine** | Refiner scopes → Builder implements → full review pipeline → keep/revert |
@@ -70,7 +70,7 @@ State detection logic lives in `factory/state.py`.
 
 ![State Machine](diagrams/state-machine.svg)
 
-> **Note:** Explicit flags (`--mode interactive`, `--mode research`, `--mode meta`, `--focus`) override auto-detection. All modes return to `has_factory` on completion.
+> **Note:** Explicit flags (`--mode design`, `--mode research`, `--mode meta`, `--focus`) override auto-detection. `--mode interactive` remains accepted as a backward-compatible alias. All modes return to `has_factory` on completion.
 
 ## Data Flow
 
@@ -82,13 +82,13 @@ factory/discovery/profile.py      → Build EvalProfile with dimensions and weig
 factory/discovery/generate.py     → Generate eval/score.py script
 ```
 
-### Ideation Pipeline (Interactive Mode)
+### Ideation Pipeline (Design Mode)
 
 ```
 1. Researcher surveys   → .factory/strategy/research.md (domain landscape)
-2. Distiller synthesizes → idea.md spec (features, architecture, non-goals)
+2. Strategist synthesizes → phased build plan (features, architecture, phased execution)
 3. CEO presents draft    → user reviews, gives feedback
-4. Iterate (2-3)         → Distiller revises, optional follow-up research
+4. Iterate (2-3)         → Strategist revises, optional follow-up research
 5. User approves         → spec persisted to .factory/strategy/current.md
 6. Transition            → proceed to Build mode
 ```

--- a/docs/diagrams/architecture.d2
+++ b/docs/diagrams/architecture.d2
@@ -122,8 +122,8 @@ agents: {
     label: "Archivist\nRecord"
     style: { fill: "#A5D6A7"; stroke: "#2E7D32"; font-color: "#0D1B2A"; font-size: 13; border-radius: 6 }
   }
-  distiller: {
-    label: "Distiller\nRefine"
+  refiner: {
+    label: "Refiner\nScope"
     style: { fill: "#A5D6A7"; stroke: "#2E7D32"; font-color: "#0D1B2A"; font-size: 13; border-radius: 6 }
   }
   failure_analyst: {

--- a/docs/diagrams/state-machine.d2
+++ b/docs/diagrams/state-machine.d2
@@ -70,8 +70,8 @@ modes: {
     label: Research
     style: { fill: "#80CBC4"; stroke: "#00695C"; font-color: "#0D1B2A"; font-size: 13; bold: true; border-radius: 6 }
   }
-  interactive: {
-    label: Interactive
+  design: {
+    label: Design
     style: { fill: "#B39DDB"; stroke: "#4527A0"; font-color: "#0D1B2A"; font-size: 13; bold: true; border-radius: 6 }
   }
   meta: {
@@ -106,7 +106,7 @@ states.has_factory -> modes.improve {
 note: {
   label: |md
     Explicit flags override auto-detection:
-    `--mode interactive` · `--mode research` · `--mode meta` · `--focus "item"`
+    `--mode design` · `--mode research` · `--mode meta` · `--focus "item"`
     All modes return to **has_factory** on completion.
   |
   shape: text

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,18 +56,18 @@ factory ceo ~/ideas/weather-dashboard.md      # longer spec as markdown
 factory ceo https://github.com/user/repo      # clone and improve
 ```
 
-### Interactive — you have a rough idea
+### Design — you have a rough idea
 
 When you want to brainstorm before committing to a design:
 
 ```bash
-factory ceo "distributed eval runner" --mode interactive
+factory ceo "distributed eval runner" --mode design
 ```
 
-Interactive mode runs a three-step loop before any code is written:
+Design mode runs a three-step loop before any code is written:
 
 1. **Research** — the Researcher surveys similar projects, tech stacks, and pitfalls
-2. **Distill** — the Distiller synthesizes the research into a structured spec (features, architecture, non-goals)
+2. **Distill** — the Strategist synthesizes the research into a structured plan (features, architecture, phased build steps)
 3. **Iterate** — the CEO presents the draft to you for feedback. Revise until you approve.
 
 Once you sign off, the spec is persisted and re:factory proceeds to Build mode. Incompatible with `--headless` and `--focus`.
@@ -80,7 +80,7 @@ For projects where the goal is to improve a measurable metric against a dataset 
 factory ceo "SWE-bench solver agent" --mode research
 ```
 
-Research ideation works like interactive mode but the Distiller collects additional configuration:
+Research ideation works like design mode but the Strategist collects additional configuration:
 
 - **Research Target** — the metric to improve, the command to run evaluation, where results are written
 - **Mutable Surfaces** — files the Builder is allowed to modify

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,8 @@ You give it a spec file, a rough idea, or an existing codebase. re:factory resea
 # Build — have a fleshed-out idea? Pass the file.
 factory ceo ~/ideas/weather-dashboard.md
 
-# Interactive — just starting to think about it? Brainstorm first.
-factory ceo "distributed eval runner" --mode interactive
+# Design — just starting to think about it? Brainstorm first.
+factory ceo "distributed eval runner" --mode design
 
 # Research — have a metric to optimize? re:factory runs experiments.
 factory ceo "SWE-bench solver agent" --mode research
@@ -50,7 +50,7 @@ graph LR
     style G fill:#e53935,color:#fff,stroke:#c62828
 ```
 
-A CEO agent orchestrates eight specialists — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Distiller, and Failure Analyst — each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. The Researcher searches the web and reads prior knowledge from the archive. The Strategist generates ranked hypotheses. The Builder implements one on an experiment branch. The Evaluator scores before and after. The CEO decides keep or revert. The Archivist records everything to `.factory/archive/` and regenerates performance reports for cross-project learning. In interactive mode, the Distiller synthesizes research into a buildable spec through user feedback. In research mode, the Failure Analyst classifies run failures to guide targeted hypothesis generation.
+A CEO agent orchestrates eight specialists — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst — each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. The Researcher searches the web and reads prior knowledge from the archive. The Strategist generates ranked hypotheses and also handles design-mode ideation. The Builder implements one on an experiment branch. The Evaluator scores before and after. The CEO decides keep or revert. The Archivist records everything to `.factory/archive/` and regenerates performance reports for cross-project learning. In design mode, the Strategist synthesizes research into a buildable plan through user feedback. In research mode, the Failure Analyst classifies run failures to guide targeted hypothesis generation.
 
 ## Workflows
 
@@ -81,13 +81,13 @@ factory ceo ~/my-project --focus "add authentication middleware"
 
 When you know exactly what you want, `--focus` pins a single backlog item, generates one hypothesis, runs one experiment, and exits. The entire pipeline is scoped to that single target.
 
-### Interactive — brainstorm before building
+### Design — brainstorm before building
 
 ```bash
-factory ceo "distributed eval runner" --mode interactive
+factory ceo "distributed eval runner" --mode design
 ```
 
-Have a rough idea? Interactive mode researches the space, drafts a structured spec via the Distiller agent, and lets you iterate on it before any code is written.
+Have a rough idea? Design mode researches the space, drafts a structured plan via the Strategist, and lets you iterate on it before any code is written.
 
 ### Research — optimize a metric iteratively
 
@@ -163,7 +163,7 @@ graph TB
     subgraph agents ["Specialist Agents"]
         R["Researcher"] ~~~ S["Strategist"] ~~~ BU["Builder"]
         RE["Reviewer"] ~~~ EV["Evaluator"] ~~~ AR["Archivist"]
-        DI["Distiller"] ~~~ FA["Failure Analyst"]
+        RF["Refiner"] ~~~ FA["Failure Analyst"]
     end
     subgraph ceo ["CEO Agent"]
         C["Detect state → Route mode → Spawn agents → Keep/Revert → Archive"]

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -20,7 +20,7 @@ You evolve the factory itself through ACE self-improvement cycles, refining the 
 
 Your decisions are grounded in metrics, eval scores, and agent reports. You weigh composite scores, compare before/after evaluations, and apply the FEEC priority heuristic (Fix > Exploit > Explore > Combine) to select the highest-impact hypotheses. You balance hygiene dimensions (tests, lint, type safety) against growth dimensions (capability surface, observability, research grounding). You are systematic, data-driven, and outcome-focused.
 
-You communicate directly with the user when running in interactive mode. You explain what you're doing, present findings clearly, and ask for input when decisions require human judgment (credentials, scope choices, ambiguous requirements). You are transparent about tradeoffs and honest about failures.
+You communicate directly with the user when running in foreground mode. You explain what you're doing, present findings clearly, and ask for input when decisions require human judgment (credentials, scope choices, ambiguous requirements). You are transparent about tradeoffs and honest about failures.
 
 **Permitted Actions (exhaustive):**
 - `factory agent <role>` — spawn specialist agents
@@ -271,7 +271,7 @@ At the start of every cycle, create a task list using `TaskCreate` **before spaw
 | 1 | Test eval dimensions | Testing eval dimensions |
 | 2 | Initialize factory config | Initializing factory |
 
-**Interactive mode (Phase 0):**
+**Design mode (Phase 0):**
 
 | # | Subject | activeForm |
 |---|---------|------------|
@@ -319,13 +319,13 @@ factory detect "$PROJECT_PATH"
 - `evals_pending_review` → **Review mode**
 - `has_factory` → **Improve mode** (or **Research mode** if `research_target` is configured and `--mode research` is set)
 
-**Exception:** If your task includes `## Interactive Ideation Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)`, enter Phase 0 first regardless of project state. After Phase 0 completes, proceed to Build mode (for new ideas) or Improve mode (for existing projects).
+**Exception:** If your task includes `## Design Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)`, enter Phase 0 first regardless of project state. After Phase 0 completes, proceed to Build mode (for new ideas) or Improve mode (for existing projects).
 
 ---
 
-## Phase 0: Ideation (Interactive Mode)
+## Phase 0: Ideation (Design Mode)
 
-This phase activates when your task includes a `## Interactive Ideation Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)` section. You are running in foreground interactive mode — the user can see your output and respond. This phase handles both **new ideas** and **existing projects**.
+This phase activates when your task includes a `## Design Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)` section. You are running in foreground mode — the user can see your output and respond. This phase handles both **new ideas** and **existing projects**.
 
 **Research ideation** works identically to regular ideation, except the Strategist MUST produce a Research Configuration section in its output. See the I1 step below for how to instruct the Strategist.
 
@@ -459,7 +459,7 @@ Apply the standard CEO Review Gate:
 
 Spawn the Strategist in ideation mode to synthesize the research into a structured spec.
 
-**For regular ideation on new ideas** (`## Interactive Ideation Mode` without `existing_project: true`):
+**For regular ideation on new ideas** (`## Design Mode` without `existing_project: true`):
 
 ```bash
 factory agent strategist --task "Distill a project specification from research and a raw idea.
@@ -473,7 +473,7 @@ Every Phase hypothesis MUST have a substantive What field (specific changes), Wh
 Produce a complete build plan. Phase 1 must be project scaffold + eval harness." --project "$PROJECT_PATH" --timeout 300
 ```
 
-**For existing projects** (`## Interactive Ideation Mode` with `existing_project: true`):
+**For existing projects** (`## Design Mode` with `existing_project: true`):
 
 ```bash
 factory agent strategist --task "Distill an improvement specification for an existing project.

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -421,9 +421,9 @@ When the CEO's task includes `loop_level: "outer"`, the research metric has plat
 
 ---
 
-## Interactive / Ideation Mode
+## Design / Ideation Mode
 
-When invoked during the factory's Interactive or Research Ideation mode (Phase 0), you switch from hypothesis generation to **build plan authoring**. Instead of producing `current.md` with hypotheses, you produce a complete, buildable phased build plan.
+When invoked during the factory's Design or Research Ideation mode (Phase 0), you switch from hypothesis generation to **build plan authoring**. Instead of producing `current.md` with hypotheses, you produce a complete, buildable phased build plan.
 
 ### Context (Ideation)
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -164,18 +164,18 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
     if _safe_is_dir(expanded):
         factory_dir = expanded / ".factory"
         label_improve = "Improve this project"
-        label_interactive = "Discuss what to work on first"
-        cmd_interactive = f'factory ceo {shlex.quote(stripped)} --mode interactive'
+        label_design = "Discuss what to work on first"
+        cmd_design = f'factory ceo {shlex.quote(stripped)} --mode design'
         if _safe_is_dir(factory_dir):
             cmd_improve = f'factory ceo {shlex.quote(stripped)} --mode improve'
             return [
                 {"label": label_improve, "explanation": "Run the improve loop on this project.", "command": cmd_improve},
-                {"label": label_interactive, "explanation": "Study the project and discuss priorities.", "command": cmd_interactive},
+                {"label": label_design, "explanation": "Study the project and discuss priorities.", "command": cmd_design},
             ]
         cmd_improve = f'factory ceo {shlex.quote(stripped)}'
         return [
             {"label": "Set up and improve this project", "explanation": "Initialize factory and start improving.", "command": cmd_improve},
-            {"label": label_interactive, "explanation": "Study the project and discuss priorities.", "command": cmd_interactive},
+            {"label": label_design, "explanation": "Study the project and discuss priorities.", "command": cmd_design},
         ]
 
     if _safe_is_file(expanded):
@@ -188,7 +188,7 @@ def _quick_classify(user_input: str) -> list[dict[str, str]] | None:
     if _is_github_url(stripped):
         return [
             {"label": "Clone and improve", "explanation": "Clone the repository and run the improve loop.", "command": f'factory ceo {shlex.quote(stripped)} --mode improve --clean-pr'},
-            {"label": "Clone and discuss", "explanation": "Clone and discuss what to work on.", "command": f'factory ceo {shlex.quote(stripped)} --mode interactive --clean-pr'},
+            {"label": "Clone and discuss", "explanation": "Clone and discuss what to work on.", "command": f'factory ceo {shlex.quote(stripped)} --mode design --clean-pr'},
         ]
 
     return None
@@ -204,13 +204,13 @@ Given the user's input, return a JSON object with two keys: "follow_ups" and "su
 
 | Command | When to use |
 |---|---|
-| `factory ceo "<idea>" --mode interactive` | Brainstorm and refine before building (vague ideas) |
+| `factory ceo "<idea>" --mode design` | Brainstorm and refine before building (vague ideas) |
 | `factory ceo "<idea>"` | Build directly (clear, specific descriptions) |
 | `factory ceo "<idea>" --mode research` | Research-driven optimization (metric-focused projects) |
 | `factory ceo {path} --mode improve` | Improve an existing project at a known path |
 | `factory ceo {path} --mode improve --focus "{issue}"` | Fix or add one specific thing in an existing project |
 | `factory ceo {path} --mode improve --focus {issue}` | Target a specific GitHub issue number |
-| `factory ceo {path} --mode interactive` | Discuss what to work on in an existing project |
+| `factory ceo {path} --mode design` | Discuss what to work on in an existing project |
 | `factory ceo {path} --mode meta` | Self-improve the factory's own agents |
 
 ## Information requirements per mode
@@ -260,8 +260,8 @@ Return ONLY a JSON object (no markdown, no explanation):
     },
     {
       "label": "Discuss first",
-      "explanation": "Interactive mode to explore what needs fixing",
-      "command": "factory ceo {path} --mode interactive"
+      "explanation": "Design mode to explore what needs fixing",
+      "command": "factory ceo {path} --mode design"
     }
   ]
 }
@@ -286,7 +286,7 @@ Return ONLY a JSON object (no markdown, no explanation):
 6. For new ideas, commands should use the literal user text in quotes — no placeholders
 7. For existing projects, use {path} placeholder and add a path follow-up
 8. If the user mentions fixing/improving an EXISTING project, do NOT wrap input as a new idea
-9. Every generated command MUST include an explicit `--mode` flag (improve, interactive, research, meta, or build)
+9. Every generated command MUST include an explicit `--mode` flag (improve, design, research, meta, or build)
 10. When the input is a GitHub URL (clone scenario), always append `--clean-pr` to the generated command
 
 User input: """
@@ -399,14 +399,14 @@ def _classify_with_llm(
 
 _CLI_REF = """\
   Build something new:
-    factory ceo "a fasta CLI that converts protein sequences to embeddings using ESM2" --mode interactive
-    factory ceo "an autograd engine in pure numpy with a pytorch-like API" --mode interactive
+    factory ceo "a fasta CLI that converts protein sequences to embeddings using ESM2" --mode design
+    factory ceo "an autograd engine in pure numpy with a pytorch-like API" --mode design
     factory ceo "a system that solves IMO geometry problems using lean4 proofs" --mode research
 
   Work on an existing project:
     factory ceo ~/projects/my-app --mode improve --focus "add OAuth2 login with Google and GitHub providers"
     factory ceo ~/projects/my-app --mode improve --focus 42
-    factory ceo ~/projects/my-app --mode interactive
+    factory ceo ~/projects/my-app --mode design
 
   Self-improve the factory:
     factory ceo /path/to/factory --mode meta\
@@ -2295,7 +2295,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     Default: interactive foreground session (user can see and interact).
     With --headless: pipe mode via claude -p (for scripting, cron, etc.).
-    With --mode interactive: brainstorm an idea via research + Strategist before building.
+    With --mode design: brainstorm an idea via research + Strategist before building.
     """
     from factory.agents.runner import resolve_prompt
     from factory.runners import get_runner
@@ -2306,6 +2306,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     raw_path = getattr(args, "path", None)
     mode = getattr(args, "mode", "auto")
+    if mode == "interactive":
+        mode = "design"
     headless = getattr(args, "headless", False)
     prompt_file = getattr(args, "prompt", None)
     focus = getattr(args, "focus", None)
@@ -2395,26 +2397,26 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         print(result)
         return code
 
-    _interactive_is_existing = (
-        mode == "interactive"
+    _design_is_existing = (
+        mode == "design"
         and raw_path
         and _safe_is_dir(Path(raw_path).expanduser().resolve())
     )
 
-    if mode == "interactive":
+    if mode == "design":
         if headless:
-            print("Error: --mode interactive requires foreground mode "
+            print("Error: --mode design requires foreground mode "
                   "(incompatible with --headless)", file=sys.stderr)
             return 1
         if prompt_file:
-            print("Error: --mode interactive and --prompt are mutually exclusive. "
-                  "Interactive mode generates the spec; --prompt provides one.",
+            print("Error: --mode design and --prompt are mutually exclusive. "
+                  "Design mode generates the spec; --prompt provides one.",
                   file=sys.stderr)
             return 1
-        if focus and not _interactive_is_existing:
-            print("Error: --mode interactive and --focus are mutually exclusive "
+        if focus and not _design_is_existing:
+            print("Error: --mode design and --focus are mutually exclusive "
                   "for new ideas. To discuss a topic on an existing project, "
-                  "pass the project path: factory ceo /path --mode interactive --focus \"topic\"",
+                  "pass the project path: factory ceo /path --mode design --focus \"topic\"",
                   file=sys.stderr)
             return 1
 
@@ -2425,26 +2427,26 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                   file=sys.stderr)
             return 1
 
-    interactive_idea: str | None = None
-    interactive_existing: bool = False
+    design_idea: str | None = None
+    design_existing: bool = False
     research_ideation: str | None = None
     deferred_spec: str | None = None
     needs_materialize = False
-    if mode == "interactive" and _interactive_is_existing:
+    if mode == "design" and _design_is_existing:
         project_path, context = _resolve_input(raw_path, dir_name=dir_name)
-        interactive_existing = True
-    elif mode == "interactive":
+        design_existing = True
+    elif mode == "design":
         resolved_file = Path(raw_path).expanduser()
         if resolved_file.is_file():
-            interactive_idea = resolved_file.read_text()
+            design_idea = resolved_file.read_text()
             slug = _slugify(dir_name) if dir_name else _slugify(resolved_file.stem.split("—")[0].strip())
-            project_path = _dedupe_project_path(_get_projects_dir() / slug, interactive_idea)
-            deferred_spec = interactive_idea
+            project_path = _dedupe_project_path(_get_projects_dir() / slug, design_idea)
+            deferred_spec = design_idea
             needs_materialize = True
             print(f"Idea file: {resolved_file.name}")
             print(f"Project directory: {project_path}")
         else:
-            interactive_idea = raw_path
+            design_idea = raw_path
             slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
             project_path = _dedupe_project_path(_get_projects_dir() / slug, raw_path)
             deferred_spec = raw_path
@@ -2511,14 +2513,14 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         print("Error: --focus (targeted mode) and --prompt are mutually exclusive. "
               "--focus builds one backlog item; --prompt executes a spec file.", file=sys.stderr)
         return 1
-    if focus and mode not in ("improve", "research") and not interactive_existing:
+    if focus and mode not in ("improve", "research") and not design_existing:
         print(f"Error: --focus (targeted mode) only works in improve or research mode, got '{mode}'. "
               "The project must already be built before targeting specific items.", file=sys.stderr)
         return 1
 
-    if interactive_existing:
-        banner_mode = "interactive"
-    elif mode in ("interactive", "research") and (interactive_idea or research_ideation):
+    if design_existing:
+        banner_mode = "design"
+    elif mode in ("design", "research") and (design_idea or research_ideation):
         banner_mode = "ideation"
     else:
         banner_mode = mode
@@ -2544,9 +2546,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     base_branch = branch or _read_target_branch(project_path)
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
-    if interactive_existing:
+    if design_existing:
         ceo_mode = "build"
-    elif mode == "interactive" or research_ideation:
+    elif mode == "design" or research_ideation:
         ceo_mode = "build"
     else:
         ceo_mode = mode
@@ -2567,8 +2569,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         wt_path, ceo_mode, context, focus=focus, prompt_file=prompt_file,
         min_growth=min_growth, max_new=max_new, branch=branch,
         discover_only=discover_only, no_github=no_github,
-        interactive_idea=interactive_idea,
-        interactive_existing=interactive_existing,
+        design_idea=design_idea,
+        design_existing=design_existing,
         research_ideation=research_ideation,
         messages=pending,
         issue_number=issue_number,
@@ -2579,7 +2581,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     session_name = _derive_session_name(
         focus=focus,
-        interactive_idea=interactive_idea,
+        design_idea=design_idea,
         research_ideation=research_ideation,
         raw_path=raw_path,
         project_path=project_path,
@@ -2767,7 +2769,7 @@ def _extract_short_description(text: str, max_words: int = 6) -> str:
 def _derive_session_name(
     *,
     focus: str | None = None,
-    interactive_idea: str | None = None,
+    design_idea: str | None = None,
     research_ideation: str | None = None,
     raw_path: str | None = None,
     project_path: Path,
@@ -2777,7 +2779,7 @@ def _derive_session_name(
 
     Priority:
     1. Focus directive (most specific)
-    2. Interactive idea / research ideation (new project from idea)
+    2. Design idea / research ideation (new project from idea)
     3. Raw idea text (new project from raw prompt, not a path/URL)
     4. Fallback: mode + project directory name
     """
@@ -2788,7 +2790,7 @@ def _derive_session_name(
         label = focus.lower()[:max_len - len(prefix)]
         return f"{prefix}{label}"
 
-    idea = interactive_idea or research_ideation
+    idea = design_idea or research_ideation
     if idea:
         desc = _extract_short_description(idea)
         if desc:
@@ -3176,8 +3178,8 @@ def _build_ceo_task(
     branch: str | None = None,
     discover_only: bool = False,
     no_github: bool = False,
-    interactive_idea: str | None = None,
-    interactive_existing: bool = False,
+    design_idea: str | None = None,
+    design_existing: bool = False,
     research_ideation: str | None = None,
     messages: list[Message] | None = None,
     issue_number: int | None = None,
@@ -3195,11 +3197,11 @@ def _build_ceo_task(
             ts = msg.timestamp.strftime("%Y-%m-%d %H:%M:%S")
             task += f"**[{ts}]** {msg.text}\n\n"
 
-    if interactive_existing:
+    if design_existing:
         task += (
-            f"\n\n## Interactive Ideation Mode (Phase 0)\n\n"
+            f"\n\n## Design Mode (Phase 0)\n\n"
             f"**existing_project: true**\n\n"
-            f"You are in interactive ideation mode on an **existing project** at `{project_path}`.\n\n"
+            f"You are in design mode on an **existing project** at `{project_path}`.\n\n"
             f"Before running any experiments, research the project (local study + external "
             f"best practices), distill an improvement spec through user feedback, then "
             f"transition to Improve mode. Follow the Phase 0: Ideation protocol in your "
@@ -3217,11 +3219,11 @@ def _build_ceo_task(
                 "look at the backlog, eval scores, open issues, and recent history — "
                 "then present your findings and recommendations.\n"
             )
-    elif interactive_idea:
+    elif design_idea:
         task += (
-            f"\n\n## Interactive Ideation Mode (Phase 0)\n\n"
-            f"**Raw idea from user:** {interactive_idea}\n\n"
-            f"You are in interactive ideation mode. Before building anything, "
+            f"\n\n## Design Mode (Phase 0)\n\n"
+            f"**Raw idea from user:** {design_idea}\n\n"
+            f"You are in design mode. Before building anything, "
             f"you must refine this idea into a complete spec through research "
             f"and iterative user feedback. Follow the Phase 0: Ideation protocol "
             f"in your system prompt.\n\n"
@@ -3233,7 +3235,7 @@ def _build_ceo_task(
         task += (
             f"\n\n## Research Ideation Mode (Phase 0)\n\n"
             f"**Raw idea from user:** {research_ideation}\n\n"
-            f"You are in research ideation mode. This is like interactive ideation, "
+            f"You are in research ideation mode. This is like design ideation, "
             f"but the Strategist MUST collect research configuration:\n"
             f"- Research Target (objective, metric, target value, run_command, result_path)\n"
             f"- Mutable Surfaces (files the Builder can modify)\n"
@@ -4042,7 +4044,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("ceo", help="Launch the Factory CEO agent (interactive by default)")
     p.add_argument("path", nargs="?", default=None,
                     help="Project path, GitHub URL, idea file path, or prompt. "
-                         "In interactive mode, pass a raw idea string")
+                         "In design mode, pass a raw idea string")
     p.add_argument(
         "--prompt", default=None,
         help="Path to a prompt/spec file (absolute or relative to project). "
@@ -4050,10 +4052,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "interactive", "research", "review"],
+        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "research", "review"],
         default="auto",
         help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
-             "build, discover, improve, meta, interactive (research + brainstorm → spec → build), "
+             "build, discover, improve, meta, design (research + brainstorm → spec → build), "
              "research (autonomous research optimization), or review (on-demand PR review)",
     )
     p.add_argument(
@@ -4094,7 +4096,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--refine", default=None, metavar="REQUEST",
         help="Refinement mode: classify and implement a user-directed change. "
-             "Mutually exclusive with --mode interactive, --mode research, --mode meta, --prompt, --focus",
+             "Mutually exclusive with --mode design, --mode research, --mode meta, --prompt, --focus",
     )
     p.add_argument("--use-profile", action="store_true", default=False,
                     help="Inject user profile (~/.factory/profile.md) into agent prompts")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,7 @@ def _mock_foreground():
          patch("factory.worktree.remove_worktree"), \
          patch("factory.worktree.prune_stale", return_value=[]), \
          patch("factory.cli._read_target_branch", return_value="main"), \
+         patch("factory.cli._is_scaffold_only", return_value=False), \
          patch("factory.cli._ensure_dashboard"):
         yield mock_run
 
@@ -112,7 +113,13 @@ class TestParser:
         assert args.project == "."
         assert args.data is None
 
-    def test_ceo_mode_interactive(self):
+    def test_ceo_mode_design(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "distributed eval runner", "--mode", "design"])
+        assert args.mode == "design"
+        assert args.path == "distributed eval runner"
+
+    def test_ceo_mode_interactive_backward_compat(self):
         parser = build_parser()
         args = parser.parse_args(["ceo", "distributed eval runner", "--mode", "interactive"])
         assert args.mode == "interactive"
@@ -120,7 +127,7 @@ class TestParser:
 
     def test_ceo_path_optional(self):
         parser = build_parser()
-        args = parser.parse_args(["ceo", "--mode", "interactive"])
+        args = parser.parse_args(["ceo", "--mode", "design"])
         assert args.path is None
 
     def test_ceo_agent_strategist_choice(self):
@@ -134,34 +141,34 @@ class TestParser:
         assert args.role == "failure_analyst"
 
 
-class TestCmdCeoInteractive:
-    def test_interactive_headless_incompatible(self, capsys):
-        result = main(["ceo", "an idea", "--mode", "interactive", "--headless"])
+class TestCmdCeoDesign:
+    def test_design_headless_incompatible(self, capsys):
+        result = main(["ceo", "an idea", "--mode", "design", "--headless"])
         assert result == 1
         assert "incompatible" in capsys.readouterr().err.lower()
 
-    def test_interactive_prompt_incompatible(self, capsys):
-        result = main(["ceo", "an idea", "--mode", "interactive", "--prompt", "file.md"])
+    def test_design_prompt_incompatible(self, capsys):
+        result = main(["ceo", "an idea", "--mode", "design", "--prompt", "file.md"])
         assert result == 1
         assert "mutually exclusive" in capsys.readouterr().err.lower()
 
-    def test_interactive_focus_incompatible_new_idea(self, capsys):
-        """--focus + --mode interactive is rejected for new ideas (non-directory paths)."""
-        result = main(["ceo", "an idea", "--mode", "interactive", "--focus", "UI"])
+    def test_design_focus_incompatible_new_idea(self, capsys):
+        """--focus + --mode design is rejected for new ideas (non-directory paths)."""
+        result = main(["ceo", "an idea", "--mode", "design", "--focus", "UI"])
         assert result == 1
         err = capsys.readouterr().err.lower()
         assert "new ideas" in err
 
-    def test_interactive_focus_allowed_existing_project(self, tmp_path):
-        """--focus + --mode interactive is allowed when path is an existing directory."""
+    def test_design_focus_allowed_existing_project(self, tmp_path):
+        """--focus + --mode design is allowed when path is an existing directory."""
         (tmp_path / ".git").mkdir()
         with _mock_foreground() as mock_run:
-            main(["ceo", str(tmp_path), "--mode", "interactive", "--focus", "auth layer"])
+            main(["ceo", str(tmp_path), "--mode", "design", "--focus", "auth layer"])
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Interactive Ideation Mode (Phase 0)" in task
+        assert "## Design Mode (Phase 0)" in task
         assert "auth layer" in task
 
     def test_no_path_fails(self, capsys):
@@ -170,61 +177,70 @@ class TestCmdCeoInteractive:
         err = capsys.readouterr().err.lower()
         assert "provide" in err or "error" in err
 
-    def test_interactive_foreground_uses_subprocess_run(self, tmp_path):
-        """--mode interactive launches via subprocess.run (foreground)."""
+    def test_design_foreground_uses_subprocess_run(self, tmp_path):
+        """--mode design launches via subprocess.run (foreground)."""
         with _mock_foreground() as mock_run:
-            main(["ceo", str(tmp_path), "--mode", "interactive"])
+            main(["ceo", str(tmp_path), "--mode", "design"])
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == "claude"
         assert "--dangerously-skip-permissions" in cmd
 
-    def test_interactive_existing_has_ideation_block(self, tmp_path):
-        """--mode interactive on an existing directory injects Ideation Mode block."""
+    def test_design_existing_has_ideation_block(self, tmp_path):
+        """--mode design on an existing directory injects Design Mode block."""
         with _mock_foreground() as mock_run:
-            main(["ceo", str(tmp_path), "--mode", "interactive"])
+            main(["ceo", str(tmp_path), "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Interactive Ideation Mode (Phase 0)" in task
+        assert "## Design Mode (Phase 0)" in task
         assert "existing_project: true" in task
 
-    def test_interactive_new_idea_has_ideation_block(self):
-        """--mode interactive with a non-directory path injects Ideation Mode block."""
+    def test_design_new_idea_has_ideation_block(self):
+        """--mode design with a non-directory path injects Design Mode block."""
         with _mock_foreground() as mock_run:
-            main(["ceo", "build a cool CLI tool", "--mode", "interactive"])
+            main(["ceo", "build a cool CLI tool", "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Interactive Ideation Mode (Phase 0)" in task
+        assert "## Design Mode (Phase 0)" in task
         assert "## Project Specification" not in task
 
-    def test_interactive_task_contains_idea_text(self):
-        """--mode interactive with raw idea text includes it in the Phase 0 block."""
+    def test_design_task_contains_idea_text(self):
+        """--mode design with raw idea text includes it in the Phase 0 block."""
         with _mock_foreground() as mock_run:
-            main(["ceo", "distributed eval runner", "--mode", "interactive"])
+            main(["ceo", "distributed eval runner", "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "distributed eval runner" in task
 
-    def test_interactive_existing_mode_is_build(self, tmp_path):
-        """--mode interactive on existing dir sets Mode: build in the CEO task."""
+    def test_design_existing_mode_is_build(self, tmp_path):
+        """--mode design on existing dir sets Mode: build in the CEO task."""
         with _mock_foreground() as mock_run:
-            main(["ceo", str(tmp_path), "--mode", "interactive"])
+            main(["ceo", str(tmp_path), "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "Mode: build" in task
 
-    def test_interactive_new_idea_mode_is_build(self):
-        """--mode interactive with new idea sets Mode: build in the CEO task."""
+    def test_design_new_idea_mode_is_build(self):
+        """--mode design with new idea sets Mode: build in the CEO task."""
         with _mock_foreground() as mock_run:
-            main(["ceo", "weather CLI", "--mode", "interactive"])
+            main(["ceo", "weather CLI", "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "Mode: build" in task
+
+    def test_interactive_backward_compat_alias(self, tmp_path):
+        """--mode interactive is accepted as a backward-compatible alias for design."""
+        with _mock_foreground() as mock_run:
+            main(["ceo", str(tmp_path), "--mode", "interactive"])
+        cmd = mock_run.call_args[0][0]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "## Design Mode (Phase 0)" in task
 
 
 def _make_config(*, research_target: dict | None = None) -> dict:
@@ -345,14 +361,14 @@ class TestCmdCeoResearchIdeation:
         task = cmd[dsp_idx + 1]
         assert "Mode: build" in task
 
-    def test_research_ideation_no_interactive_block(self):
-        """--mode research should NOT inject Interactive Ideation block."""
+    def test_research_ideation_no_design_block(self):
+        """--mode research should NOT inject Design Mode block."""
         with _mock_foreground() as mock_run:
             main(["ceo", "swe-bench solver agent", "--mode", "research"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Interactive Ideation Mode" not in task
+        assert "## Design Mode" not in task
 
     def test_research_ideation_mentions_research_config(self):
         """--mode research ideation task mentions research config fields."""
@@ -1404,45 +1420,45 @@ class TestResearchMode:
         assert mode == "improve"
 
 
-class TestBuildCeoTaskInteractive:
-    """Unit tests for _build_ceo_task interactive_existing parameter."""
+class TestBuildCeoTaskDesign:
+    """Unit tests for _build_ceo_task design_existing parameter."""
 
     def test_existing_project_emits_ideation_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
-        assert "## Interactive Ideation Mode (Phase 0)" in task
+        task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        assert "## Design Mode (Phase 0)" in task
         assert "existing_project: true" in task
         assert "existing project" in task
 
     def test_existing_project_with_focus(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", interactive_existing=True, focus="auth layer")
-        assert "## Interactive Ideation Mode (Phase 0)" in task
+        task = _build_ceo_task(tmp_path, "build", design_existing=True, focus="auth layer")
+        assert "## Design Mode (Phase 0)" in task
         assert "auth layer" in task
         assert "Focus topic" in task
 
     def test_existing_project_without_focus(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
+        task = _build_ceo_task(tmp_path, "build", design_existing=True)
         assert "No specific topic was provided" in task
 
     def test_new_idea_emits_ideation_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", interactive_idea="weather CLI")
-        assert "## Interactive Ideation Mode (Phase 0)" in task
+        task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
+        assert "## Design Mode (Phase 0)" in task
         assert "weather CLI" in task
 
     def test_existing_uses_same_header_as_new_idea(self, tmp_path):
         """Both new ideas and existing projects use the same Phase 0 header."""
-        existing_task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
-        new_task = _build_ceo_task(tmp_path, "build", interactive_idea="weather CLI")
-        assert "## Interactive Ideation Mode (Phase 0)" in existing_task
-        assert "## Interactive Ideation Mode (Phase 0)" in new_task
+        existing_task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        new_task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
+        assert "## Design Mode (Phase 0)" in existing_task
+        assert "## Design Mode (Phase 0)" in new_task
 
     def test_existing_project_has_existing_flag(self, tmp_path):
         """Existing project task includes the existing_project flag for CEO conditionals."""
-        task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
+        task = _build_ceo_task(tmp_path, "build", design_existing=True)
         assert "existing_project: true" in task
 
     def test_existing_mode_is_build(self, tmp_path):
         """When ceo_mode is build (as set by cli.py), task shows Mode: build."""
-        task = _build_ceo_task(tmp_path, "build", interactive_existing=True)
+        task = _build_ceo_task(tmp_path, "build", design_existing=True)
         assert "Mode: build" in task
 
 
@@ -1713,15 +1729,15 @@ class TestEnsureRepo:
         assert count_before == count_after
 
 
-class TestInteractiveFileInput:
-    """Tests for interactive mode with file path input (Bug 1 fix)."""
+class TestDesignFileInput:
+    """Tests for design mode with file path input (Bug 1 fix)."""
 
-    def test_file_content_becomes_interactive_idea(self, tmp_path):
-        """When --mode interactive receives a file path, the file content should be used as the idea."""
+    def test_file_content_becomes_design_idea(self, tmp_path):
+        """When --mode design receives a file path, the file content should be used as the idea."""
         spec_file = tmp_path / "my-cool-app.md"
         spec_file.write_text("Build a weather dashboard with real-time updates")
         with _mock_foreground() as mock_run:
-            main(["ceo", str(spec_file), "--mode", "interactive"])
+            main(["ceo", str(spec_file), "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
@@ -1732,16 +1748,16 @@ class TestInteractiveFileInput:
         spec_file = tmp_path / "weather-dashboard.md"
         spec_file.write_text("Build a weather dashboard")
         with _mock_foreground():
-            main(["ceo", str(spec_file), "--mode", "interactive"])
+            main(["ceo", str(spec_file), "--mode", "design"])
         output = capsys.readouterr().out
         assert "weather-dashboard" in output
         assert "Idea file: weather-dashboard.md" in output
 
     def test_raw_idea_persists_spec(self, tmp_path):
-        """When --mode interactive receives a raw string, the spec should be persisted."""
+        """When --mode design receives a raw string, the spec should be persisted."""
         with _mock_foreground(), \
              patch("factory.cli._get_projects_dir", return_value=tmp_path):
-            main(["ceo", "Build a CLI todo app", "--mode", "interactive"])
+            main(["ceo", "Build a CLI todo app", "--mode", "design"])
         matches = [p for p in tmp_path.iterdir() if p.is_dir()]
         assert len(matches) == 1
         spec_path = matches[0] / ".factory" / "strategy" / "current.md"

--- a/tests/test_cli_wizard.py
+++ b/tests/test_cli_wizard.py
@@ -148,7 +148,7 @@ class TestClassifyWithLLM:
             ],
             "suggestions": [
                 {"label": "Fix it", "explanation": "Target the issue.", "command": "factory ceo {path} --focus \"bug\""},
-                {"label": "Discuss", "explanation": "Talk first.", "command": "factory ceo {path} --mode interactive"},
+                {"label": "Discuss", "explanation": "Talk first.", "command": "factory ceo {path} --mode design"},
             ],
         }
         mock_runner = MagicMock()
@@ -168,7 +168,7 @@ class TestClassifyWithLLM:
         response = {
             "follow_ups": [],
             "suggestions": [
-                {"label": "Brainstorm first", "explanation": "Refine the idea.", "command": 'factory ceo "weather CLI" --mode interactive'},
+                {"label": "Brainstorm first", "explanation": "Refine the idea.", "command": 'factory ceo "weather CLI" --mode design'},
                 {"label": "Build directly", "explanation": "Start building.", "command": 'factory ceo "weather CLI"'},
             ],
         }
@@ -187,7 +187,7 @@ class TestClassifyWithLLM:
     def test_legacy_json_array_response(self) -> None:
         """Backward compatibility: plain JSON array still works."""
         suggestions = [
-            {"label": "Brainstorm first", "explanation": "Refine the idea.", "command": 'factory ceo "weather CLI" --mode interactive'},
+            {"label": "Brainstorm first", "explanation": "Refine the idea.", "command": 'factory ceo "weather CLI" --mode design'},
             {"label": "Build directly", "explanation": "Start building.", "command": 'factory ceo "weather CLI"'},
         ]
         mock_runner = MagicMock()
@@ -446,7 +446,7 @@ class TestAskFollowUps:
     def test_choice_follow_up(self) -> None:
         follow_ups = [
             {"key": "mode", "question": "Which mode?", "type": "choice",
-             "options": ["interactive", "build", "research"], "optional": False},
+             "options": ["design", "build", "research"], "optional": False},
         ]
         with patch("builtins.input", return_value="2"), \
              patch("sys.stderr"):
@@ -458,7 +458,7 @@ class TestAskFollowUps:
     def test_choice_follow_up_invalid_returns_none(self) -> None:
         follow_ups = [
             {"key": "mode", "question": "Which mode?", "type": "choice",
-             "options": ["interactive", "build"], "optional": False},
+             "options": ["design", "build"], "optional": False},
         ]
         with patch("builtins.input", return_value="5"), \
              patch("sys.stderr"):
@@ -518,22 +518,22 @@ class TestSubstituteAnswers:
     def test_drops_suggestion_with_unfilled_placeholder(self) -> None:
         suggestions = [
             {"label": "Fix", "command": "factory ceo {path} --focus {issue}"},
-            {"label": "Discuss", "command": "factory ceo {path} --mode interactive"},
+            {"label": "Discuss", "command": "factory ceo {path} --mode design"},
         ]
         answers = {"path": "/tmp/proj"}  # no issue
         result = _substitute_answers(suggestions, answers)
         assert len(result) == 1
         assert result[0]["label"] == "Discuss"
-        assert result[0]["command"] == "factory ceo /tmp/proj --mode interactive"
+        assert result[0]["command"] == "factory ceo /tmp/proj --mode design"
 
     def test_keeps_suggestion_without_placeholders(self) -> None:
         suggestions = [
-            {"label": "Build", "command": 'factory ceo "my idea" --mode interactive'},
+            {"label": "Build", "command": 'factory ceo "my idea" --mode design'},
         ]
         answers = {}
         result = _substitute_answers(suggestions, answers)
         assert len(result) == 1
-        assert result[0]["command"] == 'factory ceo "my idea" --mode interactive'
+        assert result[0]["command"] == 'factory ceo "my idea" --mode design'
 
     def test_drops_all_if_no_answers(self) -> None:
         suggestions = [
@@ -563,7 +563,7 @@ class TestWizardDispatch:
     def test_selects_default_option(self) -> None:
         llm_result = (
             [],
-            [{"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test" --mode interactive'}],
+            [{"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test" --mode design'}],
         )
         with patch("builtins.input", side_effect=["test idea", ""]), \
              patch("sys.stderr") as mock_stderr, \
@@ -582,7 +582,7 @@ class TestWizardDispatch:
             [],
             [
                 {"label": "Option 1", "explanation": "First.", "command": 'factory ceo "test"'},
-                {"label": "Option 2", "explanation": "Second.", "command": 'factory ceo "test" --mode interactive'},
+                {"label": "Option 2", "explanation": "Second.", "command": 'factory ceo "test" --mode design'},
             ],
         )
         with patch("builtins.input", side_effect=["test idea", "2"]), \
@@ -597,7 +597,7 @@ class TestWizardDispatch:
         assert code == 0
         mock_ceo.assert_called_once()
         ns = mock_ceo.call_args[0][0]
-        assert ns.mode == "interactive"
+        assert ns.mode == "design"
 
     def test_invalid_choice_returns_error(self) -> None:
         llm_result = (
@@ -646,7 +646,7 @@ class TestWizardDispatch:
             [{"key": "path", "question": "Path to project", "type": "path", "optional": False}],
             [
                 {"label": "Fix it", "explanation": "Go.", "command": 'factory ceo {path} --focus "fix bug"'},
-                {"label": "Discuss", "explanation": "Talk.", "command": "factory ceo {path} --mode interactive"},
+                {"label": "Discuss", "explanation": "Talk.", "command": "factory ceo {path} --mode design"},
             ],
         )
         with patch("builtins.input", side_effect=["fix a bug", str(tmp_path), ""]), \
@@ -672,7 +672,7 @@ class TestWizardDispatch:
             ],
             [
                 {"label": "Fix specific", "explanation": "Target.", "command": "factory ceo {path} --focus {issue}"},
-                {"label": "Discuss", "explanation": "Talk.", "command": "factory ceo {path} --mode interactive"},
+                {"label": "Discuss", "explanation": "Talk.", "command": "factory ceo {path} --mode design"},
             ],
         )
         # User provides path but skips optional issue
@@ -689,7 +689,7 @@ class TestWizardDispatch:
         mock_ceo.assert_called_once()
         # The selected command should be the "Discuss" one (only surviving)
         ns = mock_ceo.call_args[0][0]
-        assert ns.mode == "interactive"
+        assert ns.mode == "design"
 
     def test_follow_up_eof_exits_cleanly(self) -> None:
         llm_result = (

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -385,7 +385,7 @@ class TestCeoPrompt:
 
 class TestStrategistIdeationMode:
     def test_has_ideation_section(self, strategist_prompt: str) -> None:
-        assert "## Interactive / Ideation Mode" in strategist_prompt
+        assert "## Design / Ideation Mode" in strategist_prompt
 
     def test_has_output_format(self, strategist_prompt: str) -> None:
         assert "### Vision" in strategist_prompt


### PR DESCRIPTION
## Summary
- make `--mode design` the primary ideation mode in the CLI and wizard while preserving `--mode interactive` as a backward-compatible alias
- rename Phase 0 and strategist/CEO terminology from Interactive to Design to match the post-#523 Strategist-based ideation flow
- update top-level docs, architecture docs, source diagrams, and focused tests to describe the design workflow consistently

## Test plan
- [x] `uv run pytest tests/test_prompts.py tests/test_cli.py tests/test_cli_wizard.py tests/test_ceo_completion.py -q`


Made with [Cursor](https://cursor.com)