### PR TITLE
fix: replace :ro bind mount with docker cp for GCP credentials in ProgramBench

### DIFF
--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -128,16 +128,10 @@ log "Step 4: Starting cleanroom container"
 RESULTS_DIR="$(mktemp -d /tmp/programbench-results-XXXXXX)"
 echo "    Results directory: ${RESULTS_DIR}"
 
-GCLOUD_MOUNT_ARGS=()
 GCLOUD_ADC="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
-if [ -f "${GCLOUD_ADC}" ]; then
-    GCLOUD_MOUNT_ARGS=(-v "${GCLOUD_ADC}:/tmp/gcloud-adc.json:ro")
-    echo "    Mounting gcloud credentials"
-fi
 
 docker run -d --name "${CONTAINER_NAME}" \
     -v "${RESULTS_DIR}:/results" \
-    "${GCLOUD_MOUNT_ARGS[@]+"${GCLOUD_MOUNT_ARGS[@]}"}" \
     "${IMAGE}" \
     sleep infinity
 
@@ -176,7 +170,11 @@ docker exec "${CONTAINER_NAME}" bash -c '
     cp -r /root/.cargo/* /home/agent/.cargo/ 2>/dev/null || true
     chown -R agent:agent /home/agent
 '
-docker exec "${CONTAINER_NAME}" chmod 644 /tmp/gcloud-adc.json 2>/dev/null || true
+if [ -f "${GCLOUD_ADC}" ]; then
+    docker cp "${GCLOUD_ADC}" "${CONTAINER_NAME}:/tmp/gcloud-adc.json"
+    docker exec "${CONTAINER_NAME}" chmod 644 /tmp/gcloud-adc.json
+    echo "    Copied gcloud credentials into container"
+fi
 
 echo "    Agent user created."
 echo ""


### PR DESCRIPTION
## Summary

- GCP credentials were bind-mounted with `:ro` into the ProgramBench container, making `chmod 644` silently fail (`:ro` mounts are immutable at the VFS level)
- The non-root `agent` user couldn't read the credentials, breaking Vertex AI authentication
- Replaced the bind mount with `docker cp` after container start — creates a regular file where `chmod` works reliably
- Also improves security: host credentials file is never exposed to the container filesystem

## Changes

- Removed `GCLOUD_MOUNT_ARGS` array and `:ro` bind mount from `docker run`
- Added `docker cp` + `chmod 644` after agent user creation (before Claude Code configuration)
- Removed the old `chmod ... || true` that silently swallowed the failure

## Test plan

- [ ] Run `benchmarks/run-programbench.sh` with GCP credentials configured — verify solver authenticates with Vertex AI
- [ ] Run without GCP credentials — verify no errors (the `if [ -f ]` guard skips the copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)