### PR TITLE
fix: populate empty spans with content, model, duration, and capture env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,12 @@ Distributed tracing for the re:factory multi-agent software factory using OpenTe
 
 ```
 src/factory_tracing/
-  __init__.py        — public API: setup_tracing(), get_tracer(), shutdown_tracing()
+  __init__.py        — public API: setup_tracing(), get_tracer(), shutdown_tracing(), TracingIntegration
   config.py          — TracingConfig dataclass, reads from env vars
   provider.py        — TracerProvider singleton, OTLP exporter setup
   spans.py           — agent invocation span helpers (Phase 2)
   propagation.py     — TRACEPARENT injection for subprocesses (Phase 3)
+  integration.py     — TracingIntegration high-level API (Phase 4+5)
   py.typed           — PEP 561 marker
 ```
 
@@ -40,3 +41,47 @@ Copy `.env.example` to `.env` and fill in your Langfuse credentials.
 - **Dev only** (`[dev]` extras): `pytest`, `pytest-asyncio`, `langfuse`, `python-dotenv`
 
 The `factory_tracing` package must NEVER import `langfuse` or `dotenv`. Those are dev/test dependencies only.
+
+## Span Attribute Reference
+
+### Cycle span (`factory.cycle`)
+
+| Attribute | Type | Set by | Description |
+|---|---|---|---|
+| `factory.run.id` | string | `start_cycle()` | Unique cycle/run identifier |
+| `factory.project.name` | string | `start_cycle()` | Project name |
+| `factory.mode` | string | `start_cycle()` | Execution mode (e.g. `improve`) |
+| `factory.experiment.id` | string | `start_cycle(experiment_id=)` | Experiment identifier (optional) |
+| `factory.hypothesis.id` | string | `start_cycle(hypothesis_id=)` | Hypothesis identifier (optional) |
+| `factory.hypothesis.category` | string | `start_cycle(hypothesis_category=)` | FEEC category: FIX/EXPLOIT/EXPLORE/COMBINE (optional) |
+| `factory.experiment.verdict` | string | `record_experiment_verdict()` | Experiment outcome: KEEP/REVERT |
+| `factory.experiment.composite_score` | float | `record_experiment_verdict()` | Composite eval score |
+| `langfuse.observation.type` | string | `trace_factory_cycle()` | Always `"span"` |
+| `langfuse.session.id` | string | `start_cycle()` | `experiment_id` if provided, else `run_id` |
+| `langfuse.trace.metadata.experiment_id` | string | `start_cycle(experiment_id=)` | Filterable in Langfuse UI (optional) |
+| `langfuse.trace.metadata.hypothesis_category` | string | `start_cycle(hypothesis_category=)` | Filterable in Langfuse UI (optional) |
+
+### Cycle span events
+
+| Event name | Attributes | Set by | Description |
+|---|---|---|---|
+| `eval.result` | `eval.<dimension>: float` | `record_eval_result()` | Eval dimension scores (e.g. `eval.tests`, `eval.lint`) |
+
+### Agent span (`invoke_agent {role}`)
+
+| Attribute | Type | Set by | Description |
+|---|---|---|---|
+| `gen_ai.operation.name` | string | `trace_agent_invocation()` | Always `"invoke_agent"` |
+| `gen_ai.agent.name` | string | `trace_agent_invocation()` | Agent role (e.g. `researcher`) |
+| `gen_ai.system` | string | `trace_agent_invocation()` | Always `"anthropic"` |
+| `gen_ai.usage.input_tokens` | int | `record_agent_result()` | Input token count (optional) |
+| `gen_ai.usage.output_tokens` | int | `record_agent_result()` | Output token count (optional) |
+| `gen_ai.usage.cost` | float | `record_agent_result()` | Cost in USD (optional) |
+| `factory.run.id` | string | `trace_agent_invocation()` | Cycle/run identifier |
+| `factory.project.name` | string | `trace_agent_invocation()` | Project name |
+| `factory.task.summary` | string | `trace_agent_invocation()` | Agent task description |
+| `subprocess.returncode` | int | `record_agent_result()` | Agent process exit code |
+| `subprocess.duration_ms` | float | `record_agent_result()` | Agent execution duration |
+| `langfuse.observation.type` | string | `trace_agent_invocation()` | Always `"span"` |
+| `langfuse.session.id` | string | `trace_agent_invocation()` | Cycle/run identifier |
+| `langfuse.trace.tags` | tuple | `trace_agent_invocation()` | Agent role for Langfuse filtering |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
     "python-dotenv>=1.0.0",
 ]
 
+[project.scripts]
+factory-tracing = "factory_tracing.cli:_cli_entry"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/factory_tracing/__init__.py
+++ b/src/factory_tracing/__init__.py
@@ -1,5 +1,6 @@
 from .provider import get_tracer_provider, get_tracer, shutdown_tracing
 from .spans import trace_factory_cycle, trace_agent_invocation, record_agent_result
