### PR TITLE
fix: use explicit refspec in factory baseline fetch

### DIFF
--- a/factory/baseline.py
+++ b/factory/baseline.py
@@ -55,7 +55,8 @@ def fetch_baseline(
 
     Returns the baseline record dict, or ``None`` if no match is found.
     """
-    fetch_result = _git(["fetch", remote, branch], cwd=project_path)
+    refspec = f"{branch}:refs/remotes/{remote}/{branch}"
+    fetch_result = _git(["fetch", remote, refspec], cwd=project_path)
     if fetch_result.returncode != 0:
         log.warning("baseline.fetch_failed", remote=remote, branch=branch,
                     stderr=fetch_result.stderr.strip())

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -113,6 +113,25 @@ class TestFetchBaseline:
 
         assert result is None
 
+    def test_fetch_uses_explicit_refspec(self, tmp_path: Path) -> None:
+        calls: list[list[str]] = []
+
+        def mock_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+            calls.append(args)
+            if args[0] == "fetch":
+                return _make_completed()
+            if args[0] == "show":
+                return _make_completed(stdout=SCORES_JSONL)
+            return _make_completed(returncode=1)
+
+        with patch("factory.baseline._git", side_effect=mock_git):
+            fetch_baseline(tmp_path, commit_sha="abc123")
+
+        fetch_call = calls[0]
+        assert fetch_call[0] == "fetch"
+        assert fetch_call[1] == "origin"
+        assert fetch_call[2] == "eval-data:refs/remotes/origin/eval-data"
+
     def test_fetch_failure(self, tmp_path: Path) -> None:
         def mock_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
             if args[:2] == ["fetch", "origin"]:


### PR DESCRIPTION
## Summary

Fixes `factory baseline` failing in shallow clones (including GitHub Actions and factory worktrees).

**Root cause:** `git fetch origin eval-data` only updates `FETCH_HEAD` in shallow clones — it does not create the `origin/eval-data` remote-tracking ref. The subsequent `git show origin/eval-data:scores.jsonl` fails.

**Fix:** Use explicit refspec `eval-data:refs/remotes/origin/eval-data` so the remote-tracking branch is always created regardless of clone depth.

## Test plan

- [x] New `test_fetch_uses_explicit_refspec` verifies the refspec format
- [x] All 17 baseline tests pass
- [x] 176 smoke tests pass
- [x] Manually verified in a fresh `git clone --depth 50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)