### PR TITLE
feat: add non-blocking benchmark status check to PRs

### DIFF
--- a/.github/workflows/benchmark-status.yml
+++ b/.github/workflows/benchmark-status.yml
@@ -1,0 +1,26 @@
+name: Benchmark Status
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  statuses: write
+
+jobs:
+  set-pending:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set pending benchmark status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              context: 'benchmark-eval',
+              description: 'Benchmark evaluation not yet run. Trigger via Actions > Benchmark CI.',
+              target_url: 'https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/workflows/benchmark.yml'
+            });

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,6 +50,7 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+  statuses: write
 
 jobs:
   benchmark:
@@ -416,6 +417,30 @@ jobs:
                 body: body
               });
             }
+
+      - name: Update benchmark status to success
+        if: inputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = parseInt('${{ inputs.pr_number }}', 10);
+            if (!prNumber || isNaN(prNumber)) return;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: pr.head.sha,
+              state: 'success',
+              context: 'benchmark-eval',
+              description: 'Benchmark evaluation complete.',
+              target_url: 'https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId
+            });
 
       - name: Update release notes
         if: github.event_name == 'release'


### PR DESCRIPTION
## Changes

- **New `.github/workflows/benchmark-status.yml`**: Sets a `pending` commit status (`benchmark-eval`) on every PR open and push via `pull_request_target`, so it works for fork PRs too. The status links to the Benchmark CI workflow for easy manual triggering.
- **Updated `.github/workflows/benchmark.yml`**: Added `statuses: write` permission and a new step in the `report` job that updates the commit status to `success` after benchmarks complete for a given PR number.

The status is purely informational — it is NOT added to required checks and never blocks merging.