### PR TITLE
fix: enable claude-code solver in nightly benchmark schedule

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -77,23 +77,23 @@ jobs:
             solver: factory
             default_instance: 'cmatrix'
             enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
-          # Claude Code solver entries — disabled on schedule (nightly runs factory only)
+          # Claude Code solver entries — enabled on schedule, release, or workflow_dispatch with matching benchmark+solver
           - benchmark: swebench
             solver: claude-code
             default_instance: 'sympy__sympy-20590'
-            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: featurebench
             solver: claude-code
             default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
-            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: terminalbench
             solver: claude-code
             default_instance: 'fix-git'
-            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: programbench
             solver: claude-code
             default_instance: 'cmatrix'
-            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
 
     steps:
       - name: Skip if not enabled


### PR DESCRIPTION
## Summary

- Removed the `github.event_name != 'schedule'` guard from all four claude-code matrix entries in `benchmark.yml`
- Replaced with `github.event_name == 'schedule' ||` so claude-code runs on the nightly cron alongside the factory solver
- No change to workflow_dispatch or release behavior

## Test plan

- [ ] Trigger a manual `workflow_dispatch` with `solver=claude-code` — only claude-code entries should run
- [ ] Trigger with `solver=factory` — only factory entries should run
- [ ] Trigger with `solver=both` — both should run
- [ ] Verify nightly schedule now includes both factory and claude-code matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)