### PR TITLE
feat: emit ceo.message events in interactive mode

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -17,6 +17,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 log = structlog.get_logger()
@@ -2649,7 +2650,12 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     _ceo_start = _time.time()
 
-    ceo_tailer = _start_ceo_tailer(wt_path, cycle_span_id, _ceo_start)
+    from factory.runners.claude import _make_ceo_message_emitter
+
+    ceo_tailer = _start_ceo_tailer(
+        wt_path, cycle_span_id, _ceo_start,
+        on_line=_make_ceo_message_emitter(wt_path),
+    )
 
     if headless:
         # Non-interactive pipe mode (for scripting, cron, tmux)
@@ -2719,30 +2725,32 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
 def _start_ceo_tailer(
     wt_path: Path, cycle_span_id: str | None, start_time: float,
+    on_line: Callable[[bytes], None] | None = None,
 ) -> object | None:
     """Create the CEO span eagerly and start a TranscriptTailer."""
-    if not cycle_span_id:
-        return None
     try:
         from factory.telemetry import TranscriptTailer, begin_span, flush, is_enabled
 
-        if not is_enabled():
-            return None
-        trace_id = os.environ.get("FACTORY_TRACE_ID", "")
-        if not trace_id:
-            return None
+        trace_id = ""
+        ceo_span_id = ""
 
-        ceo_span_id = begin_span(trace_id, cycle_span_id, "ceo")
-        if ceo_span_id is None:
-            return None
+        if cycle_span_id and is_enabled():
+            trace_id = os.environ.get("FACTORY_TRACE_ID", "")
+            if trace_id:
+                span = begin_span(trace_id, cycle_span_id, "ceo")
+                if span:
+                    ceo_span_id = span
+                    flush()
 
-        flush()
+        if not trace_id and not on_line:
+            return None
 
         tailer = TranscriptTailer(
             trace_id=trace_id,
             span_id=ceo_span_id,
             project_path=wt_path,
             session_start=start_time,
+            on_line=on_line,
         )
         tailer.start()
         return tailer

--- a/factory/telemetry.py
+++ b/factory/telemetry.py
@@ -6,6 +6,7 @@ import json
 import os
 import threading
 import time as _time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -465,6 +466,8 @@ class TranscriptTailer:
         span_id: str,
         project_path: Path,
         session_start: float,
+        *,
+        on_line: Callable[[bytes], None] | None = None,
     ) -> None:
         self.trace_id = trace_id
         self.span_id = span_id
@@ -476,6 +479,7 @@ class TranscriptTailer:
         self._file_pos: int = 0
         self._transcript_path: Path | None = None
         self._total_ingested: int = 0
