### PR TITLE
fix: auto-load .env.local for Langfuse tracing

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -4399,7 +4399,22 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _load_env_local() -> None:
+    """Auto-load .env.local if present, exporting vars into os.environ."""
+    for candidate in [Path(".env.local"), Path.home() / "remote-factory" / ".env.local"]:
+        if candidate.exists():
+            for line in candidate.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" in line:
+                    key, _, value = line.partition("=")
+                    os.environ.setdefault(key.strip(), value.strip())
+            break
+
+
 def main(argv: list[str] | None = None) -> int:
+    _load_env_local()
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/infra/langfuse/README.md
+++ b/infra/langfuse/README.md
@@ -9,7 +9,12 @@ Langfuse provides LLM observability and tracing for the factory system.
 cd infra/langfuse && docker compose up -d
 ```
 
-2. Run the factory with Langfuse tracing enabled:
+2. Install the telemetry dependency group (one-time):
+```bash
+uv sync --extra telemetry
+```
+
+3. Run the factory with Langfuse tracing enabled:
 
 ```bash
 export LANGFUSE_HOST=http://localhost:3000

--- a/infra/langfuse/README.md
+++ b/infra/langfuse/README.md
@@ -14,8 +14,8 @@ cd infra/langfuse && docker compose up -d
 ```bash
 export LANGFUSE_HOST=http://localhost:3000
 export LANGFUSE_BASE_URL=http://localhost:3000
-export LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key
-export LANGFUSE_SECRET_KEY=sk-lf-dev-local-key
+export LANGFUSE_PUBLIC_KEY=<your-public-key>
+export LANGFUSE_SECRET_KEY=<your-secret-key>
 export TELEMETRY_PLATFORM=langfuse
 
 factory ceo /path/to/project
@@ -30,10 +30,12 @@ If you need to create it manually, the file should look like:
 ```
 LANGFUSE_HOST=http://localhost:3000
 LANGFUSE_BASE_URL=http://localhost:3000
-LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key
-LANGFUSE_SECRET_KEY=sk-lf-dev-local-key
+LANGFUSE_PUBLIC_KEY=<your-public-key>
+LANGFUSE_SECRET_KEY=<your-secret-key>
 TELEMETRY_PLATFORM=langfuse
 ```
+
+For local dev, `scripts/langfuse-setup start` fills in the correct keys automatically.
 
 To persist across sessions, add the `export` versions to `~/.bashrc` or `~/.zshrc`.
 
@@ -62,8 +64,8 @@ Trace: factory:<project>/<mode>
 |-----------|---------|-------|
 | `LANGFUSE_HOST` | — | Required. Set to `http://localhost:3000` for local dev |
 | `LANGFUSE_BASE_URL` | — | Same as HOST (some SDK versions use this) |
-| `LANGFUSE_PUBLIC_KEY` | — | `pk-lf-dev-local-key` for local dev |
-| `LANGFUSE_SECRET_KEY` | — | `sk-lf-dev-local-key` for local dev |
+| `LANGFUSE_PUBLIC_KEY` | — | Set by `scripts/langfuse-setup start` (see `.env.local`) |
+| `LANGFUSE_SECRET_KEY` | — | Set by `scripts/langfuse-setup start` (see `.env.local`) |
 | `TELEMETRY_PLATFORM` | — | Set to `langfuse` to enable |
 
 ### Verifying Traces

--- a/infra/langfuse/README.md
+++ b/infra/langfuse/README.md
@@ -23,7 +23,19 @@ factory ceo /path/to/project
 
 3. Open `http://localhost:3000` to view traces. Login: `dev@localhost.local` / `devpassword123`
 
