### PR TITLE
fix: ProgramBench resolved threshold requires 100% test pass rate

### DIFF
--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -495,7 +495,7 @@ passed = sum(1 for r in results if r.get('status') == 'passed')
 total = len(results)
 if total == 0:
     total = 1
-resolved = 1 if passed > 0 else 0
+resolved = 1 if passed == total else 0
 print(f'PASSED={passed}')
 print(f'RESOLVED={resolved}')
 print(f'TOTAL={total}')
@@ -516,7 +516,7 @@ else
 import json
 with open('${EVAL_JSON}') as f:
     data = json.load(f)
-resolved = 1 if data.get('score', 0) > 0.5 else 0
+resolved = 1 if data.get('score', 0) >= 1.0 else 0
 total = 1
 passed = resolved
 print(f'PASSED={passed}')


### PR DESCRIPTION
## Summary

- Changed `resolved` logic in `benchmarks/run-programbench.sh` from `passed > 0` to `passed == total` (line 498)
- Changed fallback path from `score > 0.5` to `score >= 1.0` (line 519)
- ProgramBench now only reports RESOLVED when ALL tests pass (100% pass rate)
- The `score` field continues to report the actual accuracy (passed/total)

Fixes #685

## Test plan

- [ ] Run ProgramBench with a task that passes all tests — should report RESOLVED
- [ ] Run ProgramBench with a task that passes some tests — should report NOT RESOLVED with correct score
- [ ] Verify other benchmarks are unaffected