### PR TITLE
fix: skip issue creation when focus mode targets an existing GitHub issue

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -361,6 +361,15 @@ For hypotheses with non-overlapping file scopes, execute them in parallel:
 - 3-5 hypotheses: parallel builders, sequential review
 - 5+ hypotheses: wave-based (batches of 3-5)
 
+### Issue Reuse (Focus Mode)
+
+When the task contains an `## Issue Tracking` section, an existing GitHub issue has been targeted via `--focus`. In this case:
+- Do NOT create a new issue — use the issue number from the Issue Tracking section (it appears as "working on issue #NNN")
+- Pass the existing issue number to the Builder
+- The PR should reference this existing issue (e.g., "Closes #NNN")
+
+Only create a new issue when no `## Issue Tracking` section is present in the task.
+
 ---
 
 ## Keep/Revert Decision Framework


### PR DESCRIPTION
Closes #693

## Changes
- Added an "Issue Reuse (Focus Mode)" subsection to the CEO prompt's Parallel Execution Protocol section in `factory/agents/prompts/ceo.md`
- When the CEO task contains an `## Issue Tracking` section (injected by the CLI when `--focus` targets an existing GitHub issue), the CEO now skips `gh issue create` and uses the existing issue number instead
- Normal flow (no Issue Tracking section) remains unchanged — a new issue is created as before