### PR TITLE
feat: add pr_number input and fork-safe auth to benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: '1800'
         type: string
+      pr_number:
+        description: 'PR number to post results to (optional)'
+        required: false
+        default: ''
+        type: string
   pull_request:
     types: [opened, synchronize]
     paths:
@@ -75,19 +80,31 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+
+      - name: Check auth
+        id: auth_check
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          if [ -z "$GOOGLE_APPLICATION_CREDENTIALS" ] || [ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+            echo 'skip=true' >> "$GITHUB_OUTPUT"
+            echo '::warning::GCP credentials not available (fork PR?). Skipping benchmark.'
+          else
+            echo 'skip=false' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install uv
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && steps.auth_check.outputs.skip != 'true'
         uses: astral-sh/setup-uv@v4
 
       - name: Set up Node.js
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && steps.auth_check.outputs.skip != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Install Claude Code
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && steps.auth_check.outputs.skip != 'true'
         run: |
           npm install -g @anthropic-ai/claude-code
           export PATH="$(npm prefix -g)/bin:$PATH"
@@ -96,7 +113,7 @@ jobs:
 
       - name: Determine instance ID
         id: config
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && steps.auth_check.outputs.skip != 'true'
         run: |
           INSTANCE="${{ inputs.instance_id }}"
           if [ "$INSTANCE" = "auto" ] || [ -z "$INSTANCE" ]; then
@@ -106,7 +123,7 @@ jobs:
 
       - name: Determine timeout
         id: timeout
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && steps.auth_check.outputs.skip != 'true'
         env:
           BENCHMARK_TIMEOUT: ${{ inputs.timeout }}
         run: |
@@ -117,7 +134,7 @@ jobs:
           fi
 
       - name: Run ${{ matrix.benchmark }} benchmark
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && steps.auth_check.outputs.skip != 'true'
         env:
           CLAUDE_CODE_USE_VERTEX: "1"
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
@@ -134,13 +151,13 @@ jobs:
 
       - name: Upload results
         uses: actions/upload-artifact@v4
-        if: always() && steps.gate.outputs.run == 'true'
+        if: always() && steps.gate.outputs.run == 'true' && steps.auth_check.outputs.skip != 'true'
         with:
           name: benchmark-results-${{ matrix.benchmark }}
           path: benchmarks/results/
 
       - name: Print summary
-        if: always() && steps.gate.outputs.run == 'true'
+        if: always() && steps.gate.outputs.run == 'true' && steps.auth_check.outputs.skip != 'true'
         run: |
           echo "## ${{ matrix.benchmark }} Results" >> $GITHUB_STEP_SUMMARY
           if [ -d "benchmarks/results" ]; then
@@ -166,12 +183,18 @@ jobs:
           path: results/
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        if: always() && (github.event_name == 'pull_request' || inputs.pr_number != '')
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const marker = '<!-- benchmark-results -->';
+
+            const prNumber = context.issue?.number || parseInt('${{ inputs.pr_number }}', 10);
+            if (!prNumber || isNaN(prNumber)) {
+              console.log('No PR number available, skipping comment');
+              return;
+            }
 
             if (!fs.existsSync('results/')) {
               console.log('No results directory found, skipping PR comment');
@@ -203,7 +226,7 @@ jobs:
             }
 
             const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
+              issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo
             });
@@ -219,7 +242,7 @@ jobs:
               });
             } else {
               await github.rest.issues.createComment({
-                issue_number: context.issue.number,
+                issue_number: prNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: body


### PR DESCRIPTION
## Changes

- Added `pr_number` input to `workflow_dispatch` so manual runs can target a specific PR for result comments
- Updated the PR comment step to use `pr_number` input when `context.issue.number` is unavailable (workflow_dispatch triggers)
- Added `continue-on-error` to GCP auth step for `pull_request` events so fork PRs don't fail hard
- Added `auth_check` step that detects missing GCP credentials and skips benchmark execution with a warning
- Gated all credential-dependent steps (install, config, run, upload, summary) on auth check passing

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>