### PR TITLE
fix: benchmark-data branch creation in report job

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -217,28 +217,21 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Checkout benchmark-data branch
-        id: checkout-data
-        uses: actions/checkout@v4
-        with:
-          ref: benchmark-data
-          path: benchmark-data
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create benchmark-data branch if needed
-        if: failure()
+      - name: Setup benchmark-data branch
         run: |
-          rm -rf benchmark-data
-          mkdir benchmark-data && cd benchmark-data
-          git init
-          git checkout -b benchmark-data
-          git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-          touch results.jsonl
-          git add results.jsonl
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git commit -m 'Initialize benchmark data branch'
-          git push -u origin benchmark-data
+          if git ls-remote --exit-code --heads https://github.com/${{ github.repository }}.git benchmark-data >/dev/null 2>&1; then
+            git clone --single-branch --branch benchmark-data https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git benchmark-data
+          else
+            mkdir benchmark-data && cd benchmark-data
+            git init
+            git checkout -b benchmark-data
+            git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+            touch results.jsonl
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git add . && git commit -m 'Initialize benchmark data branch'
+            git push -u origin benchmark-data
+          fi
 
       - name: Append results to history
         if: always()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -224,23 +224,24 @@ jobs:
           ref: benchmark-data
           path: benchmark-data
           token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
 
       - name: Create benchmark-data branch if needed
-        if: steps.checkout-data.outcome == 'failure'
+        if: failure()
         run: |
-          mkdir -p benchmark-data
-          cd benchmark-data
+          rm -rf benchmark-data
+          mkdir benchmark-data && cd benchmark-data
           git init
-          git remote add origin "https://github.com/${{ github.repository }}.git"
           git checkout -b benchmark-data
+          git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           touch results.jsonl
           git add results.jsonl
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git commit -m 'Initialize benchmark data branch'
+          git push -u origin benchmark-data
 
       - name: Append results to history
+        if: always()
         run: |
           cat > /tmp/append_results.py << 'PYEOF'
           import json, sys, os, glob
@@ -268,6 +269,7 @@ jobs:
           python3 /tmp/append_results.py
 
       - name: Push benchmark data
+        if: always()
         run: |
           cd benchmark-data
           git config user.name 'github-actions[bot]'


### PR DESCRIPTION
Closes #649

## Changes

- Replaced the two-step "Checkout benchmark-data branch" + "Create benchmark-data branch if needed" approach with a single "Setup benchmark-data branch" step
- The new step uses `git ls-remote` to check if the branch exists, then either clones it or initializes it from scratch
- Fixes the failure where the checkout action left a remote that conflicted with the fallback's `git remote add origin`