### PR TITLE
fix: prevent duplicate issue creation when --focus targets existing issue

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -1087,6 +1087,8 @@ Save the printed experiment ID as `$EXP_ID`.
 
 #### 2b. Create GitHub Issue
 
+**If the task includes an `## Issue Tracking` section with an existing issue number:** set `$ISSUE_NUM` to that number and skip the rest of this step (do not run `gh issue create`). The existing issue already contains the requirements.
+
 For **code-only** hypotheses (`**Type:** code` or no Type field):
 
 ```bash
@@ -1830,6 +1832,8 @@ For each approved hypothesis, sequentially:
 
 #### R3a. Begin Experiment and Create Issue
 
+**If the task includes an `## Issue Tracking` section with an existing issue number:** set `$ISSUE_NUM` to that number and skip the issue creation below (do not run `gh issue create`). The existing issue already contains the requirements.
+
 ```bash
 factory begin "$PROJECT_PATH" --hypothesis "<hypothesis text>"
 ```
@@ -2240,6 +2244,8 @@ factory begin "$PROJECT_PATH" --hypothesis "Refine: <user's request summary>"
 Save the printed experiment ID as `$EXP_ID`.
 
 ### R3: Create GitHub Issue
+
+**If the task includes an `## Issue Tracking` section with an existing issue number:** set `$ISSUE_NUM` to that number and skip the rest of this step (do not run `gh issue create`). The existing issue already contains the requirements.
 
 Create a GitHub issue from the Refiner's scoped task:
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3388,7 +3388,9 @@ def _build_ceo_task(
         if issue_number:
             task += (
                 f"\n## Issue Tracking\n\n"
-                f"This cycle is working on issue #{issue_number}. "
+                f"This cycle is working on existing issue #{issue_number}. "
+                f"Use `{issue_number}` as the issue number ($ISSUE_NUM) throughout the workflow. "
+                f"Do NOT create a new GitHub issue — skip the issue creation step (2b/R3a/R3) entirely.\n"
                 f"When finalizing, pass `--issue {issue_number}` to `factory finalize`."
             )
 


### PR DESCRIPTION
Closes #693

## Changes

- **factory/cli.py**: Updated `_build_ceo_task()` Issue Tracking section to explicitly tell the CEO to use the existing issue number as `$ISSUE_NUM` and skip issue creation steps (2b/R3a/R3)
- **factory/agents/prompts/ceo.md**: Added conditional at the top of all three `gh issue create` locations (step 2b in Improve mode, R3a in Research mode, R3 in Refine mode) to skip creation when an existing issue is provided via `## Issue Tracking`

## Test plan
- [x] `ruff check .` — lint passes
- [x] `pytest tests/test_cli.py -v` — all 229 tests pass
- [ ] Manual: run `factory ceo /path --focus <existing-issue-number>` and verify no duplicate issue is created