### PR TITLE
fix: benchmark CI — terminalbench resolved:false, $0 costs, nightly schedule

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -77,23 +77,23 @@ jobs:
             solver: factory
             default_instance: 'cmatrix'
             enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
-          # Claude Code solver entries — disabled on schedule (nightly runs factory only)
+          # Claude Code solver entries — enabled on schedule, release, or workflow_dispatch with matching benchmark+solver
           - benchmark: swebench
             solver: claude-code
             default_instance: 'sympy__sympy-20590'
-            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: featurebench
             solver: claude-code
             default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
-            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: terminalbench
             solver: claude-code
             default_instance: 'fix-git'
-            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'terminalbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: programbench
             solver: claude-code
             default_instance: 'cmatrix'
-            enabled: ${{ github.event_name != 'schedule' && ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+            enabled: ${{ github.event_name == 'schedule' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'programbench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
 
     steps:
       - name: Skip if not enabled

--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -274,7 +274,7 @@ CACHE_CREATION_TOKENS=0
 
 if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
     if [ -f "${SOLVER_LOG}" ]; then
-        COST_DATA=$(grep '"type":"result"' "${SOLVER_LOG}" | tail -1 | python3 -c "
+        COST_DATA=$(grep '"type":"result"' "${SOLVER_LOG}" 2>/dev/null | tail -1 | python3 -c "
 import sys, json
 try:
     data = json.loads(sys.stdin.readline())
@@ -285,7 +285,7 @@ try:
     print(f'CACHE_READ_TOKENS={u.get(\"cache_read_input_tokens\", 0)}')
     print(f'CACHE_CREATION_TOKENS={u.get(\"cache_creation_input_tokens\", 0)}')
 except: pass
-" 2>/dev/null)
+" 2>/dev/null || true)
         eval "${COST_DATA}" 2>/dev/null || true
     fi
 else

--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -324,7 +324,7 @@ CACHE_CREATION_TOKENS=0
 
 if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
     if [ -f "${RESULTS_DIR}/solver_output.log" ]; then
-        COST_DATA=$(grep '"type":"result"' "${RESULTS_DIR}/solver_output.log" | tail -1 | python3 -c "
+        COST_DATA=$(grep '"type":"result"' "${RESULTS_DIR}/solver_output.log" 2>/dev/null | tail -1 | python3 -c "
 import sys, json
 try:
     data = json.loads(sys.stdin.readline())
@@ -335,7 +335,7 @@ try:
     print(f'CACHE_READ_TOKENS={u.get(\"cache_read_input_tokens\", 0)}')
     print(f'CACHE_CREATION_TOKENS={u.get(\"cache_creation_input_tokens\", 0)}')
 except: pass
-" 2>/dev/null)
+" 2>/dev/null || true)
         eval "${COST_DATA}" 2>/dev/null || true
     fi
 else

--- a/benchmarks/run-swebench.sh
+++ b/benchmarks/run-swebench.sh
@@ -260,7 +260,7 @@ CACHE_CREATION_TOKENS=0
 
 if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
     if [ -f "${SOLVER_LOG}" ]; then
-        COST_DATA=$(grep '"type":"result"' "${SOLVER_LOG}" | tail -1 | python3 -c "
+        COST_DATA=$(grep '"type":"result"' "${SOLVER_LOG}" 2>/dev/null | tail -1 | python3 -c "
 import sys, json
 try:
     data = json.loads(sys.stdin.readline())
@@ -271,7 +271,7 @@ try:
     print(f'CACHE_READ_TOKENS={u.get(\"cache_read_input_tokens\", 0)}')
     print(f'CACHE_CREATION_TOKENS={u.get(\"cache_creation_input_tokens\", 0)}')
 except: pass
-" 2>/dev/null)
+" 2>/dev/null || true)
         eval "${COST_DATA}" 2>/dev/null || true
     fi
 else

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -191,6 +191,10 @@ if [ "${HARBOR_EXIT}" -ne 0 ]; then
     echo "    Harbor exited with code ${HARBOR_EXIT}"
 fi
 
+# Temporarily allow failures — cost/reward extraction uses grep/find which return
+# non-zero on no match; pipefail would kill the script before reaching STATUS=success.
+set +e
+
 # Extract cost from Harbor result
 COST_USD=0
 INPUT_TOKENS=0
@@ -215,7 +219,7 @@ fi
 if [ "${COST_USD}" = "0" ] || [ -z "${COST_USD}" ]; then
     AGENT_LOG=$(find "${JOBS_DIR}" -name 'claude-code.txt' -o -name 'claude_code_stream_output.jsonl' -o -name 'factory-ceo.txt' 2>/dev/null | head -1)
     if [ -n "${AGENT_LOG}" ]; then
-        COST_DATA=$(grep 'total_cost_usd' "${AGENT_LOG}" | tail -1 | python3 -c "
+        COST_DATA=$(grep 'total_cost_usd' "${AGENT_LOG}" 2>/dev/null | tail -1 | python3 -c "
 import sys, json
 for line in sys.stdin:
     try:
@@ -226,7 +230,7 @@ for line in sys.stdin:
             print(f'INPUT_TOKENS={u.get(\"input_tokens\", 0)}')
             print(f'OUTPUT_TOKENS={u.get(\"output_tokens\", 0)}')
     except: pass
-" 2>/dev/null)
+" 2>/dev/null || true)
         eval "${COST_DATA}" 2>/dev/null || true
     fi
 fi
@@ -342,6 +346,8 @@ else
 fi
 echo "============================================"
 echo ""
+
+set -e
 
 STATUS="success"
 


### PR DESCRIPTION
## Summary

Fixes 3 benchmark CI issues in a single PR:

1. **TerminalBench reports `resolved:false` despite Harbor showing `Mean:1.000`**: `set -euo pipefail` kills the script when `grep`/`find` return non-zero (no matches) during cost extraction, before reaching the reward extraction and `STATUS=success`. Fix: wrap cost+reward extraction in `set +e` / `set -e`, matching the pattern already used in `run-swebench.sh` and `run-featurebench.sh`.

2. **Cost is $0 for all runs**: The cost extraction `grep` pipeline fails under `pipefail` when no match is found. Fix: add `2>/dev/null` to `grep` and `|| true` to the pipeline in all four benchmark scripts (`run-terminalbench.sh`, `run-swebench.sh`, `run-featurebench.sh`, `run-programbench.sh`).

3. **Nightly schedule excludes `claude-code` solver**: The claude-code matrix entries in `benchmark.yml` had `github.event_name != 'schedule'` which excluded them from nightly runs. Fix: change to `github.event_name == 'schedule' ||` to include them, matching the factory solver pattern.

## Changes

- `benchmarks/run-terminalbench.sh`: Add `set +e` / `set -e` around cost+reward extraction; harden grep pipeline
- `benchmarks/run-swebench.sh`: Harden grep pipeline with `2>/dev/null` and `|| true`
- `benchmarks/run-featurebench.sh`: Same grep pipeline hardening
- `benchmarks/run-programbench.sh`: Same grep pipeline hardening
- `.github/workflows/benchmark.yml`: Include claude-code solver in nightly schedule runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)