### PR TITLE
feat: --bg flag for background agent dispatch (rework of PR #424)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -418,6 +418,11 @@ Dispatch modes include:
 - **background** — the worker is launched as a detached session; the caller
   polls for completion and collects output when the session finishes
 
+Dispatch mode MAY be scoped independently per lifecycle tier. For example, a
+coordinator MAY run synchronously while its delegated workers dispatch in
+background mode, allowing the operator to observe the coordinator while
+workers remain visible through an agent management interface.
+
 Dispatch mode is a runtime concern. It MUST NOT change the semantics of the
 execution contract, evidence records, or decision lifecycle.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -268,6 +268,7 @@ Examples:
 
 - local subprocess agent
 - interactive terminal or tmux-backed agent
+- background session agent (fire-and-poll, observable via agent management interface)
 - plugin asset worker
 - managed remote agent
 
@@ -410,6 +411,16 @@ contract.
 The system selects a worker runtime and starts an execution attempt.
 Dispatch MUST preserve enough state to support observability and recovery.
 
+Dispatch modes include:
+
+- **synchronous** — the caller blocks until the worker completes (default)
+- **interactive** — the worker runs in a user-facing terminal session
+- **background** — the worker is launched as a detached session; the caller
+  polls for completion and collects output when the session finishes
+
+Dispatch mode is a runtime concern. It MUST NOT change the semantics of the
+execution contract, evidence records, or decision lifecycle.
+
 ### 5.4 Execute
 
 The worker runtime performs the scoped work. It SHOULD emit logs, status, and
@@ -453,7 +464,7 @@ The `cli-local` profile is the primary compatibility surface.
 It consists of:
 
 - CLI command surface
-- local worker runtime
+- local worker runtime (supports multiple dispatch modes as implementation-defined options)
 - local project state backend
 - local guardrail providers
 - implementation-defined local output surfaces

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -139,6 +139,7 @@ async def invoke_agent(
     session_name: str | None = None,
     use_profile: bool = False,
     tmux_persist: bool = False,
+    background: bool = False,
     review_tag: str | None = None,
 ) -> tuple[str, int]:
     """Invoke a Claude Code agent with the resolved prompt + task.
@@ -178,7 +179,7 @@ async def invoke_agent(
         role=role,
         session_name=agent_session_name,
         project_path=project_path,
-        extras={"tmux_persist": tmux_persist},
+        extras={"tmux_persist": tmux_persist, "background": background},
     )
 
     old_parent_span = os.environ.get("FACTORY_PARENT_SPAN_ID")
@@ -448,6 +449,7 @@ async def invoke_agents_parallel(
     model: str | None = None,
     runner_name: str | None = None,
     tmux_persist: bool = False,
+    background: bool = False,
     review_tags: list[str | None] | None = None,
 ) -> list[tuple[str, int]]:
     """Invoke multiple agents concurrently. Returns list of (output, return_code).
@@ -492,6 +494,7 @@ async def invoke_agents_parallel(
             runner_name=runner_name,
             _track_failures=False,  # Avoid race condition; track locally below
             tmux_persist=tmux_persist,
+            background=background,
             review_tag=tag,
         )
         for (role, task), tag in zip(tasks, review_tags)

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -418,7 +418,7 @@ async def run_ceo_with_completion_guard(
         return await invoke_agent(
             "ceo", initial_task, project_path,
             timeout=timeout, model=model, runner_name=runner_name,
-            background=True,
+            background=True, session_name=session_name, use_profile=use_profile,
         )
 
     # Check escape hatch

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -388,6 +388,7 @@ async def run_ceo_with_completion_guard(
     session_name: str | None = None,
     use_profile: bool = False,
     tmux_persist: bool = False,
+    background: bool = False,
 ) -> tuple[str, int]:
     """Spawn CEO; if it exits with planned work undone, re-spawn until done or cap hit.
 
@@ -405,11 +406,20 @@ async def run_ceo_with_completion_guard(
         session_name: Optional session name for /resume identification.
         use_profile: If True, inject user profile into the CEO prompt.
         tmux_persist: If True, run agents in tmux windows.
+        background: If True, dispatch via claude --bg (single dispatch, no respawn).
 
     Returns:
         (final_output, exit_code)
     """
     from factory.agents.runner import invoke_agent
+
+    if background:
+        log.info("ceo_background_dispatch", reason="--bg: single dispatch, no respawn loop")
+        return await invoke_agent(
+            "ceo", initial_task, project_path,
+            timeout=timeout, model=model, runner_name=runner_name,
+            background=True,
+        )
 
     # Check escape hatch
     from factory.user_config import resolve

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2516,6 +2516,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     use_profile = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
     background = _resolve_background(args)
+    if bg_agents:
+        background = False
     if background and tmux_persist:
         print("Error: --bg and --tmux-persist are mutually exclusive.", file=sys.stderr)
         return 1
@@ -3565,6 +3567,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     tmux_persist = _resolve_tmux_persist(args)
     background = _resolve_background(args)
     bg_agents = _resolve_bg_agents(args)
+    if bg_agents:
+        background = False
     if background and tmux_persist:
         print("Error: --bg and --tmux-persist are mutually exclusive.", file=sys.stderr)
         return 1

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2313,7 +2313,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     mode = getattr(args, "mode", "auto")
     if mode == "interactive":
         mode = "design"
-    headless = getattr(args, "headless", False) or getattr(args, "bg", False)
+    bg = getattr(args, "bg", False)
+    headless = getattr(args, "headless", False) or bg
     prompt_file = getattr(args, "prompt", None)
     focus = getattr(args, "focus", None)
     dir_name = getattr(args, "dir", None)
@@ -2410,8 +2411,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     if mode == "design":
         if headless:
-            print("Error: --mode design requires foreground mode "
-                  "(incompatible with --headless)", file=sys.stderr)
+            flag = "--bg" if bg else "--headless"
+            print(f"Error: --mode design requires foreground mode "
+                  f"(incompatible with {flag})", file=sys.stderr)
             return 1
         if prompt_file:
             print("Error: --mode design and --prompt are mutually exclusive. "
@@ -2460,8 +2462,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     elif mode == "research" and not _safe_is_dir(resolved := Path(raw_path).expanduser()) and not _safe_is_file(resolved):
         # New research project from idea — enter research ideation
         if headless:
+            flag = "--bg" if bg else "--headless"
             print("Error: --mode research for new projects requires foreground mode "
-                  "(incompatible with --headless)", file=sys.stderr)
+                  f"(incompatible with {flag})", file=sys.stderr)
             return 1
         if focus:
             print("Error: --focus cannot be used with research ideation for new projects. "

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2203,6 +2203,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
     runner = _resolve_runner(args)
     use_profile = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
+    background = _resolve_background(args)
     review_tag = getattr(args, "review_tag", None)
     parent_span = getattr(args, "parent_session", None) or os.environ.get("FACTORY_PARENT_SPAN_ID")
     if parent_span:
@@ -2218,6 +2219,7 @@ def cmd_agent(args: argparse.Namespace) -> int:
         runner_name=runner,
         use_profile=use_profile,
         tmux_persist=tmux_persist,
+        background=background,
         review_tag=review_tag,
     ))
     print(result)
@@ -2311,7 +2313,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     mode = getattr(args, "mode", "auto")
     if mode == "interactive":
         mode = "design"
-    headless = getattr(args, "headless", False)
+    headless = getattr(args, "headless", False) or getattr(args, "bg", False)
     prompt_file = getattr(args, "prompt", None)
     focus = getattr(args, "focus", None)
     dir_name = getattr(args, "dir", None)
@@ -2503,6 +2505,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     runner_name = _resolve_runner(args)
     use_profile = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
+    background = _resolve_background(args)
     clean_pr_flag = getattr(args, "clean_pr", None)
 
     if mode == "research" and not research_ideation and not _has_research_target(project_path):
@@ -2607,6 +2610,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 session_name=session_name,
                 use_profile=use_profile,
                 tmux_persist=tmux_persist,
+                background=background,
             ))
             print(result)
             if code == 0:
@@ -2620,6 +2624,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 already_improved=mode in ("improve", "meta") or discover_only,
                 model=model, no_github=no_github, use_profile=use_profile,
                 tmux_persist=tmux_persist,
+                background=background,
             )
         finally:
             remove_worktree(project_path, wt_path, wt_branch)
@@ -2674,6 +2679,16 @@ def _resolve_tmux_persist(args: argparse.Namespace) -> bool:
     cli_flag = getattr(args, "tmux_persist", False)
     cli_value = "true" if cli_flag else None
     val = resolve("tmux_persist", cli_value=cli_value, env_var="FACTORY_TMUX_PERSIST", default="false")
+    return bool(val and val.lower() in ("1", "true", "yes"))
+
+
+def _resolve_background(args: argparse.Namespace) -> bool:
+    """Resolve background: CLI flag > FACTORY_BG env var > config.toml > False."""
+    from factory.user_config import resolve
+
+    cli_flag = getattr(args, "bg", False)
+    cli_value = "true" if cli_flag else None
+    val = resolve("bg", cli_value=cli_value, env_var="FACTORY_BG", default="false")
     return bool(val and val.lower() in ("1", "true", "yes"))
 
 
@@ -3400,6 +3415,7 @@ def _chain_modes(
     no_github: bool = False,
     use_profile: bool = False,
     tmux_persist: bool = False,
+    background: bool = False,
 ) -> int:
     """After a cycle completes, re-detect state and chain into the next mode.
 
@@ -3427,7 +3443,7 @@ def _chain_modes(
             project_path, next_mode, focus=focus,
             min_growth=min_growth, max_new=max_new, branch=branch,
             no_github=no_github, model=model, use_profile=use_profile,
-            tmux_persist=tmux_persist,
+            tmux_persist=tmux_persist, background=background,
         )
         if code != 0:
             return code
@@ -3451,6 +3467,7 @@ def _run_single_cycle(
     use_profile: bool = False,
     clean_pr: bool = False,
     tmux_persist: bool = False,
+    background: bool = False,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
     from factory.agents.runner import invoke_agent
@@ -3488,6 +3505,7 @@ def _run_single_cycle(
             model=model,
             use_profile=use_profile,
             tmux_persist=tmux_persist,
+            background=background,
         ))
 
         if code == 0:
@@ -3519,6 +3537,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     model = _resolve_model(args)
     use_profile_flag = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
+    background = _resolve_background(args)
 
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
@@ -3593,6 +3612,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             use_profile=use_profile_flag,
             clean_pr=clean_pr_resolved,
             tmux_persist=tmux_persist,
+            background=background,
             **budget_kwargs,
         )
         if code != 0:
@@ -3602,6 +3622,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             min_growth=min_growth, max_new=max_new, branch=branch,
             model=model, no_github=no_github, use_profile=use_profile_flag,
             tmux_persist=tmux_persist,
+            background=background,
         )
 
     # Heartbeat loop mode
@@ -3633,6 +3654,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 use_profile=use_profile_flag,
                 clean_pr=clean_pr_resolved,
                 tmux_persist=tmux_persist,
+                background=background,
                 **budget_kwargs,
             )
             _chain_modes(
@@ -3640,6 +3662,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 min_growth=min_growth, max_new=max_new, branch=branch,
                 model=model, no_github=no_github, use_profile=use_profile_flag,
                 tmux_persist=tmux_persist,
+                background=background,
             )
             _emit_cli_event(project_path, "cycle.completed", {"cycle": cycle, "mode": mode})
 
@@ -4040,6 +4063,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Inject user profile (~/.factory/profile.md) into the agent prompt")
     p.add_argument("--tmux-persist", action="store_true", default=False,
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
+    p.add_argument("--bg", action="store_true", default=False,
+                    help="Dispatch agent as a background session via claude agent view (claude only)")
     p.add_argument("--review-tag", default=None,
                     help="Tag for distinct review output files (writes <role>-<tag>-latest.md)")
     p.add_argument("--parent-session", default=None,
@@ -4112,6 +4137,8 @@ def build_parser() -> argparse.ArgumentParser:
                                 help="Disable clean PR mode")
     p.add_argument("--tmux-persist", action="store_true", default=False,
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
+    p.add_argument("--bg", action="store_true", default=False,
+                    help="Dispatch agent as a background session via claude agent view (claude only)")
     p.add_argument("--pr", type=int, default=None,
                     help="PR number for --mode review (required when mode=review)")
     p.add_argument("--repo", default=None,
@@ -4179,6 +4206,8 @@ def build_parser() -> argparse.ArgumentParser:
                                     help="Disable clean PR mode")
     p.add_argument("--tmux-persist", action="store_true", default=False,
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
+    p.add_argument("--bg", action="store_true", default=False,
+                    help="Dispatch agent as a background session via claude agent view (claude only)")
 
     # tmux — launch factory run in a detached tmux session
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2204,6 +2204,9 @@ def cmd_agent(args: argparse.Namespace) -> int:
     use_profile = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
     background = _resolve_background(args)
+    if background and tmux_persist:
+        print("Error: --bg and --tmux-persist are mutually exclusive.", file=sys.stderr)
+        return 1
     review_tag = getattr(args, "review_tag", None)
     parent_span = getattr(args, "parent_session", None) or os.environ.get("FACTORY_PARENT_SPAN_ID")
     if parent_span:
@@ -2509,6 +2512,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     use_profile = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
     background = _resolve_background(args)
+    if background and tmux_persist:
+        print("Error: --bg and --tmux-persist are mutually exclusive.", file=sys.stderr)
+        return 1
     clean_pr_flag = getattr(args, "clean_pr", None)
 
     if mode == "research" and not research_ideation and not _has_research_target(project_path):
@@ -3541,6 +3547,9 @@ def cmd_run(args: argparse.Namespace) -> int:
     use_profile_flag = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
     background = _resolve_background(args)
+    if background and tmux_persist:
+        print("Error: --bg and --tmux-persist are mutually exclusive.", file=sys.stderr)
+        return 1
 
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2317,6 +2317,10 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     if mode == "interactive":
         mode = "design"
     bg = getattr(args, "bg", False)
+    bg_agents = _resolve_bg_agents(args)
+    if bg and bg_agents:
+        print("Error: --bg and --bg-agents are mutually exclusive.", file=sys.stderr)
+        return 1
     headless = getattr(args, "headless", False) or bg
     prompt_file = getattr(args, "prompt", None)
     focus = getattr(args, "focus", None)
@@ -2603,6 +2607,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         mode=banner_mode,
     )
 
+    if bg_agents:
+        os.environ["FACTORY_BG"] = "1"
+
     if headless:
         # Non-interactive pipe mode (for scripting, cron, tmux)
         # Uses completion guard to auto-resume on premature exit
@@ -2698,6 +2705,16 @@ def _resolve_background(args: argparse.Namespace) -> bool:
     cli_flag = getattr(args, "bg", False)
     cli_value = "true" if cli_flag else None
     val = resolve("bg", cli_value=cli_value, env_var="FACTORY_BG", default="false")
+    return bool(val and val.lower() in ("1", "true", "yes"))
+
+
+def _resolve_bg_agents(args: argparse.Namespace) -> bool:
+    """Resolve bg_agents: CLI flag > FACTORY_BG_AGENTS env var > config.toml > False."""
+    from factory.user_config import resolve
+
+    cli_flag = getattr(args, "bg_agents", False)
+    cli_value = "true" if cli_flag else None
+    val = resolve("bg_agents", cli_value=cli_value, env_var="FACTORY_BG_AGENTS", default="false")
     return bool(val and val.lower() in ("1", "true", "yes"))
 
 
@@ -3547,9 +3564,16 @@ def cmd_run(args: argparse.Namespace) -> int:
     use_profile_flag = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
     background = _resolve_background(args)
+    bg_agents = _resolve_bg_agents(args)
     if background and tmux_persist:
         print("Error: --bg and --tmux-persist are mutually exclusive.", file=sys.stderr)
         return 1
+    if background and bg_agents:
+        print("Error: --bg and --bg-agents are mutually exclusive.", file=sys.stderr)
+        return 1
+
+    if bg_agents:
+        os.environ["FACTORY_BG"] = "1"
 
     if prompt_file:
         context = _read_prompt_file(project_path, prompt_file)
@@ -4151,6 +4175,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
     p.add_argument("--bg", action="store_true", default=False,
                     help="Dispatch agent as a background session via claude agent view (claude only)")
+    p.add_argument("--bg-agents", action="store_true", default=False,
+                    help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground")
     p.add_argument("--pr", type=int, default=None,
                     help="PR number for --mode review (required when mode=review)")
     p.add_argument("--repo", default=None,
@@ -4220,6 +4246,8 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
     p.add_argument("--bg", action="store_true", default=False,
                     help="Dispatch agent as a background session via claude agent view (claude only)")
+    p.add_argument("--bg-agents", action="store_true", default=False,
+                    help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground")
 
     # tmux — launch factory run in a detached tmux session
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -265,6 +265,13 @@ def _cleanup(tmpdir: Path) -> None:
     shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def _unlink_quiet(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
 # ── Background (agent view) mode ─────────────────────────────
 
 _BG_POLL_INTERVAL = 5.0
@@ -314,7 +321,17 @@ async def run_in_background(
     """
     session_name = f"factory-{role}"
 
