### PR TITLE
fix: remove stale factory eval patterns from CEO prompt, add QA delegation tests

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1073,17 +1073,9 @@ factory log "$PROJECT_PATH" "phase.strategy.completed" --data '{"verdict": "PROC
 
 For each CEO-approved hypothesis in `strategy/current.md`, in priority order:
 
-**Every hypothesis gets the full pipeline.** Steps 2a through 2d-qa execute sequentially for each experiment. Do NOT batch builders and skip QA. Do NOT abbreviate the pipeline for "small" changes. Initialize `$QA_ITERATION=1` fresh for each experiment.
+**Every hypothesis gets the full pipeline.** Steps 2a through 2c-qa execute sequentially for each experiment. Do NOT batch builders and skip QA. Do NOT abbreviate the pipeline for "small" changes. Initialize `$QA_ITERATION=1` fresh for each experiment.
 
-#### 2a. Baseline Eval
-
-```bash
-factory eval "$PROJECT_PATH"
-```
-
-Parse the JSON output. Save the composite score as `$SCORE_BEFORE`. If eval crashes, see Error Recovery below.
-
-#### 2b. Begin Experiment
+#### 2a. Begin Experiment
 
 ```bash
 factory begin "$PROJECT_PATH" --hypothesis "<hypothesis text>"
@@ -1091,7 +1083,7 @@ factory begin "$PROJECT_PATH" --hypothesis "<hypothesis text>"
 
 Save the printed experiment ID as `$EXP_ID`.
 
-#### 2c. Create GitHub Issue
+#### 2b. Create GitHub Issue
 
 For **code-only** hypotheses (`**Type:** code` or no Type field):
 
@@ -1146,7 +1138,7 @@ gh issue create \
 
 Save issue number as `$ISSUE_NUM`.
 
-#### 2d. Implement (Builder Agent)
+#### 2c. Implement (Builder Agent)
 
 Set `$BUILDER_TIMEOUT` based on hypothesis type: **600** for code-only hypotheses, **1800** for operational or mixed hypotheses (pipelines, benchmarks, and Docker builds need more time).
 
@@ -1168,7 +1160,7 @@ Rules: implement ONLY what the issue asks. Do NOT modify eval/score.py or .facto
 
 If Builder fails (no PR opened), see Error Recovery below.
 
-#### 2d-qa: QA Agent Verification (MANDATORY — DO NOT SKIP)
+#### 2c-qa: QA Agent Verification (MANDATORY — DO NOT SKIP)
 
 **MANDATORY FOR EVERY EXPERIMENT — NO EXCEPTIONS.** The QA Agent runs for every experiment regardless of change size, change type (code, prompt, config), or whether lint/types pass. "The change is small" is NOT a valid reason to skip. Skipping QA violates Sacred Rule 9.
 
@@ -1190,12 +1182,11 @@ factory agent qa --task "Verify experiment $EXP_ID for $PROJECT_PATH. QA iterati
 
 Hypothesis: <hypothesis text>
 PR: #$PR_NUM
-Baseline score: $SCORE_BEFORE
 Baseline SHA: $BASELINE_SHA
 Issue: #$ISSUE_NUM
 
 Run all 3 verification sections:
-1. Health Check — run: factory eval $PROJECT_PATH. Report composite score and delta vs baseline $SCORE_BEFORE.
+1. Health Check — run: factory eval $PROJECT_PATH. Capture the composite score as \$SCORE_BEFORE (baseline) and report delta. This is the authoritative baseline measurement for this experiment.
 2. Code Review — read PR diff (gh pr diff $PR_NUM), evaluate the 7-category checklist, check spec fidelity against issue #$ISSUE_NUM.
 3. Adversarial QA — actually run/test the feature described in the hypothesis. Execute the smoke test if configured in factory.md.
 
@@ -1232,7 +1223,7 @@ Report your structured verdict: CLEAN, ISSUES_FOUND: N, or REVERT." --project "$
 3. **Increment:** `$QA_ITERATION += 1`
 4. **Re-run QA:** Spawn the QA Agent again with the updated iteration number. Loop back to "Spawn the QA Agent" above.
 
-#### 2e. Hard Precheck Gate (NON-OVERRIDABLE)
+#### 2d. Hard Precheck Gate (NON-OVERRIDABLE)
 
 **Before making any keep/revert decision, run the precheck gate.** This is a hard gate — you CANNOT override a failed precheck. A failure means mandatory revert, no exceptions.
 
@@ -1263,12 +1254,22 @@ The precheck runs these checks:
 # Strip non-essential artifacts from the PR
 factory clean-pr $PROJECT_PATH --exp $EXP_ID
 
-# Verify tests still pass with stripped files
-factory eval $PROJECT_PATH
+# Re-verify after stripping via QA Agent
+factory agent qa --task "Re-verify experiment $EXP_ID after Clean PR strip for $PROJECT_PATH.
+The PR was stripped of non-essential artifacts by factory clean-pr.
+Verify the project still passes all checks after stripping.
+
+Run all 3 verification sections:
+1. Health Check — run: factory eval $PROJECT_PATH. Report composite score.
+2. Code Review — verify no essential code was stripped.
+3. Adversarial QA — run smoke test to confirm the project still works.
+
+Report structured verdict." --project "$PROJECT_PATH" --timeout 600
 ```
 
