### PR TITLE
Persistent agent session UI with orchestration graph visualization

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -163,6 +163,12 @@ async def invoke_agent(
 
     sid = _begin_span_safe(project_path, role, model=model, task=task)
 
+    parent_session_id = os.environ.get("FACTORY_SESSION_ID")
+    sess_id = _begin_session_safe(
+        project_path, role,
+        parent_id=parent_session_id, model=model, title=task[:200] if task else None,
+    )
+
     runner = get_runner(runner_name, project_path=project_path)
 
     agent_session_name = session_name or f"factory: {project_path.resolve().name}/{role}"
@@ -183,8 +189,11 @@ async def invoke_agent(
     )
 
     old_parent_span = os.environ.get("FACTORY_PARENT_SPAN_ID")
+    old_session_id = os.environ.get("FACTORY_SESSION_ID")
     if sid:
         os.environ["FACTORY_PARENT_SPAN_ID"] = sid
+    if sess_id:
+        os.environ["FACTORY_SESSION_ID"] = sess_id
     try:
         try:
             result = await runner.headless(request)
@@ -195,6 +204,7 @@ async def invoke_agent(
             logger.error("%s agent failed: %s", role, e)
             _emit_safe(project_path, "agent.failed", agent=role, data={"error": str(e)[:200]})
             _complete_span_safe(project_path, sid, status="failed")
+            _complete_session_safe(project_path, sess_id, status="failed")
             if _track_failures:
                 _consecutive_failures += 1
                 _check_failure_threshold(project_path, role)
@@ -208,6 +218,10 @@ async def invoke_agent(
             )
             _complete_span_safe(
                 project_path, sid, status="failed",
+                usage=usage, metadata=result.metadata, output=stdout,
+            )
+            _complete_session_safe(
+                project_path, sess_id, status="failed",
                 usage=usage, metadata=result.metadata, output=stdout,
             )
             if _track_failures:
@@ -238,6 +252,10 @@ async def invoke_agent(
                 project_path, sid, status="completed",
                 usage=usage, metadata=result.metadata, output=stdout,
             )
+            _complete_session_safe(
+                project_path, sess_id, status="completed",
+                usage=usage, metadata=result.metadata, output=stdout,
+            )
             if _track_failures:
                 _consecutive_failures = 0
 
@@ -249,6 +267,10 @@ async def invoke_agent(
             os.environ["FACTORY_PARENT_SPAN_ID"] = old_parent_span
         elif sid:
             os.environ.pop("FACTORY_PARENT_SPAN_ID", None)
+        if old_session_id is not None:
+            os.environ["FACTORY_SESSION_ID"] = old_session_id
+        elif sess_id:
+            os.environ.pop("FACTORY_SESSION_ID", None)
 
 
 def _check_failure_threshold(project_path: Path, last_agent: str) -> None:
@@ -358,6 +380,50 @@ def _complete_span_safe(
         logger.debug("Failed to complete span %s", span_id, exc_info=True)
 
 
+def _begin_session_safe(
+    project_path: Path,
+    role: str,
+    *,
+    parent_id: str | None = None,
+    model: str | None = None,
+    title: str | None = None,
+) -> str | None:
+    """Begin a SQLite session, swallowing errors so agent invocation is never blocked."""
+    try:
+        from factory.sessions import begin_session
+
+        return begin_session(
+            project_path, role,
+            parent_id=parent_id, model=model, title=title,
+        )
+    except Exception:
+        logger.debug("Failed to begin session for %s", role, exc_info=True)
+        return None
+
+
+def _complete_session_safe(
+    project_path: Path,
+    session_id: str | None,
+    *,
+    status: str = "completed",
+    usage: object | None = None,
+    metadata: dict[str, object] | None = None,
+    output: str | None = None,
+) -> None:
+    """Complete a SQLite session, swallowing errors so agent invocation is never blocked."""
+    if session_id is None:
+        return
+    try:
+        from factory.sessions import complete_session
+
+        complete_session(
+            project_path, session_id,
+            status=status, usage=usage, metadata=metadata, output=output,
+        )
+    except Exception:
+        logger.debug("Failed to complete session %s", session_id, exc_info=True)
+
+
 def _save_review(
     project_path: Path, role: str, output: str, return_code: int,
     review_tag: str | None = None,
@@ -396,10 +462,20 @@ def begin_cycle_session(
 ) -> str | None:
     """Create a root Langfuse trace for a factory cycle.
 
+    Also creates a root SQLite session so child agents can link via
+    FACTORY_SESSION_ID.
+
     Sets FACTORY_TRACE_ID and FACTORY_PARENT_SPAN_ID env vars so child
     agents link to this trace. Returns the span_id, or None if Langfuse
     is not configured.
     """
+    cycle_sess_id = _begin_session_safe(
+        project_path, "ceo", model=model,
+        title=f"cycle-{cycle_id}" if cycle_id else None,
+    )
+    if cycle_sess_id:
+        os.environ["FACTORY_SESSION_ID"] = cycle_sess_id
+
     try:
         from factory.telemetry import begin_trace, is_enabled
 
@@ -425,7 +501,13 @@ def complete_cycle_session(
     project_path: Path,
     span_id: str | None,
 ) -> None:
-    """Mark a root Langfuse trace as finished and flush."""
+    """Mark a root Langfuse trace as finished and flush.
+
+    Also completes the root SQLite session if one was started.
+    """
+    cycle_sess_id = os.environ.pop("FACTORY_SESSION_ID", None)
+    _complete_session_safe(project_path, cycle_sess_id, status="completed")
+
     if span_id is None:
         return
     try:

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -387,6 +387,7 @@ def _begin_session_safe(
     parent_id: str | None = None,
     model: str | None = None,
     title: str | None = None,
+    claude_session_id: str | None = None,
 ) -> str | None:
     """Begin a SQLite session, swallowing errors so agent invocation is never blocked."""
     try:
@@ -395,6 +396,7 @@ def _begin_session_safe(
         return begin_session(
             project_path, role,
             parent_id=parent_id, model=model, title=title,
+            claude_session_id=claude_session_id,
         )
     except Exception:
         logger.debug("Failed to begin session for %s", role, exc_info=True)
@@ -469,9 +471,12 @@ def begin_cycle_session(
     agents link to this trace. Returns the span_id, or None if Langfuse
     is not configured.
     """
+    claude_session_id = os.environ.get("CLAUDE_CODE_SESSION_ID")
+
     cycle_sess_id = _begin_session_safe(
         project_path, "ceo", model=model,
         title=f"cycle-{cycle_id}" if cycle_id else None,
+        claude_session_id=claude_session_id,
     )
     if cycle_sess_id:
         os.environ["FACTORY_SESSION_ID"] = cycle_sess_id
@@ -506,7 +511,14 @@ def complete_cycle_session(
     Also completes the root SQLite session if one was started.
     """
     cycle_sess_id = os.environ.pop("FACTORY_SESSION_ID", None)
-    _complete_session_safe(project_path, cycle_sess_id, status="completed")
+    claude_session_id = os.environ.get("CLAUDE_CODE_SESSION_ID")
+    metadata: dict[str, object] | None = None
+    if claude_session_id:
+        metadata = {"session_id": claude_session_id}
+    _complete_session_safe(
+        project_path, cycle_sess_id, status="completed",
+        metadata=metadata,
+    )
 
     if span_id is None:
         return

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1885,6 +1885,46 @@ def cmd_backfill_archive(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sessions(args: argparse.Namespace) -> int:
+    """List agent sessions from the SQLite session database."""
+    from factory.sessions import get_cycles, get_sessions
+
+    project_path = Path(args.path).resolve()
+    cycle_filter = getattr(args, "cycle", None)
+    role_filter = getattr(args, "role", None)
+
+    if cycle_filter:
+        rows = get_sessions(project_path, cycle_id=cycle_filter, role=role_filter)
+    elif role_filter:
+        rows = get_sessions(project_path, role=role_filter)
+    else:
+        rows = get_cycles(project_path)
+
+    if not rows:
+        print("No sessions found.")
+        return 0
+
+    header = f"{'ID':<14} {'Role':<14} {'Status':<12} {'Duration':>10} {'Cost':>10}"
+    print(header)
+    print("-" * len(header))
+
+    for r in rows:
+        sid = r.get("id", "")[:13]
+        role = (r.get("agent_role") or "unknown")[:13]
+        status = (r.get("status") or "unknown")[:11]
+        duration_ms = r.get("duration_ms") or r.get("total_duration") or 0.0
+        duration_s = duration_ms / 1000.0
+        if duration_s >= 60:
+            dur_str = f"{duration_s / 60:.1f}m"
+        else:
+            dur_str = f"{duration_s:.1f}s"
+        cost = r.get("total_cost_usd") or r.get("total_cost") or 0.0
+        cost_str = f"${cost:.4f}" if cost else "-"
+        print(f"{sid:<14} {role:<14} {status:<12} {dur_str:>10} {cost_str:>10}")
+
+    return 0
+
+
 def cmd_diff(args: argparse.Namespace) -> int:
     """Compare two experiments side-by-side."""
     from factory.analysis import compare_experiments, format_comparison
@@ -3871,6 +3911,12 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("research", help="Print research citation index for experiments")
     p.add_argument("path", help="Path to the project")
 
+    # sessions
+    p = sub.add_parser("sessions", help="List agent sessions from the local SQLite database")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--cycle", default=None, help="Filter by cycle (root session) ID")
+    p.add_argument("--role", default=None, help="Filter by agent role")
+
     # diff
     p = sub.add_parser("diff", help="Compare two experiments side-by-side")
     p.add_argument("path", help="Path to the project")
@@ -4320,6 +4366,7 @@ def main(argv: list[str] | None = None) -> int:
         "research": cmd_research,
         "backfill-citations": cmd_backfill_citations,
         "backfill-archive": cmd_backfill_archive,
+        "sessions": cmd_sessions,
         "diff": cmd_diff,
         "explain": cmd_explain,
         "export": cmd_export,

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2350,7 +2350,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     With --headless: pipe mode via claude -p (for scripting, cron, etc.).
     With --mode design: brainstorm an idea via research + Strategist before building.
     """
-    from factory.agents.runner import resolve_prompt
+    from factory.agents.runner import begin_cycle_session, complete_cycle_session, resolve_prompt
     from factory.runners import get_runner
     from factory.user_config import load_config
 
@@ -2658,6 +2658,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         # Uses completion guard to auto-resume on premature exit
         from factory.ceo_completion import run_ceo_with_completion_guard
 
+        span_id = begin_cycle_session(wt_path, cycle_id=session_name, model=model)
         try:
             result, code = _run(run_ceo_with_completion_guard(
                 wt_path,
@@ -2686,12 +2687,14 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 background=background,
             )
         finally:
+            complete_cycle_session(wt_path, span_id)
             remove_worktree(project_path, wt_path, wt_branch)
             if needs_materialize and _is_scaffold_only(project_path):
                 import shutil
                 shutil.rmtree(project_path, ignore_errors=True)
 
     # Interactive foreground mode: use subprocess.run so we can clean up the worktree.
+    span_id = begin_cycle_session(wt_path, cycle_id=session_name, model=model)
     try:
         if pending_ids:
             print(
@@ -2709,6 +2712,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             session_name=session_name,
         ))
     finally:
+        complete_cycle_session(wt_path, span_id)
         remove_worktree(project_path, wt_path, wt_branch)
         if needs_materialize and _is_scaffold_only(project_path):
             import shutil

--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -1027,6 +1027,17 @@ def _project_summary(path: Path) -> dict[str, Any]:
         except (json.JSONDecodeError, OSError, KeyError):
             pass
 
+    # Session summary
+    try:
+        cycles = get_cycles(path, limit=100)
+        info["cycle_count"] = len(cycles)
+        info["total_sessions"] = len(cycles) + sum(c.get("child_count", 0) for c in cycles)
+        if cycles:
+            info["last_cycle_at"] = cycles[0].get("created_at")
+    except Exception:
+        info["cycle_count"] = 0
+        info["total_sessions"] = 0
+
     log.debug(
         "project_summary_complete",
         project=path.name,

--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -16,7 +16,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Str
 from fastapi.staticfiles import StaticFiles
 
 from factory.events import load_events
-from factory.sessions import get_cycle, get_cycles, get_session, reingest_session
+from factory.sessions import get_children, get_cycle, get_cycles, get_session, reingest_session
 from factory.visualizer import (
     MODE_PHASES,
     PHASES,
@@ -360,6 +360,128 @@ def _phase_data_archive(
     }, None
 
 
+def _build_cycle_graph(
+    project_path: Path, cycle_id: str,
+) -> dict[str, Any]:
+    """Build a Cytoscape.js-format graph from session hierarchy and events."""
+    from factory.sessions import get_session as _get_session
+
+    root = _get_session(project_path, cycle_id)
+    if root is None:
+        return {"nodes": [], "edges": [], "timeline": {}}
+
+    children = get_children(project_path, cycle_id)
+    all_sessions = [root] + children
+
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+
+    for s in all_sessions:
+        created = s.get("created_at") or 0
+        updated = s.get("updated_at") or created
+        duration = s.get("duration_ms") or 0.0
+        end_time = created + int(duration / 1000) if duration else updated
+        task_preview = (s.get("title") or "")[:120]
+
+        nodes.append({
+            "data": {
+                "id": s["id"],
+                "role": s.get("agent_role") or "unknown",
+                "status": s.get("status") or "unknown",
+                "label": s.get("agent_role") or "unknown",
+                "task_preview": task_preview,
+                "duration_ms": duration,
+                "total_cost_usd": s.get("total_cost_usd") or 0.0,
+                "start_time": created,
+                "end_time": end_time,
+                "model": s.get("model") or "",
+                "type": "agent",
+            }
+        })
+
+    for child in children:
+        if child.get("parent_id"):
+            edges.append({
+                "data": {
+                    "id": f"e_{child['parent_id']}_{child['id']}",
+                    "source": child["parent_id"],
+                    "target": child["id"],
+                    "type": "spawned",
+                }
+            })
+
+    siblings = sorted(children, key=lambda c: c.get("created_at") or 0)
+    for i in range(len(siblings) - 1):
+        a = siblings[i]
+        b = siblings[i + 1]
+        if a.get("parent_id") == b.get("parent_id"):
+            edges.append({
+                "data": {
+                    "id": f"e_seq_{a['id']}_{b['id']}",
+                    "source": a["id"],
+                    "target": b["id"],
+                    "type": "sequential",
+                }
+            })
+
+    timeline_start = root.get("created_at") or 0
+    timeline_end = max(
+        (s.get("updated_at") or s.get("created_at") or 0) for s in all_sessions
+    )
+
+    phases: list[dict[str, Any]] = []
+    events_file = project_path / ".factory" / "events.jsonl"
+    if events_file.exists():
+        try:
+            all_events = load_events(project_path)
+            phase_events = [
+                e for e in all_events
+                if (e.get("type", "").startswith("phase."))
+                and timeline_start <= _event_ts(e) <= timeline_end + 60
+            ]
+            current_phase: dict[str, Any] | None = None
+            for ev in phase_events:
+                ts = _event_ts(ev)
+                name = ev.get("data", {}).get("phase") or ev.get("data", {}).get("name") or ""
+                if ev["type"] == "phase.started":
+                    if current_phase:
+                        current_phase["end"] = ts
+                        phases.append(current_phase)
+                    current_phase = {"name": name, "start": ts, "end": None}
+                elif ev["type"] == "phase.completed":
+                    if current_phase:
+                        current_phase["end"] = ts
+                        phases.append(current_phase)
+                        current_phase = None
+            if current_phase:
+                current_phase["end"] = timeline_end
+                phases.append(current_phase)
+        except Exception:
+            pass
+
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "timeline": {
+            "start": timeline_start,
+            "end": timeline_end,
+            "phases": phases,
+        },
+    }
+
+
+def _event_ts(event: dict[str, Any]) -> int:
+    """Extract a unix timestamp from an event's ISO timestamp string."""
+    ts_str = event.get("timestamp", "")
+    if not ts_str:
+        return 0
+    try:
+        from datetime import datetime as _dt
+        return int(_dt.fromisoformat(ts_str).timestamp())
+    except (ValueError, TypeError):
+        return 0
+
+
 def _validate_path_segment(value: str, label: str = "name") -> None:
     """Reject path segments that could escape the projects directory."""
     if not _SAFE_NAME_RE.match(value) or ".." in value:
@@ -655,6 +777,21 @@ def create_app(projects_dir: Path) -> FastAPI:
         if cycle is None:
             raise HTTPException(status_code=404, detail="Cycle not found")
         return JSONResponse(cycle)
+
+    @app.get("/api/projects/{name}/cycles/{cycle_id}/graph")
+    async def cycle_graph(name: str, cycle_id: str) -> JSONResponse:
+        _validate_path_segment(name)
+        log.info(
+            "dashboard_request",
+            endpoint="/api/projects/{name}/cycles/{cycle_id}/graph",
+            project=name,
+            cycle_id=cycle_id,
+        )
+        path = projects_dir / name
+        graph = _build_cycle_graph(path, cycle_id)
+        if not graph["nodes"]:
+            raise HTTPException(status_code=404, detail="Cycle not found")
+        return JSONResponse(graph)
 
     @app.get("/api/projects/{name}/sessions/{session_id}")
     async def session_detail(name: str, session_id: str) -> JSONResponse:

--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -835,15 +835,41 @@ def create_app(projects_dir: Path) -> FastAPI:
         if not message:
             raise HTTPException(status_code=400, detail="Empty message")
 
+        import os
         import subprocess
+        import tempfile
+
+        cmd = [
+            "claude", "--resume", claude_sid,
+            "-p", message,
+            "--output-format", "json",
+        ]
+
+        tmp_prompt_file = None
+        agent_role = session.get("agent_role")
+        if agent_role:
+            prompt_path = (
+                Path(__file__).parent.parent / "agents" / "prompts" / f"{agent_role}.md"
+            )
+            if prompt_path.exists():
+                prompt_text = prompt_path.read_text()
+                playbook_path = Path.home() / ".factory" / "playbooks" / f"{agent_role}.md"
+                if playbook_path.exists():
+                    playbook_text = playbook_path.read_text().strip()
+                    if playbook_text:
+                        from factory.ace.injector import inject_playbook
+
+                        prompt_text = inject_playbook(prompt_text, playbook_text)
+                tmp_prompt_file = tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".md", delete=False,
+                )
+                tmp_prompt_file.write(prompt_text)
+                tmp_prompt_file.close()
+                cmd.extend(["--system-prompt-file", tmp_prompt_file.name])
 
         try:
             result = subprocess.run(
-                [
-                    "claude", "--resume", claude_sid,
-                    "-p", message,
-                    "--output-format", "json",
-                ],
+                cmd,
                 capture_output=True,
                 text=True,
                 timeout=300,
@@ -855,6 +881,9 @@ def create_app(projects_dir: Path) -> FastAPI:
             )
         except subprocess.TimeoutExpired:
             raise HTTPException(status_code=504, detail="Claude timed out")
+        finally:
+            if tmp_prompt_file is not None:
+                os.unlink(tmp_prompt_file.name)
 
         usage_update = None
         if result.stdout.strip():

--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -885,6 +885,19 @@ def create_app(projects_dir: Path) -> FastAPI:
             if tmp_prompt_file is not None:
                 os.unlink(tmp_prompt_file.name)
 
+        if result.returncode != 0:
+            stderr_text = (result.stderr or "").strip()
+            log.warning(
+                "claude_resume_failed",
+                session_id=session_id,
+                returncode=result.returncode,
+                stderr=stderr_text,
+            )
+            return JSONResponse(
+                {"error": "Session cannot be resumed", "detail": stderr_text},
+                status_code=410,
+            )
+
         usage_update = None
         if result.stdout.strip():
             try:

--- a/factory/dashboard/app.py
+++ b/factory/dashboard/app.py
@@ -16,6 +16,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Str
 from fastapi.staticfiles import StaticFiles
 
 from factory.events import load_events
+from factory.sessions import get_cycle, get_cycles, get_session, reingest_session
 from factory.visualizer import (
     MODE_PHASES,
     PHASES,
@@ -630,6 +631,120 @@ def create_app(projects_dir: Path) -> FastAPI:
             "dashboard_request", endpoint="/research/{name}", project=name
         )
         return HTMLResponse((_STATIC_DIR / "research.html").read_text())
+
+    # ── Session endpoints ──
+
+    @app.get("/api/projects/{name}/cycles")
+    async def project_cycles(name: str, limit: int = 20) -> list[dict[str, Any]]:
+        _validate_path_segment(name)
+        log.info("dashboard_request", endpoint="/api/projects/{name}/cycles", project=name)
+        path = projects_dir / name
+        return get_cycles(path, limit=limit)
+
+    @app.get("/api/projects/{name}/cycles/{cycle_id}")
+    async def project_cycle_detail(name: str, cycle_id: str) -> JSONResponse:
+        _validate_path_segment(name)
+        log.info(
+            "dashboard_request",
+            endpoint="/api/projects/{name}/cycles/{cycle_id}",
+            project=name,
+            cycle_id=cycle_id,
+        )
+        path = projects_dir / name
+        cycle = get_cycle(path, cycle_id)
+        if cycle is None:
+            raise HTTPException(status_code=404, detail="Cycle not found")
+        return JSONResponse(cycle)
+
+    @app.get("/api/projects/{name}/sessions/{session_id}")
+    async def session_detail(name: str, session_id: str) -> JSONResponse:
+        _validate_path_segment(name)
+        log.info(
+            "dashboard_request",
+            endpoint="/api/projects/{name}/sessions/{session_id}",
+            project=name,
+            session_id=session_id,
+        )
+        path = projects_dir / name
+        session = get_session(path, session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return JSONResponse(session)
+
+    @app.post("/api/projects/{name}/sessions/{session_id}/message")
+    async def send_session_message(
+        name: str, session_id: str, request: Request,
+    ) -> JSONResponse:
+        _validate_path_segment(name)
+        log.info(
+            "dashboard_request",
+            endpoint="/api/projects/{name}/sessions/{session_id}/message",
+            project=name,
+            session_id=session_id,
+        )
+        path = projects_dir / name
+        session = get_session(path, session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        claude_sid = session.get("claude_session_id")
+        if not claude_sid:
+            raise HTTPException(
+                status_code=400,
+                detail="Session has no claude_session_id — cannot resume",
+            )
+
+        body = await request.json()
+        message = body.get("message", "").strip()
+        if not message:
+            raise HTTPException(status_code=400, detail="Empty message")
+
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                [
+                    "claude", "--resume", claude_sid,
+                    "-p", message,
+                    "--output-format", "json",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                cwd=str(path),
+            )
+        except FileNotFoundError:
+            raise HTTPException(
+                status_code=500, detail="claude CLI not found",
+            )
+        except subprocess.TimeoutExpired:
+            raise HTTPException(status_code=504, detail="Claude timed out")
+
+        usage_update = None
+        if result.stdout.strip():
+            try:
+                out = json.loads(result.stdout)
+                usage_update = {
+                    "input_tokens": out.get("input_tokens", 0),
+                    "output_tokens": out.get("output_tokens", 0),
+                    "cache_read_tokens": out.get("cache_read_tokens", 0),
+                    "cost_usd": out.get("cost_usd", 0.0),
+                    "num_turns": out.get("num_turns", 0),
+                }
+            except json.JSONDecodeError:
+                pass
+
+        updated = reingest_session(
+            path, session_id, usage_update=usage_update,
+        )
+        if updated is None:
+            updated = get_session(path, session_id)
+        return JSONResponse(updated)
+
+    @app.get("/sessions/{name}", response_class=HTMLResponse)
+    async def sessions_view(name: str) -> HTMLResponse:
+        _validate_path_segment(name)
+        log.info("dashboard_request", endpoint="/sessions/{name}", project=name)
+        return HTMLResponse((_STATIC_DIR / "sessions.html").read_text())
 
     @app.get("/api/events/stream")
     async def event_stream(request: Request) -> StreamingResponse:

--- a/factory/dashboard/static/index.html
+++ b/factory/dashboard/static/index.html
@@ -850,6 +850,7 @@ function renderProjects(projects) {
         ${esc(p.name)}
         ${p.name === selectedProject && currentMode ? `<span class="mode-badge">${esc(currentMode)}</span>` : ''}
         <button class="project-info-btn" onclick="event.stopPropagation(); openProjectDetails('${esc(p.name)}')" title="Project details">info</button>
+        <button class="project-info-btn" onclick="event.stopPropagation(); window.location.href='/sessions/${encodeURIComponent(p.name)}'" title="View sessions">sessions</button>
       </div>
       ${p.goal ? `<div class="project-goal">${esc(p.goal)}</div>` : ''}
       <div class="project-stats">

--- a/factory/dashboard/static/index.html
+++ b/factory/dashboard/static/index.html
@@ -78,7 +78,7 @@
   main {
     display: grid;
     grid-template-columns: 280px 1fr;
-    grid-template-rows: auto auto auto auto 1fr 1fr;
+    grid-template-rows: auto auto 1fr 1fr;
     gap: 0;
     height: calc(100vh - 80px);
   }
@@ -109,21 +109,21 @@
     flex: 1;
   }
 
-  /* Projects panel — spans content rows below pipeline/agent bars */
+  /* Projects panel — spans content rows below agent bar */
   .projects-panel {
-    grid-row: 5 / 7;
+    grid-row: 3 / 5;
   }
 
   /* Events panel — top right of content area */
   .events-panel {
     grid-column: 2;
-    grid-row: 5;
+    grid-row: 3;
   }
 
   /* Experiments panel — bottom right */
   .experiments-panel {
     grid-column: 2;
-    grid-row: 6;
+    grid-row: 4;
     border-bottom: none;
   }
 
@@ -396,45 +396,23 @@
     background: var(--surface);
   }
 
-  /* Pipeline phase bar */
-  .pipeline-bar {
-    grid-column: 1 / -1;
-    display: flex;
-    align-items: center;
-    gap: 0;
-    padding: 8px 24px;
-    border-bottom: 1px solid var(--border);
-    background: var(--surface);
-    overflow-x: auto;
-  }
-  .phase-step {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 12px;
+  /* Sessions button (prominent) */
+  .sessions-btn {
+    background: rgba(88,166,255,0.1);
+    border: 1px solid var(--accent);
+    color: var(--accent);
     font-size: 11px;
+    font-family: var(--font);
     font-weight: 600;
+    padding: 3px 10px;
+    border-radius: 4px;
+    cursor: pointer;
     text-transform: uppercase;
     letter-spacing: 0.3px;
-    color: var(--text-dim);
-    border-radius: 4px;
-    white-space: nowrap;
+    margin-left: auto;
+    transition: background 0.15s;
   }
-  .phase-step.completed { color: var(--green); }
-  .phase-step.active {
-    color: var(--bg);
-    background: var(--accent);
-  }
-  .phase-step.clickable { cursor: pointer; }
-  .phase-step.clickable:hover { background: rgba(88,166,255,0.15); }
-  .phase-step.active.clickable:hover { filter: brightness(1.15); }
-  .phase-step.selected-phase { outline: 2px solid var(--accent); outline-offset: 2px; }
-  .phase-arrow {
-    color: var(--border);
-    font-size: 14px;
-    flex-shrink: 0;
-    margin: 0 2px;
-  }
+  .sessions-btn:hover { background: rgba(88,166,255,0.25); }
 
   /* Agent activity cards */
   .agent-cards {
@@ -497,112 +475,6 @@
     flex-shrink: 0;
   }
 
-  /* Phase detail row */
-  .phase-detail-row {
-    grid-column: 1 / -1;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg);
-    padding: 0;
-    display: none;
-    max-height: 50vh;
-    overflow-y: auto;
-  }
-  .phase-detail-row.open { display: block; padding: 16px 24px; animation: fadeIn 0.3s ease; }
-  .phase-detail-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 12px;
-  }
-  .phase-detail-title {
-    font-size: 16px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-  .verdict-badge {
-    font-size: 10px;
-    padding: 2px 10px;
-    border-radius: 4px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-  }
-  .verdict-badge.proceed { background: #1a3a2a; color: var(--green); }
-  .verdict-badge.redirect { background: #3d2e1f; color: var(--yellow); }
-  .verdict-badge.abort { background: #3d1f1f; color: var(--red); }
-  .phase-detail-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-  }
-  .phase-detail-section { margin-bottom: 12px; }
-  .phase-detail-section-title {
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    color: var(--text-dim);
-    margin-bottom: 6px;
-    letter-spacing: 0.3px;
-  }
-  .phase-detail-pre {
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 12px;
-    font-size: 12px;
-    line-height: 1.6;
-    white-space: pre-wrap;
-    word-break: break-word;
-    max-height: 250px;
-    overflow-y: auto;
-  }
-  .phase-detail-kv {
-    display: grid;
-    grid-template-columns: 140px 1fr;
-    gap: 4px 12px;
-    font-size: 12px;
-  }
-  .phase-detail-kv dt { color: var(--text-dim); font-weight: 600; }
-  .phase-detail-kv dd { color: var(--text); }
-  .phase-detail-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 12px;
-  }
-  .phase-detail-table th {
-    text-align: left;
-    padding: 4px 8px;
-    color: var(--text-dim);
-    font-size: 11px;
-    border-bottom: 1px solid var(--border);
-  }
-  .phase-detail-table td { padding: 4px 8px; border-bottom: 1px solid var(--border); }
-  .score-bar-wrap {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-  .score-bar {
-    height: 8px;
-    border-radius: 4px;
-    background: var(--border);
-    flex: 1;
-    max-width: 120px;
-  }
-  .score-bar-fill { height: 100%; border-radius: 4px; }
-  .collapsible-toggle {
-    background: none;
-    border: 1px solid var(--border);
-    color: var(--text-dim);
-    padding: 4px 12px;
-    font-size: 11px;
-    font-family: var(--font);
-    cursor: pointer;
-    border-radius: 4px;
-    margin-top: 8px;
-  }
-  .collapsible-toggle:hover { background: var(--surface); color: var(--text); }
 
   /* Project info button */
   .project-info-btn {
@@ -617,20 +489,6 @@
     margin-left: auto;
   }
   .project-info-btn:hover { background: var(--surface); color: var(--accent); }
-
-  /* Project status badges */
-  .project-status-badge {
-    font-size: 9px;
-    padding: 1px 6px;
-    border-radius: 3px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-  }
-  .project-status-badge.ready { background: #1a3a2a; color: var(--green); }
-  .project-status-badge.new { background: #1f3a5f; color: var(--accent); }
-  .project-status-badge.discovering { background: #2d2a1f; color: var(--yellow); }
-  .project-status-badge.pending_review { background: #2a1f3a; color: #d2a8ff; }
 
   /* Mode indicator badge */
   .mode-badge {
@@ -755,10 +613,6 @@
 <main>
   <div class="kpi-strip" id="kpi-strip"></div>
 
-  <div class="pipeline-bar" id="pipeline-bar"></div>
-
-  <div class="phase-detail-row" id="phase-detail-row"></div>
-
   <div class="agent-cards" id="agent-cards"></div>
 
   <div class="panel projects-panel">
@@ -810,8 +664,6 @@
 <script>
 let selectedProject = null;
 let eventCount = 0;
-let expandedPhase = null;
-let currentPhaseGlobal = null;
 
 // ── Projects ──
 async function loadProjects() {
@@ -850,7 +702,7 @@ function renderProjects(projects) {
         ${esc(p.name)}
         ${p.name === selectedProject && currentMode ? `<span class="mode-badge">${esc(currentMode)}</span>` : ''}
         <button class="project-info-btn" onclick="event.stopPropagation(); openProjectDetails('${esc(p.name)}')" title="Project details">info</button>
-        <button class="project-info-btn" onclick="event.stopPropagation(); window.location.href='/sessions/${encodeURIComponent(p.name)}'" title="View sessions">sessions</button>
+        <button class="sessions-btn" onclick="event.stopPropagation(); window.location.href='/sessions/${encodeURIComponent(p.name)}'" title="View sessions">Sessions</button>
       </div>
       ${p.goal ? `<div class="project-goal">${esc(p.goal)}</div>` : ''}
       <div class="project-stats">
@@ -858,6 +710,8 @@ function renderProjects(projects) {
         <div class="stat"><span class="stat-label">Exp</span><span class="stat-value">${p.experiment_count}</span></div>
         <div class="stat"><span class="stat-value keep">${p.keep_count}K</span></div>
         <div class="stat"><span class="stat-value revert">${p.revert_count}R</span></div>
+        ${p.cycle_count ? `<div class="stat"><span class="stat-label">Cycles</span><span class="stat-value">${p.cycle_count}</span></div>` : ''}
+        ${p.total_sessions ? `<div class="stat"><span class="stat-label">Sess</span><span class="stat-value">${p.total_sessions}</span></div>` : ''}
       </div>
     </div>`;
   }).join('');
@@ -865,11 +719,6 @@ function renderProjects(projects) {
 
 async function selectProject(name) {
   selectedProject = name;
-  if (expandedPhase) {
-    expandedPhase = null;
-    document.getElementById('phase-detail-row').classList.remove('open');
-    document.getElementById('phase-detail-row').innerHTML = '';
-  }
   loadProjects();
   loadExperiments(name);
   loadLiveState();
@@ -1186,12 +1035,6 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') {
     closeModal();
     closeAgentOutput();
-    if (expandedPhase) {
-      expandedPhase = null;
-      document.getElementById('phase-detail-row').classList.remove('open');
-      document.getElementById('phase-detail-row').innerHTML = '';
-      renderPipelineBar(currentPhaseGlobal);
-    }
   }
 });
 
@@ -1380,394 +1223,9 @@ function renderKPIs(data) {
   `;
 }
 
-// ── Pipeline Phase Bar ──
-let currentPhases = ['Detect', 'Discover', 'Research', 'Strategize', 'Build', 'Review', 'Eval', 'Archive'];
-let currentLoopPhases = [];
-let currentHypothesisNumber = 0;
-
-function isLoopPhase(phase) {
-  return currentLoopPhases.includes(phase);
-}
-
-function renderPipelineBar(currentPhase) {
-  const el = document.getElementById('pipeline-bar');
-  const phases = currentPhases;
-  const phaseIdx = currentPhase ? phases.indexOf(currentPhase) : -1;
-  el.innerHTML = phases.map((p, i) => {
-    let cls = 'phase-step';
-    let clickable = false;
-    if (i < phaseIdx) { cls += ' completed'; clickable = true; }
-    else if (i === phaseIdx) { cls += ' active'; clickable = true; }
-    if (clickable) cls += ' clickable';
-    if (p === expandedPhase) cls += ' selected-phase';
-    const check = i < phaseIdx ? '&#10003; ' : '';
-    const onclick = clickable ? ` onclick="togglePhaseDetail('${p}')"` : '';
-    const arrow = i < phases.length - 1 ? '<span class="phase-arrow">&#9656;</span>' : '';
-    let label = esc(p);
-    if (currentHypothesisNumber > 0 && isLoopPhase(p) && i >= phaseIdx && phaseIdx >= 0) {
-      label += ` <span style="font-size:9px;opacity:0.7">(H${currentHypothesisNumber})</span>`;
-    }
-    return `<span class="${cls}" data-phase="${p}"${onclick}>${check}${label}</span>${arrow}`;
-  }).join('');
-}
-
-// ── Phase Detail ──
-function togglePhaseDetail(phase) {
-  const row = document.getElementById('phase-detail-row');
-  if (expandedPhase === phase) {
-    expandedPhase = null;
-    row.classList.remove('open');
-    row.innerHTML = '';
-    renderPipelineBar(currentPhaseGlobal);
-    return;
-  }
-  expandedPhase = phase;
-  row.innerHTML = '<div class="empty-state">Loading...</div>';
-  row.classList.add('open');
-  renderPipelineBar(currentPhaseGlobal);
-
-  if (!selectedProject) {
-    row.innerHTML = '<div class="empty-state">Select a project first</div>';
-    return;
-  }
-
-  fetch(`/api/projects/${selectedProject}/phase-detail/${phase}`)
-    .then(res => res.json())
-    .then(data => renderPhaseDetail(data))
-    .catch(() => { row.innerHTML = '<div class="empty-state">Failed to load phase details</div>'; });
-}
-
-function renderPhaseDetail(response) {
-  const row = document.getElementById('phase-detail-row');
-  if (response.status === 'future' || !response.data) {
-    row.innerHTML = '<div class="empty-state">No data available for this phase yet</div>';
-    return;
-  }
-  const header = buildPhaseHeader(response.phase, response.verdict);
-  const renderer = PHASE_RENDERERS[response.phase];
-  const body = renderer ? renderer(response.data) : '';
-  row.innerHTML = header + body;
-}
-
-function buildPhaseHeader(phase, verdict) {
-  let html = '<div class="phase-detail-header">';
-  html += `<span class="phase-detail-title">${esc(phase)}</span>`;
-  if (verdict) {
-    const cls = verdict.decision.toLowerCase();
-    html += `<span class="verdict-badge ${cls}">${esc(verdict.decision)}</span>`;
-  }
-  html += '</div>';
-  if (verdict && verdict.rationale) {
-    html += `<div style="font-size:12px;color:var(--text-dim);margin-bottom:12px">${esc(verdict.rationale)}</div>`;
-  }
-  if (verdict && verdict.issues && verdict.issues.length > 0) {
-    html += '<div class="phase-detail-section"><div class="phase-detail-section-title">Issues</div><ul style="font-size:12px;padding-left:16px;color:var(--red)">';
-    verdict.issues.forEach(issue => { html += `<li>${esc(issue)}</li>`; });
-    html += '</ul></div>';
-  }
-  return html;
-}
-
-function renderCollapsible(title, content) {
-  if (!content) return '';
-  const id = 'col-' + Math.random().toString(36).slice(2, 8);
-  return `<div class="phase-detail-section">
-    <div class="phase-detail-section-title">${esc(title)}</div>
-    <div class="phase-detail-pre" id="${id}" style="display:none">${esc(content)}</div>
-    <button class="collapsible-toggle" onclick="var el=document.getElementById('${id}');var shown=el.style.display!=='none';el.style.display=shown?'none':'block';this.textContent=shown?'Show':'Hide'">Show</button>
-  </div>`;
-}
-
-function renderDetectDetail(data) {
-  let html = '<dl class="phase-detail-kv">';
-  html += `<dt>Goal</dt><dd>${esc(data.goal)}</dd>`;
-  html += `<dt>Eval Command</dt><dd><code>${esc(data.eval_command)}</code></dd>`;
-  html += `<dt>Threshold</dt><dd>${data.eval_threshold ?? '—'}</dd>`;
-  html += `<dt>Dimensions</dt><dd>${data.dimensions_count}</dd>`;
-  html += `<dt>Language</dt><dd>${esc(data.language) || '—'}</dd>`;
-  if (data.scope && data.scope.length > 0) {
-    html += `<dt>Scope</dt><dd>${data.scope.map(s => esc(s)).join(', ')}</dd>`;
-  }
-  if (data.guards && data.guards.length > 0) {
-    html += `<dt>Guards</dt><dd>${data.guards.map(g => esc(g)).join('; ')}</dd>`;
-  }
-  if (data.constraints && data.constraints.length > 0) {
-    html += `<dt>Constraints</dt><dd>${data.constraints.map(c => esc(c)).join('; ')}</dd>`;
-  }
-  html += '</dl>';
-  return html;
-}
-
-function renderDiscoverDetail(data) {
-  let html = '<dl class="phase-detail-kv" style="margin-bottom:12px">';
-  html += `<dt>Project Type</dt><dd>${esc(data.project_type) || '—'}</dd>`;
-  html += `<dt>Confidence</dt><dd>${data.confidence != null ? (data.confidence * 100).toFixed(0) + '%' : '—'}</dd>`;
-  html += `<dt>Human Reviewed</dt><dd>${data.human_reviewed ? 'Yes' : 'No'}</dd>`;
-  html += '</dl>';
-  if (data.dimensions && data.dimensions.length > 0) {
-    html += '<div class="phase-detail-section"><div class="phase-detail-section-title">Eval Dimensions</div>';
-    html += '<table class="phase-detail-table"><thead><tr><th>Name</th><th>Weight</th><th>Source</th><th>Description</th></tr></thead><tbody>';
-    data.dimensions.forEach(d => {
-      html += `<tr><td style="font-weight:600">${esc(d.name)}</td><td>${d.weight}</td><td>${esc(d.source)}</td><td style="color:var(--text-dim)">${esc(d.description)}</td></tr>`;
-    });
-    html += '</tbody></table></div>';
-  }
-  return html;
-}
-
-function renderResearchDetail(data) {
-  let html = '<div class="phase-detail-grid">';
-  if (data.research) {
-    html += `<div class="phase-detail-section"><div class="phase-detail-section-title">Research Findings</div><div class="phase-detail-pre">${esc(data.research)}</div></div>`;
-  }
-  if (data.observations) {
-    html += `<div class="phase-detail-section"><div class="phase-detail-section-title">Observations</div><div class="phase-detail-pre">${esc(data.observations)}</div></div>`;
-  }
-  html += '</div>';
-  html += renderCollapsible('Agent Output', data.agent_output);
-  return html;
-}
-
-function renderStrategizeDetail(data) {
-  let html = '';
-  if (data.strategy) {
-    html += `<div class="phase-detail-section"><div class="phase-detail-section-title">Strategy</div><div class="phase-detail-pre">${esc(data.strategy)}</div></div>`;
-  }
-  if (data.backlog) {
-    html += `<div class="phase-detail-section"><div class="phase-detail-section-title">Backlog</div><div class="phase-detail-pre">${esc(data.backlog)}</div></div>`;
-  }
-  html += renderCollapsible('Agent Output', data.agent_output);
-  return html;
-}
-
-function renderBuildDetail(data) {
-  let html = '';
-  if (data.experiment_id != null) {
-    html += `<div style="font-size:12px;color:var(--text-dim);margin-bottom:8px">Experiment #${data.experiment_id}</div>`;
-  }
-  if (data.hypothesis) {
-    html += `<div class="phase-detail-section"><div class="phase-detail-section-title">Hypothesis</div><div style="font-size:13px;font-weight:600;margin-bottom:8px">${esc(data.hypothesis)}</div></div>`;
-  }
-  if (data.diff) {
-    const stats = data.diff_stats || {};
-    const statsLine = `${stats.files_changed || 0} file(s), +${stats.insertions || 0}, -${stats.deletions || 0}`;
-    html += `<div class="phase-detail-section"><div class="phase-detail-section-title">Changes <span style="font-weight:400;color:var(--text-dim);text-transform:none">${statsLine}</span></div><div class="phase-detail-pre" style="max-height:300px">${renderDiffLines(data.diff)}</div></div>`;
-  }
-  html += renderCollapsible('Agent Output', data.agent_output);
-  return html;
-}
-
-function renderDiffLines(diff) {
-  return diff.split('\n').map(line => {
-    if (line.startsWith('+') && !line.startsWith('+++')) {
-      return `<span style="color:var(--green)">${esc(line)}</span>`;
-    } else if (line.startsWith('-') && !line.startsWith('---')) {
-      return `<span style="color:var(--red)">${esc(line)}</span>`;
-    } else if (line.startsWith('@@')) {
-      return `<span style="color:var(--cyan)">${esc(line)}</span>`;
-    } else if (line.startsWith('diff --git')) {
-      return `<span style="color:var(--accent);font-weight:600">${esc(line)}</span>`;
-    }
-    return esc(line);
-  }).join('\n');
-}
-
-function renderReviewDetail(data) {
-  if (data.agent_output) {
-    return `<div class="phase-detail-section"><div class="phase-detail-section-title">Review Output</div><div class="phase-detail-pre">${esc(data.agent_output)}</div></div>`;
-  }
-  return '<div class="empty-state">No review output available</div>';
-}
-
-function renderEvalDetail(data) {
-  let html = '';
-  if (data.experiment_id != null) {
-    html += `<div style="font-size:12px;color:var(--text-dim);margin-bottom:8px">Experiment #${data.experiment_id}</div>`;
-  }
-
-  const before = data.score_before;
-  const after = data.score_after;
-  if (before && after) {
-    const delta = data.delta;
-    const deltaStr = delta != null ? (delta >= 0 ? '+' : '') + delta.toFixed(4) : '';
-    const deltaColor = delta != null ? (delta >= 0 ? 'var(--green)' : 'var(--red)') : '';
-    html += `<div style="display:flex;gap:24px;align-items:center;margin-bottom:16px">`;
-    html += `<div><div class="phase-detail-section-title">Before</div><div style="font-size:24px;font-weight:800;color:${scoreColor(before.total)}">${(before.total || 0).toFixed(3)}</div></div>`;
-    html += `<div style="font-size:20px;color:var(--text-dim)">→</div>`;
-    html += `<div><div class="phase-detail-section-title">After</div><div style="font-size:24px;font-weight:800;color:${scoreColor(after.total)}">${(after.total || 0).toFixed(3)}</div></div>`;
-    if (deltaStr) {
-      html += `<div style="font-size:18px;font-weight:700;color:${deltaColor}">${deltaStr}</div>`;
-    }
-    html += '</div>';
-
-    // Dimension comparison table
-    const beforeDims = before.results || [];
-    const afterDims = after.results || [];
-    if (beforeDims.length > 0) {
-      html += '<table class="phase-detail-table"><thead><tr><th>Dimension</th><th>Before</th><th>After</th><th>Change</th></tr></thead><tbody>';
-      afterDims.forEach(ad => {
-        const bd = beforeDims.find(b => b.name === ad.name);
-        const bScore = bd ? bd.score : 0;
-        const change = ad.score - bScore;
-        const changeStr = (change >= 0 ? '+' : '') + change.toFixed(3);
-        const changeColor = change >= 0 ? 'var(--green)' : 'var(--red)';
-        html += `<tr><td style="font-weight:600">${esc(ad.name)}</td>`;
-        html += `<td>${bScore.toFixed(3)}</td>`;
-        html += `<td>${ad.score.toFixed(3)}</td>`;
-        html += `<td style="color:${changeColor}">${changeStr}</td></tr>`;
-      });
-      html += '</tbody></table>';
-    }
-  } else if (data.last_eval) {
-    html += `<div><div class="phase-detail-section-title">Latest Score</div><div style="font-size:24px;font-weight:800">${(data.last_eval.total || 0).toFixed(3)}</div></div>`;
-  }
-
-  html += renderCollapsible('Agent Output', data.agent_output);
-  return html;
-}
-
-function renderArchiveDetail(data) {
-  let html = '';
-  if (data.session_summary) {
-    html += `<div class="phase-detail-section"><div class="phase-detail-section-title">Session Summary</div><div class="phase-detail-pre">${esc(data.session_summary)}</div></div>`;
-  }
-  if (data.performance_report) {
-    const rpt = data.performance_report;
-    html += '<div class="phase-detail-section"><div class="phase-detail-section-title">Performance Report</div>';
-    html += '<dl class="phase-detail-kv">';
-    if (rpt.total_experiments != null) html += `<dt>Total Experiments</dt><dd>${rpt.total_experiments}</dd>`;
-    if (rpt.keep_count != null) html += `<dt>Kept</dt><dd style="color:var(--green)">${rpt.keep_count}</dd>`;
-    if (rpt.revert_count != null) html += `<dt>Reverted</dt><dd style="color:var(--red)">${rpt.revert_count}</dd>`;
-    if (rpt.keep_rate != null) html += `<dt>Keep Rate</dt><dd>${(rpt.keep_rate * 100).toFixed(0)}%</dd>`;
-    if (rpt.latest_score != null) html += `<dt>Latest Score</dt><dd style="color:${scoreColor(rpt.latest_score)}">${rpt.latest_score.toFixed(3)}</dd>`;
-    html += '</dl></div>';
-  }
-  html += renderCollapsible('Agent Output', data.agent_output);
-  return html;
-}
-
-const PHASE_RENDERERS = {
-  Detect: renderDetectDetail,
-  Discover: renderDiscoverDetail,
-  Research: renderResearchDetail,
-  Strategize: renderStrategizeDetail,
-  Build: renderBuildDetail,
-  Review: renderReviewDetail,
-  Eval: renderEvalDetail,
-  Archive: renderArchiveDetail,
-  Observe: renderResearchDetail,
-  Hypothesize: renderStrategizeDetail,
-  Baseline: renderEvalDetail,
-  Analyze: renderResearchDetail,
-  Run: renderEvalDetail,
-  Verdict: renderEvalDetail,
-  Plan: renderStrategizeDetail,
-  Verify: renderEvalDetail,
-  ACE: renderArchiveDetail,
-};
-
 // ── Project Details ──
 function openProjectDetails(name) {
-  const row = document.getElementById('phase-detail-row');
-  if (expandedPhase === '__project__' && selectedProject === name) {
-    expandedPhase = null;
-    row.classList.remove('open');
-    row.innerHTML = '';
-    renderPipelineBar(currentPhaseGlobal);
-    return;
-  }
-  expandedPhase = '__project__';
-  row.innerHTML = '<div class="empty-state">Loading...</div>';
-  row.classList.add('open');
-  renderPipelineBar(currentPhaseGlobal);
-
-  fetch(`/api/projects/${name}/details`)
-    .then(res => res.json())
-    .then(data => renderProjectDetails(data))
-    .catch(() => { row.innerHTML = '<div class="empty-state">Failed to load project details</div>'; });
-}
-
-function renderProjectDetails(data) {
-  const row = document.getElementById('phase-detail-row');
-  let html = '<div class="phase-detail-header">';
-  html += `<span class="phase-detail-title">${esc(data.name)}</span>`;
-  html += `<span class="project-status-badge ${data.status}">${esc(data.status)}</span>`;
-  html += '</div>';
-
-  if (data.status === 'new') {
-    html += '<div class="empty-state">Factory not initialized. Run <code>factory ceo &lt;path&gt;</code> to start.</div>';
-    row.innerHTML = html;
-    return;
-  }
-
-  // Config summary
-  if (data.config) {
-    const c = data.config;
-    html += '<div class="phase-detail-section"><div class="phase-detail-section-title">Configuration</div>';
-    html += '<dl class="phase-detail-kv">';
-    if (c.goal) html += `<dt>Goal</dt><dd>${esc(c.goal)}</dd>`;
-    if (c.eval_command) html += `<dt>Eval Command</dt><dd><code>${esc(c.eval_command)}</code></dd>`;
-    if (c.eval_threshold != null) html += `<dt>Threshold</dt><dd>${c.eval_threshold}</dd>`;
-    if (c.scope && c.scope.length > 0) html += `<dt>Scope</dt><dd>${c.scope.map(s => esc(s)).join(', ')}</dd>`;
-    if (c.guards && c.guards.length > 0) html += `<dt>Guards</dt><dd>${c.guards.map(g => esc(g)).join('; ')}</dd>`;
-    if (c.constraints && c.constraints.length > 0) html += `<dt>Constraints</dt><dd>${c.constraints.map(x => esc(x)).join('; ')}</dd>`;
-    if (c.research_target) html += `<dt>Research Target</dt><dd>${esc(JSON.stringify(c.research_target))}</dd>`;
-    html += '</dl></div>';
-  }
-
-  // Eval profile
-  if (data.eval_profile) {
-    const ep = data.eval_profile;
-    const dims = ep.dimensions || [];
-    html += '<div class="phase-detail-section"><div class="phase-detail-section-title">Eval Profile';
-    if (ep.human_reviewed) html += ' <span style="color:var(--green);font-size:9px">REVIEWED</span>';
-    html += '</div>';
-    if (dims.length > 0) {
-      html += '<table class="phase-detail-table"><thead><tr><th>Dimension</th><th>Weight</th><th>Source</th></tr></thead><tbody>';
-      dims.forEach(d => {
-        html += `<tr><td style="font-weight:600">${esc(d.name)}</td><td>${d.weight}</td><td>${esc(d.source || '')}</td></tr>`;
-      });
-      html += '</tbody></table>';
-    }
-    html += '</div>';
-  }
-
-  // Performance report
-  if (data.performance_report) {
-    const rpt = data.performance_report;
-    html += '<div class="phase-detail-section"><div class="phase-detail-section-title">Performance</div>';
-    html += '<dl class="phase-detail-kv">';
-    if (rpt.total_experiments != null) html += `<dt>Experiments</dt><dd>${rpt.total_experiments}</dd>`;
-    if (rpt.keep_count != null) html += `<dt>Kept</dt><dd style="color:var(--green)">${rpt.keep_count}</dd>`;
-    if (rpt.revert_count != null) html += `<dt>Reverted</dt><dd style="color:var(--red)">${rpt.revert_count}</dd>`;
-    if (rpt.keep_rate != null) html += `<dt>Keep Rate</dt><dd>${(rpt.keep_rate * 100).toFixed(0)}%</dd>`;
-    if (rpt.latest_score != null) html += `<dt>Latest Score</dt><dd style="color:${scoreColor(rpt.latest_score)}">${rpt.latest_score.toFixed(3)}</dd>`;
-    html += '</dl></div>';
-  }
-
-  // Backlog
-  if (data.backlog) {
-    html += `<div class="phase-detail-section"><div class="phase-detail-section-title">Backlog</div><div class="phase-detail-pre">${esc(data.backlog)}</div></div>`;
-  }
-
-  // Checkpoint
-  if (data.checkpoint) {
-    const cp = data.checkpoint;
-    html += '<div class="phase-detail-section"><div class="phase-detail-section-title">Checkpoint (crash recovery)</div>';
-    html += '<dl class="phase-detail-kv">';
-    html += `<dt>Mode</dt><dd>${esc(cp.mode || '')}</dd>`;
-    if (cp.current_hypothesis) html += `<dt>Hypothesis</dt><dd>${esc(cp.current_hypothesis)}</dd>`;
-    if (cp.completed_agents) html += `<dt>Completed</dt><dd>${cp.completed_agents.map(a => esc(a)).join(', ')}</dd>`;
-    if (cp.pending_agents) html += `<dt>Pending</dt><dd>${cp.pending_agents.map(a => esc(a)).join(', ')}</dd>`;
-    html += '</dl></div>';
-  }
-
-  // factory.md source
-  if (data.factory_md) {
-    html += renderCollapsible('factory.md', data.factory_md);
-  }
-
-  row.innerHTML = html;
+  window.location.href = `/sessions/${encodeURIComponent(name)}`;
 }
 
 // ── Agent Activity Cards ──
@@ -1907,28 +1365,10 @@ async function loadLiveState() {
   try {
     const res = await fetch(`/api/projects/${selectedProject}/state`);
     const state = await res.json();
-    const prevPhase = currentPhaseGlobal;
-    currentPhaseGlobal = state.current_phase;
 
-    if (state.phases && state.phases.length > 0) {
-      currentPhases = state.phases;
-    }
-    if (state.loop_phases) {
-      currentLoopPhases = state.loop_phases;
-    }
-    currentHypothesisNumber = state.hypothesis_number || 0;
-
-    renderPipelineBar(state.current_phase);
     renderAgentCards(state.active_agents || {});
     updateModeIndicator(state.current_mode);
     loadProjects();
-
-    if (expandedPhase && prevPhase !== currentPhaseGlobal) {
-      fetch(`/api/projects/${selectedProject}/phase-detail/${expandedPhase}`)
-        .then(r => r.json())
-        .then(d => renderPhaseDetail(d))
-        .catch(() => {});
-    }
   } catch (e) {
     // Silently ignore — state endpoint may not have data yet
   }
@@ -1941,7 +1381,6 @@ connectSSE();
 initToggle();
 initEventFilters();
 loadLiveState();
-renderPipelineBar(null);
 // Refresh projects every 10s
 setInterval(() => {
   loadProjects();

--- a/factory/dashboard/static/sessions.html
+++ b/factory/dashboard/static/sessions.html
@@ -1,0 +1,686 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sessions — Factory Dashboard</title>
+<link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0d1117;--surface:#161b22;--border:#30363d;
+  --text:#e6edf3;--text-dim:#7d8590;--accent:#58a6ff;
+  --green:#3fb950;--red:#f85149;--yellow:#d29922;
+  --cyan:#39d2e0;--orange:#f0883e;--purple:#bc8cff;
+  --font:'SF Mono','Cascadia Code','JetBrains Mono','Fira Code',monospace;
+}
+body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;font-size:14px;line-height:1.5}
+header{display:flex;align-items:center;justify-content:space-between;padding:12px 24px;border-bottom:1px solid var(--border);background:var(--surface)}
+.logo{font-weight:700;font-size:16px;letter-spacing:2px;color:var(--accent);font-family:var(--font)}
+.header-info{display:flex;align-items:center;gap:16px}
+.back-link{color:var(--accent);text-decoration:none;font-size:13px}
+.back-link:hover{text-decoration:underline}
+
+.content{display:grid;grid-template-columns:300px 1fr;height:calc(100vh - 49px);overflow:hidden}
+
+.cycle-panel{border-right:1px solid var(--border);display:flex;flex-direction:column;overflow:hidden}
+.cycle-panel-header{padding:10px 16px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-dim);border-bottom:1px solid var(--border);background:var(--surface);flex-shrink:0;display:flex;justify-content:space-between;align-items:center;font-family:var(--font)}
+.cycle-panel-body{overflow-y:auto;flex:1;padding:4px}
+
+.cycle-item{padding:10px 14px;cursor:pointer;border-radius:6px;border:1px solid transparent;margin-bottom:2px;transition:all 0.1s}
+.cycle-item:hover{background:var(--surface);border-color:var(--border)}
+.cycle-item.selected{background:var(--surface);border-color:var(--accent)}
+.cycle-item.running{animation:itemPulse 2s infinite}
+@keyframes itemPulse{0%,100%{opacity:1}50%{opacity:0.85}}
+
+.cycle-item-top{display:flex;align-items:center;gap:8px;margin-bottom:4px}
+.cycle-item-title{font-size:13px;font-weight:600;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.cycle-item-meta{display:flex;align-items:center;gap:8px;font-size:11px;color:var(--text-dim)}
+.cycle-item-roles{display:flex;gap:3px;flex-wrap:wrap;margin-top:2px}
+
+.status-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.status-dot.running{background:var(--yellow);box-shadow:0 0 6px var(--yellow);animation:pulse 1.5s infinite}
+.status-dot.completed{background:var(--green)}
+.status-dot.failed{background:var(--red)}
+@keyframes pulse{0%,100%{opacity:1;box-shadow:0 0 0 0 rgba(210,153,34,0.4)}50%{opacity:0.7;box-shadow:0 0 0 4px rgba(210,153,34,0)}}
+
+.role-badge{display:inline-block;padding:1px 6px;border-radius:10px;font-size:10px;font-weight:600;text-transform:capitalize;color:#fff}
+.role-mini{display:inline-block;padding:0 5px;border-radius:8px;font-size:9px;font-weight:600;text-transform:capitalize;color:#fff}
+.status-badge{font-size:11px;padding:2px 8px;border-radius:4px;font-weight:600}
+.status-badge.running{background:#3d2e1f;color:var(--yellow)}
+.status-badge.completed{background:#1a3a2a;color:var(--green)}
+.status-badge.failed{background:#3d1f1f;color:var(--red)}
+
+.detail-panel{display:flex;flex-direction:column;overflow:hidden}
+.detail-empty{display:flex;align-items:center;justify-content:center;height:100%;color:var(--text-dim);font-size:13px}
+
+.cycle-header{padding:14px 20px;border-bottom:1px solid var(--border);background:var(--surface);flex-shrink:0}
+.cycle-header-top{display:flex;align-items:center;gap:10px;margin-bottom:8px;flex-wrap:wrap}
+.cycle-header-top .role-badge{font-size:12px;padding:2px 10px}
+.model-name{font-size:12px;color:var(--text-dim)}
+.cycle-stats{display:flex;gap:16px;flex-wrap:wrap;font-size:12px}
+.cycle-stat{display:flex;flex-direction:column;gap:1px}
+.cycle-stat .cs-label{font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.3px;font-family:var(--font)}
+.cycle-stat .cs-value{font-weight:600}
+
+.cycle-detail-body{overflow-y:auto;flex:1;padding:0}
+
+.agent-section{border-bottom:1px solid var(--border)}
+.agent-section:last-child{border-bottom:none}
+.agent-section-header{padding:10px 20px;cursor:pointer;display:flex;align-items:center;gap:8px;background:var(--surface);user-select:none;transition:background 0.1s}
+.agent-section-header:hover{background:#1c2129}
+.agent-section-arrow{font-size:10px;transition:transform 0.15s;width:14px;text-align:center;flex-shrink:0;color:var(--text-dim)}
+.agent-section.open .agent-section-arrow{transform:rotate(90deg)}
+.agent-section-info{display:flex;align-items:center;gap:8px;flex:1;min-width:0}
+.agent-section-meta{display:flex;gap:10px;font-size:11px;color:var(--text-dim);flex-shrink:0}
+.agent-section-body{display:none;padding:0}
+.agent-section.open .agent-section-body{display:block}
+.interactive-badge{font-size:9px;padding:1px 5px;border-radius:8px;font-weight:600;flex-shrink:0}
+.interactive-badge.interactive{background:rgba(88,166,255,0.15);color:var(--accent)}
+
+.chat-body{display:flex;flex-direction:column;gap:8px;padding:12px 20px}
+
+.chat-msg{max-width:85%;padding:10px 14px;border-radius:8px;font-size:13px;line-height:1.6;position:relative}
+.chat-msg.assistant{align-self:flex-start;background:rgba(63,185,80,0.06);border-left:2px solid var(--green);border-top-left-radius:2px}
+.chat-msg.user{align-self:flex-end;background:rgba(88,166,255,0.06);border-right:2px solid var(--accent);border-top-right-radius:2px}
+.chat-msg.tool-call{align-self:flex-start;background:rgba(240,136,62,0.08);border-left:2px solid var(--orange);border-top-left-radius:2px}
+.chat-msg.tool-output{align-self:flex-start;background:rgba(125,133,144,0.06);border-left:2px solid #555;border-top-left-radius:2px}
+.chat-msg.thinking{align-self:flex-start;background:rgba(188,140,255,0.06);border-left:2px solid var(--purple);border-top-left-radius:2px;opacity:0.7}
+
+.chat-role-label{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;color:var(--text-dim);margin-bottom:4px;font-family:var(--font)}
+.chat-msg.user .chat-role-label{text-align:right}
+
+.tool-header{display:flex;align-items:center;gap:6px;margin-bottom:6px}
+.tool-icon{font-size:12px}
+.tool-name{font-weight:700;color:var(--orange);font-size:12px}
+
+.chat-msg pre{background:var(--bg);border:1px solid var(--border);border-radius:4px;padding:8px 10px;font-size:12px;overflow-x:auto;white-space:pre-wrap;word-break:break-word;font-family:var(--font)}
+.chat-msg code:not([class*="language-"]){background:var(--bg);border:1px solid var(--border);border-radius:3px;padding:1px 5px;font-size:12px;font-family:var(--font)}
+.chat-msg .tool-output-pre{background:var(--bg);border:1px solid var(--border);border-radius:4px;padding:8px 10px;font-size:12px;overflow-x:auto;white-space:pre-wrap;word-break:break-word;max-height:400px;overflow-y:auto;font-family:var(--font)}
+.thinking-content{font-style:italic;color:var(--text-dim)}
+
+.chat-msg .md-content p{margin:0 0 8px 0}
+.chat-msg .md-content p:last-child{margin-bottom:0}
+.chat-msg .md-content ul,.chat-msg .md-content ol{margin:0 0 8px 16px}
+.chat-msg .md-content h1,.chat-msg .md-content h2,.chat-msg .md-content h3{margin:8px 0 4px 0;font-size:14px}
+
+details{border:none}
+details summary{cursor:pointer;color:var(--accent);font-size:12px;padding:4px 0;user-select:none}
+details summary:hover{text-decoration:underline}
+
+.chat-input-area{padding:12px 20px;border-top:1px solid var(--border);background:var(--surface);display:flex;gap:8px;align-items:flex-end}
+.chat-input{flex:1;background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:10px 14px;color:var(--text);font-family:inherit;font-size:13px;resize:none;min-height:40px;max-height:120px;outline:none}
+.chat-input:focus{border-color:var(--accent)}
+.chat-input:disabled{opacity:0.5}
+.chat-send-btn{background:var(--accent);color:#fff;border:none;border-radius:8px;padding:10px 16px;font-size:13px;font-weight:600;cursor:pointer;white-space:nowrap}
+.chat-send-btn:disabled{opacity:0.4;cursor:not-allowed}
+.chat-send-btn:hover:not(:disabled){filter:brightness(1.1)}
+
+.item-count-badge{font-size:9px;padding:0 5px;border-radius:8px;background:var(--border);color:var(--text-dim);font-weight:600;flex-shrink:0}
+
+@media(max-width:800px){
+  .content{grid-template-columns:1fr;grid-template-rows:280px 1fr}
+  .cycle-panel{border-right:none;border-bottom:1px solid var(--border)}
+}
+</style>
+</head>
+<body>
+<header>
+  <div class="logo">FACTORY</div>
+  <div class="header-info">
+    <span id="project-name" style="font-weight:600"></span>
+    <a href="/" class="back-link">&larr; Dashboard</a>
+  </div>
+</header>
+
+<div class="content">
+  <div class="cycle-panel">
+    <div class="cycle-panel-header">
+      <span>Cycles</span>
+      <span id="cycle-count" style="font-weight:400"></span>
+    </div>
+    <div class="cycle-panel-body" id="cycle-list">
+      <div style="text-align:center;padding:40px 20px;color:var(--text-dim)">Loading cycles...</div>
+    </div>
+  </div>
+  <div class="detail-panel" id="detail-panel">
+    <div class="detail-empty" id="detail-empty">Select a cycle from the list</div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.0/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-python.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-json.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-diff.min.js"></script>
+<script>
+var projectName = decodeURIComponent(
+  window.location.pathname.split('/').filter(Boolean).pop() || ''
+);
+document.getElementById('project-name').textContent = 'Sessions — ' + projectName;
+document.title = 'Sessions — ' + projectName;
+
+var selectedCycleId = null;
+var expandedSessions = {};
+
+function esc(str) {
+  if (!str) return '';
+  var d = document.createElement('div');
+  d.textContent = str;
+  return d.innerHTML;
+}
+
+function roleColor(role) {
+  var name = (role || '').toLowerCase();
+  var hash = 0;
+  for (var i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  var h = ((hash % 360) + 360) % 360;
+  return 'hsl(' + h + ', 65%, 55%)';
+}
+
+function formatCost(usd) {
+  if (usd == null || usd === 0) return '$0.00';
+  if (usd < 0.01) return '<$0.01';
+  return '$' + usd.toFixed(2);
+}
+
+function formatDuration(ms) {
+  if (ms == null || ms === 0) return '0s';
+  var sec = Math.round(ms / 1000);
+  if (sec < 60) return sec + 's';
+  var min = Math.floor(sec / 60);
+  var rem = sec % 60;
+  if (min < 60) return min + 'm' + rem + 's';
+  var hr = Math.floor(min / 60);
+  return hr + 'h' + (min % 60) + 'm';
+}
+
+function formatTokens(n) {
+  if (n == null || n === 0) return '0';
+  if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'k';
+  return String(n);
+}
+
+function formatTime(ts) {
+  if (!ts) return '';
+  var d = new Date(ts * 1000);
+  var now = new Date();
+  var diff = (now - d) / 1000;
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+  if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+  return d.toLocaleDateString(undefined, {month:'short', day:'numeric'}) + ' ' +
+    d.toLocaleTimeString(undefined, {hour:'2-digit', minute:'2-digit'});
+}
+
+function renderRoleBadge(role, cls) {
+  var r = (role || 'unknown').toLowerCase();
+  var c = cls || 'role-badge';
+  return '<span class="' + c + '" style="background:' + roleColor(r) + '">' + esc(r) + '</span>';
+}
+
+function renderMarkdown(text) {
+  if (!text) return '<span style="color:var(--text-dim)">(empty)</span>';
+  try {
+    var html = marked.parse(text, {breaks: true, gfm: true});
+    return '<div class="md-content">' + html + '</div>';
+  } catch (e) {
+    return '<pre>' + esc(text) + '</pre>';
+  }
+}
+
+// ── Data Loading ──
+async function loadCycles() {
+  try {
+    var resp = await fetch('/api/projects/' + encodeURIComponent(projectName) + '/cycles?limit=50');
+    if (!resp.ok) { renderEmptyCycles(); return; }
+    var cycles = await resp.json();
+    if (cycles.length === 0) { renderEmptyCycles(); return; }
+    document.getElementById('cycle-count').textContent = cycles.length + ' total';
+    renderCycleList(cycles);
+    if (!selectedCycleId && cycles.length > 0) {
+      selectCycle(cycles[0].id);
+    }
+  } catch (e) { renderEmptyCycles(); }
+}
+
+function renderEmptyCycles() {
+  document.getElementById('cycle-list').innerHTML =
+    '<div style="text-align:center;padding:40px 20px;color:var(--text-dim)">' +
+    '<div style="font-weight:600;margin-bottom:4px">No Cycles</div>' +
+    '<div style="font-size:12px">Run <code style="background:var(--border);padding:2px 6px;border-radius:4px">factory ceo &lt;path&gt;</code> to start.</div>' +
+    '</div>';
+}
+
+function renderCycleList(cycles) {
+  var el = document.getElementById('cycle-list');
+  var html = '';
+
+  cycles.forEach(function(c) {
+    var sel = selectedCycleId === c.id ? ' selected' : '';
+    var running = c.status === 'running' ? ' running' : '';
+    var statusCls = c.status || 'completed';
+    var title = c.title || formatTime(c.created_at) || 'Cycle';
+
+    html += '<div class="cycle-item' + sel + running + '" data-id="' + esc(c.id) + '" onclick="selectCycle(\'' + esc(c.id) + '\')">';
+    html += '<div class="cycle-item-top">';
+    html += '<span class="status-dot ' + esc(statusCls) + '"></span>';
+    html += '<span class="cycle-item-title">' + esc(title) + '</span>';
+    html += '<span class="cycle-item-meta">';
+    html += '<span>' + formatCost(c.total_cost || c.total_cost_usd) + '</span>';
+    html += '<span>' + formatDuration(c.total_duration || c.duration_ms) + '</span>';
+    html += '</span>';
+    html += '</div>';
+
+    var childRoles = c.child_roles ? c.child_roles.split(',') : [];
+    if (childRoles.length > 0 || c.child_count > 0) {
+      html += '<div class="cycle-item-roles">';
+      if (childRoles.length > 0) {
+        childRoles.forEach(function(r) {
+          html += renderRoleBadge(r.trim(), 'role-mini');
+        });
+      } else if (c.child_count > 0) {
+        html += '<span style="font-size:10px;color:var(--text-dim)">' + c.child_count + ' agents</span>';
+      }
+      html += '</div>';
+    }
+
+    html += '</div>';
+  });
+
+  el.innerHTML = html;
+}
+
+// ── Cycle Detail ──
+async function selectCycle(cycleId) {
+  selectedCycleId = cycleId;
+  expandedSessions = {};
+
+  document.querySelectorAll('.cycle-item').forEach(function(n) {
+    n.classList.toggle('selected', n.dataset.id === cycleId);
+  });
+
+  var panel = document.getElementById('detail-panel');
+  panel.innerHTML = '<div class="detail-empty">Loading cycle...</div>';
+
+  try {
+    var resp = await fetch('/api/projects/' + encodeURIComponent(projectName) + '/cycles/' + encodeURIComponent(cycleId));
+    if (!resp.ok) { panel.innerHTML = '<div class="detail-empty">Cycle not found</div>'; return; }
+    var cycle = await resp.json();
+    renderCycleDetail(cycle);
+  } catch (e) {
+    panel.innerHTML = '<div class="detail-empty">Failed to load cycle</div>';
+  }
+}
+
+function renderCycleDetail(cycle) {
+  var panel = document.getElementById('detail-panel');
+  var html = '';
+
+  html += '<div class="cycle-header">';
+  html += '<div class="cycle-header-top">';
+  html += renderRoleBadge('ceo');
+  html += '<span style="font-weight:600;font-size:14px">' + esc(cycle.title || 'CEO Cycle') + '</span>';
+  if (cycle.model) html += '<span class="model-name">' + esc(cycle.model) + '</span>';
+  html += '<span class="status-badge ' + esc(cycle.status || 'completed') + '">' + esc(cycle.status || 'unknown') + '</span>';
+  html += '</div>';
+
+  html += '<div class="cycle-stats">';
+  html += renderCycleStat('Total Cost', formatCost(cycle.total_cost));
+  html += renderCycleStat('Total Duration', formatDuration(cycle.total_duration));
+  html += renderCycleStat('Agents', String((cycle.children || []).length));
+  html += renderCycleStat('CEO Tokens', formatTokens((cycle.input_tokens || 0) + (cycle.output_tokens || 0)));
+  if (cycle.created_at) html += renderCycleStat('Started', formatTime(cycle.created_at));
+  html += '</div>';
+
+  var children = cycle.children || [];
+  if (children.length > 0) {
+    html += '<div style="padding:8px 0 0;display:flex;gap:4px;flex-wrap:wrap">';
+    children.forEach(function(c) {
+      var statusDot = '<span class="status-dot ' + esc(c.status || 'completed') + '" style="width:6px;height:6px"></span>';
+      html += '<span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;padding:2px 8px;border-radius:10px;border:1px solid var(--border);background:var(--bg);cursor:pointer" onclick="toggleAgentSection(\'' + esc(c.id) + '\')">' +
+        statusDot + ' ' + renderRoleBadge(c.agent_role, 'role-mini') + ' ' + formatCost(c.total_cost_usd) +
+        '</span>';
+    });
+    html += '</div>';
+  }
+  html += '</div>';
+
+  html += '<div class="cycle-detail-body">';
+
+  var ceoItems = cycle.items || [];
+  if (ceoItems.length > 0) {
+    var ceoOpen = expandedSessions[cycle.id] ? ' open' : '';
+    html += '<div class="agent-section' + ceoOpen + '" id="section-' + esc(cycle.id) + '">';
+    html += renderAgentSectionHeader(cycle, true);
+    html += '<div class="agent-section-body">';
+    html += renderSessionChat(ceoItems);
+    if (cycle.claude_session_id) {
+      html += renderChatInput(cycle.id);
+    } else {
+      html += renderViewOnly();
+    }
+    html += '</div>';
+    html += '</div>';
+  }
+
+  children.forEach(function(child, idx) {
+    var autoExpand = (idx === 0 && !Object.keys(expandedSessions).length);
+    if (autoExpand) expandedSessions[child.id] = true;
+    var isOpen = expandedSessions[child.id] ? ' open' : '';
+    html += '<div class="agent-section' + isOpen + '" id="section-' + esc(child.id) + '">';
+    html += renderAgentSectionHeader(child, false);
+    html += '<div class="agent-section-body" id="body-' + esc(child.id) + '">';
+    if (expandedSessions[child.id]) {
+      html += '<div class="chat-body" style="color:var(--text-dim);text-align:center;padding:20px">Loading...</div>';
+    }
+    html += '</div>';
+    html += '</div>';
+  });
+
+  html += '</div>';
+
+  panel.innerHTML = html;
+
+  Object.keys(expandedSessions).forEach(function(sid) {
+    if (expandedSessions[sid] && sid !== cycle.id) {
+      loadSessionItems(sid);
+    }
+  });
+}
+
+function renderAgentSectionHeader(session, isCeo) {
+  var statusCls = session.status || 'completed';
+  var itemCount = (session.items || []).length;
+  var html = '<div class="agent-section-header" onclick="toggleAgentSection(\'' + esc(session.id) + '\')">';
+  html += '<span class="agent-section-arrow">&#9656;</span>';
+  html += '<div class="agent-section-info">';
+  html += '<span class="status-dot ' + esc(statusCls) + '"></span>';
+  html += renderRoleBadge(isCeo ? 'ceo' : session.agent_role);
+  if (session.claude_session_id) {
+    html += '<span class="interactive-badge interactive">interactive</span>';
+  }
+  if (itemCount > 0) {
+    html += '<span class="item-count-badge">' + itemCount + '</span>';
+  }
+  html += '</div>';
+  html += '<div class="agent-section-meta">';
+  if (session.model) html += '<span>' + esc(session.model) + '</span>';
+  html += '<span>' + formatCost(session.total_cost_usd) + '</span>';
+  html += '<span>' + formatDuration(session.duration_ms) + '</span>';
+  html += '<span>' + formatTokens((session.input_tokens || 0) + (session.output_tokens || 0)) + ' tok</span>';
+  html += '</div>';
+  html += '</div>';
+  return html;
+}
+
+function renderCycleStat(label, value) {
+  return '<div class="cycle-stat"><span class="cs-label">' + esc(label) + '</span><span class="cs-value">' + esc(value) + '</span></div>';
+}
+
+// ── Toggle & Load Session Items ──
+function toggleAgentSection(sessionId) {
+  var section = document.getElementById('section-' + sessionId);
+  if (!section) return;
+
+  var wasOpen = section.classList.contains('open');
+  section.classList.toggle('open');
+  expandedSessions[sessionId] = !wasOpen;
+
+  if (!wasOpen) {
+    loadSessionItems(sessionId);
+  }
+}
+
+async function loadSessionItems(sessionId) {
+  var body = document.getElementById('body-' + sessionId);
+  if (!body) return;
+  if (body.dataset.loaded === 'true') return;
+
+  body.innerHTML = '<div style="color:var(--text-dim);text-align:center;padding:20px;font-size:12px">Loading conversation...</div>';
+
+  try {
+    var resp = await fetch('/api/projects/' + encodeURIComponent(projectName) + '/sessions/' + encodeURIComponent(sessionId));
+    if (!resp.ok) { body.innerHTML = '<div style="color:var(--text-dim);padding:20px">Failed to load</div>'; return; }
+    var session = await resp.json();
+    var items = session.items || [];
+
+    var html = renderSessionChat(items);
+    if (session.claude_session_id) {
+      html += renderChatInput(sessionId);
+    } else {
+      html += renderViewOnly();
+    }
+    body.innerHTML = html;
+    body.dataset.loaded = 'true';
+
+    highlightCode(body);
+  } catch (e) {
+    body.innerHTML = '<div style="color:var(--text-dim);padding:20px">Error loading session</div>';
+  }
+}
+
+function highlightCode(container) {
+  if (typeof Prism !== 'undefined') {
+    container.querySelectorAll('pre code[class*="language-"]').forEach(function(el) {
+      Prism.highlightElement(el);
+    });
+  }
+}
+
+function renderSessionChat(items) {
+  if (!items || items.length === 0) {
+    return '<div class="chat-body"><div style="text-align:center;padding:30px;color:var(--text-dim);font-size:12px">No conversation items</div></div>';
+  }
+
+  var html = '<div class="chat-body">';
+  items.forEach(function(item) {
+    html += renderChatMessage(item);
+  });
+  html += '</div>';
+  return html;
+}
+
+function renderChatInput(sessionId) {
+  return '<div class="chat-input-area">' +
+    '<textarea class="chat-input" id="chat-input-' + esc(sessionId) + '" placeholder="Send a follow-up message..." rows="1" onkeydown="handleChatKey(event, \'' + esc(sessionId) + '\')"></textarea>' +
+    '<button class="chat-send-btn" id="chat-send-' + esc(sessionId) + '" onclick="sendMessage(\'' + esc(sessionId) + '\')">Send</button>' +
+    '</div>';
+}
+
+function renderViewOnly() {
+  return '<div class="chat-input-area" style="justify-content:center">' +
+    '<span style="font-size:11px;color:var(--text-dim);padding:6px 0">view only — no interactive session</span>' +
+    '</div>';
+}
+
+// ── Chat Message Rendering ──
+function renderChatMessage(item) {
+  var type = item.type || 'message';
+  var role = item.role || '';
+  var data = item.data || '';
+
+  if (type === 'message' && role === 'assistant') {
+    return renderChatBubble('assistant', 'Assistant', renderMarkdown(data));
+  }
+  if (type === 'message' && role === 'user') {
+    return renderChatBubble('user', 'User', renderMarkdown(data));
+  }
+  if (type === 'tool_call') return renderToolCall(item);
+  if (type === 'tool_output') return renderToolOutput(item);
+  if (type === 'thinking') return renderThinking(item);
+  return renderChatBubble('assistant', type + ' / ' + role, '<pre>' + esc(data) + '</pre>');
+}
+
+function renderChatBubble(cls, label, body) {
+  return '<div class="chat-msg ' + cls + '">' +
+    '<div class="chat-role-label">' + esc(label) + '</div>' +
+    '<div>' + body + '</div></div>';
+}
+
+function renderToolCall(item) {
+  var data = item.data || '{}';
+  var name = 'unknown';
+  var input = {};
+  try {
+    var parsed = JSON.parse(data);
+    name = parsed.name || 'unknown';
+    input = parsed.input || {};
+  } catch (e) {}
+
+  var body = '';
+  if (name === 'Bash') {
+    var cmd = input.command || JSON.stringify(input);
+    body = '<pre><code class="language-bash">' + esc(cmd) + '</code></pre>';
+  } else if (name === 'Read') {
+    body = '<code>' + esc(input.file_path || '') + '</code>';
+  } else if (name === 'Write' || name === 'Edit') {
+    body = '<code>' + esc(input.file_path || '') + '</code>';
+    if (name === 'Edit' && input.old_string) {
+      body += '<details><summary>Diff</summary><pre><code class="language-diff">- ' +
+        esc(input.old_string).replace(/\n/g, '\n- ') + '\n+ ' +
+        esc(input.new_string || '').replace(/\n/g, '\n+ ') +
+        '</code></pre></details>';
+    }
+  } else {
+    var inputJson = JSON.stringify(input, null, 2);
+    body = '<details><summary>Input</summary><pre><code class="language-json">' + esc(inputJson) + '</code></pre></details>';
+  }
+
+  return '<div class="chat-msg tool-call">' +
+    '<div class="chat-role-label"><span class="tool-header"><span class="tool-icon">&#9881;</span> <span class="tool-name">' + esc(name) + '</span></span></div>' +
+    '<div>' + body + '</div></div>';
+}
+
+function renderToolOutput(item) {
+  var data = item.data || '';
+  var content = data;
+  try {
+    var parsed = JSON.parse(data);
+    if (parsed && typeof parsed === 'object' && parsed.content != null) {
+      content = parsed.content;
+    }
+  } catch (e) {}
+
+  var lines = content.split('\n');
+  var body = '';
+  if (lines.length <= 5) {
+    body = '<pre class="tool-output-pre">' + esc(content) + '</pre>';
+  } else {
+    var preview = lines.slice(0, 3).join('\n');
+    body = '<details><summary><span style="font-family:var(--font);font-size:12px">' + esc(preview) +
+      '\n... (' + (lines.length - 3) + ' more lines)</span></summary>' +
+      '<pre class="tool-output-pre">' + esc(content) + '</pre></details>';
+  }
+
+  return '<div class="chat-msg tool-output">' +
+    '<div class="chat-role-label">Output</div>' +
+    '<div>' + body + '</div></div>';
+}
+
+function renderThinking(item) {
+  var data = item.data || '';
+  var preview = item.preview || (typeof data === 'string' ? data.substring(0, 80) : '');
+  return '<div class="chat-msg thinking">' +
+    '<div class="chat-role-label">Thinking</div>' +
+    '<details><summary>' + esc(preview) + (data.length > 80 ? '...' : '') + '</summary>' +
+    '<div class="thinking-content">' + renderMarkdown(data) + '</div></details></div>';
+}
+
+// ── Send Message ──
+function handleChatKey(e, sessionId) {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    sendMessage(sessionId);
+  }
+}
+
+async function sendMessage(sessionId) {
+  var input = document.getElementById('chat-input-' + sessionId);
+  var btn = document.getElementById('chat-send-' + sessionId);
+  if (!input || !btn) return;
+  var message = input.value.trim();
+  if (!message) return;
+
+  input.disabled = true;
+  btn.disabled = true;
+  btn.textContent = 'Sending...';
+
+  var section = document.getElementById('section-' + sessionId);
+  var chatBody = section ? section.querySelector('.chat-body') : null;
+  if (chatBody) {
+    var userDiv = document.createElement('div');
+    userDiv.className = 'chat-msg user';
+    userDiv.innerHTML = '<div class="chat-role-label">User</div><div>' + renderMarkdown(message) + '</div>';
+    chatBody.appendChild(userDiv);
+
+    var loadingDiv = document.createElement('div');
+    loadingDiv.className = 'chat-msg assistant';
+    loadingDiv.id = 'loading-' + sessionId;
+    loadingDiv.innerHTML = '<div class="chat-role-label">Assistant</div><div style="color:var(--text-dim)">Processing...</div>';
+    chatBody.appendChild(loadingDiv);
+    chatBody.scrollTop = chatBody.scrollHeight;
+  }
+
+  input.value = '';
+
+  try {
+    var resp = await fetch(
+      '/api/projects/' + encodeURIComponent(projectName) +
+      '/sessions/' + encodeURIComponent(sessionId) + '/message',
+      { method: 'POST', headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({message: message}) }
+    );
+    if (!resp.ok) {
+      var err = await resp.json().catch(function() { return {}; });
+      alert('Error: ' + (err.detail || 'Request failed'));
+      var ld = document.getElementById('loading-' + sessionId);
+      if (ld && ld.parentNode) ld.parentNode.removeChild(ld);
+      return;
+    }
+
+    var body = document.getElementById('body-' + sessionId);
+    if (body) body.dataset.loaded = '';
+    expandedSessions[sessionId] = true;
+    await loadSessionItems(sessionId);
+  } catch (e) {
+    alert('Failed to send: ' + e.message);
+    var ld2 = document.getElementById('loading-' + sessionId);
+    if (ld2 && ld2.parentNode) ld2.parentNode.removeChild(ld2);
+  } finally {
+    input = document.getElementById('chat-input-' + sessionId);
+    btn = document.getElementById('chat-send-' + sessionId);
+    if (input) { input.disabled = false; input.focus(); }
+    if (btn) { btn.disabled = false; btn.textContent = 'Send'; }
+  }
+}
+
+// ── SSE Integration ──
+function connectSSE() {
+  var evtSource = new EventSource('/api/events/stream');
+  evtSource.onmessage = function(e) {
+    try {
+      var event = JSON.parse(e.data);
+      if (event.project !== projectName) return;
+      var type = event.type || '';
+      if (type === 'agent.started' || type === 'agent.completed' || type === 'agent.failed') {
+        loadCycles();
+        if (selectedCycleId) {
+          selectCycle(selectedCycleId);
+        }
+      }
+    } catch (err) {}
+  };
+  evtSource.onerror = function() {};
+}
+
+// ── Init ──
+loadCycles();
+connectSSE();
+</script>
+</body>
+</html>

--- a/factory/dashboard/static/sessions.html
+++ b/factory/dashboard/static/sessions.html
@@ -5,6 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sessions — Factory Dashboard</title>
 <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/cytoscape@3/dist/cytoscape.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dagre@0.8/dist/dagre.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/cytoscape-dagre@2/cytoscape-dagre.js"></script>
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 :root{
@@ -117,6 +120,20 @@ details summary:hover{text-decoration:underline}
 .chat-send-btn:hover:not(:disabled){filter:brightness(1.1)}
 
 .item-count-badge{font-size:9px;padding:0 5px;border-radius:8px;background:var(--border);color:var(--text-dim);font-weight:600;flex-shrink:0}
+
+.view-toggle{display:flex;gap:4px;margin-left:auto}
+.view-toggle-btn{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:4px 12px;font-size:11px;font-weight:600;color:var(--text-dim);cursor:pointer;transition:all 0.15s}
+.view-toggle-btn:hover{border-color:var(--accent);color:var(--text)}
+.view-toggle-btn.active{background:rgba(88,166,255,0.12);border-color:var(--accent);color:var(--accent)}
+
+#graph-container{width:100%;height:100%;position:relative;display:none}
+#cy{width:100%;height:100%;background:var(--bg)}
+.graph-fit-btn{position:absolute;top:12px;right:12px;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:6px 12px;font-size:11px;font-weight:600;color:var(--text-dim);cursor:pointer;z-index:10}
+.graph-fit-btn:hover{border-color:var(--accent);color:var(--text)}
+.cy-tooltip{position:absolute;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:10px 14px;font-size:12px;line-height:1.6;pointer-events:none;z-index:100;max-width:300px;box-shadow:0 4px 12px rgba(0,0,0,0.4)}
+.cy-tooltip .tt-role{font-weight:700;text-transform:capitalize;margin-bottom:4px}
+.cy-tooltip .tt-row{color:var(--text-dim);font-size:11px}
+.cy-tooltip .tt-row span{color:var(--text);font-weight:600}
 
 @media(max-width:800px){
   .content{grid-template-columns:1fr;grid-template-rows:280px 1fr}
@@ -327,6 +344,10 @@ function renderCycleDetail(cycle) {
   html += '<span style="font-weight:600;font-size:14px">' + esc(cycle.title || 'CEO Cycle') + '</span>';
   if (cycle.model) html += '<span class="model-name">' + esc(cycle.model) + '</span>';
   html += '<span class="status-badge ' + esc(cycle.status || 'completed') + '">' + esc(cycle.status || 'unknown') + '</span>';
+  html += '<div class="view-toggle">';
+  html += '<button class="view-toggle-btn active" id="btn-conversation" onclick="switchView(\'conversation\')">Conversation</button>';
+  html += '<button class="view-toggle-btn" id="btn-graph" onclick="switchView(\'graph\')">Graph</button>';
+  html += '</div>';
   html += '</div>';
 
   html += '<div class="cycle-stats">';
@@ -350,7 +371,9 @@ function renderCycleDetail(cycle) {
   }
   html += '</div>';
 
-  html += '<div class="cycle-detail-body">';
+  html += '<div id="graph-container"><button class="graph-fit-btn" onclick="fitGraph()">Fit</button><div id="cy"></div></div>';
+
+  html += '<div class="cycle-detail-body" id="conversation-container">';
 
   var ceoItems = cycle.items || [];
   if (ceoItems.length > 0) {
@@ -676,6 +699,200 @@ function connectSSE() {
     } catch (err) {}
   };
   evtSource.onerror = function() {};
+}
+
+// ── Graph View ──
+var cyInstance = null;
+var currentView = 'conversation';
+var tooltipEl = null;
+
+function switchView(view) {
+  currentView = view;
+  var convEl = document.getElementById('conversation-container');
+  var graphEl = document.getElementById('graph-container');
+  var btnConv = document.getElementById('btn-conversation');
+  var btnGraph = document.getElementById('btn-graph');
+  if (!convEl || !graphEl) return;
+
+  if (view === 'graph') {
+    convEl.style.display = 'none';
+    graphEl.style.display = 'block';
+    btnConv.classList.remove('active');
+    btnGraph.classList.add('active');
+    loadGraph();
+  } else {
+    convEl.style.display = '';
+    graphEl.style.display = 'none';
+    btnConv.classList.add('active');
+    btnGraph.classList.remove('active');
+  }
+}
+
+async function loadGraph() {
+  if (!selectedCycleId) return;
+  var cyEl = document.getElementById('cy');
+  if (!cyEl) return;
+
+  try {
+    var resp = await fetch('/api/projects/' + encodeURIComponent(projectName) +
+      '/cycles/' + encodeURIComponent(selectedCycleId) + '/graph');
+    if (!resp.ok) { cyEl.innerHTML = '<div style="text-align:center;padding:40px;color:var(--text-dim)">No graph data</div>'; return; }
+    var graph = await resp.json();
+    renderGraph(graph);
+  } catch (e) {
+    cyEl.innerHTML = '<div style="text-align:center;padding:40px;color:var(--text-dim)">Failed to load graph</div>';
+  }
+}
+
+function nodeSize(durationMs) {
+  if (!durationMs || durationMs <= 0) return 50;
+  var sec = durationMs / 1000;
+  var size = 40 + Math.min(80, Math.sqrt(sec) * 4);
+  return Math.min(120, Math.max(40, size));
+}
+
+function statusBorderStyle(status) {
+  if (status === 'running') return 'dashed';
+  if (status === 'failed') return 'dotted';
+  return 'solid';
+}
+
+function statusBorderColor(status) {
+  if (status === 'running') return '#d29922';
+  if (status === 'failed') return '#f85149';
+  return '#3fb950';
+}
+
+function renderGraph(graph) {
+  if (cyInstance) { cyInstance.destroy(); cyInstance = null; }
+  removeTooltip();
+
+  var elements = [];
+  (graph.nodes || []).forEach(function(n) {
+    var d = n.data;
+    var size = nodeSize(d.duration_ms);
+    elements.push({
+      data: Object.assign({}, d, { _size: size }),
+    });
+  });
+  (graph.edges || []).forEach(function(e) {
+    elements.push({ data: e.data });
+  });
+
+  cyInstance = cytoscape({
+    container: document.getElementById('cy'),
+    elements: elements,
+    style: [
+      {
+        selector: 'node',
+        style: {
+          'label': 'data(label)',
+          'text-valign': 'center',
+          'text-halign': 'center',
+          'color': '#e6edf3',
+          'font-size': '11px',
+          'font-weight': 'bold',
+          'text-transform': 'capitalize',
+          'shape': 'roundrectangle',
+          'width': 'data(_size)',
+          'height': 'data(_size)',
+          'background-color': function(ele) { return roleColor(ele.data('role')); },
+          'background-opacity': 0.85,
+          'border-width': 3,
+          'border-style': function(ele) { return statusBorderStyle(ele.data('status')); },
+          'border-color': function(ele) { return statusBorderColor(ele.data('status')); },
+          'text-wrap': 'wrap',
+          'text-max-width': '80px',
+        }
+      },
+      {
+        selector: 'edge[type="spawned"]',
+        style: {
+          'width': 2,
+          'line-color': '#58a6ff',
+          'target-arrow-color': '#58a6ff',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'bezier',
+          'arrow-scale': 0.8,
+        }
+      },
+      {
+        selector: 'edge[type="sequential"]',
+        style: {
+          'width': 1.5,
+          'line-color': '#30363d',
+          'line-style': 'dashed',
+          'target-arrow-color': '#30363d',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'bezier',
+          'arrow-scale': 0.6,
+        }
+      }
+    ],
+    layout: {
+      name: 'dagre',
+      rankDir: 'TB',
+      nodeSep: 40,
+      rankSep: 60,
+      padding: 30,
+    },
+    minZoom: 0.3,
+    maxZoom: 3,
+  });
+
+  cyInstance.on('tap', 'node', function(evt) {
+    var nodeId = evt.target.data('id');
+    switchView('conversation');
+    setTimeout(function() {
+      var section = document.getElementById('section-' + nodeId);
+      if (section) {
+        if (!section.classList.contains('open')) {
+          toggleAgentSection(nodeId);
+        }
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }, 100);
+  });
+
+  cyInstance.on('mouseover', 'node', function(evt) {
+    var d = evt.target.data();
+    showTooltip(evt, d);
+  });
+  cyInstance.on('mouseout', 'node', function() {
+    removeTooltip();
+  });
+  cyInstance.on('drag', 'node', function() { removeTooltip(); });
+}
+
+function showTooltip(evt, d) {
+  removeTooltip();
+  tooltipEl = document.createElement('div');
+  tooltipEl.className = 'cy-tooltip';
+  var html = '<div class="tt-role" style="color:' + roleColor(d.role) + '">' + esc(d.role) + '</div>';
+  if (d.task_preview) html += '<div class="tt-row">' + esc(d.task_preview) + '</div>';
+  html += '<div class="tt-row">Duration: <span>' + formatDuration(d.duration_ms) + '</span></div>';
+  html += '<div class="tt-row">Cost: <span>' + formatCost(d.total_cost_usd) + '</span></div>';
+  if (d.model) html += '<div class="tt-row">Model: <span>' + esc(d.model) + '</span></div>';
+  html += '<div class="tt-row">Status: <span>' + esc(d.status) + '</span></div>';
+  tooltipEl.innerHTML = html;
+  document.body.appendChild(tooltipEl);
+
+  var pos = evt.renderedPosition;
+  var cyEl = document.getElementById('cy');
+  var rect = cyEl.getBoundingClientRect();
+  tooltipEl.style.left = (rect.left + pos.x + 15) + 'px';
+  tooltipEl.style.top = (rect.top + pos.y - 10) + 'px';
+}
+
+function removeTooltip() {
+  if (tooltipEl && tooltipEl.parentNode) {
+    tooltipEl.parentNode.removeChild(tooltipEl);
+  }
+  tooltipEl = null;
+}
+
+function fitGraph() {
+  if (cyInstance) cyInstance.fit(undefined, 30);
 }
 
 // ── Init ──

--- a/factory/dashboard/static/sessions.html
+++ b/factory/dashboard/static/sessions.html
@@ -660,9 +660,14 @@ async function sendMessage(sessionId) {
     );
     if (!resp.ok) {
       var err = await resp.json().catch(function() { return {}; });
-      alert('Error: ' + (err.detail || 'Request failed'));
+      var errMsg = err.detail || err.error || 'Request failed';
       var ld = document.getElementById('loading-' + sessionId);
-      if (ld && ld.parentNode) ld.parentNode.removeChild(ld);
+      if (ld) {
+        ld.innerHTML = '<div class="chat-role-label">Error</div><div style="color:var(--red)">' + esc(errMsg) + '</div>';
+        ld.style.borderLeftColor = 'var(--red)';
+        ld.style.background = 'rgba(248,81,73,0.06)';
+        ld.id = '';
+      }
       return;
     }
 
@@ -671,9 +676,13 @@ async function sendMessage(sessionId) {
     expandedSessions[sessionId] = true;
     await loadSessionItems(sessionId);
   } catch (e) {
-    alert('Failed to send: ' + e.message);
     var ld2 = document.getElementById('loading-' + sessionId);
-    if (ld2 && ld2.parentNode) ld2.parentNode.removeChild(ld2);
+    if (ld2) {
+      ld2.innerHTML = '<div class="chat-role-label">Error</div><div style="color:var(--red)">' + esc('Failed to send: ' + e.message) + '</div>';
+      ld2.style.borderLeftColor = 'var(--red)';
+      ld2.style.background = 'rgba(248,81,73,0.06)';
+      ld2.id = '';
+    }
   } finally {
     input = document.getElementById('chat-input-' + sessionId);
     btn = document.getElementById('chat-send-' + sessionId);

--- a/factory/sessions.py
+++ b/factory/sessions.py
@@ -1,0 +1,671 @@
+"""Session persistence — SQLite capture layer for agent invocations."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+_SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS sessions (
+    id              TEXT PRIMARY KEY,
+    parent_id       TEXT REFERENCES sessions(id) ON DELETE CASCADE,
+    root_id         TEXT NOT NULL,
+    kind            TEXT NOT NULL DEFAULT 'default' CHECK(kind IN ('default','sub_agent')),
+    title           TEXT,
+    agent_role      TEXT,
+    claude_session_id TEXT,
+    status          TEXT NOT NULL DEFAULT 'running',
+    stop_reason     TEXT,
+    terminal_reason TEXT,
+    model           TEXT,
+    input_tokens    INTEGER DEFAULT 0,
+    output_tokens   INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    total_cost_usd  REAL DEFAULT 0.0,
+    duration_ms     REAL DEFAULT 0.0,
+    num_turns       INTEGER DEFAULT 0,
+    created_at      INTEGER NOT NULL,
+    updated_at      INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_parent
+    ON sessions(parent_id, created_at DESC) WHERE kind = 'sub_agent';
+CREATE INDEX IF NOT EXISTS idx_sessions_root ON sessions(root_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_role ON sessions(agent_role);
+
+CREATE TABLE IF NOT EXISTS session_items (
+    id              TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    position        INTEGER NOT NULL,
+    type            TEXT NOT NULL,
+    role            TEXT,
+    data            TEXT NOT NULL,
+    preview         TEXT,
+    created_at      INTEGER NOT NULL,
+    UNIQUE(session_id, position)
+);
+"""
+
+
+def _generate_id(prefix: str = "sess") -> str:
+    return f"{prefix}_{os.urandom(4).hex()}"
+
+
+def _db_path(project_path: Path) -> Path:
+    return project_path / ".factory" / "sessions.db"
+
+
+def _connect(project_path: Path) -> sqlite3.Connection:
+    path = _db_path(project_path)
+    conn = sqlite3.connect(str(path), timeout=5.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def init_db(project_path: Path) -> Path:
+    """Create the sessions database and tables. Returns the db file path."""
+    db = _db_path(project_path)
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = _connect(project_path)
+    try:
+        conn.executescript(_SCHEMA_SQL)
+        conn.commit()
+    finally:
+        conn.close()
+    log.debug("sessions_db_initialized", path=str(db))
+    return db
+
+
+def begin_session(
+    project_path: Path,
+    role: str,
+    *,
+    parent_id: str | None = None,
+    root_id: str | None = None,
+    title: str | None = None,
+    model: str | None = None,
+) -> str:
+    """Insert a new session row and return its ID."""
+    init_db(project_path)
+    session_id = _generate_id()
+    now = int(time.time())
+    kind = "sub_agent" if parent_id else "default"
+
+    conn = _connect(project_path)
+    try:
+        if parent_id and not root_id:
+            parent_row = conn.execute(
+                "SELECT root_id FROM sessions WHERE id = ?", (parent_id,)
+            ).fetchone()
+            effective_root = parent_row["root_id"] if parent_row else session_id
+        else:
+            effective_root = root_id or session_id
+
+        conn.execute(
+            """INSERT INTO sessions
+               (id, parent_id, root_id, kind, title, agent_role, status, model, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)""",
+            (session_id, parent_id, effective_root, kind, title, role, model, now, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    log.debug("session_started", session_id=session_id, role=role, parent_id=parent_id)
+    return session_id
+
+
+def complete_session(
+    project_path: Path,
+    session_id: str,
+    *,
+    status: str = "completed",
+    usage: object | None = None,
+    metadata: dict[str, object] | None = None,
+    output: str | None = None,
+) -> None:
+    """Update a session with completion data."""
+    now = int(time.time())
+    meta = metadata or {}
+
+    input_tokens = 0
+    output_tokens = 0
+    cache_read_tokens = 0
+    total_cost_usd = 0.0
+    duration_ms = 0.0
+    num_turns = 0
+    model: str | None = None
+
+    if usage is not None:
+        input_tokens = getattr(usage, "input_tokens", 0) or 0
+        output_tokens = getattr(usage, "output_tokens", 0) or 0
+        cache_read_tokens = getattr(usage, "cache_read_tokens", 0) or 0
+        total_cost_usd = getattr(usage, "total_cost_usd", 0.0) or 0.0
+        duration_ms = getattr(usage, "duration_ms", 0.0) or 0.0
+        num_turns = getattr(usage, "num_turns", 0) or 0
+        model = getattr(usage, "model", None)
+
+    stop_reason = meta.get("stop_reason")
+    terminal_reason = meta.get("terminal_reason")
+    claude_session_id = meta.get("session_id")
+
+    conn = _connect(project_path)
+    try:
+        conn.execute(
+            """UPDATE sessions SET
+                status = ?, stop_reason = ?, terminal_reason = ?,
+                claude_session_id = ?, model = COALESCE(?, model),
+                input_tokens = ?, output_tokens = ?, cache_read_tokens = ?,
+                total_cost_usd = ?, duration_ms = ?, num_turns = ?,
+                updated_at = ?
+               WHERE id = ?""",
+            (
+                status, stop_reason, terminal_reason,
+                claude_session_id, model,
+                input_tokens, output_tokens, cache_read_tokens,
+                total_cost_usd, duration_ms, num_turns,
+                now, session_id,
+            ),
+        )
+        ingested = False
+        if claude_session_id and isinstance(claude_session_id, str):
+            ingested = _ingest_transcript(conn, session_id, claude_session_id, project_path)
+
+        if not ingested and output:
+            item_id = _generate_id("item")
+            conn.execute(
+                """INSERT INTO session_items
+                   (id, session_id, position, type, role, data, preview, created_at)
+                   VALUES (?, ?, 0, 'message', 'assistant', ?, ?, ?)""",
+                (item_id, session_id, output, output[:200] if output else None, now),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    log.debug("session_completed", session_id=session_id, status=status)
+
+
+def _find_transcript(claude_session_id: str, project_path: Path) -> Path | None:
+    """Locate a Claude Code transcript file, trying multiple path patterns.
+
+    Tries the direct project path hash first, then scans all project dirs
+    as a fallback (handles worktree vs project dir mismatches).
+    """
+    claude_dir = Path.home() / ".claude" / "projects"
+    dir_name = str(project_path.resolve()).replace("/", "-").replace(".", "-")
+    direct = claude_dir / dir_name / f"{claude_session_id}.jsonl"
+    if direct.exists():
+        return direct
+    if claude_dir.exists():
+        for pdir in claude_dir.iterdir():
+            if pdir.is_dir():
+                candidate = pdir / f"{claude_session_id}.jsonl"
+                if candidate.exists():
+                    return candidate
+    return None
+
+
+def _discover_claude_session_id(
+    role: str,
+    created_at: int,
+    project_path: Path,
+) -> str | None:
+    """Find the claude_session_id for a running session by scanning transcripts.
+
+    Looks for JSONL files in the Claude Code project directory that were
+    modified after the session's created_at timestamp and contain a matching
+    agent-name entry.
+    """
+    claude_dir = Path.home() / ".claude" / "projects"
+    if not claude_dir.exists():
+        return None
+
+    dir_name = str(project_path.resolve()).replace("/", "-").replace(".", "-")
+    candidates: list[Path] = []
+
+    for search_dir in [claude_dir / dir_name]:
+        if not search_dir.exists():
+            continue
+        for f in search_dir.iterdir():
+            if not f.name.endswith(".jsonl") or f.is_dir():
+                continue
+            if f.stat().st_mtime >= created_at - 5:
+                candidates.append(f)
+
+    if not candidates:
+        for pdir in claude_dir.iterdir():
+            if not pdir.is_dir():
+                continue
+            for f in pdir.iterdir():
+                if f.name.endswith(".jsonl") and f.stat().st_mtime >= created_at - 5:
+                    candidates.append(f)
+
+    target_name = f"factory: {project_path.resolve().name}/{role}"
+    for f in sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True):
+        try:
+            with open(f) as fh:
+                for i, line in enumerate(fh):
+                    if i > 5:
+                        break
+                    line = line.strip()
+                    if not line:
+                        continue
+                    item = json.loads(line)
+                    if item.get("type") == "agent-name":
+                        if target_name in (item.get("agentName") or ""):
+                            return f.stem
+                    elif item.get("type") == "custom-title":
+                        if target_name in (item.get("customTitle") or ""):
+                            return f.stem
+        except Exception:
+            continue
+
+    return None
+
+
+def _ingest_transcript(
+    conn: sqlite3.Connection,
+    session_id: str,
+    claude_session_id: str,
+    project_path: Path,
+) -> bool:
+    """Read Claude Code's conversation transcript and parse into session_items.
+
+    Returns True if items were ingested, False if transcript was not found.
+    """
+    transcript_file = _find_transcript(claude_session_id, project_path)
+    if transcript_file is None:
+        return False
+
+    position = 0
+    with open(transcript_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            item_type = item.get("type", "")
+
+            if item_type == "user":
+                msg = item.get("message", {})
+                content_parts = msg.get("content", [])
+
+                tool_results: list[dict] = []
+                text_parts: list[str] = []
+
+                for part in content_parts:
+                    if isinstance(part, str):
+                        text_parts.append(part)
+                    elif isinstance(part, dict):
+                        if part.get("type") == "tool_result":
+                            raw_content = part.get("content", [])
+                            if isinstance(raw_content, list):
+                                full_text = "".join(str(c) for c in raw_content)
+                            else:
+                                full_text = str(raw_content)
+                            tool_results.append({
+                                "tool_use_id": part.get("tool_use_id", ""),
+                                "content": full_text,
+                                "is_error": part.get("is_error", False),
+                            })
+                        elif part.get("type") == "text":
+                            text_parts.append(part.get("text", ""))
+
+                if tool_results:
+                    for tr in tool_results:
+                        content = tr["content"]
+                        if not content.strip():
+                            continue
+                        data = json.dumps(tr)
+                        _insert_item(
+                            conn, session_id, position, "tool_output", "tool",
+                            data, preview=content[:150],
+                        )
+                        position += 1
+                elif text_parts:
+                    text = "".join(text_parts)
+                    if text.strip():
+                        _insert_item(conn, session_id, position, "message", "user", text)
+                        position += 1
+
+            elif item_type == "assistant":
+                msg = item.get("message", {})
+                content = msg.get("content", [])
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    ptype = part.get("type", "")
+                    if ptype == "text":
+                        text = part.get("text", "")
+                        if text.strip():
+                            _insert_item(conn, session_id, position, "message", "assistant", text)
+                            position += 1
+                    elif ptype == "tool_use":
+                        tool_name = part.get("name", "unknown")
+                        tool_input = part.get("input", {})
+                        data = json.dumps({"name": tool_name, "input": tool_input})
+                        input_str = json.dumps(tool_input)
+                        preview = f"{tool_name}({input_str[:100]})"
+                        _insert_item(
+                            conn, session_id, position, "tool_call", "assistant",
+                            data, preview=preview,
+                        )
+                        position += 1
+                    elif ptype == "thinking":
+                        text = part.get("thinking", "")
+                        if text.strip():
+                            _insert_item(
+                                conn, session_id, position, "thinking", "assistant",
+                                text, preview=text[:150],
+                            )
+                            position += 1
+
+            elif item_type == "tool_result":
+                content = item.get("content", [])
+                text = ""
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        text += part.get("text", "")
+                    elif isinstance(part, str):
+                        text += part
+                if text.strip():
+                    _insert_item(
+                        conn, session_id, position, "tool_output", "tool",
+                        text, preview=text[:150],
+                    )
+                    position += 1
+
+    return position > 0
+
+
+def _insert_item(
+    conn: sqlite3.Connection,
+    session_id: str,
+    position: int,
+    item_type: str,
+    role: str,
+    data: str,
+    *,
+    preview: str | None = None,
+) -> None:
+    item_id = _generate_id("item")
+    now = int(time.time())
+    if preview is None:
+        preview = data[:200] if data else None
+    conn.execute(
+        """INSERT OR IGNORE INTO session_items
+           (id, session_id, position, type, role, data, preview, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (item_id, session_id, position, item_type, role, data, preview, now),
+    )
+
+
+def backfill_transcripts(project_path: Path) -> int:
+    """Re-ingest transcripts for all sessions with a claude_session_id.
+
+    Deletes existing items and re-parses from the JSONL transcript.
+    Returns the number of sessions backfilled.
+    """
+    if not _db_path(project_path).exists():
+        return 0
+
+    conn = _connect(project_path)
+    try:
+        rows = conn.execute(
+            """SELECT s.id, s.claude_session_id
+               FROM sessions s
+               WHERE s.claude_session_id IS NOT NULL"""
+        ).fetchall()
+
+        count = 0
+        for row in rows:
+            sid = row["id"]
+            claude_sid = row["claude_session_id"]
+            if _find_transcript(claude_sid, project_path) is None:
+                continue
+            conn.execute(
+                "DELETE FROM session_items WHERE session_id = ?", (sid,),
+            )
+            ingested = _ingest_transcript(conn, sid, claude_sid, project_path)
+            if ingested:
+                count += 1
+
+        conn.commit()
+        return count
+    finally:
+        conn.close()
+
+
+def reingest_session(
+    project_path: Path,
+    session_id: str,
+    *,
+    usage_update: dict | None = None,
+) -> dict | None:
+    """Delete existing items and re-parse the transcript for a session.
+
+    If *usage_update* is provided, it should be a dict with keys like
+    ``input_tokens``, ``output_tokens``, ``cache_read_tokens``,
+    ``cost_usd``, ``num_turns`` — these are added to the session's
+    existing totals.
+
+    Returns the updated session dict, or None if the session has no claude_session_id.
+    """
+    if not _db_path(project_path).exists():
+        return None
+
+    conn = _connect(project_path)
+    try:
+        row = conn.execute(
+            "SELECT claude_session_id FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+        if not row or not row["claude_session_id"]:
+            return None
+
+        if usage_update:
+            now = int(time.time())
+            conn.execute(
+                """UPDATE sessions SET
+                    input_tokens = input_tokens + ?,
+                    output_tokens = output_tokens + ?,
+                    cache_read_tokens = cache_read_tokens + ?,
+                    total_cost_usd = total_cost_usd + ?,
+                    num_turns = num_turns + ?,
+                    updated_at = ?
+                   WHERE id = ?""",
+                (
+                    usage_update.get("input_tokens", 0),
+                    usage_update.get("output_tokens", 0),
+                    usage_update.get("cache_read_tokens", 0),
+                    usage_update.get("cost_usd", 0.0),
+                    usage_update.get("num_turns", 0),
+                    now,
+                    session_id,
+                ),
+            )
+
+        conn.execute("DELETE FROM session_items WHERE session_id = ?", (session_id,))
+        _ingest_transcript(conn, session_id, row["claude_session_id"], project_path)
+        conn.commit()
+    finally:
+        conn.close()
+    return get_session(project_path, session_id)
+
+
+def get_cycles(
+    project_path: Path,
+    *,
+    limit: int = 20,
+) -> list[dict]:
+    """List root sessions (CEO cycles) with aggregated stats from children."""
+    if not _db_path(project_path).exists():
+        return []
+
+    conn = _connect(project_path)
+    try:
+        rows = conn.execute(
+            """SELECT s.*,
+                (SELECT COUNT(*) FROM sessions c WHERE c.parent_id = s.id) as child_count,
+                s.total_cost_usd + COALESCE(
+                    (SELECT SUM(c.total_cost_usd) FROM sessions c WHERE c.parent_id = s.id), 0
+                ) as total_cost,
+                s.duration_ms + COALESCE(
+                    (SELECT SUM(c.duration_ms) FROM sessions c WHERE c.parent_id = s.id), 0
+                ) as total_duration,
+                (SELECT GROUP_CONCAT(DISTINCT c.agent_role)
+                    FROM sessions c WHERE c.parent_id = s.id) as child_roles
+            FROM sessions s
+            WHERE s.kind = 'default' OR s.parent_id IS NULL
+            ORDER BY s.created_at DESC
+            LIMIT ?""",
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_cycle(
+    project_path: Path,
+    cycle_id: str,
+) -> dict | None:
+    """Get a cycle with its root session and all children, plus aggregated stats."""
+    root = get_session(project_path, cycle_id)
+    if root is None:
+        return None
+
+    children = get_children(project_path, cycle_id)
+
+    total_cost = (root.get("total_cost_usd") or 0.0)
+    total_duration = (root.get("duration_ms") or 0.0)
+    for child in children:
+        total_cost += child.get("total_cost_usd") or 0.0
+        total_duration += child.get("duration_ms") or 0.0
+
+    return {
+        **root,
+        "children": children,
+        "total_cost": total_cost,
+        "total_duration": total_duration,
+    }
+
+
+def get_sessions(
+    project_path: Path,
+    *,
+    cycle_id: str | None = None,
+    role: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """List sessions with child_count, optionally filtered by root_id (cycle) or role."""
+    if not _db_path(project_path).exists():
+        return []
+
+    conditions: list[str] = []
+    params: list[object] = []
+
+    if cycle_id:
+        conditions.append("s.root_id = ?")
+        params.append(cycle_id)
+    if role:
+        conditions.append("s.agent_role = ?")
+        params.append(role)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    conn = _connect(project_path)
+    try:
+        rows = conn.execute(
+            f"""SELECT s.*,
+                       (SELECT COUNT(*) FROM sessions c WHERE c.parent_id = s.id) AS child_count
+                FROM sessions s {where}
+                ORDER BY s.created_at DESC LIMIT ?""",
+            params,
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_session(project_path: Path, session_id: str) -> dict | None:
+    """Get a single session with its items.
+
+    For running sessions with a claude_session_id, re-ingests the
+    transcript on every read so the dashboard shows live progress.
+    """
+    if not _db_path(project_path).exists():
+        return None
+
+    conn = _connect(project_path)
+    try:
+        row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+        if not row:
+            return None
+        result = dict(row)
+
+        if result["status"] == "running":
+            csid = result.get("claude_session_id")
+            if not csid:
+                csid = _discover_claude_session_id(
+                    result.get("agent_role", ""),
+                    result.get("created_at", 0),
+                    project_path,
+                )
+                if csid:
+                    conn.execute(
+                        "UPDATE sessions SET claude_session_id = ? WHERE id = ?",
+                        (csid, session_id),
+                    )
+                    result["claude_session_id"] = csid
+            if csid:
+                conn.execute(
+                    "DELETE FROM session_items WHERE session_id = ?",
+                    (session_id,),
+                )
+                _ingest_transcript(conn, session_id, csid, project_path)
+                conn.commit()
+
+        items = conn.execute(
+            "SELECT * FROM session_items WHERE session_id = ? ORDER BY position",
+            (session_id,),
+        ).fetchall()
+        result["items"] = [dict(i) for i in items]
+        return result
+    finally:
+        conn.close()
+
+
+def get_children(project_path: Path, session_id: str) -> list[dict]:
+    """Get child sessions with child_count and last message preview."""
+    if not _db_path(project_path).exists():
+        return []
+
+    conn = _connect(project_path)
+    try:
+        rows = conn.execute(
+            """SELECT s.*,
+                      (SELECT COUNT(*) FROM sessions c WHERE c.parent_id = s.id) AS child_count,
+                      (SELECT si.preview FROM session_items si
+                       WHERE si.session_id = s.id ORDER BY si.position DESC LIMIT 1) AS last_message_preview
+               FROM sessions s
+               WHERE s.parent_id = ?
+               ORDER BY s.created_at""",
+            (session_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()

--- a/factory/sessions.py
+++ b/factory/sessions.py
@@ -260,22 +260,13 @@ def _discover_claude_session_id(
     dir_name = str(project_path.resolve()).replace("/", "-").replace(".", "-")
     candidates: list[Path] = []
 
-    for search_dir in [claude_dir / dir_name]:
-        if not search_dir.exists():
-            continue
+    search_dir = claude_dir / dir_name
+    if search_dir.exists():
         for f in search_dir.iterdir():
             if not f.name.endswith(".jsonl") or f.is_dir():
                 continue
             if f.stat().st_mtime >= created_at - 5:
                 candidates.append(f)
-
-    if not candidates:
-        for pdir in claude_dir.iterdir():
-            if not pdir.is_dir():
-                continue
-            for f in pdir.iterdir():
-                if f.name.endswith(".jsonl") and f.stat().st_mtime >= created_at - 5:
-                    candidates.append(f)
 
     target_name = f"factory: {project_path.resolve().name}/{role}"
 
@@ -306,9 +297,10 @@ def _discover_claude_session_id(
             continue
 
     if role == "ceo" and candidates:
-        for f in sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True):
-            if f.stem not in matched_child_ids:
-                return f.stem
+        now = time.time()
+        non_child = [f for f in candidates if f.stem not in matched_child_ids]
+        if non_child:
+            return min(non_child, key=lambda f: abs(f.stat().st_mtime - now)).stem
 
     return None
 

--- a/factory/sessions.py
+++ b/factory/sessions.py
@@ -294,13 +294,13 @@ def _discover_claude_session_id(
                         agent_name = item.get("agentName") or ""
                         if target_name in agent_name:
                             return f.stem
-                        if "factory: " in agent_name:
+                        if "factory: " in agent_name and "/" in agent_name:
                             matched_child_ids.add(f.stem)
                     elif item.get("type") == "custom-title":
                         custom_title = item.get("customTitle") or ""
                         if target_name in custom_title:
                             return f.stem
-                        if "factory: " in custom_title:
+                        if "factory: " in custom_title and "/" in custom_title:
                             matched_child_ids.add(f.stem)
         except Exception:
             continue

--- a/factory/sessions.py
+++ b/factory/sessions.py
@@ -93,6 +93,7 @@ def begin_session(
     root_id: str | None = None,
     title: str | None = None,
     model: str | None = None,
+    claude_session_id: str | None = None,
 ) -> str:
     """Insert a new session row and return its ID."""
     init_db(project_path)
@@ -112,9 +113,11 @@ def begin_session(
 
         conn.execute(
             """INSERT INTO sessions
-               (id, parent_id, root_id, kind, title, agent_role, status, model, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)""",
-            (session_id, parent_id, effective_root, kind, title, role, model, now, now),
+               (id, parent_id, root_id, kind, title, agent_role, claude_session_id,
+                status, model, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?, ?)""",
+            (session_id, parent_id, effective_root, kind, title, role,
+             claude_session_id, model, now, now),
         )
         conn.commit()
     finally:
@@ -251,6 +254,8 @@ def _discover_claude_session_id(
                     candidates.append(f)
 
     target_name = f"factory: {project_path.resolve().name}/{role}"
+
+    matched_child_ids: set[str] = set()
     for f in sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True):
         try:
             with open(f) as fh:
@@ -262,13 +267,24 @@ def _discover_claude_session_id(
                         continue
                     item = json.loads(line)
                     if item.get("type") == "agent-name":
-                        if target_name in (item.get("agentName") or ""):
+                        agent_name = item.get("agentName") or ""
+                        if target_name in agent_name:
                             return f.stem
+                        if "factory: " in agent_name:
+                            matched_child_ids.add(f.stem)
                     elif item.get("type") == "custom-title":
-                        if target_name in (item.get("customTitle") or ""):
+                        custom_title = item.get("customTitle") or ""
+                        if target_name in custom_title:
                             return f.stem
+                        if "factory: " in custom_title:
+                            matched_child_ids.add(f.stem)
         except Exception:
             continue
+
+    if role == "ceo" and candidates:
+        for f in sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True):
+            if f.stem not in matched_child_ids:
+                return f.stem
 
     return None
 

--- a/factory/sessions.py
+++ b/factory/sessions.py
@@ -166,7 +166,8 @@ def complete_session(
         conn.execute(
             """UPDATE sessions SET
                 status = ?, stop_reason = ?, terminal_reason = ?,
-                claude_session_id = ?, model = COALESCE(?, model),
+                claude_session_id = COALESCE(?, claude_session_id),
+                model = COALESCE(?, model),
                 input_tokens = ?, output_tokens = ?, cache_read_tokens = ?,
                 total_cost_usd = ?, duration_ms = ?, num_turns = ?,
                 updated_at = ?
@@ -179,9 +180,32 @@ def complete_session(
                 now, session_id,
             ),
         )
+
+        effective_csid = claude_session_id
+        if not effective_csid:
+            row = conn.execute(
+                "SELECT claude_session_id, agent_role, created_at FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row:
+                effective_csid = row["claude_session_id"]
+                if not effective_csid:
+                    discovered = _discover_claude_session_id(
+                        row["agent_role"] or "", row["created_at"], project_path,
+                    )
+                    if discovered:
+                        conn.execute(
+                            "UPDATE sessions SET claude_session_id = ? WHERE id = ?",
+                            (discovered, session_id),
+                        )
+                        effective_csid = discovered
+
         ingested = False
-        if claude_session_id and isinstance(claude_session_id, str):
-            ingested = _ingest_transcript(conn, session_id, claude_session_id, project_path)
+        if effective_csid and isinstance(effective_csid, str):
+            conn.execute(
+                "DELETE FROM session_items WHERE session_id = ?", (session_id,),
+            )
+            ingested = _ingest_transcript(conn, session_id, effective_csid, project_path)
 
         if not ingested and output:
             item_id = _generate_id("item")

--- a/tests/test_dashboard_sessions.py
+++ b/tests/test_dashboard_sessions.py
@@ -146,6 +146,44 @@ class TestSendMessageAPI:
         )
         assert resp.status_code == 404
 
+    def test_resume_injects_system_prompt_file(
+        self, client: TestClient, session_ids: dict, projects_dir: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """When a session has an agent_role, resume should pass --system-prompt-file."""
+        import sqlite3
+        import subprocess
+
+        proj = projects_dir / "proj-a"
+        researcher_id = session_ids["researcher"]
+
+        db_path = proj / ".factory" / "sessions.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE sessions SET claude_session_id = ? WHERE id = ?",
+            ("fake-claude-sid", researcher_id),
+        )
+        conn.commit()
+        conn.close()
+
+        captured_cmd: list[str] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            result = subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        resp = client.post(
+            f"/api/projects/proj-a/sessions/{researcher_id}/message",
+            json={"message": "hello"},
+        )
+        assert resp.status_code == 200
+        assert "--system-prompt-file" in captured_cmd
+        idx = captured_cmd.index("--system-prompt-file")
+        prompt_file = Path(captured_cmd[idx + 1])
+        assert prompt_file.suffix == ".md"
+
 
 class TestSessionsPage:
     def test_sessions_html_served(self, client: TestClient):

--- a/tests/test_dashboard_sessions.py
+++ b/tests/test_dashboard_sessions.py
@@ -1,0 +1,177 @@
+"""Tests for session API endpoints in factory.dashboard."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from factory.dashboard.app import create_app
+from factory.sessions import begin_session, complete_session, init_db
+
+
+@pytest.fixture()
+def projects_dir(tmp_path: Path) -> Path:
+    """Create a projects directory with a factory-managed project containing sessions."""
+    proj = tmp_path / "proj-a"
+    factory = proj / ".factory"
+    factory.mkdir(parents=True)
+    (factory / "config.json").write_text(json.dumps({"goal": "Test sessions"}))
+
+    init_db(proj)
+
+    ceo_id = begin_session(proj, "ceo", title="Improve cycle #1")
+    researcher_id = begin_session(
+        proj, "researcher", parent_id=ceo_id, title="Research task",
+    )
+    builder_id = begin_session(
+        proj, "builder", parent_id=ceo_id, title="Build task",
+    )
+
+    complete_session(proj, researcher_id, status="completed", output="Found 3 issues")
+    complete_session(proj, builder_id, status="completed", output="Fixed 2 files")
+    complete_session(proj, ceo_id, status="completed", output="Cycle complete")
+
+    (tmp_path / "_ids.json").write_text(json.dumps({
+        "ceo": ceo_id,
+        "researcher": researcher_id,
+        "builder": builder_id,
+    }))
+
+    return tmp_path
+
+
+@pytest.fixture()
+def session_ids(projects_dir: Path) -> dict[str, str]:
+    return json.loads((projects_dir / "_ids.json").read_text())
+
+
+@pytest.fixture()
+def client(projects_dir: Path) -> TestClient:
+    app = create_app(projects_dir)
+    return TestClient(app)
+
+
+class TestCyclesAPI:
+    def test_list_cycles(self, client: TestClient, session_ids: dict):
+        resp = client.get("/api/projects/proj-a/cycles")
+        assert resp.status_code == 200
+        cycles = resp.json()
+        assert len(cycles) >= 1
+        ceo_cycle = next(c for c in cycles if c["id"] == session_ids["ceo"])
+        assert ceo_cycle["agent_role"] == "ceo"
+        assert ceo_cycle["child_count"] == 2
+        assert ceo_cycle["status"] == "completed"
+
+    def test_list_cycles_with_limit(self, client: TestClient):
+        resp = client.get("/api/projects/proj-a/cycles?limit=1")
+        assert resp.status_code == 200
+        cycles = resp.json()
+        assert len(cycles) == 1
+
+    def test_list_cycles_empty_project(self, client: TestClient, projects_dir: Path):
+        proj_b = projects_dir / "proj-b"
+        (proj_b / ".factory").mkdir(parents=True)
+        resp = client.get("/api/projects/proj-b/cycles")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_cycle_detail(self, client: TestClient, session_ids: dict):
+        ceo_id = session_ids["ceo"]
+        resp = client.get(f"/api/projects/proj-a/cycles/{ceo_id}")
+        assert resp.status_code == 200
+        cycle = resp.json()
+        assert cycle["id"] == ceo_id
+        assert cycle["status"] == "completed"
+        assert len(cycle["children"]) == 2
+        child_roles = {c["agent_role"] for c in cycle["children"]}
+        assert child_roles == {"researcher", "builder"}
+        assert cycle["total_cost"] >= 0
+        assert cycle["total_duration"] >= 0
+
+    def test_cycle_detail_not_found(self, client: TestClient):
+        resp = client.get("/api/projects/proj-a/cycles/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestSessionAPI:
+    def test_session_detail(self, client: TestClient, session_ids: dict):
+        researcher_id = session_ids["researcher"]
+        resp = client.get(f"/api/projects/proj-a/sessions/{researcher_id}")
+        assert resp.status_code == 200
+        session = resp.json()
+        assert session["id"] == researcher_id
+        assert session["agent_role"] == "researcher"
+        assert session["status"] == "completed"
+        assert "items" in session
+
+    def test_session_detail_has_output_item(self, client: TestClient, session_ids: dict):
+        builder_id = session_ids["builder"]
+        resp = client.get(f"/api/projects/proj-a/sessions/{builder_id}")
+        assert resp.status_code == 200
+        session = resp.json()
+        items = session["items"]
+        assert len(items) >= 1
+        assert any(i["data"] == "Fixed 2 files" for i in items)
+
+    def test_session_not_found(self, client: TestClient):
+        resp = client.get("/api/projects/proj-a/sessions/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestSendMessageAPI:
+    def test_message_no_claude_session(self, client: TestClient, session_ids: dict):
+        ceo_id = session_ids["ceo"]
+        resp = client.post(
+            f"/api/projects/proj-a/sessions/{ceo_id}/message",
+            json={"message": "hello"},
+        )
+        assert resp.status_code == 400
+        assert "claude_session_id" in resp.json()["detail"]
+
+    def test_message_empty_body(self, client: TestClient, session_ids: dict):
+        ceo_id = session_ids["ceo"]
+        resp = client.post(
+            f"/api/projects/proj-a/sessions/{ceo_id}/message",
+            json={"message": ""},
+        )
+        assert resp.status_code == 400
+
+    def test_message_session_not_found(self, client: TestClient):
+        resp = client.post(
+            "/api/projects/proj-a/sessions/nonexistent/message",
+            json={"message": "hello"},
+        )
+        assert resp.status_code == 404
+
+
+class TestSessionsPage:
+    def test_sessions_html_served(self, client: TestClient):
+        resp = client.get("/sessions/proj-a")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert "Sessions" in resp.text
+        assert "marked.parse" in resp.text
+
+
+class TestCycleAggregation:
+    def test_cycle_aggregates_cost(
+        self, client: TestClient, session_ids: dict, projects_dir: Path,
+    ):
+        ceo_id = session_ids["ceo"]
+        resp = client.get(f"/api/projects/proj-a/cycles/{ceo_id}")
+        cycle = resp.json()
+        assert "total_cost" in cycle
+        assert "total_duration" in cycle
+        assert isinstance(cycle["total_cost"], (int, float))
+        assert isinstance(cycle["total_duration"], (int, float))
+
+    def test_cycles_list_has_child_roles(self, client: TestClient, session_ids: dict):
+        resp = client.get("/api/projects/proj-a/cycles")
+        cycles = resp.json()
+        ceo_cycle = next(c for c in cycles if c["id"] == session_ids["ceo"])
+        child_roles = ceo_cycle.get("child_roles", "")
+        assert "researcher" in child_roles
+        assert "builder" in child_roles

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1,0 +1,195 @@
+"""Tests for the cycle graph API endpoint."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from factory.dashboard.app import create_app
+from factory.sessions import begin_session, complete_session, init_db
+
+
+@pytest.fixture()
+def graph_project(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    """Create a project with a realistic cycle: CEO + 3 children + events."""
+    proj = tmp_path / "proj-graph"
+    factory = proj / ".factory"
+    factory.mkdir(parents=True)
+    (factory / "config.json").write_text(json.dumps({"goal": "Test graph"}))
+
+    init_db(proj)
+
+    ceo_id = begin_session(proj, "ceo", title="Improve cycle")
+    researcher_id = begin_session(
+        proj, "researcher", parent_id=ceo_id, title="Investigate codebase",
+    )
+    strategist_id = begin_session(
+        proj, "strategist", parent_id=ceo_id, title="Plan improvements",
+    )
+    builder_id = begin_session(
+        proj, "builder", parent_id=ceo_id, title="Build feature",
+    )
+
+    complete_session(proj, researcher_id, status="completed", output="Found 5 issues")
+    complete_session(proj, strategist_id, status="completed", output="Strategy ready")
+    complete_session(proj, builder_id, status="failed", output="Build error")
+    complete_session(proj, ceo_id, status="completed", output="Cycle done")
+
+    events = [
+        {"type": "phase.started", "timestamp": "2025-01-01T00:00:00+00:00",
+         "project": "proj-graph", "agent": "ceo", "data": {"phase": "Research"}},
+        {"type": "phase.completed", "timestamp": "2025-01-01T00:05:00+00:00",
+         "project": "proj-graph", "agent": "ceo", "data": {"phase": "Research"}},
+        {"type": "agent.started", "timestamp": "2025-01-01T00:00:10+00:00",
+         "project": "proj-graph", "agent": "researcher", "data": {}},
+        {"type": "agent.completed", "timestamp": "2025-01-01T00:04:00+00:00",
+         "project": "proj-graph", "agent": "researcher", "data": {"total_cost_usd": 0.10}},
+    ]
+    events_file = factory / "events.jsonl"
+    events_file.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+    ids = {
+        "ceo": ceo_id,
+        "researcher": researcher_id,
+        "strategist": strategist_id,
+        "builder": builder_id,
+    }
+    return tmp_path, ids
+
+
+@pytest.fixture()
+def graph_client(graph_project: tuple[Path, dict]) -> TestClient:
+    projects_dir, _ = graph_project
+    return TestClient(create_app(projects_dir))
+
+
+@pytest.fixture()
+def graph_ids(graph_project: tuple[Path, dict]) -> dict[str, str]:
+    _, ids = graph_project
+    return ids
+
+
+class TestGraphEndpoint:
+    def test_graph_returns_correct_node_count(
+        self, graph_client: TestClient, graph_ids: dict,
+    ):
+        resp = graph_client.get(
+            f"/api/projects/proj-graph/cycles/{graph_ids['ceo']}/graph"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["nodes"]) == 4
+
+    def test_graph_has_spawned_edges(
+        self, graph_client: TestClient, graph_ids: dict,
+    ):
+        resp = graph_client.get(
+            f"/api/projects/proj-graph/cycles/{graph_ids['ceo']}/graph"
+        )
+        data = resp.json()
+        spawned = [e for e in data["edges"] if e["data"]["type"] == "spawned"]
+        assert len(spawned) == 3
+        sources = {e["data"]["source"] for e in spawned}
+        assert sources == {graph_ids["ceo"]}
+        targets = {e["data"]["target"] for e in spawned}
+        assert targets == {
+            graph_ids["researcher"],
+            graph_ids["strategist"],
+            graph_ids["builder"],
+        }
+
+    def test_graph_has_sequential_edges(
+        self, graph_client: TestClient, graph_ids: dict,
+    ):
+        resp = graph_client.get(
+            f"/api/projects/proj-graph/cycles/{graph_ids['ceo']}/graph"
+        )
+        data = resp.json()
+        sequential = [e for e in data["edges"] if e["data"]["type"] == "sequential"]
+        assert len(sequential) == 2
+
+    def test_graph_has_timeline(
+        self, graph_client: TestClient, graph_ids: dict,
+    ):
+        resp = graph_client.get(
+            f"/api/projects/proj-graph/cycles/{graph_ids['ceo']}/graph"
+        )
+        data = resp.json()
+        tl = data["timeline"]
+        assert "start" in tl
+        assert "end" in tl
+        assert tl["start"] > 0
+        assert tl["end"] >= tl["start"]
+
+    def test_graph_node_has_expected_fields(
+        self, graph_client: TestClient, graph_ids: dict,
+    ):
+        resp = graph_client.get(
+            f"/api/projects/proj-graph/cycles/{graph_ids['ceo']}/graph"
+        )
+        data = resp.json()
+        node_data = data["nodes"][0]["data"]
+        for field in ["id", "role", "status", "label", "duration_ms",
+                      "total_cost_usd", "start_time", "end_time", "type"]:
+            assert field in node_data, f"Missing field: {field}"
+
+    def test_unknown_role_produces_valid_node(
+        self, graph_project: tuple[Path, dict], graph_client: TestClient,
+    ):
+        projects_dir, ids = graph_project
+        proj = projects_dir / "proj-graph"
+        custom_id = begin_session(
+            proj, "my_custom_agent_v2", parent_id=ids["ceo"],
+            title="Custom task",
+        )
+        complete_session(proj, custom_id, status="completed", output="Done")
+
+        resp = graph_client.get(
+            f"/api/projects/proj-graph/cycles/{ids['ceo']}/graph"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["nodes"]) == 5
+        custom_nodes = [
+            n for n in data["nodes"] if n["data"]["role"] == "my_custom_agent_v2"
+        ]
+        assert len(custom_nodes) == 1
+        assert custom_nodes[0]["data"]["label"] == "my_custom_agent_v2"
+
+    def test_graph_not_found(self, graph_client: TestClient):
+        resp = graph_client.get(
+            "/api/projects/proj-graph/cycles/nonexistent/graph"
+        )
+        assert resp.status_code == 404
+
+    def test_empty_cycle_returns_minimal_graph(
+        self, graph_project: tuple[Path, dict],
+        graph_client: TestClient,
+    ):
+        projects_dir, _ = graph_project
+        proj = projects_dir / "proj-graph"
+        solo_id = begin_session(proj, "ceo", title="Solo cycle")
+        complete_session(proj, solo_id, status="completed", output="Nothing")
+
+        resp = graph_client.get(
+            f"/api/projects/proj-graph/cycles/{solo_id}/graph"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["nodes"]) == 1
+        assert len(data["edges"]) == 0
+
+    def test_failed_child_status_in_graph(
+        self, graph_client: TestClient, graph_ids: dict,
+    ):
+        resp = graph_client.get(
+            f"/api/projects/proj-graph/cycles/{graph_ids['ceo']}/graph"
+        )
+        data = resp.json()
+        builder_node = next(
+            n for n in data["nodes"] if n["data"]["id"] == graph_ids["builder"]
+        )
+        assert builder_node["data"]["status"] == "failed"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from factory.sessions import (
+    _discover_claude_session_id,
     _find_transcript,
     _ingest_transcript,
     backfill_transcripts,
@@ -524,3 +525,46 @@ def test_complete_session_preserves_existing_claude_session_id(tmp_path: Path) -
 
     session = get_session(tmp_path, sid)
     assert session["claude_session_id"] == "original-id"
+
+
+def test_discover_claude_session_id_ceo_with_mixed_transcripts(tmp_path: Path) -> None:
+    """CEO fallback finds the CEO transcript even when child agent transcripts exist.
+
+    Regression test: child agents have custom-titles like 'factory: project/role'
+    (with a '/') while CEO sessions have titles like 'factory: i want build snake game'
+    (no '/'). Both contain 'factory: ' but only child patterns should be excluded.
+    """
+    import json
+    import time
+    from unittest.mock import patch
+
+    project_resolved = str(tmp_path.resolve())
+    dir_name = project_resolved.replace("/", "-").replace(".", "-")
+    claude_dir = tmp_path / "mock_home" / ".claude" / "projects" / dir_name
+    claude_dir.mkdir(parents=True)
+
+    project_name = tmp_path.resolve().name
+    created_at = int(time.time()) - 10
+
+    # Child agent transcript — has 'factory: project/role' pattern (with '/')
+    child_transcript = claude_dir / "child-session-abc.jsonl"
+    child_lines = [
+        json.dumps({"type": "agent-name", "agentName": f"factory: {project_name}/researcher"}),
+        json.dumps({"type": "user", "message": {"content": [{"type": "text", "text": "research"}]}}),
+    ]
+    child_transcript.write_text("\n".join(child_lines) + "\n")
+
+    # CEO transcript — has 'factory: <prompt>' pattern (no '/')
+    ceo_transcript = claude_dir / "ceo-session-xyz.jsonl"
+    ceo_lines = [
+        json.dumps({"type": "custom-title", "customTitle": "factory: i want build snake game"}),
+        json.dumps({"type": "user", "message": {"content": [{"type": "text", "text": "build it"}]}}),
+    ]
+    ceo_transcript.write_text("\n".join(ceo_lines) + "\n")
+
+    with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
+        result = _discover_claude_session_id("ceo", created_at, tmp_path)
+
+    # The CEO transcript should be found via the fallback path,
+    # NOT excluded as a child agent
+    assert result == "ceo-session-xyz"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -470,3 +470,57 @@ def test_find_transcript_no_claude_dir(tmp_path: Path) -> None:
     with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
         result = _find_transcript("session", tmp_path)
     assert result is None
+
+
+def test_complete_session_discovers_claude_session_id(tmp_path: Path) -> None:
+    """complete_session discovers claude_session_id when not provided (CEO case)."""
+    import json
+    import time
+    from unittest.mock import patch
+
+    sid = begin_session(tmp_path, "ceo")
+
+    # Verify session starts with no claude_session_id
+    session = get_session(tmp_path, sid)
+    assert session["claude_session_id"] is None
+
+    # Create a transcript file that _discover_claude_session_id will find
+    project_resolved = str(tmp_path.resolve())
+    dir_name = project_resolved.replace("/", "-").replace(".", "-")
+    claude_dir = tmp_path / "mock_home" / ".claude" / "projects" / dir_name
+    claude_dir.mkdir(parents=True)
+
+    claude_sid = "discovered-ceo-session"
+    transcript = claude_dir / f"{claude_sid}.jsonl"
+    lines = [
+        json.dumps({"type": "system", "data": "init"}),
+        json.dumps({
+            "type": "user",
+            "message": {"content": [{"type": "text", "text": "Start CEO"}]},
+        }),
+        json.dumps({
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "On it."}]},
+        }),
+    ]
+    transcript.write_text("\n".join(lines) + "\n")
+    # Ensure mtime is recent enough
+    transcript.touch()
+
+    with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
+        complete_session(tmp_path, sid, status="completed")
+
+    session = get_session(tmp_path, sid)
+    assert session["claude_session_id"] == claude_sid
+    assert len(session["items"]) == 2  # user + assistant from transcript
+
+
+def test_complete_session_preserves_existing_claude_session_id(tmp_path: Path) -> None:
+    """complete_session does not overwrite an existing claude_session_id with NULL."""
+    sid = begin_session(tmp_path, "builder", claude_session_id="original-id")
+
+    # Complete without providing session_id in metadata
+    complete_session(tmp_path, sid, status="completed")
+
+    session = get_session(tmp_path, sid)
+    assert session["claude_session_id"] == "original-id"

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,472 @@
+"""Tests for factory.sessions — SQLite session persistence layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from factory.sessions import (
+    _find_transcript,
+    _ingest_transcript,
+    backfill_transcripts,
+    begin_session,
+    complete_session,
+    get_children,
+    get_cycle,
+    get_cycles,
+    get_session,
+    get_sessions,
+    init_db,
+)
+
+
+def test_init_db_creates_tables(tmp_path: Path) -> None:
+    db_path = init_db(tmp_path)
+    assert db_path.exists()
+    assert db_path.name == "sessions.db"
+
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()}
+    conn.close()
+    assert "sessions" in tables
+    assert "session_items" in tables
+
+
+def test_init_db_idempotent(tmp_path: Path) -> None:
+    init_db(tmp_path)
+    init_db(tmp_path)
+    assert (tmp_path / ".factory" / "sessions.db").exists()
+
+
+def test_begin_session_returns_prefixed_id(tmp_path: Path) -> None:
+    sid = begin_session(tmp_path, "builder")
+    assert sid.startswith("sess_")
+    assert len(sid) == 13  # "sess_" + 8 hex chars
+
+
+def test_begin_complete_roundtrip(tmp_path: Path) -> None:
+    sid = begin_session(tmp_path, "researcher", title="Test session")
+
+    from factory.models import AgentUsage
+
+    usage = AgentUsage(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_tokens=10,
+        total_cost_usd=0.05,
+        duration_ms=1234.5,
+        num_turns=3,
+        model="claude-sonnet-4-6",
+    )
+    metadata = {
+        "session_id": "abc123",
+        "stop_reason": "end_turn",
+        "terminal_reason": "end_turn",
+    }
+    complete_session(
+        tmp_path, sid,
+        usage=usage, metadata=metadata, output="I completed the task.",
+    )
+
+    session = get_session(tmp_path, sid)
+    assert session is not None
+    assert session["id"] == sid
+    assert session["agent_role"] == "researcher"
+    assert session["status"] == "completed"
+    assert session["input_tokens"] == 100
+    assert session["output_tokens"] == 50
+    assert session["cache_read_tokens"] == 10
+    assert session["total_cost_usd"] == 0.05
+    assert session["duration_ms"] == 1234.5
+    assert session["num_turns"] == 3
+    assert session["model"] == "claude-sonnet-4-6"
+    assert session["stop_reason"] == "end_turn"
+    assert session["claude_session_id"] == "abc123"
+    assert session["title"] == "Test session"
+    assert len(session["items"]) == 1
+    assert session["items"][0]["data"] == "I completed the task."
+    assert session["items"][0]["type"] == "message"
+
+
+def test_hierarchical_parent_child(tmp_path: Path) -> None:
+    parent_id = begin_session(tmp_path, "ceo")
+    child1 = begin_session(tmp_path, "researcher", parent_id=parent_id)
+    begin_session(tmp_path, "builder", parent_id=parent_id)
+
+    parent = get_session(tmp_path, parent_id)
+    assert parent is not None
+    assert parent["kind"] == "default"
+    assert parent["root_id"] == parent_id
+
+    c1 = get_session(tmp_path, child1)
+    assert c1 is not None
+    assert c1["kind"] == "sub_agent"
+    assert c1["parent_id"] == parent_id
+    assert c1["root_id"] == parent_id  # inherits root_id from parent
+
+    children = get_children(tmp_path, parent_id)
+    assert len(children) == 2
+    roles = {c["agent_role"] for c in children}
+    assert roles == {"researcher", "builder"}
+
+
+def test_hierarchical_with_root_id(tmp_path: Path) -> None:
+    root = begin_session(tmp_path, "ceo")
+    child = begin_session(tmp_path, "builder", parent_id=root, root_id=root)
+
+    session = get_session(tmp_path, child)
+    assert session is not None
+    assert session["root_id"] == root
+    assert session["parent_id"] == root
+
+
+def test_get_sessions_filter_by_role(tmp_path: Path) -> None:
+    begin_session(tmp_path, "builder")
+    begin_session(tmp_path, "researcher")
+    begin_session(tmp_path, "builder")
+
+    builders = get_sessions(tmp_path, role="builder")
+    assert len(builders) == 2
+    assert all(s["agent_role"] == "builder" for s in builders)
+
+
+def test_get_sessions_filter_by_cycle(tmp_path: Path) -> None:
+    root1 = begin_session(tmp_path, "ceo")
+    begin_session(tmp_path, "builder", parent_id=root1, root_id=root1)
+
+    root2 = begin_session(tmp_path, "ceo")
+    begin_session(tmp_path, "researcher", parent_id=root2, root_id=root2)
+
+    cycle1 = get_sessions(tmp_path, cycle_id=root1)
+    assert len(cycle1) == 2
+    assert all(s["root_id"] == root1 for s in cycle1)
+
+
+def test_get_session_not_found(tmp_path: Path) -> None:
+    init_db(tmp_path)
+    result = get_session(tmp_path, "sess_nonexist")
+    assert result is None
+
+
+def test_get_sessions_no_db(tmp_path: Path) -> None:
+    result = get_sessions(tmp_path)
+    assert result == []
+
+
+def test_get_children_no_db(tmp_path: Path) -> None:
+    result = get_children(tmp_path, "sess_nonexist")
+    assert result == []
+
+
+def test_complete_session_failed_status(tmp_path: Path) -> None:
+    sid = begin_session(tmp_path, "builder")
+    complete_session(tmp_path, sid, status="failed")
+
+    session = get_session(tmp_path, sid)
+    assert session is not None
+    assert session["status"] == "failed"
+
+
+def test_complete_session_without_output(tmp_path: Path) -> None:
+    sid = begin_session(tmp_path, "evaluator")
+    complete_session(tmp_path, sid)
+
+    session = get_session(tmp_path, sid)
+    assert session is not None
+    assert session["status"] == "completed"
+    assert session["items"] == []
+
+
+def test_root_id_inherited_from_grandparent(tmp_path: Path) -> None:
+    """root_id propagates through multi-level hierarchies."""
+    root = begin_session(tmp_path, "ceo")
+    child = begin_session(tmp_path, "researcher", parent_id=root)
+    grandchild = begin_session(tmp_path, "builder", parent_id=child)
+
+    gc = get_session(tmp_path, grandchild)
+    assert gc is not None
+    assert gc["root_id"] == root
+
+
+def test_ingest_transcript(tmp_path: Path) -> None:
+    """_ingest_transcript parses a JSONL transcript into individual items."""
+    import json
+
+    init_db(tmp_path)
+    sid = begin_session(tmp_path, "builder")
+
+    # Create a mock Claude Code transcript directory
+    project_resolved = str(tmp_path.resolve())
+    dir_name = project_resolved.replace("/", "-")
+    claude_dir = tmp_path / "mock_home" / ".claude" / "projects" / dir_name
+    claude_dir.mkdir(parents=True)
+
+    claude_session_id = "test-session-abc"
+    transcript = claude_dir / f"{claude_session_id}.jsonl"
+    lines = [
+        json.dumps({
+            "type": "user",
+            "message": {"content": [{"type": "text", "text": "Fix the bug"}]},
+        }),
+        json.dumps({
+            "type": "assistant",
+            "message": {"content": [
+                {"type": "thinking", "thinking": "Let me analyze this"},
+                {"type": "text", "text": "I'll fix it now"},
+                {"type": "tool_use", "name": "Edit", "input": {"file": "a.py", "old": "x", "new": "y"}},
+            ]},
+        }),
+        json.dumps({
+            "type": "tool_result",
+            "content": [{"type": "text", "text": "File edited successfully"}],
+        }),
+        json.dumps({
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "Done!"}]},
+        }),
+    ]
+    transcript.write_text("\n".join(lines) + "\n")
+
+    # Patch Path.home() to use our mock directory
+    from unittest.mock import patch
+
+    with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
+        from factory.sessions import _connect
+
+        conn = _connect(tmp_path)
+        try:
+            result = _ingest_transcript(conn, sid, claude_session_id, tmp_path)
+            conn.commit()
+        finally:
+            conn.close()
+
+    assert result is True
+
+    session = get_session(tmp_path, sid)
+    assert session is not None
+    items = session["items"]
+    assert len(items) == 6
+
+    assert items[0]["type"] == "message"
+    assert items[0]["role"] == "user"
+    assert "Fix the bug" in items[0]["data"]
+
+    assert items[1]["type"] == "thinking"
+    assert items[1]["role"] == "assistant"
+
+    assert items[2]["type"] == "message"
+    assert items[2]["role"] == "assistant"
+    assert "fix it now" in items[2]["data"]
+
+    assert items[3]["type"] == "tool_call"
+    assert items[3]["role"] == "assistant"
+    assert "Edit" in items[3]["data"]
+
+    assert items[4]["type"] == "tool_output"
+    assert items[4]["role"] == "tool"
+    assert "File edited" in items[4]["data"]
+
+    assert items[5]["type"] == "message"
+    assert items[5]["role"] == "assistant"
+    assert "Done!" in items[5]["data"]
+
+
+def test_backfill_transcripts(tmp_path: Path) -> None:
+    """backfill_transcripts re-ingests sessions with only 1 blob item."""
+    import json
+    from unittest.mock import patch
+
+    sid = begin_session(tmp_path, "builder")
+    claude_session_id = "backfill-test-123"
+
+    complete_session(
+        tmp_path, sid,
+        metadata={"session_id": claude_session_id},
+        output="Old blob output",
+    )
+
+    # Verify old blob is there
+    session = get_session(tmp_path, sid)
+    assert len(session["items"]) == 1
+    assert session["items"][0]["data"] == "Old blob output"
+
+    # Create transcript for backfill
+    project_resolved = str(tmp_path.resolve())
+    dir_name = project_resolved.replace("/", "-")
+    claude_dir = tmp_path / "mock_home" / ".claude" / "projects" / dir_name
+    claude_dir.mkdir(parents=True)
+
+    transcript = claude_dir / f"{claude_session_id}.jsonl"
+    lines = [
+        json.dumps({
+            "type": "user",
+            "message": {"content": [{"type": "text", "text": "Do something"}]},
+        }),
+        json.dumps({
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "Done."}]},
+        }),
+    ]
+    transcript.write_text("\n".join(lines) + "\n")
+
+    with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
+        count = backfill_transcripts(tmp_path)
+
+    assert count == 1
+    session = get_session(tmp_path, sid)
+    assert len(session["items"]) == 2
+    assert session["items"][0]["role"] == "user"
+    assert session["items"][1]["role"] == "assistant"
+
+
+def test_model_preserved_from_begin(tmp_path: Path) -> None:
+    sid = begin_session(tmp_path, "builder", model="claude-opus-4-6")
+    complete_session(tmp_path, sid)
+
+    session = get_session(tmp_path, sid)
+    assert session is not None
+    assert session["model"] == "claude-opus-4-6"
+
+
+# ── get_cycles / get_cycle tests ──
+
+
+def test_get_cycles_returns_only_roots(tmp_path: Path) -> None:
+    root1 = begin_session(tmp_path, "ceo", title="cycle-1")
+    begin_session(tmp_path, "builder", parent_id=root1, root_id=root1)
+    begin_session(tmp_path, "researcher", parent_id=root1, root_id=root1)
+
+    root2 = begin_session(tmp_path, "ceo", title="cycle-2")
+    begin_session(tmp_path, "reviewer", parent_id=root2, root_id=root2)
+
+    cycles = get_cycles(tmp_path)
+    assert len(cycles) == 2
+    assert all(c["kind"] == "default" for c in cycles)
+    assert all(c["parent_id"] is None for c in cycles)
+
+
+def test_get_cycles_with_aggregated_stats(tmp_path: Path) -> None:
+    from factory.models import AgentUsage
+
+    root = begin_session(tmp_path, "ceo", title="test-cycle")
+    child1 = begin_session(tmp_path, "builder", parent_id=root, root_id=root)
+    child2 = begin_session(tmp_path, "researcher", parent_id=root, root_id=root)
+
+    usage1 = AgentUsage(input_tokens=100, output_tokens=50, total_cost_usd=0.05, duration_ms=1000.0)
+    usage2 = AgentUsage(input_tokens=200, output_tokens=100, total_cost_usd=0.10, duration_ms=2000.0)
+    complete_session(tmp_path, child1, usage=usage1)
+    complete_session(tmp_path, child2, usage=usage2)
+
+    cycles = get_cycles(tmp_path)
+    assert len(cycles) == 1
+    cycle = cycles[0]
+    assert cycle["child_count"] == 2
+    assert set(cycle["child_roles"].split(",")) == {"builder", "researcher"}
+    assert cycle["total_cost"] >= 0.15
+
+
+def test_get_cycles_ordered_by_created_at_desc(tmp_path: Path) -> None:
+    """Cycles are returned most-recent first. We manipulate created_at directly
+    since int(time.time()) has 1-second resolution."""
+    import sqlite3
+
+    root1 = begin_session(tmp_path, "ceo", title="first")
+    root2 = begin_session(tmp_path, "ceo", title="second")
+
+    db = tmp_path / ".factory" / "sessions.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("UPDATE sessions SET created_at = 1000 WHERE id = ?", (root1,))
+    conn.execute("UPDATE sessions SET created_at = 2000 WHERE id = ?", (root2,))
+    conn.commit()
+    conn.close()
+
+    cycles = get_cycles(tmp_path)
+    assert len(cycles) == 2
+    assert cycles[0]["title"] == "second"
+    assert cycles[1]["title"] == "first"
+
+
+def test_get_cycles_empty_db(tmp_path: Path) -> None:
+    assert get_cycles(tmp_path) == []
+
+
+def test_get_cycles_no_db(tmp_path: Path) -> None:
+    assert get_cycles(tmp_path) == []
+
+
+def test_get_cycle_with_children(tmp_path: Path) -> None:
+    root = begin_session(tmp_path, "ceo", title="full-cycle")
+    begin_session(tmp_path, "builder", parent_id=root, root_id=root)
+    begin_session(tmp_path, "reviewer", parent_id=root, root_id=root)
+
+    cycle = get_cycle(tmp_path, root)
+    assert cycle is not None
+    assert cycle["id"] == root
+    assert cycle["title"] == "full-cycle"
+    assert len(cycle["children"]) == 2
+    child_roles = {c["agent_role"] for c in cycle["children"]}
+    assert child_roles == {"builder", "reviewer"}
+    assert "total_cost" in cycle
+    assert "total_duration" in cycle
+
+
+def test_get_cycle_not_found(tmp_path: Path) -> None:
+    init_db(tmp_path)
+    assert get_cycle(tmp_path, "sess_nonexist") is None
+
+
+def test_get_cycle_no_db(tmp_path: Path) -> None:
+    assert get_cycle(tmp_path, "sess_nonexist") is None
+
+
+# ── _find_transcript tests ──
+
+
+def test_find_transcript_direct_path(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    project_str = str(tmp_path.resolve())
+    dir_name = project_str.replace("/", "-").replace(".", "-")
+    claude_dir = tmp_path / "mock_home" / ".claude" / "projects" / dir_name
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "test-session.jsonl").write_text("{}\n")
+
+    with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
+        result = _find_transcript("test-session", tmp_path)
+    assert result is not None
+    assert result.name == "test-session.jsonl"
+
+
+def test_find_transcript_fallback_scan(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    other_dir = tmp_path / "mock_home" / ".claude" / "projects" / "some-other-project"
+    other_dir.mkdir(parents=True)
+    (other_dir / "session-xyz.jsonl").write_text("{}\n")
+
+    with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
+        result = _find_transcript("session-xyz", tmp_path)
+    assert result is not None
+    assert result.name == "session-xyz.jsonl"
+
+
+def test_find_transcript_not_found(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    claude_dir = tmp_path / "mock_home" / ".claude" / "projects"
+    claude_dir.mkdir(parents=True)
+
+    with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
+        result = _find_transcript("nonexistent", tmp_path)
+    assert result is None
+
+
+def test_find_transcript_no_claude_dir(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    with patch("factory.sessions.Path.home", return_value=tmp_path / "mock_home"):
+        result = _find_transcript("session", tmp_path)
+    assert result is None


### PR DESCRIPTION
## Summary

Implements #642 — a persistent agent session management UI with graphical orchestration visualization for the factory dashboard.

- **SQLite session persistence** (`factory/sessions.py`) — captures every agent invocation in a local `sessions.db` with hierarchical parent→child linking, alongside existing Langfuse telemetry (additive, not replacing)
- **Session API endpoints** — 6 new routes in the dashboard: cycles list, cycle detail, session detail, graph data, interactive resume, and sessions page
- **Session browser UI** (`sessions.html`) — two-column layout with cycle list + chat-style conversation viewer, using marked.js for markdown and Prism.js for syntax highlighting
- **Agent orchestration graph** — interactive DAG visualization using Cytoscape.js + dagre layout, showing agent spawning relationships, sequential ordering, role-colored nodes, click-to-navigate, and hover tooltips

### Key design decisions

- **Data-driven, not hardcoded**: role colors are hash-based, graph structure is derived from session hierarchy + event timeline — no mode-specific templates. Adding/removing agent roles (e.g., #630 QA agent) requires zero UI code changes.
- **SQLite, not Langfuse-dependent**: the UI works standalone with zero external dependencies. Session capture runs alongside Langfuse telemetry via the same try/except pattern.
- **Vanilla HTML/JS**: matches the existing dashboard pattern — no React/Vue build step.

### Verified

- 52+ tests across 3 test files (session CRUD, API endpoints, graph API)
- E2E verified with a real snake-game build cycle (CEO → researcher → strategist → builder)
- Interactive session resume preserves agent identity and context
- All conversation item types captured (messages, tool calls, tool outputs, thinking blocks)
- Graph correctly shows 4 nodes, 3 spawned edges, 2 sequential edges

## Test plan

```bash
uv run pytest tests/test_sessions.py tests/test_dashboard_sessions.py tests/test_graph_api.py -v
```

Manual E2E:
```bash
# Start dashboard
uv run factory dashboard --port 8420 --projects-dir /path/to/projects

# Open http://localhost:8420/sessions/<project-name>
# - Left panel: cycle list with role badges and cost stats
# - Right panel: click a cycle → conversation viewer with collapsible tool calls
# - Toggle to Graph view → interactive DAG with click-to-navigate
```

Closes #642, closes #643, closes #645, closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)