### PR TITLE
feat: SPEC.md-aware Plan Loop — Strategist reads SPEC.md, plan grounded in spec diff

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -567,6 +567,8 @@ This is a **hard gate**. The Builder MUST NOT start until you approve the plan.
 
 5. **Deferred section check:** If a Deferred section exists, verify it only contains items requiring human intervention (API keys, external accounts, manual provisioning). If it contains features or integrations that could be built without a human, REDIRECT with: "Deferred section contains buildable items — move them to build phases."
 
+6. **SPEC.md Diff check (conditional):** If SPEC.md exists in the project root, verify: (a) the plan contains a `## SPEC.md Diff` section with at least one ADDED, MODIFIED, or REMOVED subsection, and (b) every Phase hypothesis has an `**Implements:**` field referencing spec diff entries. If either is missing, REDIRECT with: "Project has SPEC.md but plan is missing spec traceability — add a ## SPEC.md Diff section and Implements fields on each Phase." Skip this check when no SPEC.md exists (greenfield projects).
+
 Write your review to `.factory/reviews/ceo-verdict-strategist.md`.
 
 If PROCEED: write `PLAN APPROVED` in your verdict file, then persist backlog items:
@@ -1146,6 +1148,25 @@ gh issue create \
 
 Save issue number as `$ISSUE_NUM`.
 
+#### 2c-spec. SPEC.md Update Instructions (conditional)
+
+When the approved plan contains a `## SPEC.md Diff` section, append the following to the GitHub issue body:
+
+```bash
+gh issue edit $ISSUE_NUM --body "$(gh issue view $ISSUE_NUM --json body -q .body)
+
+## SPEC.md Update
+
+Update SPEC.md in the same PR as code changes. Apply the SPEC.md Diff from the approved plan:
+- **ADDED** sections: insert new sections at the specified location
+- **MODIFIED** sections: replace the existing text with the updated text
+- **REMOVED** sections: delete the section entirely
+
+The SPEC.md update is part of this PR — do not open a separate PR for spec changes."
+```
+
+Skip this step when the approved plan has no `## SPEC.md Diff` section.
+
 #### 2d. Implement (Builder Agent)
 
 Set `$BUILDER_TIMEOUT` based on hypothesis type: **600** for code-only hypotheses, **1800** for operational or mixed hypotheses (pipelines, benchmarks, and Docker builds need more time).
@@ -1366,6 +1387,16 @@ Always include structured metadata in `--notes`:
 - `qa_iterations=N` — how many Builder→QA iterations were needed (1 = clean on first pass)
 
 This metadata feeds the CEO's own playbook evolution via ACE.
+
+#### 2h-spec. SPEC.md Merge Verification (conditional)
+
+When the approved plan contains a `## SPEC.md Diff` section, verify before proceeding to archival:
+
+1. **Check PR includes SPEC.md changes:** `gh pr diff $PR_NUM -- SPEC.md` — if empty, the Builder did not update SPEC.md.
+2. **Verify diff entries were applied:** ADDED sections are present, MODIFIED sections show updated text, REMOVED sections are deleted.
+3. **If SPEC.md changes are missing:** Re-invoke the Builder with: "The approved plan includes a SPEC.md Diff section but SPEC.md was not updated in the PR. Apply the spec changes from the plan to SPEC.md and commit." Max 2 re-invocation rounds.
+
+Skip this step when the approved plan has no `## SPEC.md Diff` section.
 
 #### 2h. Archivist — record experiment outcome (ASYNC)
 

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -447,6 +447,8 @@ Before writing any build plan content, you MUST ground your decisions in researc
 
 1. **Read `.factory/strategy/research.md`** and extract at least 3 specific findings (technology recommendations, architecture patterns, pitfalls, prior art). These findings must appear as citations in your build plan — not as vague references but as concrete decisions grounded in evidence.
 
