### PR TITLE
fix: add factory init step to eval-baseline CI

### DIFF
--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups
 
+      - name: Initialize factory config
+        run: uv run factory init .
+
       - name: Run eval
         id: eval
         run: |


### PR DESCRIPTION
## Summary

The eval-baseline CI workflow fails because `.factory/config.json` is gitignored and not present in CI checkouts. `factory eval` requires it.

- Adds `uv run factory init .` step before `factory eval .` to generate `.factory/config.json` from the committed `factory.md`

## Test plan

- [ ] Eval-baseline workflow passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)