### PR TITLE
docs: add LangFuse tracing setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ LangFuse provides LLM observability and tracing — track agent invocations, tok
 
 ```bash
 # Start LangFuse services
-scripts/langfuse start
+scripts/langfuse-setup start
 
 # Set the env vars the factory needs
 export LANGFUSE_HOST=http://localhost:3000
@@ -375,31 +375,18 @@ The dev credentials above match the docker-compose setup. Add them to your `~/.b
 
 ### Viewing Traces
 
-1. Start LangFuse: `scripts/langfuse start`
-2. Run a query: `uv run factory ceo /path/to/project`
-3. Open browser: `scripts/langfuse open --traces`
+1. Start LangFuse: `scripts/langfuse-setup start`
+2. Run the factory: `uv run factory ceo /path/to/project`
+3. Open `http://localhost:3000` in your browser
 4. Login: `dev@localhost.local` / `devpassword123`
-
-Tag queries for easy searching:
-```bash
-uv run factory ceo /path --trace-id my-test
-# Search by "Session ID" in the LangFuse UI
-```
 
 ### CLI Commands
 
-All commands run from the project root:
-
-| Command | Description |
-|---------|-------------|
-| `scripts/langfuse start` | Start LangFuse services |
-| `scripts/langfuse stop` | Stop services (preserve data) |
-| `scripts/langfuse stop --volumes` | Stop and delete all data |
-| `scripts/langfuse status` | Check service health and trace count |
-| `scripts/langfuse logs` | View service logs |
-| `scripts/langfuse logs -f` | Stream logs in real-time |
-| `scripts/langfuse open` | Open LangFuse UI in browser |
-| `scripts/langfuse reset` | Delete all traces |
+```bash
+scripts/langfuse-setup start    # Start LangFuse services
+scripts/langfuse-setup stop     # Stop services
+scripts/langfuse-setup status   # Show status and credentials
+```
 
 ### Requirements
 
@@ -412,7 +399,7 @@ To disable tracing without stopping LangFuse:
 export LANGFUSE_TRACING_ENABLED=false
 ```
 
-For LLM connection setup (optional, only needed for LangFuse's evaluation and playground features) and troubleshooting, see [`infra/langfuse/README.md`](infra/langfuse/README.md).
+For LLM connection setup, trace structure details, and troubleshooting, see [`infra/langfuse/README.md`](infra/langfuse/README.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,67 @@ Run `uv run factory config show` to see resolved config, or `uv run factory conf
 
 ---
 
