### PR TITLE
Integrate Sentrux architectural quality check into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   test:
@@ -36,6 +35,9 @@ jobs:
 
   quality:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       SENTRUX_VERSION: v0.5.7
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           path: |
             /usr/local/bin/sentrux
+            ~/.local/bin/sentrux
             ~/.sentrux/plugins
           key: sentrux-${{ env.SENTRUX_VERSION }}-standard-plugins
       - name: Run Sentrux quality check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,21 @@ jobs:
           files: coverage.xml
           fail_ci_if_error: false
 
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Sentrux
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/bin/sentrux
+            ~/.sentrux/plugins
+          key: sentrux-v0.5.7-standard-plugins
+      - name: Run Sentrux quality check
+        continue-on-error: true
+        run: ./scripts/sentrux-check.sh
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
 
   quality:
     runs-on: ubuntu-latest
+    env:
+      SENTRUX_VERSION: v0.5.7
     steps:
       - uses: actions/checkout@v4
       - name: Cache Sentrux
@@ -43,7 +45,7 @@ jobs:
           path: |
             /usr/local/bin/sentrux
             ~/.sentrux/plugins
-          key: sentrux-v0.5.7-standard-plugins
+          key: sentrux-${{ env.SENTRUX_VERSION }}-standard-plugins
       - name: Run Sentrux quality check
         continue-on-error: true
         run: ./scripts/sentrux-check.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test:
@@ -48,7 +49,30 @@ jobs:
           key: sentrux-${{ env.SENTRUX_VERSION }}-standard-plugins
       - name: Run Sentrux quality check
         continue-on-error: true
-        run: ./scripts/sentrux-check.sh
+        run: ./scripts/sentrux-check.sh 2>&1 | tee sentrux-output.txt
+      - name: Post Sentrux results as PR comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "<!-- sentrux-report -->"
+            echo "## Sentrux Quality Report"
+            echo ""
+            echo '```'
+            cat sentrux-output.txt
+            echo '```'
+          } > comment-body.txt
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- sentrux-report -->")) | .id' | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$(cat comment-body.txt)"
+          else
+            gh pr comment "${{ github.event.pull_request.number }}" --body-file comment-body.txt
+          fi
 
   lint:
     runs-on: ubuntu-latest

--- a/.sentrux/rules.toml
+++ b/.sentrux/rules.toml
@@ -1,3 +1,4 @@
+[constraints]
 max_cycles = 5
 max_coupling = "C"
 max_cc = 30

--- a/.sentrux/rules.toml
+++ b/.sentrux/rules.toml
@@ -1,0 +1,4 @@
+max_cycles = 5
+max_coupling = "C"
+max_cc = 30
+no_god_files = false

--- a/factory.md
+++ b/factory.md
@@ -33,6 +33,7 @@ Domain-agnostic multi-agent software evolution loop that can auto-discover evals
 - scripts/**
 - eval/**
 - factory.md
+- .sentrux/**
 
 ### Read-only
 <!-- Files the factory may read but must never modify. -->

--- a/scripts/sentrux-check.sh
+++ b/scripts/sentrux-check.sh
@@ -15,7 +15,7 @@ esac
 
 if ! command -v sentrux &>/dev/null; then
   echo >&2 "sentrux not found, installing ${SENTRUX_VERSION} for ${platform}..."
-  url="https://github.com/getsentry/sentrux/releases/download/${SENTRUX_VERSION}/sentrux-${platform}"
+  url="https://github.com/sentrux/sentrux/releases/download/${SENTRUX_VERSION}/sentrux-${platform}"
   if [ -w /usr/local/bin ]; then
     dest="/usr/local/bin/sentrux"
   else

--- a/scripts/sentrux-check.sh
+++ b/scripts/sentrux-check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SENTRUX_VERSION="${SENTRUX_VERSION:-v0.5.7}"
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64)  platform="linux-x86_64" ;;
+  aarch64) platform="linux-aarch64" ;;
+  *)
+    echo >&2 "Unsupported architecture: $arch"
+    exit 1
+    ;;
+esac
+
+if ! command -v sentrux &>/dev/null; then
+  echo >&2 "sentrux not found, installing ${SENTRUX_VERSION} for ${platform}..."
+  url="https://github.com/getsentry/sentrux/releases/download/${SENTRUX_VERSION}/sentrux-${platform}"
+  if [ -w /usr/local/bin ]; then
+    dest="/usr/local/bin/sentrux"
+  else
+    dest="$HOME/.local/bin/sentrux"
+    mkdir -p "$HOME/.local/bin"
+    export PATH="$HOME/.local/bin:$PATH"
+  fi
+  curl -fsSL "$url" -o "$dest"
+  chmod +x "$dest"
+  echo >&2 "Installed sentrux to $dest"
+fi
+
+if [ ! -d "$HOME/.sentrux/plugins" ] || [ -z "$(ls -A "$HOME/.sentrux/plugins" 2>/dev/null)" ]; then
+  echo >&2 "Installing standard plugins..."
+  sentrux plugin add-standard
+fi
+
+echo >&2 "Running sentrux check..."
+exec sentrux check .


### PR DESCRIPTION
Closes #659

## Changes
- Add `scripts/sentrux-check.sh` — portable wrapper that auto-installs pinned Sentrux v0.5.7 binary, sets up standard plugins, and runs `sentrux check .`
- Add `quality` job to `.github/workflows/ci.yml` — runs in parallel with `test` and `lint`, caches Sentrux binary and plugins, uses `continue-on-error: true` (non-blocking initially)
- Add `.sentrux/rules.toml` — initial permissive rules (max_cycles=5, max_coupling=C, max_cc=30, no_god_files=false)
- Add `.sentrux/**` to modifiable scope in `factory.md`