### PR TITLE
feat: dashboard UI overhaul and nightly scheduled benchmark runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,8 @@
 name: Benchmark CI
 
 on:
+  schedule:
+    - cron: '17 6 * * 1-5'
   workflow_dispatch:
     inputs:
       benchmark:
@@ -37,12 +39,6 @@ on:
         required: false
         default: ''
         type: string
-  # pull_request trigger disabled — use workflow_dispatch with pr_number instead
-  # pull_request:
-  #   types: [opened, synchronize]
-  #   paths:
-  #     - 'factory/**'
-  #     - 'benchmarks/**'
   release:
     types: [created]
 
@@ -63,40 +59,40 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Factory solver entries
+          # Factory solver entries — enabled on schedule, release, or workflow_dispatch with matching benchmark+solver
           - benchmark: swebench
             solver: factory
             default_instance: 'sympy__sympy-20590'
-            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: featurebench
             solver: factory
             default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
-            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: terminalbench
             solver: factory
             default_instance: 'fix-git'
-            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: programbench
             solver: factory
             default_instance: 'cmatrix'
-            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
-          # Claude Code solver entries
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
+          # Claude Code solver entries — disabled on schedule (nightly runs factory only)
           - benchmark: swebench
             solver: claude-code
             default_instance: 'sympy__sympy-20590'
-            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: featurebench
             solver: claude-code
             default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
-            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: terminalbench
             solver: claude-code
             default_instance: 'fix-git'
-            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: programbench
             solver: claude-code
             default_instance: 'cmatrix'
-            enabled: ${{ ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
 
     steps:
       - name: Skip if not enabled
@@ -162,6 +158,8 @@ jobs:
         run: |
           if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
             echo "value=$BENCHMARK_TIMEOUT" >> "$GITHUB_OUTPUT"
+          elif [ '${{ github.event_name }}' = 'schedule' ]; then
+            echo 'value=3600' >> "$GITHUB_OUTPUT"
           else
             echo 'value=600' >> "$GITHUB_OUTPUT"
           fi
@@ -257,6 +255,7 @@ jobs:
               data['commit'] = os.environ.get('COMMIT', '')
               data['ref'] = os.environ.get('REF', '')
               data['run_url'] = os.environ.get('RUN_URL', '')
+              data['trigger'] = os.environ.get('TRIGGER', '')
               with open(output, 'a') as out:
                   out.write(json.dumps(data) + '\n')
               print(f'Wrote to {output}', file=sys.stderr)
@@ -267,6 +266,7 @@ jobs:
           COMMIT="${{ github.sha }}" \
           REF="${{ github.ref }}" \
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          TRIGGER="${{ github.event_name }}" \
           python3 /tmp/append_results.py
 
           echo 'DEBUG: results dir contents:'

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -15,6 +15,11 @@
   padding: 0.6rem 0.8rem;
   border-bottom: 2px solid var(--md-default-fg-color--lightest);
   white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+#benchmark-dashboard th:hover {
+  opacity: 0.7;
 }
 #benchmark-dashboard td {
   padding: 0.5rem 0.8rem;
@@ -61,6 +66,65 @@
     grid-template-columns: 1fr;
   }
 }
+#benchmark-dashboard .summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 2rem 0;
+}
+#benchmark-dashboard .summary-card {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  padding: 1rem 1.2rem;
+}
+#benchmark-dashboard .summary-card .card-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  margin-bottom: 0.6rem;
+  opacity: 0.7;
+}
+#benchmark-dashboard .summary-card .card-score {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 0.3rem;
+}
+#benchmark-dashboard .summary-card .card-meta {
+  font-size: 0.8rem;
+  opacity: 0.6;
+}
+#benchmark-dashboard .card-score.score-pass { color: #22863a; }
+#benchmark-dashboard .card-score.score-zero { color: #b08800; }
+#benchmark-dashboard .card-score.score-none { color: #888; }
+#benchmark-dashboard .filter-bar {
+  display: flex;
+  gap: 1rem;
+  margin: 0.5rem 0 1rem 0;
+  align-items: center;
+  flex-wrap: wrap;
+}
+#benchmark-dashboard .filter-bar select {
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font-size: 0.85rem;
+}
+#benchmark-dashboard .filter-bar label {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+#benchmark-dashboard .trend-placeholder {
+  text-align: center;
+  padding: 2rem;
+  color: var(--md-default-fg-color--light);
+  font-style: italic;
+  border: 1px dashed var(--md-default-fg-color--lightest);
+  border-radius: 8px;
+  margin: 1rem 0;
+}
 </style>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -68,8 +132,6 @@
 <script>
 const REPO = 'akashgit/remote-factory';
 const JSONL_URL = `https://raw.githubusercontent.com/${REPO}/benchmark-data/results.jsonl`;
