### PR TITLE
fix: increase asyncio StreamReader limit to 1MB

### DIFF
--- a/factory/runners/_subprocess.py
+++ b/factory/runners/_subprocess.py
@@ -70,6 +70,7 @@ async def run_subprocess(
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
             env=env,
+            limit=1_048_576,
         )
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
             stream_subprocess(

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,0 +1,20 @@
+"""Tests for factory/runners/_subprocess.py."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_subprocess_readline_limit():
+    """Verify subprocess uses 1MB readline limit, not default 64KB."""
+    source = Path("factory/runners/_subprocess.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and "create_subprocess_exec" in ast.dump(node):
+            for kw in node.keywords:
+                if kw.arg == "limit":
+                    assert isinstance(kw.value, ast.Constant)
+                    assert kw.value.value >= 1_048_576
+                    return
+    raise AssertionError("No limit= kwarg found in create_subprocess_exec call")


### PR DESCRIPTION
Closes #741

## Changes
- Added `limit=1_048_576` (1MB) to `asyncio.create_subprocess_exec` in `factory/runners/_subprocess.py` to prevent `ValueError: Separator is found, but chunk is longer than limit` crashes when Claude Code emits JSON lines containing the 160KB CEO prompt
- Added `tests/test_subprocess.py` with AST-based test verifying the limit kwarg is present and >= 1MB