### PR TITLE
feat: add architecture hygiene dimension via Sentrux integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       SENTRUX_VERSION: v0.5.7
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Cache Sentrux
         uses: actions/cache@v4
         with:
@@ -50,9 +52,22 @@ jobs:
             ~/.local/bin/sentrux
             ~/.sentrux/plugins
           key: sentrux-${{ env.SENTRUX_VERSION }}-standard-plugins
-      - name: Run Sentrux quality check
+      - name: Install Sentrux
+        run: ./scripts/sentrux-check.sh --install-only 2>&1 || true
+      - name: Save baseline from base branch
+        if: github.event_name == 'pull_request'
         continue-on-error: true
-        run: ./scripts/sentrux-check.sh 2>&1 | tee sentrux-output.txt
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          sentrux gate --save . 2>&1 | tee sentrux-baseline.txt || true
+          git checkout ${{ github.sha }}
+      - name: Run Sentrux diff (gate)
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: sentrux gate . 2>&1 | tee sentrux-diff.txt || true
+      - name: Run Sentrux absolute check
+        continue-on-error: true
+        run: sentrux check . 2>&1 | tee sentrux-output.txt
       - name: Post Sentrux results as PR comment
         if: github.event_name == 'pull_request'
         env:
@@ -62,8 +77,18 @@ jobs:
             echo "<!-- sentrux-report -->"
             echo "## Sentrux Quality Report"
             echo ""
+            echo "### Absolute"
             echo '```'
             cat sentrux-output.txt
+            echo '```'
+            echo ""
+            echo "### Diff (vs base branch)"
+            echo '```'
+            if [ -f sentrux-diff.txt ]; then
+              cat sentrux-diff.txt
+            else
+              echo "No diff available"
+            fi
             echo '```'
           } > comment-body.txt
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2729,7 +2729,7 @@ def _stop_ceo_tailer(tailer: object | None) -> None:
     try:
         from factory.telemetry import end_span
 
-        tailer.stop_and_drain()  # type: ignore[union-attr]
+        tailer.stop_and_drain()  # type: ignore[attr-defined]
         trace_id = os.environ.get("FACTORY_TRACE_ID", "")
         span_id = getattr(tailer, "span_id", None)
         if trace_id and span_id:

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -1,17 +1,20 @@
 """Universal hygiene eval dimensions applied to every factory-managed project.
 
-These 6 dimensions are mandatory and cannot be removed. They are computed by
+These 7 dimensions are mandatory and cannot be removed. They are computed by
 the factory itself (not by per-project eval/score.py) and auto-detect the
 project's tooling. Projects can ADD dimensions via eval/score.py but cannot
 remove any of these.
 
-Together with the 5 growth dimensions in growth.py, these form the 11
+Together with the 5 growth dimensions in growth.py, these form the 12
 mandatory eval dimensions that define the factory's quality baseline.
 
 All functions take a project_path and return an EvalResult-compatible dict.
 If a tool is not detected for a dimension, score is 0.5 (neutral), not 0.
 """
 
+import json
+import shutil
+import subprocess
 from pathlib import Path
 
 import structlog
@@ -24,12 +27,13 @@ log = structlog.get_logger()
 # Relative weights within the hygiene category (sum to 1.0).
 # The runner normalizes these so that hygiene gets 50% of the composite.
 HYGIENE_WEIGHTS = {
-    "tests": 0.30,
-    "lint": 0.15,
-    "type_check": 0.10,
-    "coverage": 0.25,
-    "guard_patterns": 0.10,
-    "config_parser": 0.10,
+    "tests": 0.28,
+    "lint": 0.14,
+    "type_check": 0.09,
+    "coverage": 0.23,
+    "guard_patterns": 0.09,
+    "config_parser": 0.09,
+    "architecture": 0.08,
 }
 
 
@@ -314,6 +318,70 @@ def eval_config_parser(project_path: Path) -> dict:
         }
 
 
+# ── Dimension 7: architecture (weight 0.08) ──────────────────────
+
+
+def eval_architecture(project_path: Path) -> dict:
+    """Run Sentrux architecture quality check (conditional on .sentrux/rules.toml)."""
+    rules_path = project_path / ".sentrux" / "rules.toml"
+    if not rules_path.exists():
+        return _neutral("architecture", "no .sentrux/rules.toml found")
+
+    if not shutil.which("sentrux"):
+        return _neutral("architecture", "sentrux not installed")
+
+    try:
+        result = subprocess.run(
+            ["sentrux", "check", "."],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "name": "architecture",
+            "score": 0.5,
+            "weight": HYGIENE_WEIGHTS["architecture"],
+            "passed": True,
+            "details": "Timeout: sentrux check exceeded 120s",
+        }
+
+    stdout = result.stdout.strip()
+
+    try:
+        data = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        if result.returncode == 0:
+            return {
+                "name": "architecture",
+                "score": 1.0,
+                "weight": HYGIENE_WEIGHTS["architecture"],
+                "passed": True,
+                "details": f"All constraints satisfied (exit 0): {stdout[:200]}",
+            }
+        return {
+            "name": "architecture",
+            "score": 0.0,
+            "weight": HYGIENE_WEIGHTS["architecture"],
+            "passed": False,
+            "details": f"Rule violations (exit {result.returncode}): {stdout[:200]}",
+        }
+
+    quality_signal = data.get("quality_signal", 0)
+    score = max(0.0, min(1.0, quality_signal / 10000))
+    bottleneck = data.get("bottleneck", "unknown")
+    passed = result.returncode == 0
+
+    return {
+        "name": "architecture",
+        "score": round(score, 4),
+        "weight": HYGIENE_WEIGHTS["architecture"],
+        "passed": passed,
+        "details": f"quality_signal={quality_signal}/10000, bottleneck={bottleneck}",
+    }
+
+
 # ── Public API ─────────────────────────────────────────────────────
 
 
