### PR TITLE
fix: add missing pr_number input to workflow_dispatch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: '1800'
         type: string
+      pr_number:
+        description: 'PR number to post results to (optional)'
+        required: false
+        default: ''
+        type: string
   pull_request:
     types: [opened, synchronize]
     paths:


### PR DESCRIPTION
The pr_number input was referenced in the report job but never defined in the workflow_dispatch inputs. Adds the missing 4-line input definition.