### PR TITLE
fix: pass --extra-instruction-path for claude-code solver in TerminalBench

### DIFF
--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -38,6 +38,7 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0
@@ -126,18 +127,26 @@ echo "    Timeout mult:    ${TIMEOUT_MULTIPLIER}x"
 echo "    Task:            ${TASK_NAME}"
 echo ""
 
-AGENT_MODULE="${HARNESS_DIR}/benchmarks/factory_harbor_agent.py"
-export PYTHONPATH="$(dirname "${AGENT_MODULE}"):${PYTHONPATH:-}"
-
 cd "${HARNESS_DIR}"
 
 HARBOR_EXIT=0
+
+if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
+    AGENT_ARGS=(--agent claude-code --extra-instruction-path "${HARNESS_DIR}/benchmarks/terminalbench-extra-instructions.md")
+    echo "    Agent:           claude-code (Harbor built-in)"
+else
+    AGENT_MODULE="${HARNESS_DIR}/benchmarks/factory_harbor_agent.py"
+    export PYTHONPATH="$(dirname "${AGENT_MODULE}"):${PYTHONPATH:-}"
+    AGENT_ARGS=(--agent-import-path factory_harbor_agent:FactoryCeo)
+    echo "    Agent:           factory (FactoryCeo)"
+fi
+
 if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
     GCLOUD_ADC="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
     echo "    Auth mode:       Vertex AI (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
     uvx harbor run \
         --dataset terminal-bench@2.0 \
-        --agent-import-path factory_harbor_agent:FactoryCeo \
+        "${AGENT_ARGS[@]}" \
         --model "${MODEL}" \
         --include-task-name "${TASK_NAME}" \
         --n-concurrent 1 \
@@ -160,7 +169,7 @@ else
     echo "    Auth mode:       Direct API (ANTHROPIC_API_KEY)"
     uvx harbor run \
         --dataset terminal-bench@2.0 \
-        --agent-import-path factory_harbor_agent:FactoryCeo \
+        "${AGENT_ARGS[@]}" \
         --model "${MODEL}" \
         --include-task-name "${TASK_NAME}" \
         --n-concurrent 1 \


### PR DESCRIPTION
## Summary

- Adds `--extra-instruction-path` to the `claude-code` solver path in `run-terminalbench.sh`, pointing to the existing `terminalbench-extra-instructions.md`
- Without this, Harbor's built-in claude-code agent asks for confirmation and stops after 50 seconds
- Also introduces `BENCHMARK_SOLVER` conditional logic to select between `claude-code` and `factory` agents, keeping PYTHONPATH setup scoped to the factory path only

## Test plan

- [ ] Run `BENCHMARK_SOLVER=claude-code benchmarks/run-terminalbench.sh` and verify the agent runs autonomously without stopping for confirmation
- [ ] Run `benchmarks/run-terminalbench.sh` (default factory solver) and verify it still works as before
- [ ] Verify `bash -n benchmarks/run-terminalbench.sh` passes syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)