### PR TITLE
fix: reorder report job steps so artifacts survive checkout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -208,14 +208,14 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all benchmark artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: benchmark-results-*
           merge-multiple: true
           path: results/
-
-      - uses: actions/checkout@v4
 
       - name: Checkout benchmark-data branch
         id: checkout-data
@@ -275,18 +275,9 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           python3 /tmp/append_results.py
 
-          echo 'DEBUG: results dir contents:'
-          ls -la results/ 2>/dev/null || echo 'results/ not found'
-          echo 'DEBUG: benchmark-data/results.jsonl size:'
-          wc -c benchmark-data/results.jsonl 2>/dev/null || echo 'file not found'
-          cat benchmark-data/results.jsonl 2>/dev/null | head -3
-
       - name: Push benchmark data
         run: |
           cd benchmark-data
-          echo 'DEBUG: results.jsonl in benchmark-data:'
-          wc -c results.jsonl
-          git status
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add results.jsonl

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -249,9 +249,14 @@ jobs:
           output = 'benchmark-data/results.jsonl'
 
           if not os.path.isdir(results_dir):
+              print(f'ERROR: {results_dir} not found', file=sys.stderr)
               sys.exit(0)
 
-          for f in sorted(glob.glob(os.path.join(results_dir, '*.json'))):
+          files = sorted(glob.glob(os.path.join(results_dir, '*.json')))
+          print(f'Found {len(files)} result files in {results_dir}', file=sys.stderr)
+
+          for f in files:
+              print(f'Processing: {f}', file=sys.stderr)
               with open(f) as fh:
                   data = json.load(fh)
               data['run_id'] = os.environ.get('RUN_ID', '')
@@ -260,6 +265,9 @@ jobs:
               data['run_url'] = os.environ.get('RUN_URL', '')
               with open(output, 'a') as out:
                   out.write(json.dumps(data) + '\n')
+              print(f'Wrote to {output}', file=sys.stderr)
+
+          print(f'Final size: {os.path.getsize(output)} bytes', file=sys.stderr)
           PYEOF
           RUN_ID="${{ github.run_id }}" \
           COMMIT="${{ github.sha }}" \
@@ -267,9 +275,18 @@ jobs:
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           python3 /tmp/append_results.py
 
+          echo 'DEBUG: results dir contents:'
+          ls -la results/ 2>/dev/null || echo 'results/ not found'
+          echo 'DEBUG: benchmark-data/results.jsonl size:'
+          wc -c benchmark-data/results.jsonl 2>/dev/null || echo 'file not found'
+          cat benchmark-data/results.jsonl 2>/dev/null | head -3
+
       - name: Push benchmark data
         run: |
           cd benchmark-data
+          echo 'DEBUG: results.jsonl in benchmark-data:'
+          wc -c results.jsonl
+          git status
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add results.jsonl


### PR DESCRIPTION
## Summary

- Move `actions/checkout@v4` before the artifact download step in the report job so it no longer wipes the downloaded `results/` directory
- Remove debug output added during investigation

## Root cause

The report job downloaded artifacts to `results/`, then `actions/checkout@v4` wiped the entire workspace. The subsequent append step couldn't find `results/` and silently exited.

## Test plan

- [ ] Trigger a benchmark workflow run and verify the report job appends results to `benchmark-data/results.jsonl` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)