-Add these to your `~/.bashrc` or `~/.zshrc` to persist across sessions.
+**Note:** `scripts/langfuse-setup start` auto-creates a `.env.local` file with these credentials. The factory CLI auto-loads it on startup — no manual export needed.
+
+If you need to create it manually, the file should look like:
+
+```
+LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_BASE_URL=http://localhost:3000
+LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key
+LANGFUSE_SECRET_KEY=sk-lf-dev-local-key
+TELEMETRY_PLATFORM=langfuse
+```
+
+To persist across sessions, add the `export` versions to `~/.bashrc` or `~/.zshrc`.
 
 The factory creates a single Langfuse trace per CEO cycle. The trace structure:
 

--- a/scripts/langfuse-setup
+++ b/scripts/langfuse-setup
@@ -9,10 +9,12 @@
 # Web UI: http://localhost:3000
 # Login:  dev@localhost.local / devpassword123
 #
-# Factory env vars (add to shell or .env):
+# Factory env vars (auto-written to .env.local on start):
 #   export LANGFUSE_HOST=http://localhost:3000
+#   export LANGFUSE_BASE_URL=http://localhost:3000
 #   export LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key
 #   export LANGFUSE_SECRET_KEY=sk-lf-dev-local-key
+#   export TELEMETRY_PLATFORM=langfuse
 
 set -euo pipefail
 
@@ -39,11 +41,23 @@ case "${1:-status}" in
         echo ""
         echo "Langfuse starting at http://localhost:3000"
         echo "Login: dev@localhost.local / devpassword123"
+
+        # Write .env.local so tracing works with: set -a && source .env.local && set +a
+        ENV_FILE="$SCRIPT_DIR/.env.local"
+        if [ ! -f "$ENV_FILE" ]; then
+            cat > "$ENV_FILE" <<'ENVEOF'
+LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_BASE_URL=http://localhost:3000
+LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key
+LANGFUSE_SECRET_KEY=sk-lf-dev-local-key
+TELEMETRY_PLATFORM=langfuse
+ENVEOF
+            echo ""
+            echo "Created .env.local with Langfuse credentials."
+        fi
         echo ""
-        echo "Set these env vars for factory telemetry:"
-        echo "  export LANGFUSE_HOST=http://localhost:3000"
-        echo "  export LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key"
-        echo "  export LANGFUSE_SECRET_KEY=sk-lf-dev-local-key"
+        echo "Enable tracing before running the factory:"
+        echo "  set -a && source .env.local && set +a"
         ;;
     stop)
         echo "Stopping Langfuse..."
@@ -56,10 +70,8 @@ case "${1:-status}" in
         echo "Web UI: http://localhost:3000"
         echo "Login:  dev@localhost.local / devpassword123"
         echo ""
-        echo "Factory env vars:"
-        echo "  LANGFUSE_HOST=http://localhost:3000"
-        echo "  LANGFUSE_PUBLIC_KEY=pk-lf-dev-local-key"
-        echo "  LANGFUSE_SECRET_KEY=sk-lf-dev-local-key"
+        echo "Enable tracing:"
+        echo "  set -a && source .env.local && set +a"
         ;;
     *)
         echo "Usage: $0 {start|stop|status}"


### PR DESCRIPTION
## Summary

Users shouldn't need to manually export Langfuse env vars. Two fixes:

1. **`scripts/langfuse-setup start`** now auto-creates `.env.local` with all 5 required vars (was printing only 3, missing `LANGFUSE_BASE_URL` and `TELEMETRY_PLATFORM`)

2. **`factory/cli.py`** now auto-loads `.env.local` on startup via `os.environ.setdefault`, so `factory ceo` picks up Langfuse credentials automatically

### Before
```bash
scripts/langfuse-setup start
# prints 3 vars, user must copy-paste and export them
export LANGFUSE_HOST=...
export LANGFUSE_PUBLIC_KEY=...
export LANGFUSE_SECRET_KEY=...
# still missing LANGFUSE_BASE_URL and TELEMETRY_PLATFORM
factory ceo /path  # no tracing
```

### After
```bash
scripts/langfuse-setup start  # creates .env.local automatically
factory ceo /path              # tracing just works
```

Uses `os.environ.setdefault` so explicit exports still take precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)