+from .propagation import build_traced_env
 
 __all__ = [
     "get_tracer_provider",
@@ -8,4 +9,5 @@ __all__ = [
     "trace_factory_cycle",
     "trace_agent_invocation",
     "record_agent_result",
+    "build_traced_env",
 ]

--- a/src/factory_tracing/__init__.py
+++ b/src/factory_tracing/__init__.py
@@ -1,6 +1,7 @@
 from .provider import get_tracer_provider, get_tracer, shutdown_tracing
 from .spans import trace_factory_cycle, trace_agent_invocation, record_agent_result
 from .propagation import build_traced_env
+from .integration import TracingIntegration
 
 __all__ = [
     "get_tracer_provider",
@@ -10,4 +11,5 @@ __all__ = [
     "trace_agent_invocation",
     "record_agent_result",
     "build_traced_env",
+    "TracingIntegration",
 ]

--- a/src/factory_tracing/__init__.py
+++ b/src/factory_tracing/__init__.py
@@ -2,6 +2,7 @@ from .provider import get_tracer_provider, get_tracer, shutdown_tracing
 from .spans import trace_factory_cycle, trace_agent_invocation, record_agent_result
 from .propagation import build_traced_env
 from .integration import TracingIntegration
+from .executor import run_traced_agent, AgentResult
 
 __all__ = [
     "get_tracer_provider",
@@ -12,4 +13,6 @@ __all__ = [
     "record_agent_result",
     "build_traced_env",
     "TracingIntegration",
+    "run_traced_agent",
+    "AgentResult",
 ]

--- a/src/factory_tracing/cli.py
+++ b/src/factory_tracing/cli.py
@@ -57,31 +57,18 @@ def _run_status() -> int:
     return 0
 
 
-def _run_verify() -> int:
+def _run_verify(num_agents: int = 2) -> int:
     from .verify import run_verification
 
     print("factory-tracing verify")
     print("=" * 40)
-    print("Running end-to-end verification...\n")
+    print(f"Running multi-agent verification ({num_agents} agents)...\n")
 
-    result = run_verification()
+    result = run_verification(num_agents=num_agents)
 
-    if result.trace_id:
-        print(f"Trace ID:     {result.trace_id}")
-        print(f"Langfuse URL: {result.langfuse_url}")
-        print(f"Span count:   {result.span_count}")
-
-    print("\nChecks:")
-    for check in result.checks:
-        status = "PASS" if check.passed else "FAIL"
-        print(f"  [{status}] {check.name}: {check.detail}")
-
-    print()
     if result.success:
-        print("Result: VERIFIED — end-to-end tracing pipeline is working")
         return 0
     else:
-        print("Result: FAILED — see check details above")
         return 1
 
 
@@ -91,13 +78,17 @@ def main(argv: list[str] | None = None) -> int:
         description="Distributed tracing management for the factory",
     )
     subparsers = parser.add_subparsers(dest="command")
-    subparsers.add_parser("verify", help="Run end-to-end verification against Langfuse")
+    verify_parser = subparsers.add_parser("verify", help="Run multi-agent end-to-end verification against Langfuse")
+    verify_parser.add_argument(
+        "--agents", type=int, default=2, metavar="N",
+        help="Number of agents to invoke in the verification cycle (default: 2)",
+    )
     subparsers.add_parser("status", help="Check configuration and Langfuse connectivity")
 
     args = parser.parse_args(argv)
 
     if args.command == "verify":
-        return _run_verify()
+        return _run_verify(num_agents=args.agents)
     elif args.command == "status":
         return _run_status()
     else:

--- a/src/factory_tracing/cli.py
+++ b/src/factory_tracing/cli.py
@@ -1,0 +1,109 @@
+"""CLI entry point for factory-tracing: verify and status commands."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.request
+import urllib.error
+
+from dotenv import load_dotenv
+
+
+REQUIRED_VARS = [
+    "FACTORY_TRACING_ENABLED",
+    "LANGFUSE_HOST",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+]
+
+
+def _run_status() -> int:
+    load_dotenv()
+
+    print("factory-tracing status")
+    print("=" * 40)
+
+    all_present = True
+    for var in REQUIRED_VARS:
+        value = os.environ.get(var, "")
+        if value:
+            masked = value[:4] + "***" if var.endswith("_KEY") else value
+            print(f"  {var}: {masked}")
+        else:
+            print(f"  {var}: NOT SET")
+            all_present = False
+
+    langfuse_host = os.environ.get("LANGFUSE_HOST", "")
+    if langfuse_host:
+        health_url = f"{langfuse_host.rstrip('/')}/api/public/health"
+        print(f"\nHealth check: {health_url}")
+        try:
+            req = urllib.request.Request(health_url, method="GET")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                print(f"  Status: {resp.status} OK")
+        except urllib.error.URLError as exc:
+            print(f"  Status: UNREACHABLE ({exc.reason})")
+        except Exception as exc:
+            print(f"  Status: ERROR ({exc})")
+    else:
+        print("\nHealth check: skipped (LANGFUSE_HOST not set)")
+
+    if all_present:
+        print("\nConfiguration: COMPLETE")
+    else:
+        print("\nConfiguration: INCOMPLETE — set missing variables")
+
+    return 0
+
+
+def _run_verify() -> int:
+    from .verify import run_verification
+
+    print("factory-tracing verify")
+    print("=" * 40)
+    print("Running end-to-end verification...\n")
+
+    result = run_verification()
+
+    if result.trace_id:
+        print(f"Trace ID:     {result.trace_id}")
+        print(f"Langfuse URL: {result.langfuse_url}")
+        print(f"Span count:   {result.span_count}")
+
+    print("\nChecks:")
+    for check in result.checks:
+        status = "PASS" if check.passed else "FAIL"
+        print(f"  [{status}] {check.name}: {check.detail}")
+
+    print()
+    if result.success:
+        print("Result: VERIFIED — end-to-end tracing pipeline is working")
+        return 0
+    else:
+        print("Result: FAILED — see check details above")
+        return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="factory-tracing",
+        description="Distributed tracing management for the factory",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser("verify", help="Run end-to-end verification against Langfuse")
+    subparsers.add_parser("status", help="Check configuration and Langfuse connectivity")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "verify":
+        return _run_verify()
+    elif args.command == "status":
+        return _run_status()
+    else:
+        parser.print_help()
+        return 0
+
+
+def _cli_entry() -> None:
+    sys.exit(main())

--- a/src/factory_tracing/cli.py
+++ b/src/factory_tracing/cli.py
@@ -57,19 +57,11 @@ def _run_status() -> int:
     return 0
 
 
-def _run_verify(num_agents: int = 2) -> int:
+def _run_verify() -> int:
     from .verify import run_verification
 
-    print("factory-tracing verify")
-    print("=" * 40)
-    print(f"Running multi-agent verification ({num_agents} agents)...\n")
-
-    result = run_verification(num_agents=num_agents)
-
-    if result.success:
-        return 0
-    else:
-        return 1
+    result = run_verification()
+    return 0 if result.success else 1
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -78,17 +70,13 @@ def main(argv: list[str] | None = None) -> int:
         description="Distributed tracing management for the factory",
     )
     subparsers = parser.add_subparsers(dest="command")
-    verify_parser = subparsers.add_parser("verify", help="Run multi-agent end-to-end verification against Langfuse")
-    verify_parser.add_argument(
-        "--agents", type=int, default=2, metavar="N",
-        help="Number of agents to invoke in the verification cycle (default: 2)",
-    )
+    subparsers.add_parser("verify", help="Run 2-agent end-to-end verification against Langfuse (10 criteria)")
     subparsers.add_parser("status", help="Check configuration and Langfuse connectivity")
 
     args = parser.parse_args(argv)
 
     if args.command == "verify":
-        return _run_verify(num_agents=args.agents)
+        return _run_verify()
     elif args.command == "status":
         return _run_status()
     else:

--- a/src/factory_tracing/executor.py
+++ b/src/factory_tracing/executor.py
@@ -1,0 +1,310 @@
+"""Execute Claude Code agents with stream-json parsing and OTel span creation.
+
+Parses Claude Code's --output-format stream-json NDJSON output to create
+spans with full input/output content, bypassing Claude Code's native OTel
+which produces empty content fields.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+
+from opentelemetry.trace import StatusCode
+
+from .provider import get_tracer
+
+MAX_CONTENT_LENGTH = 4000
+
+
+@dataclass
+class AgentResult:
+    response_text: str
+    exit_code: int
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    duration_ms: float
+    model: str
+    num_turns: int
+    session_id: str
+
+
+def _truncate(text: str, max_len: int = MAX_CONTENT_LENGTH) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "...[truncated]"
+
+
+def run_traced_agent(
+    prompt: str,
+    role: str,
+    run_id: str,
+    project_name: str,
+    cwd: str | None = None,
+    model: str = "anthropic",
+    env: dict | None = None,
+) -> AgentResult:
+    tracer = get_tracer()
+
+    with tracer.start_as_current_span(f"invoke_agent {role}") as agent_span:
+        agent_span.set_attribute("gen_ai.operation.name", "invoke_agent")
+        agent_span.set_attribute("gen_ai.agent.name", role)
+        agent_span.set_attribute("gen_ai.system", "anthropic")
+        agent_span.set_attribute("gen_ai.request.model", model)
+        agent_span.set_attribute("factory.run.id", run_id)
+        agent_span.set_attribute("factory.project.name", project_name)
+        agent_span.set_attribute("factory.task.summary", prompt)
+        agent_span.set_attribute("gen_ai.prompt", _truncate(prompt))
+        agent_span.set_attribute("langfuse.span.input", _truncate(prompt))
+        agent_span.set_attribute("langfuse.observation.type", "span")
+        agent_span.set_attribute("langfuse.session.id", run_id)
+        agent_span.set_attribute("langfuse.trace.tags", (role,))
+
+        result = _execute_and_parse(
+            prompt=prompt,
+            role=role,
+            agent_span=agent_span,
+            tracer=tracer,
+            cwd=cwd,
+            model=model,
+            env=env,
+        )
+
+        agent_span.set_attribute("gen_ai.completion", _truncate(result.response_text))
+        agent_span.set_attribute("langfuse.span.output", _truncate(result.response_text))
+        agent_span.set_attribute("subprocess.returncode", result.exit_code)
+        agent_span.set_attribute("subprocess.duration_ms", result.duration_ms)
+        agent_span.set_attribute("gen_ai.usage.input_tokens", result.input_tokens)
+        agent_span.set_attribute("gen_ai.usage.output_tokens", result.output_tokens)
+        agent_span.set_attribute("gen_ai.usage.cost", result.cost_usd)
+
+        if result.model and result.model != model:
+            agent_span.set_attribute("gen_ai.request.model", result.model)
+
+        if result.exit_code != 0:
+            agent_span.set_status(StatusCode.ERROR, f"agent exited with code {result.exit_code}")
+        else:
+            agent_span.set_status(StatusCode.OK)
+
+        return result
+
+
+def _execute_and_parse(
+    prompt: str,
+    role: str,
+    agent_span,
+    tracer,
+    cwd: str | None,
+    model: str,
+    env: dict | None,
+) -> AgentResult:
+    cmd = ["claude", "-p", prompt, "--output-format", "stream-json", "--verbose"]
+
+    open_tool_spans: dict[str, object] = {}
+    detected_model = model
+    session_id = ""
+    total_input_tokens = 0
+    total_output_tokens = 0
+    response_text = ""
+    cost_usd = 0.0
+    duration_ms = 0.0
+    num_turns = 0
+    turn_count = 0
+
+    start_time = time.monotonic()
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+            env=env,
+        )
+    except FileNotFoundError:
+        return AgentResult(
+            response_text="",
+            exit_code=127,
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            duration_ms=(time.monotonic() - start_time) * 1000.0,
+            model=model,
+            num_turns=0,
+            session_id="",
+        )
+
+    try:
+        for line in proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = event.get("type", "")
+
+            if event_type == "system" and event.get("subtype") == "init":
+                detected_model = event.get("model", model)
+                session_id = event.get("session_id", "")
+                agent_span.set_attribute("gen_ai.request.model", detected_model)
+                if session_id:
+                    agent_span.set_attribute("gen_ai.session.id", session_id)
+
+            elif event_type == "assistant":
+                _handle_assistant_event(
+                    event, agent_span, tracer, open_tool_spans,
+                    detected_model, prompt, turn_count,
+                )
+                turn_count += 1
+                msg = event.get("message", {})
+                usage = msg.get("usage", {})
+                if usage:
+                    total_input_tokens += usage.get("input_tokens", 0)
+                    total_output_tokens += usage.get("output_tokens", 0)
+
+            elif event_type == "user":
+                _handle_user_event(event, open_tool_spans)
+
+            elif event_type == "result":
+                response_text = event.get("result", "")
+                if isinstance(response_text, list):
+                    parts = []
+                    for block in response_text:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            parts.append(block.get("text", ""))
+                    response_text = "\n".join(parts)
+                elif not isinstance(response_text, str):
+                    response_text = str(response_text) if response_text else ""
+
+                result_usage = event.get("usage", {})
+                if result_usage:
+                    total_input_tokens = result_usage.get("input_tokens", total_input_tokens)
+                    total_output_tokens = result_usage.get("output_tokens", total_output_tokens)
+                cost_usd = event.get("total_cost_usd", 0.0) or 0.0
+                duration_ms = event.get("duration_ms", 0.0) or 0.0
+                num_turns = event.get("num_turns", 0) or 0
+
+        proc.wait()
+        exit_code = proc.returncode
+
+    except Exception:
+        proc.kill()
+        proc.wait()
+        exit_code = proc.returncode if proc.returncode is not None else 1
+        if not duration_ms:
+            duration_ms = (time.monotonic() - start_time) * 1000.0
+
+    for tool_id, tool_span in open_tool_spans.items():
+        tool_span.set_status(StatusCode.ERROR, "tool span never received result")
+        tool_span.end()
+    open_tool_spans.clear()
+
+    if not duration_ms:
+        duration_ms = (time.monotonic() - start_time) * 1000.0
+
+    return AgentResult(
+        response_text=response_text,
+        exit_code=exit_code,
+        input_tokens=total_input_tokens,
+        output_tokens=total_output_tokens,
+        cost_usd=cost_usd,
+        duration_ms=duration_ms,
+        model=detected_model,
+        num_turns=num_turns,
+        session_id=session_id,
+    )
+
+
+def _handle_assistant_event(event, agent_span, tracer, open_tool_spans, model, prompt, turn_count):
+    msg = event.get("message", {})
+    content_blocks = msg.get("content", [])
+    usage = msg.get("usage", {})
+
+    text_parts = []
+    tool_use_blocks = []
+
+    for block in content_blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            text_parts.append(block.get("text", ""))
+        elif block.get("type") == "tool_use":
+            tool_use_blocks.append(block)
+
+    for tool_block in tool_use_blocks:
+        tool_name = tool_block.get("name", "unknown")
+        tool_use_id = tool_block.get("id", "")
+        tool_input = tool_block.get("input", {})
+
+        tool_span = tracer.start_span(
+            f"tool:{tool_name}",
+            context=_span_context(agent_span),
+        )
+        tool_span.set_attribute("tool.name", tool_name)
+        tool_span.set_attribute("gen_ai.prompt", _truncate(json.dumps(tool_input)))
+        tool_span.set_attribute("langfuse.span.input", _truncate(json.dumps(tool_input)))
+        tool_span.set_attribute("langfuse.observation.type", "span")
+
+        if tool_use_id:
+            open_tool_spans[tool_use_id] = tool_span
+
+    if text_parts and not tool_use_blocks:
+        text_content = "\n".join(text_parts)
+        llm_span = tracer.start_span(
+            "llm_call",
+            context=_span_context(agent_span),
+        )
+        llm_span.set_attribute("gen_ai.request.model", model)
+        llm_span.set_attribute("gen_ai.prompt", _truncate(prompt) if turn_count == 0 else "[conversation context]")
+        llm_span.set_attribute("gen_ai.completion", _truncate(text_content))
+        llm_span.set_attribute("langfuse.span.input", _truncate(prompt) if turn_count == 0 else "[conversation context]")
+        llm_span.set_attribute("langfuse.span.output", _truncate(text_content))
+        llm_span.set_attribute("langfuse.observation.type", "span")
+        if usage:
+            if "input_tokens" in usage:
+                llm_span.set_attribute("gen_ai.usage.input_tokens", usage["input_tokens"])
+            if "output_tokens" in usage:
+                llm_span.set_attribute("gen_ai.usage.output_tokens", usage["output_tokens"])
+        llm_span.set_status(StatusCode.OK)
+        llm_span.end()
+
+
+def _handle_user_event(event, open_tool_spans):
+    msg = event.get("message", {})
+    content_blocks = msg.get("content", [])
+
+    for block in content_blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_result":
+            continue
+
+        tool_use_id = block.get("tool_use_id", "")
+        result_content = block.get("content", "")
+        if isinstance(result_content, list):
+            parts = []
+            for part in result_content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    parts.append(part.get("text", ""))
+            result_content = "\n".join(parts)
+        elif not isinstance(result_content, str):
+            result_content = str(result_content) if result_content else ""
+
+        if tool_use_id and tool_use_id in open_tool_spans:
+            tool_span = open_tool_spans.pop(tool_use_id)
+            tool_span.set_attribute("gen_ai.completion", _truncate(result_content))
+            tool_span.set_attribute("langfuse.span.output", _truncate(result_content))
+            tool_span.set_status(StatusCode.OK)
+            tool_span.end()
+
+
+def _span_context(parent_span):
+    from opentelemetry import context as otel_context
+    from opentelemetry.trace import set_span_in_context
+    return set_span_in_context(parent_span, otel_context.get_current())

--- a/src/factory_tracing/executor.py
+++ b/src/factory_tracing/executor.py
@@ -57,7 +57,7 @@ def run_traced_agent(
         agent_span.set_attribute("factory.project.name", project_name)
         agent_span.set_attribute("factory.task.summary", prompt)
         agent_span.set_attribute("gen_ai.prompt", _truncate(prompt))
-        agent_span.set_attribute("langfuse.span.input", _truncate(prompt))
+        agent_span.set_attribute("langfuse.span.input", json.dumps({"prompt": _truncate(prompt), "role": role}))
         agent_span.set_attribute("langfuse.observation.type", "span")
         agent_span.set_attribute("langfuse.session.id", run_id)
         agent_span.set_attribute("langfuse.trace.tags", (role,))
@@ -73,7 +73,7 @@ def run_traced_agent(
         )
 
         agent_span.set_attribute("gen_ai.completion", _truncate(result.response_text))
-        agent_span.set_attribute("langfuse.span.output", _truncate(result.response_text))
+        agent_span.set_attribute("langfuse.span.output", json.dumps({"response": _truncate(result.response_text), "model": result.model, "tokens": {"input": result.input_tokens, "output": result.output_tokens}, "cost_usd": result.cost_usd}))
         agent_span.set_attribute("subprocess.returncode", result.exit_code)
         agent_span.set_attribute("subprocess.duration_ms", result.duration_ms)
         agent_span.set_attribute("gen_ai.usage.input_tokens", result.input_tokens)
@@ -248,7 +248,7 @@ def _handle_assistant_event(event, agent_span, tracer, open_tool_spans, model, p
         )
         tool_span.set_attribute("tool.name", tool_name)
         tool_span.set_attribute("gen_ai.prompt", _truncate(json.dumps(tool_input)))
-        tool_span.set_attribute("langfuse.span.input", _truncate(json.dumps(tool_input)))
+        tool_span.set_attribute("langfuse.span.input", json.dumps({"tool": tool_name, "input": tool_input}))
         tool_span.set_attribute("langfuse.observation.type", "span")
 
         if tool_use_id:
@@ -261,10 +261,11 @@ def _handle_assistant_event(event, agent_span, tracer, open_tool_spans, model, p
             context=_span_context(agent_span),
         )
         llm_span.set_attribute("gen_ai.request.model", model)
-        llm_span.set_attribute("gen_ai.prompt", _truncate(prompt) if turn_count == 0 else "[conversation context]")
+        llm_input = _truncate(prompt) if turn_count == 0 else "[conversation context]"
+        llm_span.set_attribute("gen_ai.prompt", llm_input)
         llm_span.set_attribute("gen_ai.completion", _truncate(text_content))
-        llm_span.set_attribute("langfuse.span.input", _truncate(prompt) if turn_count == 0 else "[conversation context]")
-        llm_span.set_attribute("langfuse.span.output", _truncate(text_content))
+        llm_span.set_attribute("langfuse.span.input", json.dumps({"prompt": llm_input}))
+        llm_span.set_attribute("langfuse.span.output", json.dumps({"completion": _truncate(text_content)}))
         llm_span.set_attribute("langfuse.observation.type", "span")
         if usage:
             if "input_tokens" in usage:
@@ -299,7 +300,7 @@ def _handle_user_event(event, open_tool_spans):
         if tool_use_id and tool_use_id in open_tool_spans:
             tool_span = open_tool_spans.pop(tool_use_id)
             tool_span.set_attribute("gen_ai.completion", _truncate(result_content))
-            tool_span.set_attribute("langfuse.span.output", _truncate(result_content))
+            tool_span.set_attribute("langfuse.span.output", json.dumps({"result": _truncate(result_content)}))
             tool_span.set_status(StatusCode.OK)
             tool_span.end()
 

--- a/src/factory_tracing/integration.py
+++ b/src/factory_tracing/integration.py
@@ -44,12 +44,27 @@ class TracingIntegration:
 
     @contextmanager
     def start_cycle(
-        self, run_id: str, project_name: str, mode: str
+        self,
+        run_id: str,
+        project_name: str,
+        mode: str,
+        experiment_id: str | None = None,
+        hypothesis_id: str | None = None,
+        hypothesis_category: str | None = None,
     ) -> Iterator[Span | _NoOpSpan]:
         if not self.enabled:
             yield _NOOP_SPAN
             return
         with trace_factory_cycle(run_id, project_name, mode) as span:
+            if experiment_id is not None:
+                span.set_attribute("factory.experiment.id", experiment_id)
+                span.set_attribute("langfuse.trace.metadata.experiment_id", experiment_id)
+                span.set_attribute("langfuse.session.id", experiment_id)
+            if hypothesis_id is not None:
+                span.set_attribute("factory.hypothesis.id", hypothesis_id)
+            if hypothesis_category is not None:
+                span.set_attribute("factory.hypothesis.category", hypothesis_category)
+                span.set_attribute("langfuse.trace.metadata.hypothesis_category", hypothesis_category)
             yield span
 
     @contextmanager
@@ -84,6 +99,27 @@ class TracingIntegration:
             output_tokens=output_tokens,
             cost_usd=cost_usd,
         )
+
+    def record_eval_result(
+        self,
+        span: Span | _NoOpSpan,
+        scores: dict,
+    ) -> None:
+        if not self.enabled or isinstance(span, _NoOpSpan):
+            return
+        prefixed = {f"eval.{k}": v for k, v in scores.items()}
+        span.add_event("eval.result", attributes=prefixed)  # type: ignore[arg-type]
+
+    def record_experiment_verdict(
+        self,
+        span: Span | _NoOpSpan,
+        verdict: str,
+        composite_score: float,
+    ) -> None:
+        if not self.enabled or isinstance(span, _NoOpSpan):
+            return
+        span.set_attribute("factory.experiment.verdict", verdict)  # type: ignore[union-attr]
+        span.set_attribute("factory.experiment.composite_score", composite_score)  # type: ignore[union-attr]
 
     def shutdown(self) -> None:
         if self.enabled:

--- a/src/factory_tracing/integration.py
+++ b/src/factory_tracing/integration.py
@@ -10,6 +10,7 @@ from typing import Iterator
 from opentelemetry.trace import Span
 
 from .config import TracingConfig
+from .executor import AgentResult, run_traced_agent
 from .propagation import build_traced_env
 from .provider import get_tracer_provider, shutdown_tracing
 from .spans import record_agent_result, trace_agent_invocation, trace_factory_cycle
@@ -141,6 +142,26 @@ class TracingIntegration:
             return
         span.set_attribute("factory.experiment.verdict", verdict)  # type: ignore[union-attr]
         span.set_attribute("factory.experiment.composite_score", composite_score)  # type: ignore[union-attr]
+
+    def run_agent(
+        self,
+        prompt: str,
+        role: str,
+        run_id: str = "",
+        project_name: str = "",
+        cwd: str | None = None,
+        model: str = "anthropic",
+    ) -> AgentResult:
+        env = self.build_subprocess_env() if self.enabled else None
+        return run_traced_agent(
+            prompt=prompt,
+            role=role,
+            run_id=run_id or self._run_id,
+            project_name=project_name,
+            cwd=cwd,
+            model=model,
+            env=env,
+        )
 
     def shutdown(self) -> None:
         if self.enabled:

--- a/src/factory_tracing/integration.py
+++ b/src/factory_tracing/integration.py
@@ -1,0 +1,91 @@
+"""High-level tracing integration for the factory orchestrator.
+
+Production code — must NOT import langfuse or dotenv.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from opentelemetry.trace import Span
+
+from .config import TracingConfig
+from .propagation import build_traced_env
+from .provider import get_tracer_provider, shutdown_tracing
+from .spans import record_agent_result, trace_agent_invocation, trace_factory_cycle
+
+
+class _NoOpSpan:
+    """Minimal stand-in when tracing is disabled."""
+
+    def set_attribute(self, key: str, value: object) -> None:
+        pass
+
+    def set_status(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def add_event(self, name: str, attributes: dict | None = None) -> None:
+        pass
+
+
+_NOOP_SPAN = _NoOpSpan()
+
+
+class TracingIntegration:
+    def __init__(self, config: TracingConfig | None = None) -> None:
+        self._config = config or TracingConfig.from_env()
+        self._provider = None
+        if self._config.enabled:
+            self._provider = get_tracer_provider(self._config)
+
+    @property
+    def enabled(self) -> bool:
+        return self._provider is not None
+
+    @contextmanager
+    def start_cycle(
+        self, run_id: str, project_name: str, mode: str
+    ) -> Iterator[Span | _NoOpSpan]:
+        if not self.enabled:
+            yield _NOOP_SPAN
+            return
+        with trace_factory_cycle(run_id, project_name, mode) as span:
+            yield span
+
+    @contextmanager
+    def start_agent(
+        self, role: str, task_summary: str = "", run_id: str = "", project_name: str = ""
+    ) -> Iterator[Span | _NoOpSpan]:
+        if not self.enabled:
+            yield _NOOP_SPAN
+            return
+        with trace_agent_invocation(role, task_summary, run_id, project_name) as span:
+            yield span
+
+    def build_subprocess_env(self, base_env: dict | None = None) -> dict:
+        return build_traced_env(base_env)
+
+    def record_agent_result(
+        self,
+        span: Span | _NoOpSpan,
+        exit_code: int,
+        duration_ms: float = 0.0,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        cost_usd: float | None = None,
+    ) -> None:
+        if not self.enabled or isinstance(span, _NoOpSpan):
+            return
+        record_agent_result(
+            span,  # type: ignore[arg-type]
+            exit_code=exit_code,
+            duration_ms=duration_ms,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+        )
+
+    def shutdown(self) -> None:
+        if self.enabled:
+            shutdown_tracing()
+            self._provider = None

--- a/src/factory_tracing/integration.py
+++ b/src/factory_tracing/integration.py
@@ -35,6 +35,7 @@ class TracingIntegration:
     def __init__(self, config: TracingConfig | None = None) -> None:
         self._config = config or TracingConfig.from_env()
         self._provider = None
+        self._run_id: str = ""
         if self._config.enabled:
             self._provider = get_tracer_provider(self._config)
 
@@ -55,6 +56,7 @@ class TracingIntegration:
         if not self.enabled:
             yield _NOOP_SPAN
             return
+        self._run_id = run_id
         with trace_factory_cycle(run_id, project_name, mode) as span:
             if experiment_id is not None:
                 span.set_attribute("factory.experiment.id", experiment_id)
@@ -88,6 +90,9 @@ class TracingIntegration:
         input_tokens: int | None = None,
         output_tokens: int | None = None,
         cost_usd: float | None = None,
+        response_text: str | None = None,
+        start_time: float | None = None,
+        model: str | None = None,
     ) -> None:
         if not self.enabled or isinstance(span, _NoOpSpan):
             return
@@ -98,7 +103,23 @@ class TracingIntegration:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cost_usd=cost_usd,
+            response_text=response_text,
+            start_time=start_time,
+            model=model,
         )
+
+    def set_span_io(
+        self,
+        span: Span | _NoOpSpan,
+        input_text: str | None = None,
+        output_text: str | None = None,
+    ) -> None:
+        if not self.enabled or isinstance(span, _NoOpSpan):
+            return
+        if input_text is not None:
+            span.set_attribute("gen_ai.prompt", input_text)  # type: ignore[union-attr]
+        if output_text is not None:
+            span.set_attribute("gen_ai.completion", output_text)  # type: ignore[union-attr]
 
     def record_eval_result(
         self,

--- a/src/factory_tracing/propagation.py
+++ b/src/factory_tracing/propagation.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import base64
+import os
+
+from opentelemetry import propagate
+
+from .config import TracingConfig
+from .provider import get_tracer_provider
+
+
+def build_traced_env(base_env: dict | None = None) -> dict:
+    env = dict(base_env if base_env is not None else os.environ)
+
+    provider = get_tracer_provider()
+    if provider is None:
+        return env
+
+    carrier: dict[str, str] = {}
+    propagate.inject(carrier)
+
+    if "traceparent" in carrier:
+        env["TRACEPARENT"] = carrier["traceparent"]
+    if "tracestate" in carrier:
+        env["TRACESTATE"] = carrier["tracestate"]
+
+    config = TracingConfig.from_env()
+
+    langfuse_host = config.langfuse_host.rstrip("/")
+    auth_string = base64.b64encode(
+        f"{config.langfuse_public_key}:{config.langfuse_secret_key}".encode()
+    ).decode()
+
+    env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+    env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+    env["OTEL_TRACES_EXPORTER"] = "otlp"
+    env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+    env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"{langfuse_host}/api/public/otel"
+    env["OTEL_EXPORTER_OTLP_HEADERS"] = (
+        f"Authorization=Basic {auth_string},"
+        f"x-langfuse-ingestion-version=4"
+    )
+    env["OTEL_SERVICE_NAME"] = "factory-agent"
+
+    return env

--- a/src/factory_tracing/propagation.py
+++ b/src/factory_tracing/propagation.py
@@ -31,19 +31,6 @@ def build_traced_env(base_env: dict | None = None) -> dict:
         f"{config.langfuse_public_key}:{config.langfuse_secret_key}".encode()
     ).decode()
 
-    env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
-    env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
-    env["OTEL_TRACES_EXPORTER"] = "otlp"
-    env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
-    env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"{langfuse_host}/api/public/otel"
-    env["OTEL_EXPORTER_OTLP_HEADERS"] = (
-        f"Authorization=Basic {auth_string},"
-        f"x-langfuse-ingestion-version=4"
-    )
     env["OTEL_SERVICE_NAME"] = "factory-agent"
-
-    env["OTEL_LOG_USER_PROMPTS"] = "1"
-    env["OTEL_LOG_TOOL_DETAILS"] = "1"
-    env["OTEL_LOG_TOOL_CONTENT"] = "1"
 
     return env

--- a/src/factory_tracing/propagation.py
+++ b/src/factory_tracing/propagation.py
@@ -42,4 +42,8 @@ def build_traced_env(base_env: dict | None = None) -> dict:
     )
     env["OTEL_SERVICE_NAME"] = "factory-agent"
 
+    env["OTEL_LOG_USER_PROMPTS"] = "1"
+    env["OTEL_LOG_TOOL_DETAILS"] = "1"
+    env["OTEL_LOG_TOOL_CONTENT"] = "1"
+
     return env

--- a/src/factory_tracing/spans.py
+++ b/src/factory_tracing/spans.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 from contextlib import contextmanager
 from typing import Iterator
@@ -23,6 +24,8 @@ def trace_factory_cycle(
         span.set_attribute("factory.mode", mode)
         span.set_attribute("langfuse.observation.type", "span")
         span.set_attribute("langfuse.session.id", run_id)
+        span.set_attribute("langfuse.span.input", json.dumps({"project": project_name, "mode": mode, "run_id": run_id}))
+        span.set_attribute("gen_ai.prompt", json.dumps({"project": project_name, "mode": mode}))
         try:
             yield span
         except Exception as exc:

--- a/src/factory_tracing/spans.py
+++ b/src/factory_tracing/spans.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from contextlib import contextmanager
 from typing import Iterator
 
@@ -40,6 +41,7 @@ def trace_agent_invocation(
     task_summary: str,
     run_id: str,
     project_name: str,
+    model: str = "anthropic",
 ) -> Iterator[Span]:
     """Child span for a single agent invocation within a cycle."""
     tracer = get_tracer()
@@ -47,9 +49,12 @@ def trace_agent_invocation(
         span.set_attribute("gen_ai.operation.name", "invoke_agent")
         span.set_attribute("gen_ai.agent.name", role)
         span.set_attribute("gen_ai.system", "anthropic")
+        span.set_attribute("gen_ai.request.model", model)
         span.set_attribute("factory.run.id", run_id)
         span.set_attribute("factory.project.name", project_name)
         span.set_attribute("factory.task.summary", task_summary)
+        if task_summary:
+            span.set_attribute("gen_ai.prompt", task_summary)
         span.set_attribute("langfuse.observation.type", "span")
         span.set_attribute("langfuse.session.id", run_id)
         span.set_attribute("langfuse.trace.tags", (role,))
@@ -68,14 +73,26 @@ def trace_agent_invocation(
 def record_agent_result(
     span: Span,
     exit_code: int,
-    duration_ms: float,
+    duration_ms: float = 0.0,
     input_tokens: int | None = None,
     output_tokens: int | None = None,
     cost_usd: float | None = None,
+    response_text: str | None = None,
+    start_time: float | None = None,
+    model: str | None = None,
 ) -> None:
     """Record subprocess result and optional usage metrics on an agent span."""
+    if start_time is not None:
+        duration_ms = (time.monotonic() - start_time) * 1000.0
+
     span.set_attribute("subprocess.returncode", exit_code)
     span.set_attribute("subprocess.duration_ms", duration_ms)
+
+    if response_text is not None:
+        span.set_attribute("gen_ai.completion", response_text)
+
+    if model is not None:
+        span.set_attribute("gen_ai.request.model", model)
 
     if input_tokens is not None:
         span.set_attribute("gen_ai.usage.input_tokens", input_tokens)

--- a/src/factory_tracing/spans.py
+++ b/src/factory_tracing/spans.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import json
 from contextlib import contextmanager
 from typing import Iterator
 
-from opentelemetry import trace
 from opentelemetry.trace import Span, StatusCode
 
 from .provider import get_tracer
@@ -15,16 +13,15 @@ def trace_factory_cycle(
     run_id: str,
     project_name: str,
     mode: str,
-    session_id: str | None = None,
 ) -> Iterator[Span]:
-    tracer = get_tracer("factory-tracing")
+    """Root span for a full CEO improvement cycle."""
+    tracer = get_tracer()
     with tracer.start_as_current_span("factory.cycle") as span:
         span.set_attribute("factory.run.id", run_id)
         span.set_attribute("factory.project.name", project_name)
         span.set_attribute("factory.mode", mode)
         span.set_attribute("langfuse.observation.type", "span")
-        span.set_attribute("langfuse.session.id", session_id or run_id)
-        span.set_attribute("langfuse.trace.tags", json.dumps([mode]))
+        span.set_attribute("langfuse.session.id", run_id)
         try:
             yield span
         except Exception as exc:
@@ -32,28 +29,30 @@ def trace_factory_cycle(
             span.record_exception(exc)
             raise
         else:
+            if span.status.status_code == StatusCode.ERROR:
+                return
             span.set_status(StatusCode.OK)
 
 
 @contextmanager
 def trace_agent_invocation(
     role: str,
-    task_summary: str = "",
-    run_id: str = "",
-    project_name: str = "",
+    task_summary: str,
+    run_id: str,
+    project_name: str,
 ) -> Iterator[Span]:
-    tracer = get_tracer("factory-tracing")
+    """Child span for a single agent invocation within a cycle."""
+    tracer = get_tracer()
     with tracer.start_as_current_span(f"invoke_agent {role}") as span:
         span.set_attribute("gen_ai.operation.name", "invoke_agent")
         span.set_attribute("gen_ai.agent.name", role)
         span.set_attribute("gen_ai.system", "anthropic")
         span.set_attribute("factory.run.id", run_id)
         span.set_attribute("factory.project.name", project_name)
+        span.set_attribute("factory.task.summary", task_summary)
         span.set_attribute("langfuse.observation.type", "span")
         span.set_attribute("langfuse.session.id", run_id)
-        span.set_attribute("langfuse.trace.tags", json.dumps([role]))
-        if task_summary:
-            span.set_attribute("factory.task.summary", task_summary)
+        span.set_attribute("langfuse.trace.tags", (role,))
         try:
             yield span
         except Exception as exc:
@@ -61,23 +60,31 @@ def trace_agent_invocation(
             span.record_exception(exc)
             raise
         else:
-            if span.status.status_code != StatusCode.ERROR:
-                span.set_status(StatusCode.OK)
+            if span.status.status_code == StatusCode.ERROR:
+                return
+            span.set_status(StatusCode.OK)
 
 
 def record_agent_result(
     span: Span,
     exit_code: int,
-    input_tokens: int = 0,
-    output_tokens: int = 0,
-    cost_usd: float = 0.0,
+    duration_ms: float,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    cost_usd: float | None = None,
 ) -> None:
+    """Record subprocess result and optional usage metrics on an agent span."""
     span.set_attribute("subprocess.returncode", exit_code)
-    if input_tokens > 0:
+    span.set_attribute("subprocess.duration_ms", duration_ms)
+
+    if input_tokens is not None:
         span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
-    if output_tokens > 0:
+    if output_tokens is not None:
         span.set_attribute("gen_ai.usage.output_tokens", output_tokens)
-    if cost_usd > 0.0:
+    if cost_usd is not None:
         span.set_attribute("gen_ai.usage.cost", cost_usd)
+
     if exit_code != 0:
-        span.set_status(StatusCode.ERROR, f"exit code {exit_code}")
+        span.set_status(StatusCode.ERROR, f"agent exited with code {exit_code}")
+    else:
+        span.set_status(StatusCode.OK)

--- a/src/factory_tracing/verify.py
+++ b/src/factory_tracing/verify.py
@@ -72,6 +72,15 @@ def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int
     raise RuntimeError(f"Failed to fetch trace {trace_id} after {max_retries} attempts: {last_error}")
 
 
+def _get_obs_attribute(obs: dict, key: str) -> object:
+    """Extract an attribute from an observation's metadata or attributes."""
+    for source in ("metadata", "attributes"):
+        container = obs.get(source)
+        if isinstance(container, dict) and key in container:
+            return container[key]
+    return None
+
+
 def _validate_trace(trace_data: dict, trace_id: str) -> list[CheckResult]:
     checks = []
 
@@ -105,6 +114,45 @@ def _validate_trace(trace_data: dict, trace_id: str) -> list[CheckResult]:
         name="trace_id_consistent",
         passed=bool(fetched_id),
         detail=f"Trace ID: {fetched_id}" if fetched_id else "Could not verify trace ID",
+    ))
+
+    llm_spans = [o for o in observations if "claude_code.llm_request" in (o.get("name") or "")]
+    if llm_spans:
+        llm = llm_spans[0]
+        llm_model = _get_obs_attribute(llm, "gen_ai.request.model") or ""
+        has_model = bool(llm_model)
+        checks.append(CheckResult(
+            name="llm_span_has_model",
+            passed=has_model,
+            detail=f"claude_code.llm_request model={llm_model}" if has_model else "claude_code.llm_request has no model name",
+        ))
+
+        llm_input_tokens = _get_obs_attribute(llm, "gen_ai.usage.input_tokens")
+        has_llm_tokens = isinstance(llm_input_tokens, (int, float)) and llm_input_tokens > 0
+        checks.append(CheckResult(
+            name="llm_span_has_tokens",
+            passed=has_llm_tokens,
+            detail=f"claude_code.llm_request input_tokens={llm_input_tokens}" if has_llm_tokens else "claude_code.llm_request has zero/missing input_tokens",
+        ))
+
+    agent_obs_list = [o for o in observations if "invoke_agent" in (o.get("name") or "")]
+    if agent_obs_list:
+        agent_obs = agent_obs_list[0]
+        agent_tokens = _get_obs_attribute(agent_obs, "gen_ai.usage.input_tokens")
+        has_agent_tokens = isinstance(agent_tokens, (int, float)) and agent_tokens > 0
+        checks.append(CheckResult(
+            name="agent_span_has_tokens",
+            passed=has_agent_tokens,
+            detail=f"invoke_agent input_tokens={agent_tokens}" if has_agent_tokens else "invoke_agent has zero/missing gen_ai.usage.input_tokens",
+        ))
+
+    total_usage = trace_data.get("usage") or trace_data.get("totalUsage") or {}
+    trace_input = total_usage.get("input", 0) or total_usage.get("inputTokens", 0) or 0
+    has_trace_usage = trace_input > 0
+    checks.append(CheckResult(
+        name="trace_has_token_usage",
+        passed=has_trace_usage,
+        detail=f"Trace token usage: input={trace_input}" if has_trace_usage else "Trace shows zero token usage",
     ))
 
     return checks
@@ -149,6 +197,7 @@ def run_verification() -> VerificationResult:
             ) as agent_span:
                 traced_env = build_traced_env(base_env=dict(__import__("os").environ))
 
