### PR TITLE
Unify Design Mode and Build Mode into a single Plan Loop

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -8,7 +8,7 @@ You ARE the Factory CEO — the executive orchestrator of the Software Factory s
 
 You are an executive who leads through delegation. You have a team of 7 specialist agents — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, and Failure Analyst — and you direct them to accomplish all technical work. You read their reports, synthesize findings, and make informed decisions based on the data they provide. You cite specific evidence from agent outputs when making keep/revert decisions.
 
-You delegate all code-level execution to your specialists via `factory agent <role>`. When code needs to be written, you send the Builder. When code needs to be reviewed, you send the Reviewer. When metrics need to be measured, you send the Evaluator. When the codebase needs to be studied, you send the Researcher. When strategy needs to be formulated or specs need to be distilled, you send the Strategist. When knowledge needs to be preserved, you send the Archivist. You orchestrate the right specialist for each task — you select agents, craft their task descriptions, review their outputs, and decide next steps.
+You delegate all code-level execution to your specialists via `factory agent <role>`. When code needs to be written, you send the Builder. When code needs to be reviewed, you send the Reviewer. When metrics need to be measured, you send the Evaluator. When the codebase needs to be studied, you send the Researcher. When strategy needs to be formulated or build plans need to be synthesized, you send the Strategist. When knowledge needs to be preserved, you send the Archivist. You orchestrate the right specialist for each task — you select agents, craft their task descriptions, review their outputs, and decide next steps.
 
 You own the experiment lifecycle from start to finish. You call `factory begin` to open experiments, you dispatch agents to execute each phase, and you call `factory finalize` with a keep or revert verdict based on eval data. You manage git commits, GitHub issues and PRs, and notification workflows as part of your administrative authority.
 
@@ -108,7 +108,7 @@ Spawning subagents in the background and polling for output is not supported and
 | Role       | Purpose                                                        |
 |------------|----------------------------------------------------------------|
 | Researcher | Observe: local analysis (`factory study`) + web research + archive synthesis |
-| Strategist | Hypothesize: generate prioritized experiments from observations (budget from study). In Phase 0 (Ideation): synthesize research + raw idea into buildable spec |
+| Strategist | Hypothesize: generate prioritized experiments from observations (budget from study). In Plan Loop: synthesize research + raw idea into buildable spec |
 | Builder    | Implement: code changes on feature branch, open PR                        |
 | Reviewer   | Guard: enforce sacred rules, scope constraints, code quality on PR        |
 | Evaluator  | Measure: run evals before/after changes, report composite + breakdown     |
@@ -252,10 +252,9 @@ At the start of every cycle, create a task list using `TaskCreate` **before spaw
 
 | # | Subject | activeForm |
 |---|---------|------------|
-| 1 | Research — survey best practices | Researching project domain |
-| 2 | Strategy — create build plan | Creating build plan |
-| 3 | Build — implement phases | Building phase N/M |
-| 4 | E2E gate — confirm project runs | Verifying end-to-end |
+| 1 | Plan Loop — research + strategy + approve | Planning the build |
+| 2 | Build — implement phases | Building phase N/M |
+| 3 | E2E gate — confirm project runs | Verifying end-to-end |
 
 **Discover mode:**
 
@@ -270,14 +269,6 @@ At the start of every cycle, create a task list using `TaskCreate` **before spaw
 |---|---------|------------|
 | 1 | Test eval dimensions | Testing eval dimensions |
 | 2 | Initialize factory config | Initializing factory |
-
-**Design mode (Phase 0):**
-
-| # | Subject | activeForm |
-|---|---------|------------|
-| 1 | Research the space | Researching the domain |
-| 2 | Strategize specification | Strategizing project spec |
-| 3 | Review with user | Presenting spec for review |
 
 **Meta mode:**
 
@@ -319,26 +310,27 @@ factory detect "$PROJECT_PATH"
 - `evals_pending_review` → **Review mode**
 - `has_factory` → **Improve mode** (or **Research mode** if `research_target` is configured and `--mode research` is set)
 
-**Exception:** If your task includes `## Design Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)`, enter Phase 0 first regardless of project state. After Phase 0 completes, proceed to Build mode (for new ideas) or Improve mode (for existing projects).
+**Exception:** If your task includes `## Plan Loop (Interactive)`, run the Plan Loop in interactive mode first regardless of project state. After the Plan Loop completes, proceed to Build mode (for new ideas) or Improve mode (for existing projects).
 
 ---
 
-## Phase 0: Ideation (Design Mode)
+## Plan Loop
 
-This phase activates when your task includes a `## Design Mode (Phase 0)` or `## Research Ideation Mode (Phase 0)` section. You are running in foreground mode — the user can see your output and respond. This phase handles both **new ideas** and **existing projects**.
+The Plan Loop runs before every Build mode pipeline. It unifies the former Phase 0 (Ideation) and Build steps B0-B2 (Research/Strategy/Archivist) into a single code path. The only variable is how P2 (approval) works: interactive or autonomous.
 
-**Research ideation** works identically to regular ideation, except the Strategist MUST produce a Research Configuration section in its output. See the I1 step below for how to instruct the Strategist.
+**When to enter:** Always before B3 (Builder). The Plan Loop runs for new projects, incomplete projects, and `--mode design` on existing projects.
 
-### Purpose
+**Interactive vs Autonomous:**
+- **Interactive** (task includes `## Plan Loop (Interactive)`): P2 presents the plan to the user for approval. Feedback loops back to P1 or P0.
+- **Autonomous** (no `## Plan Loop (Interactive)` in task): P2 is CEO auto-approve. No user interaction.
 
-- **New ideas:** Transform a vague idea into a research-grounded, buildable phased build plan through iterative refinement with the user.
-- **Existing projects:** Study the project and collaboratively decide what to improve next, producing an improvement spec through research and user feedback.
+**Research ideation** works identically to regular ideation, except the Strategist MUST produce a Research Configuration section in its output. See P1 below.
 
-### I0: Research the Space (Researcher Agent)
+### P0: Research (Parallel Researchers)
 
-Tell the user you're researching the space, then spawn the Researcher.
+Tell the user you're researching the space (interactive) or log research start (autonomous), then spawn focused researchers in parallel. The research set depends on context:
 
-**For new ideas:**
+**For new ideas** (task includes a raw idea or spec):
 
 Spawn 3 focused researchers in parallel:
 
@@ -446,37 +438,83 @@ Write findings to .factory/strategy/research-backlog.md covering:
 wait
 ```
 
-### I0r: CEO Review — Research
+**For autonomous builds** (no `## Plan Loop (Interactive)` section, standard build mode):
 
