### PR TITLE
feat: WorkflowSkill model, SkillRegistry, gate criteria, and CLI commands

### DIFF
--- a/factory.md
+++ b/factory.md
@@ -15,6 +15,7 @@ Domain-agnostic multi-agent software evolution loop that can auto-discover evals
 
 - factory/**/*.py
 - factory/agents/prompts/*.md
+- factory/workflow/gate_criteria/*.md
 - factory/agents/agents.yml
 - factory/dashboard/static/*
 - tests/**/*.py

--- a/factory/workflow/__init__.py
+++ b/factory/workflow/__init__.py
@@ -11,11 +11,14 @@ from factory.workflow.primitives import (
     ForkNode,
     GateNode,
     JoinNode,
+    SkillPhase,
     Study,
     Verdict,
     VerdictType,
     Workflow,
+    WorkflowSkill,
 )
+from factory.workflow.registry import SkillRegistry
 
 __all__ = [
     "AgentConfig",
@@ -28,9 +31,12 @@ __all__ = [
     "ForkNode",
     "GateNode",
     "JoinNode",
+    "SkillPhase",
+    "SkillRegistry",
     "Study",
     "Verdict",
     "VerdictType",
     "Workflow",
     "WorkflowExecutor",
+    "WorkflowSkill",
 ]

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -28,12 +28,13 @@ def cmd_workflow(args: argparse.Namespace) -> int:
     """Dispatch workflow subcommands."""
     sub = getattr(args, "workflow_command", None)
     if not sub:
-        print("Usage: factory workflow {run,list,show,validate}")
+        print("Usage: factory workflow {run,list,catalog,show,validate}")
         return 1
 
     handlers = {
         "run": _cmd_run,
         "list": _cmd_list,
+        "catalog": _cmd_catalog,
         "show": _cmd_show,
         "validate": _cmd_validate,
     }
@@ -52,15 +53,15 @@ def _cmd_run(args: argparse.Namespace) -> int:
     project_path = Path(args.project_path).resolve()
     dry_run = getattr(args, "dry_run", False)
 
-    workflows = register_all()
-    wf = workflows.get(name)
-    if not wf:
+    skills = register_all()
+    skill = skills.get(name)
+    if not skill:
         print(f"Unknown workflow: {name}")
-        print(f"Available: {', '.join(workflows)}")
+        print(f"Available: {', '.join(skills)}")
         return 1
 
     executor = WorkflowExecutor(
-        wf,
+        skill.workflow,
         project_path,
         agent_pool=DEFAULT_AGENT_POOL,
         dry_run=dry_run,
@@ -82,31 +83,61 @@ def _cmd_run(args: argparse.Namespace) -> int:
 
 
 def _cmd_list(args: argparse.Namespace) -> int:
-    """List all registered workflows."""
-    workflows = register_all()
+    """List all registered workflows with skill metadata."""
+    skills = register_all()
 
-    header = f"{'Name':<12} {'Nodes':>6} {'Edges':>6} {'Start Node':<20}"
+    header = f"{'Name':<12} {'Nodes':>6} {'Edges':>6} {'Phases':>7} {'Aliases':<25} {'Description'}"
     print(header)
     print("-" * len(header))
 
-    for name, wf in workflows.items():
-        print(f"{name:<12} {len(wf.nodes):>6} {len(wf.edges):>6} {wf.start_node:<20}")
+    for name, skill in skills.items():
+        wf = skill.workflow
+        aliases = ", ".join(skill.aliases) if skill.aliases else "-"
+        desc = skill.description[:50] if skill.description else "-"
+        print(
+            f"{name:<12} {len(wf.nodes):>6} {len(wf.edges):>6} "
+            f"{len(skill.phases):>7} {aliases:<25} {desc}"
+        )
 
+    return 0
+
+
+def _cmd_catalog(args: argparse.Namespace) -> int:
+    """Generate injectable markdown catalog of all workflow skills."""
+    from factory.workflow.registry import SkillRegistry
+
+    registry = SkillRegistry.create()
+    print(registry.catalog())
     return 0
 
 
 def _cmd_show(args: argparse.Namespace) -> int:
     """Show a workflow's graph as a node/edge table."""
     name = args.name
-    workflows = register_all()
-    wf = workflows.get(name)
-    if not wf:
+    skills = register_all()
+    skill = skills.get(name)
+    if not skill:
         print(f"Unknown workflow: {name}")
         return 1
 
+    wf = skill.workflow
+
     print(f"Workflow: {wf.name}")
     print(f"Start:    {wf.start_node}")
+    if skill.description:
+        print(f"Desc:     {skill.description}")
+    if skill.aliases:
+        print(f"Aliases:  {', '.join(skill.aliases)}")
+    if skill.trigger_description:
+        print(f"Trigger:  {skill.trigger_description}")
     print()
+
+    if skill.phases:
+        print("Phases:")
+        for phase in skill.phases:
+            desc = f" — {phase.description}" if phase.description else ""
+            print(f"  - {phase.name}{desc}")
+        print()
 
     # Nodes table
     print("Nodes:")
@@ -158,12 +189,13 @@ def _cmd_show(args: argparse.Namespace) -> int:
 def _cmd_validate(args: argparse.Namespace) -> int:
     """Validate a workflow using NetworkX."""
     name = args.name
-    workflows = register_all()
-    wf = workflows.get(name)
-    if not wf:
+    skills = register_all()
+    skill = skills.get(name)
+    if not skill:
         print(f"Unknown workflow: {name}")
         return 1
 
+    wf = skill.workflow
     issues = wf.validate_graph()
 
     if not issues:
@@ -188,7 +220,10 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     p.add_argument("--dry-run", action="store_true", help="Execute without real agent calls")
 
     # list
-    wf_sub.add_parser("list", help="List all registered workflows")
+    wf_sub.add_parser("list", help="List all registered workflows with skill metadata")
+
+    # catalog
+    wf_sub.add_parser("catalog", help="Generate injectable markdown catalog of all workflow skills")
 
     # show
     p = wf_sub.add_parser("show", help="Show workflow graph details")

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -20,9 +20,11 @@ from factory.workflow.primitives import (
     ForkNode,
     GateNode,
     JoinNode,
+    SkillPhase,
     Study,
     VerdictType,
     Workflow,
+    WorkflowSkill,
 )
 
 
@@ -91,6 +93,7 @@ def build_workflow() -> Workflow:
         evaluator_type="agent",
         evaluator_role=AgentRole.CEO,
         reads={".factory/strategy/research-combined.md"},
+        criteria_file="researcher-review.md",
     )
 
     # Strategist
@@ -111,6 +114,7 @@ def build_workflow() -> Workflow:
         evaluator_type="agent",
         evaluator_role=AgentRole.CEO,
         reads={".factory/strategy/current.md"},
+        criteria_file="strategist-review.md",
     )
 
     # Archivist (async, non-blocking)
