### PR TITLE
Workflow graph engine: composable primitives for factory orchestration

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -4285,6 +4285,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--session", default=None, help="Session name to stop")
     p.add_argument("--path", default=None, help="Project path (derives session name)")
 
+    # workflow — graph engine commands
+    from factory.workflow.cli import add_workflow_parser
+    add_workflow_parser(sub)
+
     return parser
 
 
@@ -4358,6 +4362,7 @@ def main(argv: list[str] | None = None) -> int:
         "tmux": cmd_tmux,
         "tmux-ls": cmd_tmux_ls,
         "tmux-stop": cmd_tmux_stop,
+        "workflow": lambda a: __import__("factory.workflow.cli", fromlist=["cmd_workflow"]).cmd_workflow(a),
     }
 
     try:

--- a/factory/workflow/__init__.py
+++ b/factory/workflow/__init__.py
@@ -1,0 +1,36 @@
+"""Workflow graph engine — composable primitives for factory orchestration."""
+
+from factory.workflow.executor import ExecutionResult, WorkflowExecutor
+from factory.workflow.primitives import (
+    AgentConfig,
+    AgentNode,
+    AgentRole,
+    Edge,
+    Factory,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    Study,
+    Verdict,
+    VerdictType,
+    Workflow,
+)
+
+__all__ = [
+    "AgentConfig",
+    "AgentNode",
+    "AgentRole",
+    "Edge",
+    "ExecutionResult",
+    "Factory",
+    "FnNode",
+    "ForkNode",
+    "GateNode",
+    "JoinNode",
+    "Study",
+    "Verdict",
+    "VerdictType",
+    "Workflow",
+    "WorkflowExecutor",
+]

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -1,0 +1,199 @@
+"""CLI subcommands for the workflow graph engine."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+import structlog
+
+from factory.workflow.definitions import register_all
+from factory.workflow.executor import WorkflowExecutor
+from factory.workflow.primitives import (
+    DEFAULT_AGENT_POOL,
+    AgentNode,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    Study,
+)
+
+log = structlog.get_logger()
+
+
+def cmd_workflow(args: argparse.Namespace) -> int:
+    """Dispatch workflow subcommands."""
+    sub = getattr(args, "workflow_command", None)
+    if not sub:
+        print("Usage: factory workflow {run,list,show,validate}")
+        return 1
+
+    handlers = {
+        "run": _cmd_run,
+        "list": _cmd_list,
+        "show": _cmd_show,
+        "validate": _cmd_validate,
+    }
+
+    handler = handlers.get(sub)
+    if handler:
+        return handler(args)
+
+    print(f"Unknown workflow subcommand: {sub}")
+    return 1
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    """Run a named workflow on a project."""
+    name = args.name
+    project_path = Path(args.project_path).resolve()
+    dry_run = getattr(args, "dry_run", False)
+
+    workflows = register_all()
+    wf = workflows.get(name)
+    if not wf:
+        print(f"Unknown workflow: {name}")
+        print(f"Available: {', '.join(workflows)}")
+        return 1
+
+    executor = WorkflowExecutor(
+        wf,
+        project_path,
+        agent_pool=DEFAULT_AGENT_POOL,
+        dry_run=dry_run,
+    )
+
+    result = asyncio.run(executor.execute())
+
+    print(json.dumps({
+        "workflow": name,
+        "success": result.success,
+        "halted": result.halted,
+        "halt_reason": result.halt_reason,
+        "nodes_executed": result.nodes_executed,
+        "duration_ms": round(result.duration_ms, 1),
+        "files_produced": sorted(result.completed_files),
+    }, indent=2))
+
+    return 0 if result.success else 1
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    """List all registered workflows."""
+    workflows = register_all()
+
+    header = f"{'Name':<12} {'Nodes':>6} {'Edges':>6} {'Start Node':<20}"
+    print(header)
+    print("-" * len(header))
+
+    for name, wf in workflows.items():
+        print(f"{name:<12} {len(wf.nodes):>6} {len(wf.edges):>6} {wf.start_node:<20}")
+
+    return 0
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    """Show a workflow's graph as a node/edge table."""
+    name = args.name
+    workflows = register_all()
+    wf = workflows.get(name)
+    if not wf:
+        print(f"Unknown workflow: {name}")
+        return 1
+
+    print(f"Workflow: {wf.name}")
+    print(f"Start:    {wf.start_node}")
+    print()
+
+    # Nodes table
+    print("Nodes:")
+    header = f"  {'ID':<25} {'Type':<12} {'Blocking':>8} {'Reads':<30} {'Writes':<30}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+
+    for nid, node in wf.nodes.items():
+        ntype = type(node).__name__
+        blocking = "yes" if node.blocking else "async"
+        reads = ", ".join(sorted(node.reads)) if node.reads else "-"
+        writes = ", ".join(sorted(node.writes)) if node.writes else "-"
+
+        if isinstance(node, AgentNode):
+            ntype = f"Agent({node.role.value})"
+        elif isinstance(node, GateNode):
+            ntype = f"Gate({node.evaluator_type})"
+        elif isinstance(node, ForkNode):
+            ntype = f"Fork({len(node.targets)})"
+        elif isinstance(node, JoinNode):
+            ntype = f"Join({len(node.sources)})"
+        elif isinstance(node, Study):
+            ntype = "Study"
+        elif isinstance(node, FnNode):
+            ntype = "Fn"
+
+        if len(reads) > 28:
+            reads = reads[:25] + "..."
+        if len(writes) > 28:
+            writes = writes[:25] + "..."
+
+        print(f"  {nid:<25} {ntype:<12} {blocking:>8} {reads:<30} {writes:<30}")
+
+    print()
+
+    # Edges table
+    print("Edges:")
+    header = f"  {'Source':<25} {'Target':<25} {'Condition':<15}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+
+    for edge in wf.edges:
+        cond = edge.condition.value if edge.condition else "-"
+        print(f"  {edge.source:<25} {edge.target:<25} {cond:<15}")
+
+    return 0
+
+
+def _cmd_validate(args: argparse.Namespace) -> int:
+    """Validate a workflow using NetworkX."""
+    name = args.name
+    workflows = register_all()
+    wf = workflows.get(name)
+    if not wf:
+        print(f"Unknown workflow: {name}")
+        return 1
+
+    issues = wf.validate_graph()
+
+    if not issues:
+        print(f"Workflow '{name}': VALID ({len(wf.nodes)} nodes, {len(wf.edges)} edges)")
+        return 0
+
+    print(f"Workflow '{name}': {len(issues)} issue(s) found:")
+    for issue in issues:
+        print(f"  - {issue}")
+    return 1
+
+
+def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the 'workflow' subcommand with its subcommands."""
+    wf_parser = sub.add_parser("workflow", help="Workflow graph engine commands")
+    wf_sub = wf_parser.add_subparsers(dest="workflow_command")
+
+    # run
+    p = wf_sub.add_parser("run", help="Run a named workflow on a project")
+    p.add_argument("name", help="Workflow name (build, design, improve, research, meta)")
+    p.add_argument("project_path", help="Path to the project")
+    p.add_argument("--dry-run", action="store_true", help="Execute without real agent calls")
+
+    # list
+    wf_sub.add_parser("list", help="List all registered workflows")
+
+    # show
+    p = wf_sub.add_parser("show", help="Show workflow graph details")
+    p.add_argument("name", help="Workflow name")
+
+    # validate
+    p = wf_sub.add_parser("validate", help="Validate workflow graph structure")
+    p.add_argument("name", help="Workflow name")

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -460,13 +460,21 @@ def research_workflow() -> Workflow:
         writes={".factory/reviews/evaluator-latest.md"},
     )
 
-    # Add plateau gate after finalize
+    # Add plateau gate after finalize — checks if score improved over prior runs
     wf.nodes["plateau_gate"] = GateNode(
         id="plateau_gate",
         evaluator_type="fn",
         evaluator_command=(
-            "python3 -c \"import json, sys; "
-            "print('PROCEED' if True else 'RELOOP')\""
+            "python3 -c \""
+            "import json, pathlib, sys; "
+            "tsv = pathlib.Path('{project_path}/.factory/results.tsv'); "
+            "lines = [l for l in tsv.read_text().strip().splitlines()[1:] if l.strip()] if tsv.exists() else []; "
+            "scores = []; "
+            "[scores.append(float(p)) for l in lines for i, p in enumerate(l.split(chr(9))) if i == 2 and p]; "
+            "recent = scores[-3:] if len(scores) >= 3 else scores; "
+            "improved = len(recent) < 2 or recent[-1] > recent[-2]; "
+            "print('RELOOP' if improved else 'PROCEED')"
+            "\""
         ),
         reads={".factory/experiments/verdict.json"},
     )
@@ -663,9 +671,6 @@ def meta_workflow() -> Workflow:
 
 
 # ── Registry ─────────────────────────────────────────────────────
-
-
-ALL_WORKFLOWS: dict[str, type[Workflow] | Any] = {}
 
 
 def register_all() -> dict[str, Workflow]:

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -1,0 +1,679 @@
+"""All 5 workflow definitions as Python functions returning Workflow objects.
+
+W₁: Build Mode
+W₂: Design Mode (= W₁ with user gate at strategy approval)
+W₃: Improve Mode
+W₄: Research Mode (= W₃ with baseline+failure_analyst, research_command eval, plateau gate)
+W₅: Meta Mode
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    Study,
+    VerdictType,
+    Workflow,
+)
+
+
+# ── W₁: Build Mode ──────────────────────────────────────────────
+
+
+def build_workflow() -> Workflow:
+    """W₁: Build Mode — new project from idea/spec.
+
+    Fork(3 researchers) → Join → CEO gate → Strategist → CEO gate →
+    Archivist(async) → Builder → CEO gate(max 3) → Evaluator → Precheck gate →
+    Archivist(async)
+    """
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # Fork: 3 parallel researchers
+    nodes["fork_research"] = ForkNode(
+        id="fork_research",
+        targets=["researcher_similar", "researcher_techstack", "researcher_pitfalls"],
+    )
+
+    nodes["researcher_similar"] = AgentNode(
+        id="researcher_similar",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Research similar projects and prior art. "
+            "Write findings to .factory/strategy/research-similar.md"
+        ),
+        writes={".factory/strategy/research-similar.md"},
+    )
+    nodes["researcher_techstack"] = AgentNode(
+        id="researcher_techstack",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Research tech stack choices, best practices, and implementation patterns. "
+            "Write findings to .factory/strategy/research-techstack.md"
+        ),
+        writes={".factory/strategy/research-techstack.md"},
+    )
+    nodes["researcher_pitfalls"] = AgentNode(
+        id="researcher_pitfalls",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Research common pitfalls, anti-patterns, and failure modes. "
+            "Write findings to .factory/strategy/research-pitfalls.md"
+        ),
+        writes={".factory/strategy/research-pitfalls.md"},
+    )
+
+    # Join
+    nodes["join_research"] = JoinNode(
+        id="join_research",
+        sources=["researcher_similar", "researcher_techstack", "researcher_pitfalls"],
+        reads={
+            ".factory/strategy/research-similar.md",
+            ".factory/strategy/research-techstack.md",
+            ".factory/strategy/research-pitfalls.md",
+        },
+        writes={".factory/strategy/research-combined.md"},
+    )
+
+    # CEO gate on research quality
+    nodes["gate_research"] = GateNode(
+        id="gate_research",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        reads={".factory/strategy/research-combined.md"},
+    )
+
+    # Strategist
+    nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Synthesize research into a phased build plan. "
+            "Read research files and write plan to .factory/strategy/current.md"
+        ),
+        reads={".factory/strategy/research-combined.md"},
+        writes={".factory/strategy/current.md"},
+    )
+
+    # CEO gate on strategy quality
+    nodes["gate_strategy"] = GateNode(
+        id="gate_strategy",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        reads={".factory/strategy/current.md"},
+    )
+
+    # Archivist (async, non-blocking)
+    nodes["archivist_plan"] = AgentNode(
+        id="archivist_plan",
+        role=AgentRole.ARCHIVIST,
+        prompt_template="Archive the approved research and strategy.",
+        reads={".factory/strategy/current.md"},
+        writes={".factory/archive/plan.md"},
+        blocking=False,
+    )
+
+    # Per-phase: Builder → CEO gate → Evaluator → Precheck → Archivist(async)
+    nodes["builder"] = AgentNode(
+        id="builder",
+        role=AgentRole.BUILDER,
+        prompt_template=(
+            "Implement the current phase from .factory/strategy/current.md. "
+            "Open a draft PR with the changes."
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    nodes["gate_build"] = GateNode(
+        id="gate_build",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    nodes["evaluator"] = AgentNode(
+        id="evaluator",
+        role=AgentRole.EVALUATOR,
+        prompt_template="Run eval command and interpret scores.",
+        reads={".factory/reviews/builder-latest.md"},
+        writes={".factory/reviews/evaluator-latest.md"},
+    )
+
+    nodes["gate_precheck"] = GateNode(
+        id="gate_precheck",
+        evaluator_type="fn",
+        evaluator_command="factory precheck {project_path} --score-before 0 --score-after 0",
+        reads={".factory/reviews/evaluator-latest.md"},
+    )
+
+    nodes["archivist_build"] = AgentNode(
+        id="archivist_build",
+        role=AgentRole.ARCHIVIST,
+        prompt_template="Archive the build phase results.",
+        reads={".factory/reviews/evaluator-latest.md"},
+        writes={".factory/archive/build.md"},
+        blocking=False,
+    )
+
+    # Edges
+    edges = [
+        # Fork to researchers
+        Edge(source="fork_research", target="researcher_similar"),
+        Edge(source="fork_research", target="researcher_techstack"),
+        Edge(source="fork_research", target="researcher_pitfalls"),
+        # Researchers to join
+        Edge(source="researcher_similar", target="join_research"),
+        Edge(source="researcher_techstack", target="join_research"),
+        Edge(source="researcher_pitfalls", target="join_research"),
+        # Join → research gate
+        Edge(source="join_research", target="gate_research"),
+        # Research gate → strategist (proceed) or back to researchers (reloop)
+        Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+        Edge(source="gate_research", target="fork_research", condition=VerdictType.RELOOP),
+        # Strategist → strategy gate
+        Edge(source="strategist", target="gate_strategy"),
+        # Strategy gate → archivist (proceed) or back (reloop)
+        Edge(source="gate_strategy", target="archivist_plan", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # Archivist → builder
+        Edge(source="archivist_plan", target="builder"),
+        # Builder → build gate
+        Edge(source="builder", target="gate_build"),
+        # Build gate → evaluator (proceed) or builder (reloop, max 3)
+        Edge(source="gate_build", target="evaluator", condition=VerdictType.PROCEED),
+        Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
+        # Evaluator → precheck gate
+        Edge(source="evaluator", target="gate_precheck"),
+        # Precheck → archivist (proceed) or halt
+        Edge(source="gate_precheck", target="archivist_build", condition=VerdictType.PROCEED),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return state in {ProjectState.NO_REPO, ProjectState.REPO_INCOMPLETE}
+
+    return Workflow(
+        name="build",
+        nodes=nodes,
+        edges=edges,
+        start_node="fork_research",
+        trigger=trigger,
+    )
+
+
+# ── W₂: Design Mode ─────────────────────────────────────────────
+
+
+def design_workflow() -> Workflow:
+    """W₂: Design Mode — W₁ with user gate at strategy approval.
+
+    W₂ = W₁[gate_strategy ← GateNode(user)]
+    """
+    wf = build_workflow()
+
+    wf.nodes["gate_strategy"] = GateNode(
+        id="gate_strategy",
+        evaluator_type="user",
+        reads={".factory/strategy/current.md"},
+    )
+
+    wf.name = "design"
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return (
+            state in {ProjectState.NO_REPO, ProjectState.REPO_INCOMPLETE}
+            and ctx.get("interactive", False)
+        )
+
+    wf.trigger = trigger
+    return wf
+
+
+# ── W₃: Improve Mode ────────────────────────────────────────────
+
+
+def improve_workflow() -> Workflow:
+    """W₃: Improve Mode — study → research → strategy → per-hypothesis build/eval loop.
+
+    Study → Researcher → CEO gate → Strategist → CEO gate →
+    per-hypothesis: begin → Builder → CEO gate(max 3) → Evaluator → Precheck →
+    finalize → Archivist(async)
+    """
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # Study
+    nodes["study"] = Study(
+        id="study",
+        command="factory study {project_path}",
+        writes={".factory/strategy/observations.md"},
+    )
+
+    # Researcher
+    nodes["researcher"] = AgentNode(
+        id="researcher",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Read observations and research the codebase. "
+            "Write findings to .factory/strategy/research-local.md"
+        ),
+        reads={".factory/strategy/observations.md"},
+        writes={".factory/strategy/research-local.md"},
+    )
+
+    # CEO gate on research
+    nodes["gate_research"] = GateNode(
+        id="gate_research",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        reads={".factory/strategy/research-local.md"},
+    )
+
+    # Strategist
+    nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Generate hypotheses from research and observations. "
+            "Write to .factory/strategy/current.md"
+        ),
+        reads={".factory/strategy/research-local.md", ".factory/strategy/observations.md"},
+        writes={".factory/strategy/current.md"},
+    )
+
+    # CEO gate on strategy
+    nodes["gate_strategy"] = GateNode(
+        id="gate_strategy",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        reads={".factory/strategy/current.md"},
+    )
+
+    # Per-hypothesis: begin → builder → gate → evaluator → precheck → finalize → archivist
+    nodes["begin"] = FnNode(
+        id="begin",
+        command='factory begin {project_path} --hypothesis "Implement hypothesis"',
+        writes={".factory/experiments/current_id"},
+    )
+
+    nodes["builder"] = AgentNode(
+        id="builder",
+        role=AgentRole.BUILDER,
+        prompt_template=(
+            "Implement the hypothesis from .factory/strategy/current.md. "
+            "Open a draft PR."
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    nodes["gate_build"] = GateNode(
+        id="gate_build",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    nodes["evaluator"] = AgentNode(
+        id="evaluator",
+        role=AgentRole.EVALUATOR,
+        prompt_template="Run eval and interpret scores.",
+        reads={".factory/reviews/builder-latest.md"},
+        writes={".factory/reviews/evaluator-latest.md"},
+    )
+
+    nodes["gate_precheck"] = GateNode(
+        id="gate_precheck",
+        evaluator_type="fn",
+        evaluator_command="factory precheck {project_path} --score-before 0 --score-after 0",
+        reads={".factory/reviews/evaluator-latest.md"},
+    )
+
+    nodes["finalize"] = FnNode(
+        id="finalize",
+        command="factory finalize {project_path} --id 1 --verdict keep --hypothesis 'hypothesis'",
+        reads={".factory/reviews/evaluator-latest.md"},
+        writes={".factory/experiments/verdict.json"},
+    )
+
+    nodes["archivist"] = AgentNode(
+        id="archivist",
+        role=AgentRole.ARCHIVIST,
+        prompt_template="Archive experiment results and learnings.",
+        reads={".factory/experiments/verdict.json"},
+        writes={".factory/archive/experiment.md"},
+        blocking=False,
+    )
+
+    edges = [
+        # Study → researcher
+        Edge(source="study", target="researcher"),
+        # Researcher → research gate
+        Edge(source="researcher", target="gate_research"),
+        # Research gate
+        Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+        Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
+        # Strategist → strategy gate
+        Edge(source="strategist", target="gate_strategy"),
+        # Strategy gate
+        Edge(source="gate_strategy", target="begin", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # begin → builder
+        Edge(source="begin", target="builder"),
+        # Builder → build gate
+        Edge(source="builder", target="gate_build"),
+        # Build gate
+        Edge(source="gate_build", target="evaluator", condition=VerdictType.PROCEED),
+        Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
+        # Evaluator → precheck
+        Edge(source="evaluator", target="gate_precheck"),
+        # Precheck → finalize (proceed) or halt
+        Edge(source="gate_precheck", target="finalize", condition=VerdictType.PROCEED),
+        # Finalize → archivist
+        Edge(source="finalize", target="archivist"),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return state == ProjectState.HAS_FACTORY
+
+    return Workflow(
+        name="improve",
+        nodes=nodes,
+        edges=edges,
+        start_node="study",
+        trigger=trigger,
+    )
+
+
+# ── W₄: Research Mode ───────────────────────────────────────────
+
+
+def research_workflow() -> Workflow:
+    """W₄: Research Mode — extends W₃ with baseline measurement, failure analyst,
+    research command eval, and plateau detection.
+
+    W₄ = W₃[study ← (baseline → failure_analyst → researcher),
+             evaluator ← research_command, + plateau_gate]
+    """
+    wf = improve_workflow()
+
+    # Replace study with baseline measurement
+    del wf.nodes["study"]
+
+    wf.nodes["baseline"] = FnNode(
+        id="baseline",
+        command="factory eval {project_path}",
+        writes={".factory/experiments/baseline.json"},
+    )
+
+    # Insert failure analyst
+    wf.nodes["failure_analyst"] = AgentNode(
+        id="failure_analyst",
+        role=AgentRole.FAILURE_ANALYST,
+        prompt_template=(
+            "Analyze baseline failures and categorize root causes. "
+            "Write to .factory/strategy/failure_analysis.md"
+        ),
+        reads={".factory/experiments/baseline.json"},
+        writes={".factory/strategy/failure_analysis.md"},
+    )
+
+    # Update researcher to read failure analysis
+    wf.nodes["researcher"] = AgentNode(
+        id="researcher",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Read failure analysis and research solutions. "
+            "Write to .factory/strategy/research-local.md"
+        ),
+        reads={".factory/strategy/failure_analysis.md"},
+        writes={".factory/strategy/research-local.md"},
+    )
+
+    # Update strategist to read failure analysis instead of observations
+    wf.nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Generate hypotheses from research and failure analysis. "
+            "Write to .factory/strategy/current.md"
+        ),
+        reads={".factory/strategy/research-local.md", ".factory/strategy/failure_analysis.md"},
+        writes={".factory/strategy/current.md"},
+    )
+
+    # Replace evaluator with research command
+    wf.nodes["evaluator"] = FnNode(
+        id="evaluator",
+        command="factory eval {project_path}",
+        reads={".factory/reviews/builder-latest.md"},
+        writes={".factory/reviews/evaluator-latest.md"},
+    )
+
+    # Add plateau gate after finalize
+    wf.nodes["plateau_gate"] = GateNode(
+        id="plateau_gate",
+        evaluator_type="fn",
+        evaluator_command=(
+            "python3 -c \"import json, sys; "
+            "print('PROCEED' if True else 'RELOOP')\""
+        ),
+        reads={".factory/experiments/verdict.json"},
+    )
+
+    # Rebuild edges for research flow
+    wf.edges = [
+        # Baseline → failure analyst → researcher
+        Edge(source="baseline", target="failure_analyst"),
+        Edge(source="failure_analyst", target="researcher"),
+        # Researcher → research gate
+        Edge(source="researcher", target="gate_research"),
+        Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+        Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
+        # Strategist → strategy gate
+        Edge(source="strategist", target="gate_strategy"),
+        Edge(source="gate_strategy", target="begin", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # begin → builder
+        Edge(source="begin", target="builder"),
+        # Builder → build gate
+        Edge(source="builder", target="gate_build"),
+        Edge(source="gate_build", target="evaluator", condition=VerdictType.PROCEED),
+        Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
+        # Evaluator → precheck
+        Edge(source="evaluator", target="gate_precheck"),
+        Edge(source="gate_precheck", target="finalize", condition=VerdictType.PROCEED),
+        # Finalize → archivist → plateau gate
+        Edge(source="finalize", target="archivist"),
+        Edge(source="archivist", target="plateau_gate"),
+        # Plateau gate: proceed (done) or reloop to baseline
+        Edge(source="plateau_gate", target="baseline", condition=VerdictType.RELOOP),
+    ]
+
+    wf.name = "research"
+    wf.start_node = "baseline"
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return state == ProjectState.HAS_FACTORY and bool(ctx.get("research_target"))
+
+    wf.trigger = trigger
+    return wf
+
+
+# ── W₅: Meta Mode ───────────────────────────────────────────────
+
+
+def meta_workflow() -> Workflow:
+    """W₅: Meta Mode — cross-project insights → playbook evolution + test pruning.
+
+    insights → Researcher → CEO gate → Strategist → User gate → apply_playbooks →
+    Fork(Archivist(async), test_pruning_branch)
+    """
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # Collect cross-project insights
+    nodes["insights"] = FnNode(
+        id="insights",
+        command="factory insights {project_path}",
+        writes={".factory/strategy/insights.md"},
+    )
+
+    # Researcher reads insights + playbooks
+    nodes["researcher"] = AgentNode(
+        id="researcher",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Read cross-project insights and current playbooks. "
+            "Identify patterns and propose improvements."
+        ),
+        reads={".factory/strategy/insights.md"},
+        writes={".factory/strategy/research-local.md"},
+    )
+
+    # CEO gate on research quality
+    nodes["gate_research"] = GateNode(
+        id="gate_research",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        reads={".factory/strategy/research-local.md"},
+    )
+
+    # Strategist proposes playbook diffs
+    nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Propose specific playbook edits based on research. "
+            "Write diffs to .factory/strategy/playbook-diffs.md"
+        ),
+        reads={".factory/strategy/research-local.md"},
+        writes={".factory/strategy/playbook-diffs.md"},
+    )
+
+    # User gate for playbook approval
+    nodes["gate_user"] = GateNode(
+        id="gate_user",
+        evaluator_type="user",
+        reads={".factory/strategy/playbook-diffs.md"},
+    )
+
+    # Apply playbooks
+    nodes["apply_playbooks"] = FnNode(
+        id="apply_playbooks",
+        command="factory ace {project_path}",
+        reads={".factory/strategy/playbook-diffs.md"},
+        writes={".factory/archive/playbooks-applied.md"},
+    )
+
+    # Fork: archivist + test pruning
+    nodes["fork_post"] = ForkNode(
+        id="fork_post",
+        targets=["archivist", "test_collect"],
+    )
+
+    # Archivist (async)
+    nodes["archivist"] = AgentNode(
+        id="archivist",
+        role=AgentRole.ARCHIVIST,
+        prompt_template="Archive playbook evolution results.",
+        reads={".factory/archive/playbooks-applied.md"},
+        writes={".factory/archive/meta.md"},
+        blocking=False,
+    )
+
+    # Test pruning branch
+    nodes["test_collect"] = FnNode(
+        id="test_collect",
+        command="pytest --co -q 2>/dev/null || true",
+        writes={".factory/strategy/test-inventory.md"},
+    )
+
+    nodes["test_researcher"] = AgentNode(
+        id="test_researcher",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Analyze test inventory for redundant, dead, or flaky tests. "
+            "Write findings to .factory/strategy/test-analysis.md"
+        ),
+        reads={".factory/strategy/test-inventory.md"},
+        writes={".factory/strategy/test-analysis.md"},
+    )
+
+    nodes["gate_test_prune"] = GateNode(
+        id="gate_test_prune",
+        evaluator_type="user",
+        reads={".factory/strategy/test-analysis.md"},
+    )
+
+    nodes["test_builder"] = AgentNode(
+        id="test_builder",
+        role=AgentRole.BUILDER,
+        prompt_template=(
+            "Delete the approved redundant tests. "
+            "Verify remaining suite still passes."
+        ),
+        reads={".factory/strategy/test-analysis.md"},
+        writes={".factory/reviews/test-pruning-latest.md"},
+    )
+
+    edges = [
+        # Insights → researcher
+        Edge(source="insights", target="researcher"),
+        # Researcher → CEO gate
+        Edge(source="researcher", target="gate_research"),
+        Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+        Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
+        # Strategist → user gate
+        Edge(source="strategist", target="gate_user"),
+        Edge(source="gate_user", target="apply_playbooks", condition=VerdictType.PROCEED),
+        Edge(source="gate_user", target="strategist", condition=VerdictType.RELOOP),
+        # Apply → fork
+        Edge(source="apply_playbooks", target="fork_post"),
+        # Fork to archivist and test collection
+        Edge(source="fork_post", target="archivist"),
+        Edge(source="fork_post", target="test_collect"),
+        # Test pruning branch
+        Edge(source="test_collect", target="test_researcher"),
+        Edge(source="test_researcher", target="gate_test_prune"),
+        Edge(source="gate_test_prune", target="test_builder", condition=VerdictType.PROCEED),
+        Edge(source="gate_test_prune", target="test_researcher", condition=VerdictType.RELOOP),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "meta"
+
+    return Workflow(
+        name="meta",
+        nodes=nodes,
+        edges=edges,
+        start_node="insights",
+        trigger=trigger,
+    )
+
+
+# ── Registry ─────────────────────────────────────────────────────
+
+
+ALL_WORKFLOWS: dict[str, type[Workflow] | Any] = {}
+
+
+def register_all() -> dict[str, Workflow]:
+    """Build and return all 5 workflow definitions."""
+    return {
+        "build": build_workflow(),
+        "design": design_workflow(),
+        "improve": improve_workflow(),
+        "research": research_workflow(),
+        "meta": meta_workflow(),
+    }

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -525,7 +525,10 @@ def meta_workflow() -> Workflow:
     """W₅: Meta Mode — cross-project insights → playbook evolution + test pruning.
 
     insights → Researcher → CEO gate → Strategist → User gate → apply_playbooks →
-    Fork(Archivist(async), test_pruning_branch)
+    Archivist(async) → test_collect → test_researcher → gate → test_builder
+
+    The archivist is non-blocking, so it fires in the background while the
+    test pruning chain proceeds immediately.
     """
     nodes: dict[str, Any] = {}
     edges: list[Edge] = []
@@ -584,13 +587,7 @@ def meta_workflow() -> Workflow:
         writes={".factory/archive/playbooks-applied.md"},
     )
 
-    # Fork: archivist + test pruning
-    nodes["fork_post"] = ForkNode(
-        id="fork_post",
-        targets=["archivist", "test_collect"],
-    )
-
-    # Archivist (async)
+    # Archivist (async, non-blocking — fires in background while test chain proceeds)
     nodes["archivist"] = AgentNode(
         id="archivist",
         role=AgentRole.ARCHIVIST,
@@ -600,7 +597,7 @@ def meta_workflow() -> Workflow:
         blocking=False,
     )
 
-    # Test pruning branch
+    # Test pruning chain
     nodes["test_collect"] = FnNode(
         id="test_collect",
         command="pytest --co -q 2>/dev/null || true",
@@ -646,11 +643,9 @@ def meta_workflow() -> Workflow:
         Edge(source="strategist", target="gate_user"),
         Edge(source="gate_user", target="apply_playbooks", condition=VerdictType.PROCEED),
         Edge(source="gate_user", target="strategist", condition=VerdictType.RELOOP),
-        # Apply → fork
-        Edge(source="apply_playbooks", target="fork_post"),
-        # Fork to archivist and test collection
-        Edge(source="fork_post", target="archivist"),
-        Edge(source="fork_post", target="test_collect"),
+        # Apply → archivist (non-blocking) → test chain
+        Edge(source="apply_playbooks", target="archivist"),
+        Edge(source="archivist", target="test_collect"),
         # Test pruning branch
         Edge(source="test_collect", target="test_researcher"),
         Edge(source="test_researcher", target="gate_test_prune"),

--- a/factory/workflow/events.py
+++ b/factory/workflow/events.py
@@ -1,0 +1,107 @@
+"""Workflow-specific event types for .factory/events.jsonl."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from factory.workflow.primitives import VerdictType
+
+
+class WorkflowEvent(BaseModel):
+    """Base for workflow events emitted to events.jsonl."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    workflow_name: str
+    run_id: str
+
+
+class WorkflowStarted(WorkflowEvent):
+    """Emitted when a workflow begins execution."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    start_node: str
+
+
+class NodeStarted(WorkflowEvent):
+    """Emitted when a node begins execution."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    node_id: str
+    node_type: str
+    iteration: int = 0
+
+
+class NodeCompleted(WorkflowEvent):
+    """Emitted when a node completes successfully."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    node_id: str
+    node_type: str
+    files_written: list[str] = []
+    duration_ms: float = 0.0
+
+
+class NodeFailed(WorkflowEvent):
+    """Emitted when a node fails."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    node_id: str
+    node_type: str
+    error: str
+
+
+class GateVerdictEvent(WorkflowEvent):
+    """Emitted when a gate produces a verdict."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    node_id: str
+    verdict_type: VerdictType
+    target: str | None = None
+    feedback: str | None = None
+    reason: str | None = None
+    iteration: int = 0
+
+
+class WorkflowCompleted(WorkflowEvent):
+    """Emitted when a workflow completes successfully."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    nodes_executed: int
+    duration_ms: float = 0.0
+
+
+class WorkflowHalted(WorkflowEvent):
+    """Emitted when a workflow is halted by a verdict or error."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    reason: str
+    halted_at_node: str
+
+
+def emit_workflow_event(
+    project_path: Any,
+    event_type: str,
+    event: WorkflowEvent,
+) -> None:
+    """Emit a workflow event to .factory/events.jsonl."""
+    from pathlib import Path
+
+    from factory.events import emit_event
+
+    path = Path(project_path) if not isinstance(project_path, Path) else project_path
+    emit_event(
+        path,
+        event_type,
+        agent="workflow",
+        data=event.model_dump(mode="python"),
+    )

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -1,0 +1,542 @@
+"""Deterministic async graph walker implementing formal execution semantics."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.workflow.events import (
+    GateVerdictEvent,
+    NodeCompleted,
+    NodeFailed,
+    NodeStarted,
+    WorkflowCompleted,
+    WorkflowHalted,
+    WorkflowStarted,
+    emit_workflow_event,
+)
+from factory.workflow.primitives import (
+    AgentConfig,
+    AgentNode,
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    NodeType,
+    Study,
+    Verdict,
+    VerdictType,
+    Workflow,
+)
+
+log = structlog.get_logger()
+
+CEO_GATE_PROMPT = """\
+You are reviewing the output of the {step_name} step in the {workflow_name} workflow.
+The output is at: {output_file}
+Previous context: {previous_context}
+
+Read the output and decide:
+- **Proceed**: the output is satisfactory, continue to the next step
+- **Reloop(target, feedback)**: the output needs improvement. Specify which step to return to and what feedback to provide.
+- **Halt(reason)**: something is fundamentally wrong, stop the workflow.
+
+Respond with exactly one of:
+PROCEED
+RELOOP target="<node_id>" feedback="<your feedback>"
+HALT reason="<your reason>"
+"""
+
+
+class ExecutionResult:
+    """Result of a workflow execution."""
+
+    def __init__(self) -> None:
+        self.success: bool = False
+        self.halted: bool = False
+        self.halt_reason: str = ""
+        self.nodes_executed: int = 0
+        self.events: list[dict[str, Any]] = []
+        self.completed_files: set[str] = set()
+        self.node_outputs: dict[str, str] = {}
+        self.duration_ms: float = 0.0
+
+
+class WorkflowExecutor:
+    """Deterministic async graph walker for workflow execution."""
+
+    def __init__(
+        self,
+        workflow: Workflow,
+        project_path: Path,
+        agent_pool: dict[str, AgentConfig] | None = None,
+        *,
+        dry_run: bool = False,
+    ) -> None:
+        self.workflow = workflow
+        self.project_path = project_path
+        self.agent_pool = agent_pool or {}
+        self.dry_run = dry_run
+        self.run_id = uuid.uuid4().hex[:12]
+        self.completed_files: set[str] = set()
+        self.node_context: dict[str, str] = {}
+        self.iteration_counts: dict[tuple[str, str], int] = {}
+        self.background_tasks: list[asyncio.Task[Any]] = []
+        self.result = ExecutionResult()
+        self._edge_index: dict[str, list[Edge]] = {}
+        for edge in workflow.edges:
+            self._edge_index.setdefault(edge.source, []).append(edge)
+
+    async def execute(self) -> ExecutionResult:
+        """Run the workflow from start to completion."""
+        start_time = time.monotonic()
+
+        self._emit(
+            "workflow.started",
+            WorkflowStarted(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                start_node=self.workflow.start_node,
+            ),
+        )
+
+        try:
+            await self._execute_from(self.workflow.start_node)
+            self.result.success = not self.result.halted
+        except Exception as exc:
+            self.result.success = False
+            self.result.halted = True
+            self.result.halt_reason = str(exc)
+            log.error("workflow.exception", error=str(exc), workflow=self.workflow.name)
+
+        if self.background_tasks:
+            done, pending = await asyncio.wait(
+                self.background_tasks,
+                timeout=30.0,
+            )
+            for task in pending:
+                task.cancel()
+
+        elapsed = (time.monotonic() - start_time) * 1000
+        self.result.duration_ms = elapsed
+        self.result.completed_files = set(self.completed_files)
+
+        if self.result.halted:
+            self._emit(
+                "workflow.halted",
+                WorkflowHalted(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    reason=self.result.halt_reason,
+                    halted_at_node="unknown",
+                ),
+            )
+        else:
+            self._emit(
+                "workflow.completed",
+                WorkflowCompleted(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    nodes_executed=self.result.nodes_executed,
+                    duration_ms=elapsed,
+                ),
+            )
+
+        return self.result
+
+    async def _execute_from(self, node_id: str) -> None:
+        """Execute starting from the given node, following edges."""
+        if self.result.halted:
+            return
+
+        node = self.workflow.nodes.get(node_id)
+        if not node:
+            self.result.halted = True
+            self.result.halt_reason = f"node '{node_id}' not found"
+            return
+
+        await self._wait_for_reads(node)
+
+        if isinstance(node, ForkNode):
+            await self._execute_fork(node)
+            return
+
+        if isinstance(node, JoinNode):
+            self.result.nodes_executed += 1
+            next_id = self._next_unconditional(node_id)
+            if next_id:
+                await self._execute_from(next_id)
+            return
+
+        if isinstance(node, GateNode):
+            await self._execute_gate(node)
+            return
+
+        await self._execute_action_node(node)
+
+    async def _execute_action_node(self, node: NodeType) -> None:
+        """Execute an AgentNode, FnNode, or Study node."""
+        node_id = node.id
+        node_type = type(node).__name__
+
+        self._emit(
+            "node.started",
+            NodeStarted(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                node_id=node_id,
+                node_type=node_type,
+            ),
+        )
+
+        start = time.monotonic()
+        try:
+            output = await self._run_node(node)
+            elapsed = (time.monotonic() - start) * 1000
+
+            self.result.node_outputs[node_id] = output
+            self.completed_files |= node.writes
+            self.result.nodes_executed += 1
+
+            self._emit(
+                "node.completed",
+                NodeCompleted(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    node_id=node_id,
+                    node_type=node_type,
+                    files_written=sorted(node.writes),
+                    duration_ms=elapsed,
+                ),
+            )
+
+            if not node.blocking:
+                next_id = self._next_unconditional(node_id)
+                if next_id:
+                    await self._execute_from(next_id)
+                return
+
+        except Exception as exc:
+            self._emit(
+                "node.failed",
+                NodeFailed(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    node_id=node_id,
+                    node_type=node_type,
+                    error=str(exc),
+                ),
+            )
+            self.result.halted = True
+            self.result.halt_reason = f"node '{node_id}' failed: {exc}"
+            return
+
+        next_id = self._next_unconditional(node_id)
+        if next_id:
+            await self._execute_from(next_id)
+
+    async def _execute_gate(self, node: GateNode) -> None:
+        """Execute a gate node, parse verdict, follow the matching edge."""
+        node_id = node.id
+        self._emit(
+            "node.started",
+            NodeStarted(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                node_id=node_id,
+                node_type="GateNode",
+            ),
+        )
+
+        try:
+            verdict = await self._evaluate_gate(node)
+        except Exception as exc:
+            self._emit(
+                "node.failed",
+                NodeFailed(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    node_id=node_id,
+                    node_type="GateNode",
+                    error=str(exc),
+                ),
+            )
+            self.result.halted = True
+            self.result.halt_reason = f"gate '{node_id}' failed: {exc}"
+            return
+
+        self.result.nodes_executed += 1
+
+        self._emit(
+            "gate.verdict",
+            GateVerdictEvent(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                node_id=node_id,
+                verdict_type=verdict.type,
+                target=verdict.target,
+                feedback=verdict.feedback,
+                reason=verdict.reason,
+            ),
+        )
+
+        if verdict.type == VerdictType.HALT:
+            self.result.halted = True
+            self.result.halt_reason = verdict.reason or "gate halted"
+            return
+
+        if verdict.type == VerdictType.RELOOP:
+            target = verdict.target
+            if not target:
+                self.result.halted = True
+                self.result.halt_reason = "reloop verdict missing target"
+                return
+
+            key = (node_id, target)
+            count = self.iteration_counts.get(key, 0) + 1
+            self.iteration_counts[key] = count
+
+            if count > verdict.max_iterations:
+                self.result.halted = True
+                self.result.halt_reason = (
+                    f"max iterations ({verdict.max_iterations}) exhausted "
+                    f"for gate '{node_id}' -> '{target}'"
+                )
+                return
+
+            if verdict.feedback:
+                existing = self.node_context.get(target, "")
+                self.node_context[target] = (
+                    f"{existing}\n\n[Feedback iteration {count}]: {verdict.feedback}"
+                    if existing
+                    else f"[Feedback iteration {count}]: {verdict.feedback}"
+                )
+
+            await self._execute_from(target)
+            return
+
+        target_id = self._next_conditional(node_id, VerdictType.PROCEED)
+        if target_id is None:
+            target_id = self._next_unconditional(node_id)
+
+        if target_id:
+            await self._execute_from(target_id)
+
+    async def _execute_fork(self, node: ForkNode) -> None:
+        """Execute all fork targets concurrently via asyncio.gather."""
+        self.result.nodes_executed += 1
+
+        async def run_branch(target_id: str) -> None:
+            target = self.workflow.nodes.get(target_id)
+            if not target:
+                return
+            await self._execute_action_node(target)
+
+        await asyncio.gather(*(run_branch(t) for t in node.targets))
+
+        next_id = self._next_unconditional(node.id)
+        if next_id:
+            await self._execute_from(next_id)
+
+    async def _run_node(self, node: NodeType) -> str:
+        """Execute a single node and return its output."""
+        if self.dry_run:
+            return f"[dry-run] {node.id} executed"
+
+        if isinstance(node, Study):
+            return await self._run_study(node)
+
+        if isinstance(node, FnNode):
+            return await self._run_fn(node)
+
+        if isinstance(node, AgentNode):
+            return await self._run_agent(node)
+
+        return f"[unknown node type] {type(node).__name__}"
+
+    async def _run_study(self, node: Study) -> str:
+        """Run factory study command."""
+        cmd = f"factory study {self.project_path}"
+        if node.focus:
+            cmd += f' --focus "{node.focus}"'
+        return await self._run_shell(cmd)
+
+    async def _run_fn(self, node: FnNode) -> str:
+        """Run a FnNode's shell command."""
+        if not node.command:
+            return ""
+        cmd = node.command.replace("{project_path}", str(self.project_path))
+        return await self._run_shell(cmd)
+
+    async def _run_agent(self, node: AgentNode) -> str:
+        """Invoke an agent via factory/agents/runner.py."""
+        from factory.agents.runner import invoke_agent
+
+        task = node.prompt_template
+        context = self.node_context.get(node.id, "")
+        if context:
+            task = f"{task}\n\n{context}"
+
+        model = node.model
+        if not model:
+            pool_entry = self.agent_pool.get(node.role.value)
+            if pool_entry:
+                model = pool_entry.model
+
+        stdout, code = await invoke_agent(
+            node.role.value,  # type: ignore[arg-type]
+            task,
+            self.project_path,
+            model=model or None,
+        )
+
+        if code != 0:
+            raise RuntimeError(f"agent {node.role.value} exited with code {code}")
+
+        return stdout
+
+    async def _evaluate_gate(self, node: GateNode) -> Verdict:
+        """Evaluate a gate and return a verdict."""
+        if self.dry_run:
+            return Verdict.proceed()
+
+        if node.evaluator_type == "user":
+            return Verdict.proceed()
+
+        if node.evaluator_type == "fn":
+            if node.evaluator_command:
+                cmd = node.evaluator_command.replace(
+                    "{project_path}", str(self.project_path),
+                )
+                try:
+                    output = await self._run_shell(cmd)
+                    return self._parse_fn_verdict(output)
+                except RuntimeError:
+                    return Verdict.halt(reason=f"gate command failed: {node.evaluator_command}")
+            return Verdict.proceed()
+
+        prompt = self._build_gate_prompt(node)
+        from factory.agents.runner import invoke_agent
+
+        model = "opus"
+        pool_entry = self.agent_pool.get("ceo")
+        if pool_entry:
+            model = pool_entry.model
+
+        stdout, code = await invoke_agent(
+            "ceo",
+            prompt,
+            self.project_path,
+            model=model,
+        )
+
+        if code != 0:
+            return Verdict.halt(reason=f"CEO gate agent exited with code {code}")
+
+        return self._parse_agent_verdict(stdout, node.id)
+
+    def _build_gate_prompt(self, node: GateNode) -> str:
+        """Build the lightweight CEO gate prompt."""
+        if node.gate_prompt:
+            return node.gate_prompt.replace(
+                "{project_path}", str(self.project_path),
+            )
+
+        output_files = sorted(node.reads) if node.reads else ["(no specific file)"]
+        context = self.node_context.get(node.id, "none")
+
+        return CEO_GATE_PROMPT.format(
+            step_name=node.id,
+            workflow_name=self.workflow.name,
+            output_file=", ".join(output_files),
+            previous_context=context,
+        )
+
+    def _parse_agent_verdict(self, output: str, gate_id: str) -> Verdict:
+        """Parse agent output into a Verdict."""
+        text = output.strip().upper()
+
+        if "HALT" in text:
+            reason_start = text.find('REASON="')
+            if reason_start != -1:
+                reason_end = text.find('"', reason_start + 8)
+                reason = output.strip()[reason_start + 8:reason_end] if reason_end != -1 else "gate halted"
+            else:
+                reason = "gate halted"
+            return Verdict.halt(reason=reason)
+
+        if "RELOOP" in text:
+            import re
+            target_match = re.search(r'TARGET="([^"]+)"', text, re.IGNORECASE)
+            feedback_match = re.search(r'FEEDBACK="([^"]+)"', text, re.IGNORECASE)
+            target = target_match.group(1) if target_match else gate_id
+            feedback = feedback_match.group(1) if feedback_match else "needs improvement"
+            return Verdict.reloop(target=target, feedback=feedback)
+
+        return Verdict.proceed()
+
+    def _parse_fn_verdict(self, output: str) -> Verdict:
+        """Parse function output into a Verdict."""
+        text = output.strip().lower()
+        if "fail" in text or "revert" in text:
+            return Verdict.halt(reason=f"precheck failed: {output.strip()[:200]}")
+        return Verdict.proceed()
+
+    async def _run_shell(self, cmd: str) -> str:
+        """Run a shell command and return stdout."""
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.project_path,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        stdout = stdout_bytes.decode() if stdout_bytes else ""
+
+        if proc.returncode != 0:
+            stderr = stderr_bytes.decode() if stderr_bytes else ""
+            raise RuntimeError(
+                f"command failed (exit {proc.returncode}): {cmd}\n{stderr[:500]}"
+            )
+
+        return stdout
+
+    async def _wait_for_reads(self, node: NodeType) -> None:
+        """Wait until all files in node.reads are available."""
+        if not node.reads:
+            return
+        missing = node.reads - self.completed_files
+        if missing:
+            log.debug(
+                "node.waiting_for_reads",
+                node=node.id,
+                missing=sorted(missing),
+            )
+
+    def _next_unconditional(self, node_id: str) -> str | None:
+        """Find the next node via unconditional edge."""
+        for edge in self._edge_index.get(node_id, []):
+            if edge.condition is None:
+                return edge.target
+        return None
+
+    def _next_conditional(self, node_id: str, verdict_type: VerdictType) -> str | None:
+        """Find the next node via conditional edge matching the verdict."""
+        for edge in self._edge_index.get(node_id, []):
+            if edge.condition == verdict_type:
+                return edge.target
+        return None
+
+    def _emit(self, event_type: str, event: Any) -> None:
+        """Emit a workflow event."""
+        self.result.events.append({"type": event_type, **event.model_dump(mode="python")})
+        try:
+            emit_workflow_event(self.project_path, event_type, event)
+        except Exception:
+            log.debug("event_emission_failed", event_type=event_type)

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -169,6 +169,7 @@ class WorkflowExecutor:
 
         if isinstance(node, JoinNode):
             self.result.nodes_executed += 1
+            self.completed_files |= node.writes
             next_id = self._next_unconditional(node_id)
             if next_id:
                 await self._execute_from(next_id)
@@ -184,6 +185,14 @@ class WorkflowExecutor:
         """Execute an AgentNode, FnNode, or Study node."""
         node_id = node.id
         node_type = type(node).__name__
+
+        if not node.blocking:
+            task = asyncio.create_task(self._run_node_background(node))
+            self.background_tasks.append(task)
+            next_id = self._next_unconditional(node_id)
+            if next_id:
+                await self._execute_from(next_id)
+            return
 
         self._emit(
             "node.started",
@@ -216,12 +225,6 @@ class WorkflowExecutor:
                 ),
             )
 
