### PR TITLE
feat: CI eval baseline pipeline + factory baseline CLI command

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -1,0 +1,104 @@
+name: Eval Baseline
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: eval-baseline-${{ github.sha }}
+
+jobs:
+  eval-baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: Run eval
+        id: eval
+        run: |
+          uv run factory eval . > eval_output.json 2>/dev/null || true
+          cat eval_output.json
+
+      - name: Setup eval-data branch
+        run: |
+          if git ls-remote --exit-code --heads https://github.com/${{ github.repository }}.git eval-data >/dev/null 2>&1; then
+            git clone --single-branch --branch eval-data https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git eval-data
+          else
+            mkdir eval-data && cd eval-data
+            git init
+            git checkout -b eval-data
+            git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+            touch scores.jsonl
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git add . && git commit -m 'Initialize eval-data branch'
+            git push -u origin eval-data
+          fi
+
+      - name: Enrich and append baseline record
+        env:
+          COMMIT: ${{ github.sha }}
+          REF: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 << 'PYEOF'
+          import json, os, sys
+          from datetime import datetime, timezone
+
+          eval_path = "eval_output.json"
+          output_path = "eval-data/scores.jsonl"
+
+          if not os.path.isfile(eval_path):
+              print("ERROR: eval_output.json not found", file=sys.stderr)
+              sys.exit(1)
+
+          with open(eval_path) as f:
+              eval_data = json.load(f)
+
+          record = {
+              "commit": os.environ.get("COMMIT", ""),
+              "ref": os.environ.get("REF", ""),
+              "timestamp": datetime.now(timezone.utc).isoformat(),
+              "run_id": os.environ.get("RUN_ID", ""),
+              "run_url": os.environ.get("RUN_URL", ""),
+              "composite_score": eval_data.get("total"),
+              "results": eval_data.get("results", []),
+              "guard_violations": eval_data.get("guard_violations", []),
+              "passed": eval_data.get("passed", False),
+          }
+
+          with open(output_path, "a") as f:
+              f.write(json.dumps(record) + "\n")
+
+          print(f"Appended baseline record for {record['commit'][:8]}", file=sys.stderr)
+          PYEOF
+
+      - name: Push to eval-data branch
+        working-directory: eval-data
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add scores.jsonl
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "Add eval baseline for ${{ github.sha }}"
+          for i in 1 2 3; do
+            git push origin eval-data && break
+            echo "Push failed (attempt $i), rebasing and retrying..."
+            git pull --rebase origin eval-data
+          done

--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Run eval
         id: eval
         run: |
-          uv run factory eval . > eval_output.json 2>/dev/null || true
+          uv run factory eval . > eval_output.json || true
           cat eval_output.json
+          python3 -c "import json; json.load(open('eval_output.json'))" || { echo 'ERROR: eval_output.json is missing or invalid JSON'; exit 1; }
 
       - name: Setup eval-data branch
         run: |
@@ -102,3 +103,4 @@ jobs:
             echo "Push failed (attempt $i), rebasing and retrying..."
             git pull --rebase origin eval-data
           done
+          git push origin eval-data || { echo 'ERROR: all push attempts failed'; exit 1; }