@@ -140,6 +144,7 @@ def build_workflow() -> Workflow:
         evaluator_type="agent",
         evaluator_role=AgentRole.CEO,
         reads={".factory/reviews/builder-latest.md"},
+        criteria_file="builder-review.md",
     )
 
     nodes["evaluator"] = AgentNode(
@@ -277,6 +282,7 @@ def improve_workflow() -> Workflow:
         evaluator_type="agent",
         evaluator_role=AgentRole.CEO,
         reads={".factory/strategy/research-local.md"},
+        criteria_file="researcher-review.md",
     )
 
     # Strategist
@@ -297,6 +303,7 @@ def improve_workflow() -> Workflow:
         evaluator_type="agent",
         evaluator_role=AgentRole.CEO,
         reads={".factory/strategy/current.md"},
+        criteria_file="strategist-review.md",
     )
 
     # Per-hypothesis: begin → builder → gate → evaluator → precheck → finalize → archivist
@@ -322,6 +329,7 @@ def improve_workflow() -> Workflow:
         evaluator_type="agent",
         evaluator_role=AgentRole.CEO,
         reads={".factory/reviews/builder-latest.md"},
+        criteria_file="builder-review.md",
     )
 
     nodes["evaluator"] = AgentNode(
@@ -668,12 +676,88 @@ def meta_workflow() -> Workflow:
 # ── Registry ─────────────────────────────────────────────────────
 
 
-def register_all() -> dict[str, Workflow]:
-    """Build and return all 5 workflow definitions."""
+def register_all() -> dict[str, WorkflowSkill]:
+    """Build and return all 5 workflow definitions wrapped as WorkflowSkills.
+
+    Ordered by trigger specificity: more constrained triggers first so that
+    select() picks the most specific match.
+    """
     return {
-        "build": build_workflow(),
-        "design": design_workflow(),
-        "improve": improve_workflow(),
-        "research": research_workflow(),
-        "meta": meta_workflow(),
+        "design": WorkflowSkill(
+            name="design",
+            workflow=design_workflow(),
+            description="Interactive design mode — build workflow with user approval gates.",
+            trigger_description="Triggers when no repo and interactive mode is enabled.",
+            phases=[
+                SkillPhase(name="research", description="Parallel research on similar projects, tech stack, and pitfalls"),
+                SkillPhase(name="strategy", description="User reviews and approves the build plan"),
+                SkillPhase(name="build", description="Implement the approved plan"),
+            ],
+            inputs=["idea or spec text", "project path"],
+            outputs=[".factory/strategy/current.md", ".factory/reviews/builder-latest.md"],
+            success_criteria="User approves strategy, project builds successfully.",
+            aliases=["interactive", "discuss"],
+        ),
+        "build": WorkflowSkill(
+            name="build",
+            workflow=build_workflow(),
+            description="Build a new project from an idea, spec file, or GitHub URL.",
+            trigger_description="Triggers when no repo exists or repo is incomplete.",
+            phases=[
+                SkillPhase(name="research", description="Parallel research on similar projects, tech stack, and pitfalls"),
+                SkillPhase(name="strategy", description="Synthesize research into a phased build plan"),
+                SkillPhase(name="build", description="Implement the plan and run evals"),
+            ],
+            inputs=["idea or spec text", "project path"],
+            outputs=[".factory/strategy/current.md", ".factory/reviews/builder-latest.md"],
+            success_criteria="Project builds, tests pass, eval score above threshold.",
+            aliases=["new", "create"],
+        ),
+        "meta": WorkflowSkill(
+            name="meta",
+            workflow=meta_workflow(),
+            description="Meta mode — cross-project insights, playbook evolution, and test pruning.",
+            trigger_description="Triggers when mode is set to 'meta'.",
+            phases=[
+                SkillPhase(name="insights", description="Collect cross-project experiment insights"),
+                SkillPhase(name="playbook_evolution", description="Propose and apply playbook improvements"),
+                SkillPhase(name="test_pruning", description="Identify and remove redundant tests"),
+            ],
+            inputs=["project path", "projects directory"],
+            outputs=[".factory/archive/meta.md", ".factory/reviews/test-pruning-latest.md"],
+            success_criteria="Playbooks updated, redundant tests removed.",
+            aliases=["self-improve", "ace"],
+        ),
+        "research": WorkflowSkill(
+            name="research",
+            workflow=research_workflow(),
+            description="Research mode — baseline measurement, failure analysis, and plateau detection.",
+            trigger_description="Triggers when project has .factory/ and research_target is set.",
+            phases=[
+                SkillPhase(name="baseline", description="Measure baseline eval score"),
+                SkillPhase(name="failure_analysis", description="Analyze and categorize failures"),
+                SkillPhase(name="research", description="Research solutions based on failure analysis"),
+                SkillPhase(name="experiment", description="Build, eval, and iterate until plateau"),
+            ],
+            inputs=["project path", "research_target"],
+            outputs=[".factory/experiments/baseline.json", ".factory/experiments/verdict.json"],
+            success_criteria="Research target metric improves; plateau gate passes.",
+            aliases=["benchmark", "optimize"],
+        ),
+        "improve": WorkflowSkill(
+            name="improve",
+            workflow=improve_workflow(),
+            description="Improve an existing project through study, hypothesis, and eval loop.",
+            trigger_description="Triggers when project has .factory/ directory.",
+            phases=[
+                SkillPhase(name="study", description="Analyze codebase and write observations"),
+                SkillPhase(name="research", description="Research the codebase based on observations"),
+                SkillPhase(name="strategy", description="Generate hypotheses from research"),
+                SkillPhase(name="experiment", description="Build, eval, and finalize each hypothesis"),
+            ],
+            inputs=["project path"],
+            outputs=[".factory/strategy/observations.md", ".factory/experiments/verdict.json"],
+            success_criteria="At least one hypothesis kept with positive eval delta.",
+            aliases=["evolve", "iterate"],
+        ),
     }

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -584,6 +584,10 @@ class WorkflowExecutor:
         criteria_dir = Path(__file__).parent / "gate_criteria"
         criteria_path = criteria_dir / criteria_file
 
+        if not criteria_path.resolve().is_relative_to(criteria_dir.resolve()):
+            log.warning("criteria_path_traversal", path=str(criteria_path))
+            return ""
+
         if not criteria_path.is_file():
             log.debug("criteria_file_not_found", path=str(criteria_path))
             return ""
@@ -591,7 +595,6 @@ class WorkflowExecutor:
         content = criteria_path.read_text()
         content = content.replace("{project_path}", str(self.project_path))
         content = content.replace("{focus_directive}", self.node_context.get("focus", ""))
-        content = content.replace("{criteria_file_content}", "")
         return content
 
     def _parse_agent_verdict(self, output: str, gate_id: str) -> Verdict:

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -548,7 +548,7 @@ class WorkflowExecutor:
         return self._parse_agent_verdict(stdout, node.id)
 
     def _build_gate_prompt(self, node: GateNode) -> str:
-        """Build the lightweight CEO gate prompt."""
+        """Build the lightweight CEO gate prompt, optionally enriched with criteria files."""
         if node.gate_prompt:
             return node.gate_prompt.replace(
                 "{project_path}", str(self.project_path),
@@ -562,13 +562,37 @@ class WorkflowExecutor:
             if edge.condition == VerdictType.RELOOP:
                 reloop_targets.append(edge.target)
 
-        return CEO_GATE_PROMPT.format(
+        criteria_content = ""
+        if node.criteria_file:
+            criteria_content = self._load_criteria_file(node.criteria_file)
+
+        base_prompt = CEO_GATE_PROMPT.format(
             step_name=node.id,
             workflow_name=self.workflow.name,
             output_file=", ".join(output_files),
             previous_context=context,
             reloop_targets=", ".join(reloop_targets) if reloop_targets else "(use exact node IDs)",
         )
+
+        if criteria_content:
+            base_prompt += f"\n\n## Review Criteria\n\n{criteria_content}"
+
+        return base_prompt
+
+    def _load_criteria_file(self, criteria_file: str) -> str:
+        """Load a gate criteria file and perform template variable substitution."""
+        criteria_dir = Path(__file__).parent / "gate_criteria"
+        criteria_path = criteria_dir / criteria_file
+
+        if not criteria_path.is_file():
+            log.debug("criteria_file_not_found", path=str(criteria_path))
+            return ""
+
+        content = criteria_path.read_text()
+        content = content.replace("{project_path}", str(self.project_path))
+        content = content.replace("{focus_directive}", self.node_context.get("focus", ""))
+        content = content.replace("{criteria_file_content}", "")
+        return content
 
     def _parse_agent_verdict(self, output: str, gate_id: str) -> Verdict:
         """Parse agent output into a Verdict by examining the last non-empty line."""

--- a/factory/workflow/gate_criteria/builder-review.md
+++ b/factory/workflow/gate_criteria/builder-review.md
@@ -1,0 +1,14 @@
+# Builder Review Criteria
+
+Review the builder's implementation for correctness and completeness.
+
+## Checklist
+
+- [ ] Implementation matches the hypothesis from the strategy
+- [ ] Code changes are within the declared scope
+- [ ] Tests pass (unit, integration, and any project-specific tests)
+- [ ] No lint or type check errors introduced
+- [ ] Draft PR is opened with descriptive title and body
+- [ ] Changes are atomic and focused (no unrelated modifications)
+- [ ] No security vulnerabilities introduced
+- [ ] Project at {project_path} builds successfully

--- a/factory/workflow/gate_criteria/qa-review.md
+++ b/factory/workflow/gate_criteria/qa-review.md
@@ -1,0 +1,14 @@
+# QA Review Criteria
+
+Independently verify the implementation quality and correctness.
+
+## Checklist
+
+- [ ] All tests pass when run from a clean state
+- [ ] Code review findings are addressed (no known issues left open)
+- [ ] Edge cases are handled appropriately
+- [ ] Error messages are clear and actionable
+- [ ] No regressions in existing functionality
+- [ ] Performance is acceptable (no obvious bottlenecks introduced)
+- [ ] Documentation is updated if public API changed
+- [ ] Verify at {project_path} that the change works end-to-end

--- a/factory/workflow/gate_criteria/researcher-review.md
+++ b/factory/workflow/gate_criteria/researcher-review.md
@@ -1,0 +1,12 @@
+# Researcher Review Criteria
+
+Review the researcher's output for completeness and quality.
+
+## Checklist
+
+- [ ] Research covers the assigned topic thoroughly
+- [ ] Findings are specific and actionable (not generic advice)
+- [ ] Sources or evidence are cited where applicable
+- [ ] Research is written to the correct output file
+- [ ] No contradictions with known project constraints
+- [ ] Findings are relevant to the current project context at {project_path}

--- a/factory/workflow/gate_criteria/strategist-review.md
+++ b/factory/workflow/gate_criteria/strategist-review.md
@@ -10,4 +10,3 @@ Review the strategist's hypotheses and plan for quality and feasibility.
 - [ ] Hypotheses are prioritized by expected impact
 - [ ] No duplicate hypotheses from previous experiments
 - [ ] Strategy accounts for project constraints and scope at {project_path}
-- [ ] {focus_directive}

--- a/factory/workflow/gate_criteria/strategist-review.md
+++ b/factory/workflow/gate_criteria/strategist-review.md
@@ -1,0 +1,13 @@
+# Strategist Review Criteria
+
+Review the strategist's hypotheses and plan for quality and feasibility.
+
+## Checklist
+
+- [ ] Hypotheses are specific and testable (not vague improvement ideas)
+- [ ] Each hypothesis has a clear expected outcome
+- [ ] Plan is feasible given the current codebase state
+- [ ] Hypotheses are prioritized by expected impact
+- [ ] No duplicate hypotheses from previous experiments
+- [ ] Strategy accounts for project constraints and scope at {project_path}
+- [ ] {focus_directive}

--- a/factory/workflow/gate_criteria/surface-check.md
+++ b/factory/workflow/gate_criteria/surface-check.md
@@ -1,0 +1,12 @@
+# Surface Check Criteria
+
+Verify that changes respect mutable/fixed surface boundaries.
+
+## Checklist
+
+- [ ] All modified files are within the declared mutable surfaces
+- [ ] No fixed surface files have been modified
+- [ ] No ground truth leakage from test data or expected outputs
+- [ ] Changes do not modify eval/score.py or .factory/ contents
+- [ ] Git diff shows only files within the allowed scope
+- [ ] Project at {project_path} has no uncommitted out-of-scope changes

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -19,6 +19,7 @@ class AgentRole(str, Enum):
     BUILDER = "builder"
     REVIEWER = "reviewer"
     EVALUATOR = "evaluator"
+    QA = "qa"
     FAILURE_ANALYST = "failure_analyst"
     CEO = "ceo"
     ARCHIVIST = "archivist"
@@ -41,6 +42,7 @@ DEFAULT_AGENT_POOL: dict[str, AgentConfig] = {
     "evaluator": AgentConfig(role=AgentRole.EVALUATOR, model="opus"),
     "failure_analyst": AgentConfig(role=AgentRole.FAILURE_ANALYST, model="opus"),
     "ceo": AgentConfig(role=AgentRole.CEO, model="opus"),
+    "qa": AgentConfig(role=AgentRole.QA, model="opus"),
     "archivist": AgentConfig(role=AgentRole.ARCHIVIST, model="haiku"),
 }
 
@@ -136,6 +138,9 @@ class GateNode(Node):
     evaluator_role: AgentRole | None = None
     evaluator_command: str | None = None
     gate_prompt: str = ""
+    user_visible: bool = False
+    criteria_file: str | None = None
+    skippable: bool = False
 
 
 class ForkNode(Node):
@@ -221,3 +226,35 @@ class Factory(BaseModel):
             if wf.trigger and wf.trigger(state, ctx):
                 return wf
         return None
+
+
+# ── workflow-as-skill ───────────────────────────────────────────
+
+
+class SkillPhase(BaseModel):
+    """A named phase within a workflow skill."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str
+    description: str = ""
+
+
+class WorkflowSkill(BaseModel):
+    """A workflow wrapped with skill metadata for registry and CEO prompt injection."""
+
+    model_config = ConfigDict(strict=True, extra="forbid", arbitrary_types_allowed=True)
+
+    name: str
+    workflow: Workflow
+    description: str = ""
+    trigger_description: str = ""
+    phases: list[SkillPhase] = Field(default_factory=list)
+    inputs: list[str] = Field(default_factory=list)
+    outputs: list[str] = Field(default_factory=list)
+    success_criteria: str = ""
+    aliases: list[str] = Field(default_factory=list)
+
+    def validate_graph(self) -> list[str]:
+        """Delegate graph validation to the inner workflow."""
+        return self.workflow.validate_graph()

--- a/factory/workflow/registry.py
+++ b/factory/workflow/registry.py
@@ -1,0 +1,79 @@
+"""Skill registry — discovers, indexes, and selects workflow skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.primitives import WorkflowSkill
+
+
+class SkillRegistry:
+    """Registry of workflow skills with auto-discovery and selection."""
+
+    def __init__(self) -> None:
+        self._skills: dict[str, WorkflowSkill] = {}
+        self._alias_map: dict[str, str] = {}
+
+    def _discover_builtin(self) -> None:
+        """Load all built-in workflows from definitions.py as WorkflowSkill objects."""
+        from factory.workflow.definitions import register_all
+
+        skills = register_all()
+        for name, skill in skills.items():
+            self._skills[name] = skill
+            for alias in skill.aliases:
+                self._alias_map[alias.lower()] = name
+
+    @classmethod
+    def create(cls) -> SkillRegistry:
+        """Create a registry with all built-in skills discovered."""
+        registry = cls()
+        registry._discover_builtin()
+        return registry
+
+    def select(self, state: ProjectState, context: dict[str, Any] | None = None) -> WorkflowSkill | None:
+        """Auto-select a workflow skill by evaluating trigger functions."""
+        ctx = context or {}
+        for skill in self._skills.values():
+            trigger = skill.workflow.trigger
+            if trigger and trigger(state, ctx):
+                return skill
+        return None
+
+    def by_name(self, name: str) -> WorkflowSkill | None:
+        """Explicit lookup by name or alias, case-insensitive."""
+        key = name.lower()
+        if key in self._skills:
+            return self._skills[key]
+        canonical = self._alias_map.get(key)
+        if canonical:
+            return self._skills.get(canonical)
+        return None
+
+    def catalog(self) -> str:
+        """Generate a markdown catalog of all skills for CEO prompt injection."""
+        lines: list[str] = ["# Available Workflow Skills", ""]
+        for name, skill in self._skills.items():
+            lines.append(f"## {name}")
+            lines.append(f"**Description:** {skill.description}")
+            lines.append(f"**Trigger:** {skill.trigger_description}")
+            if skill.aliases:
+                lines.append(f"**Aliases:** {', '.join(skill.aliases)}")
+            if skill.phases:
+                lines.append("**Phases:**")
+                for phase in skill.phases:
+                    desc = f" — {phase.description}" if phase.description else ""
+                    lines.append(f"  - {phase.name}{desc}")
+            if skill.inputs:
+                lines.append(f"**Inputs:** {', '.join(skill.inputs)}")
+            if skill.outputs:
+                lines.append(f"**Outputs:** {', '.join(skill.outputs)}")
+            if skill.success_criteria:
+                lines.append(f"**Success criteria:** {skill.success_criteria}")
+            lines.append("")
+        return "\n".join(lines)
+
+    def names(self) -> list[str]:
+        """All registered skill names."""
+        return list(self._skills.keys())

--- a/tests/test_workflow_skills.py
+++ b/tests/test_workflow_skills.py
@@ -13,11 +13,9 @@ from factory.workflow.primitives import (
     AgentConfig,
     AgentRole,
     DEFAULT_AGENT_POOL,
-    Edge,
     FnNode,
     GateNode,
     SkillPhase,
-    VerdictType,
     Workflow,
     WorkflowSkill,
 )

--- a/tests/test_workflow_skills.py
+++ b/tests/test_workflow_skills.py
@@ -1,0 +1,573 @@
+"""Tests for WorkflowSkill, SkillPhase, SkillRegistry, QA role, gate criteria, and CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from factory.models import ProjectState
+from factory.workflow.definitions import register_all
+from factory.workflow.primitives import (
+    AgentConfig,
+    AgentRole,
+    DEFAULT_AGENT_POOL,
+    Edge,
+    FnNode,
+    GateNode,
+    SkillPhase,
+    VerdictType,
+    Workflow,
+    WorkflowSkill,
+)
+from factory.workflow.registry import SkillRegistry
+
+
+# ── SkillPhase ──────────────────────────────────────────────────
+
+
+class TestSkillPhase:
+    def test_create_minimal(self) -> None:
+        p = SkillPhase(name="research")
+        assert p.name == "research"
+        assert p.description == ""
+
+    def test_create_with_description(self) -> None:
+        p = SkillPhase(name="build", description="Implement the plan")
+        assert p.name == "build"
+        assert p.description == "Implement the plan"
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            SkillPhase(name="test", unknown="bad")  # type: ignore[call-arg]
+
+    def test_serialize_roundtrip(self) -> None:
+        p = SkillPhase(name="strategy", description="Generate hypotheses")
+        data = p.model_dump()
+        p2 = SkillPhase.model_validate(data)
+        assert p2.name == p.name
+        assert p2.description == p.description
+
+
+# ── WorkflowSkill ───────────────────────────────────────────────
+
+
+class TestWorkflowSkill:
+    def _simple_workflow(self) -> Workflow:
+        return Workflow(
+            name="test",
+            nodes={"a": FnNode(id="a", command="echo a")},
+            edges=[],
+            start_node="a",
+        )
+
+    def test_create_minimal(self) -> None:
+        wf = self._simple_workflow()
+        skill = WorkflowSkill(name="test", workflow=wf)
+        assert skill.name == "test"
+        assert skill.workflow is wf
+        assert skill.description == ""
+        assert skill.aliases == []
+        assert skill.phases == []
+
+    def test_create_with_metadata(self) -> None:
+        wf = self._simple_workflow()
+        skill = WorkflowSkill(
+            name="build",
+            workflow=wf,
+            description="Build a new project",
+            trigger_description="Triggers on NO_REPO",
+            phases=[SkillPhase(name="research"), SkillPhase(name="build")],
+            inputs=["idea"],
+            outputs=["project"],
+            success_criteria="Tests pass",
+            aliases=["new", "create"],
+        )
+        assert skill.description == "Build a new project"
+        assert len(skill.phases) == 2
+        assert skill.phases[0].name == "research"
+        assert skill.aliases == ["new", "create"]
+        assert skill.inputs == ["idea"]
+        assert skill.outputs == ["project"]
+        assert skill.success_criteria == "Tests pass"
+
+    def test_validate_graph_delegates(self) -> None:
+        wf = Workflow(
+            name="test",
+            nodes={
+                "a": FnNode(id="a", command="echo a"),
+                "orphan": FnNode(id="orphan", command="echo orphan"),
+            },
+            edges=[],
+            start_node="a",
+        )
+        skill = WorkflowSkill(name="test", workflow=wf)
+        issues = skill.validate_graph()
+        assert any("orphan" in i and "unreachable" in i for i in issues)
+
+    def test_validate_graph_clean(self) -> None:
+        wf = self._simple_workflow()
+        skill = WorkflowSkill(name="test", workflow=wf)
+        issues = skill.validate_graph()
+        assert issues == []
+
+    def test_extra_fields_forbidden(self) -> None:
+        wf = self._simple_workflow()
+        with pytest.raises(ValidationError):
+            WorkflowSkill(name="test", workflow=wf, unknown="bad")  # type: ignore[call-arg]
+
+    def test_serialize_roundtrip(self) -> None:
+        wf = self._simple_workflow()
+        skill = WorkflowSkill(
+            name="test",
+            workflow=wf,
+            description="Test skill",
+            aliases=["t"],
+        )
+        data = skill.model_dump()
+        assert data["name"] == "test"
+        assert data["description"] == "Test skill"
+        assert data["aliases"] == ["t"]
+
+
+# ── QA AgentRole ────────────────────────────────────────────────
+
+
+class TestQARole:
+    def test_qa_enum_exists(self) -> None:
+        assert AgentRole.QA == "qa"
+        assert AgentRole.QA.value == "qa"
+
+    def test_qa_in_default_pool(self) -> None:
+        assert "qa" in DEFAULT_AGENT_POOL
+        qa_config = DEFAULT_AGENT_POOL["qa"]
+        assert qa_config.role == AgentRole.QA
+        assert qa_config.model == "opus"
+
+    def test_qa_config_valid(self) -> None:
+        config = AgentConfig(role=AgentRole.QA, model="opus")
+        assert config.role == AgentRole.QA
+
+    def test_existing_roles_preserved(self) -> None:
+        assert AgentRole.RESEARCHER.value == "researcher"
+        assert AgentRole.REVIEWER.value == "reviewer"
+        assert AgentRole.EVALUATOR.value == "evaluator"
+        assert AgentRole.BUILDER.value == "builder"
+        assert AgentRole.CEO.value == "ceo"
+
+
+# ── GateNode new fields ────────────────────────────────────────
+
+
+class TestGateNodeExtensions:
+    def test_defaults_backward_compat(self) -> None:
+        g = GateNode(id="gate1", evaluator_type="agent", evaluator_role=AgentRole.CEO)
+        assert g.user_visible is False
+        assert g.criteria_file is None
+        assert g.skippable is False
+
+    def test_with_criteria_file(self) -> None:
+        g = GateNode(
+            id="gate1",
+            evaluator_type="agent",
+            evaluator_role=AgentRole.CEO,
+            criteria_file="builder-review.md",
+        )
+        assert g.criteria_file == "builder-review.md"
+
+    def test_with_user_visible(self) -> None:
+        g = GateNode(
+            id="gate1",
+            evaluator_type="user",
+            user_visible=True,
+        )
+        assert g.user_visible is True
+
+    def test_with_skippable(self) -> None:
+        g = GateNode(
+            id="gate1",
+            evaluator_type="fn",
+            evaluator_command="echo ok",
+            skippable=True,
+        )
+        assert g.skippable is True
+
+    def test_serialize_roundtrip(self) -> None:
+        g = GateNode(
+            id="gate1",
+            evaluator_type="agent",
+            evaluator_role=AgentRole.CEO,
+            criteria_file="qa-review.md",
+            user_visible=True,
+            skippable=True,
+        )
+        data = g.model_dump()
+        g2 = GateNode.model_validate(data)
+        assert g2.criteria_file == "qa-review.md"
+        assert g2.user_visible is True
+        assert g2.skippable is True
+
+
+# ── SkillRegistry ───────────────────────────────────────────────
+
+
+class TestSkillRegistry:
+    def test_create_discovers_all(self) -> None:
+        registry = SkillRegistry.create()
+        names = registry.names()
+        assert len(names) == 5
+        assert set(names) == {"build", "design", "improve", "research", "meta"}
+
+    def test_by_name_exact(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.by_name("build")
+        assert skill is not None
+        assert skill.name == "build"
+
+    def test_by_name_case_insensitive(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.by_name("BUILD")
+        assert skill is not None
+        assert skill.name == "build"
+
+    def test_by_name_alias(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.by_name("new")
+        assert skill is not None
+        assert skill.name == "build"
+
+    def test_by_name_alias_case_insensitive(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.by_name("CREATE")
+        assert skill is not None
+        assert skill.name == "build"
+
+    def test_by_name_unknown(self) -> None:
+        registry = SkillRegistry.create()
+        assert registry.by_name("nonexistent") is None
+
+    def test_select_no_repo(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.select(ProjectState.NO_REPO)
+        assert skill is not None
+        assert skill.name == "build"
+
+    def test_select_has_factory(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.select(ProjectState.HAS_FACTORY)
+        assert skill is not None
+        assert skill.name == "improve"
+
+    def test_select_has_factory_research(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.select(ProjectState.HAS_FACTORY, {"research_target": "accuracy"})
+        assert skill is not None
+        assert skill.name == "research"
+
+    def test_select_meta(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.select(ProjectState.HAS_FACTORY, {"mode": "meta"})
+        assert skill is not None
+        assert skill.name == "meta"
+
+    def test_select_interactive(self) -> None:
+        registry = SkillRegistry.create()
+        skill = registry.select(ProjectState.NO_REPO, {"interactive": True})
+        assert skill is not None
+        assert skill.name == "design"
+
+    def test_catalog_markdown(self) -> None:
+        registry = SkillRegistry.create()
+        catalog = registry.catalog()
+        assert "# Available Workflow Skills" in catalog
+        assert "## build" in catalog
+        assert "## improve" in catalog
+        assert "## research" in catalog
+        assert "## meta" in catalog
+        assert "## design" in catalog
+        assert "**Description:**" in catalog
+        assert "**Trigger:**" in catalog
+        assert "**Phases:**" in catalog
+        assert "**Aliases:**" in catalog
+
+    def test_catalog_contains_all_aliases(self) -> None:
+        registry = SkillRegistry.create()
+        catalog = registry.catalog()
+        assert "new, create" in catalog
+        assert "interactive, discuss" in catalog
+        assert "evolve, iterate" in catalog
+
+    def test_names_list(self) -> None:
+        registry = SkillRegistry.create()
+        names = registry.names()
+        assert isinstance(names, list)
+        assert all(isinstance(n, str) for n in names)
+
+
+# ── register_all returns WorkflowSkill ──────────────────────────
+
+
+class TestRegisterAllSkills:
+    def test_returns_workflow_skills(self) -> None:
+        skills = register_all()
+        for name, skill in skills.items():
+            assert isinstance(skill, WorkflowSkill), f"{name} should be WorkflowSkill"
+
+    def test_all_have_descriptions(self) -> None:
+        skills = register_all()
+        for name, skill in skills.items():
+            assert skill.description, f"{name} missing description"
+
+    def test_all_have_trigger_descriptions(self) -> None:
+        skills = register_all()
+        for name, skill in skills.items():
+            assert skill.trigger_description, f"{name} missing trigger_description"
+
+    def test_all_have_phases(self) -> None:
+        skills = register_all()
+        for name, skill in skills.items():
+            assert len(skill.phases) > 0, f"{name} missing phases"
+
+    def test_all_have_aliases(self) -> None:
+        skills = register_all()
+        for name, skill in skills.items():
+            assert len(skill.aliases) > 0, f"{name} missing aliases"
+
+    def test_all_validate(self) -> None:
+        skills = register_all()
+        for name, skill in skills.items():
+            issues = skill.validate_graph()
+            assert issues == [], f"{name} has validation issues: {issues}"
+
+    def test_workflow_accessible(self) -> None:
+        skills = register_all()
+        for name, skill in skills.items():
+            wf = skill.workflow
+            assert isinstance(wf, Workflow)
+            assert wf.name == name
+
+
+# ── Gate criteria files ─────────────────────────────────────────
+
+
+class TestGateCriteriaFiles:
+    def _criteria_dir(self) -> Path:
+        return Path(__file__).parent.parent / "factory" / "workflow" / "gate_criteria"
+
+    def test_criteria_dir_exists(self) -> None:
+        assert self._criteria_dir().is_dir()
+
+    def test_all_five_files_exist(self) -> None:
+        expected = [
+            "researcher-review.md",
+            "strategist-review.md",
+            "builder-review.md",
+            "qa-review.md",
+            "surface-check.md",
+        ]
+        for fname in expected:
+            path = self._criteria_dir() / fname
+            assert path.is_file(), f"Missing criteria file: {fname}"
+
+    def test_files_have_content(self) -> None:
+        for path in self._criteria_dir().glob("*.md"):
+            content = path.read_text()
+            assert len(content) > 50, f"{path.name} is too short"
+            assert "## Checklist" in content, f"{path.name} missing Checklist section"
+
+    def test_files_have_template_vars(self) -> None:
+        for path in self._criteria_dir().glob("*.md"):
+            content = path.read_text()
+            assert "{project_path}" in content, f"{path.name} missing {{project_path}} template var"
+
+    def test_build_workflow_gates_reference_criteria(self) -> None:
+        from factory.workflow.definitions import build_workflow
+
+        wf = build_workflow()
+        gate_research = wf.nodes.get("gate_research")
+        gate_strategy = wf.nodes.get("gate_strategy")
+        gate_build = wf.nodes.get("gate_build")
+
+        assert isinstance(gate_research, GateNode)
+        assert gate_research.criteria_file == "researcher-review.md"
+
+        assert isinstance(gate_strategy, GateNode)
+        assert gate_strategy.criteria_file == "strategist-review.md"
+
+        assert isinstance(gate_build, GateNode)
+        assert gate_build.criteria_file == "builder-review.md"
+
+    def test_improve_workflow_gates_reference_criteria(self) -> None:
+        from factory.workflow.definitions import improve_workflow
+
+        wf = improve_workflow()
+        gate_research = wf.nodes.get("gate_research")
+        gate_strategy = wf.nodes.get("gate_strategy")
+        gate_build = wf.nodes.get("gate_build")
+
+        assert isinstance(gate_research, GateNode)
+        assert gate_research.criteria_file == "researcher-review.md"
+
+        assert isinstance(gate_strategy, GateNode)
+        assert gate_strategy.criteria_file == "strategist-review.md"
+
+        assert isinstance(gate_build, GateNode)
+        assert gate_build.criteria_file == "builder-review.md"
+
+
+# ── _build_gate_prompt with criteria ────────────────────────────
+
+
+class TestBuildGatePromptCriteria:
+    def test_prompt_includes_criteria_content(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        gate = GateNode(
+            id="gate_test",
+            evaluator_type="agent",
+            evaluator_role=AgentRole.CEO,
+            reads={"output.md"},
+            criteria_file="builder-review.md",
+        )
+        wf = Workflow(
+            name="test",
+            nodes={"gate_test": gate},
+            edges=[],
+            start_node="gate_test",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        prompt = executor._build_gate_prompt(gate)
+        assert "Review Criteria" in prompt
+        assert "Builder Review Criteria" in prompt
+
+    def test_prompt_substitutes_project_path(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        gate = GateNode(
+            id="gate_test",
+            evaluator_type="agent",
+            evaluator_role=AgentRole.CEO,
+            criteria_file="researcher-review.md",
+        )
+        wf = Workflow(
+            name="test",
+            nodes={"gate_test": gate},
+            edges=[],
+            start_node="gate_test",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        prompt = executor._build_gate_prompt(gate)
+        assert str(tmp_path) in prompt
+
+    def test_prompt_fallback_without_criteria(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        gate = GateNode(
+            id="gate_test",
+            evaluator_type="agent",
+            evaluator_role=AgentRole.CEO,
+        )
+        wf = Workflow(
+            name="test",
+            nodes={"gate_test": gate},
+            edges=[],
+            start_node="gate_test",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        prompt = executor._build_gate_prompt(gate)
+        assert "Review Criteria" not in prompt
+        assert "reviewing the output" in prompt
+
+    def test_prompt_fallback_missing_file(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        gate = GateNode(
+            id="gate_test",
+            evaluator_type="agent",
+            evaluator_role=AgentRole.CEO,
+            criteria_file="nonexistent-file.md",
+        )
+        wf = Workflow(
+            name="test",
+            nodes={"gate_test": gate},
+            edges=[],
+            start_node="gate_test",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        prompt = executor._build_gate_prompt(gate)
+        assert "Review Criteria" not in prompt
+
+
+# ── CLI commands ────────────────────────────────────────────────
+
+
+class TestWorkflowCLI:
+    def test_list_command(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import argparse
+
+        from factory.workflow.cli import cmd_workflow
+
+        args = argparse.Namespace(workflow_command="list")
+        code = cmd_workflow(args)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "build" in out
+        assert "improve" in out
+        assert "Phases" in out
+
+    def test_catalog_command(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import argparse
+
+        from factory.workflow.cli import cmd_workflow
+
+        args = argparse.Namespace(workflow_command="catalog")
+        code = cmd_workflow(args)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "# Available Workflow Skills" in out
+        assert "## build" in out
+        assert "**Phases:**" in out
+
+    def test_show_command(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import argparse
+
+        from factory.workflow.cli import cmd_workflow
+
+        args = argparse.Namespace(workflow_command="show", name="improve")
+        code = cmd_workflow(args)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Workflow: improve" in out
+        assert "Desc:" in out
+        assert "Aliases:" in out
+        assert "Phases:" in out
+
+    def test_show_unknown(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import argparse
+
+        from factory.workflow.cli import cmd_workflow
+
+        args = argparse.Namespace(workflow_command="show", name="nonexistent")
+        code = cmd_workflow(args)
+        assert code == 1
+
+    def test_validate_command(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import argparse
+
+        from factory.workflow.cli import cmd_workflow
+
+        args = argparse.Namespace(workflow_command="validate", name="build")
+        code = cmd_workflow(args)
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "VALID" in out
+
+    def test_no_subcommand(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import argparse
+
+        from factory.workflow.cli import cmd_workflow
+
+        args = argparse.Namespace(workflow_command=None)
+        code = cmd_workflow(args)
+        assert code == 1


### PR DESCRIPTION
Closes #665

## Changes

### Phase 1 — WorkflowSkill Model + SkillRegistry
- Added `SkillPhase` and `WorkflowSkill` Pydantic models to `primitives.py` — `WorkflowSkill` wraps `Workflow` with metadata (description, trigger_description, phases, inputs, outputs, success_criteria, aliases) via composition
- Added `QA = "qa"` to `AgentRole` enum alongside existing REVIEWER and EVALUATOR roles
- Added QA config (`"qa": AgentConfig(role=AgentRole.QA, model="opus")`) to `DEFAULT_AGENT_POOL`
- Created `factory/workflow/registry.py` with `SkillRegistry` class: `_discover_builtin()`, `select()`, `by_name()`, `catalog()`, `names()`
- Updated `register_all()` to return `dict[str, WorkflowSkill]` with full metadata for all 5 workflows, ordered by trigger specificity
- Added `factory workflow catalog` CLI command that generates injectable markdown
- Enhanced `factory workflow list` and `factory workflow show` with skill metadata (phases, aliases, descriptions)
- Updated `factory/workflow/__init__.py` exports

### Phase 2 — Gate Criteria + GateNode Extensions
- Added 3 optional fields to `GateNode`: `user_visible: bool = False`, `criteria_file: str | None = None`, `skippable: bool = False` (backward compatible defaults)
- Created `factory/workflow/gate_criteria/` with 5 review checklist files: `researcher-review.md`, `strategist-review.md`, `builder-review.md`, `qa-review.md`, `surface-check.md`
- Extended `_build_gate_prompt()` in `executor.py` to read criteria files and perform template variable substitution (`{project_path}`, `{focus_directive}`)
- Referenced criteria files in build and improve workflow gate nodes

### Tests
- 56 new tests in `tests/test_workflow_skills.py` covering all new models, registry, gate criteria, and CLI commands
- All 140 existing + new workflow tests pass
- ruff clean, mypy clean