-            if not node.blocking:
-                next_id = self._next_unconditional(node_id)
-                if next_id:
-                    await self._execute_from(next_id)
-                return
-
         except Exception as exc:
             self._emit(
                 "node.failed",
@@ -240,6 +243,50 @@ class WorkflowExecutor:
         next_id = self._next_unconditional(node_id)
         if next_id:
             await self._execute_from(next_id)
+
+    async def _run_node_background(self, node: NodeType) -> None:
+        """Run a non-blocking node as a background task."""
+        node_id = node.id
+        node_type = type(node).__name__
+        self._emit(
+            "node.started",
+            NodeStarted(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                node_id=node_id,
+                node_type=node_type,
+            ),
+        )
+        start = time.monotonic()
+        try:
+            output = await self._run_node(node)
+            elapsed = (time.monotonic() - start) * 1000
+            self.result.node_outputs[node_id] = output
+            self.completed_files |= node.writes
+            self.result.nodes_executed += 1
+            self._emit(
+                "node.completed",
+                NodeCompleted(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    node_id=node_id,
+                    node_type=node_type,
+                    files_written=sorted(node.writes),
+                    duration_ms=elapsed,
+                ),
+            )
+        except Exception as exc:
+            self._emit(
+                "node.failed",
+                NodeFailed(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    node_id=node_id,
+                    node_type=node_type,
+                    error=str(exc),
+                ),
+            )
+            log.warning("background_node_failed", node=node_id, error=str(exc))
 
     async def _execute_gate(self, node: GateNode) -> None:
         """Execute a gate node, parse verdict, follow the matching edge."""
@@ -329,18 +376,66 @@ class WorkflowExecutor:
             await self._execute_from(target_id)
 
     async def _execute_fork(self, node: ForkNode) -> None:
-        """Execute all fork targets concurrently via asyncio.gather."""
+        """Execute all fork targets concurrently via asyncio.gather.
+
+        Branches are run in isolation — they do NOT follow outgoing edges.
+        After all branches complete, the fork's own unconditional edge is followed.
+        """
         self.result.nodes_executed += 1
 
         async def run_branch(target_id: str) -> None:
             target = self.workflow.nodes.get(target_id)
             if not target:
                 return
-            await self._execute_action_node(target)
+            node_type = type(target).__name__
+            self._emit(
+                "node.started",
+                NodeStarted(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    node_id=target_id,
+                    node_type=node_type,
+                ),
+            )
+            start = time.monotonic()
+            try:
+                output = await self._run_node(target)
+                elapsed = (time.monotonic() - start) * 1000
+                self.result.node_outputs[target_id] = output
+                self.completed_files |= target.writes
+                self.result.nodes_executed += 1
+                self._emit(
+                    "node.completed",
+                    NodeCompleted(
+                        workflow_name=self.workflow.name,
+                        run_id=self.run_id,
+                        node_id=target_id,
+                        node_type=node_type,
+                        files_written=sorted(target.writes),
+                        duration_ms=elapsed,
+                    ),
+                )
+            except Exception as exc:
+                self._emit(
+                    "node.failed",
+                    NodeFailed(
+                        workflow_name=self.workflow.name,
+                        run_id=self.run_id,
+                        node_id=target_id,
+                        node_type=node_type,
+                        error=str(exc),
+                    ),
+                )
+                self.result.halted = True
+                self.result.halt_reason = f"fork branch '{target_id}' failed: {exc}"
 
         await asyncio.gather(*(run_branch(t) for t in node.targets))
 
-        next_id = self._next_unconditional(node.id)
+        if self.result.halted:
+            return
+
+        # Follow the edge from the first branch target to find the join/next node
+        next_id = self._next_unconditional(node.targets[0]) if node.targets else None
         if next_id:
             await self._execute_from(next_id)
 
@@ -459,22 +554,26 @@ class WorkflowExecutor:
         )
 
     def _parse_agent_verdict(self, output: str, gate_id: str) -> Verdict:
-        """Parse agent output into a Verdict."""
-        text = output.strip().upper()
+        """Parse agent output into a Verdict by examining the last non-empty line."""
+        import re
 
-        if "HALT" in text:
-            reason_start = text.find('REASON="')
-            if reason_start != -1:
-                reason_end = text.find('"', reason_start + 8)
-                reason = output.strip()[reason_start + 8:reason_end] if reason_end != -1 else "gate halted"
-            else:
-                reason = "gate halted"
+        lines = output.strip().splitlines()
+        last_line = ""
+        for line in reversed(lines):
+            if line.strip():
+                last_line = line.strip()
+                break
+
+        text = last_line.upper()
+
+        if text.startswith("HALT") or re.match(r"^HALT\b", text):
+            reason_match = re.search(r'REASON="([^"]+)"', last_line, re.IGNORECASE)
+            reason = reason_match.group(1) if reason_match else "gate halted"
             return Verdict.halt(reason=reason)
 
-        if "RELOOP" in text:
-            import re
-            target_match = re.search(r'TARGET="([^"]+)"', text, re.IGNORECASE)
-            feedback_match = re.search(r'FEEDBACK="([^"]+)"', text, re.IGNORECASE)
+        if text.startswith("RELOOP") or re.match(r"^RELOOP\b", text):
+            target_match = re.search(r'TARGET="([^"]+)"', last_line, re.IGNORECASE)
+            feedback_match = re.search(r'FEEDBACK="([^"]+)"', last_line, re.IGNORECASE)
             target = target_match.group(1) if target_match else gate_id
             feedback = feedback_match.group(1) if feedback_match else "needs improvement"
             return Verdict.reloop(target=target, feedback=feedback)
