### PR TITLE
fix: dashboard data pipeline — solver field, cost extraction, chart labels

### DIFF
--- a/benchmarks/lib.sh
+++ b/benchmarks/lib.sh
@@ -41,6 +41,7 @@ details = json.loads(_dj) if _dj else {}
 result = {
     'benchmark': '${BENCHMARK}',
     'instance_id': '${INSTANCE_ID}',
+    'solver': '${BENCHMARK_SOLVER:-unknown}',
     'passed': ${PASSED:-0},
     'total': ${TOTAL:-0},
     'score': round(${PASSED:-0} / max(${TOTAL:-0}, 1), 4),

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -212,6 +212,25 @@ print(f'COST_USD={cost}')
     eval "${COST_DATA}" 2>/dev/null || true
 fi
 
+if [ "${COST_USD}" = "0" ] || [ -z "${COST_USD}" ]; then
+    AGENT_LOG=$(find "${JOBS_DIR}" -name 'claude-code.txt' -o -name 'claude_code_stream_output.jsonl' -o -name 'factory-ceo.txt' 2>/dev/null | head -1)
+    if [ -n "${AGENT_LOG}" ]; then
+        COST_DATA=$(grep 'total_cost_usd' "${AGENT_LOG}" | tail -1 | python3 -c "
+import sys, json
+for line in sys.stdin:
+    try:
+        data = json.loads(line.strip())
+        if 'total_cost_usd' in data:
+            print(f'COST_USD={data[\"total_cost_usd\"]}')
+            u = data.get('usage', {})
+            print(f'INPUT_TOKENS={u.get(\"input_tokens\", 0)}')
+            print(f'OUTPUT_TOKENS={u.get(\"output_tokens\", 0)}')
+    except: pass
+" 2>/dev/null)
+        eval "${COST_DATA}" 2>/dev/null || true
+    fi
+fi
+
 echo "    Finished at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 echo ""
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -358,8 +358,13 @@ function renderTrendCharts(results) {
     const costCtx = document.getElementById('cost-chart');
     if (!durCtx || !costCtx) return;
 
+    const shortLabel = (k) => {
+      const [bench, solver] = k.split(' / ');
+      return bench + ' (' + solver + ')';
+    };
+
     const durDatasets = keys.map((k, i) => ({
-      label: k,
+      label: shortLabel(k),
       data: series[k].map(p => ({ x: p.x, y: p.duration != null ? p.duration / 60 : null })),
       borderColor: CHART_COLORS[i % CHART_COLORS.length],
       backgroundColor: CHART_COLORS[i % CHART_COLORS.length] + '33',
@@ -369,7 +374,7 @@ function renderTrendCharts(results) {
     }));
 
     const costDatasets = keys.map((k, i) => ({
-      label: k,
+      label: shortLabel(k),
       data: series[k].map(p => ({ x: p.x, y: p.cost })).filter(p => p.y != null),
       borderColor: CHART_COLORS[i % CHART_COLORS.length],
       backgroundColor: CHART_COLORS[i % CHART_COLORS.length] + '33',
@@ -385,8 +390,13 @@ function renderTrendCharts(results) {
       scales: {
         x: {
           type: 'time',
-          time: { tooltipFormat: 'MMM d, yyyy HH:mm' },
-          ticks: { color: colors.text },
+          time: {
+            unit: 'day',
+            displayFormats: { day: 'MMM d' },
+            tooltipFormat: 'MMM d, yyyy HH:mm',
+          },
+          title: { display: true, text: 'Date', color: colors.text },
+          ticks: { color: colors.text, maxRotation: 45, maxTicksLimit: 10 },
           grid: { color: colors.grid },
         },
         y: {


### PR DESCRIPTION
## Summary

- **Solver field in results**: Added `solver` as a top-level field in `write_result` (lib.sh) so the dashboard trend charts can group series by solver even when `details` is empty
- **TerminalBench cost extraction**: Falls back to parsing agent output logs (`claude-code.txt`, `factory-ceo.txt`) in the Harbor jobs directory when `result.json` has no cost data
- **Chart labels**: Trend charts now use day-level time axis (`MMM d` format) with tick rotation and count limits to prevent overlapping labels; legend labels shortened from `swebench / factory` to `swebench (factory)`

## Test plan

- [ ] Run a workflow_dispatch benchmark with solver='both' and verify the result JSON contains a top-level `solver` field
- [ ] Check the dashboard trend charts render with clean date labels after new data accumulates
- [ ] Verify TerminalBench cost is non-zero in results after a Harbor run with claude-code solver

🤖 Generated with [Claude Code](https://claude.com/claude-code)