-const WORKFLOW = 'benchmark.yml';
-const API = 'https://api.github.com';
 
 const CHART_COLORS = [
   '#4285f4', '#ea4335', '#34a853', '#fbbc04',
@@ -140,16 +202,7 @@ async function fetchJsonl() {
   }).filter(Boolean);
 }
 
-async function fetchFromApi() {
-  const resp = await fetch(
-    `${API}/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?per_page=20&status=completed`
-  );
-  if (!resp.ok) return null;
-  const data = await resp.json();
-  return data.workflow_runs || [];
-}
-
-function renderLatestTable(results) {
+function getLatestByCombo(results) {
   const byKey = {};
   for (const r of results) {
     const solver = r.details?.solver || r.solver || 'unknown';
@@ -158,45 +211,112 @@ function renderLatestTable(results) {
       byKey[key] = r;
     }
   }
+  return byKey;
+}
 
-  const latest = Object.values(byKey).sort((a, b) =>
-    (a.benchmark + (a.details?.solver || '')).localeCompare(b.benchmark + (b.details?.solver || ''))
-  );
+function renderSummaryCards(results) {
+  const byKey = getLatestByCombo(results);
+
+  const combos = Object.entries(byKey).sort(([a], [b]) => a.localeCompare(b));
 
   let html = '<div class="section-title">Latest Results</div>';
-  html += '<table><thead><tr>';
-  html += '<th>Benchmark</th><th>Solver</th><th>Result</th><th>Score</th>';
-  html += '<th>Duration</th><th>Cost</th><th>Commit</th><th>Run</th>';
-  html += '</tr></thead><tbody>';
+  html += '<div class="summary-cards">';
 
-  for (const r of latest) {
+  for (const [key, r] of combos) {
     const solver = r.details?.solver || r.solver || 'unknown';
+    const scoreVal = r.score;
+    const scoreClass = scoreVal > 0 ? 'score-pass' : scoreVal === 0 ? 'score-zero' : 'score-none';
+    const icon = r.resolved ? '✅' : '❌';
     const commit = r.commit ? r.commit.substring(0, 7) : '—';
     const commitLink = r.commit
       ? `<a href="https://github.com/${REPO}/commit/${r.commit}"><code>${commit}</code></a>`
       : commit;
-    const runLink = r.run_url
-      ? `<a href="${r.run_url}">details →</a>`
-      : '—';
-    const cost = r.details?.cost_usd;
 
-    html += '<tr>';
-    html += `<td>${r.benchmark}</td>`;
-    html += `<td>${solver}</td>`;
-    html += `<td>${statusIcon(r.resolved)}</td>`;
-    html += `<td>${r.score}</td>`;
-    html += `<td>${formatDurationShort(r.duration_seconds)}</td>`;
-    html += `<td>${formatCost(cost)}</td>`;
-    html += `<td>${commitLink}</td>`;
-    html += `<td>${runLink}</td>`;
-    html += '</tr>';
+    html += '<div class="summary-card">';
+    html += `<div class="card-title">${r.benchmark} · ${solver}</div>`;
+    html += `<div class="card-score ${scoreClass}">${icon} ${scoreVal}</div>`;
+    html += '<div class="card-meta">';
+    html += `${formatDurationShort(r.duration_seconds)} · ${formatCost(r.details?.cost_usd)}`;
+    html += `<br>${commitLink}`;
+    html += '</div>';
+    html += '</div>';
   }
 
-  html += '</tbody></table>';
+  html += '</div>';
   return html;
 }
 
-function renderCharts(results) {
+function renderComparisonChart(results) {
+  const byKey = getLatestByCombo(results);
+
+  const benchmarks = [...new Set(results.map(r => r.benchmark))].sort();
+  const factoryScores = benchmarks.map(b => {
+    const r = byKey[b + '|factory'];
+    return r ? r.score : null;
+  });
+  const claudeScores = benchmarks.map(b => {
+    const r = byKey[b + '|claude-code'];
+    return r ? r.score : null;
+  });
+
+  const hasAnyData = factoryScores.some(v => v !== null) || claudeScores.some(v => v !== null);
+  if (!hasAnyData) return '';
+
+  let html = '<div class="section-title">Factory vs Claude Code</div>';
+  html += '<div class="chart-container"><canvas id="comparison-chart"></canvas></div>';
+
+  setTimeout(() => {
+    const ctx = document.getElementById('comparison-chart');
+    if (!ctx) return;
+    const colors = chartColors();
+
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: benchmarks,
+        datasets: [
+          {
+            label: 'Factory',
+            data: factoryScores,
+            backgroundColor: '#4285f4',
+            borderRadius: 4,
+          },
+          {
+            label: 'Claude Code',
+            data: claudeScores,
+            backgroundColor: '#ea4335',
+            borderRadius: 4,
+          },
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: true,
+        plugins: {
+          legend: { labels: { color: colors.text } },
+          tooltip: { filter: (item) => item.raw !== null },
+        },
+        scales: {
+          x: {
+            ticks: { color: colors.text },
+            grid: { color: colors.grid },
+          },
+          y: {
+            min: 0,
+            max: 1,
+            title: { display: true, text: 'Score', color: colors.text },
+            ticks: { color: colors.text },
+            grid: { color: colors.grid },
+          },
+        },
+      },
+    });
+  }, 0);
+
+  return html;
+}
+
+function renderTrendCharts(results) {
   const sorted = [...results].sort((a, b) =>
     (a.timestamp || '').localeCompare(b.timestamp || '')
   );
@@ -217,10 +337,18 @@ function renderCharts(results) {
     }
   }
 
+  const totalPoints = Object.values(series).reduce((sum, s) => sum + s.length, 0);
+  if (totalPoints < 3) {
+    return '<div class="section-title">Trends Over Time</div>'
+      + '<div class="trend-placeholder">Trends will appear after at least 3 benchmark runs.</div>';
+  }
+
   const keys = Object.keys(series).sort();
   const colors = chartColors();
+  const pointSize = totalPoints < 10 ? 5 : 3;
 
-  let html = '<div class="charts-row">';
+  let html = '<div class="section-title">Trends Over Time</div>';
+  html += '<div class="charts-row">';
   html += '<div class="chart-container"><canvas id="duration-chart"></canvas></div>';
   html += '<div class="chart-container"><canvas id="cost-chart"></canvas></div>';
   html += '</div>';
@@ -236,7 +364,7 @@ function renderCharts(results) {
       borderColor: CHART_COLORS[i % CHART_COLORS.length],
       backgroundColor: CHART_COLORS[i % CHART_COLORS.length] + '33',
       tension: 0.3,
-      pointRadius: 3,
+      pointRadius: pointSize,
       spanGaps: true,
     }));
 
