### PR TITLE
fix: benchmark workflow skips all jobs on PR trigger

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,16 +56,15 @@ jobs:
           - benchmark: terminalbench
             default_instance: 'fix-git'
             enabled: ${{ (github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all' }}
-    if: true
 
     steps:
       - name: Skip if not enabled
-        if: matrix.enabled != 'true'
+        if: ${{ !matrix.enabled }}
         run: echo "Skipping ${{ matrix.benchmark }} (not selected)" && exit 0
 
       - name: Gate
         id: gate
-        if: matrix.enabled == 'true'
+        if: ${{ matrix.enabled }}
         run: echo "run=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fixes the matrix `enabled` field check — all benchmarks were being skipped on `pull_request` events because `matrix.enabled == 'true'` (string comparison) didn't match the boolean `true` produced by the expression.

**Fix:** Replace string comparisons with direct boolean checks: `${{ matrix.enabled }}` / `${{ !matrix.enabled }}`.

Also removes the no-op `if: true` on the job level.

## Test plan

- [ ] Verify benchmarks run on this PR (not skipped)