-- If eval passes → proceed to KEEP approval below.
-- If eval fails → revert the stripping and proceed with the full diff:
+Read `.factory/reviews/qa-latest.md` for the QA verdict:
+- If QA verdict is CLEAN → proceed to KEEP approval below.
+- If QA verdict is REVERT or ISSUES_FOUND → revert the stripping and proceed with the full diff:
   ```bash
   git checkout HEAD -- .
   ```
@@ -1531,7 +1532,7 @@ Then execute the FULL Mode: Refine pipeline (R0-R12):
 4. **R2:** `factory begin` — new experiment
 5. **R3:** Create GitHub issue
 6. **R4:** Spawn Builder
-7. **R5-R6:** QA Agent verification + precheck gate — IDENTICAL to Improve mode steps 2d-qa and 2e
+7. **R5-R6:** QA Agent verification + precheck gate — IDENTICAL to Improve mode steps 2c-qa and 2d
 8. **R11:** Keep/revert verdict + finalize
 9. **R12:** Archivist (single batch)
 
@@ -1920,13 +1921,9 @@ The verdict decision is driven by the research target metric, with hygiene as a 
 
 #### R5a. Hygiene Gate (NON-OVERRIDABLE)
 
-Run the standard eval to check hygiene dimensions:
+Read the QA Agent's Health Check from `.factory/reviews/qa-latest.md` (the QA Agent already ran `factory eval` during R3-qa above). Extract the per-dimension scores from the Health Check table.
 
-```bash
-factory eval "$PROJECT_PATH"
-```
-
-Read the JSON output and compare each hygiene dimension (tests, lint, type_check, coverage) against the baseline scores captured before the experiment. **If ANY hygiene dimension regresses:** mandatory revert, even if the research target improved. Hygiene is a gate, not a tradeoff.
+Compare each hygiene dimension (tests, lint, type_check, coverage) against the baseline scores captured before the experiment. **If ANY hygiene dimension regresses:** mandatory revert, even if the research target improved. Hygiene is a gate, not a tradeoff.
 
 #### R5b. Monotonic Improvement Check
 
@@ -2264,7 +2261,7 @@ If Builder fails (no PR opened), see Improve mode Error Recovery.
 
 Initialize `$QA_ITERATION=1` before entering the QA loop.
 
-#### R5: QA Agent Verification (= Improve 2d-qa)
+#### R5: QA Agent Verification (= Improve 2c-qa)
 
 ```bash
 PR_NUM=$(gh pr list --state open --json number,headRefName -q '.[0].number')
@@ -2289,7 +2286,7 @@ Report structured verdict." --project "$PROJECT_PATH" --timeout 600
 
 Apply the same QA iteration loop as Improve mode (max 3 iterations, route fixes to Builder on ISSUES_FOUND).
 
-#### R6: Hard Precheck Gate (= Improve 2g)
+#### R6: Hard Precheck Gate (= Improve 2d)
 
 ```bash
 BASELINE_SHA=$(cd "$PROJECT_PATH" && git log --format=%H -1 main)