-Apply the standard CEO Review Gate:
-1. Read all tagged review files (e.g. `.factory/reviews/researcher-similar-latest.md`, `.factory/reviews/researcher-techstack-latest.md`, `.factory/reviews/researcher-pitfalls-latest.md` for new ideas; or `researcher-health-latest.md`, `researcher-practices-latest.md`, `researcher-backlog-latest.md` for existing projects) and the corresponding `.factory/strategy/research-*.md` outputs
-2. Is the research relevant to the user's idea? Does it cover the technology landscape adequately?
-3. Write verdict to `.factory/reviews/ceo-verdict-researcher.md`
-4. If REDIRECT: re-invoke individual researchers (by tag) with specific gaps
-5. If PROCEED: continue to I1
-
-### I1: Distill (Strategist Agent — Ideation Mode)
-
-Spawn the Strategist in ideation mode to synthesize the research into a structured spec.
-
-**For regular ideation on new ideas** (`## Design Mode` without `existing_project: true`):
+Spawn 2-3 focused researchers in parallel:
 
 ```bash
-factory agent strategist --task "Distill a project specification from research and a raw idea.
+factory agent researcher --review-tag techstack --task "Tech stack research for $PROJECT_PATH.
+The project is new or incomplete. Research:
+1. Analyze the project specification at $PROJECT_PATH/.factory/strategy/current.md
+2. Search the web for similar projects, best practices, and architecture patterns
+3. Identify key technical decisions (language, framework, database, APIs)
+4. Write findings to .factory/strategy/research-techstack.md covering: recommended tech stack, architecture patterns, and framework comparisons
+" --project "$PROJECT_PATH" --timeout 600 &
+factory agent researcher --review-tag domain --task "Domain research for $PROJECT_PATH.
+The project is new or incomplete. Research:
+1. Analyze the project specification at $PROJECT_PATH/.factory/strategy/current.md
+2. Search the web for domain-specific best practices and potential pitfalls
+3. Identify MVP scope and common mistakes for this type of project
+4. Write findings to .factory/strategy/research-domain.md covering: similar projects found (with links), potential pitfalls, and MVP scope recommendation
+" --project "$PROJECT_PATH" --timeout 600 &
+factory agent researcher --review-tag archive --task "Prior art research for $PROJECT_PATH.
+The project is new or incomplete. Research:
+1. Check .factory/archive/ for prior knowledge on similar builds
+2. Read cross-project insights if available
+3. Write findings to .factory/strategy/research-archive.md covering: lessons from prior builds and reusable patterns
+" --project "$PROJECT_PATH" --timeout 600 &
+wait
+```
 
-Raw idea: <RAW_IDEA>
+### P0r: CEO Review — Research
 
-MANDATORY: Read ALL tagged research files FIRST (.factory/strategy/research-similar.md, research-techstack.md, research-pitfalls.md). Extract specific findings before writing any spec content.
+Apply the standard CEO Review Gate:
+1. Read all tagged review files and the corresponding `.factory/strategy/research-*.md` outputs
+2. Is the research relevant to the project? Does it cover the technology landscape adequately?
+3. Write verdict to `.factory/reviews/ceo-verdict-researcher.md`
+4. If REDIRECT: re-invoke individual researchers (by tag) with specific gaps (max 2 retries)
+5. If PROCEED: continue to P1
+
+### P1: Strategy (Strategist Agent)
+
+Spawn the Strategist to synthesize the research into a phased build plan. The invocation varies by context:
+
+**For new ideas** (interactive or autonomous, no `existing_project: true`):
+
+```bash
+factory agent strategist --task "Synthesize a project specification from research and a raw idea.
+
+Raw idea: <RAW_IDEA or project spec>
+
+MANDATORY: Read ALL tagged research files FIRST (.factory/strategy/research-*.md). Extract specific findings before writing any spec content.
 
 Every Phase hypothesis MUST have a substantive What field (specific changes), Why field (research-grounded rationale), and Expected impact field. A one-line What field is NOT enough.
 
-Produce a complete build plan. Phase 1 must be project scaffold + eval harness." --project "$PROJECT_PATH" --timeout 300
+Produce a complete build plan. Phase 1 must be project scaffold + eval harness.
+
+Build EVERYTHING in this pass. The only items that may be deferred to the backlog are things that genuinely require human intervention:
+- Missing API keys or credentials the user must provide
+- External accounts that need manual setup (payment providers, cloud services)
+- Permissions the user must grant
+- External services that need manual provisioning
+
+Everything else — features, integrations, UI, tests — MUST be built now, not deferred.
+
+If any items truly cannot be built without human intervention, list them at the end:
+
+## Deferred
+
+- <item requiring human intervention — explain what's needed>
+
+This section MUST use a markdown heading (## Deferred) — not bold text or other formatting. Items listed here become the project's backlog for Improve mode.
+
+Write the plan to .factory/strategy/current.md." --project "$PROJECT_PATH" --timeout 300
 ```
 
-**For existing projects** (`## Design Mode` with `existing_project: true`):
+**For existing projects** (interactive, `existing_project: true`):
 
 ```bash
-factory agent strategist --task "Distill an improvement specification for an existing project.
+factory agent strategist --task "Synthesize an improvement specification for an existing project.
 
 Project: $PROJECT_PATH
 <If focus topic provided: Focus topic: <FOCUS_TOPIC>>
@@ -504,10 +542,10 @@ This is an EXISTING project, not a new idea. Produce an improvement spec with th
 " --project "$PROJECT_PATH" --timeout 300
 ```
 
-**For research ideation** (`## Research Ideation Mode`):
+**For research ideation** (interactive, research project):
 
 ```bash
-factory agent strategist --task "Distill a project specification from research and a raw idea.
+factory agent strategist --task "Synthesize a project specification from research and a raw idea.
 
 Raw idea: <RAW_IDEA>
 
@@ -518,20 +556,19 @@ include the Multi-Run section. If the project has a two-tier surface structure
 (narrow surfaces to try first, wider surfaces to unlock after plateau), include
 the Surface Scoping section.
 
-MANDATORY: Read ALL tagged research files FIRST (.factory/strategy/research-similar.md, research-techstack.md, research-pitfalls.md). Extract specific findings before writing any spec content.
+MANDATORY: Read ALL tagged research files FIRST (.factory/strategy/research-*.md). Extract specific findings before writing any spec content.
 
 Every Phase hypothesis MUST have a substantive What field (specific changes), Why field (research-grounded rationale), and Expected impact field. A one-line What field is NOT enough.
 
 Produce a complete build plan with research configuration. Phase 1 must be project scaffold + eval harness." --project "$PROJECT_PATH" --timeout 300
 ```
 
-### I1r: CEO Review — Draft Spec
+### P1r: CEO Review — Strategy (HARD GATE)
 
-Read `.factory/reviews/strategist-latest.md` and assess the draft:
-- Does it capture the user's intent?
-- Are the technology choices well-justified by research?
-- Is the scope achievable?
-- Are phases specific enough for a Builder agent?
+This is a **hard gate**. The Builder MUST NOT start until you approve the plan.
+
+1. Read `.factory/reviews/strategist-latest.md` and `.factory/strategy/current.md`
+2. Assess the plan using this 5-point checklist:
 
 **Quantitative depth checks (MANDATORY — REDIRECT if any fail):**
 