+1b. **Check for SPEC.md at the project root.** If `SPEC.md` exists in the project directory, read it thoroughly. You MUST include a `## SPEC.md Diff` section in your output describing which spec sections are ADDED, MODIFIED, or REMOVED by this plan. If no SPEC.md exists (greenfield project), omit the section entirely.
+
 2. **Write a substantive hypothesis for each Phase** with:
    - **What:** Specific changes — project layout, deps, entry points, or feature implementation (detailed enough to implement without clarification)
    - **Why:** Research-grounded rationale — why this approach over alternatives
@@ -463,6 +465,45 @@ When your task includes a `## Prior Draft` and `## User Feedback` section, you a
 3. If the task includes `## Follow-Up Research`, incorporate the new research findings
 4. Produce a complete updated draft (not a diff — the full spec)
 5. Briefly note what changed and why at the very end under `## Changes from Prior Draft`
+
+### SPEC.md Diff Section
+
+When SPEC.md exists at the project root, your output MUST include a `## SPEC.md Diff` section describing how the spec changes. Use this format:
+
+```markdown
+## SPEC.md Diff
+
+### ADDED Requirements
+
+#### Section X.Y: <Title>
+<New requirement text using RFC 2119 language (MUST, SHOULD, MAY).
+Self-contained — a reader should understand the requirement without
+reading the rest of the plan.>
+
+### MODIFIED Requirements
+
+#### Section X.Y: <Title>
+- **Previously:** <what the spec currently says>
+- **Now:** <what it should say after this change>
+- **Rationale:** <why the change is needed>
+
+### REMOVED Requirements
+
+#### Section X.Y: <Title>
+- **Previously:** <what the spec currently says>
+- **Rationale:** <why this requirement is being removed>
+```
+
+**Rules:**
+- Reference specific SPEC.md section numbers (e.g., Section 2.3, Section 5)
+- Each entry must be self-contained — readable without the full plan context
+- Use RFC 2119 language (MUST, SHOULD, MAY) for requirements
+- Omit empty subsections (e.g., if nothing is REMOVED, omit that subsection)
+- Omit the entire `## SPEC.md Diff` section when no SPEC.md exists (greenfield projects)
+
+### Plan-Spec Traceability
+
+When a `## SPEC.md Diff` section is included, every Phase hypothesis MUST include an `**Implements:**` field listing which SPEC.md Diff entries it addresses (e.g., `**Implements:** MODIFIED Section 2, ADDED Section 5`). This creates traceability from spec → plan → implementation. If a SPEC.md Diff entry has no corresponding Phase, the plan is incomplete.
 
 ### Ideation Constraints
 
@@ -501,10 +542,16 @@ Write the build plan content to stdout using this exact structure. Each phase = 
 - **Expected impact:** <which eval dimensions improve>
 - **Priority:** high
 
+## SPEC.md Diff (when SPEC.md exists at project root)
+
+<ADDED/MODIFIED/REMOVED entries per the SPEC.md Diff Section format above.
+Omit entirely for greenfield projects with no SPEC.md.>
+
 ### Phase 2: <feature title>
 #### H2: <title>
 - **Category:** EXPLORE
 - **Growth dimension:** capability_surface
+- **Implements:** <SPEC.md Diff entries, e.g. "MODIFIED Section 2, ADDED Section 5" — required when SPEC.md Diff is present>
 - **What:** <specific, scoped change — one PR's worth>
 - **Why:** <rationale citing research>
 - **Expected impact:** <which eval dimensions improve>


### PR DESCRIPTION
## Summary

- Strategist reads SPEC.md during Grounding Protocol and produces a `## SPEC.md Diff` section with ADDED/MODIFIED/REMOVED markers anchored to SPEC.md section numbers
- Each Phase hypothesis includes an `**Implements:**` field for spec-to-plan traceability
- CEO verifies at P1r that SPEC.md-bearing projects have spec diff and traceability in the plan
- CEO appends SPEC.md update instructions to GitHub issues when a spec diff exists
- CEO verifies SPEC.md merge before KEEP verdict (2h-spec gate)
- Greenfield projects (no SPEC.md) are completely unaffected

## Test plan
- [x] `pytest tests/test_prompts.py -v` — all 71 tests pass
- [ ] Manual: run factory on a project with SPEC.md and verify Strategist output includes spec diff
- [ ] Manual: verify greenfield project is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)