### PR TITLE
feat: add --solver flag to benchmark CI for factory vs claude-code comparison

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,6 +23,15 @@ on:
         required: false
         default: '1800'
         type: string
+      solver:
+        description: 'Solver to use'
+        required: false
+        type: choice
+        default: 'factory'
+        options:
+          - factory
+          - claude-code
+          - both
       pr_number:
         description: 'PR number to post results to (optional)'
         required: false
@@ -54,18 +63,40 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Factory solver entries
           - benchmark: swebench
+            solver: factory
             default_instance: 'sympy__sympy-20590'
-            enabled: ${{ (github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all' }}
+            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: featurebench
+            solver: factory
             default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
-            enabled: ${{ (github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all' }}
+            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: terminalbench
+            solver: factory
             default_instance: 'fix-git'
-            enabled: ${{ (github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all' }}
+            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: programbench
+            solver: factory
             default_instance: 'cmatrix'
-            enabled: ${{ (github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all' }}
+            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
+          # Claude Code solver entries
+          - benchmark: swebench
+            solver: claude-code
+            default_instance: 'sympy__sympy-20590'
+            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+          - benchmark: featurebench
+            solver: claude-code
+            default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
+            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+          - benchmark: terminalbench
+            solver: claude-code
+            default_instance: 'fix-git'
+            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+          - benchmark: programbench
+            solver: claude-code
+            default_instance: 'cmatrix'
+            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
 
     steps:
       - name: Skip if not enabled
@@ -105,7 +136,7 @@ jobs:
           claude --version
 
       - name: Install Factory CLI
-        if: steps.gate.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true' && matrix.solver == 'factory'
         run: |
           uv tool install 'remote-factory @ git+https://github.com/akashgit/remote-factory.git'
           export PATH="$HOME/.local/bin:$PATH"
@@ -135,7 +166,7 @@ jobs:
             echo 'value=600' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run ${{ matrix.benchmark }} benchmark
+      - name: Run ${{ matrix.benchmark }} benchmark (${{ matrix.solver }})
         if: steps.gate.outputs.run == 'true'
         env:
           CLAUDE_CODE_USE_VERTEX: "1"
@@ -149,13 +180,13 @@ jobs:
           CLAUDE_CODE_EFFORT_LEVEL: "XHIGH"
         run: |
           chmod +x benchmarks/run.sh benchmarks/lib.sh benchmarks/run-*.sh
-          benchmarks/run.sh ${{ matrix.benchmark }} ${{ steps.config.outputs.instance }} --timeout ${{ steps.timeout.outputs.value }}
+          benchmarks/run.sh ${{ matrix.benchmark }} ${{ steps.config.outputs.instance }} --timeout ${{ steps.timeout.outputs.value }} --solver ${{ matrix.solver }}
 
       - name: Upload results
         uses: actions/upload-artifact@v4
         if: always() && steps.gate.outputs.run == 'true'
         with:
-          name: benchmark-results-${{ matrix.benchmark }}
+          name: benchmark-results-${{ matrix.benchmark }}-${{ matrix.solver }}
           path: benchmarks/results/
 
       - name: Print summary

--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -43,7 +43,7 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
-    DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"'}'
+    DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"', "solver": "'"${BENCHMARK_SOLVER:-factory}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0
@@ -84,7 +84,7 @@ if ! command -v claude &>/dev/null; then
     MISSING+=("claude (Claude Code CLI — install from https://docs.anthropic.com/en/docs/claude-code)")
 fi
 
-if ! command -v factory &>/dev/null; then
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ] && ! command -v factory &>/dev/null; then
     MISSING+=("factory (Factory CLI — install from the factory repo)")
 fi
 
@@ -99,7 +99,10 @@ fi
 echo "    python3: found"
 echo "    docker: found"
 echo "    claude: found"
-echo "    factory: found"
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ]; then
+    echo "    factory: found"
+fi
+echo "    solver: ${BENCHMARK_SOLVER:-factory}"
 
 ensure_uvx
 
@@ -181,7 +184,7 @@ echo ""
 
 # ── Step 5: Run solver (Factory CEO) ──
 
-log "Step 5: Running Factory CEO solver (timeout: ${SOLVER_TIMEOUT}s)"
+log "Step 5: Running solver [${BENCHMARK_SOLVER:-factory}] (timeout: ${SOLVER_TIMEOUT}s)"
 echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 SOLVER_PROMPT_FILE="${WORKSPACE}/solver_prompt.txt"
@@ -223,13 +226,6 @@ fi
 
 cd "${WORKSPACE}/repo"
 
-# Create minimal factory.md so factory recognizes the project
-cat > "${WORKSPACE}/repo/factory.md" << 'FACTORYEOF'
----
-goal: Implement the feature described in the problem statement
----
-FACTORYEOF
-
 export_claude_env
 
 # Temporarily allow failures — Steps 6-9 must always run regardless of solver/post-processing outcome
@@ -237,12 +233,31 @@ set +e
 
 SOLVER_LOG="${WORKSPACE}/solver_output.log"
 SOLVER_EXIT=0
-timeout "${SOLVER_TIMEOUT}" factory ceo . \
-    --headless \
-    --no-github \
-    --prompt "${SOLVER_PROMPT_FILE}" \
-    2>&1 | tee "${SOLVER_LOG}" | tail -50 || true
-SOLVER_EXIT=${PIPESTATUS[0]}
+
+if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
+    # Raw Claude Code path
+    timeout "${SOLVER_TIMEOUT}" claude -p "$(cat "${SOLVER_PROMPT_FILE}")" \
+        --model "${ANTHROPIC_MODEL}" \
+        --verbose --max-turns 200 \
+        --permission-mode bypassPermissions \
+        --output-format stream-json \
+        2>&1 | tee "${SOLVER_LOG}" | tail -50 || true
+    SOLVER_EXIT=${PIPESTATUS[0]}
+else
+    # Factory CEO path
+    cat > "${WORKSPACE}/repo/factory.md" << 'FACTORYEOF'
+---
+goal: Implement the feature described in the problem statement
+---
+FACTORYEOF
+
+    timeout "${SOLVER_TIMEOUT}" factory ceo . \
+        --headless \
+        --no-github \
+        --prompt "${SOLVER_PROMPT_FILE}" \
+        2>&1 | tee "${SOLVER_LOG}" | tail -50 || true
+    SOLVER_EXIT=${PIPESTATUS[0]}
+fi
 
 if [ "${SOLVER_EXIT}" -eq 124 ]; then
     echo "    Solver timed out after ${SOLVER_TIMEOUT}s"
@@ -250,50 +265,49 @@ elif [ "${SOLVER_EXIT}" -ne 0 ]; then
     echo "    Solver exited with code ${SOLVER_EXIT}"
 fi
 
-# Post-processing: merge factory branch changes back to default branch
-cd "${WORKSPACE}/repo"
+# Post-processing: recover factory branch/worktree changes (factory solver only)
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ]; then
+    cd "${WORKSPACE}/repo"
 
-# Strategy 1: Merge surviving factory branch
-FACTORY_BRANCH=$(git branch --list 'factory/*' | head -1 | tr -d ' *')
-if [ -n "$FACTORY_BRANCH" ]; then
-    echo "Merging factory branch: $FACTORY_BRANCH"
-    git merge "$FACTORY_BRANCH" --no-edit 2>/dev/null || git cherry-pick "$FACTORY_BRANCH" --no-edit 2>/dev/null || true
-fi
+    # Strategy 1: Merge surviving factory branch
+    FACTORY_BRANCH=$(git branch --list 'factory/*' | head -1 | tr -d ' *')
+    if [ -n "$FACTORY_BRANCH" ]; then
+        echo "Merging factory branch: $FACTORY_BRANCH"
+        git merge "$FACTORY_BRANCH" --no-edit 2>/dev/null || git cherry-pick "$FACTORY_BRANCH" --no-edit 2>/dev/null || true
+    fi
 
-# Strategy 2: Recover orphaned commits via git fsck
-if [ -z "$FACTORY_BRANCH" ]; then
-    echo "No factory branch, finding orphaned commits..."
-    ORPHAN_COMMITS=$(git fsck --unreachable --no-reflogs 2>/dev/null | grep 'unreachable commit' | awk '{print $3}')
-    if [ -n "$ORPHAN_COMMITS" ]; then
-        # Find the tip of the orphan chain — the commit with the latest timestamp
-        BEST_COMMIT=""
-        BEST_TIME=0
-        for SHA in $ORPHAN_COMMITS; do
-            COMMIT_TIME=$(git show -s --format='%ct' "$SHA" 2>/dev/null || echo 0)
-            if [ "$COMMIT_TIME" -gt "$BEST_TIME" ]; then
-                BEST_TIME=$COMMIT_TIME
-                BEST_COMMIT=$SHA
+    # Strategy 2: Recover orphaned commits via git fsck
+    if [ -z "$FACTORY_BRANCH" ]; then
+        echo "No factory branch, finding orphaned commits..."
+        ORPHAN_COMMITS=$(git fsck --unreachable --no-reflogs 2>/dev/null | grep 'unreachable commit' | awk '{print $3}')
+        if [ -n "$ORPHAN_COMMITS" ]; then
+            BEST_COMMIT=""
+            BEST_TIME=0
+            for SHA in $ORPHAN_COMMITS; do
+                COMMIT_TIME=$(git show -s --format='%ct' "$SHA" 2>/dev/null || echo 0)
+                if [ "$COMMIT_TIME" -gt "$BEST_TIME" ]; then
+                    BEST_TIME=$COMMIT_TIME
+                    BEST_COMMIT=$SHA
+                fi
+            done
+            if [ -n "$BEST_COMMIT" ]; then
+                echo "Recovering from orphan tip: $BEST_COMMIT"
+                echo "  Message: $(git log -1 --format='%s' $BEST_COMMIT 2>/dev/null)"
+                git checkout "$BEST_COMMIT" -- . 2>/dev/null || true
+                git checkout HEAD -- .factory/ eval/ factory.md 2>/dev/null || true
+                rm -rf .factory/ eval/ factory.md 2>/dev/null || true
             fi
-        done
-        if [ -n "$BEST_COMMIT" ]; then
-            echo "Recovering from orphan tip: $BEST_COMMIT"
-            echo "  Message: $(git log -1 --format='%s' $BEST_COMMIT 2>/dev/null)"
-            # Use checkout to restore ALL files from the orphan tip
-            git checkout "$BEST_COMMIT" -- . 2>/dev/null || true
-            # Clean up factory artifacts
-            git checkout HEAD -- .factory/ eval/ factory.md 2>/dev/null || true
-            rm -rf .factory/ eval/ factory.md 2>/dev/null || true
         fi
     fi
-fi
 
-# Strategy 3: Recover from surviving worktree directories
-for wt in .factory/worktrees/*/; do
-    if [ -d "$wt" ]; then
-        echo "Recovering files from worktree: $wt"
-        rsync -a --exclude='.git' --exclude='.factory' "$wt" ./ 2>/dev/null || true
-    fi
-done
+    # Strategy 3: Recover from surviving worktree directories
+    for wt in .factory/worktrees/*/; do
+        if [ -d "$wt" ]; then
+            echo "Recovering files from worktree: $wt"
+            rsync -a --exclude='.git' --exclude='.factory' "$wt" ./ 2>/dev/null || true
+        fi
+    done
+fi
 
 set -e
 

--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -58,6 +58,7 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0
@@ -140,8 +141,13 @@ echo ""
 
 # ── Step 5: Install Claude Code inside container ──
 
-log "Step 5: Installing Claude Code and Factory inside container"
-echo "    Installing Node.js 22, Claude Code, and Factory..."
+if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
+    log "Step 5: Installing Claude Code inside container"
+    echo "    Installing Node.js 22 and Claude Code..."
+else
+    log "Step 5: Installing Claude Code and Factory inside container"
+    echo "    Installing Node.js 22, Claude Code, and Factory..."
+fi
 
 docker exec "${CONTAINER_NAME}" bash -c '
     apt-get update && apt-get install -y git rsync &&
@@ -150,14 +156,17 @@ docker exec "${CONTAINER_NAME}" bash -c '
     npm install -g @anthropic-ai/claude-code
 '
 
-docker exec "${CONTAINER_NAME}" bash -c '
-    curl -LsSf https://astral.sh/uv/install.sh | sh &&
-    export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH" &&
-    uv tool install "remote-factory @ git+https://github.com/akashgit/remote-factory.git" &&
-    which factory
-'
-
-echo "    Claude Code and Factory installed."
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ]; then
+    docker exec "${CONTAINER_NAME}" bash -c '
+        curl -LsSf https://astral.sh/uv/install.sh | sh &&
+        export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH" &&
+        uv tool install "remote-factory @ git+https://github.com/akashgit/remote-factory.git" &&
+        which factory
+    '
+    echo "    Claude Code and Factory installed."
+else
+    echo "    Claude Code installed."
+fi
 
 # Create non-root agent user (Claude Code refuses --dangerously-skip-permissions as root)
 log "Step 5: Creating agent user"
@@ -212,7 +221,7 @@ echo ""
 
 # ── Step 5.5: Prepare workspace for Factory ──
 
-log "Step 5.5: Preparing workspace for Factory"
+log "Step 5.5: Preparing workspace"
 
 docker exec --user agent "${CONTAINER_NAME}" bash -c '
     cd /workspace &&
@@ -224,22 +233,24 @@ docker exec --user agent "${CONTAINER_NAME}" bash -c '
     git commit -m "initial cleanroom state" --allow-empty
 '
 
-docker exec --user agent "${CONTAINER_NAME}" bash -c 'cat > /workspace/factory.md << '\''FACTORYEOF'\''
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ]; then
+    docker exec --user agent "${CONTAINER_NAME}" bash -c 'cat > /workspace/factory.md << '\''FACTORYEOF'\''
 ---
 goal: Reverse-engineer the compiled binary and produce equivalent source code
 ---
 FACTORYEOF'
+fi
 
 docker exec --user agent "${CONTAINER_NAME}" bash -c '
     mkdir -p ~/.claude/debug ~/.claude/projects ~/.claude/shell-snapshots ~/.claude/statsig ~/.claude/todos ~/.claude/skills
 '
 
-echo "    Workspace prepared for Factory."
+echo "    Workspace prepared."
 echo ""
 
 # ── Step 6: Run solver ──
 
-log "Step 6: Running Factory CEO solver (timeout: ${SOLVER_TIMEOUT}s)"
+log "Step 6: Running solver [${BENCHMARK_SOLVER:-factory}] (timeout: ${SOLVER_TIMEOUT}s)"
 echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 SOLVER_PROMPT='You are reverse-engineering a compiled binary at /workspace/executable.
@@ -275,6 +286,13 @@ export_claude_env
 set +e
 
 SOLVER_EXIT=0
+
+if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
+    SOLVER_CMD='export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH" && cd /workspace && claude -p "$(cat /tmp/solver_prompt.txt)" --model "${ANTHROPIC_MODEL}" --verbose --max-turns 200 --permission-mode bypassPermissions --output-format stream-json'
+else
+    SOLVER_CMD='export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH" && cd /workspace && factory ceo . --headless --no-github --prompt /tmp/solver_prompt.txt'
+fi
+
 timeout "${SOLVER_TIMEOUT}" docker exec --user agent \
     -e CLAUDE_CODE_USE_VERTEX="${CLAUDE_CODE_USE_VERTEX:-}" \
     -e ANTHROPIC_VERTEX_PROJECT_ID="${ANTHROPIC_VERTEX_PROJECT_ID:-}" \
@@ -293,7 +311,7 @@ timeout "${SOLVER_TIMEOUT}" docker exec --user agent \
     -e NODE_EXTRA_CA_CERTS= \
     -e SSL_CERT_FILE= \
     "${CONTAINER_NAME}" \
-    bash -c 'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH" && cd /workspace && factory ceo . --headless --no-github --prompt /tmp/solver_prompt.txt' \
+    bash -c "${SOLVER_CMD}" \
     2>&1 | tee /dev/stderr | tail -50 || true
 SOLVER_EXIT=${PIPESTATUS[0]}
 
@@ -310,58 +328,57 @@ echo ""
 
 # ── Step 6.5: Recover factory worktree changes ──
 
-log "Step 6.5: Recovering factory worktree changes"
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ]; then
+    log "Step 6.5: Recovering factory worktree changes"
 
-docker exec --user agent "${CONTAINER_NAME}" bash -c '
-    set +e
-    cd /workspace
+    docker exec --user agent "${CONTAINER_NAME}" bash -c '
+        set +e
+        cd /workspace
 
-    # Strategy 1: Merge surviving factory branch
-    FACTORY_BRANCH=$(git branch --list "factory/*" | head -1 | tr -d " *")
-    if [ -n "$FACTORY_BRANCH" ]; then
-        echo "Merging factory branch: $FACTORY_BRANCH"
-        git merge "$FACTORY_BRANCH" --no-edit 2>/dev/null || git cherry-pick "$FACTORY_BRANCH" --no-edit 2>/dev/null || true
-    fi
+        # Strategy 1: Merge surviving factory branch
+        FACTORY_BRANCH=$(git branch --list "factory/*" | head -1 | tr -d " *")
+        if [ -n "$FACTORY_BRANCH" ]; then
+            echo "Merging factory branch: $FACTORY_BRANCH"
+            git merge "$FACTORY_BRANCH" --no-edit 2>/dev/null || git cherry-pick "$FACTORY_BRANCH" --no-edit 2>/dev/null || true
+        fi
 
-    # Strategy 2: Recover orphaned commits via git fsck
-    if [ -z "$FACTORY_BRANCH" ]; then
-        echo "No factory branch, finding orphaned commits..."
-        ORPHAN_COMMITS=$(git fsck --unreachable --no-reflogs 2>/dev/null | grep "unreachable commit" | awk "{print \$3}")
-        if [ -n "$ORPHAN_COMMITS" ]; then
-            # Find the tip of the orphan chain — the commit with the latest timestamp
-            BEST_COMMIT=""
-            BEST_TIME=0
-            for SHA in $ORPHAN_COMMITS; do
-                COMMIT_TIME=$(git show -s --format="%ct" "$SHA" 2>/dev/null || echo 0)
-                if [ "$COMMIT_TIME" -gt "$BEST_TIME" ]; then
-                    BEST_TIME=$COMMIT_TIME
-                    BEST_COMMIT=$SHA
+        # Strategy 2: Recover orphaned commits via git fsck
+        if [ -z "$FACTORY_BRANCH" ]; then
+            echo "No factory branch, finding orphaned commits..."
+            ORPHAN_COMMITS=$(git fsck --unreachable --no-reflogs 2>/dev/null | grep "unreachable commit" | awk "{print \$3}")
+            if [ -n "$ORPHAN_COMMITS" ]; then
+                BEST_COMMIT=""
+                BEST_TIME=0
+                for SHA in $ORPHAN_COMMITS; do
+                    COMMIT_TIME=$(git show -s --format="%ct" "$SHA" 2>/dev/null || echo 0)
+                    if [ "$COMMIT_TIME" -gt "$BEST_TIME" ]; then
+                        BEST_TIME=$COMMIT_TIME
+                        BEST_COMMIT=$SHA
+                    fi
+                done
+                if [ -n "$BEST_COMMIT" ]; then
+                    echo "Recovering from orphan tip: $BEST_COMMIT"
+                    echo "  Message: $(git log -1 --format="%s" $BEST_COMMIT 2>/dev/null)"
+                    git checkout "$BEST_COMMIT" -- . 2>/dev/null || true
+                    git checkout HEAD -- .factory/ eval/ factory.md 2>/dev/null || true
+                    rm -rf .factory/ eval/ factory.md 2>/dev/null || true
                 fi
-            done
-            if [ -n "$BEST_COMMIT" ]; then
-                echo "Recovering from orphan tip: $BEST_COMMIT"
-                echo "  Message: $(git log -1 --format="%s" $BEST_COMMIT 2>/dev/null)"
-                # Use checkout to restore ALL files from the orphan tip
-                git checkout "$BEST_COMMIT" -- . 2>/dev/null || true
-                # Clean up factory artifacts
-                git checkout HEAD -- .factory/ eval/ factory.md 2>/dev/null || true
-                rm -rf .factory/ eval/ factory.md 2>/dev/null || true
             fi
         fi
-    fi
 
-    # Strategy 3: Recover from surviving worktree directories
-    for wt in .factory/worktrees/*/; do
-        if [ -d "$wt" ]; then
-            echo "Recovering files from worktree: $wt"
-            rsync -a --exclude=.git --exclude=.factory "$wt" ./ 2>/dev/null || true
-        fi
-    done
+        # Strategy 3: Recover from surviving worktree directories
+        for wt in .factory/worktrees/*/; do
+            if [ -d "$wt" ]; then
+                echo "Recovering files from worktree: $wt"
+                rsync -a --exclude=.git --exclude=.factory "$wt" ./ 2>/dev/null || true
+            fi
+        done
 
-    exit 0
-'
+        exit 0
+    '
 
-echo "    Worktree recovery complete."
+    echo "    Worktree recovery complete."
+fi
 echo ""
 
 # ── Step 7: Package submission ──

--- a/benchmarks/run-swebench.sh
+++ b/benchmarks/run-swebench.sh
@@ -39,6 +39,7 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0
@@ -78,7 +79,7 @@ if ! command -v claude &>/dev/null; then
     MISSING+=("claude (Claude Code CLI — install from https://docs.anthropic.com/en/docs/claude-code)")
 fi
 
-if ! command -v factory &>/dev/null; then
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ] && ! command -v factory &>/dev/null; then
     MISSING+=("factory (Factory CLI — install from the factory repo)")
 fi
 
@@ -93,7 +94,10 @@ fi
 echo "    python3: found"
 echo "    docker: found"
 echo "    claude: found"
-echo "    factory: found"
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ]; then
+    echo "    factory: found"
+fi
+echo "    solver: ${BENCHMARK_SOLVER:-factory}"
 
 ensure_uvx
 
@@ -171,7 +175,7 @@ echo ""
 
 # ── Step 5: Run solver (Factory CEO) ──
 
-log "Step 5: Running Factory CEO solver (timeout: ${SOLVER_TIMEOUT}s)"
+log "Step 5: Running solver [${BENCHMARK_SOLVER:-factory}] (timeout: ${SOLVER_TIMEOUT}s)"
 echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 SOLVER_PROMPT_FILE="${WORKSPACE}/solver_prompt.txt"
@@ -208,13 +212,6 @@ fi
 
 cd "${WORKSPACE}/repo"
 
-# Create minimal factory.md so factory recognizes the project
-cat > "${WORKSPACE}/repo/factory.md" << 'FACTORYEOF'
----
-goal: Fix the bug described in the problem statement
----
-FACTORYEOF
-
 export_claude_env
 
 # Temporarily allow failures — Steps 6-9 must always run regardless of solver/post-processing outcome
@@ -222,12 +219,31 @@ set +e
 
 SOLVER_LOG="${WORKSPACE}/solver_output.log"
 SOLVER_EXIT=0
-timeout "${SOLVER_TIMEOUT}" factory ceo . \
-    --headless \
-    --no-github \
-    --prompt "${SOLVER_PROMPT_FILE}" \
-    2>&1 | tee "${SOLVER_LOG}" | tail -50 || true
-SOLVER_EXIT=${PIPESTATUS[0]}
+
+if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
+    # Raw Claude Code path
+    timeout "${SOLVER_TIMEOUT}" claude -p "$(cat "${SOLVER_PROMPT_FILE}")" \
+        --model "${ANTHROPIC_MODEL}" \
+        --verbose --max-turns 200 \
+        --permission-mode bypassPermissions \
+        --output-format stream-json \
+        2>&1 | tee "${SOLVER_LOG}" | tail -50 || true
+    SOLVER_EXIT=${PIPESTATUS[0]}
+else
+    # Factory CEO path
+    cat > "${WORKSPACE}/repo/factory.md" << 'FACTORYEOF'
+---
+goal: Fix the bug described in the problem statement
+---
+FACTORYEOF
+
+    timeout "${SOLVER_TIMEOUT}" factory ceo . \
+        --headless \
+        --no-github \
+        --prompt "${SOLVER_PROMPT_FILE}" \
+        2>&1 | tee "${SOLVER_LOG}" | tail -50 || true
+    SOLVER_EXIT=${PIPESTATUS[0]}
+fi
 
 if [ "${SOLVER_EXIT}" -eq 124 ]; then
     echo "    Solver timed out after ${SOLVER_TIMEOUT}s"
@@ -235,50 +251,49 @@ elif [ "${SOLVER_EXIT}" -ne 0 ]; then
     echo "    Solver exited with code ${SOLVER_EXIT}"
 fi
 
-# Post-processing: merge factory branch changes back to default branch
-cd "${WORKSPACE}/repo"
+# Post-processing: recover factory branch/worktree changes (factory solver only)
+if [ "${BENCHMARK_SOLVER:-factory}" = "factory" ]; then
+    cd "${WORKSPACE}/repo"
 
-# Strategy 1: Merge surviving factory branch
-FACTORY_BRANCH=$(git branch --list 'factory/*' | head -1 | tr -d ' *')
-if [ -n "$FACTORY_BRANCH" ]; then
-    echo "Merging factory branch: $FACTORY_BRANCH"
-    git merge "$FACTORY_BRANCH" --no-edit 2>/dev/null || git cherry-pick "$FACTORY_BRANCH" --no-edit 2>/dev/null || true
-fi
+    # Strategy 1: Merge surviving factory branch
+    FACTORY_BRANCH=$(git branch --list 'factory/*' | head -1 | tr -d ' *')
+    if [ -n "$FACTORY_BRANCH" ]; then
+        echo "Merging factory branch: $FACTORY_BRANCH"
+        git merge "$FACTORY_BRANCH" --no-edit 2>/dev/null || git cherry-pick "$FACTORY_BRANCH" --no-edit 2>/dev/null || true
+    fi
 
-# Strategy 2: Recover orphaned commits via git fsck
-if [ -z "$FACTORY_BRANCH" ]; then
-    echo "No factory branch, finding orphaned commits..."
-    ORPHAN_COMMITS=$(git fsck --unreachable --no-reflogs 2>/dev/null | grep 'unreachable commit' | awk '{print $3}')
-    if [ -n "$ORPHAN_COMMITS" ]; then
-        # Find the tip of the orphan chain — the commit with the latest timestamp
-        BEST_COMMIT=""
-        BEST_TIME=0
-        for SHA in $ORPHAN_COMMITS; do
-            COMMIT_TIME=$(git show -s --format='%ct' "$SHA" 2>/dev/null || echo 0)
-            if [ "$COMMIT_TIME" -gt "$BEST_TIME" ]; then
-                BEST_TIME=$COMMIT_TIME
-                BEST_COMMIT=$SHA
+    # Strategy 2: Recover orphaned commits via git fsck
+    if [ -z "$FACTORY_BRANCH" ]; then
+        echo "No factory branch, finding orphaned commits..."
+        ORPHAN_COMMITS=$(git fsck --unreachable --no-reflogs 2>/dev/null | grep 'unreachable commit' | awk '{print $3}')
+        if [ -n "$ORPHAN_COMMITS" ]; then
+            BEST_COMMIT=""
+            BEST_TIME=0
+            for SHA in $ORPHAN_COMMITS; do
+                COMMIT_TIME=$(git show -s --format='%ct' "$SHA" 2>/dev/null || echo 0)
+                if [ "$COMMIT_TIME" -gt "$BEST_TIME" ]; then
+                    BEST_TIME=$COMMIT_TIME
+                    BEST_COMMIT=$SHA
+                fi
+            done
+            if [ -n "$BEST_COMMIT" ]; then
+                echo "Recovering from orphan tip: $BEST_COMMIT"
+                echo "  Message: $(git log -1 --format='%s' $BEST_COMMIT 2>/dev/null)"
+                git checkout "$BEST_COMMIT" -- . 2>/dev/null || true
+                git checkout HEAD -- .factory/ eval/ factory.md 2>/dev/null || true
+                rm -rf .factory/ eval/ factory.md 2>/dev/null || true
             fi
-        done
-        if [ -n "$BEST_COMMIT" ]; then
-            echo "Recovering from orphan tip: $BEST_COMMIT"
-            echo "  Message: $(git log -1 --format='%s' $BEST_COMMIT 2>/dev/null)"
-            # Use checkout to restore ALL files from the orphan tip
-            git checkout "$BEST_COMMIT" -- . 2>/dev/null || true
-            # Clean up factory artifacts
-            git checkout HEAD -- .factory/ eval/ factory.md 2>/dev/null || true
-            rm -rf .factory/ eval/ factory.md 2>/dev/null || true
         fi
     fi
-fi
 
-# Strategy 3: Recover from surviving worktree directories
-for wt in .factory/worktrees/*/; do
-    if [ -d "$wt" ]; then
-        echo "Recovering files from worktree: $wt"
-        rsync -a --exclude='.git' --exclude='.factory' "$wt" ./ 2>/dev/null || true
-    fi
-done
+    # Strategy 3: Recover from surviving worktree directories
+    for wt in .factory/worktrees/*/; do
+        if [ -d "$wt" ]; then
+            echo "Recovering files from worktree: $wt"
+            rsync -a --exclude='.git' --exclude='.factory' "$wt" ./ 2>/dev/null || true
+        fi
+    done
+fi
 
 set -e
 

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -38,6 +38,7 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0
@@ -126,18 +127,28 @@ echo "    Timeout mult:    ${TIMEOUT_MULTIPLIER}x"
 echo "    Task:            ${TASK_NAME}"
 echo ""
 
-AGENT_MODULE="${HARNESS_DIR}/benchmarks/factory_harbor_agent.py"
-export PYTHONPATH="$(dirname "${AGENT_MODULE}"):${PYTHONPATH:-}"
-
 cd "${HARNESS_DIR}"
 
 HARBOR_EXIT=0
+
+if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
+    # Use Harbor's built-in claude-code agent
+    AGENT_ARGS=(--agent claude-code)
+    echo "    Agent:           claude-code (Harbor built-in)"
+else
+    # Use Factory Harbor agent
+    AGENT_MODULE="${HARNESS_DIR}/benchmarks/factory_harbor_agent.py"
+    export PYTHONPATH="$(dirname "${AGENT_MODULE}"):${PYTHONPATH:-}"
+    AGENT_ARGS=(--agent-import-path factory_harbor_agent:FactoryCeo)
+    echo "    Agent:           factory (FactoryCeo)"
+fi
+
 if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
     GCLOUD_ADC="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
     echo "    Auth mode:       Vertex AI (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
     uvx harbor run \
         --dataset terminal-bench@2.0 \
-        --agent-import-path factory_harbor_agent:FactoryCeo \
+        "${AGENT_ARGS[@]}" \
         --model "${MODEL}" \
         --include-task-name "${TASK_NAME}" \
         --n-concurrent 1 \
@@ -160,7 +171,7 @@ else
     echo "    Auth mode:       Direct API (ANTHROPIC_API_KEY)"
     uvx harbor run \
         --dataset terminal-bench@2.0 \
-        --agent-import-path factory_harbor_agent:FactoryCeo \
+        "${AGENT_ARGS[@]}" \
         --model "${MODEL}" \
         --include-task-name "${TASK_NAME}" \
         --n-concurrent 1 \

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # benchmarks/run.sh — Unified entry point for all benchmark runners.
 #
-# Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve]
+# Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]
 #
 # Arguments:
 #   benchmark      Required. One of: swebench, featurebench, terminalbench, programbench
@@ -13,13 +13,14 @@ set -euo pipefail
 #   --timeout N    Solver timeout in seconds
 #   --split S      Dataset split (featurebench only)
 #   --preserve     Keep workspace/volumes after run
+#   --solver S     Solver to use: factory (default) or claude-code
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ── Parse arguments ──
 
 if [ $# -lt 2 ]; then
-    echo "Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve]"
+    echo "Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]"
     echo ""
     echo "Benchmarks: swebench, featurebench, terminalbench, programbench"
     exit 1
@@ -32,6 +33,7 @@ shift 2
 TIMEOUT=""
 SPLIT=""
 PRESERVE=""
+SOLVER="factory"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -47,12 +49,29 @@ while [ $# -gt 0 ]; do
             PRESERVE=1
             shift
             ;;
+        --solver)
+            SOLVER="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown option: $1"
             exit 1
             ;;
     esac
 done
+
+# Validate solver
+case "${SOLVER}" in
+    factory|claude-code)
+        ;;
+    *)
+        echo "ERROR: Unknown solver '${SOLVER}'"
+        echo "Valid solvers: factory, claude-code"
+        exit 1
+        ;;
+esac
+
+export BENCHMARK_SOLVER="${SOLVER}"
 
 # ── Validate benchmark ──
 


### PR DESCRIPTION
Closes the solver selection task from `.factory/strategy/research-compare-claude-code.md`.

## Summary

- Adds `--solver factory|claude-code` flag to `benchmarks/run.sh`, propagated as `BENCHMARK_SOLVER` env var to all benchmark scripts
- Each benchmark script (`run-swebench.sh`, `run-featurebench.sh`, `run-terminalbench.sh`, `run-programbench.sh`) branches on `BENCHMARK_SOLVER` to use either Factory CEO or raw Claude Code as the solver
- `benchmark.yml` gains a `solver` workflow_dispatch input (`factory`/`claude-code`/`both`) that controls the matrix — selecting `both` doubles the matrix with one entry per solver per benchmark
- Factory CLI install is skipped when solver is `claude-code` (saves CI time)
- Artifact names now include the solver to avoid collisions when running both
- All result JSONs include `"solver"` in the details object for downstream comparison

## Changes

- `benchmarks/run.sh` — new `--solver` flag with validation, exported as `BENCHMARK_SOLVER`
- `benchmarks/run-swebench.sh` — claude-code path uses `claude -p` directly; factory path retains `factory ceo` + worktree recovery
- `benchmarks/run-featurebench.sh` — same pattern as swebench
- `benchmarks/run-terminalbench.sh` — claude-code uses Harbor's built-in `--agent claude-code`; factory uses custom `FactoryCeo` agent
- `benchmarks/run-programbench.sh` — claude-code skips factory CLI install and worktree recovery inside Docker
- `.github/workflows/benchmark.yml` — `solver` input, doubled matrix with solver dimension, conditional Factory CLI install

## Test plan

- [ ] Run `bash -n` on all modified scripts (done — all pass)
- [ ] Validate workflow YAML syntax (done — passes)
- [ ] Trigger workflow with `solver: factory` — should behave identically to current main
- [ ] Trigger workflow with `solver: claude-code` — should skip Factory install, use `claude -p` directly
- [ ] Trigger workflow with `solver: both` — should create 8 matrix jobs (4 benchmarks × 2 solvers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)