### PR TITLE
fix: handle transcript JSONL format in ceo.message emitter

### DIFF
--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -33,13 +33,24 @@ def _make_ceo_message_emitter(project_path: Path) -> Callable[[bytes], None]:
         if not isinstance(parsed, dict) or parsed.get("type") != "assistant":
             return
         message = parsed.get("message", "")
-        if not isinstance(message, str) or not message:
+        if isinstance(message, str):
+            text = message
+        elif isinstance(message, dict):
+            content = message.get("content", [])
+            text = "".join(
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
+        else:
+            return
+        if not text:
             return
         emit_event(
             project_path,
             "ceo.message",
             agent="ceo",
-            data={"message": message, "message_type": "assistant"},
+            data={"message": text, "message_type": "assistant"},
         )
 
     return _on_line

--- a/tests/test_ceo_message_events.py
+++ b/tests/test_ceo_message_events.py
@@ -82,13 +82,97 @@ class TestMakeCeoMessageEmitter:
         events_file = project / ".factory" / "events.jsonl"
         assert not events_file.exists()
 
-    def test_skips_non_string_message(self, tmp_path: Path) -> None:
+    def test_skips_non_string_non_dict_message(self, tmp_path: Path) -> None:
         project = tmp_path / "proj"
         project.mkdir()
         (project / ".factory").mkdir()
 
         emitter = _make_ceo_message_emitter(project)
         emitter(json.dumps({"type": "assistant", "message": 42}).encode())
+
+        events_file = project / ".factory" / "events.jsonl"
+        assert not events_file.exists()
+
+    def test_emits_event_for_transcript_format(self, tmp_path: Path) -> None:
+        """Transcript JSONL has message as dict with content array."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        emitter = _make_ceo_message_emitter(project)
+        line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Hello from transcript"}
+                ],
+            },
+        }).encode()
+        emitter(line)
+
+        events_file = project / ".factory" / "events.jsonl"
+        assert events_file.exists()
+        events = [json.loads(ln) for ln in events_file.read_text().strip().splitlines()]
+        assert len(events) == 1
+        assert events[0]["type"] == "ceo.message"
+        assert events[0]["data"]["message"] == "Hello from transcript"
+
+    def test_transcript_format_multiple_text_blocks(self, tmp_path: Path) -> None:
+        """Transcript content with multiple text blocks gets concatenated."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        emitter = _make_ceo_message_emitter(project)
+        line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Part 1. "},
+                    {"type": "tool_use", "id": "t1", "name": "Bash"},
+                    {"type": "text", "text": "Part 2."},
+                ],
+            },
+        }).encode()
+        emitter(line)
+
+        events_file = project / ".factory" / "events.jsonl"
+        events = [json.loads(ln) for ln in events_file.read_text().strip().splitlines()]
+        assert len(events) == 1
+        assert events[0]["data"]["message"] == "Part 1. Part 2."
+
+    def test_transcript_format_empty_content_skipped(self, tmp_path: Path) -> None:
+        """Transcript with empty content array produces no event."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        emitter = _make_ceo_message_emitter(project)
+        line = json.dumps({
+            "type": "assistant",
+            "message": {"content": []},
+        }).encode()
+        emitter(line)
+
+        events_file = project / ".factory" / "events.jsonl"
+        assert not events_file.exists()
+
+    def test_transcript_format_no_text_blocks_skipped(self, tmp_path: Path) -> None:
+        """Transcript with only non-text content blocks produces no event."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".factory").mkdir()
+
+        emitter = _make_ceo_message_emitter(project)
+        line = json.dumps({
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "Bash"},
+                ],
+            },
+        }).encode()
+        emitter(line)
 
         events_file = project / ".factory" / "events.jsonl"
         assert not events_file.exists()


### PR DESCRIPTION
## Changes

- Updated `_make_ceo_message_emitter()` in `factory/runners/claude.py` to handle both message formats:
  - **Stream-json format** (headless mode): `{"type": "assistant", "message": "Hello..."}`  — message is a string, used directly
  - **Transcript JSONL format** (interactive mode): `{"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello..."}]}}` — text extracted from content blocks
- Added 4 new test cases for transcript format: single text block, multiple text blocks with non-text interleaved, empty content array, and content with only non-text blocks
- Renamed `test_skips_non_string_message` → `test_skips_non_string_non_dict_message` to reflect the updated behavior (dicts are now handled, but other types like int are still skipped)