### PR TITLE
fix: wire up pr_number input for workflow_dispatch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -166,12 +166,18 @@ jobs:
           path: results/
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || inputs.pr_number != ''
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const marker = '<!-- benchmark-results -->';
+            const prNumber = context.issue?.number || parseInt('${{ inputs.pr_number }}', 10);
+
+            if (!prNumber || isNaN(prNumber)) {
+              console.log('No PR number available, skipping comment');
+              return;
+            }
 
             if (!fs.existsSync('results/')) {
               console.log('No results directory found, skipping PR comment');
@@ -203,7 +209,7 @@ jobs:
             }
 
             const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.issue.number,
+              issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo
             });
@@ -219,7 +225,7 @@ jobs:
               });
             } else {
               await github.rest.issues.createComment({
-                issue_number: context.issue.number,
+                issue_number: prNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: body


### PR DESCRIPTION
The pr_number input existed but wasn't used. Now when you run the workflow manually with a pr_number, results get posted as a comment on that PR.