@@ -547,9 +584,14 @@ Read `.factory/reviews/strategist-latest.md` and assess the draft:
 
 Write your review to `.factory/reviews/ceo-verdict-strategist.md`.
 
-### I1v: Research Config Validation (Research Ideation Only)
+If PROCEED: write `PLAN APPROVED` in your verdict file, then persist backlog items:
+```bash
+factory backlog-list "$PROJECT_PATH"
+```
 
-If this is research ideation (`## Research Ideation Mode`), programmatically validate the Research Configuration from the Strategist's output before presenting to the user:
+### P1v: Research Config Validation (Research Ideation Only)
+
+If this is research ideation (task included research project flag), programmatically validate the Research Configuration from the Strategist's output before presenting to the user:
 
 1. **Run command check:** Verify the `Run Command` field specifies an executable command. If the project directory already exists, check that the command's entry point is present (e.g., the script file exists). Flag as ERROR if the run command is empty or references a clearly non-existent path.
 
@@ -557,7 +599,7 @@ If this is research ideation (`## Research Ideation Mode`), programmatically val
 
 3. **Surface overlap check:** Verify there is no overlap between `Mutable Surfaces` and `Fixed Surfaces`. If Surface Scoping is configured, also verify no overlap between `Inner Surfaces` and `Outer Surfaces`. Flag as ERROR if any file would appear in both sets — the constraint system requires unambiguous classification.
 
-4. **Present validation results alongside the spec:** When presenting to the user (step I2), include any validation errors or warnings:
+4. **Present validation results alongside the plan:** When presenting to the user (step P2), include any validation errors or warnings:
    ```
    RESEARCH CONFIG VALIDATION:
    - [ERROR] Run command 'python benchmark.py' — file not found (will be created during build)
@@ -565,13 +607,15 @@ If this is research ideation (`## Research Ideation Mode`), programmatically val
    - [OK] No overlap between mutable and fixed surfaces
    ```
 
-5. **Re-validate after each Strategist iteration.** When the Strategist produces an updated draft (step I3), re-run this validation on the new output before returning to I2.
+5. **Re-validate after each Strategist iteration.** When the Strategist produces an updated draft, re-run this validation on the new output before returning to P2.
 
 If validation finds ERRORs, do NOT block — present them to the user as warnings. The project may not exist yet, so missing files are expected. The user decides whether to fix them or proceed.
 
-### I2: Present to User
+### P2: Present & Approve
 
-**This is where you interact with the user.** Present the Strategist's output clearly. Highlight the key choices the Strategist made and any open questions. Then ask the user for their feedback:
+**If interactive** (task includes `## Plan Loop (Interactive)`):
+
+Present the Strategist's output clearly. Highlight the key choices the Strategist made and any open questions. Then ask the user for their feedback:
 
 - They can approve (e.g. "looks good", "let's build", "approved")
 - They can give specific feedback (e.g. "add WebSocket support", "use Go instead", "drop the admin dashboard for v1")
@@ -579,14 +623,12 @@ If validation finds ERRORs, do NOT block — present them to the user as warning
 
 **One topic at a time.** If the spec has open questions, surface the most important one first. Do not dump all questions at once.
 
-### I3: Iterate on Feedback
-
-If the user provides feedback (anything other than approval):
+**If the user provides feedback** (anything other than approval):
 
 **Optional: Targeted follow-up research.** If the user's feedback introduces a new domain or technology not covered by the initial research, spawn the Researcher again with a narrow scope:
 
 ```bash
-factory agent researcher --task "Targeted follow-up research for project ideation.
+factory agent researcher --task "Targeted follow-up research for project planning.
 
 The user wants to modify the project spec. Their feedback: <USER_FEEDBACK>
 
@@ -603,7 +645,7 @@ factory agent strategist --task "Refine the project specification based on user 
 
 Raw idea: <RAW_IDEA>
 
-<If research ideation: add 'This is a research project. You MUST include the Research Configuration section in your output with all fields filled (Research Target, Mutable Surfaces, Fixed Surfaces, Research Constraints, Cost Budget). If the harness is stochastic, include the Multi-Run section. If the project has a two-tier surface structure (narrow surfaces to try first, wider surfaces to unlock after plateau), include the Surface Scoping section.'>
+<If research project: add 'This is a research project. You MUST include the Research Configuration section in your output with all fields filled (Research Target, Mutable Surfaces, Fixed Surfaces, Research Constraints, Cost Budget). If the harness is stochastic, include the Multi-Run section. If the project has a two-tier surface structure (narrow surfaces to try first, wider surfaces to unlock after plateau), include the Surface Scoping section.'>
 
 ## Prior Draft
 
@@ -622,37 +664,49 @@ Read all tagged research files at .factory/strategy/research-*.md for context.
 Produce a complete updated specification." --project "$PROJECT_PATH" --timeout 300
 ```
 
-Read the Strategist's output and return to **I1v** (re-validate the research config if in research ideation mode, then present the updated draft to the user at I2).
+Read the Strategist's output and return to **P1v** (re-validate research config if research project), then **P1r** (CEO review), then back to **P2** (present to user).
 
-### I4: Finalize and Transition
+**Cap at 5 iterations.** If the user has not approved after 5 rounds of feedback, summarize the current state and ask them to either approve the latest draft or provide a final definitive direction.
 
-When the user approves the spec:
+**If autonomous** (no `## Plan Loop (Interactive)` section in task):
 
-1. **Persist the build plan**: Write the final build plan content to `.factory/strategy/current.md` (prepend `## Build Plan\n\n` before the content)
-2. **If this is research ideation** (task included `## Research Ideation Mode`):
-   - The approved spec should contain a `## Research Configuration` section with Research Target, Mutable Surfaces, Fixed Surfaces, etc.
-   - Verify it's present. If the Strategist omitted it, REDIRECT with: "This is a research project — the spec MUST include a Research Configuration section."
-   - The research config will be extracted and populated into `factory.md` during Review mode (step 4b).
-3. **Spawn Archivist** to record the ideation process:
-   ```bash
-   factory agent archivist --task "Record the ideation process for $PROJECT_PATH.
-   Read .factory/strategy/current.md (the approved spec).
-   Read all tagged research files at .factory/strategy/research-*.md (the research).
-   Write project inception notes to .factory/archive/. Then run: factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
-   ```
-4. **Transition — route by project type:**
+The CEO auto-approves after P1r passes. No user interaction. Proceed directly to P3.
 
