### PR TITLE
feat: 3-round single-agent review protocol for --mode review

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -2397,6 +2397,109 @@ factory log "$PROJECT_PATH" "refine.completed" --data "{\"exp_id\": $EXP_ID, \"v
 
 ---
 
+## Mode: PR Review (`--mode review --pr <N>`)
+
+A 3-round single-agent review of a GitHub PR. One QA agent, three rounds of escalating depth. Each round builds on the findings of the previous rounds.
+
+### PR-R0: Read PR Context
+
+```bash
+gh pr view $PR_NUMBER --json title,body,additions,deletions,changedFiles
+gh pr diff $PR_NUMBER
+```
+
+If `--repo` was provided, append `--repo $REPO` to both commands. Save the diff — you will reference it in all 3 rounds.
+
+### PR-R1: Round 1 — Standard Review
+
+Spawn the QA agent for a standard full pass:
+
+```bash
+factory agent qa --task "Review round 1/3 for PR #$PR_NUMBER.
+
+$DIFF_AND_CONTEXT
+
+This is round 1 of 3. Perform your standard review:
+1. Health Check — run evals
+2. Code Review — 7-category checklist
+3. Adversarial QA — actually run/test the feature
+
+Report all findings with file:line references." --project $PROJECT_PATH --timeout 300
+```
+
+Read `.factory/reviews/qa-latest.md`. Summarize the key findings from round 1.
+
+### PR-R2: Round 2 — Deep Review
+
+Spawn the QA agent again with round 1 findings:
+
+```bash
+factory agent qa --task "Review round 2/3 for PR #$PR_NUMBER.
+
+$DIFF_AND_CONTEXT
+
+## Round 1 Findings
+$ROUND_1_SUMMARY
+
+This is round 2 of 3 — DEEP REVIEW. You have already reviewed this PR once. Now:
+1. Challenge your own round 1 findings — are they real issues or false positives?
+2. Look for issues you MISSED in round 1 — what did you gloss over?
+3. Go deeper on flagged areas — explore adjacent code paths
+4. Focus on edge cases and error handling you skipped
+
+Do NOT repeat round 1 findings. Report only NEW findings or escalations." --project $PROJECT_PATH --timeout 300
+```
+
+Read `.factory/reviews/qa-latest.md`. Add round 2 findings to the cumulative list.
+
+### PR-R3: Round 3 — Adversarial Stress Test
+
+Spawn the QA agent one final time with all prior findings:
+
+```bash
+factory agent qa --task "Review round 3/3 for PR #$PR_NUMBER.
+
+$DIFF_AND_CONTEXT
+
+## Round 1 Findings
+$ROUND_1_SUMMARY
+
+## Round 2 Findings
+$ROUND_2_SUMMARY
+
+This is round 3 of 3 — ADVERSARIAL STRESS TEST. Try to BREAK this PR:
+1. What assumptions does this code make that might not hold?
+2. Boundary conditions nobody tested?
+3. Race conditions, concurrency issues, TOCTOU?
+4. What if dependencies are unavailable or behave differently?
+5. Can a malicious actor exploit any of these changes?
+6. Look at every finding marked LOW or INFO — should any be escalated?
+
+Report only NEW findings. Use severity ratings." --project $PROJECT_PATH --timeout 300
+```
+
+Read `.factory/reviews/qa-latest.md`.
+
+### PR-R4: Consolidate and Post Verdict
+
+Collect all findings across 3 rounds. Post a consolidated review:
+
+```bash
+factory review \
+    --verdict $VERDICT \
+    --reason "$ONE_SENTENCE_SUMMARY" \
+    --pr $PR_NUMBER \
+    --notes "review_rounds=3 r1_issues=$R1_COUNT r2_issues=$R2_COUNT r3_issues=$R3_COUNT"
+```
+
+**Verdict rules:**
+- ANY finding rated CRITICAL across any round → REVERT
+- Multiple HIGH findings that the PR author should address → REVERT
+- Minor issues only (MEDIUM/LOW/INFO) → KEEP with notes
+- CLEAN across all 3 rounds → KEEP
+
+---
+
 ## CEO Self-Learning Protocol
 
 You learn from your own decisions. Every keep/revert decision and every agent failure is data that feeds your own playbook evolution.

--- a/factory/agents/prompts/qa.md
+++ b/factory/agents/prompts/qa.md
@@ -177,6 +177,33 @@ After all three sections, emit a machine-parseable verdict:
 - **ISSUES_FOUND: N** — Issues found but none are fatal. N = total issue count across all sections
 - **REVERT** — Score regression below threshold, fixed surface violation, or critical security/correctness bug that cannot be fixed in iteration
 