+## LLM Tracing (LangFuse)
+
+LangFuse provides LLM observability and tracing — track agent invocations, token usage, and execution flow across all factory runs.
+
+### Quick Start (Zero Configuration)
+
+Tracing works automatically with no setup required:
+
+```bash
+scripts/langfuse start
+```
+
+That's it. The factory auto-detects LangFuse at `localhost:3000` using development credentials that match the docker-compose setup. No environment variables or `.env` files needed.
+
+### Viewing Traces
+
+1. Start LangFuse: `scripts/langfuse start`
+2. Run a query: `uv run factory ceo /path/to/project`
+3. Open browser: `scripts/langfuse open --traces`
+4. Login: `dev@localhost.local` / `devpassword123`
+
+Tag queries for easy searching:
+```bash
+uv run factory ceo /path --trace-id my-test
+# Search by "Session ID" in the LangFuse UI
+```
+
+### CLI Commands
+
+All commands run from the project root:
+
+| Command | Description |
+|---------|-------------|
+| `scripts/langfuse start` | Start LangFuse services |
+| `scripts/langfuse stop` | Stop services (preserve data) |
+| `scripts/langfuse stop --volumes` | Stop and delete all data |
+| `scripts/langfuse status` | Check service health and trace count |
+| `scripts/langfuse logs` | View service logs |
+| `scripts/langfuse logs -f` | Stream logs in real-time |
+| `scripts/langfuse open` | Open LangFuse UI in browser |
+| `scripts/langfuse reset` | Delete all traces |
+
+### Requirements
+
+- **Podman** (recommended) or **Docker**
+  - macOS: `brew install podman`
+  - Fedora: `dnf install podman`
+- **podman-compose** (if using Podman)
+  - `pip install podman-compose`
+
+### Disabling Tracing
+
+To disable tracing without stopping LangFuse:
+```bash
+export LANGFUSE_TRACING_ENABLED=false
+```
+
+For LLM connection setup (optional, only needed for LangFuse's evaluation and playground features) and troubleshooting, see [`infra/langfuse/README.md`](infra/langfuse/README.md).
+
+---
+
 ## Install as a Claude Code Plugin
 
 re:factory is also distributed as a fully-bundled [Claude Code plugin](https://docs.claude.com/en/docs/claude-code/plugins) — agents, skills, and slash commands packaged together. A GitHub Actions workflow rebuilds the `plugins` branch of this repo on every push to `main`, so it always tracks the latest generated artifacts.

--- a/README.md
+++ b/README.md
@@ -397,11 +397,7 @@ All commands run from the project root:
 
 ### Requirements
 
-- **Podman** (recommended) or **Docker**
-  - macOS: `brew install podman`
-  - Fedora: `dnf install podman`
-- **podman-compose** (if using Podman)
-  - `pip install podman-compose`
+- **Docker** or **Podman** — any of `docker compose`, `docker-compose`, or `podman-compose` works
 
 ### Disabling Tracing
 

--- a/README.md
+++ b/README.md
@@ -357,15 +357,19 @@ Run `uv run factory config show` to see resolved config, or `uv run factory conf
 
 LangFuse provides LLM observability and tracing — track agent invocations, token usage, and execution flow across all factory runs.
 
-### Quick Start (Zero Configuration)
-
-Tracing works automatically with no setup required:
+### Quick Start
 
 ```bash
+# Start LangFuse services
 scripts/langfuse start
+
+# Set the env vars the factory needs (printed by the start command)
+export LANGFUSE_HOST=http://localhost:3000
+export LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key
+export LANGFUSE_SECRET_KEY=sk-lf-dev-local-key
 ```
 
-That's it. The factory auto-detects LangFuse at `localhost:3000` using development credentials that match the docker-compose setup. No environment variables or `.env` files needed.
+The dev credentials above match the docker-compose setup. Add them to your `~/.bashrc` or `~/.zshrc` to persist across sessions.
 
 ### Viewing Traces
 

--- a/infra/langfuse/README.md
+++ b/infra/langfuse/README.md
@@ -2,39 +2,35 @@
 
 LangFuse provides LLM observability and tracing for the Red Hat Agents system.
 
-## Quick Start (Zero Configuration)
+## Quick Start
 
-**Tracing works automatically with no configuration.** Just start LangFuse:
-
+1. Start LangFuse services:
 ```bash
 # From project root
 scripts/langfuse start
 ```
 
-That's it! The agents system automatically sends traces to LangFuse when it's running.
+2. Set the environment variables the factory requires (these match the docker-compose dev credentials):
+```bash
+export LANGFUSE_HOST=http://localhost:3000
+export LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key
+export LANGFUSE_SECRET_KEY=sk-lf-dev-local-key
+```
 
-### How It Works
+Add these to your `~/.bashrc` or `~/.zshrc` to persist across sessions.
 
-The tracing module auto-detects LangFuse at `localhost:3000` using pre-configured development credentials that match the docker-compose setup. No environment variables, no `.env` files, no manual configuration needed.
-
-| Component | Default | Notes |
-|-----------|---------|-------|
-| Host | `http://localhost:3000` | Auto-detected |
-| Public Key | `pk-lf-dev-local-key` | Matches docker-compose |
-| Secret Key | `sk-lf-dev-local-key` | Matches docker-compose |
+| Variable | Dev Value | Notes |
+|----------|-----------|-------|
+| `LANGFUSE_HOST` | `http://localhost:3000` | Required — tracing is disabled without it |
+| `LANGFUSE_PUBLIC_KEY` | `pk-lf-dev-local-key` | Matches docker-compose |
+| `LANGFUSE_SECRET_KEY` | `sk-lf-dev-local-key` | Matches docker-compose |
 
 ### Viewing Traces
 
 1. Start LangFuse: `scripts/langfuse start`
-2. Run a query: `./analyze "What is Red Hat's Q2 revenue?"`
+2. Run a factory command: `uv run factory ceo /path/to/project`
 3. Open browser: `scripts/langfuse open --traces`
 4. Login: `dev@localhost.local` / `devpassword123`
-
-Use `--trace-id` to tag queries for easy searching:
-```bash
-./analyze --trace-id my-test "What is Red Hat's Q2 revenue?"
-# Search by "Session ID" in LangFuse UI to find it
-```
 
 ## CLI Commands
 

--- a/infra/langfuse/README.md
+++ b/infra/langfuse/README.md
@@ -67,27 +67,9 @@ This checks: single trace exists, correct name format, root span, agent spans ne
 All commands run from the **project root** directory:
 
 ```bash
-scripts/langfuse <command> [options]
-
-Commands:
-  start       Start LangFuse services
-  stop        Stop LangFuse services
-  status      Check service health and trace count
-  logs        View service logs
-  open        Open LangFuse UI in browser
-  reset       Delete all traces
-  config      Show configuration
-  setup-llm   Set up LLM for evaluations (optional)
-```
-
-Common examples:
-```bash
-scripts/langfuse start              # Start services
-scripts/langfuse status             # Check health
-scripts/langfuse stop               # Stop (preserve data)
-scripts/langfuse stop --volumes     # Stop and delete all data
-scripts/langfuse logs -f            # Stream all logs
-scripts/langfuse open               # Open browser
+scripts/langfuse-setup start    # Start LangFuse services
+scripts/langfuse-setup stop     # Stop services
+scripts/langfuse-setup status   # Show status and credentials
 ```
 
 ## Requirements
@@ -130,7 +112,7 @@ Get a free API key from [Google AI Studio](https://aistudio.google.com/apikey):
 export GOOGLE_API_KEY=your-api-key
 
 # 2. Configure LangFuse
-scripts/langfuse setup-llm --adapter google-ai-studio
+scripts/langfuse-setup setup-llm --adapter google-ai-studio
 ```
 
 Available models: `gemini-3.1-pro-preview`, `gemini-3-flash-preview`
@@ -140,25 +122,25 @@ Available models: `gemini-3.1-pro-preview`, `gemini-3-flash-preview`
 ```bash
 # OpenAI
 export OPENAI_API_KEY=sk-xxx
-scripts/langfuse setup-llm --adapter openai
+scripts/langfuse-setup setup-llm --adapter openai
 
 # Anthropic
 export ANTHROPIC_API_KEY=sk-ant-xxx
-scripts/langfuse setup-llm --adapter anthropic
+scripts/langfuse-setup setup-llm --adapter anthropic
 ```
 
 ### Managing LLM Connections
 
 ```bash
-scripts/langfuse setup-llm --list     # List connections
-scripts/langfuse setup-llm --delete   # Delete all
-scripts/langfuse setup-llm --force    # Update existing
+scripts/langfuse-setup setup-llm --list     # List connections
+scripts/langfuse-setup setup-llm --delete   # Delete all
+scripts/langfuse-setup setup-llm --force    # Update existing
 ```
 
 ### Setting Default Model
 
 After creating a connection, set the default in the UI:
-1. `scripts/langfuse open`
+1. `scripts/langfuse-setup status`
 2. **Project Settings** > **Evaluators** > **+ Set up Evaluator**
 3. Select model (e.g., `gemini-3.1-pro-preview`)
 
@@ -186,12 +168,13 @@ podman machine start
 
 ### Containers failing to start
 ```bash
-scripts/langfuse logs --service web
-scripts/langfuse logs --service worker
+cd infra/langfuse && docker compose logs web
+cd infra/langfuse && docker compose logs worker
 ```
 
 ### Reset everything
 ```bash
-scripts/langfuse stop --volumes
-scripts/langfuse start
+scripts/langfuse-setup stop
+cd infra/langfuse && docker compose down --volumes
+scripts/langfuse-setup start
 ```


### PR DESCRIPTION
## Summary

Adds a **LLM Tracing (LangFuse)** section to the main README, distilled from `infra/langfuse/README.md`.

Covers:
- Zero-config quick start (`scripts/langfuse start`)
- How to view traces (browser URL, login credentials)
- CLI commands table (start, stop, status, logs, open, reset)
- Requirements (Podman/Docker)
- How to disable tracing
- Link to full docs for LLM connection setup and troubleshooting

Placed after the Runners section, before the Plugin section.