@@ -2457,10 +2454,11 @@ If the Builder doesn't produce a PR:
 5. Move to next hypothesis — **do NOT write the code yourself** (Sacred Rule 8)
 
 ### Eval Crash
-If `factory eval` fails without producing a valid score:
-1. Check eval script: `cat "$PROJECT_PATH/eval/score.py"`
-2. If fixable, spawn the Builder to fix it — **do NOT edit eval/score.py yourself** (Sacred Rule 8)
-3. If not fixable by an agent, finalize as error with `--notes "ceo:error eval_crashed=true"`
+If the QA Agent reports that `factory eval` failed (Health Check shows no valid score):
+1. Read the QA Agent's report at `.factory/reviews/qa-latest.md` for error details
+2. If fixable, spawn the Builder to fix the eval script — **do NOT edit eval/score.py yourself** (Sacred Rule 8)
+3. After the Builder fixes it, re-run the QA Agent to verify the fix
+4. If not fixable by an agent, finalize as error with `--notes "ceo:error eval_crashed=true"`
 
 ### Guard Violation
 If `factory guard` reports violations:

--- a/tests/fixtures/hello-cli/factory.md
+++ b/tests/fixtures/hello-cli/factory.md
@@ -1,0 +1,17 @@
+# Factory Config
+
+## Goal
+A minimal hello-world CLI for testing.
+
+## Scope
+- main.py
+
+## Eval Command
+```bash
+cd $PROJECT_PATH && python -m pytest test_main.py -q
+```
+
+## Smoke Test
+```bash
+cd $PROJECT_PATH && python main.py
+```

--- a/tests/fixtures/hello-cli/main.py
+++ b/tests/fixtures/hello-cli/main.py
@@ -1,0 +1,9 @@
+import sys
+
+
+def main() -> None:
+    print("hello")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/hello-cli/test_main.py
+++ b/tests/fixtures/hello-cli/test_main.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_hello_output():
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "main.py")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "hello" in result.stdout

