### PR TITLE
feat: add PR comments and release notes to benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,9 +22,17 @@ on:
         required: false
         default: '1800'
         type: string
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'factory/**'
+      - 'benchmarks/**'
+  release:
+    types: [created]
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
   id-token: write
 
 jobs:
@@ -37,13 +45,13 @@ jobs:
         include:
           - benchmark: swebench
             default_instance: 'sympy__sympy-20590'
-            enabled: ${{ inputs.benchmark == 'swebench' || inputs.benchmark == 'all' }}
+            enabled: ${{ (github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all' }}
           - benchmark: featurebench
             default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
-            enabled: ${{ inputs.benchmark == 'featurebench' || inputs.benchmark == 'all' }}
+            enabled: ${{ (github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all' }}
           - benchmark: terminalbench
             default_instance: 'fix-git'
-            enabled: ${{ inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all' }}
+            enabled: ${{ (github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all' }}
     if: true
 
     steps:
@@ -88,10 +96,20 @@ jobs:
         if: steps.gate.outputs.run == 'true'
         run: |
           INSTANCE="${{ inputs.instance_id }}"
-          if [ "$INSTANCE" = "auto" ]; then
+          if [ "$INSTANCE" = "auto" ] || [ -z "$INSTANCE" ]; then
             INSTANCE="${{ matrix.default_instance }}"
           fi
           echo "instance=$INSTANCE" >> "$GITHUB_OUTPUT"
+
+      - name: Determine timeout
+        id: timeout
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
+            echo 'value=${{ inputs.timeout }}' >> $GITHUB_OUTPUT
+          else
+            echo 'value=600' >> $GITHUB_OUTPUT
+          fi
 
       - name: Run ${{ matrix.benchmark }} benchmark
         if: steps.gate.outputs.run == 'true'
@@ -107,7 +125,7 @@ jobs:
           CLAUDE_CODE_EFFORT_LEVEL: "XHIGH"
         run: |
           chmod +x benchmarks/run.sh benchmarks/lib.sh benchmarks/run-*.sh
-          benchmarks/run.sh ${{ matrix.benchmark }} ${{ steps.config.outputs.instance }} --timeout ${{ inputs.timeout }}
+          benchmarks/run.sh ${{ matrix.benchmark }} ${{ steps.config.outputs.instance }} --timeout ${{ steps.timeout.outputs.value }}
 
       - name: Upload results
         uses: actions/upload-artifact@v4
@@ -127,3 +145,67 @@ jobs:
               echo '```' >> $GITHUB_STEP_SUMMARY
             fi
           done
+
+      - name: Post PR comment
+        if: always() && github.event_name == 'pull_request' && steps.gate.outputs.run == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            let body = '## Benchmark Results: ${{ matrix.benchmark }}\n\n';
+
+            const files = fs.readdirSync('benchmarks/results/');
+            for (const file of files) {
+              if (file.endsWith('.json')) {
+                const data = JSON.parse(fs.readFileSync('benchmarks/results/' + file, 'utf8'));
+                const status = data.resolved ? '✅ RESOLVED' : '❌ NOT RESOLVED';
+                body += '| Field | Value |\n|---|---|\n';
+                body += '| Benchmark | ' + data.benchmark + ' |\n';
+                body += '| Instance | `' + data.instance_id + '` |\n';
+                body += '| Result | ' + status + ' |\n';
+                body += '| Score | ' + data.score + ' |\n';
+                body += '| Duration | ' + data.duration_seconds + 's |\n\n';
+                body += '<details><summary>Full JSON</summary>\n\n```json\n' + JSON.stringify(data, null, 2) + '\n```\n</details>\n';
+              }
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+      - name: Update release notes
+        if: always() && github.event_name == 'release' && steps.gate.outputs.run == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            let benchmarkSection = '\n\n## Benchmark Results\n\n';
+            benchmarkSection += '| Benchmark | Instance | Result | Score | Duration |\n';
+            benchmarkSection += '|-----------|----------|--------|-------|----------|\n';
+
+            const files = fs.readdirSync('benchmarks/results/');
+            for (const file of files) {
+              if (file.endsWith('.json')) {
+                const data = JSON.parse(fs.readFileSync('benchmarks/results/' + file, 'utf8'));
+                const status = data.resolved ? '✅' : '❌';
+                benchmarkSection += '| ' + data.benchmark + ' | `' + data.instance_id + '` | ' + status + ' | ' + data.score + ' | ' + data.duration_seconds + 's |\n';
+              }
+            }
+
+            const release = await github.rest.repos.getRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: context.payload.release.id
+            });
+
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: context.payload.release.id,
+              body: (release.data.body || '') + benchmarkSection
+            });

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,6 +30,10 @@ on:
   release:
     types: [created]
 
+concurrency:
+  group: benchmark-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -104,11 +108,13 @@ jobs:
       - name: Determine timeout
         id: timeout
         if: steps.gate.outputs.run == 'true'
+        env:
+          BENCHMARK_TIMEOUT: ${{ inputs.timeout }}
         run: |
           if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
-            echo 'value=${{ inputs.timeout }}' >> $GITHUB_OUTPUT
+            echo "value=$BENCHMARK_TIMEOUT" >> "$GITHUB_OUTPUT"
           else
-            echo 'value=600' >> $GITHUB_OUTPUT
+            echo 'value=600' >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run ${{ matrix.benchmark }} benchmark
@@ -138,63 +144,120 @@ jobs:
         if: always() && steps.gate.outputs.run == 'true'
         run: |
           echo "## ${{ matrix.benchmark }} Results" >> $GITHUB_STEP_SUMMARY
-          for f in benchmarks/results/*.json; do
-            if [ -f "$f" ]; then
-              echo '```json' >> $GITHUB_STEP_SUMMARY
-              cat "$f" >> $GITHUB_STEP_SUMMARY
-              echo '```' >> $GITHUB_STEP_SUMMARY
-            fi
-          done
+          if [ -d "benchmarks/results" ]; then
+            for f in benchmarks/results/*.json; do
+              if [ -f "$f" ]; then
+                echo '```json' >> $GITHUB_STEP_SUMMARY
+                cat "$f" >> $GITHUB_STEP_SUMMARY
+                echo '```' >> $GITHUB_STEP_SUMMARY
+              fi
+            done
+          fi
+
+  report:
+    needs: benchmark
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all benchmark artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: benchmark-results-*
+          merge-multiple: true
+          path: results/
 
       - name: Post PR comment
-        if: always() && github.event_name == 'pull_request' && steps.gate.outputs.run == 'true'
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
+            const marker = '<!-- benchmark-results -->';
 
-            let body = '## Benchmark Results: ${{ matrix.benchmark }}\n\n';
+            if (!fs.existsSync('results/')) {
+              console.log('No results directory found, skipping PR comment');
+              return;
+            }
 
-            const files = fs.readdirSync('benchmarks/results/');
+            let body = marker + '\n## Benchmark Results\n\n';
+            const files = fs.readdirSync('results/');
+            let hasResults = false;
+
             for (const file of files) {
               if (file.endsWith('.json')) {
-                const data = JSON.parse(fs.readFileSync('benchmarks/results/' + file, 'utf8'));
+                hasResults = true;
+                const data = JSON.parse(fs.readFileSync('results/' + file, 'utf8'));
                 const status = data.resolved ? '✅ RESOLVED' : '❌ NOT RESOLVED';
+                body += '### ' + data.benchmark + '\n\n';
                 body += '| Field | Value |\n|---|---|\n';
                 body += '| Benchmark | ' + data.benchmark + ' |\n';
                 body += '| Instance | `' + data.instance_id + '` |\n';
                 body += '| Result | ' + status + ' |\n';
                 body += '| Score | ' + data.score + ' |\n';
                 body += '| Duration | ' + data.duration_seconds + 's |\n\n';
-                body += '<details><summary>Full JSON</summary>\n\n```json\n' + JSON.stringify(data, null, 2) + '\n```\n</details>\n';
+                body += '<details><summary>Full JSON</summary>\n\n```json\n' + JSON.stringify(data, null, 2) + '\n```\n</details>\n\n';
               }
             }
 
-            await github.rest.issues.createComment({
+            if (!hasResults) {
+              body += '_No benchmark results found._\n';
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
+              repo: context.repo.repo
             });
 
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            }
+
       - name: Update release notes
-        if: always() && github.event_name == 'release' && steps.gate.outputs.run == 'true'
+        if: github.event_name == 'release'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
 
+            if (!fs.existsSync('results/')) {
+              console.log('No results directory found, skipping release notes update');
+              return;
+            }
+
             let benchmarkSection = '\n\n## Benchmark Results\n\n';
             benchmarkSection += '| Benchmark | Instance | Result | Score | Duration |\n';
             benchmarkSection += '|-----------|----------|--------|-------|----------|\n';
 
-            const files = fs.readdirSync('benchmarks/results/');
+            const files = fs.readdirSync('results/');
+            let hasResults = false;
+
             for (const file of files) {
               if (file.endsWith('.json')) {
-                const data = JSON.parse(fs.readFileSync('benchmarks/results/' + file, 'utf8'));
+                hasResults = true;
+                const data = JSON.parse(fs.readFileSync('results/' + file, 'utf8'));
                 const status = data.resolved ? '✅' : '❌';
                 benchmarkSection += '| ' + data.benchmark + ' | `' + data.instance_id + '` | ' + status + ' | ' + data.score + ' | ' + data.duration_seconds + 's |\n';
               }
+            }
+
+            if (!hasResults) {
+              console.log('No JSON results found, skipping release notes update');
+              return;
             }
 
             const release = await github.rest.repos.getRelease({


### PR DESCRIPTION
## Summary

Updates the benchmark CI workflow to post results where they're visible:

- **PR comments**: When benchmarks run on a PR, results are posted as a formatted comment with score table and collapsible JSON
- **Release notes**: When benchmarks run on a release, results table is appended to the release body
- **New triggers**: `pull_request` (on `factory/**` and `benchmarks/**` changes) and `release` (on creation), in addition to existing `workflow_dispatch`
- **Smoke test timeout**: PR and release triggers use 600s timeout (vs user-specified for manual dispatch)

All benchmarks are auto-enabled for PR/release triggers. Manual dispatch retains the benchmark selector.

## Test plan

- [ ] Trigger workflow manually via Actions tab
- [ ] Verify PR comment is posted when triggered on a PR
- [ ] Verify release notes are updated when triggered on a release