### PR TITLE
feat: increase default benchmark timeout to 7200s

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ on:
       timeout:
         description: 'Solver timeout in seconds'
         required: false
-        default: '1800'
+        default: '7200'
         type: string
       solver:
         description: 'Solver to use'


### PR DESCRIPTION
Changes default solver timeout from 1800s to 7200s to give the factory enough time for longer benchmarks.