--- a/tests/test_qa_delegation.py
+++ b/tests/test_qa_delegation.py
@@ -1,0 +1,215 @@
+"""Tests for QA Agent delegation patterns in CEO and QA prompts.
+
+Verifies that:
+- The QA prompt covers all 3 verification sections
+- The CEO prompt delegates eval to the QA Agent (no direct factory eval in experiment pipeline)
+- QA follows Builder in Improve, Research, and Refine modes
+- Research R5a reads the QA report instead of running eval directly
+- Clean PR delegates post-strip verification to the QA Agent
+- Event-based flow validation detects Builder→QA sequencing
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROMPTS_DIR = Path(__file__).parent.parent / "factory" / "agents" / "prompts"
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def qa_prompt() -> str:
+    return (PROMPTS_DIR / "qa.md").read_text()
+
+
+@pytest.fixture
+def ceo_prompt() -> str:
+    return (PROMPTS_DIR / "ceo.md").read_text()
+
+
+# ── QA Prompt Structure ──────────────────────────────────────────
+
+
+class TestQAPromptStructure:
+    def test_qa_agent_prompt_covers_all_sections(self, qa_prompt: str) -> None:
+        """QA prompt must define all 3 verification sections."""
+        assert "### Section 1: Health Check" in qa_prompt
+        assert "### Section 2: Code Review" in qa_prompt
+        assert "### Section 3: Adversarial QA" in qa_prompt
+
+
+# ── CEO Delegation Patterns ──────────────────────────────────────
+
+
+class TestCEODelegation:
+    @staticmethod
+    def _extract_experiment_pipeline(ceo_prompt: str) -> str:
+        """Extract the experiment execution pipeline (Step 2 through verdict)."""
+        start = ceo_prompt.find("### Step 2: Execute (Per Approved Hypothesis)")
+        end = ceo_prompt.find("### Step 2i: Persist New Backlog Items")
+        assert start != -1, "Step 2 not found in CEO prompt"
+        assert end != -1, "Step 2i not found in CEO prompt"
+        return ceo_prompt[start:end]
+
+    def test_ceo_prompt_no_direct_eval_in_experiment_pipeline(
+        self, ceo_prompt: str
+    ) -> None:
+        """CEO must not run `factory eval` directly in the experiment pipeline.
+
+        All eval calls in Step 2 must be inside QA Agent task descriptions
+        (i.e., inside factory agent qa --task "..." blocks), not as standalone
+        CEO commands.
+        """
+        pipeline = self._extract_experiment_pipeline(ceo_prompt)
+
+        # Find all 'factory eval' occurrences in the pipeline
+        for match in re.finditer(r"factory eval", pipeline):
+            pos = match.start()
+            # Look backwards from this position for the nearest 'factory agent qa'
+            # or the nearest code block start to determine context
+            preceding = pipeline[:pos]
+
+            # Check if this eval is inside a QA agent task description
+            last_qa_task = preceding.rfind('factory agent qa --task')
+            last_code_block_end = preceding.rfind('```\n')
+
+            # If the last QA task invocation is more recent than the last
+            # code block end, this eval is inside a QA task — that's fine
+            if last_qa_task > last_code_block_end:
+                continue
+
+            # Otherwise this is a direct CEO eval call — fail
+            context = pipeline[max(0, pos - 80):pos + 40]
+            pytest.fail(
+                f"Direct 'factory eval' found in experiment pipeline outside "
+                f"QA Agent task. Context: ...{context}..."
+            )
+
+    def test_ceo_prompt_delegates_to_qa_after_builder(
+        self, ceo_prompt: str
+    ) -> None:
+        """QA Agent must follow Builder in Improve, Research, and Refine modes."""
+        # Improve mode: Builder (2c) → QA (2c-qa)
+        improve_pipeline = self._extract_experiment_pipeline(ceo_prompt)
+        builder_pos = improve_pipeline.find("#### 2c. Implement (Builder Agent)")
+        qa_pos = improve_pipeline.find(
+            "#### 2c-qa: QA Agent Verification (MANDATORY"
+        )
+        assert builder_pos != -1, "Builder step 2c not found"
+        assert qa_pos != -1, "QA step 2c-qa not found"
+        assert qa_pos > builder_pos, "QA must come after Builder in Improve mode"
+
+        # Research mode: R3b (Builder) → R3-qa (QA)
+        r3b_pos = ceo_prompt.find("#### R3b. Implement")
+        r3_qa_pos = ceo_prompt.find("**R3-qa: QA Agent Verification")
+        assert r3b_pos != -1, "Research Builder step R3b not found"
+        assert r3_qa_pos != -1, "Research QA step R3-qa not found"
+        assert r3_qa_pos > r3b_pos, "QA must come after Builder in Research mode"
+
+        # Refine mode: R4 (Builder) → R5 (QA)
+        refine_section_start = ceo_prompt.find("## Mode: Refine")
+        assert refine_section_start != -1, "Refine mode not found"
+        refine_section = ceo_prompt[refine_section_start:]
+        r4_pos = refine_section.find("### R4: Implement (Builder Agent)")
+        r5_pos = refine_section.find("### R5")
+        assert r4_pos != -1, "Refine Builder step R4 not found"
+        assert r5_pos != -1, "Refine QA step R5 not found"
+        assert r5_pos > r4_pos, "QA must come after Builder in Refine mode"
+
+    def test_research_mode_hygiene_reads_qa_report(
+        self, ceo_prompt: str
+    ) -> None:
+        """Research R5a must reference qa-latest.md, not run eval directly."""
+        r5a_start = ceo_prompt.find("#### R5a. Hygiene Gate")
+        r5b_start = ceo_prompt.find("#### R5b. Monotonic Improvement")
+        assert r5a_start != -1, "R5a not found"
+        assert r5b_start != -1, "R5b not found"
+        r5a_section = ceo_prompt[r5a_start:r5b_start]
+
+        assert "qa-latest.md" in r5a_section, (
+            "R5a must read from .factory/reviews/qa-latest.md"
+        )
+        # Must not contain a standalone `factory eval` command
+        assert "```bash" not in r5a_section or "factory eval" not in r5a_section.split("```bash")[-1].split("```")[0] if "```bash" in r5a_section else True, (
+            "R5a must not run factory eval directly — read from QA report"
+        )
+
+    def test_clean_pr_delegates_to_qa(self, ceo_prompt: str) -> None:
+        """Clean PR section must use QA Agent, not direct factory eval."""
+        clean_pr_start = ceo_prompt.find("#### 2i-clean. Clean PR")
+        assert clean_pr_start != -1, "Clean PR step not found"
+        # Find the end of the clean PR section
+        next_section = ceo_prompt.find("**Approve (DO NOT MERGE):**", clean_pr_start)
+        clean_pr_section = ceo_prompt[clean_pr_start:next_section]
+
+        assert "factory agent qa" in clean_pr_section, (
+            "Clean PR must delegate verification to QA Agent"
+        )
+        assert "qa-latest.md" in clean_pr_section, (
+            "Clean PR must read QA verdict from qa-latest.md"
+        )
+
+
+# ── Event-Based Flow Validation ──────────────────────────────────
+
+
+def _check_builder_qa_sequence(events: list[dict]) -> bool:
+    """Return True if every builder.completed is followed by a qa agent start."""
+    for i, event in enumerate(events):
+        if event.get("type") == "agent.completed" and event.get("role") == "builder":
+            remaining = events[i + 1:]
+            found_qa = any(
+                e.get("type") == "agent.started" and e.get("role") == "qa"
+                for e in remaining
+            )
+            if not found_qa:
+                return False
+    return True
+
+
+class TestEventsFlowValidation:
+    def test_events_jsonl_qa_after_builder(self) -> None:
+        """Helper detects correct Builder→QA sequencing in events."""
+        events = [
+            {"type": "agent.started", "role": "builder"},
+            {"type": "agent.completed", "role": "builder"},
+            {"type": "agent.started", "role": "qa"},
+            {"type": "agent.completed", "role": "qa"},
+        ]
+        assert _check_builder_qa_sequence(events) is True
+
+    def test_events_jsonl_detects_missing_qa(self) -> None:
+        """Helper detects missing QA after Builder in events."""
+        events = [
+            {"type": "agent.started", "role": "builder"},
+            {"type": "agent.completed", "role": "builder"},
+            {"type": "agent.started", "role": "archivist"},
+            {"type": "agent.completed", "role": "archivist"},
+        ]
+        assert _check_builder_qa_sequence(events) is False
+
+
+# ── Test Fixture Validation ──────────────────────────────────────
+
+
+class TestHelloCliFixture:
+    def test_hello_cli_fixture_is_valid(self) -> None:
+        """Fixture has required files and pytest passes."""
+        fixture_dir = FIXTURES_DIR / "hello-cli"
+        assert (fixture_dir / "main.py").is_file()
+        assert (fixture_dir / "test_main.py").is_file()
+        assert (fixture_dir / "factory.md").is_file()
+
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(fixture_dir / "test_main.py"), "-q"],
+            capture_output=True,
+            text=True,
+            cwd=str(fixture_dir),
+        )
+        assert result.returncode == 0, f"Fixture tests failed: {result.stdout}\n{result.stderr}"


### PR DESCRIPTION
Factory experiment 2. Fixes #682.

## Changes
- Removed Step 2a direct baseline eval from CEO prompt (QA Agent Health Check captures baseline)
- Fixed Clean PR bypass to delegate post-strip verification to QA Agent
- Research R5a reads QA report instead of re-running eval directly
- Error Recovery clarified to reference QA Agent report
- Added 8 structural QA delegation tests in test_qa_delegation.py
- Added hello-cli test fixture for future e2e validation

## Test plan
- 8 new tests pass in test_qa_delegation.py
- Full suite (1782+ tests) passes