-   **For new ideas** (no `existing_project: true` flag): Transition to **Build mode**. The spec is now persisted. **Skip steps B0 (Research) and B1 (Strategist build plan generation)** — the approved build plan already contains research-grounded architecture decisions and phased hypotheses. Proceed from B2 (Archivist records the approved plan) then B3 (Builder implements each phase) using the approved plan from `.factory/strategy/current.md`.
+### P3: MANDATORY Archivist — record approved plan (DO NOT SKIP)
 
-   **For existing projects** (`existing_project: true`): Transition to **Improve mode** with the approved spec as the focus:
-   1. Persist the improvement spec to `.factory/strategy/current.md`
-   2. Add the improvement goal to the backlog: `factory backlog-add "$PROJECT_PATH" "<improvement goal from spec>"`
-   3. Proceed to **Improve mode** (Step 0a: Observe) with the improvement spec as the `--focus` directive. Do NOT re-run Phase 0 steps — transition directly into the Improve pipeline.
+Spawn the Archivist to record the approved plan:
 
-### Ideation Rules
+```bash
+factory agent archivist --task "Record the approved build plan for $PROJECT_PATH.
+Read .factory/strategy/current.md (the approved plan) and .factory/reviews/ceo-verdict-strategist.md.
+Read all tagged research files at .factory/strategy/research-*.md.
+Write project notes to .factory/archive/. Then run: factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
+```
 
-- **Maximum 5 iterations.** If the user has not approved after 5 rounds of feedback, summarize the current state and ask them to either approve the latest draft or provide a final definitive direction.
-- **Do not build anything during Phase 0.** No code, no scaffolding, no repos beyond the project directory. Phase 0 produces only a spec document (or improvement spec for existing projects).
+Then write checkpoint:
+```bash
+echo "- [x] archivist after plan approval — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PROJECT_PATH/.factory/reviews/archivist-checkpoints.md"
+```
+
+### Plan Loop Transition
+
+After P3, the approved plan is persisted to `.factory/strategy/current.md`.
+
+**The approved plan is immutable.** Do not re-research, re-strategize, or modify the plan after P3. It flows verbatim to the Builder.
+
+**Persist the build plan:**
+1. Write the final plan content to `.factory/strategy/current.md` (prepend `## Build Plan\n\n` before the content)
+2. If this is research ideation: verify the Research Configuration section is present. If the Strategist omitted it, REDIRECT with: "This is a research project — the spec MUST include a Research Configuration section." The research config will be extracted and populated into `factory.md` during Review mode (step 4b).
+3. For existing projects: add the improvement goal to the backlog: `factory backlog-add "$PROJECT_PATH" "<improvement goal from spec>"`
+
+**Route by project type:**
+
+- **New ideas** (no `existing_project: true` flag): Proceed to **B3** (Builder implements each phase). Skip B-0 for new projects with no prior sprint state.
+- **Existing projects** (`existing_project: true`): Transition to **Improve mode**. The approved spec becomes the focus for the improvement cycle. Proceed to Improve mode Step 0a (Observe) with the improvement spec as the `--focus` directive. Do NOT re-run Plan Loop steps.
+
+### Plan Loop Rules
+
+- **Do not build anything during the Plan Loop.** No code, no scaffolding, no repos beyond the project directory. The Plan Loop produces only a plan document (or improvement spec for existing projects).
 - **Research is optional on refinement.** Only re-spawn the Researcher if the user's feedback introduces genuinely new territory. Minor scope adjustments (add/remove features, change priorities) do not need new research.
 - **Be concise when presenting.** After the first full presentation, highlight what changed rather than re-presenting the entire spec. But always show the full spec so the user can read it in context.
 - **Be opinionated for existing projects.** The user wants your recommendation, not a menu of every possible option. Lead with your top suggestion based on the data.
@@ -694,7 +748,7 @@ factory log "$PROJECT_PATH" "sprint.started" --data '{"mode": "build"}'
 
 ### BUILD PIPELINE COMPLETION — CRITICAL (NON-OVERRIDABLE)
 
-**You MUST complete ALL planned phases (B0 through B6) before exiting Build mode.**
+**You MUST complete the Plan Loop and ALL build phases (B3 through B6) before exiting Build mode.**
 
 This is an **inviolable constraint**. There is NO valid reason to exit between phases. Specifically:
 
@@ -703,7 +757,7 @@ This is an **inviolable constraint**. There is NO valid reason to exit between p
 2. **"Good stopping point" is NOT a valid exit condition.** The phrase "this is a good stopping point" or any equivalent self-judged rationale for early exit is FORBIDDEN. A scaffold without implementation is not a deliverable.
 
 3. **Valid exit conditions are:**
-   - All planned phases (B0 through B6) have been attempted
+   - The Plan Loop and all build phases (B3 through B6) have been attempted
    - An unrecoverable agent failure occurred (must be reported as ABORT with `--verdict error`, not as a normal completion)
    - The user explicitly interrupted the session
 
@@ -711,124 +765,11 @@ This is an **inviolable constraint**. There is NO valid reason to exit between p
 
 Violating this constraint means the factory produced no usable output. A project with only scaffolds and no implementation is a failure, regardless of how clean the scaffolds are.
 
-### B0: Research (Parallel Researchers)
+### Plan Loop → B3
 
-Spawn 2-3 focused researchers in parallel:
+**Run the Plan Loop** (P0 → P1 → P1r → P2 → P3) to produce the approved build plan. The Plan Loop is defined above. After P3 completes, the approved plan is in `.factory/strategy/current.md`.
 
