### PR TITLE
feat: benchmark data branch storage and dashboard charts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -217,6 +217,65 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Checkout benchmark-data branch
+        id: checkout-data
+        uses: actions/checkout@v4
+        with:
+          ref: benchmark-data
+          path: benchmark-data
+          token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Create benchmark-data branch if needed
+        if: steps.checkout-data.outcome == 'failure'
+        run: |
+          mkdir -p benchmark-data
+          cd benchmark-data
+          git init
+          git remote add origin "https://github.com/${{ github.repository }}.git"
+          git checkout -b benchmark-data
+          touch results.jsonl
+          git add results.jsonl
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m 'Initialize benchmark data branch'
+
+      - name: Append results to history
+        run: |
+          cat > /tmp/append_results.py << 'PYEOF'
+          import json, sys, os, glob
+
+          results_dir = 'results'
+          output = 'benchmark-data/results.jsonl'
+
+          if not os.path.isdir(results_dir):
+              sys.exit(0)
+
+          for f in sorted(glob.glob(os.path.join(results_dir, '*.json'))):
+              with open(f) as fh:
+                  data = json.load(fh)
+              data['run_id'] = os.environ.get('RUN_ID', '')
+              data['commit'] = os.environ.get('COMMIT', '')
+              data['ref'] = os.environ.get('REF', '')
+              data['run_url'] = os.environ.get('RUN_URL', '')
+              with open(output, 'a') as out:
+                  out.write(json.dumps(data) + '\n')
+          PYEOF
+          RUN_ID="${{ github.run_id }}" \
+          COMMIT="${{ github.sha }}" \
+          REF="${{ github.ref }}" \
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          python3 /tmp/append_results.py
+
+      - name: Push benchmark data
+        run: |
+          cd benchmark-data
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add results.jsonl
+          git diff --cached --quiet || git commit -m "benchmark: add results from run ${{ github.run_id }} [skip ci]"
+          git push origin benchmark-data || (git pull --rebase origin benchmark-data && git push origin benchmark-data)
+
       - name: Post PR comment
         if: github.event_name == 'pull_request' || inputs.pr_number != ''
         uses: actions/github-script@v7
@@ -260,7 +319,7 @@ jobs:
               body += '_No benchmark results found._\n';
             }
 
-            const historyPath = 'benchmarks/history.jsonl';
+            const historyPath = 'benchmark-data/results.jsonl';
             let baselines = {};
             if (fs.existsSync(historyPath)) {
               const lines = fs.readFileSync(historyPath, 'utf8').trim().split('\n').filter(Boolean);

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -39,94 +39,356 @@
   color: var(--md-default-fg-color--light);
   font-style: italic;
 }
+#benchmark-dashboard .section-title {
+  margin-top: 2rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+#benchmark-dashboard .chart-container {
+  position: relative;
+  margin: 1rem 0 2rem 0;
+  max-height: 350px;
+}
+#benchmark-dashboard .charts-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin: 1rem 0;
+}
+@media (max-width: 768px) {
+  #benchmark-dashboard .charts-row {
+    grid-template-columns: 1fr;
+  }
+}
 </style>
 
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
 <script>
 const REPO = 'akashgit/remote-factory';
+const JSONL_URL = `https://raw.githubusercontent.com/${REPO}/benchmark-data/results.jsonl`;
 const WORKFLOW = 'benchmark.yml';
 const API = 'https://api.github.com';
 
