### PR TITLE
eval: remove redundant guard_patterns hygiene dimension

### DIFF
--- a/docs/eval.md
+++ b/docs/eval.md
@@ -14,7 +14,6 @@ Auto-detected from project tooling. These measure basic code quality:
 | `lint` | No lint errors | Runs detected linter (ruff, eslint, etc.) |
 | `type_check` | Type checking passes | Runs mypy, pyright, tsc, etc. |
 | `coverage` | Test coverage level | Parses coverage reports |
-| `guard_patterns` | Guard rules respected | Checks scope, immutability rules |
 | `config_parser` | `factory.md` is valid | Validates configuration |
 
 Implementation: `factory/eval/hygiene.py`

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -166,7 +166,7 @@ You are NOT a passive pipeline. After EVERY agent completes, you MUST review its
 
 The eval system has up to **three tiers** of dimensions:
 
-**Hygiene dimensions:** tests, lint, type_check, coverage, guard_patterns, config_parser
+**Hygiene dimensions:** tests, lint, type_check, coverage, config_parser, architecture
 **Growth dimensions:** capability_surface, experiment_diversity, observability, research_grounding, factory_effectiveness
 **Project eval dimensions (optional):** user-defined in factory.md `## Project Eval` — e.g. benchmark accuracy, latency, win rate
 
@@ -203,7 +203,7 @@ Crash recovery is handled by you directly at Step 0 (Assess Sprint State). You r
 - When hygiene dimensions are all >0.7, the MAJORITY of hypotheses should target growth.
 
 **How to tell hygiene from growth:**
-- HYGIENE (does NOT count as growth): tests, lint, type_check, coverage, guard_patterns, config_parser, bugfixes, cleanup, refactoring, CI fixes, dependency updates
+- HYGIENE (does NOT count as growth): tests, lint, type_check, coverage, config_parser, architecture, bugfixes, cleanup, refactoring, CI fixes, dependency updates
 - GROWTH (the ONLY things that count): capability_surface (new features/endpoints/commands), experiment_diversity, observability (structured logging/tracing), research_grounding (evidence-based work), factory_effectiveness
 
 **Strategist review is a HARD GATE:** The Builder MUST NOT start until you explicitly approve the Strategist's plan. Before writing `PLAN APPROVED`, verify:

--- a/factory/agents/prompts/strategist.md
+++ b/factory/agents/prompts/strategist.md
@@ -51,7 +51,7 @@ You are invoked during the Improve phase after the Researcher has completed thei
 ### Growth vs Hygiene Classification
 
 - **GROWTH dimensions** (the ONLY things that count as growth): `capability_surface` (new features, endpoints, commands, pages), `experiment_diversity` (trying varied experiment types), `observability` (structured logging, tracing), `research_grounding` (evidence-based work referencing papers/repos), `factory_effectiveness` (improving factory success rate)
