### PR TITLE
fix: add factory init step to eval-baseline CI

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups
 
+      - name: Initialize factory config
+        run: uv run factory init .
+
       - name: Run eval
         id: eval
         run: |


### PR DESCRIPTION
Fixes the eval-baseline workflow by adding `factory init` before `factory eval`, since `.factory/config.json` is gitignored and not present in CI checkouts.

## Changes
- Added `uv run factory init .` step between dependency installation and eval execution in `.github/workflows/eval-baseline.yml`