@@ -508,16 +607,30 @@ class WorkflowExecutor:
         return stdout
 
     async def _wait_for_reads(self, node: NodeType) -> None:
-        """Wait until all files in node.reads are available."""
+        """Wait until all files in node.reads are available in completed_files."""
         if not node.reads:
             return
-        missing = node.reads - self.completed_files
-        if missing:
+        poll_interval = 0.1
+        max_wait = 60.0
+        waited = 0.0
+        while True:
+            missing = node.reads - self.completed_files
+            if not missing:
+                return
+            if waited >= max_wait:
+                self.result.halted = True
+                self.result.halt_reason = (
+                    f"node '{node.id}' timed out waiting for reads: {sorted(missing)}"
+                )
+                return
             log.debug(
                 "node.waiting_for_reads",
                 node=node.id,
                 missing=sorted(missing),
+                waited_s=round(waited, 1),
             )
+            await asyncio.sleep(poll_interval)
+            waited += poll_interval
 
     def _next_unconditional(self, node_id: str) -> str | None:
         """Find the next node via unconditional edge."""

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import shlex
 import time
 import uuid
 from pathlib import Path
@@ -162,6 +163,8 @@ class WorkflowExecutor:
             return
 
         await self._wait_for_reads(node)
+        if self.result.halted:
+            return
 
         if isinstance(node, ForkNode):
             await self._execute_fork(node)
@@ -426,16 +429,23 @@ class WorkflowExecutor:
                         error=str(exc),
                     ),
                 )
+                if not self.result.halted:
+                    self.result.halt_reason = f"fork branch '{target_id}' failed: {exc}"
                 self.result.halted = True
-                self.result.halt_reason = f"fork branch '{target_id}' failed: {exc}"
 
         await asyncio.gather(*(run_branch(t) for t in node.targets))
 
         if self.result.halted:
             return
 
-        # Follow the edge from the first branch target to find the join/next node
-        next_id = self._next_unconditional(node.targets[0]) if node.targets else None
+        branch_set = set(node.targets)
+        next_id: str | None = None
+        for edge in self._edge_index.get(node.id, []):
+            if edge.condition is None and edge.target not in branch_set:
+                next_id = edge.target
+                break
+        if next_id is None and node.targets:
+            next_id = self._next_unconditional(node.targets[0])
         if next_id:
             await self._execute_from(next_id)
 
@@ -457,7 +467,7 @@ class WorkflowExecutor:
 
     async def _run_study(self, node: Study) -> str:
         """Run factory study command."""
-        cmd = f"factory study {self.project_path}"
+        cmd = f"factory study {shlex.quote(str(self.project_path))}"
         if node.focus:
             cmd += f' --focus "{node.focus}"'
         return await self._run_shell(cmd)
@@ -466,7 +476,7 @@ class WorkflowExecutor:
         """Run a FnNode's shell command."""
         if not node.command:
             return ""
-        cmd = node.command.replace("{project_path}", str(self.project_path))
+        cmd = node.command.replace("{project_path}", shlex.quote(str(self.project_path)))
         return await self._run_shell(cmd)
 
     async def _run_agent(self, node: AgentNode) -> str:
@@ -507,11 +517,11 @@ class WorkflowExecutor:
         if node.evaluator_type == "fn":
             if node.evaluator_command:
                 cmd = node.evaluator_command.replace(
-                    "{project_path}", str(self.project_path),
+                    "{project_path}", shlex.quote(str(self.project_path)),
                 )
                 try:
                     output = await self._run_shell(cmd)
-                    return self._parse_fn_verdict(output)
+                    return self._parse_fn_verdict(output, node.id)
                 except RuntimeError:
                     return Verdict.halt(reason=f"gate command failed: {node.evaluator_command}")
             return Verdict.proceed()
@@ -574,17 +584,24 @@ class WorkflowExecutor:
         if text.startswith("RELOOP") or re.match(r"^RELOOP\b", text):
             target_match = re.search(r'TARGET="([^"]+)"', last_line, re.IGNORECASE)
             feedback_match = re.search(r'FEEDBACK="([^"]+)"', last_line, re.IGNORECASE)
-            target = target_match.group(1) if target_match else gate_id
+            target = target_match.group(1) if target_match else self._next_conditional(gate_id, VerdictType.RELOOP)
+            if not target:
+                return Verdict.halt(reason=f"RELOOP verdict from gate '{gate_id}' missing target and no RELOOP edge defined")
             feedback = feedback_match.group(1) if feedback_match else "needs improvement"
             return Verdict.reloop(target=target, feedback=feedback)
 
         return Verdict.proceed()
 
-    def _parse_fn_verdict(self, output: str) -> Verdict:
+    def _parse_fn_verdict(self, output: str, gate_id: str) -> Verdict:
         """Parse function output into a Verdict."""
         text = output.strip().lower()
         if "fail" in text or "revert" in text:
             return Verdict.halt(reason=f"precheck failed: {output.strip()[:200]}")
+        if "reloop" in text:
+            target = self._next_conditional(gate_id, VerdictType.RELOOP)
+            if target:
+                return Verdict.reloop(target=target, feedback="fn gate requested reloop")
+            return Verdict.halt(reason="fn gate returned RELOOP but no RELOOP edge defined")
         return Verdict.proceed()
 
     async def _run_shell(self, cmd: str) -> str:

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -523,7 +523,7 @@ class WorkflowExecutor:
                     output = await self._run_shell(cmd)
                     return self._parse_fn_verdict(output, node.id)
                 except RuntimeError:
-                    return Verdict.halt(reason=f"gate command failed: {node.evaluator_command}")
+                    return Verdict.halt(reason=f"gate command failed: {cmd}")
             return Verdict.proceed()
 
         prompt = self._build_gate_prompt(node)

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -46,7 +46,7 @@ Previous context: {previous_context}
 
 Read the output and decide:
 - **Proceed**: the output is satisfactory, continue to the next step
-- **Reloop(target, feedback)**: the output needs improvement. Specify which step to return to and what feedback to provide.
+- **Reloop(target, feedback)**: the output needs improvement. Reloop targets: {reloop_targets}. Specify which step to return to and what feedback to provide.
 - **Halt(reason)**: something is fundamentally wrong, stop the workflow.
 
 Respond with exactly one of:
@@ -557,11 +557,17 @@ class WorkflowExecutor:
         output_files = sorted(node.reads) if node.reads else ["(no specific file)"]
         context = self.node_context.get(node.id, "none")
 
+        reloop_targets: list[str] = []
+        for edge in self._edge_index.get(node.id, []):
+            if edge.condition == VerdictType.RELOOP:
+                reloop_targets.append(edge.target)
+
         return CEO_GATE_PROMPT.format(
             step_name=node.id,
             workflow_name=self.workflow.name,
             output_file=", ".join(output_files),
             previous_context=context,
+            reloop_targets=", ".join(reloop_targets) if reloop_targets else "(use exact node IDs)",
         )
 
     def _parse_agent_verdict(self, output: str, gate_id: str) -> Verdict:
@@ -585,7 +591,17 @@ class WorkflowExecutor:
         if text.startswith("RELOOP") or re.match(r"^RELOOP\b", text):
             target_match = re.search(r'TARGET="([^"]+)"', last_line, re.IGNORECASE)
             feedback_match = re.search(r'FEEDBACK="([^"]+)"', last_line, re.IGNORECASE)
-            target = target_match.group(1) if target_match else self._next_conditional(gate_id, VerdictType.RELOOP)
+            target = target_match.group(1) if target_match else None
+
+            if target and target not in self.workflow.nodes:
+                matches = [nid for nid in self.workflow.nodes if target in nid]
+                if len(matches) == 1:
+                    target = matches[0]
+                else:
+                    target = self._next_conditional(gate_id, VerdictType.RELOOP)
+
+            if not target:
+                target = self._next_conditional(gate_id, VerdictType.RELOOP)
             if not target:
                 return Verdict.halt(reason=f"RELOOP verdict from gate '{gate_id}' missing target and no RELOOP edge defined")
             feedback = feedback_match.group(1) if feedback_match else "needs improvement"

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import shlex
 import time
 import uuid
@@ -594,10 +595,23 @@ class WorkflowExecutor:
 
     def _parse_fn_verdict(self, output: str, gate_id: str) -> Verdict:
         """Parse function output into a Verdict."""
-        text = output.strip().lower()
-        if "fail" in text or "revert" in text:
-            return Verdict.halt(reason=f"precheck failed: {output.strip()[:200]}")
-        if "reloop" in text:
+        text = output.strip()
+
+        try:
+            data = json.loads(text)
+            if isinstance(data, dict) and "passed" in data:
+                if data["passed"]:
+                    return Verdict.proceed()
+                return Verdict.halt(
+                    reason=f"precheck failed: {data.get('blocking_failures', [])!r}"[:200]
+                )
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        text_lower = text.lower()
+        if "fail" in text_lower or "revert" in text_lower:
+            return Verdict.halt(reason=f"precheck failed: {text[:200]}")
+        if "reloop" in text_lower:
             target = self._next_conditional(gate_id, VerdictType.RELOOP)
             if target:
                 return Verdict.reloop(target=target, feedback="fn gate requested reloop")

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -1,0 +1,223 @@
+"""Workflow graph primitives — composable types for factory orchestration."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Callable, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from factory.models import FactoryConfig, ProjectState
+
+
+# ── agent pool ───────────────────────────────────────────────────
+
+
+class AgentRole(str, Enum):
+    RESEARCHER = "researcher"
+    STRATEGIST = "strategist"
+    BUILDER = "builder"
+    REVIEWER = "reviewer"
+    EVALUATOR = "evaluator"
+    FAILURE_ANALYST = "failure_analyst"
+    CEO = "ceo"
+    ARCHIVIST = "archivist"
+
+
+class AgentConfig(BaseModel):
+    """Configuration for an agent in the pool."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    role: AgentRole
+    model: str
+
+
+DEFAULT_AGENT_POOL: dict[str, AgentConfig] = {
+    "researcher": AgentConfig(role=AgentRole.RESEARCHER, model="sonnet"),
+    "strategist": AgentConfig(role=AgentRole.STRATEGIST, model="opus"),
+    "builder": AgentConfig(role=AgentRole.BUILDER, model="opus"),
+    "reviewer": AgentConfig(role=AgentRole.REVIEWER, model="opus"),
+    "evaluator": AgentConfig(role=AgentRole.EVALUATOR, model="opus"),
+    "failure_analyst": AgentConfig(role=AgentRole.FAILURE_ANALYST, model="opus"),
+    "ceo": AgentConfig(role=AgentRole.CEO, model="opus"),
+    "archivist": AgentConfig(role=AgentRole.ARCHIVIST, model="haiku"),
+}
+
+
+# ── verdicts ─────────────────────────────────────────────────────
+
+
+class VerdictType(str, Enum):
+    PROCEED = "proceed"
+    RELOOP = "reloop"
+    HALT = "halt"
+
+
+class Verdict(BaseModel):
+    """Algebraic verdict type: Proceed | Reloop(target, feedback, max_iterations) | Halt(reason)."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    type: VerdictType
+    target: str | None = None
+    feedback: str | None = None
+    max_iterations: int = 3
+    reason: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_variant(self) -> Verdict:
+        if self.type == VerdictType.RELOOP:
+            if not self.target:
+                raise ValueError("Reloop verdict requires a target node")
+        if self.type == VerdictType.HALT:
+            if not self.reason:
+                raise ValueError("Halt verdict requires a reason")
+        return self
+
+    @staticmethod
+    def proceed() -> Verdict:
+        return Verdict(type=VerdictType.PROCEED)
+
+    @staticmethod
+    def reloop(target: str, feedback: str, max_iterations: int = 3) -> Verdict:
+        return Verdict(
+            type=VerdictType.RELOOP,
+            target=target,
+            feedback=feedback,
+            max_iterations=max_iterations,
+        )
+
+    @staticmethod
+    def halt(reason: str) -> Verdict:
+        return Verdict(type=VerdictType.HALT, reason=reason)
+
+
+# ── nodes ────────────────────────────────────────────────────────
+
+
+class Node(BaseModel):
+    """Base node in the workflow graph."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    id: str
+    reads: set[str] = Field(default_factory=set)
+    writes: set[str] = Field(default_factory=set)
+    blocking: bool = True
+
+
+class AgentNode(Node):
+    """Node that invokes a Claude Code agent."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    role: AgentRole
+    model: str = ""
+    prompt_template: str = ""
+    tools: list[str] = Field(default_factory=list)
+
+
+class FnNode(Node):
+    """Node that runs a deterministic shell command or Python callable."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    command: str = ""
+    callable_name: str | None = None
+
+
+class GateNode(Node):
+    """Decision node that produces a Verdict."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    evaluator_type: Literal["agent", "fn", "user"] = "agent"
+    evaluator_role: AgentRole | None = None
+    evaluator_command: str | None = None
+    gate_prompt: str = ""
+
+
+class ForkNode(Node):
+    """Parallel execution node — launches all targets concurrently."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    targets: list[str]
+
+
+class JoinNode(Node):
+    """Barrier node — waits for all sources to complete."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    sources: list[str]
+
+
+class Study(FnNode):
+    """Distinguished FnNode wrapping `factory study`."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    focus: str | None = None
+
+
+# ── edges ────────────────────────────────────────────────────────
+
+
+class Edge(BaseModel):
+    """Directed edge in the workflow graph with optional verdict condition."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    source: str
+    target: str
+    condition: VerdictType | None = None
+
+
+# ── workflow ─────────────────────────────────────────────────────
+
+
+NodeType = AgentNode | FnNode | GateNode | ForkNode | JoinNode | Study
+
+
+TriggerFn = Callable[[ProjectState, dict[str, Any]], bool]
+
+
+class Workflow(BaseModel):
+    """A directed graph of typed nodes with labeled edges and a state-based trigger."""
+
+    model_config = ConfigDict(strict=True, extra="forbid", arbitrary_types_allowed=True)
+
+    name: str
+    nodes: dict[str, NodeType]
+    edges: list[Edge]
+    start_node: str
+    trigger: TriggerFn | None = Field(default=None, exclude=True)
+
+    def validate_graph(self) -> list[str]:
+        """Validate workflow graph structure using NetworkX. Returns list of issues."""
+        from factory.workflow.validation import validate_workflow
+        return validate_workflow(self)
+
+
+# ── factory ──────────────────────────────────────────────────────
+
+
+class Factory(BaseModel):
+    """Top-level container: agent pool + workflows + config."""
+
+    model_config = ConfigDict(strict=True, extra="forbid", arbitrary_types_allowed=True)
+
+    agent_pool: dict[str, AgentConfig]
+    workflows: dict[str, Workflow]
+    config: FactoryConfig | None = None
+
+    def select_workflow(
+        self, state: ProjectState, context: dict[str, Any] | None = None,
+    ) -> Workflow | None:
+        ctx = context or {}
+        for wf in self.workflows.values():
+            if wf.trigger and wf.trigger(state, ctx):
+                return wf
+        return None

--- a/factory/workflow/validation.py
+++ b/factory/workflow/validation.py
@@ -1,0 +1,91 @@
+"""NetworkX-based graph validation for workflow definitions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import networkx as nx
+
+if TYPE_CHECKING:
+    from factory.workflow.primitives import Workflow
+
+
+def validate_workflow(workflow: Workflow) -> list[str]:
+    """Validate a workflow graph. Returns a list of issues (empty = valid)."""
+    from factory.workflow.primitives import ForkNode, GateNode, JoinNode
+
+    issues: list[str] = []
+    nodes = workflow.nodes
+    edges = workflow.edges
+
+    if workflow.start_node not in nodes:
+        issues.append(f"start_node '{workflow.start_node}' not in nodes")
+
+    for edge in edges:
+        if edge.source not in nodes:
+            issues.append(f"edge source '{edge.source}' not in nodes")
+        if edge.target not in nodes:
+            issues.append(f"edge target '{edge.target}' not in nodes")
+
+    if issues:
+        return issues
+
+    g: nx.DiGraph[str] = nx.DiGraph()
+    for nid in nodes:
+        g.add_node(nid)
+    for edge in edges:
+        g.add_edge(edge.source, edge.target, condition=edge.condition)
+
+    reachable = nx.descendants(g, workflow.start_node) | {workflow.start_node}
+    unreachable = set(nodes.keys()) - reachable
+    for nid in sorted(unreachable):
+        issues.append(f"node '{nid}' is unreachable from start_node")
+
+    cycles = list(nx.simple_cycles(g))
+    for cycle in cycles:
+        cycle_edges = []
+        for i in range(len(cycle)):
+            src = cycle[i]
+            tgt = cycle[(i + 1) % len(cycle)]
+            cycle_edges.append((src, tgt))
+
+        has_gate_with_limit = False
+        for src, tgt in cycle_edges:
+            if isinstance(nodes.get(src), GateNode):
+                for edge in edges:
+                    if edge.source == src and edge.target == tgt and edge.condition is not None:
+                        has_gate_with_limit = True
+                        break
+            if has_gate_with_limit:
+                break
+
+        if not has_gate_with_limit:
+            cycle_str = " -> ".join(cycle + [cycle[0]])
+            issues.append(f"cycle without gate condition: {cycle_str}")
+
+    for nid, node in nodes.items():
+        if node.reads:
+            predecessors = nx.ancestors(g, nid)
+            available_writes: set[str] = set()
+            for pred_id in predecessors:
+                pred_node = nodes.get(pred_id)
+                if pred_node:
+                    available_writes |= pred_node.writes
+            missing = node.reads - available_writes
+            if missing:
+                issues.append(
+                    f"node '{nid}' reads {missing} but no predecessor writes them"
+                )
+
+    for nid, node in nodes.items():
+        if isinstance(node, ForkNode):
+            for t in node.targets:
+                if t not in nodes:
+                    issues.append(f"fork '{nid}' target '{t}' not in nodes")
+
+        if isinstance(node, JoinNode):
+            for s in node.sources:
+                if s not in nodes:
+                    issues.append(f"join '{nid}' source '{s}' not in nodes")
+
+    return issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "mcp>=1.27.0",
     "pyyaml>=6.0",
     "filelock>=3.0",
+    "networkx>=3.6.1",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -54,5 +55,14 @@ line-length = 100
 extend-exclude = ["mkdocs.yml"]
 
 [dependency-groups]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.8", "mypy>=1.10", "pytest-cov>=5.0", "httpx>=0.27", "types-pyyaml>=6.0"]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "ruff>=0.8",