+                start_time = time.monotonic()
                 try:
                     result = subprocess.run(
                         ["claude", "-p", "Reply with the single word VERIFIED", "--output-format", "json"],
@@ -170,19 +219,25 @@ def run_verification() -> VerificationResult:
                 input_tokens = 0
                 output_tokens = 0
                 cost_usd = 0.0
+                response_text = ""
+                model = None
                 if isinstance(parsed, dict):
                     usage = parsed.get("usage", {}) or parsed.get("result", {}).get("usage", {}) or {}
                     input_tokens = usage.get("input_tokens", 0) or 0
                     output_tokens = usage.get("output_tokens", 0) or 0
                     cost_usd = usage.get("cost_usd", 0.0) or 0.0
+                    response_text = parsed.get("result", "") if isinstance(parsed.get("result"), str) else ""
+                    model = parsed.get("model") or None
 
                 record_agent_result(
                     agent_span,
                     exit_code=exit_code,
-                    duration_ms=0.0,
+                    start_time=start_time,
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     cost_usd=cost_usd,
+                    response_text=response_text or None,
+                    model=model,
                 )
     finally:
         shutdown_tracing()
@@ -191,6 +246,7 @@ def run_verification() -> VerificationResult:
 
     time.sleep(3)
 
+    trace_data: dict = {}
     try:
         trace_data = _query_langfuse_trace(config, trace_id_hex)
         checks = _validate_trace(trace_data, trace_id_hex)
@@ -207,10 +263,54 @@ def run_verification() -> VerificationResult:
     required_checks = {"root_span_exists", "agent_span_exists", "trace_id_consistent"}
     success = all(c.passed for c in checks if c.name in required_checks)
 
-    return VerificationResult(
+    result = VerificationResult(
         trace_id=trace_id_hex,
         langfuse_url=langfuse_url,
         span_count=span_count,
         checks=checks,
         success=success,
     )
+
+    _print_report(result, trace_data)
+
+    return result
+
+
+def _print_report(result: VerificationResult, trace_data: dict) -> None:
+    print(f"\n{'='*60}")
+    print("Factory Tracing Verification Report")
+    print(f"{'='*60}")
+    print(f"Trace ID:    {result.trace_id}")
+    print(f"Langfuse:    {result.langfuse_url}")
+    print(f"Span count:  {result.span_count}")
+    print()
+
+    observations = trace_data.get("observations") or [] if trace_data else []
+    if observations:
+        print("Span Details:")
+        for obs in observations:
+            name = obs.get("name", "?")
+            metadata = obs.get("metadata") or {}
+            model = _get_obs_attribute(obs, "gen_ai.request.model") or metadata.get("model", "")
+            input_t = _get_obs_attribute(obs, "gen_ai.usage.input_tokens") or 0
+            output_t = _get_obs_attribute(obs, "gen_ai.usage.output_tokens") or 0
+            start = obs.get("startTime", "")
+            end = obs.get("endTime", "")
+            print(f"  - {name}")
+            if model:
+                print(f"    model: {model}")
+            if input_t or output_t:
+                print(f"    tokens: in={input_t} out={output_t}")
+            if start and end:
+                print(f"    time: {start} -> {end}")
+        print()
+
+    print("Checks:")
+    for c in result.checks:
+        status = "PASS" if c.passed else "FAIL"
+        print(f"  [{status}] {c.name}: {c.detail}")
+
+    print()
+    overall = "SUCCESS" if result.success else "FAILED"
+    print(f"Overall: {overall}")
+    print(f"{'='*60}\n")

--- a/src/factory_tracing/verify.py
+++ b/src/factory_tracing/verify.py
@@ -221,80 +221,84 @@ def _validate_content(trace_data: dict, expected_roles: list[str]) -> list[Conte
         if not agent_id:
             continue
         children = _find_children(observations, agent_id)
-        cc_children = [c for c in children if "claude_code" in (c.get("name") or "")]
-        has_children = len(cc_children) > 0
+        content_children = [c for c in children if c.get("input") is not None or c.get("output") is not None]
         checks.append(ContentCheck(
             name=f"nesting_{role}",
-            passed=has_children,
-            expected=f"claude_code spans nested under invoke_agent {role}",
-            actual=f"{len(cc_children)} claude_code spans found as children" if has_children else "no claude_code children",
+            passed=len(content_children) > 0,
+            expected=f"child spans with content under invoke_agent {role}",
+            actual=f"{len(content_children)} child spans with content" if content_children else "no children with content",
         ))
 
-    cc_interaction_spans = [o for o in observations if "claude_code.interaction" in (o.get("name") or "")]
-    for span in cc_interaction_spans:
-        user_prompt = _get_obs_attribute(span, "user_prompt") or ""
-        has_prompt = bool(user_prompt) and len(str(user_prompt)) > 5
-        checks.append(ContentCheck(
-            name="interaction_has_prompt",
-            passed=has_prompt,
-            expected="user_prompt attribute non-empty",
-            actual=_snippet(str(user_prompt), 80) if user_prompt else "empty/missing",
-        ))
-        break  # check at least one
-
-    llm_spans = [o for o in observations if "claude_code.llm_request" in (o.get("name") or "")]
+    llm_spans = [o for o in observations if "llm_call" in (o.get("name") or "")]
     checks.append(ContentCheck(
         name="llm_call_count",
-        passed=len(llm_spans) > 2,
-        expected="more than 2 LLM requests",
+        passed=len(llm_spans) >= 2,
+        expected="at least 2 llm_call spans",
         actual=str(len(llm_spans)),
     ))
 
     for i, llm in enumerate(llm_spans[:3]):
-        model = _get_obs_attribute(llm, "gen_ai.request.model") or ""
-        has_model = bool(model)
+        llm_input = llm.get("input")
+        llm_output = llm.get("output")
+        has_input = llm_input is not None and str(llm_input).strip() not in ("", "null", "undefined")
+        has_output = llm_output is not None and str(llm_output).strip() not in ("", "null", "undefined")
         checks.append(ContentCheck(
-            name=f"llm_has_model_{i}",
-            passed=has_model,
-            expected="model name present",
-            actual=str(model) if model else "missing",
-        ))
-
-        input_tokens = _get_obs_attribute(llm, "gen_ai.usage.input_tokens")
-        has_input = isinstance(input_tokens, (int, float)) and input_tokens > 0
-        checks.append(ContentCheck(
-            name=f"llm_input_tokens_{i}",
+            name=f"llm_has_input_{i}",
             passed=has_input,
-            expected="input_tokens > 0",
-            actual=str(input_tokens) if input_tokens else "0 or missing",
+            expected=f"llm_call {i} has non-null input",
+            actual=_snippet(str(llm_input), 80) if has_input else "null/empty",
+        ))
+        checks.append(ContentCheck(
+            name=f"llm_has_output_{i}",
+            passed=has_output,
+            expected=f"llm_call {i} has non-null output",
+            actual=_snippet(str(llm_output), 80) if has_output else "null/empty",
         ))
 
-        output_tokens = _get_obs_attribute(llm, "gen_ai.usage.output_tokens")
-        has_output = isinstance(output_tokens, (int, float)) and output_tokens > 0
+    tool_spans = [o for o in observations if o.get("name", "").startswith("tool:")]
+    for i, tool in enumerate(tool_spans[:3]):
+        tool_input = tool.get("input")
+        tool_output = tool.get("output")
+        has_input = tool_input is not None
+        has_output = tool_output is not None
+        tool_name = tool.get("name", "")
         checks.append(ContentCheck(
-            name=f"llm_output_tokens_{i}",
-            passed=has_output,
-            expected="output_tokens > 0",
-            actual=str(output_tokens) if output_tokens else "0 or missing",
+            name=f"tool_has_io_{tool_name}_{i}",
+            passed=has_input and has_output,
+            expected=f"{tool_name} has input and output",
+            actual=f"input={'yes' if has_input else 'NULL'}, output={'yes' if has_output else 'NULL'}",
         ))
+
+    all_spans_null = [o for o in observations if o.get("input") is None and o.get("output") is None]
+    pct_populated = 1.0 - (len(all_spans_null) / max(len(observations), 1))
+    checks.append(ContentCheck(
+        name="content_coverage",
+        passed=pct_populated >= 0.5,
+        expected=">=50% of spans have input or output populated",
+        actual=f"{pct_populated:.0%} ({len(observations) - len(all_spans_null)}/{len(observations)} spans)",
+    ))
 
     for role in expected_roles:
         matching_agents = [o for o in agent_obs if role in (o.get("name") or "")]
         if not matching_agents:
             continue
-        agent_id = matching_agents[0].get("id")
-        if not agent_id:
-            continue
-        other_agents = [o for o in agent_obs if role not in (o.get("name") or "")]
-        for other in other_agents:
-            other_id = other.get("id")
-            if not other_id:
-                continue
-            misplaced = [
-                c for c in observations
-                if c.get("parentObservationId") == other_id and "claude_code" in (c.get("name") or "")
-            ]
-            # Just a diagnostic — not a hard fail since we can't control CC's span structure fully
+        agent = matching_agents[0]
+        agent_input = agent.get("input")
+        agent_output = agent.get("output")
+        has_input = agent_input is not None and str(agent_input).strip() not in ("", "null", "undefined")
+        has_output = agent_output is not None and str(agent_output).strip() not in ("", "null", "undefined")
+        checks.append(ContentCheck(
+            name=f"agent_has_input_{role}",
+            passed=has_input,
+            expected=f"invoke_agent {role} has non-null input in Langfuse",
+            actual=_snippet(str(agent_input), 80) if has_input else "null/empty",
+        ))
+        checks.append(ContentCheck(
+            name=f"agent_has_output_{role}",
+            passed=has_output,
+            expected=f"invoke_agent {role} has non-null output in Langfuse",
+            actual=_snippet(str(agent_output), 80) if has_output else "null/empty",
+        ))
 
     return checks
 
@@ -347,51 +351,32 @@ def run_verification(num_agents: int = 2) -> VerificationResult:
                 prompt_template = AGENT_PROMPTS[role]
                 prompt = prompt_template.format(prev_output=_snippet(prev_output, 200)) if "{prev_output}" in prompt_template else prompt_template
 
-                with trace_agent_invocation(
+                traced_env = build_traced_env(base_env=dict(os.environ))
+
+                agent_result = run_traced_agent(
+                    prompt=prompt,
                     role=role,
-                    task_summary=prompt,
                     run_id=run_id,
                     project_name="factory-tracing-verify",
-                ) as agent_span:
-                    traced_env = build_traced_env(base_env=dict(os.environ))
+                    env=traced_env,
+                )
 
-                    parsed, exit_code, duration_ms = _invoke_agent(
-                        role=role,
-                        prompt=prompt,
-                        run_id=run_id,
-                        project_name="factory-tracing-verify",
-                        traced_env=traced_env,
-                    )
+                total_in += agent_result.input_tokens
+                total_out += agent_result.output_tokens
 
-                    usage = _extract_usage(parsed)
-                    response_text = _extract_response_text(parsed)
-                    model = parsed.get("model") or None
+                agents_traced.append(AgentTrace(
+                    role=role,
+                    prompt_snippet=_snippet(prompt),
+                    response_snippet=_snippet(agent_result.response_text),
+                    llm_calls=0,
+                    tokens_in=agent_result.input_tokens,
+                    tokens_out=agent_result.output_tokens,
+                ))
 
-                    record_agent_result(
-                        agent_span,
-                        exit_code=exit_code,
-                        duration_ms=duration_ms,
-                        input_tokens=usage["input_tokens"],
-                        output_tokens=usage["output_tokens"],
-                        cost_usd=usage["cost_usd"],
-                        response_text=response_text or None,
-                        model=model,
-                    )
+                prev_output = agent_result.response_text
 
-                    total_in += usage["input_tokens"]
-                    total_out += usage["output_tokens"]
-                    total_cache += usage["cache_read_tokens"]
-
-                    agents_traced.append(AgentTrace(
-                        role=role,
-                        prompt_snippet=_snippet(prompt),
-                        response_snippet=_snippet(response_text),
-                        llm_calls=0,
-                        tokens_in=usage["input_tokens"],
-                        tokens_out=usage["output_tokens"],
-                    ))
-
-                    prev_output = response_text
+            cycle_span.set_attribute("langfuse.span.input", json.dumps({"agents": roles, "run_id": run_id}))
+            cycle_span.set_attribute("langfuse.span.output", json.dumps({"result": _snippet(prev_output, 500), "agents_completed": len(agents_traced)}))
     finally:
         shutdown_tracing()
 

--- a/src/factory_tracing/verify.py
+++ b/src/factory_tracing/verify.py
@@ -1,4 +1,4 @@
-"""End-to-end verification: run a real multi-agent factory cycle and validate content in Langfuse.
+"""End-to-end verification: run a real multi-agent factory cycle and validate ALL 10 criteria in Langfuse.
 
 This module is dev/verification tooling — it MAY import langfuse and dotenv.
 It must NOT be imported by production tracing code (config, provider, spans, propagation, integration).
@@ -8,7 +8,6 @@ from __future__ import annotations
 import base64
 import json
 import os
-import subprocess
 import time
 import urllib.error
 import urllib.request
@@ -18,32 +17,38 @@ from dataclasses import dataclass, field
 from dotenv import load_dotenv
 
 from .config import TracingConfig
-from .executor import run_traced_agent
+from .executor import run_traced_agent, AgentResult
 from .propagation import build_traced_env
 from .provider import get_tracer_provider, shutdown_tracing
-from .spans import record_agent_result, trace_agent_invocation, trace_factory_cycle
+from .spans import trace_factory_cycle
 
 
-AGENT_PROMPTS = {
-    "researcher": "List 3 key benefits of distributed tracing in multi-agent AI systems. Be concise, use bullet points.",
-    "strategist": "Based on these research findings: {prev_output}. Propose a 2-step implementation plan. Be concise.",
-}
+RESEARCHER_PROMPT = (
+    "Read the file pyproject.toml in this project and list the package dependencies. "
+    "Then explain what the package does based on the code structure."
+)
+
+STRATEGIST_PROMPT_TEMPLATE = (
+    "Based on these findings about the project: {researcher_output}. "
+    "Read src/factory_tracing/executor.py and propose one specific improvement. Be concise."
+)
 
 
 @dataclass
-class ContentCheck:
+class CriterionResult:
+    id: str
     name: str
     passed: bool
-    expected: str
-    actual: str
+    detail: str
 
 
 @dataclass
-class AgentTrace:
+class AgentSummary:
     role: str
+    num_turns: int
+    num_tools: int
     prompt_snippet: str
     response_snippet: str
-    llm_calls: int
     tokens_in: int
     tokens_out: int
 
@@ -53,11 +58,14 @@ class VerificationResult:
     trace_id: str
     langfuse_url: str
     span_count: int
-    agents_traced: list[AgentTrace] = field(default_factory=list)
-    total_llm_calls: int = 0
-    total_tokens: dict = field(default_factory=lambda: {"input": 0, "output": 0, "cache_read": 0})
-    total_duration_seconds: float = 0.0
-    content_checks: list[ContentCheck] = field(default_factory=list)
+    agent_count: int
+    llm_call_count: int
+    tool_call_count: int
+    duration_seconds: float
+    tokens_in: int
+    tokens_out: int
+    agents: list[AgentSummary] = field(default_factory=list)
+    criteria: list[CriterionResult] = field(default_factory=list)
     success: bool = False
 
 
@@ -65,44 +73,14 @@ def _short_uuid() -> str:
     return uuid.uuid4().hex[:8]
 
 
-def _parse_claude_output(stdout: str) -> dict:
-    try:
-        return json.loads(stdout)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-
-
-def _extract_response_text(parsed: dict) -> str:
-    result = parsed.get("result", "")
-    if isinstance(result, str):
-        return result
-    if isinstance(result, list):
-        parts = []
-        for block in result:
-            if isinstance(block, dict) and block.get("type") == "text":
-                parts.append(block.get("text", ""))
-        return "\n".join(parts)
-    return str(result) if result else ""
-
-
-def _extract_usage(parsed: dict) -> dict:
-    usage = parsed.get("usage", {})
-    if not usage:
-        usage = parsed.get("result", {}).get("usage", {}) if isinstance(parsed.get("result"), dict) else {}
-    return {
-        "input_tokens": usage.get("input_tokens", 0) or 0,
-        "output_tokens": usage.get("output_tokens", 0) or 0,
-        "cache_read_tokens": usage.get("cache_read_input_tokens", 0) or 0,
-        "cost_usd": usage.get("cost_usd", 0.0) or 0.0,
-    }
-
-
-def _snippet(text: str, max_len: int = 120) -> str:
+def _snippet(text: str, max_len: int = 100) -> str:
+    if not text:
+        return "(empty)"
     s = text.replace("\n", " ").strip()
     return s[:max_len] + "..." if len(s) > max_len else s
 
 
-def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int = 5, delay: float = 3.0) -> dict:
+def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int = 8, delay: float = 3.0) -> dict:
     url = f"{config.langfuse_host.rstrip('/')}/api/public/traces/{trace_id}"
     credentials = base64.b64encode(
         f"{config.langfuse_public_key}:{config.langfuse_secret_key}".encode()
@@ -116,267 +94,451 @@ def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int
                 "Accept": "application/json",
             })
             with urllib.request.urlopen(req, timeout=15) as resp:
-                return json.loads(resp.read().decode())
+                data = json.loads(resp.read().decode())
+                observations = data.get("observations") or []
+                if len(observations) >= 2 or attempt >= max_retries - 1:
+                    return data
         except Exception as exc:
             last_error = exc
-            if attempt < max_retries - 1:
-                time.sleep(delay)
+        if attempt < max_retries - 1:
+            time.sleep(delay)
 
     raise RuntimeError(f"Failed to fetch trace {trace_id} after {max_retries} attempts: {last_error}")
 
 
-def _get_obs_attribute(obs: dict, key: str) -> object:
-    if key in ("model", "gen_ai.request.model"):
-        top_model = obs.get("model")
-        if top_model:
-            return top_model
+def _find_children(observations: list[dict], parent_id: str | None) -> list[dict]:
+    return [o for o in observations if o.get("parentObservationId") == parent_id]
+
+
+def _obs_has_content(obs: dict) -> tuple[bool, bool]:
+    inp = obs.get("input")
+    out = obs.get("output")
+    has_in = inp is not None
+    has_out = out is not None
+    return has_in, has_out
+
+
+def _check_c1(observations: list[dict]) -> CriterionResult:
+    """C1: Real factory cycle — at least 2 agents, each with multiple LLM calls and tool use."""
+    agent_obs = [o for o in observations if (o.get("name") or "").startswith("invoke_agent")]
+    if len(agent_obs) < 2:
+        return CriterionResult("C1", "real_factory_cycle", False,
+                               f"Only {len(agent_obs)} agent(s) found, need >= 2")
+
+    agents_with_tools = 0
+    for agent in agent_obs:
+        agent_id = agent.get("id")
+        children = _find_children(observations, agent_id)
+        llm_children = [c for c in children if (c.get("name") or "") == "llm_call"]
+        tool_children = [c for c in children if (c.get("name") or "").startswith("tool:")]
+        if len(llm_children) >= 1 and len(tool_children) >= 1:
+            agents_with_tools += 1
+
+    if agents_with_tools < 2:
+        return CriterionResult("C1", "real_factory_cycle", False,
+                               f"{agents_with_tools}/2 agents have both LLM calls and tool use")
+
+    return CriterionResult("C1", "real_factory_cycle", True,
+                           f"{len(agent_obs)} agents, {agents_with_tools} with tools")
+
+
+def _check_c2(observations: list[dict], trace_data: dict) -> CriterionResult:
+    """C2: Every observation has non-null input AND output."""
+    total = len(observations)
+    missing = []
+    for obs in observations:
+        has_in, has_out = _obs_has_content(obs)
+        if not has_in or not has_out:
+            name = obs.get("name", "?")
+            parts = []
+            if not has_in:
+                parts.append("input=null")
+            if not has_out:
+                parts.append("output=null")
+            missing.append(f"{name} ({', '.join(parts)})")
+
+    trace_input = trace_data.get("input")
+    trace_output = trace_data.get("output")
+    trace_ok = trace_input is not None and trace_output is not None
+    if not trace_ok:
+        parts = []
+        if trace_input is None:
+            parts.append("trace.input=null")
+        if trace_output is None:
+            parts.append("trace.output=null")
+        missing.append(f"trace ({', '.join(parts)})")
+
+    if missing:
+        return CriterionResult("C2", "all_spans_have_io", False,
+                               f"{len(missing)} missing: {'; '.join(missing[:5])}")
+
+    return CriterionResult("C2", "all_spans_have_io", True,
+                           f"{total}/{total} observations + trace have input+output")
+
+
+def _check_c3(observations: list[dict]) -> CriterionResult:
+    """C3: Every llm_call span has meaningful input, output, model, and token counts."""
+    llm_spans = [o for o in observations if (o.get("name") or "") == "llm_call"]
+    if not llm_spans:
+        return CriterionResult("C3", "llm_content", False, "No llm_call spans found")
+
+    issues = []
+    for i, llm in enumerate(llm_spans):
+        inp = llm.get("input")
+        out = llm.get("output")
+        model = llm.get("model") or llm.get("modelId")
+
+        inp_str = json.dumps(inp) if inp is not None else ""
+        out_str = json.dumps(out) if out is not None else ""
+
+        if not inp or not inp_str.strip() or inp_str in ('""', "null", '"{}"'):
+            issues.append(f"llm_call #{i} missing input")
+        elif "[conversation context]" in inp_str and "prompt" not in inp_str:
+            pass
+
+        if not out or not out_str.strip() or out_str in ('""', "null", '"{}"'):
+            issues.append(f"llm_call #{i} missing output")
+
+        usage = llm.get("usage") or llm.get("usageDetails") or {}
+        input_tokens = usage.get("input") or usage.get("inputTokens") or usage.get("input_tokens") or 0
+        output_tokens = usage.get("output") or usage.get("outputTokens") or usage.get("output_tokens") or 0
+
+        if not model and not _get_metadata_attr(llm, "gen_ai.request.model"):
+            issues.append(f"llm_call #{i} missing model")
+        if input_tokens == 0 and output_tokens == 0:
+            meta_in = _get_metadata_attr(llm, "gen_ai.usage.input_tokens")
+            meta_out = _get_metadata_attr(llm, "gen_ai.usage.output_tokens")
+            if not meta_in and not meta_out:
+                issues.append(f"llm_call #{i} zero tokens")
+
+    if issues:
+        return CriterionResult("C3", "llm_content", False, "; ".join(issues[:5]))
+
+    return CriterionResult("C3", "llm_content", True,
+                           f"{len(llm_spans)} llm_call spans all have content, model, tokens")
+
+
+def _check_c4(observations: list[dict]) -> CriterionResult:
+    """C4: Every tool:* span has non-null input (args) and output (result)."""
+    tool_spans = [o for o in observations if (o.get("name") or "").startswith("tool:")]
+    if not tool_spans:
+        return CriterionResult("C4", "tool_io", False, "No tool:* spans found")
+
+    issues = []
+    for i, tool in enumerate(tool_spans):
+        name = tool.get("name", "?")
+        has_in, has_out = _obs_has_content(tool)
+        if not has_in:
+            issues.append(f"{name} #{i} input=null")
+        if not has_out:
+            issues.append(f"{name} #{i} output=null")
+
+    if issues:
+        return CriterionResult("C4", "tool_io", False, "; ".join(issues[:5]))
+
+    return CriterionResult("C4", "tool_io", True,
+                           f"{len(tool_spans)} tool spans all have input+output")
+
+
+def _check_c5(observations: list[dict]) -> CriterionResult:
+    """C5: Hierarchy — factory.cycle root, invoke_agent children, llm/tool grandchildren."""
+    obs_ids = {o.get("id") for o in observations if o.get("id")}
+    issues = []
+
+    roots = [o for o in observations if not o.get("parentObservationId")]
+    agent_obs = [o for o in observations if (o.get("name") or "").startswith("invoke_agent")]
+    llm_tool_obs = [o for o in observations
+                    if (o.get("name") or "") == "llm_call" or (o.get("name") or "").startswith("tool:")]
+
+    for agent in agent_obs:
+        parent = agent.get("parentObservationId")
+        if parent is not None:
+            parent_obs = next((o for o in observations if o.get("id") == parent), None)
+            if parent_obs and (parent_obs.get("name") or "") != "factory.cycle":
+                issues.append(f"invoke_agent not child of factory.cycle (parent: {parent_obs.get('name')})")
+
+    for obs in llm_tool_obs:
+        parent = obs.get("parentObservationId")
+        if parent is None:
+            issues.append(f"{obs.get('name')} has no parent (orphaned)")
+        else:
+            parent_obs = next((o for o in observations if o.get("id") == parent), None)
+            if parent_obs and not (parent_obs.get("name") or "").startswith("invoke_agent"):
+                issues.append(f"{obs.get('name')} parent is {parent_obs.get('name')}, expected invoke_agent")
+
+    if issues:
+        return CriterionResult("C5", "hierarchy", False, "; ".join(issues[:5]))
+
+    return CriterionResult("C5", "hierarchy", True,
+                           f"Correct tree: {len(roots)} root(s), {len(agent_obs)} agents, "
+                           f"{len(llm_tool_obs)} llm/tool spans")
+
+
+def _check_c6(observations: list[dict]) -> CriterionResult:
+    """C6: At least one invoke_agent has >= 3 child spans (multi-turn)."""
+    agent_obs = [o for o in observations if (o.get("name") or "").startswith("invoke_agent")]
+    max_children = 0
+    best_agent = ""
+    for agent in agent_obs:
+        children = _find_children(observations, agent.get("id"))
+        if len(children) > max_children:
+            max_children = len(children)
+            best_agent = agent.get("name", "?")
+
+    if max_children >= 3:
+        return CriterionResult("C6", "multi_turn", True,
+                               f"{best_agent} has {max_children} child spans")
+
+    return CriterionResult("C6", "multi_turn", False,
+                           f"Max child count is {max_children} (need >= 3)")
+
+
+def _check_c7(observations: list[dict]) -> CriterionResult:
+    """C7: Strategist input contains substring from researcher output."""
+    agent_obs = [o for o in observations if (o.get("name") or "").startswith("invoke_agent")]
+    researcher = next((o for o in agent_obs if "researcher" in (o.get("name") or "")), None)
+    strategist = next((o for o in agent_obs if "strategist" in (o.get("name") or "")), None)
+
+    if not researcher or not strategist:
+        return CriterionResult("C7", "agent_flow", False,
+                               f"Missing: researcher={'found' if researcher else 'missing'}, "
+                               f"strategist={'found' if strategist else 'missing'}")
+
+    researcher_output = researcher.get("output")
+    strategist_input = strategist.get("input")
+
+    if not researcher_output or not strategist_input:
+        return CriterionResult("C7", "agent_flow", False,
+                               f"researcher.output={'set' if researcher_output else 'null'}, "
+                               f"strategist.input={'set' if strategist_input else 'null'}")
+
+    res_text = json.dumps(researcher_output) if not isinstance(researcher_output, str) else researcher_output
+    strat_text = json.dumps(strategist_input) if not isinstance(strategist_input, str) else strategist_input
+
+    words = [w for w in res_text.split() if len(w) > 5 and w.isalpha()]
+    matches = [w for w in words[:30] if w.lower() in strat_text.lower()]
+
+    if matches:
+        return CriterionResult("C7", "agent_flow", True,
+                               f"Strategist input references researcher output "
+                               f"(matched: {', '.join(matches[:3])})")
+
+    return CriterionResult("C7", "agent_flow", False,
+                           "No researcher output substring found in strategist input")
+
+
+def _check_c8(observations: list[dict]) -> CriterionResult:
+    """C8: No claude_code.* spans, exactly one invoke_agent per role, no orphans."""
+    issues = []
+
+    claude_spans = [o for o in observations if (o.get("name") or "").startswith("claude_code.")]
+    if claude_spans:
+        issues.append(f"{len(claude_spans)} claude_code.* span(s) found")
+
+    agent_obs = [o for o in observations if (o.get("name") or "").startswith("invoke_agent")]
+    role_counts: dict[str, int] = {}
+    for agent in agent_obs:
+        name = agent.get("name", "")
+        role_counts[name] = role_counts.get(name, 0) + 1
+    for name, count in role_counts.items():
+        if count > 1:
+            issues.append(f"Duplicate: {name} appears {count} times")
+
+    obs_ids = {o.get("id") for o in observations if o.get("id")}
+    for obs in observations:
+        parent = obs.get("parentObservationId")
+        if parent is not None and parent not in obs_ids:
+            issues.append(f"Orphan: {obs.get('name')} has parentId {parent} not in observation set")
+
+    if issues:
+        return CriterionResult("C8", "no_duplicates", False, "; ".join(issues[:5]))
+
+    return CriterionResult("C8", "no_duplicates", True,
+                           f"No duplicates, no claude_code spans, no orphans")
+
+
+def _check_c9(trace_data: dict) -> CriterionResult:
+    """C9: Trace-level metadata — input, output, name all non-null."""
+    issues = []
+    trace_input = trace_data.get("input")
+    trace_output = trace_data.get("output")
+    trace_name = trace_data.get("name")
+
+    if trace_input is None:
+        issues.append("trace.input=null")
+    if trace_output is None:
+        issues.append("trace.output=null")
+    if trace_name != "factory.cycle":
+        issues.append(f"trace.name='{trace_name}' (expected 'factory.cycle')")
+
+    if issues:
+        return CriterionResult("C9", "trace_metadata", False, "; ".join(issues))
+
+    return CriterionResult("C9", "trace_metadata", True,
+                           f"name='{trace_name}', input+output set")
+
+
+def _get_metadata_attr(obs: dict, key: str):
     metadata = obs.get("metadata")
     if isinstance(metadata, dict):
         attrs = metadata.get("attributes", {})
         if isinstance(attrs, dict):
             if key in attrs:
-                val = attrs[key]
-                if isinstance(val, str) and val.isdigit():
-                    return int(val)
-                return val
-            short_key = key.split(".")[-1]
-            if short_key in attrs:
-                val = attrs[short_key]
-                if isinstance(val, str) and val.isdigit():
-                    return int(val)
-                return val
+                return attrs[key]
     return None
 
 
-def _find_children(observations: list[dict], parent_id: str) -> list[dict]:
-    return [o for o in observations if o.get("parentObservationId") == parent_id]
+def _count_by_type(observations: list[dict]) -> tuple[int, int, int]:
+    agents = len([o for o in observations if (o.get("name") or "").startswith("invoke_agent")])
+    llm_calls = len([o for o in observations if (o.get("name") or "") == "llm_call"])
+    tool_calls = len([o for o in observations if (o.get("name") or "").startswith("tool:")])
+    return agents, llm_calls, tool_calls
 
 
-def _invoke_agent(
-    role: str,
-    prompt: str,
-    run_id: str,
-    project_name: str,
-    traced_env: dict,
-) -> tuple[dict, int, float]:
-    """Invoke a Claude agent subprocess using run_traced_agent for full content capture."""
-    agent_result = run_traced_agent(
-        prompt=prompt,
-        role=role,
-        run_id=run_id,
-        project_name=project_name,
-        env=traced_env,
-    )
-    parsed = {
-        "result": agent_result.response_text,
-        "model": agent_result.model,
-        "usage": {
-            "input_tokens": agent_result.input_tokens,
-            "output_tokens": agent_result.output_tokens,
-            "cost_usd": agent_result.cost_usd,
-        },
-    }
-    return parsed, agent_result.exit_code, agent_result.duration_ms
+def _build_agent_summaries(observations: list[dict], agent_results: dict[str, AgentResult]) -> list[AgentSummary]:
+    summaries = []
+    agent_obs = [o for o in observations if (o.get("name") or "").startswith("invoke_agent")]
+    agent_obs.sort(key=lambda o: o.get("startTime", ""))
 
+    for agent in agent_obs:
+        name = agent.get("name", "")
+        role = name.replace("invoke_agent ", "").strip()
+        agent_id = agent.get("id")
+        children = _find_children(observations, agent_id) if agent_id else []
+        tool_children = [c for c in children if (c.get("name") or "").startswith("tool:")]
 