-- **HYGIENE dimensions** (do NOT count as growth): `tests`, `lint`, `type_check`, `coverage`, `guard_patterns`, `config_parser`. Also: bugfixes, cleanup, refactoring, dependency updates, CI fixes — these are ALL hygiene, not growth.
+- **HYGIENE dimensions** (do NOT count as growth): `tests`, `lint`, `type_check`, `coverage`, `config_parser`, `architecture`. Also: bugfixes, cleanup, refactoring, dependency updates, CI fixes — these are ALL hygiene, not growth.
 - A hypothesis is growth ONLY IF it directly targets one of the 5 growth dimensions listed above.
 - When hygiene dimensions are all >0.7, the MAJORITY of hypotheses must target growth
 - If the project is scoring well (>0.9) and observability is good, focus on new capabilities (capability_surface) rather than optimization

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -1,11 +1,11 @@
 """Universal hygiene eval dimensions applied to every factory-managed project.
 
-These 7 dimensions are mandatory and cannot be removed. They are computed by
+These 6 dimensions are mandatory and cannot be removed. They are computed by
 the factory itself (not by per-project eval/score.py) and auto-detect the
 project's tooling. Projects can ADD dimensions via eval/score.py but cannot
 remove any of these.
 
-Together with the 5 growth dimensions in growth.py, these form the 12
+Together with the 6 growth dimensions in growth.py, these form the 12
 mandatory eval dimensions that define the factory's quality baseline.
 
 All functions take a project_path and return an EvalResult-compatible dict.
@@ -27,13 +27,12 @@ log = structlog.get_logger()
 # Relative weights within the hygiene category (sum to 1.0).
 # The runner normalizes these so that hygiene gets 50% of the composite.
 HYGIENE_WEIGHTS = {
-    "tests": 0.28,
-    "lint": 0.14,
-    "type_check": 0.09,
-    "coverage": 0.23,
-    "guard_patterns": 0.09,
-    "config_parser": 0.09,
-    "architecture": 0.08,
+    "tests": 0.31,
+    "lint": 0.15,
+    "type_check": 0.10,
+    "coverage": 0.25,
+    "config_parser": 0.10,
+    "architecture": 0.09,
 }
 
 
@@ -145,77 +144,7 @@ def eval_coverage(project_path: Path) -> dict:
     return _aggregate(fragments, "coverage")
 
 
-# ── Dimension 5: guard_patterns (weight 0.10) ─────────────────────
-
-
-def eval_guard_patterns(project_path: Path) -> dict:
-    """Test that the factory's guard glob matching works correctly on this project."""
-    try:
-        from factory.eval.guards import _glob_match
-    except (ImportError, AttributeError) as exc:
-        return {
-            "name": "guard_patterns",
-            "score": 0.0,
-            "weight": HYGIENE_WEIGHTS["guard_patterns"],
-            "passed": False,
-            "details": f"Could not import _glob_match: {exc}",
-        }
-
-    # Read project scope from config if available
-    scope_patterns: list[str] = []
-    config_path = project_path / ".factory" / "config.json"
-    if config_path.exists():
-        import json
-        try:
-            data = json.loads(config_path.read_text())
-            scope_patterns = data.get("scope", [])
-        except (json.JSONDecodeError, KeyError):
-            pass
-
-    # Build test cases from the project's actual scope + universal cases
-    test_cases: list[tuple[str, str, bool]] = [
-        # Universal: .factory/ should never match user scope
-        ("src/**/*.py", ".factory/config.json", False),
-        ("src/**/*.py", "src/main.py", True),
-        ("tests/**/*.py", "tests/test_main.py", True),
-        ("tests/**/*.py", "src/main.py", False),
-    ]
-
-    # Add project-specific scope tests
-    for pattern in scope_patterns[:4]:
-        # The pattern itself should match something reasonable
-        if "**" in pattern:
-            parts = pattern.split("**")
-            prefix = parts[0].rstrip("/")
-            if prefix:
-                test_cases.append((pattern, f"{prefix}/example.py", True))
-                test_cases.append((pattern, "unrelated/file.txt", False))
-
-    correct = 0
-    details: list[str] = []
-    for pattern, filepath, expected in test_cases:
-        actual = _glob_match(filepath, pattern)
-        if actual == expected:
-            correct += 1
-        else:
-            details.append(f"FAIL: {pattern} vs {filepath} expected={expected} got={actual}")
-
-    total = len(test_cases)
-    score = correct / total if total > 0 else 1.0
-    summary = f"{correct}/{total} pattern tests passed"
-    if details:
-        summary += "; " + "; ".join(details[:3])
-
-    return {
-        "name": "guard_patterns",
-        "score": round(score, 4),
-        "weight": HYGIENE_WEIGHTS["guard_patterns"],
-        "passed": correct == total,
-        "details": summary,
-    }
-
-
-# ── Dimension 6: config_parser (weight 0.10) ──────────────────────
+# ── Dimension 5: config_parser (weight 0.10) ──────────────────────
 
 
 def _parse_factory_md(path: Path) -> dict[str, str | list[str] | float]:
@@ -318,7 +247,7 @@ def eval_config_parser(project_path: Path) -> dict:
         }
 
 
-# ── Dimension 7: architecture (weight 0.08) ──────────────────────
+# ── Dimension 6: architecture (weight 0.09) ──────────────────────
 
 
 def eval_architecture(project_path: Path) -> dict:
@@ -404,14 +333,13 @@ def _collect_test_and_coverage(project_path: Path, timeout: int = 300) -> tuple[
 
 
 def compute_hygiene_results(project_path: Path, test_timeout: int = 600) -> list[dict]:
-    """Compute all 7 mandatory hygiene dimensions for a project."""
+    """Compute all 6 mandatory hygiene dimensions for a project."""
     test_result, cov_result = _collect_test_and_coverage(project_path, timeout=test_timeout)
     return [
         test_result,
         eval_lint(project_path),
         eval_type_check(project_path),
         cov_result,
-        eval_guard_patterns(project_path),
         eval_config_parser(project_path),
         eval_architecture(project_path),
     ]

--- a/factory/eval/runner.py
+++ b/factory/eval/runner.py
@@ -1,7 +1,7 @@
 """EvalRunner — compute mandatory dimensions and merge with project-specific evals.
 
 The factory's eval system has mandatory dimensions that apply to every project:
-  - 6 hygiene dimensions (tests, lint, type_check, coverage, guard_patterns, config_parser)
+  - 6 hygiene dimensions (tests, lint, type_check, coverage, config_parser, architecture)
   - 5 growth dimensions (capability_surface, experiment_diversity, observability,
     research_grounding, factory_effectiveness)
 

--- a/factory/models.py
+++ b/factory/models.py
@@ -170,7 +170,6 @@ class TierWeights(BaseModel):
     lint: float | None = None
     type_check: float | None = None
     coverage: float | None = None
-    guard_patterns: float | None = None
     config_parser: float | None = None
     capability_surface: float | None = None
     experiment_diversity: float | None = None

--- a/tests/eval/test_hygiene.py
+++ b/tests/eval/test_hygiene.py
@@ -6,7 +6,6 @@ from factory.eval.hygiene import (
     compute_hygiene_results,
     eval_config_parser,
     eval_coverage,
-    eval_guard_patterns,
     eval_lint,
     eval_tests,
     eval_type_check,
@@ -18,9 +17,9 @@ class TestHygieneWeights:
         total = sum(HYGIENE_WEIGHTS.values())
         assert abs(total - 1.0) < 1e-9
 
-    def test_all_seven_dimensions(self):
+    def test_all_six_dimensions(self):
         assert set(HYGIENE_WEIGHTS.keys()) == {
-            "tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser",
+            "tests", "lint", "type_check", "coverage", "config_parser",
             "architecture",
         }
 
@@ -89,23 +88,6 @@ class TestEvalCoverage:
         assert result["score"] == 0.5
 
 
-class TestEvalGuardPatterns:
-    def test_basic_patterns(self, tmp_path):
-        result = eval_guard_patterns(tmp_path)
-        assert result["name"] == "guard_patterns"
-        assert result["score"] > 0.0
-
-    def test_with_factory_config(self, tmp_path):
-        import json
-        factory_dir = tmp_path / ".factory"
-        factory_dir.mkdir()
-        config = {"scope": ["src/**/*.py", "tests/**/*.py"], "goal": "", "guards": [],
-                  "eval_command": "", "eval_threshold": 0.8, "constraints": []}
-        (factory_dir / "config.json").write_text(json.dumps(config))
-        result = eval_guard_patterns(tmp_path)
-        assert result["name"] == "guard_patterns"
-
-
 class TestEvalConfigParser:
     def test_no_factory_md_returns_neutral(self, tmp_path):
         result = eval_config_parser(tmp_path)
@@ -126,11 +108,11 @@ class TestEvalConfigParser:
 
 
 class TestComputeHygieneResults:
-    def test_returns_all_seven(self, tmp_path):
+    def test_returns_all_six(self, tmp_path):
         results = compute_hygiene_results(tmp_path)
-        assert len(results) == 7
+        assert len(results) == 6
         names = {r["name"] for r in results}
-        assert names == {"tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser", "architecture"}
+        assert names == {"tests", "lint", "type_check", "coverage", "config_parser", "architecture"}
 
     def test_all_have_required_keys(self, tmp_path):
         results = compute_hygiene_results(tmp_path)
@@ -144,4 +126,4 @@ class TestComputeHygieneResults:
     def test_accepts_test_timeout_parameter(self, tmp_path):
         """compute_hygiene_results should accept test_timeout parameter."""
         results = compute_hygiene_results(tmp_path, test_timeout=900)
-        assert len(results) == 7
+        assert len(results) == 6

--- a/tests/eval/test_runner.py
+++ b/tests/eval/test_runner.py
@@ -16,7 +16,7 @@ class TestRunEval:
         assert "lint" in names
         assert "type_check" in names
         assert "coverage" in names
-        assert "guard_patterns" in names
+        assert "architecture" in names
         assert "config_parser" in names
         assert "capability_surface" in names
         assert "experiment_diversity" in names
@@ -85,7 +85,7 @@ class TestRunEval:
     async def test_weight_split_is_50_50(self, tmp_path):
         """Hygiene dimensions get 50% total weight, growth gets 50%."""
         result = await run_eval("true", tmp_path, threshold=0.0)
-        hygiene_names = {"tests", "lint", "type_check", "coverage", "guard_patterns", "config_parser", "architecture"}
+        hygiene_names = {"tests", "lint", "type_check", "coverage", "config_parser", "architecture"}
         growth_names = {
             "capability_surface", "experiment_diversity", "observability",
             "research_grounding", "factory_effectiveness", "spec_compliance",


### PR DESCRIPTION
## Summary

- Remove `eval_guard_patterns` from hygiene dimensions — it tests the factory's own `_glob_match()` function, not the target project, and always scores 1.0
- Redistribute weights across remaining 6 hygiene dimensions
- Clean up all references in agent prompts, docs, models, and tests

## Context

From issue #766 data (snake-test-v3), `guard_patterns` scored 1.0 across all 5 QA evaluations. No project can influence this score — it's a factory self-test. The factory's own test suite (`tests/eval/test_guards.py`) covers `_glob_match()` correctness.

## Test plan

- [ ] `pytest tests/eval/test_hygiene.py -v` — all hygiene tests pass with 6 dimensions
- [ ] `pytest tests/eval/test_runner.py -v` — runner tests pass without guard_patterns
- [ ] Verify hygiene weights sum to 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)