### PR TITLE
fix: disable benchmark CI from running on every PR

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,11 +27,12 @@ on:
         required: false
         default: ''
         type: string
-  pull_request:
-    types: [opened, synchronize]
-    paths:
-      - 'factory/**'
-      - 'benchmarks/**'
+  # pull_request trigger disabled — use workflow_dispatch with pr_number instead
+  # pull_request:
+  #   types: [opened, synchronize]
+  #   paths:
+  #     - 'factory/**'
+  #     - 'benchmarks/**'
   release:
     types: [created]
 


### PR DESCRIPTION
Disables the pull_request trigger. Use workflow_dispatch with pr_number instead to run benchmarks on a specific PR.