### PR TITLE
fix: move artifact download after checkout so results/ survives

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -208,14 +208,14 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all benchmark artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: benchmark-results-*
           merge-multiple: true
           path: results/
-
-      - uses: actions/checkout@v4
 
       - name: Setup benchmark-data branch
         run: |


### PR DESCRIPTION
actions/checkout wipes the workspace, deleting the downloaded artifacts. Moving the download step after checkout fixes this.