### PR TITLE
demo: test full benchmark-eval check requires all 4 factory benchmarks

### DIFF
--- a/benchmarks/lib.sh
+++ b/benchmarks/lib.sh
@@ -125,3 +125,4 @@ setup_vertex_env() {
         export CLOUD_ML_REGION="${CLOUD_ML_REGION:-global}"
     fi
 }
+# Demo PR for benchmark check


### PR DESCRIPTION
Test PR to verify the benchmark-eval status check requires all 4 factory benchmarks to run before flipping to success.