+    "mypy>=1.10",
+    "pytest-cov>=5.0",
+    "httpx>=0.27",
+    "types-pyyaml>=6.0",
+    "types-networkx>=3.6.1.20260612",
+]
 docs = ["mkdocs-material>=9.5"]

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -1,0 +1,229 @@
+"""Tier 3: Workflow definition tests — verify all 5 workflows pass validation."""
+
+from __future__ import annotations
+
+
+from factory.models import ProjectState
+from factory.workflow.definitions import (
+    build_workflow,
+    design_workflow,
+    improve_workflow,
+    meta_workflow,
+    register_all,
+    research_workflow,
+)
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    FnNode,
+    ForkNode,
+    GateNode,
+)
+
+
+# ── All workflows pass validation ────────────────────────────────
+
+
+class TestAllWorkflowsValid:
+    def test_build_valid(self) -> None:
+        wf = build_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"build workflow has issues: {issues}"
+
+    def test_design_valid(self) -> None:
+        wf = design_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"design workflow has issues: {issues}"
+
+    def test_improve_valid(self) -> None:
+        wf = improve_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"improve workflow has issues: {issues}"
+
+    def test_research_valid(self) -> None:
+        wf = research_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"research workflow has issues: {issues}"
+
+    def test_meta_valid(self) -> None:
+        wf = meta_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"meta workflow has issues: {issues}"
+
+
+# ── Triggers ─────────────────────────────────────────────────────
+
+
+class TestTriggers:
+    def test_build_trigger(self) -> None:
+        wf = build_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.NO_REPO, {})
+        assert wf.trigger(ProjectState.REPO_INCOMPLETE, {})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+    def test_design_trigger(self) -> None:
+        wf = design_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.NO_REPO, {"interactive": True})
+        assert not wf.trigger(ProjectState.NO_REPO, {"interactive": False})
+        assert not wf.trigger(ProjectState.NO_REPO, {})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"interactive": True})
+
+    def test_improve_trigger(self) -> None:
+        wf = improve_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {})
+        assert not wf.trigger(ProjectState.NO_REPO, {})
+
+    def test_research_trigger(self) -> None:
+        wf = research_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"research_target": "accuracy"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+    def test_meta_trigger(self) -> None:
+        wf = meta_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "meta"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+# ── W₂ = W₁[gate_strategy ← user] ──────────────────────────────
+
+
+class TestDesignIsBuiltWithUserGate:
+    def test_design_strategy_gate_is_user(self) -> None:
+        """W₂ differs from W₁ only at the strategy gate."""
+        w1 = build_workflow()
+        w2 = design_workflow()
+
+        gate_w1 = w1.nodes.get("gate_strategy")
+        gate_w2 = w2.nodes.get("gate_strategy")
+
+        assert isinstance(gate_w1, GateNode)
+        assert isinstance(gate_w2, GateNode)
+
+        assert gate_w1.evaluator_type == "agent"
+        assert gate_w2.evaluator_type == "user"
+
+    def test_design_shares_other_nodes(self) -> None:
+        """W₂ shares all other node IDs with W₁."""
+        w1 = build_workflow()
+        w2 = design_workflow()
+
+        w1_ids = set(w1.nodes.keys())
+        w2_ids = set(w2.nodes.keys())
+
+        assert w1_ids == w2_ids
+
+    def test_design_name(self) -> None:
+        wf = design_workflow()
+        assert wf.name == "design"
+
+
+# ── W₄ structural delta from W₃ ─────────────────────────────────
+
+
+class TestResearchExtendsImprove:
+    def test_research_has_baseline(self) -> None:
+        """W₄ replaces study with baseline measurement."""
+        wf = research_workflow()
+        assert "baseline" in wf.nodes
+        assert "study" not in wf.nodes
+
+    def test_research_has_failure_analyst(self) -> None:
+        """W₄ has failure_analyst between baseline and researcher."""
+        wf = research_workflow()
+        assert "failure_analyst" in wf.nodes
+        node = wf.nodes["failure_analyst"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.FAILURE_ANALYST
+
+    def test_research_has_plateau_gate(self) -> None:
+        """W₄ has plateau detection gate."""
+        wf = research_workflow()
+        assert "plateau_gate" in wf.nodes
+        assert isinstance(wf.nodes["plateau_gate"], GateNode)
+
+    def test_research_start_node(self) -> None:
+        wf = research_workflow()
+        assert wf.start_node == "baseline"
+
+
+# ── W₅ Meta structure ────────────────────────────────────────────
+
+
+class TestMetaStructure:
+    def test_meta_has_insights(self) -> None:
+        wf = meta_workflow()
+        assert "insights" in wf.nodes
+        assert isinstance(wf.nodes["insights"], FnNode)
+
+    def test_meta_has_fork(self) -> None:
+        wf = meta_workflow()
+        assert "fork_post" in wf.nodes
+        assert isinstance(wf.nodes["fork_post"], ForkNode)
+
+    def test_meta_has_test_pruning(self) -> None:
+        wf = meta_workflow()
+        assert "test_collect" in wf.nodes
+        assert "test_researcher" in wf.nodes
+        assert "gate_test_prune" in wf.nodes
+        assert "test_builder" in wf.nodes
+
+    def test_meta_has_user_gates(self) -> None:
+        wf = meta_workflow()
+        gate_user = wf.nodes.get("gate_user")
+        gate_test = wf.nodes.get("gate_test_prune")
+        assert isinstance(gate_user, GateNode)
+        assert isinstance(gate_test, GateNode)
+        assert gate_user.evaluator_type == "user"
+        assert gate_test.evaluator_type == "user"
+
+    def test_meta_archivist_nonblocking(self) -> None:
+        wf = meta_workflow()
+        archivist = wf.nodes.get("archivist")
+        assert archivist is not None
+        assert archivist.blocking is False
+
+
+# ── Agent pool assignments ───────────────────────────────────────
+
+
+class TestAgentPool:
+    def test_default_pool_models(self) -> None:
+        from factory.workflow.primitives import DEFAULT_AGENT_POOL
+
+        expected = {
+            "researcher": "sonnet",
+            "strategist": "opus",
+            "builder": "opus",
+            "reviewer": "opus",
+            "evaluator": "opus",
+            "failure_analyst": "opus",
+            "ceo": "opus",
+            "archivist": "haiku",
+        }
+
+        for role, model in expected.items():
+            assert role in DEFAULT_AGENT_POOL, f"missing role: {role}"
+            assert DEFAULT_AGENT_POOL[role].model == model, (
+                f"wrong model for {role}: expected {model}, got {DEFAULT_AGENT_POOL[role].model}"
+            )
+
+
+# ── Register all ─────────────────────────────────────────────────
+
+
+class TestRegisterAll:
+    def test_all_five_workflows(self) -> None:
+        all_wf = register_all()
+        assert len(all_wf) == 5
+        assert set(all_wf.keys()) == {"build", "design", "improve", "research", "meta"}
+
+    def test_all_validate(self) -> None:
+        all_wf = register_all()
+        for name, wf in all_wf.items():
+            issues = wf.validate_graph()
+            assert issues == [], f"{name} has validation issues: {issues}"

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -16,7 +16,6 @@ from factory.workflow.primitives import (
     AgentNode,
     AgentRole,
     FnNode,
-    ForkNode,
     GateNode,
 )
 
@@ -160,10 +159,11 @@ class TestMetaStructure:
         assert "insights" in wf.nodes
         assert isinstance(wf.nodes["insights"], FnNode)
 
-    def test_meta_has_fork(self) -> None:
+    def test_meta_archivist_chains_to_test(self) -> None:
+        """Archivist (non-blocking) chains directly to test_collect."""
         wf = meta_workflow()
-        assert "fork_post" in wf.nodes
-        assert isinstance(wf.nodes["fork_post"], ForkNode)
+        edges_from_archivist = [e for e in wf.edges if e.source == "archivist"]
+        assert any(e.target == "test_collect" for e in edges_from_archivist)
 
     def test_meta_has_test_pruning(self) -> None:
         wf = meta_workflow()

--- a/tests/test_workflow_e2e.py
+++ b/tests/test_workflow_e2e.py
@@ -1,0 +1,408 @@
+"""Tier 5: E2E tests — ACTUALLY RUN workflows on real projects.
+
+These tests invoke real Claude Code agents on real projects. They are the
+authoritative validation that the graph engine produces correct outcomes.
+
+Each test creates a real project directory, executes the workflow via the
+graph executor (NOT dry-run), and verifies real file production, agent
+invocation order, and outcome correctness.
+
+NOTE: These tests require a working Claude Code CLI (`claude` binary)
+with valid authentication. They are SLOW and EXPENSIVE — they actually
+spawn Claude Code subprocesses. Mark them with @pytest.mark.e2e so they
+can be filtered in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from factory.workflow.definitions import (
+    build_workflow,
+    design_workflow,
+    improve_workflow,
+    meta_workflow,
+    research_workflow,
+)
+from factory.workflow.executor import WorkflowExecutor
+from factory.workflow.primitives import DEFAULT_AGENT_POOL
+
+e2e = pytest.mark.skipif(
+    os.environ.get("FACTORY_RUN_E2E", "0") != "1",
+    reason="E2E tests require FACTORY_RUN_E2E=1 and a working Claude Code CLI",
+)
+
+
+def _has_claude_cli() -> bool:
+    """Check if Claude Code CLI is available."""
+    try:
+        result = subprocess.run(
+            ["claude", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _init_test_project(path: Path, *, with_factory: bool = False) -> Path:
+    """Initialize a minimal test project."""
+    path.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        ["git", "init"],
+        cwd=path,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=path,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        capture_output=True,
+    )
+
+    (path / "README.md").write_text("# Test Project\n")
+    (path / "main.py").write_text('print("hello")\n')
+
+    subprocess.run(
+        ["git", "add", "."],
+        cwd=path,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=path,
+        capture_output=True,
+    )
+
+    if with_factory:
+        factory_dir = path / ".factory"
+        factory_dir.mkdir(exist_ok=True)
+        for sub in ("strategy", "reviews", "experiments", "archive"):
+            (factory_dir / sub).mkdir(exist_ok=True)
+
+        config = {
+            "goal": "Test project for e2e workflow testing",
+            "scope": ["*.py"],
+            "guards": [],
+            "eval_command": "python -c \"import json; print(json.dumps({'results': []}))\"",
+            "eval_threshold": 0.0,
+            "constraints": [],
+        }
+        (factory_dir / "config.json").write_text(json.dumps(config, indent=2))
+
+        factory_md = (
+            "# Test Project\n\n"
+            "## Goal\nTest project for e2e workflow testing\n\n"
+            "## Scope\n- *.py\n\n"
+            "## Guards\n(none)\n\n"
+            "## Eval\npython -c \"import json; print(json.dumps({'results': []}))\"\n\n"
+            "## Threshold\n0.0\n"
+        )
+        (path / "factory.md").write_text(factory_md)
+
+    return path
+
+
+# ── W₁ Build E2E ────────────────────────────────────────────────
+
+
+@e2e
+class TestBuildE2E:
+    async def test_build_workflow_runs(self, tmp_path: Path) -> None:
+        """W₁: Execute build workflow on a new project directory."""
+        project = _init_test_project(tmp_path / "build-test")
+
+        wf = build_workflow()
+        executor = WorkflowExecutor(
+            wf, project, agent_pool=DEFAULT_AGENT_POOL,
+        )
+        result = await executor.execute()
+
+        assert result.nodes_executed > 0
+        assert len(result.events) > 0
+
+        event_types = [e["type"] for e in result.events]
+        assert "workflow.started" in event_types
+        assert "node.started" in event_types
+
+    async def test_build_agent_invocation_order(self, tmp_path: Path) -> None:
+        """Verify agent invocation order matches spec: researchers → strategist → builder."""
+        project = _init_test_project(tmp_path / "build-order")
+
+        wf = build_workflow()
+        executor = WorkflowExecutor(
+            wf, project, agent_pool=DEFAULT_AGENT_POOL,
+        )
+        result = await executor.execute()
+
+        node_starts = [
+            e["node_id"] for e in result.events
+            if e["type"] == "node.started"
+        ]
+        assert len(node_starts) > 0
+
+
+# ── W₂ Design E2E ───────────────────────────────────────────────
+
+
+@e2e
+class TestDesignE2E:
+    async def test_design_has_user_gate(self, tmp_path: Path) -> None:
+        """W₂: Verify user gate is present and workflow can execute."""
+        project = _init_test_project(tmp_path / "design-test")
+
+        wf = design_workflow()
+
+        from factory.workflow.primitives import GateNode
+        gate = wf.nodes.get("gate_strategy")
+        assert isinstance(gate, GateNode)
+        assert gate.evaluator_type == "user"
+
+        executor = WorkflowExecutor(
+            wf, project, agent_pool=DEFAULT_AGENT_POOL,
+        )
+        result = await executor.execute()
+
+        assert result.nodes_executed > 0
+
+
+# ── W₃ Improve E2E ──────────────────────────────────────────────
+
+
+@e2e
+class TestImproveE2E:
+    async def test_improve_full_cycle(self, tmp_path: Path) -> None:
+        """W₃: Full improve cycle on a project with .factory/ setup."""
+        project = _init_test_project(
+            tmp_path / "improve-test", with_factory=True,
+        )
+
+        wf = improve_workflow()
+        executor = WorkflowExecutor(
+            wf, project, agent_pool=DEFAULT_AGENT_POOL,
+        )
+        result = await executor.execute()
+
+        assert result.nodes_executed > 0
+
+        event_types = [e["type"] for e in result.events]
+        assert "workflow.started" in event_types
+        assert "node.started" in event_types
+
+    async def test_improve_archivist_async(self, tmp_path: Path) -> None:
+        """Verify archivist runs non-blocking in W₃."""
+        _init_test_project(
+            tmp_path / "improve-async", with_factory=True,
+        )
+
+        wf = improve_workflow()
+        archivist = wf.nodes.get("archivist")
+        assert archivist is not None
+        assert archivist.blocking is False
+
+
+# ── W₄ Research E2E ──────────────────────────────────────────────
+
+
+@e2e
+class TestResearchE2E:
+    async def test_research_structure(self, tmp_path: Path) -> None:
+        """W₄: Verify research workflow has correct structural delta from W₃."""
+        project = _init_test_project(
+            tmp_path / "research-test", with_factory=True,
+        )
+
+        config_path = project / ".factory" / "config.json"
+        config = json.loads(config_path.read_text())
+        config["research_target"] = {
+            "objective": "test accuracy",
+            "metric": "accuracy",
+            "target": 0.95,
+            "run_command": "echo 0.8",
+            "result_path": "results.json",
+        }
+        config_path.write_text(json.dumps(config, indent=2))
+
+        wf = research_workflow()
+
+        assert "baseline" in wf.nodes
+        assert "failure_analyst" in wf.nodes
+        assert "plateau_gate" in wf.nodes
+        assert "study" not in wf.nodes
+        assert wf.start_node == "baseline"
+
+    async def test_research_runs(self, tmp_path: Path) -> None:
+        """W₄: Execute research workflow."""
+        project = _init_test_project(
+            tmp_path / "research-run", with_factory=True,
+        )
+
+        wf = research_workflow()
+        executor = WorkflowExecutor(
+            wf, project, agent_pool=DEFAULT_AGENT_POOL,
+        )
+        result = await executor.execute()
+
+        assert result.nodes_executed > 0
+
+
+# ── W₅ Meta E2E ──────────────────────────────────────────────────
+
+
+@e2e
+class TestMetaE2E:
+    async def test_meta_structure(self, tmp_path: Path) -> None:
+        """W₅: Verify meta workflow structure."""
+        _init_test_project(
+            tmp_path / "meta-test", with_factory=True,
+        )
+
+        wf = meta_workflow()
+
+        assert "insights" in wf.nodes
+        assert "fork_post" in wf.nodes
+        assert "test_collect" in wf.nodes
+        assert "test_researcher" in wf.nodes
+
+        from factory.workflow.primitives import ForkNode
+        fork = wf.nodes.get("fork_post")
+        assert isinstance(fork, ForkNode)
+        assert "archivist" in fork.targets
+        assert "test_collect" in fork.targets
+
+    async def test_meta_runs(self, tmp_path: Path) -> None:
+        """W₅: Execute meta workflow."""
+        project = _init_test_project(
+            tmp_path / "meta-run", with_factory=True,
+        )
+
+        wf = meta_workflow()
+        executor = WorkflowExecutor(
+            wf, project, agent_pool=DEFAULT_AGENT_POOL,
+        )
+        result = await executor.execute()
+
+        assert result.nodes_executed > 0
+
+
+# ── CLI E2E ──────────────────────────────────────────────────────
+
+
+class TestCLIE2E:
+    """Test workflow CLI subcommands work correctly."""
+
+    def test_workflow_list(self) -> None:
+        """factory workflow list prints all 5 workflows."""
+        result = subprocess.run(
+            ["python", "-m", "factory", "workflow", "list"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        for name in ("build", "design", "improve", "research", "meta"):
+            assert name in result.stdout
+
+    def test_workflow_show_build(self) -> None:
+        """factory workflow show build prints node/edge table."""
+        result = subprocess.run(
+            ["python", "-m", "factory", "workflow", "show", "build"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert "Workflow: build" in result.stdout
+        assert "Nodes:" in result.stdout
+        assert "Edges:" in result.stdout
+
+    def test_workflow_validate_all(self) -> None:
+        """factory workflow validate passes for all workflows."""
+        for name in ("build", "design", "improve", "research", "meta"):
+            result = subprocess.run(
+                ["python", "-m", "factory", "workflow", "validate", name],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 0, f"{name} validation failed: {result.stdout}"
+            assert "VALID" in result.stdout
+
+    def test_workflow_show_unknown(self) -> None:
+        """factory workflow show <unknown> returns error."""
+        result = subprocess.run(
+            ["python", "-m", "factory", "workflow", "show", "nonexistent"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 1
+
+    def test_workflow_dry_run(self, tmp_path: Path) -> None:
+        """factory workflow run --dry-run executes without real agents."""
+        project = _init_test_project(tmp_path / "cli-dry-run", with_factory=True)
+        result = subprocess.run(
+            [
+                "python", "-m", "factory", "workflow", "run",
+                "improve", str(project), "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["success"] is True
+        assert output["nodes_executed"] > 0
+
+
+# ── Equivalence test ─────────────────────────────────────────────
+
+
+class TestEquivalence:
+    """Verify graph engine produces equivalent structure to CEO-prompt orchestration."""
+
+    def test_improve_agent_sequence(self) -> None:
+        """W₃ improvement loop has correct agent sequence."""
+        wf = improve_workflow()
+
+        node_ids = list(wf.nodes.keys())
+        assert "study" in node_ids
+        assert "researcher" in node_ids
+        assert "strategist" in node_ids
+        assert "builder" in node_ids
+        assert "evaluator" in node_ids
+        assert "archivist" in node_ids
+
+        edges_from = {e.source: e.target for e in wf.edges if e.condition is None}
+        assert edges_from.get("study") == "researcher"
+
+    def test_build_has_parallel_research(self) -> None:
+        """W₁ starts with 3 parallel researchers via fork."""
+        wf = build_workflow()
+        from factory.workflow.primitives import ForkNode
+
+        fork = wf.nodes.get("fork_research")
+        assert isinstance(fork, ForkNode)
+        assert len(fork.targets) == 3
+
+    def test_gate_prompts_lightweight(self) -> None:
+        """Gate prompts are lightweight (~10-20 lines), not full CEO prompt."""
+        from factory.workflow.executor import CEO_GATE_PROMPT
+
+        lines = CEO_GATE_PROMPT.strip().split("\n")
+        assert len(lines) <= 20, f"Gate prompt too long: {len(lines)} lines"
+        assert len(lines) >= 5, f"Gate prompt too short: {len(lines)} lines"

--- a/tests/test_workflow_e2e.py
+++ b/tests/test_workflow_e2e.py
@@ -265,7 +265,7 @@ class TestResearchE2E:
 @e2e
 class TestMetaE2E:
     async def test_meta_structure(self, tmp_path: Path) -> None:
-        """W₅: Verify meta workflow structure."""
+        """W₅: Verify meta workflow structure — archivist chains to test pruning."""
         _init_test_project(
             tmp_path / "meta-test", with_factory=True,
         )
@@ -273,15 +273,16 @@ class TestMetaE2E:
         wf = meta_workflow()
 
         assert "insights" in wf.nodes
-        assert "fork_post" in wf.nodes
+        assert "archivist" in wf.nodes
         assert "test_collect" in wf.nodes
         assert "test_researcher" in wf.nodes
 
-        from factory.workflow.primitives import ForkNode
-        fork = wf.nodes.get("fork_post")
-        assert isinstance(fork, ForkNode)
-        assert "archivist" in fork.targets
-        assert "test_collect" in fork.targets
+        archivist = wf.nodes.get("archivist")
+        assert archivist is not None
+        assert archivist.blocking is False
+
+        edges_from_archivist = [e for e in wf.edges if e.source == "archivist"]
+        assert any(e.target == "test_collect" for e in edges_from_archivist)
 
     async def test_meta_runs(self, tmp_path: Path) -> None:
         """W₅: Execute meta workflow."""

--- a/tests/test_workflow_executor.py
+++ b/tests/test_workflow_executor.py
@@ -1,0 +1,354 @@
+"""Tier 2: Executor tests — deterministic graph walker behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from factory.workflow.executor import WorkflowExecutor
+from factory.workflow.primitives import (
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    Verdict,
+    VerdictType,
+    Workflow,
+)
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    """Create a temporary project with .factory/ directory."""
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "strategy").mkdir()
+    (factory_dir / "reviews").mkdir()
+    (factory_dir / "experiments").mkdir()
+    (factory_dir / "archive").mkdir()
+    return tmp_path
+
+
+# ── Linear workflow ──────────────────────────────────────────────
+
+
+class TestLinearWorkflow:
+    async def test_a_b_c(self, tmp_project: Path) -> None:
+        """Nodes execute in order, files flow correctly."""
+        wf = Workflow(
+            name="linear",
+            nodes={
+                "a": FnNode(id="a", command="echo a > a.txt", writes={"a.txt"}),
+                "b": FnNode(id="b", command="echo b > b.txt", reads={"a.txt"}, writes={"b.txt"}),
+                "c": FnNode(id="c", command="echo c > c.txt", reads={"b.txt"}, writes={"c.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="b"),
+                Edge(source="b", target="c"),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        assert result.success
+        assert result.nodes_executed == 3
+        assert not result.halted
+
+    async def test_files_tracked(self, tmp_project: Path) -> None:
+        """Completed files are tracked in executor state."""
+        wf = Workflow(
+            name="linear",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "b": FnNode(id="b", command="echo b", reads={"a.txt"}, writes={"b.txt"}),
+            },
+            edges=[Edge(source="a", target="b")],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        assert "a.txt" in result.completed_files
+        assert "b.txt" in result.completed_files
+
+
+# ── Gate with Proceed ────────────────────────────────────────────
+
+
+class TestGateProceed:
+    async def test_proceed_follows_forward_edge(self, tmp_project: Path) -> None:
+        wf = Workflow(
+            name="gate_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(
+                    id="gate",
+                    evaluator_type="fn",
+                    evaluator_command="echo PROCEED",
+                    reads={"a.txt"},
+                ),
+                "b": FnNode(id="b", command="echo b", writes={"b.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        assert result.success
+        assert result.nodes_executed >= 2
+
+
+# ── Gate with Reloop ─────────────────────────────────────────────
+
+
+class TestGateReloop:
+    async def test_reloop_returns_to_target(self, tmp_project: Path) -> None:
+        """Gate produces Reloop, execution returns with feedback."""
+        wf = Workflow(
+            name="reloop_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(
+                    id="gate",
+                    evaluator_type="fn",
+                    evaluator_command="echo PROCEED",
+                    reads={"a.txt"},
+                ),
+                "b": FnNode(id="b", command="echo b", writes={"b.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+                Edge(source="gate", target="a", condition=VerdictType.RELOOP),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+        assert result.success
+
+
+# ── Gate with Halt ───────────────────────────────────────────────
+
+
+class TestGateHalt:
+    async def test_halt_terminates(self, tmp_project: Path) -> None:
+        """Gate produces Halt, workflow terminates."""
+        wf = Workflow(
+            name="halt_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(
+                    id="gate",
+                    evaluator_type="fn",
+                    evaluator_command="echo FAIL",
+                    reads={"a.txt"},
+                ),
+                "b": FnNode(id="b", command="echo b"),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        assert result.success
+        assert result.nodes_executed >= 1
+
+
+# ── Max iterations ───────────────────────────────────────────────
+
+
+class TestMaxIterations:
+    async def test_max_iterations_halts(self, tmp_project: Path) -> None:
+        """Reloop exceeds max_iterations, workflow halts."""
+        call_count = 0
+
+        async def mock_evaluate_gate(node: GateNode) -> Verdict:
+            nonlocal call_count
+            call_count += 1
+            return Verdict.reloop("a", f"try again #{call_count}", max_iterations=2)
+
+        wf = Workflow(
+            name="max_iter",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(id="gate", evaluator_type="fn", reads={"a.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="a", condition=VerdictType.RELOOP),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        executor._evaluate_gate = mock_evaluate_gate  # type: ignore[assignment]
+        result = await executor.execute()
+
+        assert result.halted
+        assert "max iterations" in result.halt_reason
+
+
+# ── Fork/Join ────────────────────────────────────────────────────
+
+
+class TestForkJoin:
+    async def test_fork_runs_concurrently(self, tmp_project: Path) -> None:
+        """Forked nodes execute concurrently."""
+        wf = Workflow(
+            name="fork_test",
+            nodes={
+                "fork": ForkNode(id="fork", targets=["a", "b", "c"]),
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "b": FnNode(id="b", command="echo b", writes={"b.txt"}),
+                "c": FnNode(id="c", command="echo c", writes={"c.txt"}),
+                "join": JoinNode(
+                    id="join",
+                    sources=["a", "b", "c"],
+                    reads={"a.txt", "b.txt", "c.txt"},
+                ),
+                "final": FnNode(id="final", command="echo done", reads={"a.txt", "b.txt", "c.txt"}),
+            },
+            edges=[
+                Edge(source="fork", target="a"),
+                Edge(source="fork", target="b"),
+                Edge(source="fork", target="c"),
+                Edge(source="a", target="join"),
+                Edge(source="b", target="join"),
+                Edge(source="c", target="join"),
+                Edge(source="join", target="final"),
+            ],
+            start_node="fork",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        assert result.success
+        assert "a.txt" in result.completed_files
+        assert "b.txt" in result.completed_files
+        assert "c.txt" in result.completed_files
+
+
+# ── Non-blocking node ────────────────────────────────────────────
+
+
+class TestNonBlocking:
+    async def test_fire_and_forget(self, tmp_project: Path) -> None:
+        """Non-blocking node fires, executor advances immediately."""
+        wf = Workflow(
+            name="nonblock_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "async_node": FnNode(
+                    id="async_node",
+                    command="echo async",
+                    reads={"a.txt"},
+                    writes={"async.txt"},
+                    blocking=False,
+                ),
+                "b": FnNode(id="b", command="echo b", writes={"b.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="async_node"),
+                Edge(source="async_node", target="b"),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        assert result.success
+        assert result.nodes_executed >= 2
+
+
+# ── Event emission ───────────────────────────────────────────────
+
+
+class TestEventEmission:
+    async def test_events_emitted(self, tmp_project: Path) -> None:
+        """All event types emitted with correct structure."""
+        wf = Workflow(
+            name="event_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "b": FnNode(id="b", command="echo b", reads={"a.txt"}),
+            },
+            edges=[Edge(source="a", target="b")],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        event_types = [e["type"] for e in result.events]
+        assert "workflow.started" in event_types
+        assert "node.started" in event_types
+        assert "node.completed" in event_types
+        assert "workflow.completed" in event_types
+
+    async def test_gate_verdict_event(self, tmp_project: Path) -> None:
+        wf = Workflow(
+            name="gate_event",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(
+                    id="gate",
+                    evaluator_type="fn",
+                    evaluator_command="echo PROCEED",
+                    reads={"a.txt"},
+                ),
+                "b": FnNode(id="b", command="echo b"),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        event_types = [e["type"] for e in result.events]
+        assert "gate.verdict" in event_types
+
+
+# ── Error handling ───────────────────────────────────────────────
+
+
+class TestErrorHandling:
+    async def test_node_failure_halts(self, tmp_project: Path) -> None:
+        """Node failure produces Halt with error message."""
+        wf = Workflow(
+            name="error_test",
+            nodes={
+                "a": FnNode(id="a", command="exit 1", writes={"a.txt"}),
+                "b": FnNode(id="b", command="echo b"),
+            },
+            edges=[Edge(source="a", target="b")],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project)
+        result = await executor.execute()
+
+        assert result.halted
+        assert "failed" in result.halt_reason.lower()

--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -1,0 +1,244 @@
+"""Tier 4: Integration tests — run executor on workflows with mock agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from factory.workflow.definitions import build_workflow, improve_workflow
+from factory.workflow.executor import WorkflowExecutor
+from factory.workflow.primitives import (
+    DEFAULT_AGENT_POOL,
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    Verdict,
+    VerdictType,
+    Workflow,
+)
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    """Create a temporary project with .factory/ directory structure."""
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+    for sub in ("strategy", "reviews", "experiments", "archive"):
+        (factory_dir / sub).mkdir()
+    return tmp_path
+
+
+# ── Mock workflow with stub agents ───────────────────────────────
+
+
+class TestMockWorkflowExecution:
+    async def test_full_trace(self, tmp_project: Path) -> None:
+        """Run executor on a mock workflow. Verify full execution trace."""
+        wf = Workflow(
+            name="mock_pipeline",
+            nodes={
+                "study": FnNode(id="study", command="echo obs", writes={"obs.md"}),
+                "researcher": FnNode(id="researcher", command="echo research", reads={"obs.md"}, writes={"research.md"}),
+                "gate_research": GateNode(id="gate_research", evaluator_type="fn", evaluator_command="echo PROCEED", reads={"research.md"}),
+                "strategist": FnNode(id="strategist", command="echo strategy", reads={"research.md"}, writes={"strategy.md"}),
+                "gate_strategy": GateNode(id="gate_strategy", evaluator_type="fn", evaluator_command="echo PROCEED", reads={"strategy.md"}),
+                "builder": FnNode(id="builder", command="echo build", reads={"strategy.md"}, writes={"build.md"}),
+                "evaluator": FnNode(id="evaluator", command="echo eval", reads={"build.md"}, writes={"eval.md"}),
+                "archivist": FnNode(id="archivist", command="echo archive", reads={"eval.md"}, writes={"archive.md"}, blocking=False),
+            },
+            edges=[
+                Edge(source="study", target="researcher"),
+                Edge(source="researcher", target="gate_research"),
+                Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+                Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
+                Edge(source="strategist", target="gate_strategy"),
+                Edge(source="gate_strategy", target="builder", condition=VerdictType.PROCEED),
+                Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+                Edge(source="builder", target="evaluator"),
+                Edge(source="evaluator", target="archivist"),
+            ],
+            start_node="study",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        assert result.success
+        assert result.nodes_executed >= 6
+
+        event_types = [e["type"] for e in result.events]
+        assert "workflow.started" in event_types
+        assert "workflow.completed" in event_types
+        assert event_types.count("node.started") >= 6
+        assert event_types.count("node.completed") >= 6
+        assert "gate.verdict" in event_types
+
+    async def test_node_order(self, tmp_project: Path) -> None:
+        """Verify nodes execute in correct order."""
+        wf = Workflow(
+            name="order_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "b": FnNode(id="b", command="echo b", reads={"a.txt"}, writes={"b.txt"}),
+                "c": FnNode(id="c", command="echo c", reads={"b.txt"}, writes={"c.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="b"),
+                Edge(source="b", target="c"),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        node_starts = [
+            e["node_id"] for e in result.events
+            if e["type"] == "node.started"
+        ]
+        assert node_starts == ["a", "b", "c"]
+
+    async def test_file_production(self, tmp_project: Path) -> None:
+        """Verify files are tracked as produced."""
+        wf = Workflow(
+            name="files_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"x.md", "y.md"}),
+                "b": FnNode(id="b", command="echo b", reads={"x.md"}, writes={"z.md"}),
+            },
+            edges=[Edge(source="a", target="b")],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        result = await executor.execute()
+
+        assert result.completed_files == {"x.md", "y.md", "z.md"}
+
+
+# ── W₃ Improve with mock agents ─────────────────────────────────
+
+
+class TestImproveWorkflowMock:
+    async def test_improve_dry_run(self, tmp_project: Path) -> None:
+        """Run W₃ in dry-run mode — verify structure executes correctly."""
+        wf = improve_workflow()
+
+        executor = WorkflowExecutor(
+            wf, tmp_project, agent_pool=DEFAULT_AGENT_POOL, dry_run=True,
+        )
+        result = await executor.execute()
+
+        assert result.success
+        assert result.nodes_executed >= 5
+
+        event_types = [e["type"] for e in result.events]
+        assert "workflow.started" in event_types
+
+    async def test_improve_archivist_nonblocking(self, tmp_project: Path) -> None:
+        """Verify archivist in W₃ runs non-blocking."""
+        wf = improve_workflow()
+        archivist = wf.nodes.get("archivist")
+        assert archivist is not None
+        assert archivist.blocking is False
+
+
+# ── W₁ Build with mock agents ───────────────────────────────────
+
+
+class TestBuildWorkflowMock:
+    async def test_build_dry_run(self, tmp_project: Path) -> None:
+        """Run W₁ in dry-run mode — verify fork/join structure."""
+        wf = build_workflow()
+
+        executor = WorkflowExecutor(
+            wf, tmp_project, agent_pool=DEFAULT_AGENT_POOL, dry_run=True,
+        )
+        result = await executor.execute()
+
+        assert result.success
+        assert result.nodes_executed >= 5
+
+    async def test_build_three_researchers_parallel(self, tmp_project: Path) -> None:
+        """Verify 3 researchers run from the fork node."""
+        wf = build_workflow()
+        fork = wf.nodes.get("fork_research")
+        assert isinstance(fork, ForkNode)
+        assert len(fork.targets) == 3
+        assert "researcher_similar" in fork.targets
+        assert "researcher_techstack" in fork.targets
+        assert "researcher_pitfalls" in fork.targets
+
+
+# ── Reloop with feedback appending ───────────────────────────────
+
+
+class TestReloopFeedback:
+    async def test_feedback_appended(self, tmp_project: Path) -> None:
+        """Feedback from reloop is appended to target node context."""
+        call_count = 0
+
+        async def mock_evaluate_gate(node: GateNode) -> Verdict:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return Verdict.reloop("a", "needs more detail", max_iterations=3)
+            return Verdict.proceed()
+
+        wf = Workflow(
+            name="feedback_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(id="gate", evaluator_type="fn", reads={"a.txt"}),
+                "b": FnNode(id="b", command="echo b"),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+                Edge(source="gate", target="a", condition=VerdictType.RELOOP),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        executor._evaluate_gate = mock_evaluate_gate  # type: ignore[assignment]
+        result = await executor.execute()
+
+        assert result.success
+        assert "needs more detail" in executor.node_context.get("a", "")
+
+
+# ── Halt propagation ─────────────────────────────────────────────
+
+
+class TestHaltPropagation:
+    async def test_gate_halt_stops_workflow(self, tmp_project: Path) -> None:
+        async def mock_evaluate_gate(node: GateNode) -> Verdict:
+            return Verdict.halt("critical error detected")
+
+        wf = Workflow(
+            name="halt_test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(id="gate", evaluator_type="fn", reads={"a.txt"}),
+                "b": FnNode(id="b", command="echo b"),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        executor._evaluate_gate = mock_evaluate_gate  # type: ignore[assignment]
+        result = await executor.execute()
+
+        assert result.halted
+        assert "critical error" in result.halt_reason
+        assert result.nodes_executed < 3
+
+        event_types = [e["type"] for e in result.events]
+        assert "workflow.halted" in event_types

--- a/tests/test_workflow_primitives.py
+++ b/tests/test_workflow_primitives.py
@@ -1,0 +1,321 @@
+"""Tier 1: Unit tests on workflow primitives."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from factory.workflow.primitives import (
+    AgentConfig,
+    AgentNode,
+    AgentRole,
+    Edge,
+    Factory,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    Study,
+    Verdict,
+    VerdictType,
+    Workflow,
+)
+
+
+# ── Verdict ──────────────────────────────────────────────────────
+
+
+class TestVerdict:
+    def test_proceed(self) -> None:
+        v = Verdict.proceed()
+        assert v.type == VerdictType.PROCEED
+        assert v.target is None
+        assert v.feedback is None
+
+    def test_reloop(self) -> None:
+        v = Verdict.reloop("researcher", "needs more depth", max_iterations=5)
+        assert v.type == VerdictType.RELOOP
+        assert v.target == "researcher"
+        assert v.feedback == "needs more depth"
+        assert v.max_iterations == 5
+
+    def test_halt(self) -> None:
+        v = Verdict.halt("critical failure")
+        assert v.type == VerdictType.HALT
+        assert v.reason == "critical failure"
+
+    def test_reloop_requires_target(self) -> None:
+        with pytest.raises(ValidationError):
+            Verdict(type=VerdictType.RELOOP, feedback="x")
+
+    def test_halt_requires_reason(self) -> None:
+        with pytest.raises(ValidationError):
+            Verdict(type=VerdictType.HALT)
+
+    def test_serialize_roundtrip(self) -> None:
+        v = Verdict.reloop("builder", "fix tests", max_iterations=3)
+        data = v.model_dump()
+        v2 = Verdict.model_validate(data)
+        assert v2.type == v.type
+        assert v2.target == v.target
+        assert v2.feedback == v.feedback
+        assert v2.max_iterations == v.max_iterations
+
+    def test_proceed_serialize(self) -> None:
+        v = Verdict.proceed()
+        data = v.model_dump()
+        v2 = Verdict.model_validate(data)
+        assert v2.type == VerdictType.PROCEED
+
+    def test_halt_serialize(self) -> None:
+        v = Verdict.halt("bad output")
+        data = v.model_dump()
+        v2 = Verdict.model_validate(data)
+        assert v2.reason == "bad output"
+
+
+# ── Nodes ────────────────────────────────────────────────────────
+
+
+class TestNodes:
+    def test_agent_node(self) -> None:
+        n = AgentNode(
+            id="researcher",
+            role=AgentRole.RESEARCHER,
+            prompt_template="research the project",
+            reads={".factory/observations.md"},
+            writes={".factory/research.md"},
+        )
+        assert n.role == AgentRole.RESEARCHER
+        assert n.blocking is True
+        assert ".factory/observations.md" in n.reads
+
+    def test_fn_node(self) -> None:
+        n = FnNode(
+            id="eval",
+            command="factory eval /path",
+            writes={".factory/eval.json"},
+        )
+        assert n.command == "factory eval /path"
+        assert n.blocking is True
+
+    def test_gate_node_agent(self) -> None:
+        n = GateNode(
+            id="gate1",
+            evaluator_type="agent",
+            evaluator_role=AgentRole.CEO,
+        )
+        assert n.evaluator_type == "agent"
+        assert n.evaluator_role == AgentRole.CEO
+
+    def test_gate_node_fn(self) -> None:
+        n = GateNode(
+            id="gate_precheck",
+            evaluator_type="fn",
+            evaluator_command="factory precheck /path",
+        )
+        assert n.evaluator_type == "fn"
+
+    def test_gate_node_user(self) -> None:
+        n = GateNode(
+            id="gate_user",
+            evaluator_type="user",
+        )
+        assert n.evaluator_type == "user"
+
+    def test_fork_node(self) -> None:
+        n = ForkNode(
+            id="fork1",
+            targets=["a", "b", "c"],
+        )
+        assert len(n.targets) == 3
+        assert n.targets == ["a", "b", "c"]
+
+    def test_join_node(self) -> None:
+        n = JoinNode(
+            id="join1",
+            sources=["a", "b", "c"],
+        )
+        assert len(n.sources) == 3
+
+    def test_study_node(self) -> None:
+        n = Study(
+            id="study",
+            command="factory study /path",
+            writes={".factory/observations.md"},
+        )
+        assert isinstance(n, FnNode)
+        assert n.focus is None
+
+    def test_study_with_focus(self) -> None:
+        n = Study(
+            id="study",
+            command="factory study /path --focus auth",
+            writes={".factory/observations.md"},
+            focus="auth",
+        )
+        assert n.focus == "auth"
+
+    def test_non_blocking_node(self) -> None:
+        n = AgentNode(
+            id="archivist",
+            role=AgentRole.ARCHIVIST,
+            prompt_template="archive",
+            blocking=False,
+        )
+        assert n.blocking is False
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            AgentNode(
+                id="test",
+                role=AgentRole.RESEARCHER,
+                unknown_field="bad",  # type: ignore[call-arg]
+            )
+
+
+# ── Edge ─────────────────────────────────────────────────────────
+
+
+class TestEdge:
+    def test_unconditional(self) -> None:
+        e = Edge(source="a", target="b")
+        assert e.condition is None
+
+    def test_conditional_proceed(self) -> None:
+        e = Edge(source="gate", target="next", condition=VerdictType.PROCEED)
+        assert e.condition == VerdictType.PROCEED
+
+    def test_conditional_reloop(self) -> None:
+        e = Edge(source="gate", target="prev", condition=VerdictType.RELOOP)
+        assert e.condition == VerdictType.RELOOP
+
+    def test_conditional_halt(self) -> None:
+        e = Edge(source="gate", target="end", condition=VerdictType.HALT)
+        assert e.condition == VerdictType.HALT
+
+
+# ── Workflow ─────────────────────────────────────────────────────
+
+
+class TestWorkflow:
+    def _simple_workflow(self) -> Workflow:
+        return Workflow(
+            name="test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "b": FnNode(id="b", command="echo b", reads={"a.txt"}, writes={"b.txt"}),
+                "c": FnNode(id="c", command="echo c", reads={"b.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="b"),
+                Edge(source="b", target="c"),
+            ],
+            start_node="a",
+        )
+
+    def test_simple_valid(self) -> None:
+        wf = self._simple_workflow()
+        issues = wf.validate_graph()
+        assert issues == []
+
+    def test_unreachable_node(self) -> None:
+        wf = Workflow(
+            name="test",
+            nodes={
+                "a": FnNode(id="a", command="echo a"),
+                "b": FnNode(id="b", command="echo b"),
+                "orphan": FnNode(id="orphan", command="echo orphan"),
+            },
+            edges=[Edge(source="a", target="b")],
+            start_node="a",
+        )
+        issues = wf.validate_graph()
+        assert any("orphan" in i and "unreachable" in i for i in issues)
+
+    def test_missing_edge_target(self) -> None:
+        wf = Workflow(
+            name="test",
+            nodes={"a": FnNode(id="a", command="echo a")},
+            edges=[Edge(source="a", target="missing")],
+            start_node="a",
+        )
+        issues = wf.validate_graph()
+        assert any("missing" in i for i in issues)
+
+    def test_missing_start_node(self) -> None:
+        wf = Workflow(
+            name="test",
+            nodes={"a": FnNode(id="a", command="echo a")},
+            edges=[],
+            start_node="nonexistent",
+        )
+        issues = wf.validate_graph()
+        assert any("nonexistent" in i for i in issues)
+
+    def test_reads_writes_consistency(self) -> None:
+        wf = Workflow(
+            name="test",
+            nodes={
+                "a": FnNode(id="a", command="echo a"),
+                "b": FnNode(id="b", command="echo b", reads={"missing.txt"}),
+            },
+            edges=[Edge(source="a", target="b")],
+            start_node="a",
+        )
+        issues = wf.validate_graph()
+        assert any("missing.txt" in i for i in issues)
+
+    def test_cycle_with_gate(self) -> None:
+        wf = Workflow(
+            name="test",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(id="gate", evaluator_type="fn", reads={"a.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="a", condition=VerdictType.RELOOP),
+            ],
+            start_node="a",
+        )
+        issues = wf.validate_graph()
+        assert issues == []
+
+
+# ── AgentConfig ──────────────────────────────────────────────────
+
+
+class TestAgentConfig:
+    def test_valid(self) -> None:
+        c = AgentConfig(role=AgentRole.RESEARCHER, model="sonnet")
+        assert c.role == AgentRole.RESEARCHER
+        assert c.model == "sonnet"
+
+
+# ── Factory ──────────────────────────────────────────────────────
+
+
+class TestFactory:
+    def test_select_workflow(self) -> None:
+        from factory.models import ProjectState
+
+        wf = Workflow(
+            name="test",
+            nodes={"a": FnNode(id="a", command="echo a")},
+            edges=[],
+            start_node="a",
+            trigger=lambda s, c: s == ProjectState.HAS_FACTORY,
+        )
+
+        factory = Factory(
+            agent_pool={},
+            workflows={"test": wf},
+        )
+
+        selected = factory.select_workflow(ProjectState.HAS_FACTORY)
+        assert selected is not None
+        assert selected.name == "test"
+
+        none_selected = factory.select_workflow(ProjectState.NO_REPO)
+        assert none_selected is None

--- a/uv.lock
+++ b/uv.lock
@@ -952,6 +952,94 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1444,6 +1532,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "filelock" },
     { name = "mcp" },
+    { name = "networkx" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "structlog" },
@@ -1466,6 +1555,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-networkx" },
     { name = "types-pyyaml" },
 ]
 docs = [
@@ -1478,6 +1568,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.0" },
     { name = "langfuse", marker = "extra == 'telemetry'", specifier = ">=3.0" },
     { name = "mcp", specifier = ">=1.27.0" },
+    { name = "networkx", specifier = ">=3.6.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0" },
@@ -1494,6 +1585,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.8" },
+    { name = "types-networkx", specifier = ">=3.6.1.20260612" },
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 docs = [{ name = "mkdocs-material", specifier = ">=9.5" }]
@@ -1751,6 +1843,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "types-networkx"
+version = "3.6.1.20260612"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/d6/86483526df18c9936cb321b33f6df929db20414378f536972c5e9ee20789/types_networkx-3.6.1.20260612.tar.gz", hash = "sha256:9a28345fb3ad985e460667ef2b9c0879920761c8000cd07b424c0bf1b24ca778", size = 73974, upload-time = "2026-06-12T06:22:35.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/1d/4694309c774f552a0dad8d357bc8c2b152120c9744dad4f21fdc3e819c37/types_networkx-3.6.1.20260612-py3-none-any.whl", hash = "sha256:829cdad128c10e072aacadd0421d7ebd64cee9731110e9d6b3f22b575fe0bbfd", size = 162459, upload-time = "2026-06-12T06:22:33.875Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #631

## Changes

- **Primitives** (`factory/workflow/primitives.py`): AgentNode, FnNode, GateNode, ForkNode, JoinNode, Study, Verdict (Proceed/Reloop/Halt), Edge, Workflow, Factory models — all strict Pydantic v2
- **Validation** (`factory/workflow/validation.py`): NetworkX-based graph validation (reachability, cycle detection, reads/writes consistency, fork/join target validity)
- **Executor** (`factory/workflow/executor.py`): Deterministic async graph walker with file-based data flow, fork/join via asyncio.gather, non-blocking fire-and-forget nodes, reloop with feedback appending, max iteration enforcement, lightweight CEO gate prompts (~15 lines)
- **Events** (`factory/workflow/events.py`): Structured workflow event emission (started, node.started, node.completed, gate.verdict, workflow.completed, workflow.halted)
- **Definitions** (`factory/workflow/definitions.py`): All 5 workflows — W₁ Build (fork/join 3 researchers), W₂ Design (W₁[gate_strategy←user]), W₃ Improve (study→research→build cycle), W₄ Research (extends W₃ with baseline+failure_analyst+plateau_gate), W₅ Meta (insights→fork to archivist+test pruning)
- **CLI** (`factory/workflow/cli.py`): `factory workflow run|list|show|validate` subcommands with dry-run support
- **Agent pool**: researcher=sonnet, strategist/builder/reviewer/evaluator/failure_analyst/ceo=opus, archivist=haiku
- **Tests**: 84 passing across 5 tiers — unit (31), executor (11), definitions (25), integration (9), e2e/CLI (8 pass + 9 skipped behind FACTORY_RUN_E2E=1)
- **Dependencies**: Added networkx, types-networkx