+## Review Round Protocol
+
+When invoked for `--mode review` (as opposed to improve-mode QA verification), you may receive a **review round number** (1/3, 2/3, or 3/3) and findings from prior rounds in your task.
+
+### Round 1/3 — Standard Review
+Perform your standard 3-section review (Health Check, Code Review, Adversarial QA) as documented above. This is your fresh, unbiased first pass.
+
+### Round 2/3 — Deep Review
+You receive your own round 1 findings. Your job is to go DEEPER:
+- **Challenge your round 1 findings:** Are they real issues or false positives? Did you misread the code?
+- **Find what you missed:** What code paths did you skip? What edge cases did you ignore?
+- **Explore adjacent code:** Follow the changed code into its callers and callees — are there interaction bugs?
+- **Deepen edge case analysis:** For each function touched, consider: empty inputs, max-size inputs, concurrent access, partial failures
+
+Do NOT repeat round 1 findings. Report only NEW issues or escalated severities.
+
+### Round 3/3 — Adversarial Stress Test
+You receive findings from rounds 1 and 2. Your job is to try to BREAK the PR:
+- **Assumption hunting:** What does this code assume about its environment, inputs, or dependencies?
+- **Boundary conditions:** What happens at 0, 1, MAX_INT, empty string, null, very long strings?
+- **Concurrency:** Race conditions, TOCTOU, deadlocks, data races?
+- **Failure modes:** What if a network call fails? A file is missing? Disk is full? Permission denied?
+- **Security:** Can any input be crafted to cause injection, path traversal, or privilege escalation?
+- **Severity review:** Look at all LOW/INFO findings from rounds 1 and 2 — should any be escalated?
+
+Report only NEW findings or severity escalations.
+
 ## Constraints
 
 - **Read-only:** You MUST NOT modify any source files. You observe, measure, test, and report. Tools: Bash (read-only commands), Read, Grep, Glob.

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2374,20 +2374,15 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
         _print_banner("review")
 
-        repo_clause = f" in repo `{repo}`" if repo else ""
         task = (
             f"Project: {project_path}\nMode: review\n\n"
             f"## PR Review Directive\n\n"
-            f"Review PR #{pr_number}{repo_clause}.\n\n"
-            f"1. Read the PR diff: `gh pr diff {pr_number}"
-            f"{' --repo ' + repo if repo else ''}`\n"
-            f"2. Read the PR description: `gh pr view {pr_number}"
-            f"{' --repo ' + repo if repo else ''}`\n"
-            f"3. Run the project's test suite and lint checks\n"
-            f"4. Spawn the QA agent for health check, code review, and adversarial QA\n"
-            f"5. Post your review verdict on the PR using "
-            f"`factory review --verdict <KEEP|REVERT> --pr {pr_number}"
-            f"{' --repo ' + repo if repo else ''}`\n"
+            f"Review PR #{pr_number}{' in repo `' + repo + '`' if repo else ''}"
+            f" using the 3-round review protocol.\n\n"
+            f"Follow the `## Mode: PR Review` section in your prompt.\n\n"
+            f"PR number: {pr_number}\n"
+            + (f"Repo: {repo}\n" if repo else "")
+            + f"Project path: {project_path}\n"
         )
 
         if not headless:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1026,8 +1026,8 @@ class TestCmdCeoReview:
         task = mock_agent.call_args[0][1]
         assert "Mode: review" in task
         assert "PR #42" in task
-        assert "gh pr diff 42" in task
-        assert "gh pr view 42" in task
+        assert "3-round review protocol" in task
+        assert "PR number: 42" in task
 
     def test_review_mode_headless_with_repo(self, tmp_path, capsys):
         """--mode review --pr 42 --repo owner/repo includes repo in task."""
@@ -1037,7 +1037,7 @@ class TestCmdCeoReview:
         assert result == 0
         task = mock_agent.call_args[0][1]
         assert "owner/repo" in task
-        assert "--repo owner/repo" in task
+        assert "Repo: owner/repo" in task
 
     def test_review_mode_skips_worktree(self, tmp_path):
         """Review mode does not create worktrees or touch experiment store."""


### PR DESCRIPTION
Fixes #708. Single QA agent, 3 sequential rounds of escalating depth.

## Changes
- **factory/cli.py**: Replace 5-step review task string with a concise 3-round protocol directive that points the CEO to its prompt section
- **factory/agents/prompts/ceo.md**: Add `## Mode: PR Review` section with the full 3-round protocol (R0 context read, R1 standard, R2 deep, R3 adversarial, R4 consolidate)
- **factory/agents/prompts/qa.md**: Add `## Review Round Protocol` section teaching the QA agent how to adjust depth based on round number (1/3, 2/3, 3/3)
- **tests/test_cli.py**: Update review mode test assertions to match new task format