-async function apiFetch(url) {
-  const resp = await fetch(url);
-  if (!resp.ok) {
-    if (resp.status === 403) throw new Error('GitHub API rate limit exceeded. Try again later.');
-    throw new Error(`GitHub API error: ${resp.status}`);
-  }
-  return resp.json();
+const CHART_COLORS = [
+  '#4285f4', '#ea4335', '#34a853', '#fbbc04',
+  '#8e24aa', '#00acc1', '#ff7043', '#9ccc65'
+];
+
+function isDarkMode() {
+  return document.body.getAttribute('data-md-color-scheme') === 'slate';
 }
 
-function statusIcon(conclusion) {
-  if (conclusion === 'success') return '<span class="status-success">✅ pass</span>';
-  if (conclusion === 'failure') return '<span class="status-failure">❌ fail</span>';
-  if (conclusion === 'cancelled') return '<span class="status-pending">⏭ cancelled</span>';
-  if (!conclusion) return '<span class="status-pending">⏳ running</span>';
-  return '<span class="status-pending">' + conclusion + '</span>';
+function chartColors() {
+  const dark = isDarkMode();
+  return {
+    text: dark ? '#ccc' : '#333',
+    grid: dark ? '#444' : '#e0e0e0',
+    bg: dark ? '#1e1e1e' : '#fff',
+  };
 }
 
-function formatDate(iso) {
+function formatDurationShort(seconds) {
+  if (seconds == null) return '—';
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return m > 0 ? m + 'm ' + s + 's' : s + 's';
+}
+
+function formatCost(usd) {
+  if (usd == null) return '—';
+  return '$' + usd.toFixed(2);
+}
+
+function formatDate(ts) {
+  if (!ts) return '—';
+  const iso = ts.replace(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/,
+    '$1-$2-$3T$4:$5:$6Z'
+  );
   const d = new Date(iso);
+  if (isNaN(d)) return ts;
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
     + ' ' + d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
 }
 
-function formatDuration(startedAt, completedAt) {
-  if (!startedAt || !completedAt) return '—';
-  const ms = new Date(completedAt) - new Date(startedAt);
-  const mins = Math.floor(ms / 60000);
-  const secs = Math.floor((ms % 60000) / 1000);
-  if (mins > 0) return mins + 'm ' + secs + 's';
-  return secs + 's';
+function parseTimestamp(ts) {
+  if (!ts) return null;
+  const iso = ts.replace(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/,
+    '$1-$2-$3T$4:$5:$6Z'
+  );
+  const d = new Date(iso);
+  return isNaN(d) ? null : d;
+}
+
+function statusIcon(resolved) {
+  return resolved
+    ? '<span class="status-success">PASS</span>'
+    : '<span class="status-failure">FAIL</span>';
+}
+
+async function fetchJsonl() {
+  const resp = await fetch(JSONL_URL);
+  if (!resp.ok) return null;
+  const text = await resp.text();
+  const lines = text.trim().split('\n').filter(Boolean);
+  return lines.map(l => {
+    try { return JSON.parse(l); }
+    catch { return null; }
+  }).filter(Boolean);
+}
+
+async function fetchFromApi() {
+  const resp = await fetch(
+    `${API}/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?per_page=20&status=completed`
+  );
+  if (!resp.ok) return null;
+  const data = await resp.json();
+  return data.workflow_runs || [];
+}
+
+function renderLatestTable(results) {
+  const byKey = {};
+  for (const r of results) {
+    const solver = r.details?.solver || r.solver || 'unknown';
+    const key = r.benchmark + '|' + solver;
+    if (!byKey[key] || (r.timestamp > byKey[key].timestamp)) {
+      byKey[key] = r;
+    }
+  }
+
+  const latest = Object.values(byKey).sort((a, b) =>
+    (a.benchmark + (a.details?.solver || '')).localeCompare(b.benchmark + (b.details?.solver || ''))
+  );
+
+  let html = '<div class="section-title">Latest Results</div>';
+  html += '<table><thead><tr>';
+  html += '<th>Benchmark</th><th>Solver</th><th>Result</th><th>Score</th>';
+  html += '<th>Duration</th><th>Cost</th><th>Commit</th><th>Run</th>';
+  html += '</tr></thead><tbody>';
+
+  for (const r of latest) {
+    const solver = r.details?.solver || r.solver || 'unknown';
+    const commit = r.commit ? r.commit.substring(0, 7) : '—';
+    const commitLink = r.commit
+      ? `<a href="https://github.com/${REPO}/commit/${r.commit}"><code>${commit}</code></a>`
+      : commit;
+    const runLink = r.run_url
+      ? `<a href="${r.run_url}">details →</a>`
+      : '—';
+    const cost = r.details?.cost_usd;
+
+    html += '<tr>';
+    html += `<td>${r.benchmark}</td>`;
+    html += `<td>${solver}</td>`;
+    html += `<td>${statusIcon(r.resolved)}</td>`;
+    html += `<td>${r.score}</td>`;
+    html += `<td>${formatDurationShort(r.duration_seconds)}</td>`;
+    html += `<td>${formatCost(cost)}</td>`;
+    html += `<td>${commitLink}</td>`;
+    html += `<td>${runLink}</td>`;
+    html += '</tr>';
+  }
+
+  html += '</tbody></table>';
+  return html;
+}
+
+function renderCharts(results) {
+  const sorted = [...results].sort((a, b) =>
+    (a.timestamp || '').localeCompare(b.timestamp || '')
+  );
+
+  const series = {};
+  for (const r of sorted) {
+    const solver = r.details?.solver || r.solver || 'unknown';
+    const key = r.benchmark + ' / ' + solver;
+    if (!series[key]) series[key] = [];
+    const date = parseTimestamp(r.timestamp);
+    if (date) {
+      series[key].push({
+        x: date,
+        duration: r.duration_seconds,
+        cost: r.details?.cost_usd,
+        score: r.score,
+      });
+    }
+  }
+
+  const keys = Object.keys(series).sort();
+  const colors = chartColors();
+
+  let html = '<div class="charts-row">';
+  html += '<div class="chart-container"><canvas id="duration-chart"></canvas></div>';
+  html += '<div class="chart-container"><canvas id="cost-chart"></canvas></div>';
+  html += '</div>';
+
+  setTimeout(() => {
+    const durCtx = document.getElementById('duration-chart');
+    const costCtx = document.getElementById('cost-chart');
+    if (!durCtx || !costCtx) return;
+
+    const durDatasets = keys.map((k, i) => ({
+      label: k,
+      data: series[k].map(p => ({ x: p.x, y: p.duration != null ? p.duration / 60 : null })),
+      borderColor: CHART_COLORS[i % CHART_COLORS.length],
+      backgroundColor: CHART_COLORS[i % CHART_COLORS.length] + '33',
+      tension: 0.3,
+      pointRadius: 3,
+      spanGaps: true,
+    }));
+
+    const costDatasets = keys.map((k, i) => ({
+      label: k,
+      data: series[k].map(p => ({ x: p.x, y: p.cost })).filter(p => p.y != null),
+      borderColor: CHART_COLORS[i % CHART_COLORS.length],
+      backgroundColor: CHART_COLORS[i % CHART_COLORS.length] + '33',
+      tension: 0.3,
+      pointRadius: 3,
+      spanGaps: true,
+    }));
+
+    const commonOptions = {
+      responsive: true,
+      maintainAspectRatio: true,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        x: {
+          type: 'time',
+          time: { tooltipFormat: 'MMM d, yyyy HH:mm' },
+          ticks: { color: colors.text },
+          grid: { color: colors.grid },
+        },
+        y: {
+          ticks: { color: colors.text },
+          grid: { color: colors.grid },
+        },
+      },
+      plugins: {
+        legend: { labels: { color: colors.text } },
+      },
+    };
+
+    new Chart(durCtx, {
+      type: 'line',
+      data: { datasets: durDatasets },
+      options: {
+        ...commonOptions,
+        plugins: {
+          ...commonOptions.plugins,
+          title: { display: true, text: 'Duration (minutes)', color: colors.text },
+        },
+      },
+    });
+
+    new Chart(costCtx, {
+      type: 'line',
+      data: { datasets: costDatasets },
+      options: {
+        ...commonOptions,
+        plugins: {
+          ...commonOptions.plugins,
+          title: { display: true, text: 'Cost (USD)', color: colors.text },
+        },
+      },
+    });
+  }, 0);
+
+  return html;
+}
+
+function renderHistoryTable(results) {
+  const sorted = [...results].sort((a, b) =>
+    (b.timestamp || '').localeCompare(a.timestamp || '')
+  );
+
+  let html = '<div class="section-title">Full History</div>';
+  html += '<table><thead><tr>';
+  html += '<th>Date</th><th>Benchmark</th><th>Solver</th><th>Result</th>';
+  html += '<th>Score</th><th>Duration</th><th>Cost</th><th>Commit</th><th>Run</th>';
+  html += '</tr></thead><tbody>';
+
+  for (const r of sorted) {
+    const solver = r.details?.solver || r.solver || 'unknown';
+    const commit = r.commit ? r.commit.substring(0, 7) : '—';
+    const commitLink = r.commit
+      ? `<a href="https://github.com/${REPO}/commit/${r.commit}"><code>${commit}</code></a>`
+      : commit;
+    const runLink = r.run_url
+      ? `<a href="${r.run_url}">details →</a>`
+      : '—';
+    const cost = r.details?.cost_usd;
+
+    html += '<tr>';
+    html += `<td style="white-space:nowrap">${formatDate(r.timestamp)}</td>`;
+    html += `<td>${r.benchmark}</td>`;
+    html += `<td>${solver}</td>`;
+    html += `<td>${statusIcon(r.resolved)}</td>`;
+    html += `<td>${r.score}</td>`;
+    html += `<td>${formatDurationShort(r.duration_seconds)}</td>`;
+    html += `<td>${formatCost(cost)}</td>`;
+    html += `<td>${commitLink}</td>`;
+    html += `<td>${runLink}</td>`;
+    html += '</tr>';
+  }
+
+  html += '</tbody></table>';
+  return html;
+}
+
+function renderApiFallback(runs) {
+  let html = '<div class="section-title">Recent Workflow Runs</div>';
+  html += '<p class="error-msg">Benchmark data branch not available yet. Showing workflow run metadata from GitHub API.</p>';
+  html += '<table><thead><tr>';
+  html += '<th>Date</th><th>Commit</th><th>Trigger</th><th>Status</th><th></th>';
+  html += '</tr></thead><tbody>';
+
+  for (const run of runs) {
+    const d = new Date(run.created_at);
+    const date = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+      + ' ' + d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+    const commit = run.head_sha ? run.head_sha.substring(0, 7) : '—';
+    const conclusion = run.conclusion || 'running';
+    const statusClass = conclusion === 'success' ? 'status-success'
+      : conclusion === 'failure' ? 'status-failure' : 'status-pending';
+
+    html += '<tr>';
+    html += `<td>${date}</td>`;
+    html += `<td><a href="https://github.com/${REPO}/commit/${run.head_sha}"><code>${commit}</code></a></td>`;
+    html += `<td>${run.event}</td>`;
+    html += `<td><span class="${statusClass}">${conclusion}</span></td>`;
+    html += `<td><a href="${run.html_url}">details →</a></td>`;
+    html += '</tr>';
+  }
+
+  html += '</tbody></table>';
+  return html;
 }
 
 async function renderDashboard() {
   const container = document.getElementById('benchmark-dashboard');
 
   try {
-    const data = await apiFetch(
-      `${API}/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?per_page=20&status=completed`
-    );
-    const runs = data.workflow_runs || [];
+    const results = await fetchJsonl();
 
-    if (runs.length === 0) {
-      container.innerHTML = '<p class="error-msg">No benchmark runs found.</p>';
+    if (results && results.length > 0) {
+      let html = '';
+      html += renderLatestTable(results);
+      html += renderCharts(results);
+      html += renderHistoryTable(results);
+      container.innerHTML = html;
       return;
     }
 
-    const jobPromises = runs.slice(0, 15).map(run =>
-      apiFetch(`${API}/repos/${REPO}/actions/runs/${run.id}/jobs?per_page=30`)
-        .then(d => ({ run, jobs: d.jobs || [] }))
-    );
-    const entries = await Promise.all(jobPromises);
-
-    let html = '<table><thead><tr>';
-    html += '<th>Date</th><th>Commit</th><th>Trigger</th><th>Benchmarks</th>';
-    html += '<th>Duration</th><th>Status</th><th></th>';
-    html += '</tr></thead><tbody>';
-
-    for (const { run, jobs } of entries) {
-      const benchmarkJobs = jobs.filter(j => j.name.startsWith('benchmark'));
-
-      const benchmarks = benchmarkJobs.map(j => {
-        const match = j.name.match(/benchmark\s*\(([^,]+),\s*([^,]+)/);
-        if (!match) return null;
-        const icon = j.conclusion === 'success' ? '✅' : j.conclusion === 'failure' ? '❌' : '⏳';
-        return `<span class="benchmark-tag">${icon} ${match[1]} (${match[2]})</span>`;
-      }).filter(Boolean).join('<br>');
-
-      html += '<tr>';
-      html += `<td>${formatDate(run.created_at)}</td>`;
-      html += `<td><a href="https://github.com/${REPO}/commit/${run.head_sha}"><code>${run.head_sha.substring(0, 7)}</code></a></td>`;
-      html += `<td>${run.event}</td>`;
-      html += `<td>${benchmarks || '<span class="error-msg">—</span>'}</td>`;
-      html += `<td>${formatDuration(run.run_started_at, run.updated_at)}</td>`;
-      html += `<td>${statusIcon(run.conclusion)}</td>`;
-      html += `<td><a href="${run.html_url}">details →</a></td>`;
-      html += '</tr>';
+    const runs = await fetchFromApi();
+    if (runs && runs.length > 0) {
+      container.innerHTML = renderApiFallback(runs);
+      return;
     }
 
-    html += '</tbody></table>';
-    container.innerHTML = html;
-
+    container.innerHTML = '<p class="error-msg">No benchmark data available yet.</p>';
   } catch (err) {
     container.innerHTML = `<p class="error-msg">${err.message}</p>`;
   }


### PR DESCRIPTION
## Summary

- **Benchmark data storage**: The `report` job now checks out (or creates) a dedicated `benchmark-data` branch and appends each result as a JSONL line to `results.jsonl`. This replaces the broken history commit approach that couldn't push to protected `main`.
- **Dashboard with charts**: Rewrites `docs/benchmarks.md` to fetch `results.jsonl` from `raw.githubusercontent.com`, rendering a latest results table, duration/cost trend charts via Chart.js, and a full history table. Falls back to GitHub API if the data branch doesn't exist yet.
- **Baseline comparison fix**: PR comment baseline comparison now reads from `benchmark-data/results.jsonl` instead of the empty `benchmarks/history.jsonl`.

## Changes

### `.github/workflows/benchmark.yml`
- Add steps to checkout `benchmark-data` branch (with `continue-on-error` and auto-creation if missing)
- Add Python script to append result JSONs with metadata (`run_id`, `commit`, `ref`, `run_url`) to `results.jsonl`
- Add push step with rebase fallback for concurrent write safety
- Update PR comment baseline to read from `benchmark-data/results.jsonl`

### `docs/benchmarks.md`
- Fetch JSONL from `raw.githubusercontent.com/akashgit/remote-factory/benchmark-data/results.jsonl`
- Latest Results table: benchmark, solver, result, score, duration, cost, commit link, run link
- Duration Chart (Chart.js): line chart per benchmark+solver, x=date, y=minutes
- Cost Chart (Chart.js): line chart per benchmark+solver, x=date, y=USD
- Full History table: all results sorted by date descending
- Fallback to GitHub Actions API if `results.jsonl` is not available
- Dark mode support via MkDocs Material theme detection

## Test plan

- [ ] Trigger a benchmark workflow run and verify `benchmark-data` branch is created with `results.jsonl`
- [ ] Verify subsequent runs append to the existing `results.jsonl`
- [ ] Load the dashboard page and verify charts render with data
- [ ] Verify fallback to API table when `benchmark-data` branch doesn't exist
- [ ] Verify dark mode chart styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)