### PR TITLE
fix: read correct cost field name from Claude Code JSON output

### DIFF
--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -30,7 +30,7 @@ def _parse_usage(data: dict) -> AgentUsage:
         output_tokens=usage_block.get("output_tokens", 0),
         cache_read_tokens=usage_block.get("cache_read_input_tokens", 0),
         cache_creation_tokens=usage_block.get("cache_creation_input_tokens", 0),
-        total_cost_usd=data.get("cost_usd", 0.0) or 0.0,
+        total_cost_usd=data.get("total_cost_usd", 0.0) or 0.0,
         duration_ms=data.get("duration_ms", 0.0) or 0.0,
         num_turns=data.get("num_turns", 0) or 0,
         model=data.get("model", ""),


### PR DESCRIPTION
## Summary

- Fix `_parse_usage()` in `factory/runners/claude.py` to read `total_cost_usd` instead of `cost_usd` from Claude Code's JSON output
- Claude Code's `--output-format json` uses `total_cost_usd` at the top level, but the factory was reading `cost_usd` which doesn't exist, causing all agent cost tracking to report `0.0`

## Test plan

- [ ] Run a factory agent invocation and verify `total_cost_usd` is non-zero in `.factory/events.jsonl`
- [ ] Verify benchmark results include correct cost values

🤖 Generated with [Claude Code](https://claude.com/claude-code)