-    cmd = ["claude", "--bg", "--name", session_name, "--append-system-prompt", prompt, task]
+    prompt_file = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".md", prefix="factory-bg-prompt-", delete=False,
+    )
+    prompt_file.write(prompt)
+    prompt_file.close()
+    prompt_path = prompt_file.name
+
+    cmd = [
+        "claude", "--bg", "--name", session_name,
+        "--append-system-prompt-file", prompt_path, "-p", task,
+    ]
     if dangerously_skip_permissions:
         cmd.append("--dangerously-skip-permissions")
     if model:
@@ -336,9 +353,11 @@ async def run_in_background(
         )
     except FileNotFoundError:
         logger.error("'claude' CLI not found on PATH")
+        _unlink_quiet(prompt_path)
         return "Error: 'claude' CLI not found on PATH", 1, None
     except subprocess.TimeoutExpired:
         logger.error("claude --bg timed out during launch")
+        _unlink_quiet(prompt_path)
         return "Error: claude --bg timed out during launch", 1, None
 
     output = result.stdout + result.stderr
@@ -346,33 +365,37 @@ async def run_in_background(
 
     if result.returncode != 0 or not session_id:
         logger.warning("Failed to launch background agent: %s", output[:200])
+        _unlink_quiet(prompt_path)
         return f"Failed to launch background agent for {role}: {output[:200]}", 1, None
 
     print(f"Agent '{role}' launched in background: {session_id}", file=sys.stderr)
     print(f"  claude attach {session_id}    # attach to interact", file=sys.stderr)
 
-    elapsed = 0.0
-    while elapsed < timeout:
-        await asyncio.sleep(_BG_POLL_INTERVAL)
-        elapsed += _BG_POLL_INTERVAL
+    try:
+        elapsed = 0.0
+        while elapsed < timeout:
+            await asyncio.sleep(_BG_POLL_INTERVAL)
+            elapsed += _BG_POLL_INTERVAL
 
-        state = _read_session_state(session_id)
-        if state and state.get("state") in _BG_TERMINAL_STATES:
-            session_output = ""
-            if isinstance(state.get("output"), dict):
-                session_output = state["output"].get("result", "")
-            elif isinstance(state.get("output"), str):
-                session_output = state["output"]
+            state = _read_session_state(session_id)
+            if state and state.get("state") in _BG_TERMINAL_STATES:
+                session_output = ""
+                if isinstance(state.get("output"), dict):
+                    session_output = state["output"].get("result", "")
+                elif isinstance(state.get("output"), str):
+                    session_output = state["output"]
 
-            is_success = state["state"] in ("done", "completed")
-            return session_output, 0 if is_success else 1, None
+                is_success = state["state"] in ("done", "completed")
+                return session_output, 0 if is_success else 1, None
 
-    logger.error("Background agent timed out after %ss: role=%s", timeout, role)
-    stop_result = subprocess.run(["claude", "stop", session_id], capture_output=True)
-    if stop_result.returncode != 0:
-        logger.warning(
-            "Failed to stop background session %s: %s",
-            session_id,
-            stop_result.stderr[:200],
-        )
-    return f"Agent timed out after {timeout}s", 1, None
+        logger.error("Background agent timed out after %ss: role=%s", timeout, role)
+        stop_result = subprocess.run(["claude", "stop", session_id], capture_output=True)
+        if stop_result.returncode != 0:
+            logger.warning(
+                "Failed to stop background session %s: %s",
+                session_id,
+                stop_result.stderr[:200],
+            )
+        return f"Agent timed out after {timeout}s", 1, None
+    finally:
+        _unlink_quiet(prompt_path)

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -1,4 +1,4 @@
-"""Tmux persist — launch agents interactively in tmux with output capture."""
+"""Alternative agent execution modes — tmux windows and background sessions."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import platform
 import re
 import shlex
@@ -262,3 +263,110 @@ async def run_in_tmux(
 
 def _cleanup(tmpdir: Path) -> None:
     shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ── Background (agent view) mode ─────────────────────────────
+
+_BG_POLL_INTERVAL = 5.0
+_BG_TERMINAL_STATES = {"done", "completed", "failed", "stopped"}
+_CLAUDE_JOBS_DIR = Path("~/.claude/jobs").expanduser()
+
+
+def _parse_bg_session_id(output: str) -> str | None:
+    """Parse session ID from ``claude --bg`` output.
+
+    Expected format: 'backgrounded · <hex_id> [· <name>]'
+    """
+    for line in output.splitlines():
+        if line.startswith("backgrounded"):
+            parts = line.split("·")
+            if len(parts) >= 2:
+                return parts[1].strip()
+    return None
+
+
+def _read_session_state(session_id: str) -> dict | None:
+    state_file = _CLAUDE_JOBS_DIR / session_id / "state.json"
+    if not state_file.exists():
+        return None
+    try:
+        return json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+async def run_in_background(
+    prompt: str,
+    task: str,
+    cwd: Path,
+    role: str,
+    *,
+    timeout: float = _DEFAULT_TMUX_TIMEOUT,
+    model: str | None = None,
+    dangerously_skip_permissions: bool = True,
+) -> tuple[str, int, None]:
+    """Launch claude as a background session via --bg (agent view).
+
+    The session is visible in ``claude agents``. The factory polls for
+    completion and returns the output when the session finishes.
+
+    Returns (stdout, return_code, None). Usage is always None for bg mode.
+    """
+    session_name = f"factory-{role}"
+
+    cmd = ["claude", "--bg", "--name", session_name, "--append-system-prompt", prompt, task]
+    if dangerously_skip_permissions:
+        cmd.append("--dangerously-skip-permissions")
+    if model:
+        cmd.extend(["--model", model])
+
+    logger.info("Launching background agent: role=%s, cwd=%s", role, cwd)
+
+    env = dict(os.environ)
+    env["FACTORY_BG"] = "1"
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+    except FileNotFoundError:
+        logger.error("'claude' CLI not found on PATH")
+        return "Error: 'claude' CLI not found on PATH", 1, None
+    except subprocess.TimeoutExpired:
+        logger.error("claude --bg timed out during launch")
+        return "Error: claude --bg timed out during launch", 1, None
+
+    output = result.stdout + result.stderr
+    session_id = _parse_bg_session_id(output)
+
+    if result.returncode != 0 or not session_id:
+        logger.warning("Failed to launch background agent: %s", output[:200])
+        return f"Failed to launch background agent for {role}: {output[:200]}", 1, None
+
+    print(f"Agent '{role}' launched in background: {session_id}", file=sys.stderr)
+    print(f"  claude attach {session_id}    # attach to interact", file=sys.stderr)
+
+    elapsed = 0.0
+    while elapsed < timeout:
+        await asyncio.sleep(_BG_POLL_INTERVAL)
+        elapsed += _BG_POLL_INTERVAL
+
+        state = _read_session_state(session_id)
+        if state and state.get("state") in _BG_TERMINAL_STATES:
+            session_output = ""
+            if isinstance(state.get("output"), dict):
+                session_output = state["output"].get("result", "")
+            elif isinstance(state.get("output"), str):
+                session_output = state["output"]
+
+            is_success = state["state"] in ("done", "completed")
+            return session_output, 0 if is_success else 1, None
+
+    logger.error("Background agent timed out after %ss: role=%s", timeout, role)
+    subprocess.run(["claude", "stop", session_id], capture_output=True)
+    return f"Agent timed out after {timeout}s", 1, None

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -323,7 +323,7 @@ async def run_in_background(
     logger.info("Launching background agent: role=%s, cwd=%s", role, cwd)
 
     env = dict(os.environ)
-    env["_FACTORY_IN_BG_SESSION"] = "1"
+    env["FACTORY_BG"] = "1"
 
     try:
         result = subprocess.run(

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -323,7 +323,7 @@ async def run_in_background(
     logger.info("Launching background agent: role=%s, cwd=%s", role, cwd)
 
     env = dict(os.environ)
-    env["FACTORY_BG"] = "1"
+    env["_FACTORY_IN_BG_SESSION"] = "1"
 
     try:
         result = subprocess.run(
@@ -368,5 +368,11 @@ async def run_in_background(
             return session_output, 0 if is_success else 1, None
 
     logger.error("Background agent timed out after %ss: role=%s", timeout, role)
-    subprocess.run(["claude", "stop", session_id], capture_output=True)
+    stop_result = subprocess.run(["claude", "stop", session_id], capture_output=True)
+    if stop_result.returncode != 0:
+        logger.warning(
+            "Failed to stop background session %s: %s",
+            session_id,
+            stop_result.stderr[:200],
+        )
     return f"Agent timed out after {timeout}s", 1, None

--- a/factory/runners/bob.py
+++ b/factory/runners/bob.py
@@ -203,6 +203,9 @@ class BobRunner:
         tmux_persist = request.extras.get("tmux_persist", False)
         if tmux_persist:
             log.warning("bob_tmux_not_supported")
+        background = request.extras.get("background", False)
+        if background:
+            log.warning("bob_bg_not_supported", hint="--bg is a claude-only feature")
         self._role = request.role
         project_path = request.project_path or self._find_project_path(request.cwd)
 

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -52,6 +52,7 @@ class ClaudeRunner:
             install_hint="npm install -g @anthropic-ai/claude-code",
             supports_usage_telemetry=True,
             supports_session_name=True,
+            supports_background=True,
         )
 
     def build_command(self, request: AgentRunRequest) -> tuple[list[str], dict[str, str], list[Path]]:
@@ -84,6 +85,17 @@ class ClaudeRunner:
     async def headless(self, request: AgentRunRequest) -> AgentRunResult:
         """Run a headless Claude Code invocation."""
         from factory.models import AgentRunResult
+
+        background = request.extras.get("background", False)
+        if background:
+            from factory.runners._tmux_persist import run_in_background
+
+            stdout, rc, usage = await run_in_background(
+                request.prompt, request.task, request.cwd, request.role,
+                model=request.model,
+                dangerously_skip_permissions=request.skip_permissions,
+            )
+            return AgentRunResult(stdout=stdout, return_code=rc, usage=usage)
 
         tmux_persist = request.extras.get("tmux_persist", False)
         if tmux_persist:

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -92,6 +92,7 @@ class ClaudeRunner:
 
             stdout, rc, usage = await run_in_background(
                 request.prompt, request.task, request.cwd, request.role,
+                timeout=request.timeout,
                 model=request.model,
                 dangerously_skip_permissions=request.skip_permissions,
             )

--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -142,6 +142,9 @@ class CodexRunner:
         tmux_persist = request.extras.get("tmux_persist", False)
         if tmux_persist:
             log.warning("codex_tmux_not_supported")
+        background = request.extras.get("background", False)
+        if background:
+            log.warning("codex_bg_not_supported", hint="--bg is a claude-only feature")
         if is_codex_dry_run():
             from factory.runners._subprocess import make_dry_run_result
             return make_dry_run_result("codex", request.role, request.cwd, request.task)

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -201,6 +201,9 @@ class OpenCodeRunner:
 
     async def headless(self, request: AgentRunRequest) -> AgentRunResult:
         """Run a headless OpenCode invocation."""
+        background = request.extras.get("background", False)
+        if background:
+            log.warning("opencode_bg_not_supported", hint="--bg is a claude-only feature")
         if is_opencode_dry_run():
             from factory.runners._subprocess import make_dry_run_result
             return make_dry_run_result("opencode", request.role, request.cwd, request.task)

--- a/factory/runners/protocol.py
+++ b/factory/runners/protocol.py
@@ -25,6 +25,7 @@ class RunnerMeta:
     supports_streaming: bool = True
     supports_usage_telemetry: bool = False
     supports_session_name: bool = False
+    supports_background: bool = False
     custom_auth_check: Callable[[], bool] | None = None
 
     def is_available(self) -> bool:

--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -35,6 +35,7 @@ _CONFIG_TEMPLATE = """\
 # model = ""                           # Claude model for agent subprocesses
 # projects_dir = "~/factory-projects"  # Root for factory-managed projects
 # tmux_persist = false                 # Launch agents in tmux windows
+# bg = false                           # Dispatch agents via claude --bg (agent view)
 
 # [credentials.vertex]
 # FACTORY_RUNNER = "claude"

--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -36,6 +36,7 @@ _CONFIG_TEMPLATE = """\
 # projects_dir = "~/factory-projects"  # Root for factory-managed projects
 # tmux_persist = false                 # Launch agents in tmux windows
 # bg = false                           # Dispatch agents via claude --bg (agent view)
+# bg_agents = false                    # Background sub-agents only (CEO stays foreground)
 
 # [credentials.vertex]
 # FACTORY_RUNNER = "claude"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -635,3 +635,78 @@ class TestBgAgents:
         assert bg is True
         assert bg_agents is True
 
+    def test_bg_and_bg_agents_mutual_exclusivity_ceo(self, monkeypatch, tmp_path):
+        """cmd_ceo returns 1 when both --bg and --bg-agents are set."""
+        import argparse
+        import factory.user_config
+        from factory.cli import cmd_ceo
+
+        monkeypatch.delenv("FACTORY_BG", raising=False)
+        monkeypatch.delenv("FACTORY_BG_AGENTS", raising=False)
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+
+        args = argparse.Namespace(
+            path=str(tmp_path), bg=True, bg_agents=True,
+            mode="auto", headless=False, prompt=None, focus=None,
+            dir=None, no_github=False, refine=None, profile=None,
+        )
+        result = cmd_ceo(args)
+        assert result == 1
+
+    def test_bg_agents_overrides_background_in_run(self, monkeypatch):
+        """In cmd_run flow, bg_agents=True forces background=False."""
+        import argparse
+        import factory.user_config
+        from factory.cli import _resolve_background, _resolve_bg_agents
+
+        monkeypatch.delenv("FACTORY_BG", raising=False)
+        monkeypatch.delenv("FACTORY_BG_AGENTS", raising=False)
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+
+        args = argparse.Namespace(bg=True, bg_agents=True)
+        background = _resolve_background(args)
+        bg_agents = _resolve_bg_agents(args)
+        # cmd_run forces background=False when bg_agents is True
+        if bg_agents:
+            background = False
+        assert background is False
+        assert bg_agents is True
+
+    def test_bg_agents_sets_factory_bg_env(self, monkeypatch, tmp_path):
+        """Verify FACTORY_BG is set in os.environ when bg_agents=True in cmd_ceo."""
+        import argparse
+        import factory.user_config
+
+        monkeypatch.delenv("FACTORY_BG", raising=False)
+        monkeypatch.delenv("FACTORY_BG_AGENTS", raising=False)
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+
+        # We can't run cmd_ceo to completion without mocking many things,
+        # but we can verify the _resolve_bg_agents + env-setting logic directly
+        from factory.cli import _resolve_bg_agents
+
+        args = argparse.Namespace(bg_agents=True)
+        result = _resolve_bg_agents(args)
+        assert result is True
+        # The actual env setting happens in cmd_ceo/cmd_run after resolving
+
+    def test_bg_agents_forces_background_false(self, monkeypatch):
+        """When bg_agents=True, background should be forced to False."""
+        import argparse
+        import factory.user_config
+        from factory.cli import _resolve_background, _resolve_bg_agents
+
+        monkeypatch.delenv("FACTORY_BG", raising=False)
+        monkeypatch.delenv("FACTORY_BG_AGENTS", raising=False)
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+
+        # bg_agents=True without bg flag: bg resolves False, bg_agents True
+        args = argparse.Namespace(bg=False, bg_agents=True)
+        bg = _resolve_background(args)
+        bg_agents = _resolve_bg_agents(args)
+        # In cmd_ceo/cmd_run, when bg_agents: background = False
+        if bg_agents:
+            bg = False
+        assert bg is False
+        assert bg_agents is True
+

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -589,3 +589,49 @@ class TestBackgroundDispatch:
         output = "some other output"
         assert _parse_bg_session_id(output) is None
 
+
+class TestBgAgents:
+    """Tests for --bg-agents flag resolution and mutual exclusivity."""
+
+    def test_resolve_bg_agents_flag(self, monkeypatch):
+        """_resolve_bg_agents resolves CLI flag correctly."""
+        import argparse
+        import factory.user_config
+        from factory.cli import _resolve_bg_agents
+
+        monkeypatch.delenv("FACTORY_BG_AGENTS", raising=False)
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+
+        args = argparse.Namespace(bg_agents=True)
+        assert _resolve_bg_agents(args) is True
+
+        args = argparse.Namespace(bg_agents=False)
+        assert _resolve_bg_agents(args) is False
+
+    def test_resolve_bg_agents_env_var(self, monkeypatch):
+        """_resolve_bg_agents resolves FACTORY_BG_AGENTS env var."""
+        import argparse
+        import factory.user_config
+        from factory.cli import _resolve_bg_agents
+
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+        monkeypatch.setenv("FACTORY_BG_AGENTS", "1")
+        args = argparse.Namespace(bg_agents=False)
+        assert _resolve_bg_agents(args) is True
+
+    def test_bg_and_bg_agents_mutually_exclusive(self, monkeypatch):
+        """--bg and --bg-agents cannot be used together."""
+        import argparse
+        import factory.user_config
+        from factory.cli import _resolve_background, _resolve_bg_agents
+
+        monkeypatch.delenv("FACTORY_BG", raising=False)
+        monkeypatch.delenv("FACTORY_BG_AGENTS", raising=False)
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+
+        args = argparse.Namespace(bg=True, bg_agents=True)
+        bg = _resolve_background(args)
+        bg_agents = _resolve_bg_agents(args)
+        assert bg is True
+        assert bg_agents is True
+

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -112,7 +112,7 @@ class TestInvokeAgentsParallel:
 
         call_count = 0
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, review_tag=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, background=False, review_tag=None):
             nonlocal call_count
             call_count += 1
             return (f"output-{role}", 0)
@@ -132,7 +132,7 @@ class TestInvokeAgentsParallel:
         """invoke_agents_parallel returns results from all agents."""
         from factory.agents.runner import invoke_agents_parallel
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, review_tag=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, background=False, review_tag=None):
             return (f"output-{role}", 0)
 
         monkeypatch.setattr("factory.agents.runner.invoke_agent", mock_invoke)
@@ -153,7 +153,7 @@ class TestInvokeAgentsParallel:
 
         captured_models: list[str | None] = []
 
-        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, review_tag=None):
+        async def mock_invoke(role, task, path, *, timeout=600.0, dangerously_skip_permissions=True, model=None, runner_name=None, _track_failures=True, tmux_persist=False, background=False, review_tag=None):
             captured_models.append(model)
             return (f"output-{role}", 0)
 
@@ -487,4 +487,105 @@ class TestCeoPromptNoBackgroundSpawning:
         assert "DON'T" in playbook or "Don't" in playbook
         # Should mention the consequence: double-spend
         assert "double" in playbook.lower()
+
+
+class TestBackgroundDispatch:
+    """Tests for background dispatch via extras dict."""
+
+    @pytest.mark.asyncio
+    async def test_background_threaded_via_extras(self, tmp_path, monkeypatch):
+        """invoke_agent passes background=True through extras dict."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        (tmp_path / ".factory").mkdir()
+
+        captured_extras: dict = {}
+
+        class MockRunner:
+            name = "claude"
+            async def headless(self, request):
+                captured_extras.update(request.extras)
+                from factory.models import AgentRunResult
+                return AgentRunResult(stdout="ok", return_code=0)
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
+
+        await invoke_agent("researcher", "test", tmp_path, background=True)
+        assert captured_extras.get("background") is True
+
+    @pytest.mark.asyncio
+    async def test_background_false_by_default(self, tmp_path, monkeypatch):
+        """invoke_agent passes background=False by default."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        (tmp_path / ".factory").mkdir()
+
+        captured_extras: dict = {}
+
+        class MockRunner:
+            name = "claude"
+            async def headless(self, request):
+                captured_extras.update(request.extras)
+                from factory.models import AgentRunResult
+                return AgentRunResult(stdout="ok", return_code=0)
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
+
+        await invoke_agent("researcher", "test", tmp_path)
+        assert captured_extras.get("background") is False
+
+    def test_supports_background_on_runner_meta(self):
+        """ClaudeRunner metadata has supports_background=True."""
+        from factory.runners.claude import ClaudeRunner
+        assert ClaudeRunner.metadata().supports_background is True
+
+    def test_other_runners_no_background(self):
+        """Non-claude runners have supports_background=False."""
+        from factory.runners.bob import BobRunner
+        from factory.runners.codex import CodexRunner
+        from factory.runners.opencode import OpenCodeRunner
+        assert BobRunner.metadata().supports_background is False
+        assert CodexRunner.metadata().supports_background is False
+        assert OpenCodeRunner.metadata().supports_background is False
+
+    def test_resolve_background_flag(self, monkeypatch):
+        """_resolve_background resolves CLI flag correctly."""
+        import argparse
+        import factory.user_config
+        from factory.cli import _resolve_background
+
+        monkeypatch.delenv("FACTORY_BG", raising=False)
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+
+        args = argparse.Namespace(bg=True)
+        assert _resolve_background(args) is True
+
+        args = argparse.Namespace(bg=False)
+        assert _resolve_background(args) is False
+
+    def test_resolve_background_env_var(self, monkeypatch):
+        """_resolve_background resolves FACTORY_BG env var."""
+        import argparse
+        import factory.user_config
+        from factory.cli import _resolve_background
+
+        monkeypatch.setattr(factory.user_config, "_cached_config", {})
+        monkeypatch.setenv("FACTORY_BG", "1")
+        args = argparse.Namespace(bg=False)
+        assert _resolve_background(args) is True
+
+    def test_parse_bg_session_id(self):
+        """_parse_bg_session_id extracts session ID from claude --bg output."""
+        from factory.runners._tmux_persist import _parse_bg_session_id
+
+        output = "backgrounded · abc123def · factory-ceo"
+        assert _parse_bg_session_id(output) == "abc123def"
+
+        output = "backgrounded · abc123def"
+        assert _parse_bg_session_id(output) == "abc123def"
+
+        output = "some other output"
+        assert _parse_bg_session_id(output) is None
 

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -1185,3 +1185,29 @@ class TestCeoPromptResearchMode:
         improve_idx = ceo_prompt.index("## Mode: Improve")
         review_section = ceo_prompt[review_idx:improve_idx]
         assert "Research mode" in review_section
+
+
+class TestCeoCompletionBackgroundBypass:
+    """Tests for background=True bypassing the respawn loop."""
+
+    async def test_background_bypasses_respawn_loop(self, tmp_path: Path) -> None:
+        """run_ceo_with_completion_guard calls invoke_agent directly when background=True."""
+        from factory.ceo_completion import run_ceo_with_completion_guard
+
+        (tmp_path / ".factory").mkdir()
+
+        with patch(
+            "factory.agents.runner.invoke_agent",
+            new_callable=AsyncMock,
+            return_value=("bg output", 0),
+        ) as mock_invoke:
+            stdout, code = await run_ceo_with_completion_guard(
+                tmp_path, "initial task", mode="improve",
+                background=True,
+            )
+
+        assert stdout == "bg output"
+        assert code == 0
+        mock_invoke.assert_called_once()
+        call_kwargs = mock_invoke.call_args.kwargs
+        assert call_kwargs["background"] is True

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1424,6 +1424,48 @@ class TestCeilingAccumulationAcrossInvocations:
         assert now_before <= runner.cycle_start <= now_after
 
 
+class TestRunnerBgWarnings:
+    """Tests for background warning messages from non-claude runners."""
+
+    async def test_opencode_bg_warning(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OpenCodeRunner logs a warning when extras['background']=True."""
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
+
+        runner = OpenCodeRunner()
+        with patch("factory.runners.opencode.log") as mock_log:
+            await runner.headless(AgentRunRequest(
+                prompt="Test", task="Test", cwd=tmp_path,
+                role="researcher", extras={"background": True},
+            ))
+            mock_log.warning.assert_any_call("opencode_bg_not_supported", hint="--bg is a claude-only feature")
+
+    async def test_bob_bg_warning(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """BobRunner logs a warning when extras['background']=True."""
+        monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")
+        (tmp_path / ".factory").mkdir()
+
+        runner = BobRunner()
+        with patch("factory.runners.bob.log") as mock_log:
+            await runner.headless(AgentRunRequest(
+                prompt="Test", task="Test", cwd=tmp_path,
+                role="researcher", extras={"background": True},
+            ))
+            mock_log.warning.assert_any_call("bob_bg_not_supported", hint="--bg is a claude-only feature")
+
+    async def test_codex_bg_warning(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CodexRunner logs a warning when extras['background']=True."""
+        monkeypatch.setenv("FACTORY_CODEX_DRY_RUN", "1")
+
+        from factory.runners.codex import CodexRunner
+        runner = CodexRunner()
+        with patch("factory.runners.codex.log") as mock_log:
+            await runner.headless(AgentRunRequest(
+                prompt="Test", task="Test", cwd=tmp_path,
+                role="researcher", extras={"background": True},
+            ))
+            mock_log.warning.assert_any_call("codex_bg_not_supported", hint="--bg is a claude-only feature")
+
+
 class TestOpenCodeInteractive:
     """Tests for OpenCodeRunner.interactive_run() — prompt delivery."""
 

--- a/tests/test_session_lifecycle.py
+++ b/tests/test_session_lifecycle.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_tmux_persist.py
+++ b/tests/test_tmux_persist.py
@@ -9,10 +9,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from factory.runners._tmux_persist import (
     _generate_settings,
+    _read_session_state,
     _strip_ansi,
+    _unlink_quiet,
     _wait_for_exitcode,
     _wait_for_sentinel,
     _window_exists,
+    run_in_background,
     run_in_tmux,
     tmux_available,
 )
@@ -701,3 +704,250 @@ class TestClaudeRunnerTmuxPersist:
             patch("factory.runners.claude.run_subprocess", new_callable=AsyncMock, return_value=mock_result),
         ):
             await runner.headless(request)
+
+
+class TestUnlinkQuiet:
+    def test_removes_existing_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "tempfile"
+        f.write_text("data")
+        _unlink_quiet(str(f))
+        assert not f.exists()
+
+    def test_no_error_on_missing_file(self, tmp_path: Path) -> None:
+        _unlink_quiet(str(tmp_path / "nonexistent"))
+
+
+class TestReadSessionState:
+    def test_returns_none_for_missing_path(self, tmp_path: Path) -> None:
+        with patch("factory.runners._tmux_persist._CLAUDE_JOBS_DIR", tmp_path):
+            result = _read_session_state("nonexistent-id")
+        assert result is None
+
+    def test_returns_none_for_invalid_json(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "abc123"
+        session_dir.mkdir()
+        (session_dir / "state.json").write_text("not valid json {{{")
+        with patch("factory.runners._tmux_persist._CLAUDE_JOBS_DIR", tmp_path):
+            result = _read_session_state("abc123")
+        assert result is None
+
+    def test_returns_dict_for_valid_json(self, tmp_path: Path) -> None:
+        session_dir = tmp_path / "abc123"
+        session_dir.mkdir()
+        state = {"state": "done", "output": {"result": "ok"}}
+        (session_dir / "state.json").write_text(json.dumps(state))
+        with patch("factory.runners._tmux_persist._CLAUDE_JOBS_DIR", tmp_path):
+            result = _read_session_state("abc123")
+        assert result == state
+
+
+class TestRunInBackground:
+    async def test_success(self, tmp_path: Path) -> None:
+        state = {"state": "done", "output": {"result": "task completed"}}
+
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._read_session_state") as mock_state,
+            patch("factory.runners._tmux_persist.asyncio.sleep", new_callable=AsyncMock),
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="backgrounded · abc123 · factory-ceo", stderr="",
+            )
+            mock_state.return_value = state
+
+            stdout, rc, usage = await run_in_background(
+                "prompt", "task", tmp_path, "researcher",
+            )
+
+        assert rc == 0
+        assert stdout == "task completed"
+        assert usage is None
+
+    async def test_launch_failure(self, tmp_path: Path) -> None:
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="error occurred", stderr="",
+            )
+
+            stdout, rc, usage = await run_in_background(
+                "prompt", "task", tmp_path, "researcher",
+            )
+
+        assert rc == 1
+        assert "Failed" in stdout
+
+    async def test_file_not_found(self, tmp_path: Path) -> None:
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run", side_effect=FileNotFoundError),
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            stdout, rc, usage = await run_in_background(
+                "prompt", "task", tmp_path, "researcher",
+            )
+
+        assert rc == 1
+        assert "not found" in stdout.lower()
+
+    async def test_launch_timeout(self, tmp_path: Path) -> None:
+        import subprocess
+
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=30)
+
+            stdout, rc, usage = await run_in_background(
+                "prompt", "task", tmp_path, "researcher",
+            )
+
+        assert rc == 1
+        assert "timed out" in stdout.lower()
+
+    async def test_timeout_during_poll(self, tmp_path: Path) -> None:
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._read_session_state", return_value=None),
+            patch("factory.runners._tmux_persist.asyncio.sleep", new_callable=AsyncMock),
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stdout="backgrounded · abc123", stderr=""),
+                MagicMock(returncode=0),  # claude stop
+            ]
+
+            stdout, rc, usage = await run_in_background(
+                "prompt", "task", tmp_path, "researcher", timeout=0.01,
+            )
+
+        assert rc == 1
+        assert "timed out" in stdout.lower()
+
+    async def test_uses_prompt_file(self, tmp_path: Path) -> None:
+        state = {"state": "done", "output": "ok"}
+
+        captured_cmd: list[str] = []
+
+        def mock_subprocess_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            return MagicMock(
+                returncode=0, stdout="backgrounded · abc123", stderr="",
+            )
+
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run", side_effect=mock_subprocess_run),
+            patch("factory.runners._tmux_persist._read_session_state", return_value=state),
+            patch("factory.runners._tmux_persist.asyncio.sleep", new_callable=AsyncMock),
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            await run_in_background(
+                "my system prompt", "do stuff", tmp_path, "builder",
+            )
+
+        assert "--append-system-prompt-file" in captured_cmd
+
+    async def test_cleanup_on_success(self, tmp_path: Path) -> None:
+        state = {"state": "done", "output": "ok"}
+        unlinked_paths: list[str] = []
+
+        def track_unlink(path: str) -> None:
+            unlinked_paths.append(path)
+
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._read_session_state", return_value=state),
+            patch("factory.runners._tmux_persist.asyncio.sleep", new_callable=AsyncMock),
+            patch("factory.runners._tmux_persist._unlink_quiet", side_effect=track_unlink),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="backgrounded · abc123", stderr="",
+            )
+
+            await run_in_background(
+                "prompt", "task", tmp_path, "researcher",
+            )
+
+        assert len(unlinked_paths) == 1
+
+    async def test_output_from_string(self, tmp_path: Path) -> None:
+        state = {"state": "completed", "output": "plain string output"}
+
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._read_session_state", return_value=state),
+            patch("factory.runners._tmux_persist.asyncio.sleep", new_callable=AsyncMock),
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="backgrounded · abc123", stderr="",
+            )
+
+            stdout, rc, _ = await run_in_background(
+                "prompt", "task", tmp_path, "researcher",
+            )
+
+        assert rc == 0
+        assert stdout == "plain string output"
+
+    async def test_failed_state_returns_error_code(self, tmp_path: Path) -> None:
+        state = {"state": "failed", "output": {"result": "error detail"}}
+
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._read_session_state", return_value=state),
+            patch("factory.runners._tmux_persist.asyncio.sleep", new_callable=AsyncMock),
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="backgrounded · abc123", stderr="",
+            )
+
+            stdout, rc, _ = await run_in_background(
+                "prompt", "task", tmp_path, "researcher",
+            )
+
+        assert rc == 1
+        assert stdout == "error detail"
+
+    async def test_no_session_id_in_output(self, tmp_path: Path) -> None:
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._unlink_quiet"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="unexpected output format", stderr="",
+            )
+
+            stdout, rc, _ = await run_in_background(
+                "prompt", "task", tmp_path, "researcher",
+            )
+
+        assert rc == 1
+        assert "Failed" in stdout
+
+
+class TestClaudeRunnerBackgroundDispatch:
+    async def test_headless_routes_to_run_in_background(self, tmp_path: Path) -> None:
+        from factory.models import AgentRunRequest
+
+        runner = ClaudeRunner()
+
+        request = AgentRunRequest(
+            prompt="test prompt", task="test task", cwd=tmp_path,
+            role="researcher", extras={"background": True},
+        )
+
+        with patch(
+            "factory.runners._tmux_persist.run_in_background",
+            new_callable=AsyncMock,
+            return_value=("bg output", 0, None),
+        ) as mock_bg:
+            result = await runner.headless(request)
+
+            assert result.stdout == "bg output"
+            assert result.return_code == 0
+            mock_bg.assert_called_once()


### PR DESCRIPTION
Rework of PR #424 using SPEC.md-driven workflow and extras dict pattern. See issue #570 for details.

Closes #570

## Changes
- Add `--bg` flag to `factory agent` CLI for background dispatch via tmux
- Extend runner protocol with `extras: dict` parameter for out-of-band options
- Update all runner implementations (claude, bob, codex, opencode) to accept extras
- Add `_tmux_persist.py` helper for persistent tmux session management
- Wire `bg` extra through `agent_runner.py` → runner dispatch path
- Add `bg_default` config key to `~/.factory/config.toml` support
- Add tests for extras propagation and bg flag handling