### PR TITLE
debug: diagnostic output for benchmark data append

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -249,9 +249,14 @@ jobs:
           output = 'benchmark-data/results.jsonl'
 
           if not os.path.isdir(results_dir):
+              print(f'ERROR: {results_dir} not found', file=sys.stderr)
               sys.exit(0)
 
-          for f in sorted(glob.glob(os.path.join(results_dir, '*.json'))):
+          files = sorted(glob.glob(os.path.join(results_dir, '*.json')))
+          print(f'Found {len(files)} result files in {results_dir}', file=sys.stderr)
+
+          for f in files:
+              print(f'Processing: {f}', file=sys.stderr)
               with open(f) as fh:
                   data = json.load(fh)
               data['run_id'] = os.environ.get('RUN_ID', '')
@@ -260,6 +265,9 @@ jobs:
               data['run_url'] = os.environ.get('RUN_URL', '')
               with open(output, 'a') as out:
                   out.write(json.dumps(data) + '\n')
+              print(f'Wrote to {output}', file=sys.stderr)
+
+          print(f'Final size: {os.path.getsize(output)} bytes', file=sys.stderr)
           PYEOF
           RUN_ID="${{ github.run_id }}" \
           COMMIT="${{ github.sha }}" \
@@ -267,9 +275,18 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           python3 /tmp/append_results.py
 
+          echo 'DEBUG: results dir contents:'
+          ls -la results/ 2>/dev/null || echo 'results/ not found'
+          echo 'DEBUG: benchmark-data/results.jsonl size:'
+          wc -c benchmark-data/results.jsonl 2>/dev/null || echo 'file not found'
+          cat benchmark-data/results.jsonl 2>/dev/null | head -3
+
       - name: Push benchmark data
         run: |
           cd benchmark-data
+          echo 'DEBUG: results.jsonl in benchmark-data:'
+          wc -c results.jsonl
+          git status
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add results.jsonl


### PR DESCRIPTION
## Changes

- **Improved Python script error handling**: Added stderr logging when `results/` directory is missing, per-file processing logs, and final output size confirmation
- **Debug output in Append step**: After the Python script runs, logs the contents of `results/` and the size/contents of `benchmark-data/results.jsonl`
- **Debug output in Push step**: Before `git add`, logs the size of `results.jsonl` and `git status` to show whether the file has actually changed

The likely root cause is that `actions/checkout@v4` (line 218) runs after `actions/download-artifact@v4` and wipes the downloaded `results/` directory. These debug statements will confirm that in CI logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)