--- a/factory/baseline.py
+++ b/factory/baseline.py
@@ -1,0 +1,93 @@
+"""Fetch stored eval baselines from the eval-data branch."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _parse_scores_jsonl(raw: str) -> dict[str, dict]:
+    """Parse scores.jsonl content into a {commit: record} lookup dict.
+
+    Malformed lines are silently skipped.
+    """
+    lookup: dict[str, dict] = {}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        commit = record.get("commit")
+        if commit:
+            lookup[commit] = record
+    return lookup
+
+
+def fetch_baseline(
+    project_path: Path,
+    commit_sha: str | None = None,
+    remote: str = "origin",
+    branch: str = "eval-data",
+) -> dict | None:
+    """Fetch the stored eval baseline for a commit.
+
+    1. ``git fetch <remote> <branch>``
+    2. Read ``scores.jsonl`` via ``git show``
+    3. Exact SHA match first
+    4. Ancestor walk via ``git rev-list`` (up to 50 commits)
+
+    Returns the baseline record dict, or ``None`` if no match is found.
+    """
+    fetch_result = _git(["fetch", remote, branch], cwd=project_path)
+    if fetch_result.returncode != 0:
+        log.warning("baseline.fetch_failed", remote=remote, branch=branch,
+                    stderr=fetch_result.stderr.strip())
+        return None
+
+    show_result = _git(
+        ["show", f"{remote}/{branch}:scores.jsonl"],
+        cwd=project_path,
+    )
+    if show_result.returncode != 0:
+        log.warning("baseline.show_failed", ref=f"{remote}/{branch}:scores.jsonl",
+                    stderr=show_result.stderr.strip())
+        return None
+
+    lookup = _parse_scores_jsonl(show_result.stdout)
+    if not lookup:
+        return None
+
+    sha = commit_sha or ""
+
+    if sha in lookup:
+        return lookup[sha]
+
+    if sha:
+        rev_list = _git(
+            ["rev-list", sha, "--max-count=50"],
+            cwd=project_path,
+        )
+        if rev_list.returncode == 0:
+            for ancestor in rev_list.stdout.strip().splitlines():
+                ancestor = ancestor.strip()
+                if ancestor in lookup:
+                    return lookup[ancestor]
+
+    return None

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1701,6 +1701,34 @@ def cmd_clean_pr(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_baseline(args: argparse.Namespace) -> int:
+    """Fetch stored eval baseline for a commit from the eval-data branch."""
+    from factory.baseline import fetch_baseline
+
+    project_path = Path(args.path).resolve()
+
+    commit = getattr(args, "commit", None)
+    if not commit:
+        result = subprocess.run(
+            ["git", "merge-base", "HEAD", _read_target_branch(project_path)],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print("Error: could not determine merge-base commit.", file=sys.stderr)
+            return 1
+        commit = result.stdout.strip()
+
+    baseline = fetch_baseline(project_path, commit_sha=commit)
+    if baseline is None:
+        print(f"No baseline found for commit {commit[:12]}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(baseline, indent=2, default=str))
+    return 0
+
+
 def cmd_review(args: argparse.Namespace) -> int:
     """Format and optionally post a review on a GitHub PR."""
     from factory.review import ReviewPayload, format_review, post_review
@@ -4005,6 +4033,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("path", help="Path to the project")
     p.add_argument("--exp", type=int, default=None, help="Experiment ID (archives full diff before stripping)")
 
+    # baseline
+    p = sub.add_parser("baseline", help="Fetch stored eval baseline from eval-data branch")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--commit", default=None,
+                    help="Commit SHA to look up (default: git merge-base HEAD <target-branch>)")
+
     # refine-status
     p = sub.add_parser("refine-status", help="Print refinement state and regrounding output")
     p.add_argument("path", help="Path to the project")
@@ -4397,6 +4431,7 @@ def main(argv: list[str] | None = None) -> int:
         "archive": cmd_archive,
         "precheck": cmd_precheck,
         "clean-pr": cmd_clean_pr,
+        "baseline": cmd_baseline,
         "leakage-check": cmd_leakage_check,
         "validate-research": cmd_validate_research,
         "refine-status": cmd_refine_status,

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import argparse
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -160,3 +162,53 @@ class TestBaselineCLI:
         from factory.cli import cmd_baseline
 
         assert callable(cmd_baseline)
+
+    def test_cmd_baseline_success(self, tmp_path: Path, capsys) -> None:
+        from factory.cli import cmd_baseline
+
+        baseline_data = {"commit": "abc123", "composite_score": 0.85, "passed": True}
+        args = argparse.Namespace(path=str(tmp_path), commit="abc123")
+
+        with patch("factory.baseline.fetch_baseline", return_value=baseline_data):
+            rc = cmd_baseline(args)
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["composite_score"] == 0.85
+        assert parsed["commit"] == "abc123"
+
+    def test_cmd_baseline_no_match(self, tmp_path: Path, capsys) -> None:
+        from factory.cli import cmd_baseline
+
+        args = argparse.Namespace(path=str(tmp_path), commit="deadbeef1234")
+
+        with patch("factory.baseline.fetch_baseline", return_value=None):
+            rc = cmd_baseline(args)
+
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "No baseline found" in captured.err
+
+    def test_cmd_baseline_default_commit(self, tmp_path: Path, capsys) -> None:
+        from factory.cli import cmd_baseline
+
+        baseline_data = {"commit": "resolved_sha", "composite_score": 0.90}
+        args = argparse.Namespace(path=str(tmp_path))
+
+        merge_base_result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="resolved_sha\n", stderr=""
+        )
+
+        with (
+            patch("factory.baseline.fetch_baseline", return_value=baseline_data) as mock_fetch,
+            patch("subprocess.run", return_value=merge_base_result) as mock_run,
+            patch("factory.cli._read_target_branch", return_value="main"),
+        ):
+            rc = cmd_baseline(args)
+
+        assert rc == 0
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert "merge-base" in call_args[0][0]
+        mock_fetch.assert_called_once_with(tmp_path, commit_sha="resolved_sha")

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -6,8 +6,6 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from factory.baseline import _parse_scores_jsonl, fetch_baseline
 
 
@@ -64,7 +62,7 @@ SCORES_JSONL = (
 
 
 class TestFetchBaseline:
-    def test_exact_match(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_exact_match(self, tmp_path: Path) -> None:
         calls: list[list[str]] = []
 
         def mock_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,164 @@
+"""Tests for factory.baseline — JSONL parsing, commit lookup, and CLI integration."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from factory.baseline import _parse_scores_jsonl, fetch_baseline
+
+
+# ── JSONL parsing ─────────────────────────────────────────────
+
+
+class TestParseScoresJsonl:
+    def test_valid_records(self) -> None:
+        raw = (
+            '{"commit": "aaa111", "composite_score": 0.85, "passed": true}\n'
+            '{"commit": "bbb222", "composite_score": 0.90, "passed": true}\n'
+        )
+        lookup = _parse_scores_jsonl(raw)
+        assert len(lookup) == 2
+        assert lookup["aaa111"]["composite_score"] == 0.85
+        assert lookup["bbb222"]["composite_score"] == 0.90
+
+    def test_malformed_lines_skipped(self) -> None:
+        raw = (
+            '{"commit": "aaa111", "composite_score": 0.85}\n'
+            'NOT VALID JSON\n'
+            '{"commit": "bbb222", "composite_score": 0.90}\n'
+        )
+        lookup = _parse_scores_jsonl(raw)
+        assert len(lookup) == 2
+        assert "aaa111" in lookup
+        assert "bbb222" in lookup
+
+    def test_empty_input(self) -> None:
+        assert _parse_scores_jsonl("") == {}
+
+    def test_blank_lines_skipped(self) -> None:
+        raw = '\n\n{"commit": "aaa111", "composite_score": 0.85}\n\n'
+        lookup = _parse_scores_jsonl(raw)
+        assert len(lookup) == 1
+
+    def test_missing_commit_key(self) -> None:
+        raw = '{"no_commit": "x", "composite_score": 0.5}\n'
+        lookup = _parse_scores_jsonl(raw)
+        assert len(lookup) == 0
+
+
+# ── Commit lookup ─────────────────────────────────────────────
+
+
+def _make_completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+SCORES_JSONL = (
+    '{"commit": "abc123", "composite_score": 0.85, "passed": true}\n'
+    '{"commit": "def456", "composite_score": 0.90, "passed": true}\n'
+)
+
+
+class TestFetchBaseline:
+    def test_exact_match(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[list[str]] = []
+
+        def mock_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+            calls.append(args)
+            if args[:2] == ["fetch", "origin"]:
+                return _make_completed()
+            if args[0] == "show":
+                return _make_completed(stdout=SCORES_JSONL)
+            return _make_completed(returncode=1)
+
+        with patch("factory.baseline._git", side_effect=mock_git):
+            result = fetch_baseline(tmp_path, commit_sha="abc123")
+
+        assert result is not None
+        assert result["composite_score"] == 0.85
+
+    def test_ancestor_walk(self, tmp_path: Path) -> None:
+        def mock_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+            if args[:2] == ["fetch", "origin"]:
+                return _make_completed()
+            if args[0] == "show":
+                return _make_completed(stdout=SCORES_JSONL)
+            if args[0] == "rev-list":
+                return _make_completed(stdout="unknown1\ndef456\nold789\n")
+            return _make_completed(returncode=1)
+
+        with patch("factory.baseline._git", side_effect=mock_git):
+            result = fetch_baseline(tmp_path, commit_sha="newer_commit")
+
+        assert result is not None
+        assert result["commit"] == "def456"
+        assert result["composite_score"] == 0.90
+
+    def test_no_match(self, tmp_path: Path) -> None:
+        def mock_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+            if args[:2] == ["fetch", "origin"]:
+                return _make_completed()
+            if args[0] == "show":
+                return _make_completed(stdout=SCORES_JSONL)
+            if args[0] == "rev-list":
+                return _make_completed(stdout="no_match_1\nno_match_2\n")
+            return _make_completed(returncode=1)
+
+        with patch("factory.baseline._git", side_effect=mock_git):
+            result = fetch_baseline(tmp_path, commit_sha="nonexistent")
+
+        assert result is None
+
+    def test_fetch_failure(self, tmp_path: Path) -> None:
+        def mock_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+            if args[:2] == ["fetch", "origin"]:
+                return _make_completed(returncode=1)
+            return _make_completed(returncode=1)
+
+        with patch("factory.baseline._git", side_effect=mock_git):
+            result = fetch_baseline(tmp_path, commit_sha="abc123")
+
+        assert result is None
+
+    def test_empty_scores(self, tmp_path: Path) -> None:
+        def mock_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+            if args[:2] == ["fetch", "origin"]:
+                return _make_completed()
+            if args[0] == "show":
+                return _make_completed(stdout="")
+            return _make_completed(returncode=1)
+
+        with patch("factory.baseline._git", side_effect=mock_git):
+            result = fetch_baseline(tmp_path, commit_sha="abc123")
+
+        assert result is None
+
+
+# ── CLI argument parsing ──────────────────────────────────────
+
+
+class TestBaselineCLI:
+    def test_parser_accepts_path(self) -> None:
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["baseline", "/tmp/project"])
+        assert args.command == "baseline"
+        assert args.path == "/tmp/project"
+        assert args.commit is None
+
+    def test_parser_accepts_commit_flag(self) -> None:
+        from factory.cli import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["baseline", "/tmp/project", "--commit", "abc123"])
+        assert args.commit == "abc123"
+
+    def test_handler_registered(self) -> None:
+        from factory.cli import cmd_baseline
+
+        assert callable(cmd_baseline)


### PR DESCRIPTION
## Summary

Closes #727. Adds infrastructure to store and retrieve per-commit eval baselines in CI.

- **`.github/workflows/eval-baseline.yml`** — CI workflow that runs `factory eval .` on every push to `main`, enriches the result with commit metadata, and appends it as JSONL to a new `eval-data` orphan branch (`scores.jsonl`). Uses rebase-retry pattern for concurrent push safety.
- **`factory/baseline.py`** — New module with `fetch_baseline()` that retrieves stored baselines by commit SHA (exact match first, then ancestor walk via `git rev-list --max-count=50`).
- **`factory baseline <path> [--commit SHA]`** — New CLI command registered in `cli.py`. Defaults `--commit` to `git merge-base HEAD <target-branch>`.
- **`tests/test_baseline.py`** — 16 tests covering JSONL parsing, commit lookup (exact, ancestor, no-match, fetch failure), and `cmd_baseline` integration (success, no-match, default-commit).

## Test plan

- [x] `pytest tests/test_baseline.py -v` — all 16 pass
- [x] `ruff check factory/baseline.py` — clean
- [x] Codecov patch coverage passes
- [ ] After merge: verify `eval-data` branch is created with `scores.jsonl` on first push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)