### PR TITLE
Fix Codex runner stale --full-auto flag

### DIFF
--- a/factory/runners/codex.py
+++ b/factory/runners/codex.py
@@ -182,7 +182,7 @@ class CodexRunner:
             cmd.append("--ignore-user-config")
 
         if request.skip_permissions:
-            cmd.append("--full-auto")
+            cmd.append("--dangerously-bypass-approvals-and-sandbox")
 
         if request.model:
             cmd.extend(["--model", request.model])

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -473,7 +473,7 @@ class TestCodexBuildInteractiveCommand:
         assert "--" not in cmd
         assert "--skip-git-repo-check" not in cmd
         assert "--ignore-user-config" in cmd
-        assert "--full-auto" in cmd
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
         assert "--model" in cmd
         assert "gpt-5.4" in cmd
         assert temp_files == []
@@ -493,7 +493,7 @@ class TestCodexBuildInteractiveCommand:
                 prompt="Test", task="Test", cwd=tmp_path, skip_permissions=False,
             ))
 
-        assert "--full-auto" not in cmd
+        assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
         assert "--sandbox" not in cmd
 
         if hasattr(runner, "_tmpdir") and runner._tmpdir is not None:
@@ -560,7 +560,7 @@ class TestCodexInteractive:
             cmd = mock_run.call_args[0][0]
             assert cmd[0] == "codex"
             assert "--ignore-user-config" in cmd
-            assert "--full-auto" in cmd
+            assert "--dangerously-bypass-approvals-and-sandbox" in cmd
             assert "--model" in cmd
             assert "gpt-5.4" in cmd
 
@@ -584,7 +584,7 @@ class TestCodexInteractive:
             )
 
             cmd = mock_run.call_args[0][0]
-            assert "--full-auto" not in cmd
+            assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
 
     def test_interactive_run_passes_env(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #586

## Changes
- Replaced `--full-auto` with `--dangerously-bypass-approvals-and-sandbox` in `build_interactive_command()` at `factory/runners/codex.py:185`
- Updated all test assertions in `tests/test_codex_runner.py` to verify the new flag

The `--full-auto` flag was removed in Codex CLI 0.139.0+ and replaced with `--dangerously-bypass-approvals-and-sandbox`. The headless path already used the correct flags (`--sandbox workspace-write --ask-for-approval never`) — only the interactive path had the stale reference.