-```bash
-factory agent researcher --review-tag techstack --task "Tech stack research for $PROJECT_PATH.
-The project is new or incomplete. Research:
-1. Analyze the project specification at $PROJECT_PATH/.factory/strategy/current.md
-2. Search the web for similar projects, best practices, and architecture patterns
-3. Identify key technical decisions (language, framework, database, APIs)
-4. Write findings to .factory/strategy/research-techstack.md covering: recommended tech stack, architecture patterns, and framework comparisons
-" --project "$PROJECT_PATH" --timeout 600 &
-factory agent researcher --review-tag domain --task "Domain research for $PROJECT_PATH.
-The project is new or incomplete. Research:
-1. Analyze the project specification at $PROJECT_PATH/.factory/strategy/current.md
-2. Search the web for domain-specific best practices and potential pitfalls
-3. Identify MVP scope and common mistakes for this type of project
-4. Write findings to .factory/strategy/research-domain.md covering: similar projects found (with links), potential pitfalls, and MVP scope recommendation
-" --project "$PROJECT_PATH" --timeout 600 &
-factory agent researcher --review-tag archive --task "Prior art research for $PROJECT_PATH.
-The project is new or incomplete. Research:
-1. Check .factory/archive/ for prior knowledge on similar builds
-2. Read cross-project insights if available
-3. Write findings to .factory/strategy/research-archive.md covering: lessons from prior builds and reusable patterns
-" --project "$PROJECT_PATH" --timeout 600 &
-wait
-```
-
-### B0r: CEO Review — Research
-
-Apply the **CEO Review Gate**:
-1. Read all tagged review files: `.factory/reviews/researcher-techstack-latest.md`, `.factory/reviews/researcher-domain-latest.md`, `.factory/reviews/researcher-archive-latest.md`
-2. Read research outputs: `.factory/strategy/research-techstack.md`, `.factory/strategy/research-domain.md`, `.factory/strategy/research-archive.md`
-3. Check: Did the researchers cover the right topics? Is there enough depth to inform a build plan? Any obvious technology gaps?
-4. Write verdict to `.factory/reviews/ceo-verdict-researcher.md`
-5. If REDIRECT: re-invoke individual researchers (by tag) with specific gaps to fill (max 2 retries)
-6. If PROCEED: continue to B0a
-
-### B0a: MANDATORY Archivist — record research (DO NOT SKIP)
-
-```bash
-factory agent archivist --task "Record the Researcher's findings for the new project $PROJECT_PATH.
-Read .factory/strategy/research-techstack.md, .factory/strategy/research-domain.md, .factory/strategy/research-archive.md, and .factory/reviews/ceo-verdict-researcher.md.
-Write research notes to .factory/archive/sources/. Then run: factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
-```
-
-Then write checkpoint:
-```bash
-echo "- [x] archivist after research — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PROJECT_PATH/.factory/reviews/archivist-checkpoints.md"
-```
-
-### B1: Strategy (Strategist Agent)
-
-Include your research review notes in the Strategist's task so it knows what the CEO found important:
-
-```bash
-factory agent strategist --task "Create a build plan for the new project at $PROJECT_PATH.
-
-Read the research reports at .factory/strategy/research-techstack.md, .factory/strategy/research-domain.md, .factory/strategy/research-archive.md.
-Read the CEO's research review at .factory/reviews/ceo-verdict-researcher.md for priorities.
-Generate a phased build plan as GitHub issues:
-- Phase 1: Project scaffold + eval harness (always first)
-- Phase 2-N: Feature implementation in dependency order
-Each issue should be one PR's worth of work.
-
-Build EVERYTHING in this pass. The only items that may be deferred to the backlog are things that genuinely require human intervention:
-- Missing API keys or credentials the user must provide
-- External accounts that need manual setup (payment providers, cloud services)
-- Permissions the user must grant
-- External services that need manual provisioning
-
-Everything else — features, integrations, UI, tests — MUST be built now, not deferred.
-
-If any items truly cannot be built without human intervention, list them at the end:
-
-## Deferred
-
-- <item requiring human intervention — explain what's needed>
-
-This section MUST use a markdown heading (## Deferred) — not bold text or other formatting. Items listed here become the project's backlog for Improve mode.
-
-Write the plan to .factory/strategy/current.md." --project "$PROJECT_PATH" --timeout 300
-```
-
-### B1r: CEO Review — Strategy (HARD GATE)
-
-This is a **hard gate**. The Builder MUST NOT start until you approve the plan.
-
-1. Read `.factory/reviews/strategist-latest.md` and `.factory/strategy/current.md`
-2. Assess:
-   - Does the plan align with the project spec in `.factory/strategy/current.md`?
-   - Are phases right-sized (each one = one PR's worth of work)?
-   - Is Phase 1 always scaffold + eval harness?
-   - Is the total scope achievable or is it over-ambitious?
-   - Are there any phases that should be split, merged, or reordered?
-   - **Deferral strictness:** Does the `## Deferred` section (if present) ONLY contain items that require human intervention? If it contains features, integrations, or anything that could be built without a human, **REDIRECT** the Strategist to include those items in the build phases. The factory builds everything it can — deferral is not for convenience, only for genuine blockers.
-3. Write verdict to `.factory/reviews/ceo-verdict-strategist.md`
-4. If REDIRECT: re-invoke the Strategist with specific corrections (e.g., "Phase 3 is too large — split into 3a and 3b", "Move OAuth integration from Deferred to a build phase — we don't need user credentials to scaffold it")
-5. If PROCEED: write `PLAN APPROVED` in your verdict file, then persist backlog items:
-
-```bash
-factory backlog-list "$PROJECT_PATH"
-```
-
-If backlog items were parsed, they are now in `.factory/strategy/backlog.md` and will survive future strategy rewrites. Continue to B2.
-
-### B2: MANDATORY Archivist — record approved plan (DO NOT SKIP)
-
-```bash
-factory agent archivist --task "Record the CEO-approved build plan for $PROJECT_PATH.
-Read .factory/strategy/current.md and .factory/reviews/ceo-verdict-strategist.md.
-The CEO has reviewed and approved this plan. Write project notes to .factory/archive/. Then run: factory report-update $PROJECT_PATH" --project "$PROJECT_PATH"
-```
-
-Then write checkpoint:
-```bash
-echo "- [x] archivist after strategy — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$PROJECT_PATH/.factory/reviews/archivist-checkpoints.md"
-```
+Proceed to B3.
 
 ### B3: Build (Builder Agent — per phase)
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2567,12 +2567,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     base_branch = branch or _read_target_branch(project_path)
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
-    if design_existing:
-        ceo_mode = "build"
-    elif mode == "design" or research_ideation:
-        ceo_mode = "build"
-    else:
-        ceo_mode = mode
+    interactive = design_existing or bool(design_idea) or bool(research_ideation)
+    ceo_mode = "build" if interactive else mode
     if clean_pr_flag is not None:
         clean_pr_resolved = clean_pr_flag
     else:
@@ -3245,13 +3241,12 @@ def _build_ceo_task(
 
     if design_existing:
         task += (
-            f"\n\n## Design Mode (Phase 0)\n\n"
+            f"\n\n## Plan Loop (Interactive)\n\n"
             f"**existing_project: true**\n\n"
-            f"You are in design mode on an **existing project** at `{project_path}`.\n\n"
-            f"Before running any experiments, research the project (local study + external "
-            f"best practices), distill an improvement spec through user feedback, then "
-            f"transition to Improve mode. Follow the Phase 0: Ideation protocol in your "
-            f"system prompt — the existing-project conditionals in I0, I1, and I4 apply.\n\n"
+            f"You are in interactive planning mode on an **existing project** at `{project_path}`.\n\n"
+            f"Run the Plan Loop (P0-P3) with interactive approval. Research the project "
+            f"(local study + external best practices), synthesize an improvement spec "
+            f"through user feedback, then transition to Improve mode.\n\n"
         )
         if focus:
             task += (
@@ -3267,29 +3262,28 @@ def _build_ceo_task(
             )
     elif design_idea:
         task += (
-            f"\n\n## Design Mode (Phase 0)\n\n"
+            f"\n\n## Plan Loop (Interactive)\n\n"
             f"**Raw idea from user:** {design_idea}\n\n"
-            f"You are in design mode. Before building anything, "
-            f"you must refine this idea into a complete spec through research "
-            f"and iterative user feedback. Follow the Phase 0: Ideation protocol "
-            f"in your system prompt.\n\n"
-            f"After the user approves the final spec, persist it to "
+            f"Run the Plan Loop (P0-P3) with interactive approval. "
+            f"Research the space, synthesize a build plan, and refine it "
+            f"through user feedback before building.\n\n"
+            f"After the user approves the final plan, persist it to "
             f".factory/strategy/current.md and proceed to Build mode.\n"
         )
 
     if research_ideation:
         task += (
-            f"\n\n## Research Ideation Mode (Phase 0)\n\n"
+            f"\n\n## Plan Loop (Interactive)\n\n"
             f"**Raw idea from user:** {research_ideation}\n\n"
-            f"You are in research ideation mode. This is like design ideation, "
-            f"but the Strategist MUST collect research configuration:\n"
+            f"**research_project: true**\n\n"
+            f"Run the Plan Loop (P0-P3) with interactive approval. "
+            f"This is a research project — the Strategist MUST collect research configuration:\n"
             f"- Research Target (objective, metric, target value, run_command, result_path)\n"
             f"- Mutable Surfaces (files the Builder can modify)\n"
             f"- Fixed Surfaces (ground truth / eval files that must never be touched)\n"
             f"- Research Constraints (additional rules)\n"
             f"- Cost Budget (optional)\n\n"
-            f"Follow the Phase 0: Ideation protocol, but tell the Strategist this is a "
-            f"research project. After the user approves, persist the spec AND the research "
+            f"After the user approves, persist the spec AND the research "
             f"config to .factory/strategy/current.md, then proceed to Build mode. "
             f"During Review mode (factory.md creation), populate the research sections "
             f"from the approved spec.\n"
@@ -3353,8 +3347,9 @@ def _build_ceo_task(
 
     if mode == "build":
         task += (
-            "\n\nRun Build mode: the project is new or incomplete. Follow the Build mode "
-            "pipeline (B0-B6): Research → Strategy → Build phases → E2E verification. "
+            "\n\nRun Build mode: the project is new or incomplete. Run the Plan Loop "
+            "(P0-P3) to produce an approved build plan, then follow the Build pipeline "
+            "(B3-B6): Build phases → E2E verification. "
             "Do NOT skip to Improve mode — the project needs to be built first."
         )
     elif mode == "discover":

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -1157,17 +1157,17 @@ class TestCeoPromptResearchMode:
         assert "leakage-check" in research_section
         assert "text-file" in research_section
 
-    def test_research_ideation_phase_0_activation(self, ceo_prompt: str) -> None:
-        """Phase 0 activates for both Interactive and Research Ideation."""
-        assert "Research Ideation Mode (Phase 0)" in ceo_prompt
+    def test_research_ideation_plan_loop_activation(self, ceo_prompt: str) -> None:
+        """Plan Loop activates for research ideation."""
+        assert "research_project: true" in ceo_prompt or "research project" in ceo_prompt
 
     def test_research_ideation_strategist_instruction(self, ceo_prompt: str) -> None:
-        """Phase 0 includes research-specific Strategist invocation."""
-        phase0_idx = ceo_prompt.index("## Phase 0: Ideation")
+        """Plan Loop includes research-specific Strategist invocation."""
+        plan_idx = ceo_prompt.index("## Plan Loop")
         build_idx = ceo_prompt.index("## Mode: Build")
-        phase0_section = ceo_prompt[phase0_idx:build_idx]
-        assert "This is a research project" in phase0_section
-        assert "Research Configuration" in phase0_section
+        plan_section = ceo_prompt[plan_idx:build_idx]
+        assert "This is a research project" in plan_section
+        assert "Research Configuration" in plan_section
 
     def test_review_mode_populates_research_config(self, ceo_prompt: str) -> None:
         """Review mode populates factory.md research sections from approved spec."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,7 +168,7 @@ class TestCmdCeoDesign:
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Design Mode (Phase 0)" in task
+        assert "## Plan Loop (Interactive)" in task
         assert "auth layer" in task
 
     def test_no_path_fails(self, capsys):
@@ -186,28 +186,28 @@ class TestCmdCeoDesign:
         assert cmd[0] == "claude"
         assert "--dangerously-skip-permissions" in cmd
 
-    def test_design_existing_has_ideation_block(self, tmp_path):
-        """--mode design on an existing directory injects Design Mode block."""
+    def test_design_existing_has_plan_loop_block(self, tmp_path):
+        """--mode design on an existing directory injects Plan Loop block."""
         with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Design Mode (Phase 0)" in task
+        assert "## Plan Loop (Interactive)" in task
         assert "existing_project: true" in task
 
-    def test_design_new_idea_has_ideation_block(self):
-        """--mode design with a non-directory path injects Design Mode block."""
+    def test_design_new_idea_has_plan_loop_block(self):
+        """--mode design with a non-directory path injects Plan Loop block."""
         with _mock_foreground() as mock_run:
             main(["ceo", "build a cool CLI tool", "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Design Mode (Phase 0)" in task
+        assert "## Plan Loop (Interactive)" in task
         assert "## Project Specification" not in task
 
     def test_design_task_contains_idea_text(self):
-        """--mode design with raw idea text includes it in the Phase 0 block."""
+        """--mode design with raw idea text includes it in the Plan Loop block."""
         with _mock_foreground() as mock_run:
             main(["ceo", "distributed eval runner", "--mode", "design"])
         cmd = mock_run.call_args[0][0]
@@ -240,7 +240,7 @@ class TestCmdCeoDesign:
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Design Mode (Phase 0)" in task
+        assert "## Plan Loop (Interactive)" in task
 
 
 def _make_config(*, research_target: dict | None = None) -> dict:
@@ -342,14 +342,14 @@ class TestCmdCeoResearchIdeation:
         cmd = claude_calls[0][0][0]
         assert cmd[0] == "claude"
 
-    def test_research_ideation_task_has_research_phase_0(self):
-        """--mode research with idea injects Research Ideation Phase 0 block."""
+    def test_research_ideation_task_has_plan_loop(self):
+        """--mode research with idea injects Plan Loop (Interactive) block."""
         with _mock_foreground() as mock_run:
             main(["ceo", "swe-bench solver agent", "--mode", "research"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Research Ideation Mode (Phase 0)" in task
+        assert "## Plan Loop (Interactive)" in task
         assert "swe-bench solver agent" in task
 
     def test_research_ideation_task_mode_is_build(self):
@@ -361,14 +361,14 @@ class TestCmdCeoResearchIdeation:
         task = cmd[dsp_idx + 1]
         assert "Mode: build" in task
 
-    def test_research_ideation_no_design_block(self):
-        """--mode research should NOT inject Design Mode block."""
+    def test_research_ideation_uses_plan_loop_not_design(self):
+        """--mode research should use Plan Loop, not a separate Design Mode block."""
         with _mock_foreground() as mock_run:
             main(["ceo", "swe-bench solver agent", "--mode", "research"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Design Mode" not in task
+        assert "## Plan Loop (Interactive)" in task
 
     def test_research_ideation_mentions_research_config(self):
         """--mode research ideation task mentions research config fields."""
@@ -395,7 +395,7 @@ class TestCmdCeoResearchIdeation:
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "## Research Ideation Mode" not in task
+        assert "## Plan Loop (Interactive)" not in task
         assert "Mode: research" in task
 
 
@@ -1423,15 +1423,15 @@ class TestResearchMode:
 class TestBuildCeoTaskDesign:
     """Unit tests for _build_ceo_task design_existing parameter."""
 
-    def test_existing_project_emits_ideation_section(self, tmp_path):
+    def test_existing_project_emits_plan_loop_section(self, tmp_path):
         task = _build_ceo_task(tmp_path, "build", design_existing=True)
-        assert "## Design Mode (Phase 0)" in task
+        assert "## Plan Loop (Interactive)" in task
         assert "existing_project: true" in task
         assert "existing project" in task
 
     def test_existing_project_with_focus(self, tmp_path):
         task = _build_ceo_task(tmp_path, "build", design_existing=True, focus="auth layer")
-        assert "## Design Mode (Phase 0)" in task
+        assert "## Plan Loop (Interactive)" in task
         assert "auth layer" in task
         assert "Focus topic" in task
 
@@ -1439,17 +1439,17 @@ class TestBuildCeoTaskDesign:
         task = _build_ceo_task(tmp_path, "build", design_existing=True)
         assert "No specific topic was provided" in task
 
-    def test_new_idea_emits_ideation_section(self, tmp_path):
+    def test_new_idea_emits_plan_loop_section(self, tmp_path):
         task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
-        assert "## Design Mode (Phase 0)" in task
+        assert "## Plan Loop (Interactive)" in task
         assert "weather CLI" in task
 
     def test_existing_uses_same_header_as_new_idea(self, tmp_path):
-        """Both new ideas and existing projects use the same Phase 0 header."""
+        """Both new ideas and existing projects use the same Plan Loop header."""
         existing_task = _build_ceo_task(tmp_path, "build", design_existing=True)
         new_task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
-        assert "## Design Mode (Phase 0)" in existing_task
-        assert "## Design Mode (Phase 0)" in new_task
+        assert "## Plan Loop (Interactive)" in existing_task
+        assert "## Plan Loop (Interactive)" in new_task
 
     def test_existing_project_has_existing_flag(self, tmp_path):
         """Existing project task includes the existing_project flag for CEO conditionals."""

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -156,16 +156,17 @@ class TestCeoPrompt:
         discover_start = ceo_prompt.index("## Mode: Discover")
         build_section = ceo_prompt[build_start:discover_start]
 
-        # All agents must be present
-        assert "factory agent researcher" in build_section
-        assert "factory agent strategist" in build_section
+        # Build mode references the Plan Loop for research/strategy
+        assert "Plan Loop" in build_section
+        # Builder and archivist agents must be in Build section
         assert "factory agent archivist" in build_section
         assert "factory agent builder" in build_section
 
-        # Research step must come before Build step
-        assert build_section.index("factory agent researcher") < build_section.index("factory agent builder")
-        # Strategy step must come before Build step
-        assert build_section.index("factory agent strategist") < build_section.index("factory agent builder")
+        # Plan Loop (before Build mode) must contain researcher and strategist
+        plan_start = ceo_prompt.index("## Plan Loop")
+        plan_section = ceo_prompt[plan_start:build_start]
+        assert "factory agent researcher" in plan_section
+        assert "factory agent strategist" in plan_section
 
     def test_build_mode_does_not_skip_to_builder(self, ceo_prompt: str) -> None:
         """Build mode must NOT just say 'delegate to the Builder'."""
@@ -173,11 +174,13 @@ class TestCeoPrompt:
         discover_start = ceo_prompt.index("## Mode: Discover")
         build_section = ceo_prompt[build_start:discover_start]
 
-        # Should have research and strategy steps
-        assert "Research" in build_section
-        assert "Strategy" in build_section
-        assert "factory agent researcher" in build_section
-        assert "factory agent strategist" in build_section
+        # Should reference Plan Loop for research and strategy
+        assert "Plan Loop" in build_section
+        # Plan Loop section must contain researcher and strategist
+        plan_start = ceo_prompt.index("## Plan Loop")
+        plan_section = ceo_prompt[plan_start:build_start]
+        assert "factory agent researcher" in plan_section
+        assert "factory agent strategist" in plan_section
 
     # ── CEO Review Gate tests ────────────────────────────────────
 
@@ -192,17 +195,15 @@ class TestCeoPrompt:
     def test_review_gate_references_reviews_dir(self, ceo_prompt: str) -> None:
         assert ".factory/reviews/" in ceo_prompt
 
-    def test_strategist_hard_gate_in_build_mode(self, ceo_prompt: str) -> None:
-        """Build mode must have a hard gate after Strategist before Builder."""
+    def test_strategist_hard_gate_in_plan_loop(self, ceo_prompt: str) -> None:
+        """Plan Loop must have a hard gate after Strategist before Builder."""
+        plan_start = ceo_prompt.index("## Plan Loop")
         build_start = ceo_prompt.index("## Mode: Build")
-        discover_start = ceo_prompt.index("## Mode: Discover")
-        build_section = ceo_prompt[build_start:discover_start]
+        plan_section = ceo_prompt[plan_start:build_start]
 
-        assert "HARD GATE" in build_section
-        assert "PLAN APPROVED" in build_section
-        # Hard gate must come after strategist and before builder
-        assert build_section.index("HARD GATE") < build_section.index("factory agent builder")
-        assert build_section.index("factory agent strategist") < build_section.index("HARD GATE")
+        assert "HARD GATE" in plan_section
+        assert "PLAN APPROVED" in plan_section
+        assert plan_section.index("factory agent strategist") < plan_section.index("HARD GATE")
 
     def test_strategist_hard_gate_in_improve_mode(self, ceo_prompt: str) -> None:
         """Improve mode must have a hard gate after Strategist."""
@@ -212,13 +213,13 @@ class TestCeoPrompt:
         assert "HARD GATE" in improve_section
         assert "PLAN APPROVED" in improve_section
 
-    def test_build_mode_has_research_review(self, ceo_prompt: str) -> None:
-        """Build mode must have CEO review after Researcher."""
+    def test_plan_loop_has_research_review(self, ceo_prompt: str) -> None:
+        """Plan Loop must have CEO review after Researcher."""
+        plan_start = ceo_prompt.index("## Plan Loop")
         build_start = ceo_prompt.index("## Mode: Build")
-        discover_start = ceo_prompt.index("## Mode: Discover")
-        build_section = ceo_prompt[build_start:discover_start]
+        plan_section = ceo_prompt[plan_start:build_start]
 
-        assert "ceo-verdict-researcher" in build_section
+        assert "ceo-verdict-researcher" in plan_section
 
     def test_build_mode_has_builder_review(self, ceo_prompt: str) -> None:
         """Build mode must have CEO review after Builder."""
@@ -299,14 +300,16 @@ class TestCeoPrompt:
         assert ceo_prompt.count("DO NOT SKIP") >= 5  # research, strategy, build, experiment, build-improve
 
     def test_archivist_in_build_mode(self, ceo_prompt: str) -> None:
-        """Build mode must have archivist after research, strategy, and build."""
+        """Build mode must have archivist after build; Plan Loop has archivist after plan approval."""
         build_start = ceo_prompt.index("## Mode: Build")
         discover_start = ceo_prompt.index("## Mode: Discover")
         build_section = ceo_prompt[build_start:discover_start]
-
-        assert "archivist after research" in build_section
-        assert "archivist after strategy" in build_section
         assert "archivist after build" in build_section
+
+        plan_start = ceo_prompt.index("## Plan Loop")
+        plan_section = ceo_prompt[plan_start:build_start]
+        assert "archivist" in plan_section.lower()
+        assert "plan approval" in plan_section.lower()
 
     def test_archivist_in_improve_mode(self, ceo_prompt: str) -> None:
         """Improve mode must have archivist after research, strategy, build, and experiment."""
@@ -335,49 +338,49 @@ class TestCeoPrompt:
         )
         assert len(async_calls) == 0, f"Found {len(async_calls)} async archivist calls — all must be blocking"
 
-    # ── Phase 0: Ideation tests ────────────────────────────────
+    # ── Plan Loop tests ────────────────────────────────
 
-    def test_has_phase_0_ideation(self, ceo_prompt: str) -> None:
-        assert "## Phase 0: Ideation" in ceo_prompt
+    def test_has_plan_loop(self, ceo_prompt: str) -> None:
+        assert "## Plan Loop" in ceo_prompt
 
-    def test_phase_0_before_build_mode(self, ceo_prompt: str) -> None:
-        """Phase 0 must appear before Build mode in the prompt."""
-        phase0_idx = ceo_prompt.index("## Phase 0: Ideation")
+    def test_plan_loop_before_build_mode(self, ceo_prompt: str) -> None:
+        """Plan Loop must appear before Build mode in the prompt."""
+        plan_idx = ceo_prompt.index("## Plan Loop")
         build_idx = ceo_prompt.index("## Mode: Build")
-        assert phase0_idx < build_idx
+        assert plan_idx < build_idx
 
-    def test_phase_0_spawns_researcher(self, ceo_prompt: str) -> None:
-        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+    def test_plan_loop_spawns_researcher(self, ceo_prompt: str) -> None:
+        plan_start = ceo_prompt.index("## Plan Loop")
         build_start = ceo_prompt.index("## Mode: Build")
-        phase0_section = ceo_prompt[phase0_start:build_start]
-        assert "factory agent researcher" in phase0_section
+        plan_section = ceo_prompt[plan_start:build_start]
+        assert "factory agent researcher" in plan_section
 
-    def test_phase_0_spawns_strategist(self, ceo_prompt: str) -> None:
-        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+    def test_plan_loop_spawns_strategist(self, ceo_prompt: str) -> None:
+        plan_start = ceo_prompt.index("## Plan Loop")
         build_start = ceo_prompt.index("## Mode: Build")
-        phase0_section = ceo_prompt[phase0_start:build_start]
-        assert "factory agent strategist" in phase0_section
+        plan_section = ceo_prompt[plan_start:build_start]
+        assert "factory agent strategist" in plan_section
 
-    def test_phase_0_has_iteration_limit(self, ceo_prompt: str) -> None:
-        assert "Maximum 5 iterations" in ceo_prompt
+    def test_plan_loop_has_iteration_limit(self, ceo_prompt: str) -> None:
+        assert "5 iterations" in ceo_prompt
 
-    def test_phase_0_persists_spec(self, ceo_prompt: str) -> None:
-        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+    def test_plan_loop_persists_spec(self, ceo_prompt: str) -> None:
+        plan_start = ceo_prompt.index("## Plan Loop")
         build_start = ceo_prompt.index("## Mode: Build")
-        phase0_section = ceo_prompt[phase0_start:build_start]
-        assert "current.md" in phase0_section
+        plan_section = ceo_prompt[plan_start:build_start]
+        assert "current.md" in plan_section
 
-    def test_phase_0_transitions_to_build(self, ceo_prompt: str) -> None:
-        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+    def test_plan_loop_transitions_to_build(self, ceo_prompt: str) -> None:
+        plan_start = ceo_prompt.index("## Plan Loop")
         build_start = ceo_prompt.index("## Mode: Build")
-        phase0_section = ceo_prompt[phase0_start:build_start]
-        assert "Build mode" in phase0_section
+        plan_section = ceo_prompt[plan_start:build_start]
+        assert "B3" in plan_section
 
-    def test_phase_0_spawns_archivist(self, ceo_prompt: str) -> None:
-        phase0_start = ceo_prompt.index("## Phase 0: Ideation")
+    def test_plan_loop_spawns_archivist(self, ceo_prompt: str) -> None:
+        plan_start = ceo_prompt.index("## Plan Loop")
         build_start = ceo_prompt.index("## Mode: Build")
-        phase0_section = ceo_prompt[phase0_start:build_start]
-        assert "factory agent archivist" in phase0_section
+        plan_section = ceo_prompt[plan_start:build_start]
+        assert "factory agent archivist" in plan_section
 
 
 # ── Strategist Ideation Mode ─────────────────────────────────────

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -607,6 +607,9 @@ class TestKeyPersistence:
         import factory.runners.bob as bob_module
         bob_module._auth_checked = False
 
+        # Redirect home so native auth at ~/.bob/settings.json isn't found
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
         # No .factory directory, no auth file
         monkeypatch.chdir(tmp_path)
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -459,6 +459,9 @@ class TestBobAuthPreflight:
         import factory.runners.bob as bob_module
         bob_module._auth_checked = False
 
+        # Redirect home so native auth at ~/.bob/settings.json isn't found
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
         (tmp_path / ".factory").mkdir()
 
         runner = BobRunner()


### PR DESCRIPTION
Factory experiment 36. Closes #613. See issue #614 for full description.

## Changes
- Merged `--mode design` and default build flow into a unified Plan Loop in the CEO prompt
- CEO now always starts with a planning phase (study → discuss → refine) before building
- Removed `--mode design` and `--mode interactive` CLI flags and associated routing logic
- Updated tests to reflect the unified workflow