### PR TITLE
test: trigger benchmark CI on PR

### DIFF
--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# benchmarks/run.sh — Unified entry point for all benchmark runners.
+# benchmarks/run.sh — Unified entry point for all benchmark runners. — Unified entry point for all benchmark runners.
 #
 # Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve]
 #


### PR DESCRIPTION
Trivial change to benchmarks/run.sh to test the benchmark CI workflow triggers on PRs.