### PR TITLE
feat: add benchmark CI pipeline for pre-release validation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,129 @@
+name: Benchmark CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      benchmark:
+        description: 'Benchmark to run'
+        required: true
+        type: choice
+        options:
+          - swebench
+          - featurebench
+          - terminalbench
+          - all
+      instance_id:
+        description: 'Instance ID (leave default for smoke test)'
+        required: false
+        default: 'auto'
+        type: string
+      timeout:
+        description: 'Solver timeout in seconds'
+        required: false
+        default: '1800'
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - benchmark: swebench
+            default_instance: 'sympy__sympy-20590'
+            enabled: ${{ inputs.benchmark == 'swebench' || inputs.benchmark == 'all' }}
+          - benchmark: featurebench
+            default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
+            enabled: ${{ inputs.benchmark == 'featurebench' || inputs.benchmark == 'all' }}
+          - benchmark: terminalbench
+            default_instance: 'fix-git'
+            enabled: ${{ inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all' }}
+    if: true
+
+    steps:
+      - name: Skip if not enabled
+        if: matrix.enabled != 'true'
+        run: echo "Skipping ${{ matrix.benchmark }} (not selected)" && exit 0
+
+      - name: Gate
+        id: gate
+        if: matrix.enabled == 'true'
+        run: echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.run == 'true'
+
+      - name: Authenticate to Google Cloud
+        if: steps.gate.outputs.run == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Install uv
+        if: steps.gate.outputs.run == 'true'
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Node.js
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Claude Code
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          export PATH="$(npm prefix -g)/bin:$PATH"
+          echo "PATH=$(npm prefix -g)/bin:$PATH" >> "$GITHUB_ENV"
+          claude --version
+
+      - name: Determine instance ID
+        id: config
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          INSTANCE="${{ inputs.instance_id }}"
+          if [ "$INSTANCE" = "auto" ]; then
+            INSTANCE="${{ matrix.default_instance }}"
+          fi
+          echo "instance=$INSTANCE" >> "$GITHUB_OUTPUT"
+
+      - name: Run ${{ matrix.benchmark }} benchmark
+        if: steps.gate.outputs.run == 'true'
+        env:
+          CLAUDE_CODE_USE_VERTEX: "1"
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
+          CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}
+          CLAUDE_CODE_SUBAGENT_MODEL: "claude-opus-4-6[1m]"
+          CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"
+          ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6[1m]"
+          CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
+          MAX_THINKING_TOKENS: "128000"
+          CLAUDE_CODE_EFFORT_LEVEL: "XHIGH"
+        run: |
+          chmod +x benchmarks/run.sh benchmarks/lib.sh benchmarks/run-*.sh
+          benchmarks/run.sh ${{ matrix.benchmark }} ${{ steps.config.outputs.instance }} --timeout ${{ inputs.timeout }}
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always() && steps.gate.outputs.run == 'true'
+        with:
+          name: benchmark-results-${{ matrix.benchmark }}
+          path: benchmarks/results/
+
+      - name: Print summary
+        if: always() && steps.gate.outputs.run == 'true'
+        run: |
+          echo "## ${{ matrix.benchmark }} Results" >> $GITHUB_STEP_SUMMARY
+          for f in benchmarks/results/*.json; do
+            if [ -f "$f" ]; then
+              echo '```json' >> $GITHUB_STEP_SUMMARY
+              cat "$f" >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+            fi
+          done

--- a/benchmarks/lib.sh
+++ b/benchmarks/lib.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# benchmarks/lib.sh — Shared functions for benchmark CI pipelines.
+# Source this from individual benchmark scripts.
+
+set -euo pipefail
+
+# ── Shared State ──
+
+HARNESS_DIR="${HARNESS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+TIMESTAMP="${TIMESTAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+CI_RESULTS_DIR="${CI_RESULTS_DIR:-${HARNESS_DIR}/benchmarks/results}"
+START_TIME="${START_TIME:-$(date +%s)}"
+STATUS="${STATUS:-failed}"
+
+# ── Functions ──
+
+log() { echo "==> $*"; }
+
+show_banner() {
+    local name="$1"
+    echo "============================================"
+    echo "  ${name} CI Pipeline"
+    echo "============================================"
+    echo ""
+}
+
+# write_result — Write a standardized result JSON file.
+# Reads from environment variables set by the calling script:
+#   BENCHMARK, INSTANCE_ID, PASSED, TOTAL, RESOLVED, STATUS, TIMESTAMP
+#   RESULT_FILE — output path
+#   DETAILS_JSON — optional JSON object string for benchmark-specific extras
+write_result() {
+    local end_time duration
+    end_time="$(date +%s)"
+    duration=$(( end_time - START_TIME ))
+    mkdir -p "${CI_RESULTS_DIR}"
+    python3 -c "
+import json, sys
+_dj = '${DETAILS_JSON:-}'
+details = json.loads(_dj) if _dj else {}
+result = {
+    'benchmark': '${BENCHMARK}',
+    'instance_id': '${INSTANCE_ID}',
+    'passed': ${PASSED:-0},
+    'total': ${TOTAL:-0},
+    'score': round(${PASSED:-0} / max(${TOTAL:-0}, 1), 4),
+    'resolved': bool(${RESOLVED:-0}),
+    'duration_seconds': ${duration},
+    'status': '${STATUS}',
+    'timestamp': '${TIMESTAMP}',
+    'details': details,
+}
+json.dump(result, sys.stdout, indent=2)
+print()
+" > "${RESULT_FILE}"
+    echo ""
+    log "Results written to ${RESULT_FILE}"
+    cat "${RESULT_FILE}"
+}
+
+ensure_uvx() {
+    if ! command -v uvx &>/dev/null; then
+        if ! command -v uv &>/dev/null; then
+            echo "    uv: not found, installing..."
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH="${HOME}/.local/bin:${PATH}"
+            if ! command -v uv &>/dev/null; then
+                echo "    ERROR: uv installation failed"
+                exit 1
+            fi
+            echo "    uv: installed"
+        fi
+    fi
+    echo "    uvx: ready"
+}
+
+# check_gcloud_creds — Check for application default credentials.
+# Usage: check_gcloud_creds required   (exit 1 if missing)
+#        check_gcloud_creds warning    (warn if missing)
+check_gcloud_creds() {
+    local mode="${1:-warning}"
+    if [ ! -f "${HOME}/.config/gcloud/application_default_credentials.json" ]; then
+        if [ "${mode}" = "required" ]; then
+            echo "    ERROR: gcloud application default credentials not found."
+            echo "    Run: gcloud auth application-default login"
+            exit 1
+        else
+            echo "    WARNING: gcloud application default credentials not found."
+            echo "    If using Vertex AI, run: gcloud auth application-default login"
+        fi
+    else
+        echo "    gcloud credentials: found"
+    fi
+}
+
+# setup_vertex_env — Source .env if present, configure Vertex AI environment.
+export_claude_env() {
+    export ANTHROPIC_MODEL="${ANTHROPIC_MODEL:-claude-opus-4-6[1m]}"
+    export CLAUDE_CODE_SUBAGENT_MODEL="${CLAUDE_CODE_SUBAGENT_MODEL:-claude-opus-4-6[1m]}"
+    export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS="${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}"
+    export ANTHROPIC_DEFAULT_OPUS_MODEL="${ANTHROPIC_DEFAULT_OPUS_MODEL:-claude-opus-4-6[1m]}"
+    export CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING="${CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING:-1}"
+    export MAX_THINKING_TOKENS="${MAX_THINKING_TOKENS:-128000}"
+    export CLAUDE_CODE_EFFORT_LEVEL="${CLAUDE_CODE_EFFORT_LEVEL:-XHIGH}"
+}
+
+setup_vertex_env() {
+    if [ -f "${HARNESS_DIR}/.env" ]; then
+        echo "    .env: found at ${HARNESS_DIR}/.env"
+        set -a
+        source "${HARNESS_DIR}/.env"
+        set +a
+    elif [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+        echo "    .env: not found, using environment variables"
+    else
+        echo "    WARNING: No .env file and ANTHROPIC_VERTEX_PROJECT_ID not set."
+        echo "    Claude Code will use its default API configuration."
+    fi
+
+    if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+        export CLAUDE_CODE_USE_VERTEX=1
+        export ANTHROPIC_VERTEX_PROJECT_ID
+        export CLOUD_ML_REGION="${CLOUD_ML_REGION:-global}"
+    fi
+}

--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# benchmarks/run-featurebench.sh — Standalone CI pipeline for FeatureBench.
+# Runs the complete solve+eval cycle: load instance, clone repo, run Claude Code solver,
+# capture patch, evaluate with FeatureBench harness.
+
+# ── Shared library ──
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# ── Configuration ──
+
+INSTANCE_ID="${1:-pypa__packaging.013f3b03.test_metadata.e00b5801.lv1}"
+SOLVER_TIMEOUT="${2:-1800}"
+SPLIT="${3:-fast}"
+
+BENCHMARK="featurebench"
+RUN_ID="ci-featurebench-${TIMESTAMP}"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-featurebench.json"
+
+FB_CMD="uvx --from featurebench fb"
+FB_PYTHON="uvx --from featurebench python"
+
+DATASET="LiberCoders/FeatureBench"
+WORKSPACE=""
+
+PASSED=0
+RESOLVED=0
+PASS_RATE=0
+TOTAL=1
+
+# ── Helpers ──
+
+cleanup() {
+    local exit_code=$?
+    if [ -n "${WORKSPACE}" ] && [ -d "${WORKSPACE}" ]; then
+        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
+            log "Preserving workspace at ${WORKSPACE} (PRESERVE_WORKSPACE=1)"
+        else
+            log "Cleaning up workspace"
+            rm -rf "${WORKSPACE}"
+        fi
+    fi
+    PASSED="${RESOLVED}"
+    DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"'}'
+    write_result
+    if [ "${STATUS}" = "success" ]; then
+        exit 0
+    else
+        exit "${exit_code:-1}"
+    fi
+}
+
+trap cleanup EXIT
+
+# ── Step 1: Parse and display configuration ──
+
+show_banner "FeatureBench"
+log "Step 1: Configuration"
+echo "    Instance ID:     ${INSTANCE_ID}"
+echo "    Dataset:         ${DATASET}"
+echo "    Split:           ${SPLIT}"
+echo "    Solver timeout:  ${SOLVER_TIMEOUT}s ($(( SOLVER_TIMEOUT / 3600 ))h $(( (SOLVER_TIMEOUT % 3600) / 60 ))m)"
+echo "    Run ID:          ${RUN_ID}"
+echo "    Timestamp:       ${TIMESTAMP}"
+echo ""
+
+# ── Step 2: Validate prerequisites ──
+
+log "Step 2: Validating prerequisites"
+
+MISSING=()
+
+if ! command -v python3 &>/dev/null; then
+    MISSING+=("python3 >= 3.12 (install via your system package manager)")
+fi
+
+if ! command -v docker &>/dev/null && [ ! -x /usr/bin/docker ]; then
+    MISSING+=("docker (install from https://docs.docker.com/get-docker/)")
+fi
+
+if ! command -v claude &>/dev/null; then
+    MISSING+=("claude (Claude Code CLI — install from https://docs.anthropic.com/en/docs/claude-code)")
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "    ERROR: Missing prerequisites:"
+    for m in "${MISSING[@]}"; do
+        echo "      - ${m}"
+    done
+    exit 1
+fi
+
+echo "    python3: found"
+echo "    docker: found"
+echo "    claude: found"
+
+ensure_uvx
+
+# Verify featurebench is usable via uvx
+echo "    featurebench: checking availability via uvx..."
+if ! ${FB_CMD} --help &>/dev/null; then
+    echo "    featurebench: installing via uvx..."
+    ${FB_CMD} --help >/dev/null || {
+        echo "    ERROR: Failed to install/run featurebench via uvx"
+        exit 1
+    }
+fi
+echo "    featurebench: available"
+
+check_gcloud_creds warning
+setup_vertex_env
+
+echo "    All prerequisites satisfied."
+echo ""
+
+# ── Step 3: Load instance from HuggingFace ──
+
+log "Step 3: Loading instance ${INSTANCE_ID} from ${DATASET}"
+
+INSTANCE_JSON="$(mktemp /tmp/featurebench-instance-XXXXXX.json)"
+
+${FB_PYTHON} -c "
+import json, sys
+from datasets import load_dataset
+
+ds = load_dataset('${DATASET}', split='${SPLIT}')
+matches = [x for x in ds if x['instance_id'] == '${INSTANCE_ID}']
+if not matches:
+    print('ERROR: Instance ${INSTANCE_ID} not found in ${DATASET} (split=${SPLIT})', file=sys.stderr)
+    sys.exit(1)
+instance = matches[0]
+repo = instance['repo']
+# Normalize repo format: __ -> / for GitHub clone URLs
+if '/' not in repo and '__' in repo:
+    repo = repo.replace('__', '/', 1)
+json.dump({
+    'instance_id': instance['instance_id'],
+    'repo': repo,
+    'base_commit': instance['base_commit'],
+    'problem_statement': instance['problem_statement'],
+}, open('${INSTANCE_JSON}', 'w'), indent=2)
+print(f'Loaded: {instance[\"instance_id\"]}')
+print(f'Repo:   {repo}')
+print(f'Commit: {instance[\"base_commit\"][:12]}...')
+"
+
+if [ ! -s "${INSTANCE_JSON}" ]; then
+    echo "    ERROR: Failed to load instance data"
+    exit 1
+fi
+
+REPO="$(python3 -c "import json; print(json.load(open('${INSTANCE_JSON}'))['repo'])")"
+BASE_COMMIT="$(python3 -c "import json; print(json.load(open('${INSTANCE_JSON}'))['base_commit'])")"
+
+echo "    Instance loaded successfully."
+echo ""
+
+# ── Step 4: Setup workspace ──
+
+log "Step 4: Setting up workspace"
+
+WORKSPACE="$(mktemp -d /tmp/featurebench-workspace-XXXXXX)"
+echo "    Workspace: ${WORKSPACE}"
+echo "    Cloning https://github.com/${REPO}..."
+
+git clone --quiet "https://github.com/${REPO}.git" "${WORKSPACE}/repo"
+cd "${WORKSPACE}/repo"
+git checkout --quiet "${BASE_COMMIT}"
+
+echo "    Checked out ${BASE_COMMIT:0:12}"
+echo "    Working directory: ${WORKSPACE}/repo"
+
+echo ""
+
+# ── Step 5: Run solver (Claude Code) ──
+
+log "Step 5: Running Claude Code solver (timeout: ${SOLVER_TIMEOUT}s)"
+echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+SOLVER_PROMPT_FILE="${WORKSPACE}/solver_prompt.txt"
+python3 -c "
+import json
+with open('${INSTANCE_JSON}') as f:
+    instance = json.load(f)
+
+# Rewrite /testbed/ paths to relative paths (we can't create /testbed symlink)
+problem_statement = instance['problem_statement']
+problem_statement = problem_statement.replace('/testbed/', './')
+
+prompt = '''You are implementing a new feature in an open-source Python project.
+
+## Problem Statement
+
+''' + problem_statement + '''
+
+## Instructions
+
+1. Read the problem statement carefully — it describes a feature to implement
+2. Explore the repository to understand the codebase architecture
+3. Implement the feature as described in the problem statement
+4. The problem statement contains detailed interface specifications — follow them exactly
+5. Do NOT assume the feature is already implemented just because existing tests pass
+6. The evaluation will use NEW tests (not the ones in the repo) to verify your implementation
+7. Focus on implementing the interfaces, classes, and functions described in the problem statement
+8. Make sure you don't break existing functionality
+
+IMPORTANT: Even if existing tests pass, you MUST implement the feature described above.
+The evaluation tests are DIFFERENT from the tests currently in the repository.
+
+The repository is available at the current working directory.'''
+with open('${SOLVER_PROMPT_FILE}', 'w') as f:
+    f.write(prompt)
+"
+
+if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+    echo "    Using Vertex AI (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
+fi
+
+cd "${WORKSPACE}/repo"
+
+export_claude_env
+
+SOLVER_LOG="${WORKSPACE}/solver_output.log"
+SOLVER_EXIT=0
+timeout "${SOLVER_TIMEOUT}" claude -p "$(cat "${SOLVER_PROMPT_FILE}")" \
+    --model "${ANTHROPIC_MODEL}" \
+    --verbose \
+    --max-turns 200 \
+    --permission-mode bypassPermissions \
+    --output-format stream-json \
+    2>&1 | tee "${SOLVER_LOG}" | tail -50 || true
+SOLVER_EXIT=${PIPESTATUS[0]}
+
+if [ "${SOLVER_EXIT}" -eq 124 ]; then
+    echo "    Solver timed out after ${SOLVER_TIMEOUT}s"
+elif [ "${SOLVER_EXIT}" -ne 0 ]; then
+    echo "    Solver exited with code ${SOLVER_EXIT}"
+fi
+
+echo "    Finished at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# ── Step 6: Capture patch ──
+
+log "Step 6: Capturing patch"
+
+cd "${WORKSPACE}/repo"
+PATCH_FILE="${WORKSPACE}/model_patch.diff"
+git diff > "${PATCH_FILE}"
+
+PATCH_SIZE="$(wc -c < "${PATCH_FILE}")"
+if [ "${PATCH_SIZE}" -eq 0 ]; then
+    echo "    WARNING: Solver produced no changes (empty diff)"
+    echo "    Evaluation will proceed but instance will not be resolved."
+else
+    PATCH_LINES="$(wc -l < "${PATCH_FILE}")"
+    PATCH_FILES="$(git diff --name-only | wc -l)"
+    echo "    Patch: ${PATCH_LINES} lines across ${PATCH_FILES} file(s)"
+fi
+echo ""
+
+# ── Step 7: Write predictions.jsonl ──
+
+log "Step 7: Writing predictions.jsonl"
+
+PREDICTIONS_DIR="$(mktemp -d /tmp/featurebench-predictions-XXXXXX)"
+PREDICTIONS_FILE="${PREDICTIONS_DIR}/predictions.jsonl"
+
+python3 -c "
+import json
+
+with open('${PATCH_FILE}') as f:
+    model_patch = f.read()
+
+prediction = {
+    'instance_id': '${INSTANCE_ID}',
+    'model_name_or_path': 'claude-code',
+    'model_patch': model_patch,
+    'n_attempt': 1,
+    'success': True,
+}
+with open('${PREDICTIONS_FILE}', 'w') as f:
+    json.dump(prediction, f)
+    f.write('\n')
+print('    Written to ${PREDICTIONS_FILE}')
+"
+
+echo ""
+
+# ── Step 8: Run FeatureBench evaluation ──
+
+log "Step 8: Running FeatureBench evaluation"
+echo "    This may take several minutes (Docker image pull + evaluation)..."
+
+cd "${HARNESS_DIR}"
+
+EVAL_EXIT=0
+${FB_CMD} eval \
+    -p "${PREDICTIONS_FILE}" \
+    --split "${SPLIT}" \
+    --task-id "${INSTANCE_ID}" \
+    --n-concurrent 1 \
+    2>&1 || EVAL_EXIT=$?
+
+if [ "${EVAL_EXIT}" -ne 0 ]; then
+    echo "    ERROR: FeatureBench evaluation failed with exit code ${EVAL_EXIT}"
+    exit 1
+fi
+
+echo "    Evaluation complete."
+echo ""
+
+# ── Step 9: Extract and report results ──
+
+log "Step 9: Extracting results"
+
+RESULTS_JSON=""
+
+for candidate in "${HARNESS_DIR}"/runs/*/eval_outputs/"${INSTANCE_ID}"/attempt-*/report.json; do
+    if [ -f "${candidate}" ]; then
+        RESULTS_JSON="${candidate}"
+    fi
+done
+
+if [ -z "${RESULTS_JSON}" ]; then
+    for candidate in "${HARNESS_DIR}"/runs/*/report.json; do
+        if [ -f "${candidate}" ]; then
+            RESULTS_JSON="${candidate}"
+        fi
+    done
+fi
+
+if [ -z "${RESULTS_JSON}" ]; then
+    for candidate in "${HARNESS_DIR}"/*.json; do
+        if [ -f "${candidate}" ] && python3 -c "
+import json, sys
+with open('${candidate}') as f:
+    data = json.load(f)
+if 'attempt_1' in data or '${INSTANCE_ID}' in data:
+    sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+            RESULTS_JSON="${candidate}"
+            break
+        fi
+    done
+fi
+
+if [ -n "${RESULTS_JSON}" ] && [ -f "${RESULTS_JSON}" ]; then
+    echo "    Results file: ${RESULTS_JSON}"
+    eval "$(python3 -c "
+import json
+
+with open('${RESULTS_JSON}') as f:
+    data = json.load(f)
+
+resolved = 0
+total = 0
+pass_rate = 0.0
+
+# Per-instance report: {instance_id: {resolved: bool, pass_rate: float, ...}}
+if '${INSTANCE_ID}' in data:
+    result = data['${INSTANCE_ID}']
+    total = 1
+    if result.get('resolved', False):
+        resolved = 1
+    pass_rate = result.get('pass_rate', 0.0)
+
+# Summary report: {attempt_1: {resolved_rate: float, pass_rate: float, ...}}
+elif 'attempt_1' in data:
+    attempt = data['attempt_1']
+    total = attempt.get('total_instances', attempt.get('completed_instances', 1))
+    resolved = attempt.get('resolved_instances', 0)
+    pass_rate = attempt.get('pass_rate', 0.0)
+
+# Flat dict with resolved/pass_rate keys
+elif 'resolved' in data:
+    total = 1
+    if data.get('resolved', False):
+        resolved = 1
+    pass_rate = data.get('pass_rate', 0.0)
+
+print(f'RESOLVED={resolved}')
+print(f'TOTAL={max(total, 1)}')
+print(f'PASS_RATE={pass_rate}')
+")"
+else
+    echo "    No results files found. Marking as unresolved."
+    RESOLVED=0
+    TOTAL=1
+    PASS_RATE=0
+fi
+
+echo ""
+echo "============================================"
+if [ "${RESOLVED}" -gt 0 ]; then
+    echo "  Result: RESOLVED (${RESOLVED}/${TOTAL})"
+else
+    echo "  Result: NOT RESOLVED (${RESOLVED}/${TOTAL})"
+fi
+echo "  Pass Rate: ${PASS_RATE}"
+echo "============================================"
+echo ""
+
+STATUS="success"
+
+# cleanup trap will write the final result JSON and exit 0

--- a/benchmarks/run-swebench.sh
+++ b/benchmarks/run-swebench.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# benchmarks/run-swebench.sh — Standalone CI pipeline for SWE-bench.
+# Runs the complete solve+eval cycle: load instance, clone repo, run Claude Code solver,
+# capture patch, evaluate with SWE-bench harness.
+
+# ── Shared library ──
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# ── Configuration ──
+
+INSTANCE_ID="${1:-sympy__sympy-20590}"
+SOLVER_TIMEOUT="${2:-1800}"
+DATASET="${3:-princeton-nlp/SWE-bench_Lite}"
+
+BENCHMARK="swebench"
+RUN_ID="ci-swebench-${TIMESTAMP}"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-swebench.json"
+
+SWEBENCH="uvx --from swebench python"
+WORKSPACE=""
+
+PASSED=0
+RESOLVED=0
+TOTAL=1
+
+# ── Helpers ──
+
+cleanup() {
+    local exit_code=$?
+    if [ -n "${WORKSPACE}" ] && [ -d "${WORKSPACE}" ]; then
+        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
+            log "Preserving workspace at ${WORKSPACE} (PRESERVE_WORKSPACE=1)"
+        else
+            log "Cleaning up workspace"
+            rm -rf "${WORKSPACE}"
+        fi
+    fi
+    PASSED="${RESOLVED}"
+    write_result
+    if [ "${STATUS}" = "success" ]; then
+        exit 0
+    else
+        exit "${exit_code:-1}"
+    fi
+}
+
+trap cleanup EXIT
+
+# ── Step 1: Parse and display configuration ──
+
+show_banner "SWE-bench"
+log "Step 1: Configuration"
+echo "    Instance ID:     ${INSTANCE_ID}"
+echo "    Dataset:         ${DATASET}"
+echo "    Solver timeout:  ${SOLVER_TIMEOUT}s ($(( SOLVER_TIMEOUT / 3600 ))h $(( (SOLVER_TIMEOUT % 3600) / 60 ))m)"
+echo "    Run ID:          ${RUN_ID}"
+echo "    Timestamp:       ${TIMESTAMP}"
+echo ""
+
+# ── Step 2: Validate prerequisites ──
+
+log "Step 2: Validating prerequisites"
+
+MISSING=()
+
+if ! command -v python3 &>/dev/null; then
+    MISSING+=("python3 (install via your system package manager)")
+fi
+
+if ! command -v docker &>/dev/null && [ ! -x /usr/bin/docker ]; then
+    MISSING+=("docker (install from https://docs.docker.com/get-docker/)")
+fi
+
+if ! command -v claude &>/dev/null; then
+    MISSING+=("claude (Claude Code CLI — install from https://docs.anthropic.com/en/docs/claude-code)")
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "    ERROR: Missing prerequisites:"
+    for m in "${MISSING[@]}"; do
+        echo "      - ${m}"
+    done
+    exit 1
+fi
+
+echo "    python3: found"
+echo "    docker: found"
+echo "    claude: found"
+
+ensure_uvx
+
+# Verify swebench is usable via uvx
+echo "    swebench: checking availability via uvx..."
+if ! ${SWEBENCH} -c "import swebench; print(f'swebench {swebench.__version__}')" 2>/dev/null; then
+    echo "    swebench: installing via uvx..."
+    uvx --from swebench python -c "import swebench; print(f'swebench {swebench.__version__}')" || {
+        echo "    ERROR: Failed to install/run swebench via uvx"
+        exit 1
+    }
+fi
+echo "    swebench: available"
+
+check_gcloud_creds warning
+setup_vertex_env
+
+echo "    All prerequisites satisfied."
+echo ""
+
+# ── Step 3: Load instance from HuggingFace ──
+
+log "Step 3: Loading instance ${INSTANCE_ID} from ${DATASET}"
+
+INSTANCE_JSON="$(mktemp /tmp/swebench-instance-XXXXXX.json)"
+
+${SWEBENCH} -c "
+import json, sys
+from datasets import load_dataset
+
+ds = load_dataset('${DATASET}', split='test')
+matches = [x for x in ds if x['instance_id'] == '${INSTANCE_ID}']
+if not matches:
+    print('ERROR: Instance ${INSTANCE_ID} not found in ${DATASET}', file=sys.stderr)
+    sys.exit(1)
+instance = matches[0]
+json.dump({
+    'instance_id': instance['instance_id'],
+    'repo': instance['repo'],
+    'base_commit': instance['base_commit'],
+    'problem_statement': instance['problem_statement'],
+}, open('${INSTANCE_JSON}', 'w'), indent=2)
+print(f'Loaded: {instance[\"instance_id\"]}')
+print(f'Repo:   {instance[\"repo\"]}')
+print(f'Commit: {instance[\"base_commit\"][:12]}...')
+"
+
+if [ ! -s "${INSTANCE_JSON}" ]; then
+    echo "    ERROR: Failed to load instance data"
+    exit 1
+fi
+
+REPO="$(python3 -c "import json; print(json.load(open('${INSTANCE_JSON}'))['repo'])")"
+BASE_COMMIT="$(python3 -c "import json; print(json.load(open('${INSTANCE_JSON}'))['base_commit'])")"
+
+echo "    Instance loaded successfully."
+echo ""
+
+# ── Step 4: Setup workspace ──
+
+log "Step 4: Setting up workspace"
+
+WORKSPACE="$(mktemp -d /tmp/swebench-workspace-XXXXXX)"
+echo "    Workspace: ${WORKSPACE}"
+echo "    Cloning https://github.com/${REPO}..."
+
+git clone --quiet "https://github.com/${REPO}.git" "${WORKSPACE}/repo"
+cd "${WORKSPACE}/repo"
+git checkout --quiet "${BASE_COMMIT}"
+
+echo "    Checked out ${BASE_COMMIT:0:12}"
+echo "    Working directory: ${WORKSPACE}/repo"
+
+echo ""
+
+# ── Step 5: Run solver (Claude Code) ──
+
+log "Step 5: Running Claude Code solver (timeout: ${SOLVER_TIMEOUT}s)"
+echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+SOLVER_PROMPT_FILE="${WORKSPACE}/solver_prompt.txt"
+python3 -c "
+import json
+with open('${INSTANCE_JSON}') as f:
+    instance = json.load(f)
+
+# Rewrite /testbed/ paths to relative paths (we can't create /testbed symlink)
+problem_statement = instance['problem_statement']
+problem_statement = problem_statement.replace('/testbed/', './')
+
+prompt = '''You are fixing a bug in an open-source Python project.
+
+## Problem Statement
+
+''' + problem_statement + '''
+
+## Instructions
+
+1. Read the problem statement carefully
+2. Explore the repository to understand the codebase
+3. Find the root cause of the bug
+4. Implement a fix
+5. Run the relevant tests to verify your fix works
+6. Make sure you don't break existing tests
+
+The repository is available at the current working directory.'''
+with open('${SOLVER_PROMPT_FILE}', 'w') as f:
+    f.write(prompt)
+"
+
+if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+    echo "    Using Vertex AI (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
+fi
+
+cd "${WORKSPACE}/repo"
+
+export_claude_env
+
+SOLVER_LOG="${WORKSPACE}/solver_output.log"
+SOLVER_EXIT=0
+timeout "${SOLVER_TIMEOUT}" claude -p "$(cat "${SOLVER_PROMPT_FILE}")" \
+    --model "${ANTHROPIC_MODEL}" \
+    --verbose \
+    --max-turns 200 \
+    --permission-mode bypassPermissions \
+    --output-format stream-json \
+    2>&1 | tee "${SOLVER_LOG}" | tail -50 || true
+SOLVER_EXIT=${PIPESTATUS[0]}
+
+if [ "${SOLVER_EXIT}" -eq 124 ]; then
+    echo "    Solver timed out after ${SOLVER_TIMEOUT}s"
+elif [ "${SOLVER_EXIT}" -ne 0 ]; then
+    echo "    Solver exited with code ${SOLVER_EXIT}"
+fi
+
+echo "    Finished at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# ── Step 6: Capture patch ──
+
+log "Step 6: Capturing patch"
+
+cd "${WORKSPACE}/repo"
+PATCH_FILE="${WORKSPACE}/model_patch.diff"
+git diff > "${PATCH_FILE}"
+
+PATCH_SIZE="$(wc -c < "${PATCH_FILE}")"
+if [ "${PATCH_SIZE}" -eq 0 ]; then
+    echo "    WARNING: Solver produced no changes (empty diff)"
+    echo "    Evaluation will proceed but instance will not be resolved."
+else
+    PATCH_LINES="$(wc -l < "${PATCH_FILE}")"
+    PATCH_FILES="$(git diff --name-only | wc -l)"
+    echo "    Patch: ${PATCH_LINES} lines across ${PATCH_FILES} file(s)"
+fi
+echo ""
+
+# ── Step 7: Write predictions.jsonl ──
+
+log "Step 7: Writing predictions.jsonl"
+
+PREDICTIONS_DIR="$(mktemp -d /tmp/swebench-predictions-XXXXXX)"
+PREDICTIONS_FILE="${PREDICTIONS_DIR}/predictions.jsonl"
+
+python3 -c "
+import json
+
+with open('${PATCH_FILE}') as f:
+    model_patch = f.read()
+
+prediction = {
+    'instance_id': '${INSTANCE_ID}',
+    'model_name_or_path': 'claude-code',
+    'model_patch': model_patch,
+}
+with open('${PREDICTIONS_FILE}', 'w') as f:
+    json.dump(prediction, f)
+    f.write('\n')
+print('    Written to ${PREDICTIONS_FILE}')
+"
+
+echo ""
+
+# ── Step 8: Run SWE-bench evaluation ──
+
+log "Step 8: Running SWE-bench evaluation"
+echo "    This may take 10-30 minutes on first run (Docker image build)..."
+
+cd "${HARNESS_DIR}"
+
+EVAL_EXIT=0
+${SWEBENCH} -m swebench.harness.run_evaluation \
+    --dataset_name "${DATASET}" \
+    --predictions_path "${PREDICTIONS_FILE}" \
+    --instance_ids "${INSTANCE_ID}" \
+    --max_workers 1 \
+    --run_id "${RUN_ID}" \
+    --cache_level env \
+    --timeout 1800 \
+    2>&1 || EVAL_EXIT=$?
+
+if [ "${EVAL_EXIT}" -ne 0 ]; then
+    echo "    ERROR: SWE-bench evaluation failed with exit code ${EVAL_EXIT}"
+    exit 1
+fi
+
+echo "    Evaluation complete."
+echo ""
+
+# ── Step 9: Extract and report results ──
+
+log "Step 9: Extracting results"
+
+MODEL_NAME="claude-code"
+RESULTS_JSON=""
+
+for candidate in \
+    "${HARNESS_DIR}/${MODEL_NAME}.${RUN_ID}.json" \
+    "${HARNESS_DIR}/logs/run_evaluation/${RUN_ID}/${MODEL_NAME}/${INSTANCE_ID}/report.json" \
+    "${HARNESS_DIR}/evaluation_results/${RUN_ID}/results.json"; do
+    if [ -f "${candidate}" ]; then
+        RESULTS_JSON="${candidate}"
+        break
+    fi
+done
+
+if [ -z "${RESULTS_JSON}" ]; then
+    echo "    Known paths not found, searching for results..."
+    for candidate in $(find "${HARNESS_DIR}" -maxdepth 3 -name "*${RUN_ID}*.json" 2>/dev/null | head -5); do
+        if [ -f "${candidate}" ]; then
+            RESULTS_JSON="${candidate}"
+            break
+        fi
+    done
+fi
+
+if [ -n "${RESULTS_JSON}" ] && [ -f "${RESULTS_JSON}" ]; then
+    echo "    Results file: ${RESULTS_JSON}"
+    eval "$(python3 -c "
+import json
+
+with open('${RESULTS_JSON}') as f:
+    data = json.load(f)
+
+resolved = 0
+total = 0
+
+if isinstance(data, dict) and 'resolved_instances' in data:
+    resolved = int(data['resolved_instances'])
+    total = int(data.get('total_instances', 1))
+elif isinstance(data, dict):
+    for iid, result in data.items():
+        if isinstance(result, dict):
+            total += 1
+            if result.get('resolved', False):
+                resolved += 1
+elif isinstance(data, list):
+    for result in data:
+        if isinstance(result, dict):
+            total += 1
+            if result.get('resolved', False):
+                resolved += 1
+
+print(f'RESOLVED={resolved}')
+print(f'TOTAL={max(total, 1)}')
+")"
+else
+    echo "    No results files found. Marking as unresolved."
+    RESOLVED=0
+    TOTAL=1
+fi
+
+echo ""
+echo "============================================"
+if [ "${RESOLVED}" -gt 0 ]; then
+    echo "  Result: RESOLVED (${RESOLVED}/${TOTAL})"
+else
+    echo "  Result: NOT RESOLVED (${RESOLVED}/${TOTAL})"
+fi
+echo "============================================"
+echo ""
+
+STATUS="success"
+
+# cleanup trap will write the final result JSON and exit 0

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# benchmarks/run-terminalbench.sh — Standalone CI pipeline for TerminalBench.
+# Thin wrapper around Harbor, which handles the entire lifecycle:
+# container orchestration, agent execution, verification, and scoring.
+
+# ── Shared library ──
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# ── Configuration ──
+
+TASK_NAME="${1:-regex-chess}"
+SOLVER_TIMEOUT="${2:-1800}"
+
+BENCHMARK="terminalbench"
+INSTANCE_ID="${TASK_NAME}"
+RUN_ID="ci-terminalbench-${TIMESTAMP}"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-terminalbench.json"
+
+JOBS_DIR=""
+
+PASSED=0
+RESOLVED=0
+TOTAL=1
+
+# ── Helpers ──
+
+cleanup() {
+    local exit_code=$?
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
+            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
+        else
+            log "Cleaning up harbor jobs directory"
+            rm -rf "${JOBS_DIR}"
+        fi
+    fi
+    PASSED="${RESOLVED}"
+    write_result
+    if [ "${STATUS}" = "success" ]; then
+        exit 0
+    else
+        exit "${exit_code:-1}"
+    fi
+}
+
+trap cleanup EXIT
+
+# ── Step 1: Parse and display configuration ──
+
+show_banner "TerminalBench"
+log "Step 1: Configuration"
+echo "    Task name:       ${TASK_NAME}"
+echo "    Solver timeout:  ${SOLVER_TIMEOUT}s ($(( SOLVER_TIMEOUT / 3600 ))h $(( (SOLVER_TIMEOUT % 3600) / 60 ))m)"
+echo "    Run ID:          ${RUN_ID}"
+echo "    Timestamp:       ${TIMESTAMP}"
+echo ""
+
+# ── Step 2: Validate prerequisites ──
+
+log "Step 2: Validating prerequisites"
+
+MISSING=()
+
+if ! command -v docker &>/dev/null && [ ! -x /usr/bin/docker ]; then
+    MISSING+=("docker (install from https://docs.docker.com/get-docker/)")
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "    ERROR: Missing prerequisites:"
+    for m in "${MISSING[@]}"; do
+        echo "      - ${m}"
+    done
+    exit 1
+fi
+
+echo "    docker: found"
+
+ensure_uvx
+
+echo "    harbor: checking availability via uvx..."
+if ! uvx harbor --version &>/dev/null 2>&1; then
+    echo "    harbor: installing via uvx..."
+    uvx harbor --version || {
+        echo "    ERROR: Failed to install/run harbor via uvx"
+        exit 1
+    }
+fi
+echo "    harbor: available"
+
+# API key configuration — Harbor's claude-code agent needs API access
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "    ANTHROPIC_API_KEY: set"
+else
+    setup_vertex_env
+    if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+        echo "    Vertex AI: configured (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
+    else
+        echo "    WARNING: No ANTHROPIC_API_KEY or Vertex AI configuration found."
+        echo "    Harbor's claude-code agent requires API access."
+    fi
+fi
+
+echo "    All prerequisites satisfied."
+echo ""
+
+# ── Step 3: Run Harbor evaluation ──
+
+log "Step 3: Running Harbor evaluation"
+
+JOBS_DIR="$(mktemp -d /tmp/terminalbench-jobs-XXXXXX)"
+echo "    Jobs directory: ${JOBS_DIR}"
+echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Agent timeout multiplier scales the per-task timeout from task.toml.
+# Default task timeout is typically 120s; multiplier adjusts to our desired solver timeout.
+TIMEOUT_MULTIPLIER=$(( SOLVER_TIMEOUT / 120 ))
+[ "${TIMEOUT_MULTIPLIER}" -lt 1 ] && TIMEOUT_MULTIPLIER=1
+
+MODEL="anthropic/claude-opus-4-6"
+
+echo "    Model:           ${MODEL}"
+echo "    Timeout mult:    ${TIMEOUT_MULTIPLIER}x"
+echo "    Task:            ${TASK_NAME}"
+echo ""
+
+cd "${HARNESS_DIR}"
+
+HARBOR_EXIT=0
+if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+    GCLOUD_ADC="${HOME}/.config/gcloud/application_default_credentials.json"
+    echo "    Auth mode:       Vertex AI (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
+    uvx harbor run \
+        --dataset terminal-bench@2.0 \
+        --agent claude-code \
+        --model "${MODEL}" \
+        --include-task-name "${TASK_NAME}" \
+        --n-concurrent 1 \
+        --jobs-dir "${JOBS_DIR}" \
+        --agent-timeout-multiplier "${TIMEOUT_MULTIPLIER}" \
+        --ae "CLAUDE_CODE_USE_VERTEX=1" \
+        --ae "ANTHROPIC_VERTEX_PROJECT_ID=${ANTHROPIC_VERTEX_PROJECT_ID}" \
+        --ae "CLOUD_ML_REGION=${CLOUD_ML_REGION:-us-east5}" \
+        --ae "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcloud-adc.json" \
+        --ae "CLAUDE_CODE_SUBAGENT_MODEL=${CLAUDE_CODE_SUBAGENT_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
+        --ae "ANTHROPIC_DEFAULT_OPUS_MODEL=${ANTHROPIC_DEFAULT_OPUS_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=${CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING:-1}" \
+        --ae "MAX_THINKING_TOKENS=${MAX_THINKING_TOKENS:-128000}" \
+        --ae "CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL:-XHIGH}" \
+        --mounts '[{"type": "bind", "source": "'"${GCLOUD_ADC}"'", "target": "/tmp/gcloud-adc.json", "read_only": true}]' \
+        2>&1 || HARBOR_EXIT=$?
+else
+    echo "    Auth mode:       Direct API (ANTHROPIC_API_KEY)"
+    uvx harbor run \
+        --dataset terminal-bench@2.0 \
+        --agent claude-code \
+        --model "${MODEL}" \
+        --include-task-name "${TASK_NAME}" \
+        --n-concurrent 1 \
+        --jobs-dir "${JOBS_DIR}" \
+        --agent-timeout-multiplier "${TIMEOUT_MULTIPLIER}" \
+        --ae "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_SUBAGENT_MODEL=${CLAUDE_CODE_SUBAGENT_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
+        --ae "ANTHROPIC_DEFAULT_OPUS_MODEL=${ANTHROPIC_DEFAULT_OPUS_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=${CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING:-1}" \
+        --ae "MAX_THINKING_TOKENS=${MAX_THINKING_TOKENS:-128000}" \
+        --ae "CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL:-XHIGH}" \
+        2>&1 || HARBOR_EXIT=$?
+fi
+
+if [ "${HARBOR_EXIT}" -ne 0 ]; then
+    echo "    Harbor exited with code ${HARBOR_EXIT}"
+fi
+
+echo "    Finished at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# ── Step 4: Extract and report results ──
+
+log "Step 4: Extracting results"
+
+# Harbor writes reward files inside its jobs directory.
+# Path pattern: jobs/<name>/trials/<task>/attempt_<n>/logs/verifier/reward.txt
+# Search for reward.json first (multi-metric), then reward.txt (single score).
+REWARD_FILE=""
+
+for candidate in $(find "${JOBS_DIR}" -name 'reward.json' 2>/dev/null); do
+    if [ -f "${candidate}" ]; then
+        REWARD_FILE="${candidate}"
+        break
+    fi
+done
+
+if [ -z "${REWARD_FILE}" ]; then
+    for candidate in $(find "${JOBS_DIR}" -name 'reward.txt' 2>/dev/null); do
+        if [ -f "${candidate}" ]; then
+            REWARD_FILE="${candidate}"
+            break
+        fi
+    done
+fi
+
+if [ -n "${REWARD_FILE}" ] && [ -f "${REWARD_FILE}" ]; then
+    echo "    Reward file: ${REWARD_FILE}"
+
+    if [[ "${REWARD_FILE}" == *.json ]]; then
+        eval "$(python3 -c "
+import json
+with open('${REWARD_FILE}') as f:
+    data = json.load(f)
+if isinstance(data, dict):
+    values = [v for v in data.values() if isinstance(v, (int, float))]
+    score = sum(values) / len(values) if values else 0.0
+    resolved = 1 if score > 0.5 else 0
+elif isinstance(data, (int, float)):
+    resolved = 1 if float(data) > 0.5 else 0
+else:
+    resolved = 0
+print(f'RESOLVED={resolved}')
+print(f'TOTAL=1')
+")"
+    else
+        REWARD_VALUE="$(cat "${REWARD_FILE}" | tr -d '[:space:]')"
+        echo "    Reward value: ${REWARD_VALUE}"
+        if [ "${REWARD_VALUE}" = "1" ] || [ "${REWARD_VALUE}" = "1.0" ]; then
+            RESOLVED=1
+        else
+            RESOLVED=0
+        fi
+        TOTAL=1
+    fi
+else
+    # Fallback: search for summary/results files
+    SUMMARY_FILE=""
+    for candidate in $(find "${JOBS_DIR}" -name 'results*.json' -o -name 'summary*.json' 2>/dev/null); do
+        if [ -f "${candidate}" ]; then
+            SUMMARY_FILE="${candidate}"
+            break
+        fi
+    done
+
+    if [ -n "${SUMMARY_FILE}" ] && [ -f "${SUMMARY_FILE}" ]; then
+        echo "    Summary file: ${SUMMARY_FILE}"
+        eval "$(python3 -c "
+import json
+with open('${SUMMARY_FILE}') as f:
+    data = json.load(f)
+resolved = 0
+total = 1
+if isinstance(data, dict):
+    if 'reward' in data:
+        resolved = 1 if float(data['reward']) > 0.5 else 0
+    elif 'score' in data:
+        resolved = 1 if float(data['score']) > 0.5 else 0
+    elif 'results' in data:
+        results = data['results']
+        if isinstance(results, dict):
+            total = len(results)
+            resolved = sum(1 for v in results.values()
+                         if isinstance(v, dict) and v.get('reward', 0) > 0.5)
+        elif isinstance(results, list):
+            total = len(results)
+            resolved = sum(1 for v in results
+                         if isinstance(v, dict) and v.get('reward', 0) > 0.5)
+print(f'RESOLVED={resolved}')
+print(f'TOTAL={max(total, 1)}')
+")"
+    else
+        echo "    No results files found. Marking as unresolved."
+        echo "    Contents of jobs directory:"
+        find "${JOBS_DIR}" -type f 2>/dev/null | head -20 || echo "      (empty)"
+        RESOLVED=0
+        TOTAL=1
+    fi
+fi
+
+echo ""
+echo "============================================"
+if [ "${RESOLVED}" -gt 0 ]; then
+    echo "  Result: RESOLVED (${RESOLVED}/${TOTAL})"
+else
+    echo "  Result: NOT RESOLVED (${RESOLVED}/${TOTAL})"
+fi
+echo "============================================"
+echo ""
+
+STATUS="success"
+
+# cleanup trap will write the final result JSON and exit 0

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# benchmarks/run.sh — Unified entry point for all benchmark runners.
+#
+# Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve]
+#
+# Arguments:
+#   benchmark      Required. One of: swebench, featurebench, terminalbench
+#   instance_id    Required. Benchmark-specific instance identifier
+#
+# Options:
+#   --timeout N    Solver timeout in seconds
+#   --split S      Dataset split (featurebench only)
+#   --preserve     Keep workspace/volumes after run
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Parse arguments ──
+
+if [ $# -lt 2 ]; then
+    echo "Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve]"
+    echo ""
+    echo "Benchmarks: swebench, featurebench, terminalbench"
+    exit 1
+fi
+
+BENCHMARK="$1"
+INSTANCE_ID="$2"
+shift 2
+
+TIMEOUT=""
+SPLIT=""
+PRESERVE=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --timeout)
+            TIMEOUT="$2"
+            shift 2
+            ;;
+        --split)
+            SPLIT="$2"
+            shift 2
+            ;;
+        --preserve)
+            PRESERVE=1
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# ── Validate benchmark ──
+
+case "${BENCHMARK}" in
+    swebench|featurebench|terminalbench)
+        ;;
+    programbench)
+        echo "ERROR: ProgramBench requires a self-hosted runner and is not available in this CI setup."
+        echo "See the programbench-factory repository for ProgramBench support."
+        exit 1
+        ;;
+    *)
+        echo "ERROR: Unknown benchmark '${BENCHMARK}'"
+        echo "Valid benchmarks: swebench, featurebench, terminalbench"
+        exit 1
+        ;;
+esac
+
+# ── Dispatch ──
+
+case "${BENCHMARK}" in
+    swebench)
+        [ -n "${PRESERVE}" ] && export PRESERVE_WORKSPACE=1
+        exec "${SCRIPT_DIR}/run-swebench.sh" "${INSTANCE_ID}" ${TIMEOUT:+"${TIMEOUT}"}
+        ;;
+    featurebench)
+        [ -n "${PRESERVE}" ] && export PRESERVE_WORKSPACE=1
+        # Split is $3, so if it's set we must also pass timeout as $2
+        if [ -n "${SPLIT}" ]; then
+            exec "${SCRIPT_DIR}/run-featurebench.sh" "${INSTANCE_ID}" "${TIMEOUT:-1800}" "${SPLIT}"
+        else
+            exec "${SCRIPT_DIR}/run-featurebench.sh" "${INSTANCE_ID}" ${TIMEOUT:+"${TIMEOUT}"}
+        fi
+        ;;
+    terminalbench)
+        [ -n "${PRESERVE}" ] && export PRESERVE_WORKSPACE=1
+        exec "${SCRIPT_DIR}/run-terminalbench.sh" "${INSTANCE_ID}" ${TIMEOUT:+"${TIMEOUT}"}
+        ;;
+esac


### PR DESCRIPTION
## Summary

- Add `benchmarks/` directory with runner scripts for SWE-bench, FeatureBench, and TerminalBench (adapted from programbench-factory)
- Add `.github/workflows/benchmark.yml` — a `workflow_dispatch` workflow for manual benchmark runs before releases
- Supports running individual benchmarks or all three in parallel via matrix strategy
- ProgramBench is excluded (requires self-hosted runner) — dispatcher prints a clear error if attempted
- Auth pattern follows the existing `ceo-review.yml` workflow (GCP SA key + Vertex AI)

## Changes

- `benchmarks/run.sh` — unified entry point dispatcher
- `benchmarks/lib.sh` — shared functions (result writing, env setup, credential checks); fixed `CI_RESULTS_DIR` to point to `benchmarks/results/`
- `benchmarks/run-swebench.sh` — full SWE-bench solve+eval pipeline
- `benchmarks/run-featurebench.sh` — full FeatureBench solve+eval pipeline  
- `benchmarks/run-terminalbench.sh` — TerminalBench via Harbor
- `benchmarks/results/.gitkeep` — results directory placeholder
- `.github/workflows/benchmark.yml` — workflow_dispatch with benchmark selector, instance ID, and timeout inputs

## Test plan

- [ ] Trigger workflow manually with `benchmark: swebench` and default instance
- [ ] Trigger workflow with `benchmark: all` to verify parallel matrix execution
- [ ] Verify results artifacts are uploaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)