+        self._on_line = on_line
 
     def start(self) -> None:
         self._thread = threading.Thread(
@@ -529,9 +533,10 @@ class TranscriptTailer:
             while not self._stop_event.is_set():
                 try:
                     self._ingest_new_lines()
-                    saved = _trace_names.get(self.trace_id)
-                    if saved:
-                        _update_trace_via_api(self.trace_id, saved[0], saved[1])
+                    if self.trace_id:
+                        saved = _trace_names.get(self.trace_id)
+                        if saved:
+                            _update_trace_via_api(self.trace_id, saved[0], saved[1])
                 except Exception:
                     log.debug("tailer_ingest_error", exc_info=True)
                 self._stop_event.wait(self.POLL_INTERVAL)
@@ -542,10 +547,6 @@ class TranscriptTailer:
         if self._transcript_path is None or not self._transcript_path.exists():
             return
 
-        parent = _observations.get(self.span_id)
-        if parent is None:
-            return
-
         with open(self._transcript_path) as f:
             f.seek(self._file_pos)
             new_lines = f.readlines()
@@ -554,10 +555,22 @@ class TranscriptTailer:
         if not new_lines:
             return
 
+        parent = _observations.get(self.span_id) if self.span_id else None
+
         for raw_line in new_lines:
             raw_line = raw_line.strip()
             if not raw_line:
                 continue
+
+            if self._on_line is not None:
+                try:
+                    self._on_line(raw_line.encode())
+                except Exception:
+                    log.debug("tailer_on_line_error", exc_info=True)
+
+            if parent is None:
+                continue
+
             try:
                 item = json.loads(raw_line)
             except json.JSONDecodeError:

--- a/tests/test_ceo_message_events.py
+++ b/tests/test_ceo_message_events.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from factory.runners.claude import _make_ceo_message_emitter
@@ -252,3 +253,156 @@ class TestTeeStreamOnLineCallback:
 
         assert len(buffer) == 1
         assert buffer[0] == b"test line\n"
+
+
+class TestTranscriptTailerOnLine:
+    """Test TranscriptTailer on_line callback for interactive ceo.message events."""
+
+    def test_transcript_tailer_on_line_callback(self, tmp_path: Path) -> None:
+        """on_line fires for each line and emits ceo.message events."""
+        import time
+
+        from factory.telemetry import TranscriptTailer
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        claude_dir = Path.home() / ".claude" / "projects"
+        dir_name = str(project.resolve()).replace("/", "-").replace(".", "-")
+        proj_dir = claude_dir / dir_name
+        proj_dir.mkdir(parents=True, exist_ok=True)
+
+        transcript = proj_dir / "test-session.jsonl"
+        start_time = time.time() - 1
+        transcript.write_text(
+            json.dumps({"type": "assistant", "message": "hello from tailer"}) + "\n"
+            + json.dumps({"type": "user", "message": {"content": []}}) + "\n"
+        )
+
+        emitter = _make_ceo_message_emitter(project)
+        tailer = TranscriptTailer(
+            trace_id="",
+            span_id="",
+            project_path=project,
+            session_start=start_time,
+            on_line=emitter,
+        )
+        tailer.start()
+        time.sleep(1.0)
+        ingested = tailer.stop_and_drain()
+
+        assert ingested == 0
+
+        events_file = project / ".factory" / "events.jsonl"
+        assert events_file.exists()
+        events = [json.loads(ln) for ln in events_file.read_text().strip().splitlines()]
+        ceo_events = [e for e in events if e["type"] == "ceo.message"]
+        assert len(ceo_events) == 1
+        assert ceo_events[0]["data"]["message"] == "hello from tailer"
+
+    def test_transcript_tailer_on_line_fires_without_langfuse(self, tmp_path: Path) -> None:
+        """on_line fires even when Langfuse is not configured (empty trace_id/span_id)."""
+        import time
+
+        from factory.telemetry import TranscriptTailer
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        claude_dir = Path.home() / ".claude" / "projects"
+        dir_name = str(project.resolve()).replace("/", "-").replace(".", "-")
+        proj_dir = claude_dir / dir_name
+        proj_dir.mkdir(parents=True, exist_ok=True)
+
+        transcript = proj_dir / "test-session2.jsonl"
+        start_time = time.time() - 1
+        transcript.write_text(
+            json.dumps({"type": "assistant", "message": "line1"}) + "\n"
+            + json.dumps({"type": "assistant", "message": "line2"}) + "\n"
+        )
+
+        captured: list[bytes] = []
+
+        def capture(line: bytes) -> None:
+            captured.append(line)
+
+        tailer = TranscriptTailer(
+            trace_id="",
+            span_id="",
+            project_path=project,
+            session_start=start_time,
+            on_line=capture,
+        )
+        tailer.start()
+        time.sleep(1.0)
+        ingested = tailer.stop_and_drain()
+
+        assert ingested == 0
+        assert len(captured) == 2
+
+    def test_transcript_tailer_on_line_ignores_non_assistant(self, tmp_path: Path) -> None:
+        """The emitter callback only emits ceo.message for assistant-type lines."""
+        import time
+
+        from factory.telemetry import TranscriptTailer
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        claude_dir = Path.home() / ".claude" / "projects"
+        dir_name = str(project.resolve()).replace("/", "-").replace(".", "-")
+        proj_dir = claude_dir / dir_name
+        proj_dir.mkdir(parents=True, exist_ok=True)
+
+        transcript = proj_dir / "test-session3.jsonl"
+        start_time = time.time() - 1
+        transcript.write_text(
+            json.dumps({"type": "user", "message": {"content": []}}) + "\n"
+            + json.dumps({"type": "tool_use", "name": "Bash"}) + "\n"
+            + json.dumps({"type": "result", "result": "done"}) + "\n"
+        )
+
+        emitter = _make_ceo_message_emitter(project)
+        tailer = TranscriptTailer(
+            trace_id="",
+            span_id="",
+            project_path=project,
+            session_start=start_time,
+            on_line=emitter,
+        )
+        tailer.start()
+        time.sleep(1.0)
+        tailer.stop_and_drain()
+
+        events_file = project / ".factory" / "events.jsonl"
+        assert not events_file.exists()
+
+    def test_start_ceo_tailer_with_on_line_no_langfuse(self, tmp_path: Path) -> None:
+        """_start_ceo_tailer returns a tailer (not None) when on_line is provided,
+        even without Langfuse or cycle_span_id."""
+        import time
+        from unittest.mock import patch
+
+        from factory.cli import _start_ceo_tailer
+
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        captured: list[bytes] = []
+
+        def capture(line: bytes) -> None:
+            captured.append(line)
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FACTORY_TRACE_ID", None)
+            os.environ.pop("LANGFUSE_HOST", None)
+
+            tailer = _start_ceo_tailer(
+                project, None, time.time(), on_line=capture,
+            )
+
+        assert tailer is not None
+        tailer.stop_and_drain()  # type: ignore[union-attr]


### PR DESCRIPTION
Closes #756

## Changes

- Extended `TranscriptTailer` with an optional `on_line: Callable[[bytes], None]` callback that fires for each raw transcript line **before** the Langfuse guard, so it works even without Langfuse configured
- Restructured `_ingest_new_lines()` to read lines first, call `on_line` for each, then conditionally process through Langfuse
- Guarded `_update_trace_via_api` in `_run()` with `if self.trace_id:` so non-Langfuse tailers skip it
- Modified `_start_ceo_tailer()` in `cli.py` to accept an `on_line` parameter and create a tailer even without Langfuse when `on_line` is provided
- Wired `_make_ceo_message_emitter()` as the `on_line` callback at the call site — reuses the existing emitter from `factory/runners/claude.py`
- Added 4 new tests covering: callback firing, working without Langfuse, filtering non-assistant lines, and `_start_ceo_tailer` creating a tailer without Langfuse