@@ -336,7 +404,7 @@ def _collect_test_and_coverage(project_path: Path, timeout: int = 300) -> tuple[
 
 
 def compute_hygiene_results(project_path: Path, test_timeout: int = 600) -> list[dict]:
-    """Compute all 6 mandatory hygiene dimensions for a project."""
+    """Compute all 7 mandatory hygiene dimensions for a project."""
     test_result, cov_result = _collect_test_and_coverage(project_path, timeout=test_timeout)
     return [
         test_result,
@@ -345,4 +413,5 @@ def compute_hygiene_results(project_path: Path, test_timeout: int = 600) -> list
         cov_result,
         eval_guard_patterns(project_path),
         eval_config_parser(project_path),
+        eval_architecture(project_path),
     ]

--- a/scripts/sentrux-check.sh
+++ b/scripts/sentrux-check.sh
@@ -33,5 +33,10 @@ if [ ! -d "$HOME/.sentrux/plugins" ] || [ -z "$(ls -A "$HOME/.sentrux/plugins" 2
   sentrux plugin add-standard
 fi
 
+if [ "${1:-}" = "--install-only" ]; then
+  echo >&2 "Sentrux installed successfully."
+  exit 0
+fi
+
 echo >&2 "Running sentrux check..."
 exec sentrux check .

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -18,9 +18,10 @@ class TestHygieneWeights:
         total = sum(HYGIENE_WEIGHTS.values())
         assert abs(total - 1.0) < 1e-9
 
-    def test_all_six_dimensions(self):
+    def test_all_seven_dimensions(self):
         assert set(HYGIENE_WEIGHTS.keys()) == {
             "tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser",
+            "architecture",
         }
 
 
@@ -125,11 +126,11 @@ class TestEvalConfigParser:
 
 
 class TestComputeHygieneResults:
-    def test_returns_all_six(self, tmp_path):
+    def test_returns_all_seven(self, tmp_path):
         results = compute_hygiene_results(tmp_path)
-        assert len(results) == 6
+        assert len(results) == 7
         names = {r["name"] for r in results}
-        assert names == {"tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser"}
+        assert names == {"tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser", "architecture"}
 
     def test_all_have_required_keys(self, tmp_path):
         results = compute_hygiene_results(tmp_path)
@@ -143,4 +144,4 @@ class TestComputeHygieneResults:
     def test_accepts_test_timeout_parameter(self, tmp_path):
         """compute_hygiene_results should accept test_timeout parameter."""
         results = compute_hygiene_results(tmp_path, test_timeout=900)
-        assert len(results) == 6
+        assert len(results) == 7

--- a/tests/eval/test_runner.py
+++ b/tests/eval/test_runner.py
@@ -85,7 +85,7 @@ class TestRunEval:
     async def test_weight_split_is_50_50(self, tmp_path):
         """Hygiene dimensions get 50% total weight, growth gets 50%."""
         result = await run_eval("true", tmp_path, threshold=0.0)
-        hygiene_names = {"tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser"}
+        hygiene_names = {"tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser", "architecture"}
         growth_names = {
             "capability_surface", "experiment_diversity", "observability",
             "research_grounding", "factory_effectiveness", "spec_compliance",

--- a/tests/test_hygiene_architecture.py
+++ b/tests/test_hygiene_architecture.py
@@ -1,0 +1,135 @@
+"""Tests for the eval_architecture() hygiene dimension."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from factory.eval.hygiene import (
+    HYGIENE_WEIGHTS,
+    eval_architecture,
+)
+
+
+def test_neutral_when_no_rules_toml(tmp_path: Path) -> None:
+    result = eval_architecture(tmp_path)
+    assert result["name"] == "architecture"
+    assert result["score"] == 0.5
+    assert result["passed"] is True
+    assert "no .sentrux/rules.toml found" in result["details"]
+
+
+def test_neutral_when_sentrux_not_installed(tmp_path: Path) -> None:
+    rules_dir = tmp_path / ".sentrux"
+    rules_dir.mkdir()
+    (rules_dir / "rules.toml").write_text("[constraints]\nmax_cc = 30\n")
+
+    with patch("factory.eval.hygiene.shutil.which", return_value=None):
+        result = eval_architecture(tmp_path)
+
+    assert result["score"] == 0.5
+    assert result["passed"] is True
+    assert "sentrux not installed" in result["details"]
+
+
+def test_pass_with_full_quality(tmp_path: Path) -> None:
+    rules_dir = tmp_path / ".sentrux"
+    rules_dir.mkdir()
+    (rules_dir / "rules.toml").write_text("[constraints]\nmax_cc = 30\n")
+
+    mock_output = json.dumps({"quality_signal": 10000, "bottleneck": "none"})
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout=mock_output, stderr="")
+
+    with (
+        patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/sentrux"),
+        patch("factory.eval.hygiene.subprocess.run", return_value=completed),
+    ):
+        result = eval_architecture(tmp_path)
+
+    assert result["score"] == 1.0
+    assert result["passed"] is True
+    assert "quality_signal=10000" in result["details"]
+
+
+def test_partial_quality_score(tmp_path: Path) -> None:
+    rules_dir = tmp_path / ".sentrux"
+    rules_dir.mkdir()
+    (rules_dir / "rules.toml").write_text("[constraints]\nmax_cc = 30\n")
+
+    mock_output = json.dumps({"quality_signal": 7342, "bottleneck": "modularity"})
+    completed = subprocess.CompletedProcess(args=[], returncode=1, stdout=mock_output, stderr="")
+
+    with (
+        patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/sentrux"),
+        patch("factory.eval.hygiene.subprocess.run", return_value=completed),
+    ):
+        result = eval_architecture(tmp_path)
+
+    assert result["score"] == 0.7342
+    assert result["passed"] is False
+    assert "bottleneck=modularity" in result["details"]
+
+
+def test_parse_error_with_exit_zero(tmp_path: Path) -> None:
+    rules_dir = tmp_path / ".sentrux"
+    rules_dir.mkdir()
+    (rules_dir / "rules.toml").write_text("[constraints]\nmax_cc = 30\n")
+
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="All rules pass", stderr=""
+    )
+
+    with (
+        patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/sentrux"),
+        patch("factory.eval.hygiene.subprocess.run", return_value=completed),
+    ):
+        result = eval_architecture(tmp_path)
+
+    assert result["score"] == 1.0
+    assert result["passed"] is True
+    assert "All constraints satisfied" in result["details"]
+
+
+def test_parse_error_with_exit_nonzero(tmp_path: Path) -> None:
+    rules_dir = tmp_path / ".sentrux"
+    rules_dir.mkdir()
+    (rules_dir / "rules.toml").write_text("[constraints]\nmax_cc = 30\n")
+
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout="VIOLATION: max_cc exceeded", stderr=""
+    )
+
+    with (
+        patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/sentrux"),
+        patch("factory.eval.hygiene.subprocess.run", return_value=completed),
+    ):
+        result = eval_architecture(tmp_path)
+
+    assert result["score"] == 0.0
+    assert result["passed"] is False
+    assert "Rule violations" in result["details"]
+
+
+def test_timeout_returns_neutral(tmp_path: Path) -> None:
+    rules_dir = tmp_path / ".sentrux"
+    rules_dir.mkdir()
+    (rules_dir / "rules.toml").write_text("[constraints]\nmax_cc = 30\n")
+
+    with (
+        patch("factory.eval.hygiene.shutil.which", return_value="/usr/bin/sentrux"),
+        patch(
+            "factory.eval.hygiene.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="sentrux", timeout=120),
+        ),
+    ):
+        result = eval_architecture(tmp_path)
+
+    assert result["score"] == 0.5
+    assert result["passed"] is True
+    assert "Timeout" in result["details"]
+
+
+def test_hygiene_weights_sum_to_one() -> None:
+    total = sum(HYGIENE_WEIGHTS.values())
+    assert abs(total - 1.0) < 1e-9, f"HYGIENE_WEIGHTS sum to {total}, expected 1.0"
+    assert "architecture" in HYGIENE_WEIGHTS


### PR DESCRIPTION
Closes #699

## Changes

- **Part 1 — `factory/eval/hygiene.py`**: Added `eval_architecture()` as 7th mandatory hygiene dimension. Returns neutral 0.5 when `.sentrux/rules.toml` absent or `sentrux` binary not installed. When available, runs `sentrux check .` and normalizes `quality_signal` (0-10000) to 0.0-1.0. Rebalanced `HYGIENE_WEIGHTS` to include `"architecture": 0.08` (sum = 1.0).

- **Part 2 — `.github/workflows/ci.yml`**: Enhanced quality job to checkout base branch and run `sentrux gate --save .` for baseline, then `sentrux gate .` on PR branch for diff comparison, plus `sentrux check .` for absolute enforcement. PR comment now shows both Absolute and Diff sections. Added `--install-only` flag to `scripts/sentrux-check.sh` to support separating installation from execution.

- **Part 3 — `tests/test_hygiene_architecture.py`**: Added 8 test cases covering all paths: neutral (no rules.toml), neutral (no binary), full quality pass, partial quality score, parse error with exit 0, parse error with exit non-zero, timeout handling, and weights sum validation.