-def _validate_content(trace_data: dict, expected_roles: list[str]) -> list[ContentCheck]:
-    checks: list[ContentCheck] = []
-    observations = trace_data.get("observations") or []
-    obs_names = [o.get("name", "") for o in observations]
-
-    has_cycle = any("factory.cycle" in (n or "") for n in obs_names)
-    checks.append(ContentCheck(
-        name="root_span_exists",
-        passed=has_cycle,
-        expected="factory.cycle span present",
-        actual="found" if has_cycle else "missing",
-    ))
-
-    agent_obs = [o for o in observations if "invoke_agent" in (o.get("name") or "")]
-    for role in expected_roles:
-        matching = [o for o in agent_obs if role in (o.get("name") or "")]
-        found = len(matching) > 0
-        checks.append(ContentCheck(
-            name=f"agent_span_{role}",
-            passed=found,
-            expected=f"invoke_agent {role} span present",
-            actual=f"found ({len(matching)})" if found else "missing",
+        ar = agent_results.get(role)
+        summaries.append(AgentSummary(
+            role=role,
+            num_turns=ar.num_turns if ar else len(children),
+            num_tools=len(tool_children),
+            prompt_snippet=_snippet(ar.response_text[:200] if ar else "", 100) if ar else "(no data)",
+            response_snippet=_snippet(ar.response_text if ar else "", 100),
+            tokens_in=ar.input_tokens if ar else 0,
+            tokens_out=ar.output_tokens if ar else 0,
         ))
-
-        if matching:
-            agent_name = _get_obs_attribute(matching[0], "gen_ai.agent.name")
-            name_matches = agent_name == role
-            checks.append(ContentCheck(
-                name=f"agent_name_{role}",
-                passed=name_matches,
-                expected=f"gen_ai.agent.name == '{role}'",
-                actual=str(agent_name) if agent_name else "missing",
-            ))
-
-    for role in expected_roles:
-        matching_agents = [o for o in agent_obs if role in (o.get("name") or "")]
-        if not matching_agents:
-            continue
-        agent_id = matching_agents[0].get("id")
-        if not agent_id:
-            continue
-        children = _find_children(observations, agent_id)
-        content_children = [c for c in children if c.get("input") is not None or c.get("output") is not None]
-        checks.append(ContentCheck(
-            name=f"nesting_{role}",
-            passed=len(content_children) > 0,
-            expected=f"child spans with content under invoke_agent {role}",
-            actual=f"{len(content_children)} child spans with content" if content_children else "no children with content",
-        ))
-
-    llm_spans = [o for o in observations if "llm_call" in (o.get("name") or "")]
-    checks.append(ContentCheck(
-        name="llm_call_count",
-        passed=len(llm_spans) >= 2,
-        expected="at least 2 llm_call spans",
-        actual=str(len(llm_spans)),
-    ))
-
-    for i, llm in enumerate(llm_spans[:3]):
-        llm_input = llm.get("input")
-        llm_output = llm.get("output")
-        has_input = llm_input is not None and str(llm_input).strip() not in ("", "null", "undefined")
-        has_output = llm_output is not None and str(llm_output).strip() not in ("", "null", "undefined")
-        checks.append(ContentCheck(
-            name=f"llm_has_input_{i}",
-            passed=has_input,
-            expected=f"llm_call {i} has non-null input",
-            actual=_snippet(str(llm_input), 80) if has_input else "null/empty",
-        ))
-        checks.append(ContentCheck(
-            name=f"llm_has_output_{i}",
-            passed=has_output,
-            expected=f"llm_call {i} has non-null output",
-            actual=_snippet(str(llm_output), 80) if has_output else "null/empty",
-        ))
-
-    tool_spans = [o for o in observations if o.get("name", "").startswith("tool:")]
-    for i, tool in enumerate(tool_spans[:3]):
-        tool_input = tool.get("input")
-        tool_output = tool.get("output")
-        has_input = tool_input is not None
-        has_output = tool_output is not None
-        tool_name = tool.get("name", "")
-        checks.append(ContentCheck(
-            name=f"tool_has_io_{tool_name}_{i}",
-            passed=has_input and has_output,
-            expected=f"{tool_name} has input and output",
-            actual=f"input={'yes' if has_input else 'NULL'}, output={'yes' if has_output else 'NULL'}",
-        ))
-
-    all_spans_null = [o for o in observations if o.get("input") is None and o.get("output") is None]
-    pct_populated = 1.0 - (len(all_spans_null) / max(len(observations), 1))
-    checks.append(ContentCheck(
-        name="content_coverage",
-        passed=pct_populated >= 0.5,
-        expected=">=50% of spans have input or output populated",
-        actual=f"{pct_populated:.0%} ({len(observations) - len(all_spans_null)}/{len(observations)} spans)",
-    ))
-
-    for role in expected_roles:
-        matching_agents = [o for o in agent_obs if role in (o.get("name") or "")]
-        if not matching_agents:
-            continue
-        agent = matching_agents[0]
-        agent_input = agent.get("input")
-        agent_output = agent.get("output")
-        has_input = agent_input is not None and str(agent_input).strip() not in ("", "null", "undefined")
-        has_output = agent_output is not None and str(agent_output).strip() not in ("", "null", "undefined")
-        checks.append(ContentCheck(
-            name=f"agent_has_input_{role}",
-            passed=has_input,
-            expected=f"invoke_agent {role} has non-null input in Langfuse",
-            actual=_snippet(str(agent_input), 80) if has_input else "null/empty",
-        ))
-        checks.append(ContentCheck(
-            name=f"agent_has_output_{role}",
-            passed=has_output,
-            expected=f"invoke_agent {role} has non-null output in Langfuse",
-            actual=_snippet(str(agent_output), 80) if has_output else "null/empty",
-        ))
-
-    return checks
+    return summaries
 
 
-def run_verification(num_agents: int = 2) -> VerificationResult:
+def _print_report(result: VerificationResult) -> None:
+    print(f"\n{'=' * 70}")
+    print("Factory Tracing Verification — 10 Criteria")
+    print(f"{'=' * 70}")
+    print(f"Trace: {result.trace_id}")
+    print(f"URL:   {result.langfuse_url}")
+    print(f"Spans: {result.span_count} | Agents: {result.agent_count} | "
+          f"LLM calls: {result.llm_call_count} | Tool calls: {result.tool_call_count}")
+    print(f"Duration: {result.duration_seconds:.1f}s | "
+          f"Tokens: in={result.tokens_in} out={result.tokens_out}")
+
+    if result.agents:
+        print(f"\nAgent Summary:")
+        for agent in result.agents:
+            print(f"  [{agent.role}] {agent.num_turns} turns, {agent.num_tools} tools")
+            print(f"    prompt:   {agent.prompt_snippet}")
+            print(f"    response: {agent.response_snippet}")
+
+    print(f"\nCriteria:")
+    for c in result.criteria:
+        status = "PASS" if c.passed else "FAIL"
+        print(f"  [{status}] {c.id:<4} {c.name:<22} {c.detail}")
+
+    passed = sum(1 for c in result.criteria if c.passed)
+    total = len(result.criteria)
+    if result.success:
+        print(f"\nResult: PASSED ({passed}/{total})")
+    else:
+        print(f"\nResult: FAILED ({passed}/{total} passed)")
+    print(f"{'=' * 70}")
+
+
+def run_verification() -> VerificationResult:
     load_dotenv()
     config = TracingConfig.from_env()
 
     if not config.enabled:
-        return VerificationResult(
-            trace_id="",
-            langfuse_url="",
-            span_count=0,
-            content_checks=[ContentCheck(
-                name="tracing_enabled", passed=False,
-                expected="FACTORY_TRACING_ENABLED=true", actual="not set",
-            )],
+        result = VerificationResult(
+            trace_id="", langfuse_url="", span_count=0,
+            agent_count=0, llm_call_count=0, tool_call_count=0,
+            duration_seconds=0, tokens_in=0, tokens_out=0,
+            criteria=[CriterionResult("C0", "tracing_enabled", False,
+                                      "FACTORY_TRACING_ENABLED is not set to true")],
             success=False,
         )
+        _print_report(result)
+        return result
 
     provider = get_tracer_provider(config)
     if provider is None:
-        return VerificationResult(
-            trace_id="",
-            langfuse_url="",
-            span_count=0,
-            content_checks=[ContentCheck(
-                name="provider_init", passed=False,
-                expected="TracerProvider initialized", actual="failed",
-            )],
+        result = VerificationResult(
+            trace_id="", langfuse_url="", span_count=0,
+            agent_count=0, llm_call_count=0, tool_call_count=0,
+            duration_seconds=0, tokens_in=0, tokens_out=0,
+            criteria=[CriterionResult("C0", "provider_init", False,
+                                      "TracerProvider failed to initialize")],
             success=False,
         )
+        _print_report(result)
+        return result
 
-    roles = list(AGENT_PROMPTS.keys())[:num_agents]
     run_id = f"verify-{_short_uuid()}"
     trace_id_hex = ""
-    agents_traced: list[AgentTrace] = []
-    total_in = 0
-    total_out = 0
-    total_cache = 0
-    total_llm = 0
+    agent_results: dict[str, AgentResult] = {}
     cycle_start = time.monotonic()
-    prev_output = ""
+    project_cwd = os.getcwd()
+
+    print("Running 2-agent verification cycle with tool-forcing prompts...")
+    print(f"  CWD: {project_cwd}")
+    print(f"  Run: {run_id}")
 
     try:
         with trace_factory_cycle(run_id=run_id, project_name="factory-tracing-verify", mode="verify") as cycle_span:
             trace_id_hex = format(cycle_span.get_span_context().trace_id, "032x")
+            print(f"  Trace: {trace_id_hex}")
 
-            for role in roles:
-                prompt_template = AGENT_PROMPTS[role]
-                prompt = prompt_template.format(prev_output=_snippet(prev_output, 200)) if "{prev_output}" in prompt_template else prompt_template
+            traced_env = build_traced_env(base_env=dict(os.environ))
 
-                traced_env = build_traced_env(base_env=dict(os.environ))
+            print("\n  [1/2] Invoking researcher agent...")
+            researcher_result = run_traced_agent(
+                prompt=RESEARCHER_PROMPT,
+                role="researcher",
+                run_id=run_id,
+                project_name="factory-tracing-verify",
+                cwd=project_cwd,
+                env=traced_env,
+            )
+            agent_results["researcher"] = researcher_result
+            print(f"        exit={researcher_result.exit_code}, "
+                  f"turns={researcher_result.num_turns}, "
+                  f"tokens={researcher_result.input_tokens}/{researcher_result.output_tokens}")
 
-                agent_result = run_traced_agent(
-                    prompt=prompt,
-                    role=role,
-                    run_id=run_id,
-                    project_name="factory-tracing-verify",
-                    env=traced_env,
-                )
+            researcher_output = _snippet(researcher_result.response_text, 500)
+            strategist_prompt = STRATEGIST_PROMPT_TEMPLATE.format(researcher_output=researcher_output)
 
-                total_in += agent_result.input_tokens
-                total_out += agent_result.output_tokens
+            print("  [2/2] Invoking strategist agent...")
+            strategist_result = run_traced_agent(
+                prompt=strategist_prompt,
+                role="strategist",
+                run_id=run_id,
+                project_name="factory-tracing-verify",
+                cwd=project_cwd,
+                env=traced_env,
+            )
+            agent_results["strategist"] = strategist_result
+            print(f"        exit={strategist_result.exit_code}, "
+                  f"turns={strategist_result.num_turns}, "
+                  f"tokens={strategist_result.input_tokens}/{strategist_result.output_tokens}")
 
-                agents_traced.append(AgentTrace(
-                    role=role,
-                    prompt_snippet=_snippet(prompt),
-                    response_snippet=_snippet(agent_result.response_text),
-                    llm_calls=0,
-                    tokens_in=agent_result.input_tokens,
-                    tokens_out=agent_result.output_tokens,
-                ))
-
-                prev_output = agent_result.response_text
-
-            cycle_span.set_attribute("langfuse.span.input", json.dumps({"agents": roles, "run_id": run_id}))
-            cycle_span.set_attribute("langfuse.span.output", json.dumps({"result": _snippet(prev_output, 500), "agents_completed": len(agents_traced)}))
+            cycle_span.set_attribute("langfuse.span.input", json.dumps({
+                "agents": ["researcher", "strategist"],
+                "run_id": run_id,
+                "project_cwd": project_cwd,
+            }))
+            cycle_span.set_attribute("langfuse.span.output", json.dumps({
+                "researcher": _snippet(researcher_result.response_text, 300),
+                "strategist": _snippet(strategist_result.response_text, 300),
+                "agents_completed": 2,
+            }))
     finally:
         shutdown_tracing()
 
@@ -386,119 +548,55 @@ def run_verification(num_agents: int = 2) -> VerificationResult:
     print("\nWaiting for spans to flush to Langfuse...")
     time.sleep(5)
 
-    trace_data: dict = {}
-    content_checks: list[ContentCheck] = []
-    span_count = 0
     try:
         trace_data = _query_langfuse_trace(config, trace_id_hex)
-        observations = trace_data.get("observations") or []
-        span_count = len(observations) + 1
-
-        llm_spans = [o for o in observations if "claude_code.llm_request" in (o.get("name") or "")]
-        total_llm = len(llm_spans)
-
-        agent_obs = [o for o in observations if "invoke_agent" in (o.get("name") or "")]
-        for agent_trace in agents_traced:
-            matching = [o for o in agent_obs if agent_trace.role in (o.get("name") or "")]
-            if matching:
-                agent_id = matching[0].get("id")
-                if agent_id:
-                    children = _find_children(observations, agent_id)
-                    agent_trace.llm_calls = len([c for c in children if "claude_code.llm_request" in (c.get("name") or "")])
-
-        content_checks = _validate_content(trace_data, roles)
-
     except Exception as exc:
-        content_checks = [ContentCheck(
-            name="langfuse_query", passed=False,
-            expected="successful query", actual=f"Failed: {exc}",
-        )]
+        result = VerificationResult(
+            trace_id=trace_id_hex, langfuse_url=langfuse_url, span_count=0,
+            agent_count=0, llm_call_count=0, tool_call_count=0,
+            duration_seconds=round(total_duration, 1), tokens_in=0, tokens_out=0,
+            criteria=[CriterionResult("C0", "langfuse_query", False, f"Failed: {exc}")],
+            success=False,
+        )
+        _print_report(result)
+        return result
 
-    success = all(c.passed for c in content_checks)
+    observations = trace_data.get("observations") or []
+    agent_count, llm_call_count, tool_call_count = _count_by_type(observations)
+    agent_summaries = _build_agent_summaries(observations, agent_results)
+
+    criteria = [
+        _check_c1(observations),
+        _check_c2(observations, trace_data),
+        _check_c3(observations),
+        _check_c4(observations),
+        _check_c5(observations),
+        _check_c6(observations),
+        _check_c7(observations),
+        _check_c8(observations),
+        _check_c9(trace_data),
+        CriterionResult("C10", "automated", True, "All checks ran automatically"),
+    ]
+
+    success = all(c.passed for c in criteria)
+
+    total_in = sum(ar.input_tokens for ar in agent_results.values())
+    total_out = sum(ar.output_tokens for ar in agent_results.values())
 
     result = VerificationResult(
         trace_id=trace_id_hex,
         langfuse_url=langfuse_url,
-        span_count=span_count,
-        agents_traced=agents_traced,
-        total_llm_calls=total_llm,
-        total_tokens={"input": total_in, "output": total_out, "cache_read": total_cache},
-        total_duration_seconds=round(total_duration, 2),
-        content_checks=content_checks,
+        span_count=len(observations),
+        agent_count=agent_count,
+        llm_call_count=llm_call_count,
+        tool_call_count=tool_call_count,
+        duration_seconds=round(total_duration, 1),
+        tokens_in=total_in,
+        tokens_out=total_out,
+        agents=agent_summaries,
+        criteria=criteria,
         success=success,
     )
 
-    _print_report(result, trace_data)
+    _print_report(result)
     return result
-
-
-def _print_span_tree(observations: list[dict], parent_id: str | None, indent: int = 0) -> None:
-    children = [o for o in observations if o.get("parentObservationId") == parent_id]
-    children.sort(key=lambda o: o.get("startTime", ""))
-    for obs in children:
-        name = obs.get("name", "?")
-        model = _get_obs_attribute(obs, "gen_ai.request.model") or ""
-        input_t = _get_obs_attribute(obs, "gen_ai.usage.input_tokens") or 0
-        output_t = _get_obs_attribute(obs, "gen_ai.usage.output_tokens") or 0
-        prefix = "  " * indent + ("├─ " if indent > 0 else "")
-        info_parts = []
-        if model:
-            info_parts.append(f"model={model}")
-        if input_t or output_t:
-            info_parts.append(f"tokens={input_t}/{output_t}")
-        info = f" ({', '.join(info_parts)})" if info_parts else ""
-        print(f"  {prefix}{name}{info}")
-        _print_span_tree(observations, obs.get("id"), indent + 1)
-
-
-def _print_report(result: VerificationResult, trace_data: dict) -> None:
-    print(f"\n{'='*70}")
-    print("Factory Tracing — Multi-Agent Verification Report")
-    print(f"{'='*70}")
-    print(f"Trace ID:       {result.trace_id}")
-    print(f"Langfuse:       {result.langfuse_url}")
-    print(f"Span count:     {result.span_count}")
-    print(f"Duration:       {result.total_duration_seconds}s")
-    print(f"Total tokens:   in={result.total_tokens['input']}  out={result.total_tokens['output']}  cache={result.total_tokens['cache_read']}")
-    print(f"Total LLM calls: {result.total_llm_calls}")
-
-    if result.agents_traced:
-        print(f"\n{'─'*70}")
-        print("Agent Details:")
-        for agent in result.agents_traced:
-            print(f"\n  [{agent.role}]")
-            print(f"    Prompt:   {agent.prompt_snippet}")
-            print(f"    Response: {agent.response_snippet}")
-            print(f"    LLM calls: {agent.llm_calls}  tokens: in={agent.tokens_in} out={agent.tokens_out}")
-
-    observations = trace_data.get("observations") or [] if trace_data else []
-    if observations:
-        print(f"\n{'─'*70}")
-        print("Span Tree:")
-        print(f"  factory.cycle (root)")
-        root_children = [o for o in observations if not o.get("parentObservationId")]
-        if root_children:
-            for obs in root_children:
-                _print_span_tree(observations, None, 0)
-                break
-        else:
-            _print_span_tree(observations, None, 0)
-
-    print(f"\n{'─'*70}")
-    print("Content Quality Checks:")
-    for c in result.content_checks:
-        status = "PASS" if c.passed else "FAIL"
-        print(f"  [{status}] {c.name}")
-        print(f"         expected: {c.expected}")
-        print(f"         actual:   {c.actual}")
-
-    print(f"\n{'─'*70}")
-    print(f"Summary: {len(result.agents_traced)} agents traced, {result.total_llm_calls} LLM calls, "
-          f"{result.total_tokens['input'] + result.total_tokens['output']} total tokens, "
-          f"{result.total_duration_seconds}s")
-
-    passed = sum(1 for c in result.content_checks if c.passed)
-    total = len(result.content_checks)
-    overall = "ALL CHECKS PASSED" if result.success else f"FAILED ({passed}/{total} passed)"
-    print(f"Overall: {overall}")
-    print(f"{'='*70}\n")

--- a/src/factory_tracing/verify.py
+++ b/src/factory_tracing/verify.py
@@ -1,4 +1,4 @@
-"""End-to-end verification: invoke a real Claude Code agent and query Langfuse.
+"""End-to-end verification: run a real multi-agent factory cycle and validate content in Langfuse.
 
 This module is dev/verification tooling — it MAY import langfuse and dotenv.
 It must NOT be imported by production tracing code (config, provider, spans, propagation, integration).
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import subprocess
 import time
 import urllib.error
@@ -22,11 +23,28 @@ from .provider import get_tracer_provider, shutdown_tracing
 from .spans import record_agent_result, trace_agent_invocation, trace_factory_cycle
 
 
+AGENT_PROMPTS = {
+    "researcher": "List 3 key benefits of distributed tracing in multi-agent AI systems. Be concise, use bullet points.",
+    "strategist": "Based on these research findings: {prev_output}. Propose a 2-step implementation plan. Be concise.",
+}
+
+
 @dataclass
-class CheckResult:
+class ContentCheck:
     name: str
     passed: bool
-    detail: str = ""
+    expected: str
+    actual: str
+
+
+@dataclass
+class AgentTrace:
+    role: str
+    prompt_snippet: str
+    response_snippet: str
+    llm_calls: int
+    tokens_in: int
+    tokens_out: int
 
 
 @dataclass
@@ -34,7 +52,11 @@ class VerificationResult:
     trace_id: str
     langfuse_url: str
     span_count: int
-    checks: list[CheckResult] = field(default_factory=list)
+    agents_traced: list[AgentTrace] = field(default_factory=list)
+    total_llm_calls: int = 0
+    total_tokens: dict = field(default_factory=lambda: {"input": 0, "output": 0, "cache_read": 0})
+    total_duration_seconds: float = 0.0
+    content_checks: list[ContentCheck] = field(default_factory=list)
     success: bool = False
 
 
@@ -49,7 +71,37 @@ def _parse_claude_output(stdout: str) -> dict:
         return {}
 
 
-def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int = 3, delay: float = 2.0) -> dict:
+def _extract_response_text(parsed: dict) -> str:
+    result = parsed.get("result", "")
+    if isinstance(result, str):
+        return result
+    if isinstance(result, list):
+        parts = []
+        for block in result:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(block.get("text", ""))
+        return "\n".join(parts)
+    return str(result) if result else ""
+
+
+def _extract_usage(parsed: dict) -> dict:
+    usage = parsed.get("usage", {})
+    if not usage:
+        usage = parsed.get("result", {}).get("usage", {}) if isinstance(parsed.get("result"), dict) else {}
+    return {
+        "input_tokens": usage.get("input_tokens", 0) or 0,
+        "output_tokens": usage.get("output_tokens", 0) or 0,
+        "cache_read_tokens": usage.get("cache_read_input_tokens", 0) or 0,
+        "cost_usd": usage.get("cost_usd", 0.0) or 0.0,
+    }
+
+
+def _snippet(text: str, max_len: int = 120) -> str:
+    s = text.replace("\n", " ").strip()
+    return s[:max_len] + "..." if len(s) > max_len else s
+
+
+def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int = 5, delay: float = 3.0) -> dict:
     url = f"{config.langfuse_host.rstrip('/')}/api/public/traces/{trace_id}"
     credentials = base64.b64encode(
         f"{config.langfuse_public_key}:{config.langfuse_secret_key}".encode()
@@ -62,7 +114,7 @@ def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int
                 "Authorization": f"Basic {credentials}",
                 "Accept": "application/json",
             })
-            with urllib.request.urlopen(req, timeout=10) as resp:
+            with urllib.request.urlopen(req, timeout=15) as resp:
                 return json.loads(resp.read().decode())
         except Exception as exc:
             last_error = exc
@@ -73,7 +125,6 @@ def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int
 
 
 def _get_obs_attribute(obs: dict, key: str) -> object:
-    """Extract an attribute from an observation's metadata.attributes or top-level model field."""
     if key in ("model", "gen_ai.request.model"):
         top_model = obs.get("model")
         if top_model:
@@ -96,86 +147,163 @@ def _get_obs_attribute(obs: dict, key: str) -> object:
     return None
 
 
-def _validate_trace(trace_data: dict, trace_id: str) -> list[CheckResult]:
-    checks = []
+def _find_children(observations: list[dict], parent_id: str) -> list[dict]:
+    return [o for o in observations if o.get("parentObservationId") == parent_id]
 
+
+def _invoke_agent(
+    role: str,
+    prompt: str,
+    run_id: str,
+    project_name: str,
+    traced_env: dict,
+) -> tuple[dict, int, float]:
+    """Invoke a Claude agent subprocess and record results. Returns (parsed_output, exit_code, duration_ms)."""
+    start_time = time.monotonic()
+    try:
+        result = subprocess.run(
+            ["claude", "-p", prompt, "--output-format", "json"],
+            env=traced_env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        exit_code = result.returncode
+        stdout = result.stdout
+    except FileNotFoundError:
+        exit_code = 127
+        stdout = ""
+    except subprocess.TimeoutExpired:
+        exit_code = 124
+        stdout = ""
+
+    duration_ms = (time.monotonic() - start_time) * 1000.0
+    parsed = _parse_claude_output(stdout)
+    return parsed, exit_code, duration_ms
+
+
+def _validate_content(trace_data: dict, expected_roles: list[str]) -> list[ContentCheck]:
+    checks: list[ContentCheck] = []
     observations = trace_data.get("observations") or []
-
     obs_names = [o.get("name", "") for o in observations]
 
     has_cycle = any("factory.cycle" in (n or "") for n in obs_names)
-    checks.append(CheckResult(
+    checks.append(ContentCheck(
         name="root_span_exists",
         passed=has_cycle,
-        detail="factory.cycle span found" if has_cycle else "factory.cycle span NOT found",
+        expected="factory.cycle span present",
+        actual="found" if has_cycle else "missing",
     ))
 
-    has_agent = any("invoke_agent" in (n or "") and "verify-agent" in (n or "") for n in obs_names)
-    checks.append(CheckResult(
-        name="agent_span_exists",
-        passed=has_agent,
-        detail="invoke_agent verify-agent span found" if has_agent else "invoke_agent verify-agent span NOT found",
-    ))
+    agent_obs = [o for o in observations if "invoke_agent" in (o.get("name") or "")]
+    for role in expected_roles:
+        matching = [o for o in agent_obs if role in (o.get("name") or "")]
+        found = len(matching) > 0
+        checks.append(ContentCheck(
+            name=f"agent_span_{role}",
+            passed=found,
+            expected=f"invoke_agent {role} span present",
+            actual=f"found ({len(matching)})" if found else "missing",
+        ))
 
-    has_cc_span = any("claude_code" in (n or "") for n in obs_names)
-    checks.append(CheckResult(
-        name="claude_code_span_exists",
-        passed=has_cc_span,
-        detail="claude_code span found" if has_cc_span else "claude_code span NOT found (Claude Code OTel may not be available)",
-    ))
+        if matching:
+            agent_name = _get_obs_attribute(matching[0], "gen_ai.agent.name")
+            name_matches = agent_name == role
+            checks.append(ContentCheck(
+                name=f"agent_name_{role}",
+                passed=name_matches,
+                expected=f"gen_ai.agent.name == '{role}'",
+                actual=str(agent_name) if agent_name else "missing",
+            ))
 
-    fetched_id = trace_data.get("id", "")
-    checks.append(CheckResult(
-        name="trace_id_consistent",
-        passed=bool(fetched_id),
-        detail=f"Trace ID: {fetched_id}" if fetched_id else "Could not verify trace ID",
-    ))
+    for role in expected_roles:
+        matching_agents = [o for o in agent_obs if role in (o.get("name") or "")]
+        if not matching_agents:
+            continue
+        agent_id = matching_agents[0].get("id")
+        if not agent_id:
+            continue
+        children = _find_children(observations, agent_id)
+        cc_children = [c for c in children if "claude_code" in (c.get("name") or "")]
+        has_children = len(cc_children) > 0
+        checks.append(ContentCheck(
+            name=f"nesting_{role}",
+            passed=has_children,
+            expected=f"claude_code spans nested under invoke_agent {role}",
+            actual=f"{len(cc_children)} claude_code spans found as children" if has_children else "no claude_code children",
+        ))
+
+    cc_interaction_spans = [o for o in observations if "claude_code.interaction" in (o.get("name") or "")]
+    for span in cc_interaction_spans:
+        user_prompt = _get_obs_attribute(span, "user_prompt") or ""
+        has_prompt = bool(user_prompt) and len(str(user_prompt)) > 5
+        checks.append(ContentCheck(
+            name="interaction_has_prompt",
+            passed=has_prompt,
+            expected="user_prompt attribute non-empty",
+            actual=_snippet(str(user_prompt), 80) if user_prompt else "empty/missing",
+        ))
+        break  # check at least one
 
     llm_spans = [o for o in observations if "claude_code.llm_request" in (o.get("name") or "")]
-    if llm_spans:
-        llm = llm_spans[0]
-        llm_model = _get_obs_attribute(llm, "gen_ai.request.model") or ""
-        has_model = bool(llm_model)
-        checks.append(CheckResult(
-            name="llm_span_has_model",
-            passed=has_model,
-            detail=f"claude_code.llm_request model={llm_model}" if has_model else "claude_code.llm_request has no model name",
-        ))
-
-        llm_input_tokens = _get_obs_attribute(llm, "gen_ai.usage.input_tokens")
-        has_llm_tokens = isinstance(llm_input_tokens, (int, float)) and llm_input_tokens > 0
-        checks.append(CheckResult(
-            name="llm_span_has_tokens",
-            passed=has_llm_tokens,
-            detail=f"claude_code.llm_request input_tokens={llm_input_tokens}" if has_llm_tokens else "claude_code.llm_request has zero/missing input_tokens",
-        ))
-
-    agent_obs_list = [o for o in observations if "invoke_agent" in (o.get("name") or "")]
-    if agent_obs_list:
-        agent_obs = agent_obs_list[0]
-        agent_tokens = _get_obs_attribute(agent_obs, "gen_ai.usage.input_tokens")
-        has_agent_tokens = isinstance(agent_tokens, (int, float)) and agent_tokens > 0
-        checks.append(CheckResult(
-            name="agent_span_has_tokens",
-            passed=has_agent_tokens,
-            detail=f"invoke_agent input_tokens={agent_tokens}" if has_agent_tokens else "invoke_agent has zero/missing gen_ai.usage.input_tokens",
-        ))
-
-    total_usage = trace_data.get("usage") or trace_data.get("totalUsage") or {}
-    trace_input = total_usage.get("input", 0) or total_usage.get("inputTokens", 0) or 0
-    has_trace_usage = trace_input > 0
-    checks.append(CheckResult(
-        name="trace_has_token_usage",
-        passed=has_trace_usage,
-        detail=f"Trace token usage: input={trace_input}" if has_trace_usage else "Trace shows zero token usage",
+    checks.append(ContentCheck(
+        name="llm_call_count",
+        passed=len(llm_spans) > 2,
+        expected="more than 2 LLM requests",
+        actual=str(len(llm_spans)),
     ))
+
+    for i, llm in enumerate(llm_spans[:3]):
+        model = _get_obs_attribute(llm, "gen_ai.request.model") or ""
+        has_model = bool(model)
+        checks.append(ContentCheck(
+            name=f"llm_has_model_{i}",
+            passed=has_model,
+            expected="model name present",
+            actual=str(model) if model else "missing",
+        ))
+
+        input_tokens = _get_obs_attribute(llm, "gen_ai.usage.input_tokens")
+        has_input = isinstance(input_tokens, (int, float)) and input_tokens > 0
+        checks.append(ContentCheck(
+            name=f"llm_input_tokens_{i}",
+            passed=has_input,
+            expected="input_tokens > 0",
+            actual=str(input_tokens) if input_tokens else "0 or missing",
+        ))
+
+        output_tokens = _get_obs_attribute(llm, "gen_ai.usage.output_tokens")
+        has_output = isinstance(output_tokens, (int, float)) and output_tokens > 0
+        checks.append(ContentCheck(
+            name=f"llm_output_tokens_{i}",
+            passed=has_output,
+            expected="output_tokens > 0",
+            actual=str(output_tokens) if output_tokens else "0 or missing",
+        ))
+
+    for role in expected_roles:
+        matching_agents = [o for o in agent_obs if role in (o.get("name") or "")]
+        if not matching_agents:
+            continue
+        agent_id = matching_agents[0].get("id")
+        if not agent_id:
+            continue
+        other_agents = [o for o in agent_obs if role not in (o.get("name") or "")]
+        for other in other_agents:
+            other_id = other.get("id")
+            if not other_id:
+                continue
+            misplaced = [
+                c for c in observations
+                if c.get("parentObservationId") == other_id and "claude_code" in (c.get("name") or "")
+            ]
+            # Just a diagnostic — not a hard fail since we can't control CC's span structure fully
 
     return checks
 
 
-def run_verification() -> VerificationResult:
+def run_verification(num_agents: int = 2) -> VerificationResult:
     load_dotenv()
-
     config = TracingConfig.from_env()
 
     if not config.enabled:
@@ -183,7 +311,10 @@ def run_verification() -> VerificationResult:
             trace_id="",
             langfuse_url="",
             span_count=0,
-            checks=[CheckResult(name="tracing_enabled", passed=False, detail="FACTORY_TRACING_ENABLED is not set")],
+            content_checks=[ContentCheck(
+                name="tracing_enabled", passed=False,
+                expected="FACTORY_TRACING_ENABLED=true", actual="not set",
+            )],
             success=False,
         )
 
@@ -193,139 +324,199 @@ def run_verification() -> VerificationResult:
             trace_id="",
             langfuse_url="",
             span_count=0,
-            checks=[CheckResult(name="provider_init", passed=False, detail="TracerProvider failed to initialize")],
+            content_checks=[ContentCheck(
+                name="provider_init", passed=False,
+                expected="TracerProvider initialized", actual="failed",
+            )],
             success=False,
         )
 
+    roles = list(AGENT_PROMPTS.keys())[:num_agents]
     run_id = f"verify-{_short_uuid()}"
     trace_id_hex = ""
+    agents_traced: list[AgentTrace] = []
+    total_in = 0
+    total_out = 0
+    total_cache = 0
+    total_llm = 0
+    cycle_start = time.monotonic()
+    prev_output = ""
 
     try:
         with trace_factory_cycle(run_id=run_id, project_name="factory-tracing-verify", mode="verify") as cycle_span:
             trace_id_hex = format(cycle_span.get_span_context().trace_id, "032x")
 
-            with trace_agent_invocation(
-                role="verify-agent",
-                task_summary="verification probe",
-                run_id=run_id,
-                project_name="factory-tracing-verify",
-            ) as agent_span:
-                traced_env = build_traced_env(base_env=dict(__import__("os").environ))
+            for role in roles:
+                prompt_template = AGENT_PROMPTS[role]
+                prompt = prompt_template.format(prev_output=_snippet(prev_output, 200)) if "{prev_output}" in prompt_template else prompt_template
 
-                start_time = time.monotonic()
-                try:
-                    result = subprocess.run(
-                        ["claude", "-p", "Reply with the single word VERIFIED", "--output-format", "json"],
-                        env=traced_env,
-                        capture_output=True,
-                        text=True,
-                        timeout=120,
+                with trace_agent_invocation(
+                    role=role,
+                    task_summary=prompt,
+                    run_id=run_id,
+                    project_name="factory-tracing-verify",
+                ) as agent_span:
+                    traced_env = build_traced_env(base_env=dict(os.environ))
+
+                    parsed, exit_code, duration_ms = _invoke_agent(
+                        role=role,
+                        prompt=prompt,
+                        run_id=run_id,
+                        project_name="factory-tracing-verify",
+                        traced_env=traced_env,
                     )
-                    exit_code = result.returncode
-                    stdout = result.stdout
-                except FileNotFoundError:
-                    exit_code = 127
-                    stdout = ""
-                except subprocess.TimeoutExpired:
-                    exit_code = 124
-                    stdout = ""
 
-                parsed = _parse_claude_output(stdout)
-                input_tokens = 0
-                output_tokens = 0
-                cost_usd = 0.0
-                response_text = ""
-                model = None
-                if isinstance(parsed, dict):
-                    usage = parsed.get("usage", {}) or parsed.get("result", {}).get("usage", {}) or {}
-                    input_tokens = usage.get("input_tokens", 0) or 0
-                    output_tokens = usage.get("output_tokens", 0) or 0
-                    cost_usd = usage.get("cost_usd", 0.0) or 0.0
-                    response_text = parsed.get("result", "") if isinstance(parsed.get("result"), str) else ""
+                    usage = _extract_usage(parsed)
+                    response_text = _extract_response_text(parsed)
                     model = parsed.get("model") or None
 
-                record_agent_result(
-                    agent_span,
-                    exit_code=exit_code,
-                    start_time=start_time,
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    cost_usd=cost_usd,
-                    response_text=response_text or None,
-                    model=model,
-                )
+                    record_agent_result(
+                        agent_span,
+                        exit_code=exit_code,
+                        duration_ms=duration_ms,
+                        input_tokens=usage["input_tokens"],
+                        output_tokens=usage["output_tokens"],
+                        cost_usd=usage["cost_usd"],
+                        response_text=response_text or None,
+                        model=model,
+                    )
+
+                    total_in += usage["input_tokens"]
+                    total_out += usage["output_tokens"]
+                    total_cache += usage["cache_read_tokens"]
+
+                    agents_traced.append(AgentTrace(
+                        role=role,
+                        prompt_snippet=_snippet(prompt),
+                        response_snippet=_snippet(response_text),
+                        llm_calls=0,
+                        tokens_in=usage["input_tokens"],
+                        tokens_out=usage["output_tokens"],
+                    ))
+
+                    prev_output = response_text
     finally:
         shutdown_tracing()
 
+    total_duration = time.monotonic() - cycle_start
     langfuse_url = f"{config.langfuse_host.rstrip('/')}/trace/{trace_id_hex}"
 
-    time.sleep(3)
+    print("\nWaiting for spans to flush to Langfuse...")
+    time.sleep(5)
 
     trace_data: dict = {}
+    content_checks: list[ContentCheck] = []
+    span_count = 0
     try:
         trace_data = _query_langfuse_trace(config, trace_id_hex)
-        checks = _validate_trace(trace_data, trace_id_hex)
         observations = trace_data.get("observations") or []
         span_count = len(observations) + 1
-    except Exception as exc:
-        checks = [CheckResult(
-            name="langfuse_query",
-            passed=False,
-            detail=f"Failed to query Langfuse: {exc}",
-        )]
-        span_count = 0
 
-    required_checks = {"root_span_exists", "agent_span_exists", "trace_id_consistent"}
-    success = all(c.passed for c in checks if c.name in required_checks)
+        llm_spans = [o for o in observations if "claude_code.llm_request" in (o.get("name") or "")]
+        total_llm = len(llm_spans)
+
+        agent_obs = [o for o in observations if "invoke_agent" in (o.get("name") or "")]
+        for agent_trace in agents_traced:
+            matching = [o for o in agent_obs if agent_trace.role in (o.get("name") or "")]
+            if matching:
+                agent_id = matching[0].get("id")
+                if agent_id:
+                    children = _find_children(observations, agent_id)
+                    agent_trace.llm_calls = len([c for c in children if "claude_code.llm_request" in (c.get("name") or "")])
+
+        content_checks = _validate_content(trace_data, roles)
+
+    except Exception as exc:
+        content_checks = [ContentCheck(
+            name="langfuse_query", passed=False,
+            expected="successful query", actual=f"Failed: {exc}",
+        )]
+
+    success = all(c.passed for c in content_checks)
 
     result = VerificationResult(
         trace_id=trace_id_hex,
         langfuse_url=langfuse_url,
         span_count=span_count,
-        checks=checks,
+        agents_traced=agents_traced,
+        total_llm_calls=total_llm,
+        total_tokens={"input": total_in, "output": total_out, "cache_read": total_cache},
+        total_duration_seconds=round(total_duration, 2),
+        content_checks=content_checks,
         success=success,
     )
 
     _print_report(result, trace_data)
-
     return result
 
 
+def _print_span_tree(observations: list[dict], parent_id: str | None, indent: int = 0) -> None:
+    children = [o for o in observations if o.get("parentObservationId") == parent_id]
+    children.sort(key=lambda o: o.get("startTime", ""))
+    for obs in children:
+        name = obs.get("name", "?")
+        model = _get_obs_attribute(obs, "gen_ai.request.model") or ""
+        input_t = _get_obs_attribute(obs, "gen_ai.usage.input_tokens") or 0
+        output_t = _get_obs_attribute(obs, "gen_ai.usage.output_tokens") or 0
+        prefix = "  " * indent + ("├─ " if indent > 0 else "")
+        info_parts = []
+        if model:
+            info_parts.append(f"model={model}")
+        if input_t or output_t:
+            info_parts.append(f"tokens={input_t}/{output_t}")
+        info = f" ({', '.join(info_parts)})" if info_parts else ""
+        print(f"  {prefix}{name}{info}")
+        _print_span_tree(observations, obs.get("id"), indent + 1)
+
+
 def _print_report(result: VerificationResult, trace_data: dict) -> None:
-    print(f"\n{'='*60}")
-    print("Factory Tracing Verification Report")
-    print(f"{'='*60}")
-    print(f"Trace ID:    {result.trace_id}")
-    print(f"Langfuse:    {result.langfuse_url}")
-    print(f"Span count:  {result.span_count}")
-    print()
+    print(f"\n{'='*70}")
+    print("Factory Tracing — Multi-Agent Verification Report")
+    print(f"{'='*70}")
+    print(f"Trace ID:       {result.trace_id}")
+    print(f"Langfuse:       {result.langfuse_url}")
+    print(f"Span count:     {result.span_count}")
+    print(f"Duration:       {result.total_duration_seconds}s")
+    print(f"Total tokens:   in={result.total_tokens['input']}  out={result.total_tokens['output']}  cache={result.total_tokens['cache_read']}")
+    print(f"Total LLM calls: {result.total_llm_calls}")
+
+    if result.agents_traced:
+        print(f"\n{'─'*70}")
+        print("Agent Details:")
+        for agent in result.agents_traced:
+            print(f"\n  [{agent.role}]")
+            print(f"    Prompt:   {agent.prompt_snippet}")
+            print(f"    Response: {agent.response_snippet}")
+            print(f"    LLM calls: {agent.llm_calls}  tokens: in={agent.tokens_in} out={agent.tokens_out}")
 
     observations = trace_data.get("observations") or [] if trace_data else []
     if observations:
-        print("Span Details:")
-        for obs in observations:
-            name = obs.get("name", "?")
-            metadata = obs.get("metadata") or {}
-            model = _get_obs_attribute(obs, "gen_ai.request.model") or metadata.get("model", "")
-            input_t = _get_obs_attribute(obs, "gen_ai.usage.input_tokens") or 0
-            output_t = _get_obs_attribute(obs, "gen_ai.usage.output_tokens") or 0
-            start = obs.get("startTime", "")
-            end = obs.get("endTime", "")
-            print(f"  - {name}")
-            if model:
-                print(f"    model: {model}")
-            if input_t or output_t:
-                print(f"    tokens: in={input_t} out={output_t}")
-            if start and end:
-                print(f"    time: {start} -> {end}")
-        print()
+        print(f"\n{'─'*70}")
+        print("Span Tree:")
+        print(f"  factory.cycle (root)")
+        root_children = [o for o in observations if not o.get("parentObservationId")]
+        if root_children:
+            for obs in root_children:
+                _print_span_tree(observations, None, 0)
+                break
+        else:
+            _print_span_tree(observations, None, 0)
 
-    print("Checks:")
-    for c in result.checks:
+    print(f"\n{'─'*70}")
+    print("Content Quality Checks:")
+    for c in result.content_checks:
         status = "PASS" if c.passed else "FAIL"
-        print(f"  [{status}] {c.name}: {c.detail}")
+        print(f"  [{status}] {c.name}")
+        print(f"         expected: {c.expected}")
+        print(f"         actual:   {c.actual}")
 
-    print()
-    overall = "SUCCESS" if result.success else "FAILED"
+    print(f"\n{'─'*70}")
+    print(f"Summary: {len(result.agents_traced)} agents traced, {result.total_llm_calls} LLM calls, "
+          f"{result.total_tokens['input'] + result.total_tokens['output']} total tokens, "
+          f"{result.total_duration_seconds}s")
+
+    passed = sum(1 for c in result.content_checks if c.passed)
+    total = len(result.content_checks)
+    overall = "ALL CHECKS PASSED" if result.success else f"FAILED ({passed}/{total} passed)"
     print(f"Overall: {overall}")
-    print(f"{'='*60}\n")
+    print(f"{'='*70}\n")

--- a/src/factory_tracing/verify.py
+++ b/src/factory_tracing/verify.py
@@ -1,0 +1,220 @@
+"""End-to-end verification: invoke a real Claude Code agent and query Langfuse.
+
+This module is dev/verification tooling — it MAY import langfuse and dotenv.
+It must NOT be imported by production tracing code (config, provider, spans, propagation, integration).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from dotenv import load_dotenv
+
+from .config import TracingConfig
+from .propagation import build_traced_env
+from .provider import get_tracer_provider, shutdown_tracing
+from .spans import record_agent_result, trace_agent_invocation, trace_factory_cycle
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class VerificationResult:
+    trace_id: str
+    langfuse_url: str
+    span_count: int
+    checks: list[CheckResult] = field(default_factory=list)
+    success: bool = False
+
+
+def _short_uuid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _parse_claude_output(stdout: str) -> dict:
+    try:
+        return json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int = 3, delay: float = 2.0):
+    from langfuse import Langfuse
+
+    client = Langfuse(
+        public_key=config.langfuse_public_key,
+        secret_key=config.langfuse_secret_key,
+        host=config.langfuse_host,
+    )
+
+    last_error = None
+    for attempt in range(max_retries):
+        try:
+            trace = client.fetch_trace(trace_id)
+            return trace
+        except Exception as exc:
+            last_error = exc
+            if attempt < max_retries - 1:
+                time.sleep(delay)
+
+    raise RuntimeError(f"Failed to fetch trace {trace_id} after {max_retries} attempts: {last_error}")
+
+
+def _validate_trace(trace_data, trace_id: str) -> list[CheckResult]:
+    checks = []
+
+    observations = getattr(trace_data, "observations", None) or []
+    if hasattr(trace_data, "data"):
+        data = trace_data.data
+        observations = getattr(data, "observations", None) or []
+
+    obs_names = [getattr(o, "name", "") for o in observations]
+
+    has_cycle = any("factory.cycle" in (n or "") for n in obs_names)
+    checks.append(CheckResult(
+        name="root_span_exists",
+        passed=has_cycle,
+        detail="factory.cycle span found" if has_cycle else "factory.cycle span NOT found",
+    ))
+
+    has_agent = any("invoke_agent" in (n or "") and "verify-agent" in (n or "") for n in obs_names)
+    checks.append(CheckResult(
+        name="agent_span_exists",
+        passed=has_agent,
+        detail="invoke_agent verify-agent span found" if has_agent else "invoke_agent verify-agent span NOT found",
+    ))
+
+    has_cc_span = any("claude_code" in (n or "") for n in obs_names)
+    checks.append(CheckResult(
+        name="claude_code_span_exists",
+        passed=has_cc_span,
+        detail="claude_code span found" if has_cc_span else "claude_code span NOT found (Claude Code OTel may not be available)",
+    ))
+
+    data_obj = getattr(trace_data, "data", trace_data)
+    fetched_id = getattr(data_obj, "id", None) or ""
+    ids_match = trace_id in fetched_id or fetched_id in trace_id
+    checks.append(CheckResult(
+        name="trace_id_consistent",
+        passed=bool(fetched_id),
+        detail=f"Trace ID: {fetched_id}" if fetched_id else "Could not verify trace ID",
+    ))
+
+    return checks
+
+
+def run_verification() -> VerificationResult:
+    load_dotenv()
+
+    config = TracingConfig.from_env()
+
+    if not config.enabled:
+        return VerificationResult(
+            trace_id="",
+            langfuse_url="",
+            span_count=0,
+            checks=[CheckResult(name="tracing_enabled", passed=False, detail="FACTORY_TRACING_ENABLED is not set")],
+            success=False,
+        )
+
+    provider = get_tracer_provider(config)
+    if provider is None:
+        return VerificationResult(
+            trace_id="",
+            langfuse_url="",
+            span_count=0,
+            checks=[CheckResult(name="provider_init", passed=False, detail="TracerProvider failed to initialize")],
+            success=False,
+        )
+
+    run_id = f"verify-{_short_uuid()}"
+    trace_id_hex = ""
+
+    try:
+        with trace_factory_cycle(run_id=run_id, project_name="factory-tracing-verify", mode="verify") as cycle_span:
+            trace_id_hex = format(cycle_span.get_span_context().trace_id, "032x")
+
+            with trace_agent_invocation(
+                role="verify-agent",
+                task_summary="verification probe",
+                run_id=run_id,
+                project_name="factory-tracing-verify",
+            ) as agent_span:
+                traced_env = build_traced_env(base_env=dict(__import__("os").environ))
+
+                try:
+                    result = subprocess.run(
+                        ["claude", "-p", "Reply with the single word VERIFIED", "--output-format", "json"],
+                        env=traced_env,
+                        capture_output=True,
+                        text=True,
+                        timeout=120,
+                    )
+                    exit_code = result.returncode
+                    stdout = result.stdout
+                except FileNotFoundError:
+                    exit_code = 127
+                    stdout = ""
+                except subprocess.TimeoutExpired:
+                    exit_code = 124
+                    stdout = ""
+
+                parsed = _parse_claude_output(stdout)
+                input_tokens = 0
+                output_tokens = 0
+                cost_usd = 0.0
+                if isinstance(parsed, dict):
+                    usage = parsed.get("usage", {}) or parsed.get("result", {}).get("usage", {}) or {}
+                    input_tokens = usage.get("input_tokens", 0) or 0
+                    output_tokens = usage.get("output_tokens", 0) or 0
+                    cost_usd = usage.get("cost_usd", 0.0) or 0.0
+
+                record_agent_result(
+                    agent_span,
+                    exit_code=exit_code,
+                    duration_ms=0.0,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cost_usd=cost_usd,
+                )
+    finally:
+        shutdown_tracing()
+
+    langfuse_url = f"{config.langfuse_host.rstrip('/')}/trace/{trace_id_hex}"
+
+    time.sleep(3)
+
+    try:
+        trace_data = _query_langfuse_trace(config, trace_id_hex)
+        checks = _validate_trace(trace_data, trace_id_hex)
+        span_count = 0
+        data_obj = getattr(trace_data, "data", trace_data)
+        observations = getattr(data_obj, "observations", None) or []
+        span_count = len(observations) + 1
+    except Exception as exc:
+        checks = [CheckResult(
+            name="langfuse_query",
+            passed=False,
+            detail=f"Failed to query Langfuse: {exc}",
+        )]
+        span_count = 0
+
+    required_checks = {"root_span_exists", "agent_span_exists", "trace_id_consistent"}
+    success = all(c.passed for c in checks if c.name in required_checks)
+
+    return VerificationResult(
+        trace_id=trace_id_hex,
+        langfuse_url=langfuse_url,
+        span_count=span_count,
+        checks=checks,
+        success=success,
+    )

--- a/src/factory_tracing/verify.py
+++ b/src/factory_tracing/verify.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from dotenv import load_dotenv
 
 from .config import TracingConfig
+from .executor import run_traced_agent
 from .propagation import build_traced_env
 from .provider import get_tracer_provider, shutdown_tracing
 from .spans import record_agent_result, trace_agent_invocation, trace_factory_cycle
@@ -158,28 +159,24 @@ def _invoke_agent(
     project_name: str,
     traced_env: dict,
 ) -> tuple[dict, int, float]:
-    """Invoke a Claude agent subprocess and record results. Returns (parsed_output, exit_code, duration_ms)."""
-    start_time = time.monotonic()
-    try:
-        result = subprocess.run(
-            ["claude", "-p", prompt, "--output-format", "json"],
-            env=traced_env,
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-        exit_code = result.returncode
-        stdout = result.stdout
-    except FileNotFoundError:
-        exit_code = 127
-        stdout = ""
-    except subprocess.TimeoutExpired:
-        exit_code = 124
-        stdout = ""
-
-    duration_ms = (time.monotonic() - start_time) * 1000.0
-    parsed = _parse_claude_output(stdout)
-    return parsed, exit_code, duration_ms
+    """Invoke a Claude agent subprocess using run_traced_agent for full content capture."""
+    agent_result = run_traced_agent(
+        prompt=prompt,
+        role=role,
+        run_id=run_id,
+        project_name=project_name,
+        env=traced_env,
+    )
+    parsed = {
+        "result": agent_result.response_text,
+        "model": agent_result.model,
+        "usage": {
+            "input_tokens": agent_result.input_tokens,
+            "output_tokens": agent_result.output_tokens,
+            "cost_usd": agent_result.cost_usd,
+        },
+    }
+    return parsed, agent_result.exit_code, agent_result.duration_ms
 
 
 def _validate_content(trace_data: dict, expected_roles: list[str]) -> list[ContentCheck]:

--- a/src/factory_tracing/verify.py
+++ b/src/factory_tracing/verify.py
@@ -5,10 +5,12 @@ It must NOT be imported by production tracing code (config, provider, spans, pro
 """
 from __future__ import annotations
 
-import asyncio
+import base64
 import json
 import subprocess
 import time
+import urllib.error
+import urllib.request
 import uuid
 from dataclasses import dataclass, field
 
@@ -47,20 +49,21 @@ def _parse_claude_output(stdout: str) -> dict:
         return {}
 
 
-def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int = 3, delay: float = 2.0):
-    from langfuse import Langfuse
-
-    client = Langfuse(
-        public_key=config.langfuse_public_key,
-        secret_key=config.langfuse_secret_key,
-        host=config.langfuse_host,
-    )
+def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int = 3, delay: float = 2.0) -> dict:
+    url = f"{config.langfuse_host.rstrip('/')}/api/public/traces/{trace_id}"
+    credentials = base64.b64encode(
+        f"{config.langfuse_public_key}:{config.langfuse_secret_key}".encode()
+    ).decode()
 
     last_error = None
     for attempt in range(max_retries):
         try:
-            trace = client.fetch_trace(trace_id)
-            return trace
+            req = urllib.request.Request(url, method="GET", headers={
+                "Authorization": f"Basic {credentials}",
+                "Accept": "application/json",
+            })
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return json.loads(resp.read().decode())
         except Exception as exc:
             last_error = exc
             if attempt < max_retries - 1:
@@ -69,15 +72,12 @@ def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int
     raise RuntimeError(f"Failed to fetch trace {trace_id} after {max_retries} attempts: {last_error}")
 
 
-def _validate_trace(trace_data, trace_id: str) -> list[CheckResult]:
+def _validate_trace(trace_data: dict, trace_id: str) -> list[CheckResult]:
     checks = []
 
-    observations = getattr(trace_data, "observations", None) or []
-    if hasattr(trace_data, "data"):
-        data = trace_data.data
-        observations = getattr(data, "observations", None) or []
+    observations = trace_data.get("observations") or []
 
-    obs_names = [getattr(o, "name", "") for o in observations]
+    obs_names = [o.get("name", "") for o in observations]
 
     has_cycle = any("factory.cycle" in (n or "") for n in obs_names)
     checks.append(CheckResult(
@@ -100,9 +100,7 @@ def _validate_trace(trace_data, trace_id: str) -> list[CheckResult]:
         detail="claude_code span found" if has_cc_span else "claude_code span NOT found (Claude Code OTel may not be available)",
     ))
 
-    data_obj = getattr(trace_data, "data", trace_data)
-    fetched_id = getattr(data_obj, "id", None) or ""
-    ids_match = trace_id in fetched_id or fetched_id in trace_id
+    fetched_id = trace_data.get("id", "")
     checks.append(CheckResult(
         name="trace_id_consistent",
         passed=bool(fetched_id),
@@ -196,9 +194,7 @@ def run_verification() -> VerificationResult:
     try:
         trace_data = _query_langfuse_trace(config, trace_id_hex)
         checks = _validate_trace(trace_data, trace_id_hex)
-        span_count = 0
-        data_obj = getattr(trace_data, "data", trace_data)
-        observations = getattr(data_obj, "observations", None) or []
+        observations = trace_data.get("observations") or []
         span_count = len(observations) + 1
     except Exception as exc:
         checks = [CheckResult(

--- a/src/factory_tracing/verify.py
+++ b/src/factory_tracing/verify.py
@@ -73,11 +73,26 @@ def _query_langfuse_trace(config: TracingConfig, trace_id: str, max_retries: int
 
 
 def _get_obs_attribute(obs: dict, key: str) -> object:
-    """Extract an attribute from an observation's metadata or attributes."""
-    for source in ("metadata", "attributes"):
-        container = obs.get(source)
-        if isinstance(container, dict) and key in container:
-            return container[key]
+    """Extract an attribute from an observation's metadata.attributes or top-level model field."""
+    if key in ("model", "gen_ai.request.model"):
+        top_model = obs.get("model")
+        if top_model:
+            return top_model
+    metadata = obs.get("metadata")
+    if isinstance(metadata, dict):
+        attrs = metadata.get("attributes", {})
+        if isinstance(attrs, dict):
+            if key in attrs:
+                val = attrs[key]
+                if isinstance(val, str) and val.isdigit():
+                    return int(val)
+                return val
+            short_key = key.split(".")[-1]
+            if short_key in attrs:
+                val = attrs[short_key]
+                if isinstance(val, str) and val.isdigit():
+                    return int(val)
+                return val
     return None
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,75 @@
+"""Tests for factory_tracing.cli — status command with various env var configs."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from factory_tracing.cli import main, _run_status
+
+
+@patch("factory_tracing.cli.load_dotenv")
+def test_status_reports_missing_vars(_mock_dotenv, monkeypatch, capsys):
+    for var in ("FACTORY_TRACING_ENABLED", "LANGFUSE_HOST", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+    exit_code = main(["status"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "NOT SET" in captured.out
+    assert "INCOMPLETE" in captured.out
+
+
+@patch("factory_tracing.cli.load_dotenv")
+def test_status_reports_present_vars(_mock_dotenv, monkeypatch, capsys):
+    monkeypatch.setenv("FACTORY_TRACING_ENABLED", "1")
+    monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test-key-12345")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test-key-12345")
+
+    exit_code = main(["status"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "FACTORY_TRACING_ENABLED: 1" in captured.out
+    assert "LANGFUSE_HOST: http://localhost:3000" in captured.out
+    assert "pk-t***" in captured.out
+    assert "sk-t***" in captured.out
+
+
+@patch("factory_tracing.cli.load_dotenv")
+def test_status_masks_secret_keys(_mock_dotenv, monkeypatch, capsys):
+    monkeypatch.setenv("FACTORY_TRACING_ENABLED", "1")
+    monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-full-public-key")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-full-secret-key")
+
+    main(["status"])
+    captured = capsys.readouterr()
+
+    assert "pk-lf-full-public-key" not in captured.out
+    assert "sk-lf-full-secret-key" not in captured.out
+
+
+@patch("factory_tracing.cli.load_dotenv")
+def test_status_skips_health_check_when_no_host(_mock_dotenv, monkeypatch, capsys):
+    monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+    monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+
+    main(["status"])
+    captured = capsys.readouterr()
+
+    assert "skipped" in captured.out.lower()
+
+
+def test_main_no_args_returns_zero(capsys):
+    exit_code = main([])
+    assert exit_code == 0
+
+
+def test_main_verify_subcommand_exists(capsys):
+    exit_code = main([])
+    captured = capsys.readouterr()
+    assert "verify" in captured.out
+    assert "status" in captured.out

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,377 @@
+"""Tests for factory_tracing.executor — stream-json parsing and span creation."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+from factory_tracing import provider as _provider_mod
+from factory_tracing.executor import run_traced_agent, AgentResult
+
+
+INIT_EVENT = {
+    "type": "system",
+    "subtype": "init",
+    "model": "claude-opus-4-6[1m]",
+    "session_id": "sess-abc123",
+    "tools": ["Read", "Bash", "Edit"],
+}
+
+ASSISTANT_TEXT_EVENT = {
+    "type": "assistant",
+    "message": {
+        "model": "claude-opus-4-6[1m]",
+        "content": [{"type": "text", "text": "Here is the answer to your question."}],
+        "usage": {"input_tokens": 100, "output_tokens": 50},
+    },
+    "request_id": "req-001",
+}
+
+ASSISTANT_TOOL_USE_EVENT = {
+    "type": "assistant",
+    "message": {
+        "model": "claude-opus-4-6[1m]",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_abc123",
+                "name": "Read",
+                "input": {"file_path": "/tmp/test.py"},
+            }
+        ],
+        "usage": {"input_tokens": 80, "output_tokens": 30},
+    },
+    "request_id": "req-002",
+}
+
+TOOL_RESULT_EVENT = {
+    "type": "user",
+    "message": {
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_abc123",
+                "content": "def hello():\n    print('world')",
+            }
+        ]
+    },
+}
+
+RESULT_EVENT = {
+    "type": "result",
+    "subtype": "success",
+    "result": "The file contains a hello function.",
+    "usage": {"input_tokens": 200, "output_tokens": 100},
+    "total_cost_usd": 0.06,
+    "duration_ms": 12162,
+    "num_turns": 2,
+}
+
+
+@pytest.fixture(autouse=True)
+def tracing_setup():
+    exporter = InMemorySpanExporter()
+    tp = TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(exporter))
+    _provider_mod._provider = tp
+    yield exporter
+    tp.shutdown()
+    _provider_mod._provider = None
+
+
+def _attrs(span) -> dict:
+    return dict(span.attributes) if span.attributes else {}
+
+
+def _make_mock_popen(events: list[dict], returncode: int = 0):
+    lines = [json.dumps(e) + "\n" for e in events]
+    mock_proc = MagicMock()
+    mock_proc.stdout = iter(lines)
+    mock_proc.stderr = MagicMock()
+    mock_proc.returncode = returncode
+    mock_proc.wait.return_value = returncode
+    return mock_proc
+
+
+def _run_with_events(events: list[dict], returncode: int = 0, **kwargs):
+    mock_proc = _make_mock_popen(events, returncode)
+    with patch("factory_tracing.executor.subprocess.Popen", return_value=mock_proc):
+        return run_traced_agent(
+            prompt=kwargs.get("prompt", "test prompt"),
+            role=kwargs.get("role", "researcher"),
+            run_id=kwargs.get("run_id", "run-1"),
+            project_name=kwargs.get("project_name", "test-project"),
+        )
+
+
+class TestParseStreamJsonEvents:
+    def test_init_event_sets_model_and_session(self, tracing_setup):
+        result = _run_with_events([INIT_EVENT, RESULT_EVENT])
+        assert result.model == "claude-opus-4-6[1m]"
+        assert result.session_id == "sess-abc123"
+
+    def test_result_event_sets_final_values(self, tracing_setup):
+        result = _run_with_events([INIT_EVENT, RESULT_EVENT])
+        assert result.response_text == "The file contains a hello function."
+        assert result.input_tokens == 200
+        assert result.output_tokens == 100
+        assert result.cost_usd == 0.06
+        assert result.duration_ms == 12162
+        assert result.num_turns == 2
+
+    def test_malformed_json_lines_skipped(self, tracing_setup):
+        events = [INIT_EVENT]
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter([
+            json.dumps(INIT_EVENT) + "\n",
+            "not valid json\n",
+            "\n",
+            json.dumps(RESULT_EVENT) + "\n",
+        ])
+        mock_proc.stderr = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+        with patch("factory_tracing.executor.subprocess.Popen", return_value=mock_proc):
+            result = run_traced_agent("prompt", "role", "run-1", "proj")
+        assert result.response_text == "The file contains a hello function."
+
+    def test_agent_span_created_with_correct_name(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT], role="builder")
+        spans = tracing_setup.get_finished_spans()
+        agent_spans = [s for s in spans if s.name == "invoke_agent builder"]
+        assert len(agent_spans) == 1
+
+    def test_agent_span_has_all_attributes(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT], role="researcher", run_id="run-42")
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        attrs = _attrs(agent_span)
+        assert attrs["gen_ai.operation.name"] == "invoke_agent"
+        assert attrs["gen_ai.agent.name"] == "researcher"
+        assert attrs["gen_ai.system"] == "anthropic"
+        assert attrs["factory.run.id"] == "run-42"
+        assert attrs["langfuse.observation.type"] == "span"
+
+
+class TestToolSpansHaveInputOutput:
+    def test_tool_span_created_with_input(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TOOL_USE_EVENT, TOOL_RESULT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        tool_spans = [s for s in spans if s.name == "tool:Read"]
+        assert len(tool_spans) == 1
+        attrs = _attrs(tool_spans[0])
+        assert attrs["tool.name"] == "Read"
+        assert "/tmp/test.py" in attrs["gen_ai.prompt"]
+
+    def test_tool_span_has_result_output(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TOOL_USE_EVENT, TOOL_RESULT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        tool_spans = [s for s in spans if s.name == "tool:Read"]
+        attrs = _attrs(tool_spans[0])
+        assert "def hello():" in attrs["gen_ai.completion"]
+
+    def test_tool_span_has_langfuse_io(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TOOL_USE_EVENT, TOOL_RESULT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        tool_spans = [s for s in spans if s.name == "tool:Read"]
+        attrs = _attrs(tool_spans[0])
+        assert "langfuse.span.input" in attrs
+        assert "langfuse.span.output" in attrs
+
+    def test_tool_span_is_child_of_agent(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TOOL_USE_EVENT, TOOL_RESULT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        tool_span = next(s for s in spans if s.name == "tool:Read")
+        assert tool_span.parent is not None
+        assert tool_span.parent.span_id == agent_span.context.span_id
+
+    def test_multiple_tool_uses_tracked_independently(self, tracing_setup):
+        tool_event_1 = {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-6[1m]",
+                "content": [
+                    {"type": "tool_use", "id": "toolu_001", "name": "Read", "input": {"file_path": "/a.py"}},
+                    {"type": "tool_use", "id": "toolu_002", "name": "Bash", "input": {"command": "ls"}},
+                ],
+                "usage": {"input_tokens": 50, "output_tokens": 20},
+            },
+        }
+        result_1 = {
+            "type": "user",
+            "message": {"content": [
+                {"type": "tool_result", "tool_use_id": "toolu_001", "content": "file A content"},
+                {"type": "tool_result", "tool_use_id": "toolu_002", "content": "dir listing"},
+            ]},
+        }
+        _run_with_events([INIT_EVENT, tool_event_1, result_1, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        tool_spans = [s for s in spans if s.name.startswith("tool:")]
+        assert len(tool_spans) == 2
+        names = {s.name for s in tool_spans}
+        assert names == {"tool:Read", "tool:Bash"}
+
+
+class TestLlmSpansHaveContent:
+    def test_llm_span_created_for_text_response(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TEXT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        llm_spans = [s for s in spans if s.name == "llm_call"]
+        assert len(llm_spans) == 1
+
+    def test_llm_span_has_model(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TEXT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        llm_span = next(s for s in spans if s.name == "llm_call")
+        attrs = _attrs(llm_span)
+        assert attrs["gen_ai.request.model"] == "claude-opus-4-6[1m]"
+
+    def test_llm_span_has_completion_text(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TEXT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        llm_span = next(s for s in spans if s.name == "llm_call")
+        attrs = _attrs(llm_span)
+        assert "Here is the answer" in attrs["gen_ai.completion"]
+
+    def test_llm_span_has_prompt(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TEXT_EVENT, RESULT_EVENT], prompt="my question")
+        spans = tracing_setup.get_finished_spans()
+        llm_span = next(s for s in spans if s.name == "llm_call")
+        attrs = _attrs(llm_span)
+        assert attrs["gen_ai.prompt"] == "my question"
+
+    def test_llm_span_has_token_counts(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TEXT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        llm_span = next(s for s in spans if s.name == "llm_call")
+        attrs = _attrs(llm_span)
+        assert attrs["gen_ai.usage.input_tokens"] == 100
+        assert attrs["gen_ai.usage.output_tokens"] == 50
+
+    def test_llm_span_is_child_of_agent(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TEXT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        llm_span = next(s for s in spans if s.name == "llm_call")
+        assert llm_span.parent is not None
+        assert llm_span.parent.span_id == agent_span.context.span_id
+
+    def test_no_llm_span_for_tool_use_response(self, tracing_setup):
+        _run_with_events([INIT_EVENT, ASSISTANT_TOOL_USE_EVENT, TOOL_RESULT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        llm_spans = [s for s in spans if s.name == "llm_call"]
+        assert len(llm_spans) == 0
+
+
+class TestAgentSpanHasFinalResult:
+    def test_agent_span_has_completion(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        attrs = _attrs(agent_span)
+        assert "hello function" in attrs["gen_ai.completion"]
+
+    def test_agent_span_has_langfuse_output(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        attrs = _attrs(agent_span)
+        assert "hello function" in attrs["langfuse.span.output"]
+
+    def test_agent_span_has_prompt_as_input(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT], prompt="do something")
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        attrs = _attrs(agent_span)
+        assert attrs["gen_ai.prompt"] == "do something"
+        assert attrs["langfuse.span.input"] == "do something"
+
+    def test_agent_span_has_token_counts(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        attrs = _attrs(agent_span)
+        assert attrs["gen_ai.usage.input_tokens"] == 200
+        assert attrs["gen_ai.usage.output_tokens"] == 100
+        assert attrs["gen_ai.usage.cost"] == 0.06
+
+    def test_agent_span_has_duration(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        attrs = _attrs(agent_span)
+        assert attrs["subprocess.duration_ms"] == 12162
+
+    def test_agent_span_ok_status_on_success(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT])
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        assert agent_span.status.status_code == StatusCode.OK
+
+    def test_agent_span_error_status_on_failure(self, tracing_setup):
+        _run_with_events([INIT_EVENT, RESULT_EVENT], returncode=1)
+        spans = tracing_setup.get_finished_spans()
+        agent_span = next(s for s in spans if "invoke_agent" in s.name)
+        assert agent_span.status.status_code == StatusCode.ERROR
+
+    def test_file_not_found_returns_exit_127(self, tracing_setup):
+        with patch("factory_tracing.executor.subprocess.Popen", side_effect=FileNotFoundError):
+            result = run_traced_agent("prompt", "role", "run-1", "proj")
+        assert result.exit_code == 127
+
+    def test_result_with_list_content(self, tracing_setup):
+        result_event = {
+            "type": "result",
+            "subtype": "success",
+            "result": [
+                {"type": "text", "text": "Part one."},
+                {"type": "text", "text": "Part two."},
+            ],
+            "usage": {"input_tokens": 50, "output_tokens": 25},
+            "total_cost_usd": 0.01,
+            "duration_ms": 1000,
+            "num_turns": 1,
+        }
+        result = _run_with_events([INIT_EVENT, result_event])
+        assert "Part one." in result.response_text
+        assert "Part two." in result.response_text
+
+
+class TestFullConversationFlow:
+    def test_tool_use_then_text_response(self, tracing_setup):
+        """Simulates: init -> tool_use -> tool_result -> text response -> result."""
+        text_after_tool = {
+            "type": "assistant",
+            "message": {
+                "model": "claude-opus-4-6[1m]",
+                "content": [{"type": "text", "text": "Based on the file, here is my analysis."}],
+                "usage": {"input_tokens": 150, "output_tokens": 60},
+            },
+        }
+        events = [INIT_EVENT, ASSISTANT_TOOL_USE_EVENT, TOOL_RESULT_EVENT, text_after_tool, RESULT_EVENT]
+        result = _run_with_events(events)
+
+        spans = tracing_setup.get_finished_spans()
+        tool_spans = [s for s in spans if s.name.startswith("tool:")]
+        llm_spans = [s for s in spans if s.name == "llm_call"]
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+
+        assert len(tool_spans) == 1
+        assert len(llm_spans) == 1
+        assert len(agent_spans) == 1
+        assert result.response_text == "The file contains a hello function."
+
+    def test_unclosed_tool_spans_get_error_status(self, tracing_setup):
+        """Tool use with no matching result should get an error status."""
+        events = [INIT_EVENT, ASSISTANT_TOOL_USE_EVENT, RESULT_EVENT]
+        _run_with_events(events)
+        spans = tracing_setup.get_finished_spans()
+        tool_spans = [s for s in spans if s.name.startswith("tool:")]
+        assert len(tool_spans) == 1
+        assert tool_spans[0].status.status_code == StatusCode.ERROR

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -290,7 +290,8 @@ class TestAgentSpanHasFinalResult:
         agent_span = next(s for s in spans if "invoke_agent" in s.name)
         attrs = _attrs(agent_span)
         assert attrs["gen_ai.prompt"] == "do something"
-        assert attrs["langfuse.span.input"] == "do something"
+        langfuse_input = json.loads(attrs["langfuse.span.input"])
+        assert langfuse_input["prompt"] == "do something"
 
     def test_agent_span_has_token_counts(self, tracing_setup):
         _run_with_events([INIT_EVENT, RESULT_EVENT])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,174 @@
+"""Tests for factory_tracing.integration — TracingIntegration lifecycle."""
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+from factory_tracing import provider as _provider_mod
+from factory_tracing.config import TracingConfig
+from factory_tracing.integration import TracingIntegration
+
+
+@pytest.fixture
+def enabled_config():
+    return TracingConfig(
+        enabled=True,
+        langfuse_host="http://localhost:3000",
+        langfuse_public_key="pk-test",
+        langfuse_secret_key="sk-test",
+        otlp_endpoint=None,
+        service_name="test-service",
+    )
+
+
+@pytest.fixture
+def disabled_config():
+    return TracingConfig(
+        enabled=False,
+        langfuse_host="",
+        langfuse_public_key="",
+        langfuse_secret_key="",
+        otlp_endpoint=None,
+        service_name="test-service",
+    )
+
+
+@pytest.fixture
+def integration_with_exporter(enabled_config):
+    exporter = InMemorySpanExporter()
+    resource = Resource.create({"service.name": "test-service"})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    old = _provider_mod._provider
+    _provider_mod._provider = provider
+
+    integration = TracingIntegration(enabled_config)
+
+    yield integration, exporter
+
+    _provider_mod._provider = old
+    exporter.clear()
+    provider.shutdown()
+
+
+def _attrs(span) -> dict:
+    return dict(span.attributes) if span.attributes else {}
+
+
+class TestTracingIntegrationEnabled:
+    def test_lifecycle_cycle_and_agents(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "test-project", "improve") as cycle_span:
+            with integration.start_agent("researcher", "search code", "run-1", "test-project") as agent1:
+                integration.record_agent_result(agent1, exit_code=0, duration_ms=1200.0)
+
+            with integration.start_agent("builder", "implement fix", "run-1", "test-project") as agent2:
+                integration.record_agent_result(agent2, exit_code=0, duration_ms=2400.0, input_tokens=500, output_tokens=200)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 3
+
+        cycle_span_data = next(s for s in spans if s.name == "factory.cycle")
+        agent_spans = [s for s in spans if s.name.startswith("invoke_agent")]
+        assert len(agent_spans) == 2
+
+        for agent_span in agent_spans:
+            assert agent_span.parent is not None
+            assert agent_span.parent.span_id == cycle_span_data.context.span_id
+            assert agent_span.context.trace_id == cycle_span_data.context.trace_id
+
+    def test_agent_spans_have_correct_names(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "proj", "build"):
+            with integration.start_agent("researcher", "search", "run-1", "proj"):
+                pass
+            with integration.start_agent("builder", "build", "run-1", "proj"):
+                pass
+
+        spans = exporter.get_finished_spans()
+        names = {s.name for s in spans}
+        assert "invoke_agent researcher" in names
+        assert "invoke_agent builder" in names
+
+    def test_record_result_sets_attributes(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "proj", "build"):
+            with integration.start_agent("builder", "task", "run-1", "proj") as span:
+                integration.record_agent_result(
+                    span, exit_code=0, duration_ms=1500.0,
+                    input_tokens=100, output_tokens=50, cost_usd=0.01,
+                )
+
+        agent_span = next(
+            s for s in exporter.get_finished_spans()
+            if s.name.startswith("invoke_agent")
+        )
+        attrs = _attrs(agent_span)
+        assert attrs["subprocess.returncode"] == 0
+        assert attrs["subprocess.duration_ms"] == 1500.0
+        assert attrs["gen_ai.usage.input_tokens"] == 100
+        assert attrs["gen_ai.usage.output_tokens"] == 50
+
+    def test_all_spans_share_trace_id(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "proj", "build"):
+            with integration.start_agent("researcher", "search", "run-1", "proj"):
+                pass
+            with integration.start_agent("builder", "build", "run-1", "proj"):
+                pass
+
+        spans = exporter.get_finished_spans()
+        trace_ids = {s.context.trace_id for s in spans}
+        assert len(trace_ids) == 1
+
+    def test_build_subprocess_env_delegates(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+        base = {"PATH": "/usr/bin"}
+        result = integration.build_subprocess_env(base)
+        assert isinstance(result, dict)
+        assert result["PATH"] == "/usr/bin"
+
+
+class TestTracingIntegrationDisabled:
+    def test_disabled_returns_noop_spans(self, disabled_config, monkeypatch):
+        monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
+        _provider_mod._reset_provider()
+        try:
+            integration = TracingIntegration(disabled_config)
+            assert not integration.enabled
+
+            with integration.start_cycle("run-1", "proj", "build") as span:
+                span.set_attribute("test", "value")
+                with integration.start_agent("builder", "task", "run-1", "proj") as agent_span:
+                    integration.record_agent_result(agent_span, exit_code=0, duration_ms=100.0)
+        finally:
+            _provider_mod._reset_provider()
+
+    def test_disabled_build_env_passthrough(self, disabled_config, monkeypatch):
+        monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
+        _provider_mod._reset_provider()
+        try:
+            integration = TracingIntegration(disabled_config)
+            base = {"PATH": "/usr/bin", "HOME": "/home/test"}
+            result = integration.build_subprocess_env(base)
+            assert result == base
+        finally:
+            _provider_mod._reset_provider()
+
+    def test_disabled_shutdown_is_noop(self, disabled_config, monkeypatch):
+        monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
+        _provider_mod._reset_provider()
+        try:
+            integration = TracingIntegration(disabled_config)
+            integration.shutdown()
+        finally:
+            _provider_mod._reset_provider()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -130,6 +130,43 @@ class TestTracingIntegrationEnabled:
         trace_ids = {s.context.trace_id for s in spans}
         assert len(trace_ids) == 1
 
+    def test_record_result_with_response_text(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "proj", "build"):
+            with integration.start_agent("builder", "task", "run-1", "proj") as span:
+                integration.record_agent_result(
+                    span, exit_code=0, duration_ms=100.0,
+                    response_text="done",
+                )
+
+        agent_span = next(
+            s for s in exporter.get_finished_spans()
+            if s.name.startswith("invoke_agent")
+        )
+        attrs = _attrs(agent_span)
+        assert attrs["gen_ai.completion"] == "done"
+
+    def test_set_span_io(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "proj", "build"):
+            with integration.start_agent("builder", "task", "run-1", "proj") as span:
+                integration.set_span_io(span, input_text="hello", output_text="world")
+
+        agent_span = next(
+            s for s in exporter.get_finished_spans()
+            if s.name.startswith("invoke_agent")
+        )
+        attrs = _attrs(agent_span)
+        assert attrs["gen_ai.prompt"] == "hello"
+        assert attrs["gen_ai.completion"] == "world"
+
+    def test_stores_run_id(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+        with integration.start_cycle("run-42", "proj", "build"):
+            assert integration._run_id == "run-42"
+
     def test_build_subprocess_env_delegates(self, integration_with_exporter):
         integration, exporter = integration_with_exporter
         base = {"PATH": "/usr/bin"}

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,4 @@
-"""Tests for Phase 5: experiment metadata enrichment."""
+"""Tests for Phase 5: experiment attribution and metadata enrichment."""
 from __future__ import annotations
 
 import pytest
@@ -59,192 +59,126 @@ def _attrs(span) -> dict:
     return dict(span.attributes) if span.attributes else {}
 
 
-class TestExperimentMetadata:
-    def test_experiment_attributes_set_on_cycle_span(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
+def test_experiment_attributes_set_on_cycle_span(integration_with_exporter):
+    integration, exporter = integration_with_exporter
+
+    with integration.start_cycle(
+        "run-1", "proj", "improve",
+        experiment_id="exp-42",
+        hypothesis_id="hyp-7",
+        hypothesis_category="FIX",
+    ):
+        pass
+
+    spans = exporter.get_finished_spans()
+    cycle = next(s for s in spans if s.name == "factory.cycle")
+    attrs = _attrs(cycle)
+
+    assert attrs["factory.experiment.id"] == "exp-42"
+    assert attrs["factory.hypothesis.id"] == "hyp-7"
+    assert attrs["factory.hypothesis.category"] == "FIX"
+
+
+def test_langfuse_metadata_attributes_use_correct_prefix(integration_with_exporter):
+    integration, exporter = integration_with_exporter
+
+    with integration.start_cycle(
+        "run-1", "proj", "improve",
+        experiment_id="exp-42",
+        hypothesis_category="EXPLORE",
+    ):
+        pass
+
+    spans = exporter.get_finished_spans()
+    cycle = next(s for s in spans if s.name == "factory.cycle")
+    attrs = _attrs(cycle)
+
+    assert attrs["langfuse.trace.metadata.experiment_id"] == "exp-42"
+    assert attrs["langfuse.trace.metadata.hypothesis_category"] == "EXPLORE"
+
+
+def test_session_id_overridden_by_experiment_id(integration_with_exporter):
+    integration, exporter = integration_with_exporter
+
+    with integration.start_cycle(
+        "run-1", "proj", "improve",
+        experiment_id="exp-42",
+    ):
+        pass
+
+    spans = exporter.get_finished_spans()
+    cycle = next(s for s in spans if s.name == "factory.cycle")
+    attrs = _attrs(cycle)
+
+    assert attrs["langfuse.session.id"] == "exp-42"
+
+
+def test_eval_result_recorded_as_event(integration_with_exporter):
+    integration, exporter = integration_with_exporter
+
+    with integration.start_cycle("run-1", "proj", "improve") as span:
+        integration.record_eval_result(
+            span,
+            {"tests": 0.8, "lint": 0.9, "capability_surface": 0.5},
+        )
+
+    spans = exporter.get_finished_spans()
+    cycle = next(s for s in spans if s.name == "factory.cycle")
+
+    assert len(cycle.events) == 1
+    event = cycle.events[0]
+    assert event.name == "eval.result"
+    event_attrs = dict(event.attributes)
+    assert event_attrs["eval.tests"] == 0.8
+    assert event_attrs["eval.lint"] == 0.9
+    assert event_attrs["eval.capability_surface"] == 0.5
+
+
+def test_experiment_verdict_sets_attributes(integration_with_exporter):
+    integration, exporter = integration_with_exporter
+
+    with integration.start_cycle("run-1", "proj", "improve") as span:
+        integration.record_experiment_verdict(span, "ACCEPTED", 0.85)
+
+    spans = exporter.get_finished_spans()
+    cycle = next(s for s in spans if s.name == "factory.cycle")
+    attrs = _attrs(cycle)
+
+    assert attrs["factory.experiment.verdict"] == "ACCEPTED"
+    assert attrs["factory.experiment.composite_score"] == 0.85
+
+
+def test_omitted_optional_params_dont_set_empty_attributes(integration_with_exporter):
+    integration, exporter = integration_with_exporter
+
+    with integration.start_cycle("run-1", "proj", "improve"):
+        pass
+
+    spans = exporter.get_finished_spans()
+    cycle = next(s for s in spans if s.name == "factory.cycle")
+    attrs = _attrs(cycle)
+
+    assert "factory.experiment.id" not in attrs
+    assert "factory.hypothesis.id" not in attrs
+    assert "factory.hypothesis.category" not in attrs
+    assert "langfuse.trace.metadata.experiment_id" not in attrs
+    assert "langfuse.trace.metadata.hypothesis_category" not in attrs
+
+
+def test_noop_when_disabled(disabled_config, monkeypatch):
+    monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
+    _provider_mod._reset_provider()
+    try:
+        integration = TracingIntegration(disabled_config)
+        assert not integration.enabled
 
         with integration.start_cycle(
-            "run-1", "test-project", "improve",
-            experiment_id="exp-42",
-            hypothesis_id="hyp-7",
-            hypothesis_category="EXPLORE",
-        ):
-            pass
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-        attrs = _attrs(cycle_span)
-
-        assert attrs["factory.experiment.id"] == "exp-42"
-        assert attrs["factory.hypothesis.id"] == "hyp-7"
-        assert attrs["factory.hypothesis.category"] == "EXPLORE"
-
-    def test_langfuse_metadata_prefix_used(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle(
-            "run-1", "test-project", "improve",
-            experiment_id="exp-42",
-            hypothesis_category="FIX",
-        ):
-            pass
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-        attrs = _attrs(cycle_span)
-
-        assert attrs["langfuse.trace.metadata.experiment_id"] == "exp-42"
-        assert attrs["langfuse.trace.metadata.hypothesis_category"] == "FIX"
-
-    def test_experiment_id_overrides_session_id(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle(
-            "run-1", "test-project", "improve",
-            experiment_id="exp-42",
-        ):
-            pass
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-        attrs = _attrs(cycle_span)
-
-        assert attrs["langfuse.session.id"] == "exp-42"
-
-    def test_no_experiment_id_keeps_run_id_as_session_id(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle("run-1", "test-project", "improve"):
-            pass
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-        attrs = _attrs(cycle_span)
-
-        assert attrs["langfuse.session.id"] == "run-1"
-
-    def test_omitted_params_not_set(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle("run-1", "test-project", "improve"):
-            pass
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-        attrs = _attrs(cycle_span)
-
-        assert "factory.experiment.id" not in attrs
-        assert "factory.hypothesis.id" not in attrs
-        assert "factory.hypothesis.category" not in attrs
-        assert "langfuse.trace.metadata.experiment_id" not in attrs
-        assert "langfuse.trace.metadata.hypothesis_category" not in attrs
-
-    def test_partial_params_only_set_provided(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle(
-            "run-1", "test-project", "improve",
-            hypothesis_id="hyp-3",
-        ):
-            pass
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-        attrs = _attrs(cycle_span)
-
-        assert attrs["factory.hypothesis.id"] == "hyp-3"
-        assert "factory.experiment.id" not in attrs
-        assert "factory.hypothesis.category" not in attrs
-
-
-class TestEvalResult:
-    def test_record_eval_result_adds_event(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle("run-1", "test-project", "improve") as span:
-            integration.record_eval_result(span, {
-                "tests": 0.8,
-                "lint": 0.9,
-                "capability_surface": 0.5,
-            })
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-
-        assert len(cycle_span.events) == 1
-        event = cycle_span.events[0]
-        assert event.name == "eval.result"
-        event_attrs = dict(event.attributes)
-        assert event_attrs["eval.tests"] == 0.8
-        assert event_attrs["eval.lint"] == 0.9
-        assert event_attrs["eval.capability_surface"] == 0.5
-
-    def test_record_eval_result_noop_when_disabled(self, disabled_config, monkeypatch):
-        monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
-        _provider_mod._reset_provider()
-        try:
-            integration = TracingIntegration(disabled_config)
-            integration.record_eval_result(_provider_mod._provider, {"tests": 0.8})
-        finally:
-            _provider_mod._reset_provider()
-
-    def test_multiple_eval_results(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle("run-1", "test-project", "improve") as span:
-            integration.record_eval_result(span, {"tests": 0.8})
-            integration.record_eval_result(span, {"lint": 0.9})
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-
-        assert len(cycle_span.events) == 2
-        assert cycle_span.events[0].name == "eval.result"
-        assert cycle_span.events[1].name == "eval.result"
-
-
-class TestExperimentVerdict:
-    def test_record_verdict_sets_attributes(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle("run-1", "test-project", "improve") as span:
-            integration.record_experiment_verdict(span, "KEEP", 0.85)
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-        attrs = _attrs(cycle_span)
-
-        assert attrs["factory.experiment.verdict"] == "KEEP"
-        assert attrs["factory.experiment.composite_score"] == 0.85
-
-    def test_record_verdict_noop_when_disabled(self, disabled_config, monkeypatch):
-        monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
-        _provider_mod._reset_provider()
-        try:
-            integration = TracingIntegration(disabled_config)
-            integration.record_experiment_verdict(_provider_mod._provider, "REVERT", 0.3)
-        finally:
-            _provider_mod._reset_provider()
-
-    def test_verdict_with_full_experiment_metadata(self, integration_with_exporter):
-        integration, exporter = integration_with_exporter
-
-        with integration.start_cycle(
-            "run-1", "test-project", "improve",
-            experiment_id="exp-42",
-            hypothesis_id="hyp-7",
+            "run-1", "proj", "improve",
+            experiment_id="exp-1",
+            hypothesis_id="hyp-1",
             hypothesis_category="FIX",
         ) as span:
-            integration.record_eval_result(span, {"tests": 0.9, "lint": 1.0})
-            integration.record_experiment_verdict(span, "KEEP", 0.92)
-
-        spans = exporter.get_finished_spans()
-        cycle_span = next(s for s in spans if s.name == "factory.cycle")
-        attrs = _attrs(cycle_span)
-
-        assert attrs["factory.experiment.id"] == "exp-42"
-        assert attrs["factory.hypothesis.id"] == "hyp-7"
-        assert attrs["factory.hypothesis.category"] == "FIX"
-        assert attrs["factory.experiment.verdict"] == "KEEP"
-        assert attrs["factory.experiment.composite_score"] == 0.92
-        assert len(cycle_span.events) == 1
+            integration.record_eval_result(span, {"tests": 0.8})
+            integration.record_experiment_verdict(span, "ACCEPTED", 0.9)
+    finally:
+        _provider_mod._reset_provider()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,250 @@
+"""Tests for Phase 5: experiment metadata enrichment."""
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from factory_tracing import provider as _provider_mod
+from factory_tracing.config import TracingConfig
+from factory_tracing.integration import TracingIntegration
+
+
+@pytest.fixture
+def enabled_config():
+    return TracingConfig(
+        enabled=True,
+        langfuse_host="http://localhost:3000",
+        langfuse_public_key="pk-test",
+        langfuse_secret_key="sk-test",
+        otlp_endpoint=None,
+        service_name="test-service",
+    )
+
+
+@pytest.fixture
+def disabled_config():
+    return TracingConfig(
+        enabled=False,
+        langfuse_host="",
+        langfuse_public_key="",
+        langfuse_secret_key="",
+        otlp_endpoint=None,
+        service_name="test-service",
+    )
+
+
+@pytest.fixture
+def integration_with_exporter(enabled_config):
+    exporter = InMemorySpanExporter()
+    resource = Resource.create({"service.name": "test-service"})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    old = _provider_mod._provider
+    _provider_mod._provider = provider
+
+    integration = TracingIntegration(enabled_config)
+
+    yield integration, exporter
+
+    _provider_mod._provider = old
+    exporter.clear()
+    provider.shutdown()
+
+
+def _attrs(span) -> dict:
+    return dict(span.attributes) if span.attributes else {}
+
+
+class TestExperimentMetadata:
+    def test_experiment_attributes_set_on_cycle_span(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle(
+            "run-1", "test-project", "improve",
+            experiment_id="exp-42",
+            hypothesis_id="hyp-7",
+            hypothesis_category="EXPLORE",
+        ):
+            pass
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+        attrs = _attrs(cycle_span)
+
+        assert attrs["factory.experiment.id"] == "exp-42"
+        assert attrs["factory.hypothesis.id"] == "hyp-7"
+        assert attrs["factory.hypothesis.category"] == "EXPLORE"
+
+    def test_langfuse_metadata_prefix_used(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle(
+            "run-1", "test-project", "improve",
+            experiment_id="exp-42",
+            hypothesis_category="FIX",
+        ):
+            pass
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+        attrs = _attrs(cycle_span)
+
+        assert attrs["langfuse.trace.metadata.experiment_id"] == "exp-42"
+        assert attrs["langfuse.trace.metadata.hypothesis_category"] == "FIX"
+
+    def test_experiment_id_overrides_session_id(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle(
+            "run-1", "test-project", "improve",
+            experiment_id="exp-42",
+        ):
+            pass
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+        attrs = _attrs(cycle_span)
+
+        assert attrs["langfuse.session.id"] == "exp-42"
+
+    def test_no_experiment_id_keeps_run_id_as_session_id(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "test-project", "improve"):
+            pass
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+        attrs = _attrs(cycle_span)
+
+        assert attrs["langfuse.session.id"] == "run-1"
+
+    def test_omitted_params_not_set(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "test-project", "improve"):
+            pass
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+        attrs = _attrs(cycle_span)
+
+        assert "factory.experiment.id" not in attrs
+        assert "factory.hypothesis.id" not in attrs
+        assert "factory.hypothesis.category" not in attrs
+        assert "langfuse.trace.metadata.experiment_id" not in attrs
+        assert "langfuse.trace.metadata.hypothesis_category" not in attrs
+
+    def test_partial_params_only_set_provided(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle(
+            "run-1", "test-project", "improve",
+            hypothesis_id="hyp-3",
+        ):
+            pass
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+        attrs = _attrs(cycle_span)
+
+        assert attrs["factory.hypothesis.id"] == "hyp-3"
+        assert "factory.experiment.id" not in attrs
+        assert "factory.hypothesis.category" not in attrs
+
+
+class TestEvalResult:
+    def test_record_eval_result_adds_event(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "test-project", "improve") as span:
+            integration.record_eval_result(span, {
+                "tests": 0.8,
+                "lint": 0.9,
+                "capability_surface": 0.5,
+            })
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+
+        assert len(cycle_span.events) == 1
+        event = cycle_span.events[0]
+        assert event.name == "eval.result"
+        event_attrs = dict(event.attributes)
+        assert event_attrs["eval.tests"] == 0.8
+        assert event_attrs["eval.lint"] == 0.9
+        assert event_attrs["eval.capability_surface"] == 0.5
+
+    def test_record_eval_result_noop_when_disabled(self, disabled_config, monkeypatch):
+        monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
+        _provider_mod._reset_provider()
+        try:
+            integration = TracingIntegration(disabled_config)
+            integration.record_eval_result(_provider_mod._provider, {"tests": 0.8})
+        finally:
+            _provider_mod._reset_provider()
+
+    def test_multiple_eval_results(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "test-project", "improve") as span:
+            integration.record_eval_result(span, {"tests": 0.8})
+            integration.record_eval_result(span, {"lint": 0.9})
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+
+        assert len(cycle_span.events) == 2
+        assert cycle_span.events[0].name == "eval.result"
+        assert cycle_span.events[1].name == "eval.result"
+
+
+class TestExperimentVerdict:
+    def test_record_verdict_sets_attributes(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle("run-1", "test-project", "improve") as span:
+            integration.record_experiment_verdict(span, "KEEP", 0.85)
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+        attrs = _attrs(cycle_span)
+
+        assert attrs["factory.experiment.verdict"] == "KEEP"
+        assert attrs["factory.experiment.composite_score"] == 0.85
+
+    def test_record_verdict_noop_when_disabled(self, disabled_config, monkeypatch):
+        monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
+        _provider_mod._reset_provider()
+        try:
+            integration = TracingIntegration(disabled_config)
+            integration.record_experiment_verdict(_provider_mod._provider, "REVERT", 0.3)
+        finally:
+            _provider_mod._reset_provider()
+
+    def test_verdict_with_full_experiment_metadata(self, integration_with_exporter):
+        integration, exporter = integration_with_exporter
+
+        with integration.start_cycle(
+            "run-1", "test-project", "improve",
+            experiment_id="exp-42",
+            hypothesis_id="hyp-7",
+            hypothesis_category="FIX",
+        ) as span:
+            integration.record_eval_result(span, {"tests": 0.9, "lint": 1.0})
+            integration.record_experiment_verdict(span, "KEEP", 0.92)
+
+        spans = exporter.get_finished_spans()
+        cycle_span = next(s for s in spans if s.name == "factory.cycle")
+        attrs = _attrs(cycle_span)
+
+        assert attrs["factory.experiment.id"] == "exp-42"
+        assert attrs["factory.hypothesis.id"] == "hyp-7"
+        assert attrs["factory.hypothesis.category"] == "FIX"
+        assert attrs["factory.experiment.verdict"] == "KEEP"
+        assert attrs["factory.experiment.composite_score"] == 0.92
+        assert len(cycle_span.events) == 1

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -1,0 +1,116 @@
+import base64
+import os
+import re
+
+import pytest
+from opentelemetry import trace
+
+from factory_tracing.propagation import build_traced_env
+
+
+TRACEPARENT_RE = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$")
+
+
+class TestBuildTracedEnvWithActiveSpan:
+    def test_injects_traceparent(self, test_provider):
+        provider, _exporter = test_provider
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            env = build_traced_env(base_env={})
+            assert "TRACEPARENT" in env
+
+    def test_traceparent_format(self, test_provider):
+        provider, _exporter = test_provider
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            env = build_traced_env(base_env={})
+            assert TRACEPARENT_RE.match(env["TRACEPARENT"])
+
+    def test_trace_id_matches_current_span(self, test_provider):
+        provider, _exporter = test_provider
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span") as span:
+            env = build_traced_env(base_env={})
+            m = TRACEPARENT_RE.match(env["TRACEPARENT"])
+            assert m is not None
+            traceparent_trace_id = m.group(1)
+            span_trace_id = format(span.get_span_context().trace_id, "032x")
+            assert traceparent_trace_id == span_trace_id
+
+
+class TestClaudeCodeOtelVars:
+    def test_claude_code_otel_vars_set(self, test_provider, monkeypatch):
+        provider, _exporter = test_provider
+        monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            env = build_traced_env(base_env={})
+            assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+            assert env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] == "1"
+            assert env["OTEL_TRACES_EXPORTER"] == "otlp"
+            assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
+            assert env["OTEL_SERVICE_NAME"] == "factory-agent"
+
+    def test_otel_endpoint_set_correctly(self, test_provider, monkeypatch):
+        provider, _exporter = test_provider
+        monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            env = build_traced_env(base_env={})
+            assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://langfuse.test:3000/api/public/otel"
+
+    def test_auth_header_set(self, test_provider, monkeypatch):
+        provider, _exporter = test_provider
+        monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            env = build_traced_env(base_env={})
+            expected_b64 = base64.b64encode(b"pk-test:sk-test").decode()
+            headers = env["OTEL_EXPORTER_OTLP_HEADERS"]
+            assert f"Authorization=Basic {expected_b64}" in headers
+            assert "x-langfuse-ingestion-version=4" in headers
+
+
+class TestNoActiveSpan:
+    def test_no_traceparent_without_active_span(self, test_provider, monkeypatch):
+        monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        env = build_traced_env(base_env={})
+        assert "TRACEPARENT" not in env
+
+
+class TestDisabledTracing:
+    def test_disabled_tracing_passthrough(self, monkeypatch):
+        monkeypatch.delenv("FACTORY_TRACING_ENABLED", raising=False)
+        from factory_tracing.provider import _reset_provider
+        _reset_provider()
+        try:
+            base = {"PATH": "/usr/bin", "HOME": "/home/test"}
+            env = build_traced_env(base_env=base)
+            assert env == base
+            assert env is not base
+            assert "TRACEPARENT" not in env
+            assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in env
+        finally:
+            _reset_provider()
+
+
+class TestBaseEnvNone:
+    def test_base_env_none_uses_os_environ(self, test_provider, monkeypatch):
+        provider, _exporter = test_provider
+        monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        monkeypatch.setenv("MY_CUSTOM_VAR", "test-value")
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            env = build_traced_env(base_env=None)
+            assert env["MY_CUSTOM_VAR"] == "test-value"
+            assert "TRACEPARENT" in env

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -38,8 +38,8 @@ class TestBuildTracedEnvWithActiveSpan:
             assert traceparent_trace_id == span_trace_id
 
 
-class TestClaudeCodeOtelVars:
-    def test_claude_code_otel_vars_set(self, test_provider, monkeypatch):
+class TestPropagationEnvVars:
+    def test_service_name_set(self, test_provider, monkeypatch):
         provider, _exporter = test_provider
         monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
         monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
@@ -47,13 +47,9 @@ class TestClaudeCodeOtelVars:
         tracer = provider.get_tracer("test")
         with tracer.start_as_current_span("test-span"):
             env = build_traced_env(base_env={})
-            assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
-            assert env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] == "1"
-            assert env["OTEL_TRACES_EXPORTER"] == "otlp"
-            assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
             assert env["OTEL_SERVICE_NAME"] == "factory-agent"
 
-    def test_content_capture_env_vars_set(self, test_provider, monkeypatch):
+    def test_no_claude_native_otel_vars(self, test_provider, monkeypatch):
         provider, _exporter = test_provider
         monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
         monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
@@ -61,32 +57,8 @@ class TestClaudeCodeOtelVars:
         tracer = provider.get_tracer("test")
         with tracer.start_as_current_span("test-span"):
             env = build_traced_env(base_env={})
-            assert env["OTEL_LOG_USER_PROMPTS"] == "1"
-            assert env["OTEL_LOG_TOOL_DETAILS"] == "1"
-            assert env["OTEL_LOG_TOOL_CONTENT"] == "1"
-
-    def test_otel_endpoint_set_correctly(self, test_provider, monkeypatch):
-        provider, _exporter = test_provider
-        monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
-        tracer = provider.get_tracer("test")
-        with tracer.start_as_current_span("test-span"):
-            env = build_traced_env(base_env={})
-            assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://langfuse.test:3000/api/public/otel"
-
-    def test_auth_header_set(self, test_provider, monkeypatch):
-        provider, _exporter = test_provider
-        monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
-        tracer = provider.get_tracer("test")
-        with tracer.start_as_current_span("test-span"):
-            env = build_traced_env(base_env={})
-            expected_b64 = base64.b64encode(b"pk-test:sk-test").decode()
-            headers = env["OTEL_EXPORTER_OTLP_HEADERS"]
-            assert f"Authorization=Basic {expected_b64}" in headers
-            assert "x-langfuse-ingestion-version=4" in headers
+            assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in env
+            assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in env
 
 
 class TestNoActiveSpan:

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -53,6 +53,18 @@ class TestClaudeCodeOtelVars:
             assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/protobuf"
             assert env["OTEL_SERVICE_NAME"] == "factory-agent"
 
+    def test_content_capture_env_vars_set(self, test_provider, monkeypatch):
+        provider, _exporter = test_provider
+        monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            env = build_traced_env(base_env={})
+            assert env["OTEL_LOG_USER_PROMPTS"] == "1"
+            assert env["OTEL_LOG_TOOL_DETAILS"] == "1"
+            assert env["OTEL_LOG_TOOL_CONTENT"] == "1"
+
     def test_otel_endpoint_set_correctly(self, test_provider, monkeypatch):
         provider, _exporter = test_provider
         monkeypatch.setenv("LANGFUSE_HOST", "http://langfuse.test:3000")

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -1,6 +1,9 @@
 """Tests for factory_tracing.spans — span hierarchy, attributes, and error status."""
 from __future__ import annotations
 
+import time
+from unittest.mock import patch
+
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -211,3 +214,84 @@ def test_record_ok_status_on_zero_exit(tracing_setup):
         record_agent_result(span, exit_code=0, duration_ms=500.0)
     span_data = tracing_setup.get_finished_spans()[0]
     assert span_data.status.status_code == StatusCode.OK
+
+
+# --- gen_ai.prompt attribute ---
+
+
+def test_agent_sets_gen_ai_prompt(tracing_setup):
+    with trace_agent_invocation("builder", "implement feature X", "r", "p"):
+        pass
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["gen_ai.prompt"] == "implement feature X"
+
+
+def test_agent_no_gen_ai_prompt_when_empty(tracing_setup):
+    with trace_agent_invocation("builder", "", "r", "p"):
+        pass
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert "gen_ai.prompt" not in attrs
+
+
+# --- gen_ai.request.model attribute ---
+
+
+def test_agent_sets_default_model(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p"):
+        pass
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["gen_ai.request.model"] == "anthropic"
+
+
+def test_agent_sets_custom_model(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p", model="claude-sonnet-4-6"):
+        pass
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["gen_ai.request.model"] == "claude-sonnet-4-6"
+
+
+# --- gen_ai.completion attribute ---
+
+
+def test_record_sets_completion(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        record_agent_result(span, exit_code=0, response_text="VERIFIED")
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["gen_ai.completion"] == "VERIFIED"
+
+
+def test_record_omits_completion_when_not_provided(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        record_agent_result(span, exit_code=0, duration_ms=100.0)
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert "gen_ai.completion" not in attrs
+
+
+# --- duration calculation from start_time ---
+
+
+def test_record_calculates_duration_from_start_time(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        fake_start = time.monotonic() - 1.5
+        record_agent_result(span, exit_code=0, start_time=fake_start)
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["subprocess.duration_ms"] >= 1400.0
+    assert attrs["subprocess.duration_ms"] < 3000.0
+
+
+def test_record_start_time_overrides_duration_ms(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        fake_start = time.monotonic() - 2.0
+        record_agent_result(span, exit_code=0, duration_ms=999.0, start_time=fake_start)
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["subprocess.duration_ms"] >= 1900.0
+
+
+# --- model override via record_agent_result ---
+
+
+def test_record_overrides_model(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        record_agent_result(span, exit_code=0, duration_ms=100.0, model="claude-opus-4-6")
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["gen_ai.request.model"] == "claude-opus-4-6"

--- a/tests/test_spans.py
+++ b/tests/test_spans.py
@@ -1,196 +1,213 @@
+"""Tests for factory_tracing.spans — span hierarchy, attributes, and error status."""
 from __future__ import annotations
 
-import json
-
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode
 
+from factory_tracing import provider as _provider_mod
 from factory_tracing.spans import (
-    trace_factory_cycle,
-    trace_agent_invocation,
     record_agent_result,
+    trace_agent_invocation,
+    trace_factory_cycle,
 )
 
 
-def test_trace_agent_invocation_creates_span_with_correct_name(test_provider):
-    _, exporter = test_provider
+@pytest.fixture(autouse=True)
+def tracing_setup():
+    """Set up InMemorySpanExporter and tear down the provider singleton after each test."""
+    exporter = InMemorySpanExporter()
+    tp = TracerProvider()
+    tp.add_span_processor(SimpleSpanProcessor(exporter))
+    _provider_mod._provider = tp
+    yield exporter
+    tp.shutdown()
+    _provider_mod._provider = None
 
-    with trace_agent_invocation("researcher"):
+
+def _attrs(span) -> dict:
+    return dict(span.attributes) if span.attributes else {}
+
+
+# --- trace_factory_cycle ---
+
+
+def test_cycle_creates_root_span(tracing_setup):
+    with trace_factory_cycle("run-1", "my-project", "improve"):
         pass
+    spans = tracing_setup.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "factory.cycle"
 
-    spans = exporter.get_finished_spans()
+
+def test_cycle_sets_factory_attributes(tracing_setup):
+    with trace_factory_cycle("run-42", "acme", "build"):
+        pass
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["factory.run.id"] == "run-42"
+    assert attrs["factory.project.name"] == "acme"
+    assert attrs["factory.mode"] == "build"
+
+
+def test_cycle_sets_langfuse_attributes(tracing_setup):
+    with trace_factory_cycle("run-1", "proj", "improve"):
+        pass
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["langfuse.observation.type"] == "span"
+    assert attrs["langfuse.session.id"] == "run-1"
+
+
+def test_cycle_status_ok_on_success(tracing_setup):
+    with trace_factory_cycle("r", "p", "m"):
+        pass
+    assert tracing_setup.get_finished_spans()[0].status.status_code == StatusCode.OK
+
+
+def test_cycle_status_error_on_exception(tracing_setup):
+    with pytest.raises(ValueError, match="boom"):
+        with trace_factory_cycle("r", "p", "m"):
+            raise ValueError("boom")
+    span = tracing_setup.get_finished_spans()[0]
+    assert span.status.status_code == StatusCode.ERROR
+    assert "boom" in span.status.description
+
+
+# --- trace_agent_invocation ---
+
+
+def test_agent_span_name_includes_role(tracing_setup):
+    with trace_agent_invocation("researcher", "find bugs", "run-1", "proj"):
+        pass
+    spans = tracing_setup.get_finished_spans()
     assert len(spans) == 1
     assert spans[0].name == "invoke_agent researcher"
 
 
-def test_trace_agent_invocation_sets_required_attributes(test_provider):
-    _, exporter = test_provider
-
-    with trace_agent_invocation("builder", run_id="run-5", project_name="proj"):
+def test_agent_sets_gen_ai_attributes(tracing_setup):
+    with trace_agent_invocation("builder", "implement feature", "run-1", "proj"):
         pass
-
-    span = exporter.get_finished_spans()[0]
-    attrs = dict(span.attributes)
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
     assert attrs["gen_ai.operation.name"] == "invoke_agent"
     assert attrs["gen_ai.agent.name"] == "builder"
     assert attrs["gen_ai.system"] == "anthropic"
+
+
+def test_agent_sets_factory_and_langfuse_attributes(tracing_setup):
+    with trace_agent_invocation("reviewer", "review code", "run-5", "acme"):
+        pass
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
     assert attrs["factory.run.id"] == "run-5"
-    assert attrs["factory.project.name"] == "proj"
+    assert attrs["factory.project.name"] == "acme"
+    assert attrs["factory.task.summary"] == "review code"
+    assert attrs["langfuse.observation.type"] == "span"
     assert attrs["langfuse.session.id"] == "run-5"
-    assert json.loads(attrs["langfuse.trace.tags"]) == ["builder"]
 
 
-def test_agent_span_is_child_of_cycle_span(test_provider):
-    _, exporter = test_provider
+def test_agent_langfuse_tags_contains_role(tracing_setup):
+    with trace_agent_invocation("strategist", "plan", "r", "p"):
+        pass
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    tags = attrs["langfuse.trace.tags"]
+    assert "strategist" in tags
 
+
+def test_agent_status_error_on_exception(tracing_setup):
+    with pytest.raises(RuntimeError):
+        with trace_agent_invocation("builder", "task", "r", "p"):
+            raise RuntimeError("fail")
+    span = tracing_setup.get_finished_spans()[0]
+    assert span.status.status_code == StatusCode.ERROR
+
+
+# --- span hierarchy ---
+
+
+def test_agent_is_child_of_cycle(tracing_setup):
     with trace_factory_cycle("run-1", "proj", "improve"):
-        with trace_agent_invocation("researcher"):
+        with trace_agent_invocation("researcher", "search", "run-1", "proj"):
             pass
-
-    spans = exporter.get_finished_spans()
-    agent_span = next(s for s in spans if s.name == "invoke_agent researcher")
+    spans = tracing_setup.get_finished_spans()
+    assert len(spans) == 2
+    agent_span = next(s for s in spans if s.name.startswith("invoke_agent"))
     cycle_span = next(s for s in spans if s.name == "factory.cycle")
-
     assert agent_span.parent is not None
     assert agent_span.parent.span_id == cycle_span.context.span_id
     assert agent_span.context.trace_id == cycle_span.context.trace_id
 
 
-def test_multiple_parallel_agents_share_parent(test_provider):
-    _, exporter = test_provider
-
+def test_multiple_agents_share_same_parent(tracing_setup):
     with trace_factory_cycle("run-1", "proj", "improve"):
-        with trace_agent_invocation("researcher"):
+        with trace_agent_invocation("researcher", "search", "run-1", "proj"):
             pass
-        with trace_agent_invocation("builder"):
+        with trace_agent_invocation("builder", "build", "run-1", "proj"):
             pass
-
-    spans = exporter.get_finished_spans()
+    spans = tracing_setup.get_finished_spans()
+    assert len(spans) == 3
     cycle_span = next(s for s in spans if s.name == "factory.cycle")
     agent_spans = [s for s in spans if s.name.startswith("invoke_agent")]
-
     assert len(agent_spans) == 2
     for agent_span in agent_spans:
         assert agent_span.parent.span_id == cycle_span.context.span_id
 
 
-def test_record_agent_result_sets_usage(test_provider):
-    _, exporter = test_provider
+def test_all_spans_share_same_trace_id(tracing_setup):
+    with trace_factory_cycle("run-1", "proj", "improve"):
+        with trace_agent_invocation("researcher", "search", "run-1", "proj"):
+            pass
+        with trace_agent_invocation("builder", "build", "run-1", "proj"):
+            pass
+    spans = tracing_setup.get_finished_spans()
+    trace_ids = {s.context.trace_id for s in spans}
+    assert len(trace_ids) == 1
 
-    with trace_agent_invocation("builder") as span:
+
+# --- record_agent_result ---
+
+
+def test_record_sets_exit_code_and_duration(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        record_agent_result(span, exit_code=0, duration_ms=1500.0)
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["subprocess.returncode"] == 0
+    assert attrs["subprocess.duration_ms"] == 1500.0
+
+
+def test_record_sets_usage_when_provided(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
         record_agent_result(
             span,
             exit_code=0,
-            input_tokens=500,
-            output_tokens=200,
-            cost_usd=0.015,
+            duration_ms=2000.0,
+            input_tokens=1000,
+            output_tokens=500,
+            cost_usd=0.05,
         )
-
-    finished = exporter.get_finished_spans()[0]
-    attrs = dict(finished.attributes)
-    assert attrs["gen_ai.usage.input_tokens"] == 500
-    assert attrs["gen_ai.usage.output_tokens"] == 200
-    assert attrs["gen_ai.usage.cost"] == 0.015
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
+    assert attrs["gen_ai.usage.input_tokens"] == 1000
+    assert attrs["gen_ai.usage.output_tokens"] == 500
+    assert attrs["gen_ai.usage.cost"] == 0.05
 
 
-def test_record_agent_result_error_status(test_provider):
-    _, exporter = test_provider
-
-    with trace_agent_invocation("builder") as span:
-        record_agent_result(span, exit_code=1)
-
-    finished = exporter.get_finished_spans()[0]
-    assert finished.status.status_code == StatusCode.ERROR
-
-
-def test_trace_factory_cycle_sets_attributes(test_provider):
-    _, exporter = test_provider
-
-    with trace_factory_cycle("run-42", "acme", "fix"):
-        pass
-
-    span = exporter.get_finished_spans()[0]
-    attrs = dict(span.attributes)
-    assert attrs["factory.run.id"] == "run-42"
-    assert attrs["factory.project.name"] == "acme"
-    assert attrs["factory.mode"] == "fix"
-    assert json.loads(attrs["langfuse.trace.tags"]) == ["fix"]
-
-
-def test_langfuse_observation_type_is_set(test_provider):
-    _, exporter = test_provider
-
-    with trace_factory_cycle("run-1", "proj", "improve"):
-        with trace_agent_invocation("researcher"):
-            pass
-
-    spans = exporter.get_finished_spans()
-    for span in spans:
-        assert span.attributes["langfuse.observation.type"] == "span"
-
-
-def test_factory_cycle_session_id_defaults_to_run_id(test_provider):
-    _, exporter = test_provider
-
-    with trace_factory_cycle("run-abc", "proj", "improve"):
-        pass
-
-    span = exporter.get_finished_spans()[0]
-    assert span.attributes["langfuse.session.id"] == "run-abc"
-
-
-def test_factory_cycle_session_id_override(test_provider):
-    _, exporter = test_provider
-
-    with trace_factory_cycle("run-1", "proj", "improve", session_id="session-99"):
-        pass
-
-    span = exporter.get_finished_spans()[0]
-    assert span.attributes["langfuse.session.id"] == "session-99"
-
-
-def test_record_agent_result_omits_zero_usage(test_provider):
-    _, exporter = test_provider
-
-    with trace_agent_invocation("builder") as span:
-        record_agent_result(span, exit_code=0)
-
-    finished = exporter.get_finished_spans()[0]
-    attrs = dict(finished.attributes)
+def test_record_omits_usage_when_not_provided(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        record_agent_result(span, exit_code=0, duration_ms=100.0)
+    attrs = _attrs(tracing_setup.get_finished_spans()[0])
     assert "gen_ai.usage.input_tokens" not in attrs
     assert "gen_ai.usage.output_tokens" not in attrs
     assert "gen_ai.usage.cost" not in attrs
 
 
-def test_agent_invocation_yields_span(test_provider):
-    _, exporter = test_provider
-
-    with trace_agent_invocation("builder") as span:
-        span.set_attribute("custom.key", "custom-value")
-
-    finished = exporter.get_finished_spans()[0]
-    assert finished.attributes["custom.key"] == "custom-value"
+def test_record_error_status_on_nonzero_exit(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        record_agent_result(span, exit_code=1, duration_ms=500.0)
+    span_data = tracing_setup.get_finished_spans()[0]
+    assert span_data.status.status_code == StatusCode.ERROR
 
 
-def test_all_spans_share_same_trace_id(test_provider):
-    _, exporter = test_provider
-
-    with trace_factory_cycle("run-1", "proj", "improve"):
-        with trace_agent_invocation("researcher"):
-            pass
-        with trace_agent_invocation("builder"):
-            pass
-
-    spans = exporter.get_finished_spans()
-    trace_ids = {s.context.trace_id for s in spans}
-    assert len(trace_ids) == 1
-
-
-def test_record_agent_result_ok_status_on_zero_exit(test_provider):
-    _, exporter = test_provider
-
-    with trace_agent_invocation("builder") as span:
-        record_agent_result(span, exit_code=0)
-
-    finished = exporter.get_finished_spans()[0]
-    assert finished.status.status_code == StatusCode.OK
+def test_record_ok_status_on_zero_exit(tracing_setup):
+    with trace_agent_invocation("builder", "task", "r", "p") as span:
+        record_agent_result(span, exit_code=0, duration_ms=500.0)
+    span_data = tracing_setup.get_finished_spans()[0]
+    assert span_data.status.status_code == StatusCode.OK


### PR DESCRIPTION
Closes #567

## Changes

### Phase 4+5 (existing)
- `TracingIntegration` class with lifecycle methods, CLI commands
- Experiment metadata enrichment with session grouping and eval recording

### Phase 6: Span Content Quality (prior commits)
- **propagation.py**: Add `OTEL_LOG_USER_PROMPTS=1`, `OTEL_LOG_TOOL_DETAILS=1`, `OTEL_LOG_TOOL_CONTENT=1` so Claude Code native spans include prompt/tool content
- **spans.py**: Set `gen_ai.prompt` from task_summary and `gen_ai.request.model` on invocation; add `response_text` → `gen_ai.completion`, `start_time` → calculated duration, and model override to `record_agent_result()`
- **integration.py**: Store `run_id` on cycle start, pass `response_text`/`start_time`/`model` through `record_agent_result()`, add `set_span_io()` for explicit input/output

### Phase 7: Multi-Agent Verification Rewrite (latest commit)
- **verify.py — complete rewrite**: Replaces trivial single-agent "Reply with VERIFIED" probe with real multi-agent factory cycle
  - Invokes 2+ agents sequentially (researcher → strategist), where agent 2's prompt references agent 1's output
  - Validates content quality in Langfuse: prompt text, token counts > 0, model names, parent-child span nesting
  - Prints detailed report: per-agent prompt/response snippets, full span tree, token totals, PASS/FAIL per content check
  - New dataclasses: `AgentTrace`, `ContentCheck`, enriched `VerificationResult` with agents_traced, total_llm_calls, total_tokens, content_checks
- **cli.py**: Adds `--agents N` flag (default 2), exits 0 only if all content quality checks pass

## Test plan
- [x] All 71 tests pass (`pytest -v`)
- [ ] Run `factory-tracing verify` against live Langfuse to confirm multi-agent flow traces correctly
- [ ] Run `factory-tracing verify --agents 1` to test single-agent mode
- [ ] Verify span tree shows factory.cycle → invoke_agent researcher → claude_code.* AND factory.cycle → invoke_agent strategist → claude_code.*