@@ -246,7 +374,7 @@ function renderCharts(results) {
       borderColor: CHART_COLORS[i % CHART_COLORS.length],
       backgroundColor: CHART_COLORS[i % CHART_COLORS.length] + '33',
       tension: 0.3,
-      pointRadius: 3,
+      pointRadius: pointSize,
       spanGaps: true,
     }));
 
@@ -300,14 +428,29 @@ function renderCharts(results) {
 }
 
 function renderHistoryTable(results) {
+  const benchmarks = [...new Set(results.map(r => r.benchmark))].sort();
+  const solvers = [...new Set(results.map(r => r.details?.solver || r.solver || 'unknown'))].sort();
+
+  let html = '<div class="section-title">Full History</div>';
+
+  html += '<div class="filter-bar">';
+  html += '<label>Benchmark: <select id="filter-benchmark"><option value="">All</option>';
+  for (const b of benchmarks) html += `<option value="${b}">${b}</option>`;
+  html += '</select></label>';
+  html += '<label>Solver: <select id="filter-solver"><option value="">All</option>';
+  for (const s of solvers) html += `<option value="${s}">${s}</option>`;
+  html += '</select></label>';
+  html += '</div>';
+
   const sorted = [...results].sort((a, b) =>
     (b.timestamp || '').localeCompare(a.timestamp || '')
   );
 
-  let html = '<div class="section-title">Full History</div>';
-  html += '<table><thead><tr>';
-  html += '<th>Date</th><th>Benchmark</th><th>Solver</th><th>Result</th>';
-  html += '<th>Score</th><th>Duration</th><th>Cost</th><th>Commit</th><th>Run</th>';
+  html += '<table id="history-table"><thead><tr>';
+  html += '<th data-col="date">Date</th><th data-col="benchmark">Benchmark</th>';
+  html += '<th data-col="solver">Solver</th><th data-col="result">Result</th>';
+  html += '<th data-col="score">Score</th><th data-col="duration">Duration</th>';
+  html += '<th data-col="cost">Cost</th><th data-col="commit">Commit</th><th data-col="run">Run</th>';
   html += '</tr></thead><tbody>';
 
   for (const r of sorted) {
@@ -321,7 +464,7 @@ function renderHistoryTable(results) {
       : '—';
     const cost = r.details?.cost_usd;
 
-    html += '<tr>';
+    html += `<tr data-benchmark="${r.benchmark}" data-solver="${solver}">`;
     html += `<td style="white-space:nowrap">${formatDate(r.timestamp)}</td>`;
     html += `<td>${r.benchmark}</td>`;
     html += `<td>${solver}</td>`;
@@ -335,35 +478,27 @@ function renderHistoryTable(results) {
   }
 
   html += '</tbody></table>';
-  return html;
-}
 
-function renderApiFallback(runs) {
-  let html = '<div class="section-title">Recent Workflow Runs</div>';
-  html += '<p class="error-msg">Benchmark data branch not available yet. Showing workflow run metadata from GitHub API.</p>';
-  html += '<table><thead><tr>';
-  html += '<th>Date</th><th>Commit</th><th>Trigger</th><th>Status</th><th></th>';
-  html += '</tr></thead><tbody>';
+  setTimeout(() => {
+    const benchSelect = document.getElementById('filter-benchmark');
+    const solverSelect = document.getElementById('filter-solver');
+    if (!benchSelect || !solverSelect) return;
 
-  for (const run of runs) {
-    const d = new Date(run.created_at);
-    const date = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-      + ' ' + d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
-    const commit = run.head_sha ? run.head_sha.substring(0, 7) : '—';
-    const conclusion = run.conclusion || 'running';
-    const statusClass = conclusion === 'success' ? 'status-success'
-      : conclusion === 'failure' ? 'status-failure' : 'status-pending';
+    function applyFilters() {
+      const bv = benchSelect.value;
+      const sv = solverSelect.value;
+      const rows = document.querySelectorAll('#history-table tbody tr');
+      for (const row of rows) {
+        const matchB = !bv || row.dataset.benchmark === bv;
+        const matchS = !sv || row.dataset.solver === sv;
+        row.style.display = (matchB && matchS) ? '' : 'none';
+      }
+    }
 
-    html += '<tr>';
-    html += `<td>${date}</td>`;
-    html += `<td><a href="https://github.com/${REPO}/commit/${run.head_sha}"><code>${commit}</code></a></td>`;
-    html += `<td>${run.event}</td>`;
-    html += `<td><span class="${statusClass}">${conclusion}</span></td>`;
-    html += `<td><a href="${run.html_url}">details →</a></td>`;
-    html += '</tr>';
-  }
+    benchSelect.addEventListener('change', applyFilters);
+    solverSelect.addEventListener('change', applyFilters);
+  }, 0);
 
-  html += '</tbody></table>';
   return html;
 }
 
@@ -375,20 +510,15 @@ async function renderDashboard() {
 
     if (results && results.length > 0) {
       let html = '';
-      html += renderLatestTable(results);
-      html += renderCharts(results);
+      html += renderSummaryCards(results);
+      html += renderComparisonChart(results);
+      html += renderTrendCharts(results);
       html += renderHistoryTable(results);
       container.innerHTML = html;
       return;
     }
 
-    const runs = await fetchFromApi();
-    if (runs && runs.length > 0) {
-      container.innerHTML = renderApiFallback(runs);
-      return;
-    }
-
-    container.innerHTML = '<p class="error-msg">No benchmark data available yet.</p>';
+    container.innerHTML = '<p class="error-msg">No benchmark data available yet.<br>Run the benchmark workflow to generate initial data: Actions → Benchmark CI → Run workflow</p>';
   } catch (err) {
     container.innerHTML = `<p class="error-msg">${err.message}</p>`;
   }


### PR DESCRIPTION
## Summary

- **Dashboard rewrite**: Removed GitHub API fallback entirely. Dashboard now only fetches `results.jsonl` from the `benchmark-data` branch. Added summary cards (latest score per benchmark+solver), a grouped bar chart (factory vs claude-code comparison), trend line charts (only shown with ≥3 data points), and filter dropdowns on the history table.
- **Nightly schedule**: Added weekday cron trigger (`6:17 AM UTC Mon-Fri`). Schedule runs all 4 benchmarks with factory solver only (claude-code disabled for nightly). Fixed matrix `enabled` expressions to handle missing `inputs.*` on schedule events.
- **Trigger metadata**: Each result now includes a `trigger` field (`schedule`, `workflow_dispatch`, `release`) for dashboard filtering.
- **Schedule timeout**: Nightly runs use 3600s timeout (vs 1800s for manual, 600s for release).

## Test plan

- [ ] Verify dashboard renders empty state correctly when no `results.jsonl` exists
- [ ] Verify dashboard renders all 4 sections when data is present
- [ ] Verify nightly schedule triggers correctly (check Actions tab after merge)
- [ ] Verify `workflow_dispatch` still works with all input combinations
- [ ] Verify claude-code solver is excluded from scheduled runs
- [ ] Verify trigger metadata appears in `results.jsonl` entries

Closes the dashboard UI and nightly runs items from the research plan.