### PR TITLE
QA Agent: add plan completion verification to prompt

### DIFF
--- a/factory/agents/prompts/qa.md
+++ b/factory/agents/prompts/qa.md
@@ -79,7 +79,21 @@ Read the full PR diff and evaluate against a structured checklist. This section 
 
 4. **Spec fidelity check:** Read the GitHub issue (`gh issue view <issue_number>`) and verify the PR implements ALL acceptance criteria. Flag any scope shrinkage.
 
-5. **Surface constraint checks (research mode only):** If `fixed_surfaces` are declared:
+5. **Plan completion check:** Verify the Builder implemented everything the strategy plan requires — not just what the issue says.
+   1. Read `.factory/strategy/current.md` and find the hypothesis (H1, H2, etc.) matching this experiment
+   2. Extract EVERY deliverable from the hypothesis's **What** field — files to create, functions to implement, tests to write, behaviors to add
+   3. For each deliverable, check the git diff:
+      - **Files:** Does the file appear in `git diff --name-only`?
+      - **Functions/classes:** Are they present in the diff AND have real implementations (not just `pass`, `...`, or `raise NotImplementedError`)?
+      - **Tests:** Are they in the diff AND do they appear in Section 1's pytest results?
+   4. Check the **Expected impact** field — if it claims dimension improvements, verify against Section 1's health check scores
+   5. Flag items that are:
+      - **Missing** — not in the diff at all
+      - **Stubbed** — function body is `pass`, `...`, or `raise NotImplementedError`
+      - **Deferred without valid justification** — the only valid deferral reasons are: needs API keys, needs credentials, needs external provisioning, needs human decision on ambiguous requirements. All other deferrals are unjustified scope shrinkage.
+   6. Report a plan completion summary: satisfied vs unsatisfied items, with completion rate
+
+6. **Surface constraint checks (research mode only):** If `fixed_surfaces` are declared:
    - Check that no fixed_surfaces files appear in `git diff --name-only`
    - Run: `factory guard $PROJECT_PATH --baseline $BASELINE_SHA --check-surfaces`
 
@@ -105,6 +119,13 @@ Output format:
 ### Spec Fidelity
 - Acceptance criteria met: N/M
 - Scope shrinkage: <none | list of missing items>
+
+### Plan Completion
+- Hypothesis: <H#> — <title>
+- Deliverables satisfied: N/M
+- Missing: <list or none>
+- Stubbed: <list or none>
+- Unjustified deferrals: <list or none>
 
 ### Issues
 1. [<severity>] [<category>] <file>:<line> — <description>

--- a/factory/plan_check/__init__.py
+++ b/factory/plan_check/__init__.py
@@ -1,3 +1,4 @@
+from factory.plan_check.cli import PlanCheckError
 from factory.plan_check.criteria_extractor import extract_criteria, parse_and_extract
 from factory.plan_check.models import (
     AcceptanceCriterion,
@@ -13,6 +14,7 @@ __all__ = [
     "CriterionResult",
     "HypothesisVerdict",
     "ParsedHypothesis",
+    "PlanCheckError",
     "ReportSummary",
     "VerificationReport",
     "extract_criteria",

--- a/factory/plan_check/__init__.py
+++ b/factory/plan_check/__init__.py
@@ -1,3 +1,4 @@
+from factory.plan_check.criteria_extractor import extract_criteria, parse_and_extract
 from factory.plan_check.models import (
     AcceptanceCriterion,
     CriterionResult,
@@ -5,11 +6,16 @@ from factory.plan_check.models import (
     ReportSummary,
     VerificationReport,
 )
+from factory.plan_check.parser import ParsedHypothesis, parse_strategy_plan
 
 __all__ = [
     "AcceptanceCriterion",
     "CriterionResult",
     "HypothesisVerdict",
+    "ParsedHypothesis",
     "ReportSummary",
     "VerificationReport",
+    "extract_criteria",
+    "parse_and_extract",
+    "parse_strategy_plan",
 ]

--- a/factory/plan_check/__init__.py
+++ b/factory/plan_check/__init__.py
@@ -1,0 +1,15 @@
+from factory.plan_check.models import (
+    AcceptanceCriterion,
+    CriterionResult,
+    HypothesisVerdict,
+    ReportSummary,
+    VerificationReport,
+)
+
+__all__ = [
+    "AcceptanceCriterion",
+    "CriterionResult",
+    "HypothesisVerdict",
+    "ReportSummary",
+    "VerificationReport",
+]

--- a/factory/plan_check/cli.py
+++ b/factory/plan_check/cli.py
@@ -1,0 +1,153 @@
+"""CLI subcommand for plan-check acceptance criteria verification."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import structlog
+
+from factory.plan_check.criteria_extractor import parse_and_extract
+from factory.plan_check.models import VerificationReport
+from factory.plan_check.reporter import generate_report, to_json, to_markdown
+from factory.plan_check.verifier import verify_plan
+
+log = structlog.get_logger()
+
+
+def add_subcommand(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    parser = subparsers.add_parser(
+        "plan-check",
+        help="Verify acceptance criteria from the strategy plan",
+    )
+    parser.add_argument(
+        "project_path",
+        type=Path,
+        help="Path to the project being checked",
+    )
+    parser.add_argument(
+        "--baseline",
+        default=None,
+        help="Baseline git SHA (defaults to .factory/config.json target_branch)",
+    )
+    parser.add_argument(
+        "--strategy",
+        type=Path,
+        default=None,
+        help="Path to strategy plan (defaults to .factory/strategy/current.md)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Where to write reports (defaults to .factory/reports/)",
+    )
+    parser.add_argument(
+        "--format",
+        dest="report_format",
+        choices=["json", "markdown", "both"],
+        default="both",
+        help="Report format (default: both)",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_stdout",
+        action="store_true",
+        default=False,
+        help="Print JSON to stdout (for piping to CEO)",
+    )
+    parser.set_defaults(handler=_handle_plan_check)
+
+
+def _handle_plan_check(args: argparse.Namespace) -> None:
+    project_path = args.project_path.resolve()
+    strategy_path = args.strategy or (project_path / ".factory" / "strategy" / "current.md")
+    output_dir = args.output_dir or (project_path / ".factory" / "reports")
+
+    try:
+        report = run_plan_check(
+            project_path=project_path,
+            baseline=args.baseline,
+            strategy_path=strategy_path,
+            output_dir=output_dir,
+            report_format=args.report_format,
+        )
+    except SystemExit:
+        raise
+    except Exception:
+        log.exception("plan_check_error")
+        sys.exit(2)
+
+    if args.json_stdout:
+        print(to_json(report))
+
+    if report.summary.all_passed:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+def run_plan_check(
+    project_path: Path,
+    baseline: str | None = None,
+    strategy_path: Path | None = None,
+    output_dir: Path | None = None,
+    report_format: str = "both",
+) -> VerificationReport:
+    if strategy_path is None:
+        strategy_path = project_path / ".factory" / "strategy" / "current.md"
+    if output_dir is None:
+        output_dir = project_path / ".factory" / "reports"
+
+    if not strategy_path.exists():
+        log.error("strategy_file_not_found", path=str(strategy_path))
+        sys.exit(2)
+
+    log.info("reading_strategy_plan", path=str(strategy_path))
+    content = strategy_path.read_text()
+
+    log.info("parsing_plan")
+    hypotheses_with_criteria = parse_and_extract(content)
+
+    total_criteria = sum(len(criteria) for _, criteria in hypotheses_with_criteria)
+    log.info(
+        "parsed_plan",
+        hypotheses=len(hypotheses_with_criteria),
+        total_criteria=total_criteria,
+    )
+
+    log.info("verifying_criteria", project_path=str(project_path))
+    report = verify_plan(hypotheses_with_criteria, project_path)
+
+    report = generate_report(report)
+
+    for verdict in report.hypotheses:
+        passed_count = sum(1 for c in verdict.criteria if c.passed)
+        total_count = len(verdict.criteria)
+        log.info(
+            "hypothesis_result",
+            hypothesis_id=verdict.hypothesis_id,
+            passed=verdict.passed,
+            criteria=f"{passed_count}/{total_count}",
+        )
+
+    if report_format in ("both", "markdown"):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        md_path = output_dir / "acceptance-verification.md"
+        md_path.write_text(to_markdown(report))
+        log.info("wrote_markdown_report", path=str(md_path))
+
+    if report_format in ("both", "json"):
+        output_dir.mkdir(parents=True, exist_ok=True)
+        json_path = output_dir / "acceptance-verification.json"
+        json_path.write_text(to_json(report))
+        log.info("wrote_json_report", path=str(json_path))
+
+    log.info(
+        "plan_check_complete",
+        all_passed=report.summary.all_passed,
+        pass_rate=f"{report.summary.pass_rate:.0%}",
+    )
+
+    return report

--- a/factory/plan_check/cli.py
+++ b/factory/plan_check/cli.py
@@ -16,6 +16,10 @@ from factory.plan_check.verifier import verify_plan
 log = structlog.get_logger()
 
 
+class PlanCheckError(Exception):
+    """Raised when plan-check encounters a configuration or runtime error."""
+
+
 def add_subcommand(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     parser = subparsers.add_parser(
         "plan-check",
@@ -73,8 +77,9 @@ def _handle_plan_check(args: argparse.Namespace) -> None:
             output_dir=output_dir,
             report_format=args.report_format,
         )
-    except SystemExit:
-        raise
+    except PlanCheckError as exc:
+        log.error("plan_check_error", detail=str(exc))
+        sys.exit(2)
     except Exception:
         log.exception("plan_check_error")
         sys.exit(2)
@@ -101,8 +106,7 @@ def run_plan_check(
         output_dir = project_path / ".factory" / "reports"
 
     if not strategy_path.exists():
-        log.error("strategy_file_not_found", path=str(strategy_path))
-        sys.exit(2)
+        raise PlanCheckError(f"Strategy file not found: {strategy_path}")
 
     log.info("reading_strategy_plan", path=str(strategy_path))
     content = strategy_path.read_text()

--- a/factory/plan_check/criteria_extractor.py
+++ b/factory/plan_check/criteria_extractor.py
@@ -1,0 +1,7 @@
+"""Extract verifiable acceptance criteria from parsed hypotheses."""
+
+from __future__ import annotations
+
+
+def extract_criteria(hypothesis: object) -> list:
+    raise NotImplementedError

--- a/factory/plan_check/criteria_extractor.py
+++ b/factory/plan_check/criteria_extractor.py
@@ -2,6 +2,149 @@
 
 from __future__ import annotations
 
+import re
 
-def extract_criteria(hypothesis: object) -> list:
-    raise NotImplementedError
+from factory.plan_check.models import AcceptanceCriterion
+from factory.plan_check.parser import ParsedHypothesis
+
+_ARROW_RE = re.compile(r"(\w+)\s+[\d.]+\s*[→\->]+\s*([\d.]+)")
+_PLUS_RE = re.compile(r"(\w+)\s+\+([\d.]+)")
+_FILE_PATH_RE = re.compile(r"`([\w][\w.\-]*/[\w][\w.\-/]*\.\w+)`")
+_FUNCTION_RE = re.compile(r"`(\w+)\(")
+_TEST_NAME_RE = re.compile(r"`(test_\w+)`")
+
+
+def extract_criteria(hypothesis: ParsedHypothesis) -> list[AcceptanceCriterion]:
+    criteria: list[AcceptanceCriterion] = []
+    criteria.extend(_extract_eval_targets(hypothesis))
+    criteria.extend(_extract_file_deliverables(hypothesis))
+    criteria.extend(_extract_function_deliverables(hypothesis))
+    criteria.extend(_extract_test_requirements(hypothesis))
+    return criteria
+
+
+def _extract_eval_targets(hypothesis: ParsedHypothesis) -> list[AcceptanceCriterion]:
+    if not hypothesis.expected_impact:
+        return []
+
+    criteria: list[AcceptanceCriterion] = []
+    text = hypothesis.expected_impact
+    seen: set[str] = set()
+
+    for m in _ARROW_RE.finditer(text):
+        dim = m.group(1)
+        target_val = float(m.group(2))
+        if dim not in seen:
+            seen.add(dim)
+            criteria.append(AcceptanceCriterion(
+                criterion_id=f"{hypothesis.id}.eval.{dim}",
+                hypothesis_id=hypothesis.id,
+                criterion_type="eval_target",
+                description=f"{dim} score reaches {target_val}",
+                verification_method="eval_score",
+                target={"dimension": dim, "min_expected": target_val},
+            ))
+
+    for m in _PLUS_RE.finditer(text):
+        dim = m.group(1)
+        delta = float(m.group(2))
+        if dim not in seen:
+            seen.add(dim)
+            criteria.append(AcceptanceCriterion(
+                criterion_id=f"{hypothesis.id}.eval.{dim}",
+                hypothesis_id=hypothesis.id,
+                criterion_type="eval_target",
+                description=f"{dim} score improves by +{delta}",
+                verification_method="eval_score",
+                target={"dimension": dim, "delta": delta},
+            ))
+
+    return criteria
+
+
+def _extract_file_deliverables(hypothesis: ParsedHypothesis) -> list[AcceptanceCriterion]:
+    if not hypothesis.what:
+        return []
+
+    criteria: list[AcceptanceCriterion] = []
+    seen: set[str] = set()
+
+    for m in _FILE_PATH_RE.finditer(hypothesis.what):
+        path = m.group(1)
+        if path not in seen:
+            seen.add(path)
+            slug = path.replace("/", "_").replace(".", "_")
+            criteria.append(AcceptanceCriterion(
+                criterion_id=f"{hypothesis.id}.deliverable.{slug}",
+                hypothesis_id=hypothesis.id,
+                criterion_type="deliverable",
+                description=f"{path} exists",
+                verification_method="file_exists",
+                target={"path": path},
+            ))
+
+    return criteria
+
+
+def _extract_function_deliverables(hypothesis: ParsedHypothesis) -> list[AcceptanceCriterion]:
+    if not hypothesis.what:
+        return []
+
+    criteria: list[AcceptanceCriterion] = []
+    seen: set[str] = set()
+    last_file_path = ""
+
+    for line in hypothesis.what.split("\n"):
+        file_match = _FILE_PATH_RE.search(line)
+        if file_match:
+            last_file_path = file_match.group(1)
+
+        if "function" not in line.lower():
+            continue
+
+        for func_match in _FUNCTION_RE.finditer(line):
+            func_name = func_match.group(1)
+            if func_name not in seen:
+                seen.add(func_name)
+                criteria.append(AcceptanceCriterion(
+                    criterion_id=f"{hypothesis.id}.deliverable.{func_name}",
+                    hypothesis_id=hypothesis.id,
+                    criterion_type="deliverable",
+                    description=f"function {func_name} exists",
+                    verification_method="function_exists",
+                    target={"path": last_file_path, "symbol": func_name},
+                ))
+
+    return criteria
+
+
+def _extract_test_requirements(hypothesis: ParsedHypothesis) -> list[AcceptanceCriterion]:
+    if not hypothesis.what:
+        return []
+
+    criteria: list[AcceptanceCriterion] = []
+    seen: set[str] = set()
+
+    for m in _TEST_NAME_RE.finditer(hypothesis.what):
+        test_name = m.group(1)
+        if test_name not in seen:
+            seen.add(test_name)
+            criteria.append(AcceptanceCriterion(
+                criterion_id=f"{hypothesis.id}.test.{test_name}",
+                hypothesis_id=hypothesis.id,
+                criterion_type="test_requirement",
+                description=f"test {test_name} passes",
+                verification_method="test_passes",
+                target={"test_name": test_name},
+            ))
+
+    return criteria
+
+
+def parse_and_extract(
+    content: str,
+) -> list[tuple[ParsedHypothesis, list[AcceptanceCriterion]]]:
+    from factory.plan_check.parser import parse_strategy_plan
+
+    hypotheses = parse_strategy_plan(content)
+    return [(h, extract_criteria(h)) for h in hypotheses]

--- a/factory/plan_check/criteria_extractor.py
+++ b/factory/plan_check/criteria_extractor.py
@@ -95,25 +95,34 @@ def _extract_function_deliverables(hypothesis: ParsedHypothesis) -> list[Accepta
     last_file_path = ""
 
     for line in hypothesis.what.split("\n"):
-        file_match = _FILE_PATH_RE.search(line)
-        if file_match:
-            last_file_path = file_match.group(1)
+        file_matches = list(_FILE_PATH_RE.finditer(line))
+        if file_matches:
+            last_file_path = file_matches[-1].group(1)
 
         if "function" not in line.lower():
             continue
 
         for func_match in _FUNCTION_RE.finditer(line):
             func_name = func_match.group(1)
-            if func_name not in seen:
-                seen.add(func_name)
-                criteria.append(AcceptanceCriterion(
-                    criterion_id=f"{hypothesis.id}.deliverable.{func_name}",
-                    hypothesis_id=hypothesis.id,
-                    criterion_type="deliverable",
-                    description=f"function {func_name} exists",
-                    verification_method="function_exists",
-                    target={"path": last_file_path, "symbol": func_name},
-                ))
+            if func_name in seen:
+                continue
+            seen.add(func_name)
+            associated_path = last_file_path
+            if file_matches:
+                func_pos = func_match.start()
+                best = file_matches[0]
+                for fm in file_matches:
+                    if fm.start() <= func_pos:
+                        best = fm
+                associated_path = best.group(1)
+            criteria.append(AcceptanceCriterion(
+                criterion_id=f"{hypothesis.id}.deliverable.{func_name}",
+                hypothesis_id=hypothesis.id,
+                criterion_type="deliverable",
+                description=f"function {func_name} exists",
+                verification_method="function_exists",
+                target={"path": associated_path, "symbol": func_name},
+            ))
 
     return criteria
 

--- a/factory/plan_check/models.py
+++ b/factory/plan_check/models.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, computed_field
+
+
+class AcceptanceCriterion(BaseModel):
+    criterion_id: str
+    hypothesis_id: str
+    criterion_type: Literal[
+        "eval_target", "deliverable", "test_requirement", "functional"
+    ]
+    description: str
+    verification_method: Literal[
+        "eval_score",
+        "file_exists",
+        "function_exists",
+        "test_passes",
+        "command_exits_zero",
+        "grep_match",
+    ]
+    target: dict[str, Any]
+
+
+class CriterionResult(BaseModel):
+    criterion: AcceptanceCriterion
+    passed: bool
+    actual_value: str | None = None
+    expected_value: str | None = None
+    evidence: list[str] = []
+    error: str | None = None
+
+
+class HypothesisVerdict(BaseModel):
+    hypothesis_id: str
+    hypothesis_title: str
+    criteria: list[CriterionResult]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def passed(self) -> bool:
+        return all(c.passed for c in self.criteria)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def pass_rate(self) -> float:
+        if not self.criteria:
+            return 0.0
+        return sum(1 for c in self.criteria if c.passed) / len(self.criteria)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def unsatisfied(self) -> list[str]:
+        return [c.criterion.description for c in self.criteria if not c.passed]
+
+
+class ReportSummary(BaseModel):
+    total_criteria: int
+    passed_criteria: int
+    failed_criteria: int
+    error_criteria: int
+    failed_hypotheses: list[str] = []
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def pass_rate(self) -> float:
+        if self.total_criteria == 0:
+            return 0.0
+        return self.passed_criteria / self.total_criteria
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def all_passed(self) -> bool:
+        return self.failed_criteria == 0 and self.error_criteria == 0
+
+
+class VerificationReport(BaseModel):
+    hypotheses: list[HypothesisVerdict]
+    summary: ReportSummary
+
+    def to_json(self) -> str:
+        return self.model_dump_json(indent=2)
+
+    def to_markdown(self) -> str:
+        lines: list[str] = []
+        lines.append("## Acceptance Criteria Verification Report\n")
+        s = self.summary
+        lines.append(f"**Total:** {s.total_criteria} | "
+                      f"**Passed:** {s.passed_criteria} | "
+                      f"**Failed:** {s.failed_criteria} | "
+                      f"**Errors:** {s.error_criteria} | "
+                      f"**Pass rate:** {s.pass_rate:.0%}\n")
+
+        for verdict in self.hypotheses:
+            status = "PASS" if verdict.passed else "FAIL"
+            passed_count = sum(1 for c in verdict.criteria if c.passed)
+            total_count = len(verdict.criteria)
+            lines.append(
+                f"### {verdict.hypothesis_id}: {verdict.hypothesis_title} "
+                f"— {status} ({passed_count}/{total_count} criteria satisfied)\n"
+            )
+            for cr in verdict.criteria:
+                if cr.passed:
+                    lines.append(f"- [x] {cr.criterion.description}")
+                else:
+                    lines.append(f"- [ ] {cr.criterion.description}")
+                    if cr.expected_value:
+                        lines.append(f"  - **Expected:** {cr.expected_value}")
+                    if cr.actual_value:
+                        lines.append(f"  - **Actual:** {cr.actual_value}")
+                    if cr.evidence:
+                        lines.append("  - **Evidence:**")
+                        for e in cr.evidence:
+                            lines.append(f"    - {e}")
+                    if cr.error:
+                        lines.append(f"  - **Error:** {cr.error}")
+            lines.append("")
+
+        unsatisfied = [
+            cr
+            for verdict in self.hypotheses
+            for cr in verdict.criteria
+            if not cr.passed
+        ]
+        if unsatisfied:
+            lines.append("### Unsatisfied Acceptance Criteria\n")
+            for cr in unsatisfied:
+                lines.append(f"- **{cr.criterion.criterion_id}**: {cr.criterion.description}")
+            lines.append("")
+
+        if s.all_passed:
+            lines.append("**VERDICT: ALL CRITERIA MET**")
+        else:
+            n = s.failed_criteria + s.error_criteria
+            ids = ", ".join(s.failed_hypotheses)
+            lines.append(
+                f"**VERDICT: {n} CRITERIA UNSATISFIED — REDIRECT NEEDED** ({ids})"
+            )
+
+        return "\n".join(lines)

--- a/factory/plan_check/parser.py
+++ b/factory/plan_check/parser.py
@@ -2,6 +2,84 @@
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 
-def parse_strategy_plan(content: str) -> list:
-    raise NotImplementedError
+
+_HEADER_RE = re.compile(r"^####\s+(H\d+):\s*(.+)$", re.MULTILINE)
+_FIELD_RE = re.compile(r"^-\s+\*\*(.+?):\*\*\s*(.*)")
+
+
+@dataclass
+class ParsedHypothesis:
+    id: str
+    title: str
+    category: str = ""
+    what: str = ""
+    expected_impact: str = ""
+    growth_dimension: str = ""
+    type: str = ""
+    priority: str = ""
+
+
+def parse_strategy_plan(content: str) -> list[ParsedHypothesis]:
+    headers = list(_HEADER_RE.finditer(content))
+    if not headers:
+        return []
+
+    results: list[ParsedHypothesis] = []
+    for i, match in enumerate(headers):
+        h_id = match.group(1)
+        title = match.group(2).strip()
+
+        start = match.end()
+        end = headers[i + 1].start() if i + 1 < len(headers) else len(content)
+        block = content[start:end]
+
+        fields = _extract_fields(block)
+
+        results.append(ParsedHypothesis(
+            id=h_id,
+            title=title,
+            category=fields.get("Category", ""),
+            what=fields.get("What", ""),
+            expected_impact=fields.get("Expected impact", ""),
+            growth_dimension=fields.get("Growth dimension", ""),
+            type=fields.get("Type", ""),
+            priority=fields.get("Priority", ""),
+        ))
+
+    return results
+
+
+def _extract_fields(block: str) -> dict[str, str]:
+    """Extract - **FieldName:** value entries from a hypothesis block."""
+    fields: dict[str, str] = {}
+    current_field: str | None = None
+    current_lines: list[str] = []
+
+    for line in block.split("\n"):
+        if line.startswith("### ") or line.startswith("#### "):
+            break
+
+        field_match = _FIELD_RE.match(line)
+        if field_match:
+            if current_field is not None:
+                fields[current_field] = "\n".join(current_lines).strip()
+            current_field = field_match.group(1)
+            value = field_match.group(2).strip()
+            current_lines = [value] if value else []
+        elif current_field is not None and line.startswith("  "):
+            current_lines.append(line)
+        elif line.strip() == "":
+            continue
+        else:
+            if current_field is not None:
+                fields[current_field] = "\n".join(current_lines).strip()
+                current_field = None
+                current_lines = []
+
+    if current_field is not None:
+        fields[current_field] = "\n".join(current_lines).strip()
+
+    return fields

--- a/factory/plan_check/parser.py
+++ b/factory/plan_check/parser.py
@@ -1,0 +1,7 @@
+"""Parse strategy plan (current.md) into structured hypothesis objects."""
+
+from __future__ import annotations
+
+
+def parse_strategy_plan(content: str) -> list:
+    raise NotImplementedError

--- a/factory/plan_check/qa_integration.py
+++ b/factory/plan_check/qa_integration.py
@@ -1,0 +1,70 @@
+"""QA Agent integration helpers for plan-check reports."""
+
+from __future__ import annotations
+
+from factory.plan_check.models import VerificationReport
+
+
+def format_for_qa(report: VerificationReport) -> str:
+    lines: list[str] = []
+    lines.append("#### Acceptance Criteria Verification\n")
+
+    s = report.summary
+    lines.append(
+        f"**{s.passed_criteria}/{s.total_criteria}** criteria satisfied "
+        f"({s.pass_rate:.0%} pass rate)\n"
+    )
+
+    unsatisfied = [
+        (verdict.hypothesis_id, cr)
+        for verdict in report.hypotheses
+        for cr in verdict.criteria
+        if not cr.passed
+    ]
+
+    if unsatisfied:
+        lines.append("**UNSATISFIED CRITERIA:**\n")
+        for hyp_id, cr in unsatisfied:
+            lines.append(f"- **{hyp_id} / {cr.criterion.criterion_id}**: {cr.criterion.description}")
+            if cr.expected_value and cr.actual_value:
+                lines.append(f"  - Expected: {cr.expected_value} | Actual: {cr.actual_value}")
+            elif cr.error:
+                lines.append(f"  - Error: {cr.error}")
+        lines.append("")
+    else:
+        lines.append("All acceptance criteria satisfied.\n")
+
+    lines.append("*Run `factory plan-check $PROJECT_PATH --json` for full details.*")
+
+    return "\n".join(lines)
+
+
+def get_redirect_payload(report: VerificationReport) -> dict:
+    unsatisfied: list[dict[str, str | None]] = []
+    for verdict in report.hypotheses:
+        for cr in verdict.criteria:
+            if not cr.passed:
+                unsatisfied.append({
+                    "hypothesis_id": verdict.hypothesis_id,
+                    "criterion": cr.criterion.description,
+                    "expected": cr.expected_value,
+                    "actual": cr.actual_value,
+                })
+
+    parts: list[str] = []
+    if unsatisfied:
+        parts.append(
+            f"{len(unsatisfied)} acceptance criteria unsatisfied across "
+            f"{len(report.summary.failed_hypotheses)} hypothesis(es): "
+            f"{', '.join(report.summary.failed_hypotheses)}."
+        )
+        for item in unsatisfied:
+            detail = f"  - {item['hypothesis_id']}: {item['criterion']}"
+            if item.get("expected") and item.get("actual"):
+                detail += f" (expected {item['expected']}, got {item['actual']})"
+            parts.append(detail)
+
+    return {
+        "unsatisfied": unsatisfied,
+        "redirect_message": "\n".join(parts) if parts else "All criteria satisfied.",
+    }

--- a/factory/plan_check/reporter.py
+++ b/factory/plan_check/reporter.py
@@ -1,0 +1,9 @@
+"""Generate verification reports in JSON and markdown formats."""
+
+from __future__ import annotations
+
+from factory.plan_check.models import VerificationReport
+
+
+def generate_report(report: VerificationReport) -> VerificationReport:
+    raise NotImplementedError

--- a/factory/plan_check/reporter.py
+++ b/factory/plan_check/reporter.py
@@ -2,8 +2,127 @@
 
 from __future__ import annotations
 
-from factory.plan_check.models import VerificationReport
+import json
+from pathlib import Path
+
+from factory.plan_check.models import (
+    CriterionResult,
+    HypothesisVerdict,
+    VerificationReport,
+)
+
+
+def _criterion_sort_key(cr: CriterionResult) -> tuple[int, str]:
+    if not cr.passed and cr.error is None:
+        return (0, cr.criterion.criterion_id)
+    if cr.error is not None:
+        return (1, cr.criterion.criterion_id)
+    return (2, cr.criterion.criterion_id)
 
 
 def generate_report(report: VerificationReport) -> VerificationReport:
-    raise NotImplementedError
+    sorted_hypotheses: list[HypothesisVerdict] = []
+    for verdict in report.hypotheses:
+        sorted_criteria = sorted(verdict.criteria, key=_criterion_sort_key)
+        sorted_hypotheses.append(
+            verdict.model_copy(update={"criteria": sorted_criteria})
+        )
+    sorted_hypotheses.sort(key=lambda v: (v.passed, v.hypothesis_id))
+    return report.model_copy(update={"hypotheses": sorted_hypotheses})
+
+
+def to_markdown(report: VerificationReport) -> str:
+    lines: list[str] = []
+    lines.append("## Acceptance Criteria Verification Report\n")
+    s = report.summary
+    lines.append(
+        f"**Total:** {s.total_criteria} | "
+        f"**Passed:** {s.passed_criteria} | "
+        f"**Failed:** {s.failed_criteria} | "
+        f"**Errors:** {s.error_criteria} | "
+        f"**Pass rate:** {s.pass_rate:.0%}\n"
+    )
+
+    for verdict in report.hypotheses:
+        status = "PASS" if verdict.passed else "FAIL"
+        passed_count = sum(1 for c in verdict.criteria if c.passed)
+        total_count = len(verdict.criteria)
+        lines.append(
+            f"### {verdict.hypothesis_id}: {verdict.hypothesis_title} "
+            f"— {status} ({passed_count}/{total_count} criteria satisfied)\n"
+        )
+        for cr in verdict.criteria:
+            if cr.passed:
+                lines.append(f"- [x] {cr.criterion.description}")
+            else:
+                lines.append(f"- [ ] {cr.criterion.description}")
+                if cr.expected_value:
+                    lines.append(f"  - **Expected:** {cr.expected_value}")
+                if cr.actual_value:
+                    lines.append(f"  - **Actual:** {cr.actual_value}")
+                if cr.evidence:
+                    lines.append("  - **Evidence:**")
+                    for e in cr.evidence:
+                        lines.append(f"    - {e}")
+                if cr.error:
+                    lines.append(f"  - **Error:** {cr.error}")
+        lines.append("")
+
+    unsatisfied = [
+        cr
+        for verdict in report.hypotheses
+        for cr in verdict.criteria
+        if not cr.passed
+    ]
+    if unsatisfied:
+        lines.append("### Unsatisfied Acceptance Criteria\n")
+        for cr in unsatisfied:
+            lines.append(
+                f"- **{cr.criterion.criterion_id}**: {cr.criterion.description}"
+            )
+        lines.append("")
+
+    if s.all_passed:
+        lines.append("**VERDICT: ALL CRITERIA MET**")
+    else:
+        n = s.failed_criteria + s.error_criteria
+        ids = ", ".join(s.failed_hypotheses)
+        lines.append(
+            f"**VERDICT: {n} CRITERIA UNSATISFIED — REDIRECT NEEDED** ({ids})"
+        )
+
+    return "\n".join(lines)
+
+
+def to_json(report: VerificationReport) -> str:
+    data = report.model_dump(mode="python")
+    s = report.summary
+    data["all_passed"] = s.all_passed
+    data["pass_rate"] = s.pass_rate
+    data["redirect_needed"] = not s.all_passed
+    unsatisfied: list[dict[str, str | None]] = []
+    for verdict in report.hypotheses:
+        for cr in verdict.criteria:
+            if not cr.passed:
+                unsatisfied.append(
+                    {
+                        "hypothesis_id": verdict.hypothesis_id,
+                        "criterion_id": cr.criterion.criterion_id,
+                        "description": cr.criterion.description,
+                        "expected": cr.expected_value,
+                        "actual": cr.actual_value,
+                    }
+                )
+    data["unsatisfied_criteria"] = unsatisfied
+    return json.dumps(data, indent=2)
+
+
+def write_report(
+    report: VerificationReport, output_dir: Path
+) -> tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    md_path = output_dir / "acceptance-verification.md"
+    json_path = output_dir / "acceptance-verification.json"
+    md_path.write_text(to_markdown(report))
+    json_path.write_text(to_json(report))
+    return md_path, json_path

--- a/factory/plan_check/verifier.py
+++ b/factory/plan_check/verifier.py
@@ -2,14 +2,494 @@
 
 from __future__ import annotations
 
+import ast
+import json
+import subprocess
 from pathlib import Path
 
-from factory.plan_check.models import AcceptanceCriterion, CriterionResult
+import structlog
+
+from factory.plan_check.models import (
+    AcceptanceCriterion,
+    CriterionResult,
+    HypothesisVerdict,
+    ReportSummary,
+    VerificationReport,
+)
+from factory.plan_check.parser import ParsedHypothesis
+
+log = structlog.get_logger()
+
+DEFAULT_TIMEOUT = 60
+
+_STUB_PATTERNS = frozenset({"pass", "Ellipsis", "raise NotImplementedError"})
+
+
+def detect_stubs(source: str, symbol: str) -> list[str]:
+    """Scan a Python source for stub functions/classes matching *symbol*.
+
+    Returns a list of evidence strings for each stub body found, or an
+    empty list when the symbol is not a stub.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    evidence: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name != symbol:
+                continue
+            if _is_stub_body(node.body):
+                first_line = source.splitlines()[node.lineno - 1].strip()
+                evidence.append(first_line)
+    return evidence
+
+
+def _is_stub_body(body: list[ast.stmt]) -> bool:
+    stmts = [s for s in body if not isinstance(s, (ast.Pass,))]
+    if not stmts and any(isinstance(s, ast.Pass) for s in body):
+        return True
+
+    real = [s for s in body if not _is_docstring(s)]
+    if not real:
+        return False
+
+    if len(real) == 1:
+        s = real[0]
+        if isinstance(s, ast.Pass):
+            return True
+        if isinstance(s, ast.Expr) and isinstance(s.value, ast.Constant) and s.value.value is ...:
+            return True
+        if isinstance(s, ast.Raise):
+            if isinstance(s.exc, ast.Name) and s.exc.id == "NotImplementedError":
+                return True
+            if isinstance(s.exc, ast.Call):
+                func = s.exc.func
+                if isinstance(func, ast.Name) and func.id == "NotImplementedError":
+                    return True
+                if isinstance(func, ast.Attribute) and func.attr == "NotImplementedError":
+                    return True
+    return False
+
+
+def _is_docstring(node: ast.stmt) -> bool:
+    return isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant) and isinstance(
+        node.value.value, str
+    )
+
+
+# ---------------------------------------------------------------------------
+# Individual verifiers
+# ---------------------------------------------------------------------------
+
+
+def _verify_eval_score(
+    criterion: AcceptanceCriterion,
+    project_path: Path,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> CriterionResult:
+    target = criterion.target
+    dimension = target.get("dimension", "")
+    min_expected = target.get("min_expected")
+
+    scores_path = project_path / ".factory" / "eval" / "scores.json"
+    actual_score: float | None = None
+
+    if scores_path.exists():
+        try:
+            data = json.loads(scores_path.read_text())
+            if isinstance(data, dict):
+                actual_score = data.get(dimension)
+        except (json.JSONDecodeError, OSError) as exc:
+            return CriterionResult(
+                criterion=criterion,
+                passed=False,
+                error=f"Failed to read scores: {exc}",
+            )
+    else:
+        try:
+            result = subprocess.run(
+                ["factory", "eval", str(project_path)],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=str(project_path),
+            )
+            if result.returncode != 0:
+                return CriterionResult(
+                    criterion=criterion,
+                    passed=False,
+                    error=f"factory eval failed (exit {result.returncode})",
+                    evidence=[result.stderr[:500]] if result.stderr else [],
+                )
+            try:
+                data = json.loads(result.stdout)
+                if isinstance(data, dict):
+                    results = data.get("results", [])
+                    for r in results:
+                        if isinstance(r, dict) and r.get("dimension") == dimension:
+                            actual_score = r.get("score")
+                            break
+            except json.JSONDecodeError:
+                return CriterionResult(
+                    criterion=criterion,
+                    passed=False,
+                    error="Could not parse factory eval output",
+                )
+        except subprocess.TimeoutExpired:
+            return CriterionResult(
+                criterion=criterion,
+                passed=False,
+                error=f"verification timed out after {timeout}s",
+            )
+        except FileNotFoundError:
+            return CriterionResult(
+                criterion=criterion,
+                passed=False,
+                error="factory command not found",
+            )
+
+    if actual_score is None:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            actual_value=f"{dimension} score not found",
+            expected_value=f"{dimension} >= {min_expected}" if min_expected is not None else None,
+        )
+
+    if min_expected is not None:
+        passed = actual_score >= min_expected
+        return CriterionResult(
+            criterion=criterion,
+            passed=passed,
+            actual_value=f"{dimension}={actual_score}",
+            expected_value=f"{dimension}>={min_expected}",
+        )
+
+    delta = target.get("delta")
+    if delta is not None:
+        return CriterionResult(
+            criterion=criterion,
+            passed=True,
+            actual_value=f"{dimension}={actual_score}",
+            expected_value=f"{dimension} +{delta}",
+            evidence=["Baseline comparison not implemented; passing on score existence"],
+        )
+
+    return CriterionResult(
+        criterion=criterion,
+        passed=actual_score is not None,
+        actual_value=f"{dimension}={actual_score}",
+    )
+
+
+def _verify_file_exists(
+    criterion: AcceptanceCriterion,
+    project_path: Path,
+) -> CriterionResult:
+    target_path = criterion.target.get("path", "")
+    full_path = project_path / target_path
+    exists = full_path.exists()
+    return CriterionResult(
+        criterion=criterion,
+        passed=exists,
+        actual_value="exists" if exists else "not found",
+        expected_value=f"{target_path} exists",
+        evidence=[f"checked: {full_path}"],
+    )
+
+
+def _verify_function_exists(
+    criterion: AcceptanceCriterion,
+    project_path: Path,
+) -> CriterionResult:
+    target_path = criterion.target.get("path", "")
+    symbol = criterion.target.get("symbol", "")
+    full_path = project_path / target_path
+
+    if not full_path.exists():
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            actual_value=f"file {target_path} not found",
+            expected_value=f"function {symbol} in {target_path}",
+        )
+
+    try:
+        source = full_path.read_text()
+    except OSError as exc:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error=f"Could not read {target_path}: {exc}",
+        )
+
+    if not target_path.endswith(".py"):
+        found = symbol in source
+        return CriterionResult(
+            criterion=criterion,
+            passed=found,
+            actual_value="found" if found else f"symbol '{symbol}' not found in {target_path}",
+            expected_value=f"symbol {symbol} in {target_path}",
+        )
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error=f"Syntax error in {target_path}: {exc}",
+        )
+
+    found = False
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name == symbol:
+                found = True
+                break
+
+    if not found:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            actual_value=f"symbol '{symbol}' not found in {target_path}",
+            expected_value=f"function {symbol} in {target_path}",
+        )
+
+    stub_evidence = detect_stubs(source, symbol)
+    if stub_evidence:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            actual_value="function exists but is a stub",
+            expected_value=f"function {symbol} in {target_path} (non-stub)",
+            evidence=stub_evidence,
+        )
+
+    return CriterionResult(
+        criterion=criterion,
+        passed=True,
+        actual_value="found",
+        expected_value=f"function {symbol} in {target_path}",
+    )
+
+
+def _verify_test_passes(
+    criterion: AcceptanceCriterion,
+    project_path: Path,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> CriterionResult:
+    test_name = criterion.target.get("test_name", "")
+    try:
+        result = subprocess.run(
+            ["python", "-m", "pytest", "-x", "-q", "--tb=short", "--no-header", "-k", test_name],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(project_path),
+        )
+    except subprocess.TimeoutExpired:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error=f"verification timed out after {timeout}s",
+        )
+    except FileNotFoundError:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error="pytest not found",
+        )
+
+    output = result.stdout + result.stderr
+    if "no tests ran" in output:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            actual_value="test not found",
+            expected_value=f"test {test_name} passes",
+            evidence=[output[:1000]],
+        )
+
+    if result.returncode == 0:
+        return CriterionResult(
+            criterion=criterion,
+            passed=True,
+            actual_value="passed",
+            expected_value=f"test {test_name} passes",
+            evidence=[output[:1000]],
+        )
+
+    return CriterionResult(
+        criterion=criterion,
+        passed=False,
+        actual_value="failed",
+        expected_value=f"test {test_name} passes",
+        evidence=[output[:1000]],
+    )
+
+
+def _verify_command_exits_zero(
+    criterion: AcceptanceCriterion,
+    project_path: Path,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> CriterionResult:
+    command = criterion.target.get("command", "")
+    if not command:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error="No command specified in target",
+        )
+
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(project_path),
+        )
+    except subprocess.TimeoutExpired:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error=f"verification timed out after {timeout}s",
+        )
+
+    output = (result.stdout + result.stderr)[:1000]
+    passed = result.returncode == 0
+    return CriterionResult(
+        criterion=criterion,
+        passed=passed,
+        actual_value=f"exit code {result.returncode}",
+        expected_value="exit code 0",
+        evidence=[output] if output else [],
+    )
+
+
+def _verify_grep_match(
+    criterion: AcceptanceCriterion,
+    project_path: Path,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> CriterionResult:
+    pattern = criterion.target.get("pattern", "")
+    if not pattern:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error="No pattern specified in target",
+        )
+
+    try:
+        result = subprocess.run(
+            ["grep", "-r", pattern, "."],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(project_path),
+        )
+    except subprocess.TimeoutExpired:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error=f"verification timed out after {timeout}s",
+        )
+
+    passed = result.returncode == 0
+    matches = result.stdout.strip().splitlines()
+    return CriterionResult(
+        criterion=criterion,
+        passed=passed,
+        actual_value=f"{len(matches)} matches" if passed else "no matches",
+        expected_value=f"pattern '{pattern}' found",
+        evidence=matches[:10],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch & aggregation
+# ---------------------------------------------------------------------------
+
+_VERIFIERS = {
+    "eval_score": _verify_eval_score,
+    "file_exists": _verify_file_exists,
+    "function_exists": _verify_function_exists,
+    "test_passes": _verify_test_passes,
+    "command_exits_zero": _verify_command_exits_zero,
+    "grep_match": _verify_grep_match,
+}
 
 
 def verify_criteria(
     criteria: list[AcceptanceCriterion],
     project_path: Path,
     baseline_sha: str | None = None,
+    timeout: int = DEFAULT_TIMEOUT,
 ) -> list[CriterionResult]:
-    raise NotImplementedError
+    results: list[CriterionResult] = []
+    for criterion in criteria:
+        method = criterion.verification_method
+        verifier = _VERIFIERS.get(method)
+        if verifier is None:
+            results.append(CriterionResult(
+                criterion=criterion,
+                passed=False,
+                error=f"Unknown verification method: {method}",
+            ))
+            continue
+
+        log.info("verifying_criterion", criterion_id=criterion.criterion_id, method=method)
+
+        if method in ("eval_score", "test_passes", "command_exits_zero", "grep_match"):
+            result = verifier(criterion, project_path, timeout=timeout)
+        else:
+            result = verifier(criterion, project_path)
+
+        results.append(result)
+    return results
+
+
+def verify_hypothesis(
+    hypothesis: ParsedHypothesis,
+    criteria: list[AcceptanceCriterion],
+    project_path: Path,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> HypothesisVerdict:
+    results = verify_criteria(criteria, project_path, timeout=timeout)
+    return HypothesisVerdict(
+        hypothesis_id=hypothesis.id,
+        hypothesis_title=hypothesis.title,
+        criteria=results,
+    )
+
+
+def verify_plan(
+    hypotheses_with_criteria: list[tuple[ParsedHypothesis, list[AcceptanceCriterion]]],
+    project_path: Path,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> VerificationReport:
+    verdicts: list[HypothesisVerdict] = []
+    for hypothesis, criteria in hypotheses_with_criteria:
+        verdict = verify_hypothesis(hypothesis, criteria, project_path, timeout=timeout)
+        verdicts.append(verdict)
+
+    all_results = [cr for v in verdicts for cr in v.criteria]
+    passed_count = sum(1 for r in all_results if r.passed)
+    failed_count = sum(1 for r in all_results if not r.passed and r.error is None)
+    error_count = sum(1 for r in all_results if r.error is not None)
+    failed_hypotheses = [v.hypothesis_id for v in verdicts if not v.passed]
+
+    summary = ReportSummary(
+        total_criteria=len(all_results),
+        passed_criteria=passed_count,
+        failed_criteria=failed_count,
+        error_criteria=error_count,
+        failed_hypotheses=failed_hypotheses,
+    )
+
+    return VerificationReport(hypotheses=verdicts, summary=summary)

--- a/factory/plan_check/verifier.py
+++ b/factory/plan_check/verifier.py
@@ -1,0 +1,15 @@
+"""Verify acceptance criteria by running actual checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from factory.plan_check.models import AcceptanceCriterion, CriterionResult
+
+
+def verify_criteria(
+    criteria: list[AcceptanceCriterion],
+    project_path: Path,
+    baseline_sha: str | None = None,
+) -> list[CriterionResult]:
+    raise NotImplementedError

--- a/factory/plan_check/verifier.py
+++ b/factory/plan_check/verifier.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import json
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -172,10 +173,9 @@ def _verify_eval_score(
     if delta is not None:
         return CriterionResult(
             criterion=criterion,
-            passed=True,
-            actual_value=f"{dimension}={actual_score}",
+            passed=False,
+            actual_value="baseline comparison requires --baseline SHA",
             expected_value=f"{dimension} +{delta}",
-            evidence=["Baseline comparison not implemented; passing on score existence"],
         )
 
     return CriterionResult(
@@ -188,6 +188,7 @@ def _verify_eval_score(
 def _verify_file_exists(
     criterion: AcceptanceCriterion,
     project_path: Path,
+    timeout: int = DEFAULT_TIMEOUT,
 ) -> CriterionResult:
     target_path = criterion.target.get("path", "")
     full_path = project_path / target_path
@@ -204,6 +205,7 @@ def _verify_file_exists(
 def _verify_function_exists(
     criterion: AcceptanceCriterion,
     project_path: Path,
+    timeout: int = DEFAULT_TIMEOUT,
 ) -> CriterionResult:
     target_path = criterion.target.get("path", "")
     symbol = criterion.target.get("symbol", "")
@@ -346,9 +348,17 @@ def _verify_command_exits_zero(
         )
 
     try:
+        cmd_list = shlex.split(command)
+    except ValueError as exc:
+        return CriterionResult(
+            criterion=criterion,
+            passed=False,
+            error=f"Invalid command syntax: {exc}",
+        )
+
+    try:
         result = subprocess.run(
-            command,
-            shell=True,
+            cmd_list,
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -444,12 +454,7 @@ def verify_criteria(
             continue
 
         log.info("verifying_criterion", criterion_id=criterion.criterion_id, method=method)
-
-        if method in ("eval_score", "test_passes", "command_exits_zero", "grep_match"):
-            result = verifier(criterion, project_path, timeout=timeout)
-        else:
-            result = verifier(criterion, project_path)
-
+        result = verifier(criterion, project_path, timeout=timeout)
         results.append(result)
     return results
 

--- a/tests/test_plan_check/test_cli.py
+++ b/tests/test_plan_check/test_cli.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 import pytest
 
-from factory.plan_check.cli import add_subcommand, run_plan_check
+from factory.plan_check.cli import PlanCheckError, add_subcommand, run_plan_check
 
 
 def _make_parser() -> argparse.ArgumentParser:
@@ -56,15 +56,14 @@ class TestCliArgsParsing:
 
 
 class TestCliMissingStrategy:
-    def test_exits_2_when_strategy_missing(self, tmp_path: Path):
+    def test_raises_plan_check_error_when_strategy_missing(self, tmp_path: Path):
         strategy = tmp_path / "nonexistent.md"
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(PlanCheckError, match="Strategy file not found"):
             run_plan_check(
                 project_path=tmp_path,
                 strategy_path=strategy,
                 output_dir=tmp_path / "reports",
             )
-        assert exc_info.value.code == 2
 
 
 class TestCliJsonStdout:

--- a/tests/test_plan_check/test_cli.py
+++ b/tests/test_plan_check/test_cli.py
@@ -1,0 +1,98 @@
+"""Tests for plan-check CLI subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import pytest
+
+from factory.plan_check.cli import add_subcommand, run_plan_check
+
+
+def _make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers()
+    add_subcommand(sub)
+    return parser
+
+
+class TestCliArgsParsing:
+    def test_required_project_path(self):
+        parser = _make_parser()
+        args = parser.parse_args(["plan-check", "/tmp/myproject"])
+        assert args.project_path == Path("/tmp/myproject")
+
+    def test_default_values(self):
+        parser = _make_parser()
+        args = parser.parse_args(["plan-check", "/tmp/myproject"])
+        assert args.baseline is None
+        assert args.strategy is None
+        assert args.output_dir is None
+        assert args.report_format == "both"
+        assert args.json_stdout is False
+
+    def test_all_optional_args(self):
+        parser = _make_parser()
+        args = parser.parse_args([
+            "plan-check", "/tmp/myproject",
+            "--baseline", "abc123",
+            "--strategy", "/tmp/plan.md",
+            "--output-dir", "/tmp/reports",
+            "--format", "json",
+            "--json",
+        ])
+        assert args.baseline == "abc123"
+        assert args.strategy == Path("/tmp/plan.md")
+        assert args.output_dir == Path("/tmp/reports")
+        assert args.report_format == "json"
+        assert args.json_stdout is True
+
+    def test_format_choices(self):
+        parser = _make_parser()
+        for fmt in ("json", "markdown", "both"):
+            args = parser.parse_args(["plan-check", "/tmp/p", "--format", fmt])
+            assert args.report_format == fmt
+
+
+class TestCliMissingStrategy:
+    def test_exits_2_when_strategy_missing(self, tmp_path: Path):
+        strategy = tmp_path / "nonexistent.md"
+        with pytest.raises(SystemExit) as exc_info:
+            run_plan_check(
+                project_path=tmp_path,
+                strategy_path=strategy,
+                output_dir=tmp_path / "reports",
+            )
+        assert exc_info.value.code == 2
+
+
+class TestCliJsonStdout:
+    def test_json_stdout(self, tmp_path: Path):
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        strategy_file = strategy_dir / "current.md"
+        strategy_file.write_text(
+            "## Plan\n"
+            "#### H1: Simple test\n"
+            "- **Category:** EXPLORE\n"
+            "- **What:**\n"
+            "  Create `sample/hello.py`\n"
+            "- **Expected impact:** tests 0.0 → 0.5\n"
+        )
+        (tmp_path / "sample").mkdir()
+        (tmp_path / "sample" / "hello.py").write_text("x = 1\n")
+
+        report = run_plan_check(
+            project_path=tmp_path,
+            strategy_path=strategy_file,
+            output_dir=tmp_path / "reports",
+            report_format="json",
+        )
+
+        from factory.plan_check.reporter import to_json
+        json_output = to_json(report)
+        parsed = json.loads(json_output)
+        assert "all_passed" in parsed
+        assert "hypotheses" in parsed
+        assert isinstance(parsed["unsatisfied_criteria"], list)

--- a/tests/test_plan_check/test_criteria_extractor.py
+++ b/tests/test_plan_check/test_criteria_extractor.py
@@ -125,6 +125,21 @@ def test_extract_from_real_hypothesis():
     assert len(criteria) == 9
 
 
+def test_extract_function_multiple_files_same_line():
+    h = _hyp(
+        what=(
+            "Create `src/a.py` with function `foo()` and "
+            "`src/b.py` with function `bar()`"
+        )
+    )
+    criteria = extract_criteria(h)
+    funcs = [c for c in criteria if c.verification_method == "function_exists"]
+    assert len(funcs) == 2
+    by_name = {c.target["symbol"]: c.target["path"] for c in funcs}
+    assert by_name["foo"] == "src/a.py"
+    assert by_name["bar"] == "src/b.py"
+
+
 def test_no_criteria_from_empty_what():
     h = _hyp(what="", expected_impact="")
     criteria = extract_criteria(h)

--- a/tests/test_plan_check/test_criteria_extractor.py
+++ b/tests/test_plan_check/test_criteria_extractor.py
@@ -1,0 +1,131 @@
+from factory.plan_check.criteria_extractor import extract_criteria
+from factory.plan_check.parser import ParsedHypothesis
+
+
+def _hyp(**kwargs) -> ParsedHypothesis:
+    defaults = {"id": "H1", "title": "Test hypothesis"}
+    defaults.update(kwargs)
+    return ParsedHypothesis(**defaults)
+
+
+def test_extract_eval_target_arrow():
+    h = _hyp(expected_impact="tests 0.5 → 0.7")
+    criteria = extract_criteria(h)
+    evals = [c for c in criteria if c.criterion_type == "eval_target"]
+    assert len(evals) == 1
+    assert evals[0].target["dimension"] == "tests"
+    assert evals[0].target["min_expected"] == 0.7
+    assert evals[0].verification_method == "eval_score"
+    assert evals[0].criterion_id == "H1.eval.tests"
+
+
+def test_extract_eval_target_plus():
+    h = _hyp(expected_impact="capability_surface +0.1")
+    criteria = extract_criteria(h)
+    evals = [c for c in criteria if c.criterion_type == "eval_target"]
+    assert len(evals) == 1
+    assert evals[0].target["dimension"] == "capability_surface"
+    assert evals[0].target["delta"] == 0.1
+    assert "min_expected" not in evals[0].target
+
+
+def test_extract_multiple_eval_targets():
+    h = _hyp(expected_impact="capability_surface 0.5 → 0.8, tests 0.7 → 0.85")
+    criteria = extract_criteria(h)
+    evals = [c for c in criteria if c.criterion_type == "eval_target"]
+    assert len(evals) == 2
+    dims = {c.target["dimension"] for c in evals}
+    assert dims == {"capability_surface", "tests"}
+    cap = next(c for c in evals if c.target["dimension"] == "capability_surface")
+    assert cap.target["min_expected"] == 0.8
+    tests = next(c for c in evals if c.target["dimension"] == "tests")
+    assert tests.target["min_expected"] == 0.85
+
+
+def test_extract_file_deliverable():
+    h = _hyp(what="Create `factory/plan_check/models.py` with Pydantic v2 models")
+    criteria = extract_criteria(h)
+    files = [c for c in criteria if c.verification_method == "file_exists"]
+    assert len(files) == 1
+    assert files[0].target["path"] == "factory/plan_check/models.py"
+    assert files[0].criterion_type == "deliverable"
+
+
+def test_extract_function_deliverable():
+    h = _hyp(
+        what='Create `factory/plan_check/analyzer.py` with function `analyze_completion()`'
+    )
+    criteria = extract_criteria(h)
+    funcs = [c for c in criteria if c.verification_method == "function_exists"]
+    assert len(funcs) == 1
+    assert funcs[0].target["symbol"] == "analyze_completion"
+    assert funcs[0].target["path"] == "factory/plan_check/analyzer.py"
+    assert funcs[0].criterion_type == "deliverable"
+
+
+def test_extract_test_requirements():
+    h = _hyp(
+        what=(
+            "Tests in `tests/test_plan_check/test_parser.py`:\n"
+            "  - `test_parse_single_hypothesis` -- one block\n"
+            "  - `test_parse_multiple_hypotheses` -- many blocks"
+        )
+    )
+    criteria = extract_criteria(h)
+    tests = [c for c in criteria if c.verification_method == "test_passes"]
+    assert len(tests) == 2
+    names = {c.target["test_name"] for c in tests}
+    assert names == {"test_parse_single_hypothesis", "test_parse_multiple_hypotheses"}
+    for c in tests:
+        assert c.criterion_type == "test_requirement"
+
+
+def test_extract_from_real_hypothesis():
+    h = _hyp(
+        id="H2",
+        title="Parse current.md and extract criteria",
+        category="EXPLORE",
+        growth_dimension="capability_surface",
+        what=(
+            "  - Implement `factory/plan_check/parser.py` with function "
+            "`parse_strategy_plan(content: str) -> list[ParsedHypothesis]`:\n"
+            "    - Split content on regex\n"
+            "    - Extract fields from each block\n"
+            "  - Implement `factory/plan_check/criteria_extractor.py` with function "
+            "`extract_criteria(hypothesis) -> list[AcceptanceCriterion]`:\n"
+            "    - Eval target extraction\n"
+            "    - Deliverable extraction\n"
+            "  - Tests in `tests/test_plan_check/test_parser.py`:\n"
+            "    - `test_parse_single_hypothesis`\n"
+            "    - `test_parse_multiple_hypotheses`"
+        ),
+        expected_impact="capability_surface 0.2 → 0.5, tests 0.5 → 0.7",
+        priority="high",
+    )
+    criteria = extract_criteria(h)
+
+    evals = [c for c in criteria if c.criterion_type == "eval_target"]
+    assert len(evals) == 2
+
+    files = [c for c in criteria if c.verification_method == "file_exists"]
+    assert len(files) == 3
+    paths = {c.target["path"] for c in files}
+    assert "factory/plan_check/parser.py" in paths
+    assert "factory/plan_check/criteria_extractor.py" in paths
+    assert "tests/test_plan_check/test_parser.py" in paths
+
+    funcs = [c for c in criteria if c.verification_method == "function_exists"]
+    assert len(funcs) == 2
+    symbols = {c.target["symbol"] for c in funcs}
+    assert symbols == {"parse_strategy_plan", "extract_criteria"}
+
+    tests = [c for c in criteria if c.verification_method == "test_passes"]
+    assert len(tests) == 2
+
+    assert len(criteria) == 9
+
+
+def test_no_criteria_from_empty_what():
+    h = _hyp(what="", expected_impact="")
+    criteria = extract_criteria(h)
+    assert criteria == []

--- a/tests/test_plan_check/test_e2e.py
+++ b/tests/test_plan_check/test_e2e.py
@@ -1,0 +1,150 @@
+"""End-to-end test: temp git repo with passing/failing hypotheses."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from factory.plan_check.cli import run_plan_check
+from factory.plan_check.reporter import to_json
+
+SAMPLE_PLAN = """\
+## Build Plan
+
+### Phase 1
+#### H1: Implement greeting module
+- **Category:** EXPLORE
+- **Growth dimension:** capability_surface
+- **What:**
+  - Create `src/greeter.py` with function `greet()`
+  - Tests in `tests/test_greeter.py`:
+    - `test_greet_returns_string`
+- **Expected impact:** capability_surface 0.0 → 0.5
+- **Priority:** high
+
+### Phase 2
+#### H2: Implement broken farewell module
+- **Category:** EXPLORE
+- **Growth dimension:** capability_surface
+- **What:**
+  - Create `src/farewell.py` with function `farewell()`
+  - Tests in `tests/test_farewell.py`:
+    - `test_farewell_returns_string`
+- **Expected impact:** capability_surface 0.5 → 0.8
+- **Priority:** high
+"""
+
+
+@pytest.fixture
+def e2e_project(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", str(tmp_path)], capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        capture_output=True, check=True, cwd=str(tmp_path),
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        capture_output=True, check=True, cwd=str(tmp_path),
+    )
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "greeter.py").write_text(
+        "def greet() -> str:\n"
+        "    return 'hello'\n"
+    )
+    (tmp_path / "src" / "farewell.py").write_text(
+        "def farewell():\n"
+        "    pass\n"
+    )
+
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_greeter.py").write_text(
+        "from src.greeter import greet\n\n"
+        "def test_greet_returns_string():\n"
+        "    assert isinstance(greet(), str)\n"
+    )
+    (tmp_path / "tests" / "test_farewell.py").write_text(
+        "from src.farewell import farewell\n\n"
+        "def test_farewell_returns_string():\n"
+        "    result = farewell()\n"
+        "    assert isinstance(result, str), 'farewell() should return a string'\n"
+    )
+
+    strategy_dir = tmp_path / ".factory" / "strategy"
+    strategy_dir.mkdir(parents=True)
+    (strategy_dir / "current.md").write_text(SAMPLE_PLAN)
+
+    (tmp_path / "conftest.py").write_text(
+        "import sys\n"
+        "sys.path.insert(0, str(__import__('pathlib').Path(__file__).parent))\n"
+    )
+
+    subprocess.run(
+        ["git", "add", "."],
+        capture_output=True, check=True, cwd=str(tmp_path),
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        capture_output=True, check=True, cwd=str(tmp_path),
+    )
+
+    return tmp_path
+
+
+def test_e2e_h1_passes_h2_fails(e2e_project: Path):
+    report = run_plan_check(
+        project_path=e2e_project,
+        strategy_path=e2e_project / ".factory" / "strategy" / "current.md",
+        output_dir=e2e_project / ".factory" / "reports",
+    )
+
+    verdicts = {v.hypothesis_id: v for v in report.hypotheses}
+
+    h1 = verdicts["H1"]
+    file_criteria = [c for c in h1.criteria if c.criterion.verification_method == "file_exists"]
+    func_criteria = [c for c in h1.criteria if c.criterion.verification_method == "function_exists"]
+    assert all(c.passed for c in file_criteria), "H1 file deliverables should pass"
+    assert all(c.passed for c in func_criteria), "H1 function deliverables should pass"
+
+    h2 = verdicts["H2"]
+    assert not h2.passed, "H2 should fail (farewell is a stub)"
+    stub_failures = [
+        c for c in h2.criteria
+        if not c.passed and c.actual_value and "stub" in c.actual_value
+    ]
+    assert len(stub_failures) >= 1, "H2 should have at least one stub failure"
+
+    json_str = to_json(report)
+    parsed = json.loads(json_str)
+    assert parsed["redirect_needed"] is True
+    assert any(
+        u["hypothesis_id"] == "H2"
+        for u in parsed["unsatisfied_criteria"]
+    )
+
+
+def test_e2e_exit_code_is_1_when_failures_exist(e2e_project: Path):
+    report = run_plan_check(
+        project_path=e2e_project,
+        strategy_path=e2e_project / ".factory" / "strategy" / "current.md",
+        output_dir=e2e_project / ".factory" / "reports",
+    )
+    assert not report.summary.all_passed
+
+
+def test_e2e_report_files_created(e2e_project: Path):
+    output_dir = e2e_project / ".factory" / "reports"
+    run_plan_check(
+        project_path=e2e_project,
+        strategy_path=e2e_project / ".factory" / "strategy" / "current.md",
+        output_dir=output_dir,
+    )
+    assert (output_dir / "acceptance-verification.md").exists()
+    assert (output_dir / "acceptance-verification.json").exists()
+
+    md_content = (output_dir / "acceptance-verification.md").read_text()
+    assert "Unsatisfied Acceptance Criteria" in md_content
+    assert "REDIRECT NEEDED" in md_content

--- a/tests/test_plan_check/test_models.py
+++ b/tests/test_plan_check/test_models.py
@@ -1,0 +1,115 @@
+from factory.plan_check.models import (
+    AcceptanceCriterion,
+    CriterionResult,
+    HypothesisVerdict,
+    ReportSummary,
+)
+
+
+def _make_criterion(**overrides):
+    defaults = {
+        "criterion_id": "H1.deliverable.models_py",
+        "hypothesis_id": "H1",
+        "criterion_type": "deliverable",
+        "description": "models.py exists",
+        "verification_method": "file_exists",
+        "target": {"path": "factory/plan_check/models.py"},
+    }
+    defaults.update(overrides)
+    return AcceptanceCriterion(**defaults)
+
+
+def _make_result(passed: bool = True, **overrides):
+    defaults = {
+        "criterion": _make_criterion(),
+        "passed": passed,
+    }
+    defaults.update(overrides)
+    return CriterionResult(**defaults)
+
+
+def test_acceptance_criterion_serialization():
+    original = _make_criterion()
+    data = original.model_dump()
+    restored = AcceptanceCriterion.model_validate(data)
+    assert restored == original
+    assert restored.criterion_id == "H1.deliverable.models_py"
+    assert restored.target == {"path": "factory/plan_check/models.py"}
+
+    json_str = original.model_dump_json()
+    from_json = AcceptanceCriterion.model_validate_json(json_str)
+    assert from_json == original
+
+
+def test_criterion_result_with_failure():
+    result = _make_result(
+        passed=False,
+        actual_value="file not found",
+        expected_value="factory/plan_check/models.py exists",
+        evidence=["checked path: factory/plan_check/models.py"],
+        error=None,
+    )
+    assert not result.passed
+    assert result.actual_value == "file not found"
+    assert result.expected_value == "factory/plan_check/models.py exists"
+    assert len(result.evidence) == 1
+
+
+def test_hypothesis_verdict_all_pass():
+    results = [
+        _make_result(passed=True, criterion=_make_criterion(criterion_id=f"H1.d.{i}"))
+        for i in range(3)
+    ]
+    verdict = HypothesisVerdict(
+        hypothesis_id="H1",
+        hypothesis_title="Scaffold package",
+        criteria=results,
+    )
+    assert verdict.passed is True
+    assert verdict.pass_rate == 1.0
+    assert verdict.unsatisfied == []
+
+
+def test_hypothesis_verdict_partial_fail():
+    c1 = _make_result(
+        passed=True,
+        criterion=_make_criterion(criterion_id="H1.d.1", description="file A exists"),
+    )
+    c2 = _make_result(
+        passed=True,
+        criterion=_make_criterion(criterion_id="H1.d.2", description="file B exists"),
+    )
+    c3 = _make_result(
+        passed=False,
+        criterion=_make_criterion(criterion_id="H1.d.3", description="file C exists"),
+    )
+    verdict = HypothesisVerdict(
+        hypothesis_id="H1",
+        hypothesis_title="Scaffold package",
+        criteria=[c1, c2, c3],
+    )
+    assert verdict.passed is False
+    assert abs(verdict.pass_rate - 2 / 3) < 1e-9
+    assert verdict.unsatisfied == ["file C exists"]
+
+
+def test_report_summary_math():
+    summary = ReportSummary(
+        total_criteria=10,
+        passed_criteria=7,
+        failed_criteria=2,
+        error_criteria=1,
+        failed_hypotheses=["H2", "H3"],
+    )
+    assert summary.pass_rate == 0.7
+    assert summary.all_passed is False
+
+    summary_perfect = ReportSummary(
+        total_criteria=5,
+        passed_criteria=5,
+        failed_criteria=0,
+        error_criteria=0,
+        failed_hypotheses=[],
+    )
+    assert summary_perfect.pass_rate == 1.0
+    assert summary_perfect.all_passed is True

--- a/tests/test_plan_check/test_parser.py
+++ b/tests/test_plan_check/test_parser.py
@@ -1,0 +1,100 @@
+from factory.plan_check.parser import parse_strategy_plan
+
+
+SINGLE_HYPOTHESIS = """\
+## Build Plan
+
+### Phase 1: Scaffold
+#### H1: Set up package with models
+- **Category:** EXPLORE
+- **Growth dimension:** capability_surface
+- **What:**
+  - Create `factory/plan_check/__init__.py`
+  - Create `factory/plan_check/models.py` with Pydantic v2 models
+- **Expected impact:** capability_surface 0.0 → 0.2, tests 0.0 → 0.5
+- **Priority:** high
+"""
+
+MULTIPLE_HYPOTHESES = """\
+### Phase 1
+#### H1: Scaffold package
+- **Category:** EXPLORE
+- **Growth dimension:** capability_surface
+- **What:**
+  - Create models
+- **Expected impact:** capability_surface 0.0 → 0.2
+- **Priority:** high
+
+### Phase 2
+#### H2: Build parser
+- **Category:** EXPLORE
+- **Growth dimension:** capability_surface
+- **What:**
+  - Implement parser
+- **Expected impact:** capability_surface 0.2 → 0.5
+- **Priority:** high
+
+### Phase 3
+#### H3: Build verifier
+- **Category:** FIX
+- **Growth dimension:** tests
+- **What:**
+  - Implement verifier
+- **Expected impact:** tests 0.5 → 0.8
+- **Priority:** medium
+"""
+
+
+def test_parse_single_hypothesis():
+    results = parse_strategy_plan(SINGLE_HYPOTHESIS)
+    assert len(results) == 1
+    h = results[0]
+    assert h.id == "H1"
+    assert h.title == "Set up package with models"
+    assert h.category == "EXPLORE"
+    assert h.growth_dimension == "capability_surface"
+    assert h.expected_impact == "capability_surface 0.0 → 0.2, tests 0.0 → 0.5"
+    assert h.priority == "high"
+
+
+def test_parse_multiple_hypotheses():
+    results = parse_strategy_plan(MULTIPLE_HYPOTHESES)
+    assert len(results) == 3
+    assert results[0].id == "H1"
+    assert results[1].id == "H2"
+    assert results[2].id == "H3"
+    assert results[0].title == "Scaffold package"
+    assert results[1].title == "Build parser"
+    assert results[2].title == "Build verifier"
+    assert results[2].category == "FIX"
+    assert results[2].growth_dimension == "tests"
+    assert results[2].priority == "medium"
+
+
+def test_parse_multiline_what():
+    results = parse_strategy_plan(SINGLE_HYPOTHESIS)
+    h = results[0]
+    assert "`factory/plan_check/__init__.py`" in h.what
+    assert "`factory/plan_check/models.py`" in h.what
+    assert "Pydantic v2 models" in h.what
+    lines = [ln.strip() for ln in h.what.split("\n") if ln.strip()]
+    assert len(lines) >= 2
+
+
+def test_parse_missing_optional_fields():
+    content = """\
+#### H1: Minimal hypothesis
+- **What:**
+  - Do something
+"""
+    results = parse_strategy_plan(content)
+    assert len(results) == 1
+    h = results[0]
+    assert h.id == "H1"
+    assert h.title == "Minimal hypothesis"
+    assert h.category == ""
+    assert h.growth_dimension == ""
+    assert h.expected_impact == ""
+    assert h.type == ""
+    assert h.priority == ""
+    assert "Do something" in h.what

--- a/tests/test_plan_check/test_qa_integration.py
+++ b/tests/test_plan_check/test_qa_integration.py
@@ -1,0 +1,123 @@
+"""Tests for QA Agent integration helpers."""
+
+from __future__ import annotations
+
+from factory.plan_check.models import (
+    AcceptanceCriterion,
+    CriterionResult,
+    HypothesisVerdict,
+    ReportSummary,
+    VerificationReport,
+)
+from factory.plan_check.qa_integration import format_for_qa, get_redirect_payload
+
+
+def _make_report(*, with_failures: bool = True) -> VerificationReport:
+    passing_criterion = CriterionResult(
+        criterion=AcceptanceCriterion(
+            criterion_id="H1.deliverable.greeter_py",
+            hypothesis_id="H1",
+            criterion_type="deliverable",
+            description="greeter.py exists",
+            verification_method="file_exists",
+            target={"path": "src/greeter.py"},
+        ),
+        passed=True,
+        actual_value="exists",
+        expected_value="src/greeter.py exists",
+    )
+
+    failing_criterion = CriterionResult(
+        criterion=AcceptanceCriterion(
+            criterion_id="H2.eval.tests",
+            hypothesis_id="H2",
+            criterion_type="eval_target",
+            description="tests score reaches 0.7",
+            verification_method="eval_score",
+            target={"dimension": "tests", "min_expected": 0.7},
+        ),
+        passed=False,
+        actual_value="tests=0.55",
+        expected_value="tests>=0.7",
+    )
+
+    h1 = HypothesisVerdict(
+        hypothesis_id="H1",
+        hypothesis_title="Implement greeter",
+        criteria=[passing_criterion],
+    )
+
+    if with_failures:
+        h2 = HypothesisVerdict(
+            hypothesis_id="H2",
+            hypothesis_title="Implement farewell",
+            criteria=[failing_criterion],
+        )
+        hypotheses = [h1, h2]
+        summary = ReportSummary(
+            total_criteria=2,
+            passed_criteria=1,
+            failed_criteria=1,
+            error_criteria=0,
+            failed_hypotheses=["H2"],
+        )
+    else:
+        hypotheses = [h1]
+        summary = ReportSummary(
+            total_criteria=1,
+            passed_criteria=1,
+            failed_criteria=0,
+            error_criteria=0,
+        )
+
+    return VerificationReport(hypotheses=hypotheses, summary=summary)
+
+
+class TestFormatForQa:
+    def test_highlights_failures(self):
+        report = _make_report(with_failures=True)
+        output = format_for_qa(report)
+        assert "UNSATISFIED CRITERIA" in output
+        assert "H2" in output
+        assert "tests score reaches 0.7" in output
+        assert "tests>=0.7" in output
+        assert "tests=0.55" in output
+
+    def test_all_passed_message(self):
+        report = _make_report(with_failures=False)
+        output = format_for_qa(report)
+        assert "All acceptance criteria satisfied" in output
+        assert "UNSATISFIED" not in output
+
+    def test_includes_command_hint(self):
+        report = _make_report(with_failures=True)
+        output = format_for_qa(report)
+        assert "factory plan-check" in output
+
+
+class TestRedirectPayload:
+    def test_structure_with_failures(self):
+        report = _make_report(with_failures=True)
+        payload = get_redirect_payload(report)
+
+        assert "unsatisfied" in payload
+        assert "redirect_message" in payload
+        assert isinstance(payload["unsatisfied"], list)
+        assert len(payload["unsatisfied"]) == 1
+
+        item = payload["unsatisfied"][0]
+        assert item["hypothesis_id"] == "H2"
+        assert item["criterion"] == "tests score reaches 0.7"
+        assert item["expected"] == "tests>=0.7"
+        assert item["actual"] == "tests=0.55"
+
+    def test_structure_all_passed(self):
+        report = _make_report(with_failures=False)
+        payload = get_redirect_payload(report)
+        assert payload["unsatisfied"] == []
+        assert "All criteria satisfied" in payload["redirect_message"]
+
+    def test_redirect_message_includes_hypothesis_ids(self):
+        report = _make_report(with_failures=True)
+        payload = get_redirect_payload(report)
+        assert "H2" in payload["redirect_message"]

--- a/tests/test_plan_check/test_reporter.py
+++ b/tests/test_plan_check/test_reporter.py
@@ -1,0 +1,252 @@
+"""Tests for factory.plan_check.reporter — Phase 4 report generator."""
+
+from __future__ import annotations
+
+import json
+
+from factory.plan_check.models import (
+    AcceptanceCriterion,
+    CriterionResult,
+    HypothesisVerdict,
+    ReportSummary,
+    VerificationReport,
+)
+from factory.plan_check.reporter import (
+    generate_report,
+    to_json,
+    to_markdown,
+    write_report,
+)
+
+
+def _criterion(
+    cid: str,
+    hyp: str,
+    desc: str,
+    *,
+    ctype: str = "deliverable",
+    method: str = "file_exists",
+    target: dict | None = None,
+) -> AcceptanceCriterion:
+    return AcceptanceCriterion(
+        criterion_id=cid,
+        hypothesis_id=hyp,
+        criterion_type=ctype,
+        description=desc,
+        verification_method=method,
+        target=target or {"path": "some/file.py"},
+    )
+
+
+def _result(
+    cid: str,
+    hyp: str,
+    desc: str,
+    *,
+    passed: bool = True,
+    actual: str | None = None,
+    expected: str | None = None,
+    evidence: list[str] | None = None,
+    error: str | None = None,
+) -> CriterionResult:
+    return CriterionResult(
+        criterion=_criterion(cid, hyp, desc),
+        passed=passed,
+        actual_value=actual,
+        expected_value=expected,
+        evidence=evidence or [],
+        error=error,
+    )
+
+
+def _all_pass_report() -> VerificationReport:
+    h1 = HypothesisVerdict(
+        hypothesis_id="H1",
+        hypothesis_title="Set up scaffold",
+        criteria=[
+            _result("H1.file.models", "H1", "models.py exists"),
+            _result("H1.file.init", "H1", "__init__.py exists"),
+        ],
+    )
+    h2 = HypothesisVerdict(
+        hypothesis_id="H2",
+        hypothesis_title="Parser works",
+        criteria=[
+            _result("H2.test.parse", "H2", "test_parse passes"),
+        ],
+    )
+    return VerificationReport(
+        hypotheses=[h1, h2],
+        summary=ReportSummary(
+            total_criteria=3,
+            passed_criteria=3,
+            failed_criteria=0,
+            error_criteria=0,
+            failed_hypotheses=[],
+        ),
+    )
+
+
+def _mixed_report() -> VerificationReport:
+    h1 = HypothesisVerdict(
+        hypothesis_id="H1",
+        hypothesis_title="Set up scaffold",
+        criteria=[
+            _result("H1.file.models", "H1", "models.py exists"),
+            _result("H1.file.init", "H1", "__init__.py exists"),
+            _result(
+                "H1.eval.tests",
+                "H1",
+                "tests score >= 0.7",
+                passed=False,
+                actual="tests score = 0.55",
+                expected="tests score >= 0.7",
+                evidence=["pytest: 3 passed, 2 failed"],
+            ),
+        ],
+    )
+    h2 = HypothesisVerdict(
+        hypothesis_id="H2",
+        hypothesis_title="Parser works",
+        criteria=[
+            _result("H2.test.parse", "H2", "test_parse passes"),
+            _result(
+                "H2.func.extract",
+                "H2",
+                "extract_criteria function exists",
+                passed=False,
+                actual="function is a stub",
+                expected="non-stub implementation",
+            ),
+        ],
+    )
+    return VerificationReport(
+        hypotheses=[h1, h2],
+        summary=ReportSummary(
+            total_criteria=5,
+            passed_criteria=3,
+            failed_criteria=2,
+            error_criteria=0,
+            failed_hypotheses=["H1", "H2"],
+        ),
+    )
+
+
+def test_report_all_criteria_pass():
+    report = _all_pass_report()
+    enriched = generate_report(report)
+    md = to_markdown(enriched)
+    j = to_json(enriched)
+    data = json.loads(j)
+
+    assert data["all_passed"] is True
+    assert data["redirect_needed"] is False
+    assert data["unsatisfied_criteria"] == []
+    assert "ALL CRITERIA MET" in md
+
+
+def test_report_some_criteria_fail():
+    report = _mixed_report()
+    enriched = generate_report(report)
+    j = to_json(enriched)
+    data = json.loads(j)
+
+    assert data["all_passed"] is False
+    assert data["redirect_needed"] is True
+    assert len(data["unsatisfied_criteria"]) == 2
+    unsatisfied_ids = {u["criterion_id"] for u in data["unsatisfied_criteria"]}
+    assert unsatisfied_ids == {"H1.eval.tests", "H2.func.extract"}
+
+
+def test_report_actual_vs_expected_in_markdown():
+    report = _mixed_report()
+    enriched = generate_report(report)
+    md = to_markdown(enriched)
+
+    assert "**Expected:** tests score >= 0.7" in md
+    assert "**Actual:** tests score = 0.55" in md
+
+
+def test_report_evidence_included():
+    report = _mixed_report()
+    enriched = generate_report(report)
+    md = to_markdown(enriched)
+
+    assert "**Evidence:**" in md
+    assert "pytest: 3 passed, 2 failed" in md
+
+
+def test_report_failed_first_ordering():
+    report = _mixed_report()
+    enriched = generate_report(report)
+
+    assert not enriched.hypotheses[0].passed
+    assert not enriched.hypotheses[1].passed
+
+    all_pass = _all_pass_report()
+    combined = VerificationReport(
+        hypotheses=[all_pass.hypotheses[0], report.hypotheses[0]],
+        summary=ReportSummary(
+            total_criteria=5,
+            passed_criteria=4,
+            failed_criteria=1,
+            error_criteria=0,
+            failed_hypotheses=["H1"],
+        ),
+    )
+    enriched2 = generate_report(combined)
+    assert not enriched2.hypotheses[0].passed, "failed hypothesis should be first"
+    assert enriched2.hypotheses[1].passed, "passing hypothesis should be second"
+
+    failing_h = enriched2.hypotheses[0]
+    first_criterion = failing_h.criteria[0]
+    assert not first_criterion.passed, "failed criteria should sort before passed"
+
+
+def test_report_json_roundtrip():
+    report = _mixed_report()
+    enriched = generate_report(report)
+    j = to_json(enriched)
+    data = json.loads(j)
+
+    assert isinstance(data["hypotheses"], list)
+    assert len(data["hypotheses"]) == 2
+    assert "summary" in data
+    assert data["pass_rate"] == data["summary"]["pass_rate"]
+    assert "unsatisfied_criteria" in data
+
+    for h in data["hypotheses"]:
+        assert "hypothesis_id" in h
+        assert "criteria" in h
+        for cr in h["criteria"]:
+            assert "criterion" in cr
+            assert "passed" in cr
+
+
+def test_report_unsatisfied_section():
+    report = _mixed_report()
+    enriched = generate_report(report)
+    md = to_markdown(enriched)
+
+    assert "### Unsatisfied Acceptance Criteria" in md
+    assert "**H1.eval.tests**" in md
+    assert "**H2.func.extract**" in md
+    assert "REDIRECT NEEDED" in md
+
+
+def test_report_write_creates_files(tmp_path):
+    report = _all_pass_report()
+    enriched = generate_report(report)
+    out = tmp_path / "reports"
+    md_path, json_path = write_report(enriched, out)
+
+    assert md_path.exists()
+    assert json_path.exists()
+    assert md_path.name == "acceptance-verification.md"
+    assert json_path.name == "acceptance-verification.json"
+
+    md_content = md_path.read_text()
+    assert "Acceptance Criteria Verification Report" in md_content
+
+    json_content = json.loads(json_path.read_text())
+    assert json_content["all_passed"] is True

--- a/tests/test_plan_check/test_verifier.py
+++ b/tests/test_plan_check/test_verifier.py
@@ -333,6 +333,60 @@ def test_detect_stubs_with_docstring_and_pass() -> None:
 
 
 # ---------------------------------------------------------------------------
+# eval_score — delta fails without baseline
+# ---------------------------------------------------------------------------
+
+
+def test_verify_eval_score_delta_fails_without_baseline(tmp_path: Path) -> None:
+    scores_dir = tmp_path / ".factory" / "eval"
+    scores_dir.mkdir(parents=True)
+    (scores_dir / "scores.json").write_text(json.dumps({"tests": 0.75}))
+    c = _criterion(
+        "eval_score",
+        {"dimension": "tests", "delta": 0.1},
+        criterion_type="eval_target",
+    )
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert "baseline" in (result.actual_value or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# command_exits_zero — uses shlex.split (no shell=True)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_command_shlex_split(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "ok"
+    mock_result.stderr = ""
+    c = _criterion(
+        "command_exits_zero",
+        {"command": "echo hello world"},
+        criterion_type="functional",
+    )
+    with patch("factory.plan_check.verifier.subprocess.run", return_value=mock_result) as mock_run:
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is True
+    call_args = mock_run.call_args
+    assert call_args[0][0] == ["echo", "hello", "world"]
+    assert call_args[1].get("shell") is None or call_args[1].get("shell") is False
+
+
+def test_verify_command_invalid_shlex(tmp_path: Path) -> None:
+    c = _criterion(
+        "command_exits_zero",
+        {"command": "echo 'unterminated"},
+        criterion_type="functional",
+    )
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert result.error is not None
+    assert "Invalid command syntax" in result.error
+
+
+# ---------------------------------------------------------------------------
 # verify_hypothesis
 # ---------------------------------------------------------------------------
 

--- a/tests/test_plan_check/test_verifier.py
+++ b/tests/test_plan_check/test_verifier.py
@@ -1,0 +1,403 @@
+"""Unit tests for factory.plan_check.verifier — subprocess calls are mocked."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from factory.plan_check.models import AcceptanceCriterion
+from factory.plan_check.parser import ParsedHypothesis
+from factory.plan_check.verifier import (
+    detect_stubs,
+    verify_criteria,
+    verify_hypothesis,
+    verify_plan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _criterion(
+    method: str,
+    target: dict | None = None,
+    *,
+    criterion_id: str = "H1.test",
+    hypothesis_id: str = "H1",
+    criterion_type: str = "deliverable",
+    description: str = "test criterion",
+) -> AcceptanceCriterion:
+    return AcceptanceCriterion(
+        criterion_id=criterion_id,
+        hypothesis_id=hypothesis_id,
+        criterion_type=criterion_type,
+        description=description,
+        verification_method=method,
+        target=target or {},
+    )
+
+
+def _hypothesis(h_id: str = "H1", title: str = "Test hypothesis") -> ParsedHypothesis:
+    return ParsedHypothesis(id=h_id, title=title)
+
+
+# ---------------------------------------------------------------------------
+# file_exists
+# ---------------------------------------------------------------------------
+
+
+def test_verify_file_exists_pass(tmp_path: Path) -> None:
+    (tmp_path / "src" / "main.py").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "src" / "main.py").write_text("print('hello')")
+    c = _criterion("file_exists", {"path": "src/main.py"})
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is True
+    assert result.actual_value == "exists"
+
+
+def test_verify_file_exists_fail(tmp_path: Path) -> None:
+    c = _criterion("file_exists", {"path": "nonexistent.py"})
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert result.actual_value == "not found"
+
+
+# ---------------------------------------------------------------------------
+# function_exists
+# ---------------------------------------------------------------------------
+
+
+def test_verify_function_exists_pass(tmp_path: Path) -> None:
+    py = tmp_path / "lib.py"
+    py.write_text("def analyze_completion(data):\n    return len(data)\n")
+    c = _criterion("function_exists", {"path": "lib.py", "symbol": "analyze_completion"})
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is True
+
+
+def test_verify_function_exists_fail(tmp_path: Path) -> None:
+    py = tmp_path / "lib.py"
+    py.write_text("def other_func():\n    pass\n")
+    c = _criterion("function_exists", {"path": "lib.py", "symbol": "analyze_completion"})
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert "not found" in (result.actual_value or "")
+
+
+def test_verify_function_exists_stub(tmp_path: Path) -> None:
+    py = tmp_path / "lib.py"
+    py.write_text("def analyze_completion():\n    pass\n")
+    c = _criterion("function_exists", {"path": "lib.py", "symbol": "analyze_completion"})
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert "stub" in (result.actual_value or "")
+
+
+def test_verify_function_exists_stub_ellipsis(tmp_path: Path) -> None:
+    py = tmp_path / "lib.py"
+    py.write_text("def analyze_completion():\n    ...\n")
+    c = _criterion("function_exists", {"path": "lib.py", "symbol": "analyze_completion"})
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert "stub" in (result.actual_value or "")
+
+
+def test_verify_function_exists_stub_not_implemented(tmp_path: Path) -> None:
+    py = tmp_path / "lib.py"
+    py.write_text("def analyze_completion():\n    raise NotImplementedError\n")
+    c = _criterion("function_exists", {"path": "lib.py", "symbol": "analyze_completion"})
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert "stub" in (result.actual_value or "")
+
+
+# ---------------------------------------------------------------------------
+# test_passes
+# ---------------------------------------------------------------------------
+
+
+def test_verify_test_passes_pass(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "1 passed"
+    mock_result.stderr = ""
+    c = _criterion(
+        "test_passes",
+        {"test_name": "test_something"},
+        criterion_type="test_requirement",
+    )
+    with patch("factory.plan_check.verifier.subprocess.run", return_value=mock_result):
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is True
+    assert result.actual_value == "passed"
+
+
+def test_verify_test_passes_fail(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = "FAILED test_something - AssertionError"
+    mock_result.stderr = ""
+    c = _criterion(
+        "test_passes",
+        {"test_name": "test_something"},
+        criterion_type="test_requirement",
+    )
+    with patch("factory.plan_check.verifier.subprocess.run", return_value=mock_result):
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert result.actual_value == "failed"
+
+
+def test_verify_test_passes_not_found(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.returncode = 5
+    mock_result.stdout = "no tests ran"
+    mock_result.stderr = ""
+    c = _criterion(
+        "test_passes",
+        {"test_name": "test_nonexistent"},
+        criterion_type="test_requirement",
+    )
+    with patch("factory.plan_check.verifier.subprocess.run", return_value=mock_result):
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert result.actual_value == "test not found"
+
+
+# ---------------------------------------------------------------------------
+# eval_score
+# ---------------------------------------------------------------------------
+
+
+def test_verify_eval_score_pass(tmp_path: Path) -> None:
+    scores_dir = tmp_path / ".factory" / "eval"
+    scores_dir.mkdir(parents=True)
+    (scores_dir / "scores.json").write_text(json.dumps({"tests": 0.75, "lint": 0.9}))
+    c = _criterion(
+        "eval_score",
+        {"dimension": "tests", "min_expected": 0.7},
+        criterion_type="eval_target",
+    )
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is True
+    assert result.actual_value == "tests=0.75"
+    assert result.expected_value == "tests>=0.7"
+
+
+def test_verify_eval_score_fail(tmp_path: Path) -> None:
+    scores_dir = tmp_path / ".factory" / "eval"
+    scores_dir.mkdir(parents=True)
+    (scores_dir / "scores.json").write_text(json.dumps({"tests": 0.55}))
+    c = _criterion(
+        "eval_score",
+        {"dimension": "tests", "min_expected": 0.7},
+        criterion_type="eval_target",
+    )
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert result.actual_value == "tests=0.55"
+    assert result.expected_value == "tests>=0.7"
+
+
+def test_verify_eval_score_dimension_missing(tmp_path: Path) -> None:
+    scores_dir = tmp_path / ".factory" / "eval"
+    scores_dir.mkdir(parents=True)
+    (scores_dir / "scores.json").write_text(json.dumps({"lint": 0.9}))
+    c = _criterion(
+        "eval_score",
+        {"dimension": "tests", "min_expected": 0.7},
+        criterion_type="eval_target",
+    )
+    [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert "not found" in (result.actual_value or "")
+
+
+# ---------------------------------------------------------------------------
+# command_exits_zero
+# ---------------------------------------------------------------------------
+
+
+def test_verify_command_exits_zero_pass(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "ok"
+    mock_result.stderr = ""
+    c = _criterion(
+        "command_exits_zero",
+        {"command": "echo ok"},
+        criterion_type="functional",
+    )
+    with patch("factory.plan_check.verifier.subprocess.run", return_value=mock_result):
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is True
+
+
+def test_verify_command_exits_zero_fail(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    mock_result.stderr = "error"
+    c = _criterion(
+        "command_exits_zero",
+        {"command": "false"},
+        criterion_type="functional",
+    )
+    with patch("factory.plan_check.verifier.subprocess.run", return_value=mock_result):
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert result.actual_value == "exit code 1"
+
+
+# ---------------------------------------------------------------------------
+# grep_match
+# ---------------------------------------------------------------------------
+
+
+def test_verify_grep_match_pass(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "./lib.py:def hello():\n"
+    mock_result.stderr = ""
+    c = _criterion("grep_match", {"pattern": "def hello"})
+    with patch("factory.plan_check.verifier.subprocess.run", return_value=mock_result):
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is True
+    assert "1 matches" in (result.actual_value or "")
+
+
+def test_verify_grep_match_fail(tmp_path: Path) -> None:
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+    mock_result.stdout = ""
+    mock_result.stderr = ""
+    c = _criterion("grep_match", {"pattern": "nonexistent_symbol"})
+    with patch("factory.plan_check.verifier.subprocess.run", return_value=mock_result):
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+
+
+# ---------------------------------------------------------------------------
+# Timeout
+# ---------------------------------------------------------------------------
+
+
+def test_verify_timeout(tmp_path: Path) -> None:
+    c = _criterion(
+        "test_passes",
+        {"test_name": "test_slow"},
+        criterion_type="test_requirement",
+    )
+    with patch(
+        "factory.plan_check.verifier.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="pytest", timeout=60),
+    ):
+        [result] = verify_criteria([c], tmp_path)
+    assert result.passed is False
+    assert result.error is not None
+    assert "timed out" in result.error
+
+
+# ---------------------------------------------------------------------------
+# detect_stubs
+# ---------------------------------------------------------------------------
+
+
+def test_detect_stubs_pass_body() -> None:
+    source = "def foo():\n    pass\n"
+    assert len(detect_stubs(source, "foo")) > 0
+
+
+def test_detect_stubs_ellipsis_body() -> None:
+    source = "def foo():\n    ...\n"
+    assert len(detect_stubs(source, "foo")) > 0
+
+
+def test_detect_stubs_not_implemented() -> None:
+    source = "def foo():\n    raise NotImplementedError\n"
+    assert len(detect_stubs(source, "foo")) > 0
+
+
+def test_detect_stubs_real_body() -> None:
+    source = "def foo():\n    return 42\n"
+    assert detect_stubs(source, "foo") == []
+
+
+def test_detect_stubs_with_docstring_and_pass() -> None:
+    source = 'def foo():\n    """Docstring."""\n    pass\n'
+    assert len(detect_stubs(source, "foo")) > 0
+
+
+# ---------------------------------------------------------------------------
+# verify_hypothesis
+# ---------------------------------------------------------------------------
+
+
+def test_verify_hypothesis_all_pass(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n")
+    (tmp_path / "b.py").write_text("y = 2\n")
+    (tmp_path / "c.txt").write_text("hello\n")
+
+    criteria = [
+        _criterion("file_exists", {"path": "a.py"}, criterion_id="H1.1"),
+        _criterion("file_exists", {"path": "b.py"}, criterion_id="H1.2"),
+        _criterion("file_exists", {"path": "c.txt"}, criterion_id="H1.3"),
+    ]
+    h = _hypothesis()
+    verdict = verify_hypothesis(h, criteria, tmp_path)
+    assert verdict.passed is True
+    assert verdict.pass_rate == 1.0
+    assert verdict.unsatisfied == []
+
+
+def test_verify_hypothesis_partial_fail(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n")
+    (tmp_path / "b.py").write_text("y = 2\n")
+
+    criteria = [
+        _criterion("file_exists", {"path": "a.py"}, criterion_id="H1.1", description="a.py exists"),
+        _criterion("file_exists", {"path": "b.py"}, criterion_id="H1.2", description="b.py exists"),
+        _criterion(
+            "file_exists",
+            {"path": "missing.py"},
+            criterion_id="H1.3",
+            description="missing.py exists",
+        ),
+    ]
+    h = _hypothesis()
+    verdict = verify_hypothesis(h, criteria, tmp_path)
+    assert verdict.passed is False
+    assert len(verdict.unsatisfied) == 1
+    assert "missing.py exists" in verdict.unsatisfied
+
+
+# ---------------------------------------------------------------------------
+# verify_plan
+# ---------------------------------------------------------------------------
+
+
+def test_verify_plan_summary(tmp_path: Path) -> None:
+    (tmp_path / "exists.py").write_text("x = 1\n")
+
+    h1 = _hypothesis("H1", "First")
+    c1 = [_criterion("file_exists", {"path": "exists.py"}, criterion_id="H1.1", hypothesis_id="H1")]
+
+    h2 = _hypothesis("H2", "Second")
+    c2 = [
+        _criterion("file_exists", {"path": "exists.py"}, criterion_id="H2.1", hypothesis_id="H2"),
+        _criterion(
+            "file_exists", {"path": "gone.py"}, criterion_id="H2.2", hypothesis_id="H2"
+        ),
+    ]
+
+    report = verify_plan([(h1, c1), (h2, c2)], tmp_path)
+    assert report.summary.total_criteria == 3
+    assert report.summary.passed_criteria == 2
+    assert report.summary.failed_criteria == 1
+    assert report.summary.all_passed is False
+    assert "H2" in report.summary.failed_hypotheses
+    assert "H1" not in report.summary.failed_hypotheses

--- a/tests/test_plan_check/test_verifier_integration.py
+++ b/tests/test_plan_check/test_verifier_integration.py
@@ -1,0 +1,117 @@
+"""Integration tests — real files, no mocking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from factory.plan_check.models import AcceptanceCriterion
+from factory.plan_check.verifier import verify_criteria
+
+
+def _criterion(
+    method: str,
+    target: dict,
+    *,
+    criterion_id: str = "H1.test",
+) -> AcceptanceCriterion:
+    return AcceptanceCriterion(
+        criterion_id=criterion_id,
+        hypothesis_id="H1",
+        criterion_type="deliverable",
+        description="integration test criterion",
+        verification_method=method,
+        target=target,
+    )
+
+
+def test_e2e_verify_real_file(tmp_path: Path) -> None:
+    """Create a real temp file and verify file_exists without mocking."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "src").mkdir()
+    real_file = project / "src" / "main.py"
+    real_file.write_text("print('hello world')\n")
+
+    c_pass = _criterion("file_exists", {"path": "src/main.py"}, criterion_id="H1.1")
+    c_fail = _criterion("file_exists", {"path": "src/missing.py"}, criterion_id="H1.2")
+
+    results = verify_criteria([c_pass, c_fail], project)
+    assert results[0].passed is True
+    assert results[1].passed is False
+
+
+def test_e2e_verify_real_function(tmp_path: Path) -> None:
+    """Create a temp .py with a real function and verify function_exists without mocking."""
+    project = tmp_path / "project"
+    project.mkdir()
+    py_file = project / "module.py"
+    py_file.write_text(
+        "def analyze_completion(data: list) -> int:\n"
+        "    return len(data)\n"
+        "\n"
+        "class MyModel:\n"
+        "    def predict(self):\n"
+        "        return 0\n"
+    )
+
+    c_func = _criterion(
+        "function_exists",
+        {"path": "module.py", "symbol": "analyze_completion"},
+        criterion_id="H1.func",
+    )
+    c_class = _criterion(
+        "function_exists",
+        {"path": "module.py", "symbol": "MyModel"},
+        criterion_id="H1.class",
+    )
+    c_missing = _criterion(
+        "function_exists",
+        {"path": "module.py", "symbol": "nonexistent"},
+        criterion_id="H1.missing",
+    )
+
+    results = verify_criteria([c_func, c_class, c_missing], project)
+    assert results[0].passed is True
+    assert results[1].passed is True
+    assert results[2].passed is False
+    assert "not found" in (results[2].actual_value or "")
+
+
+def test_e2e_verify_stub_detection(tmp_path: Path) -> None:
+    """Real stub detection without mocking."""
+    project = tmp_path / "project"
+    project.mkdir()
+    py_file = project / "stubs.py"
+    py_file.write_text(
+        "def real_func():\n"
+        "    return 42\n"
+        "\n"
+        "def stub_pass():\n"
+        "    pass\n"
+        "\n"
+        "def stub_ellipsis():\n"
+        "    ...\n"
+        "\n"
+        "def stub_not_impl():\n"
+        "    raise NotImplementedError\n"
+    )
+
+    criteria = [
+        _criterion("function_exists", {"path": "stubs.py", "symbol": "real_func"}, criterion_id="1"),
+        _criterion("function_exists", {"path": "stubs.py", "symbol": "stub_pass"}, criterion_id="2"),
+        _criterion(
+            "function_exists", {"path": "stubs.py", "symbol": "stub_ellipsis"}, criterion_id="3"
+        ),
+        _criterion(
+            "function_exists", {"path": "stubs.py", "symbol": "stub_not_impl"}, criterion_id="4"
+        ),
+    ]
+
+    results = verify_criteria(criteria, project)
+    assert results[0].passed is True
+    assert results[1].passed is False
+    assert "stub" in (results[1].actual_value or "")
+    assert results[2].passed is False
+    assert "stub" in (results[2].actual_value or "")
+    assert results[3].passed is False
+    assert "stub" in (results[3].actual_value or "")


### PR DESCRIPTION
Closes #780

## Changes

- Added a **Plan Completion Check** step (step 5) to the QA Agent's Section 2 (Code Review), inserted after spec fidelity (step 4) and before surface constraint checks (renumbered to step 6)
- The new step instructs the QA Agent to:
  - Read `.factory/strategy/current.md` and match the hypothesis to the current experiment
  - Extract every deliverable from the hypothesis's **What** field
  - Verify each deliverable against the git diff — checking for missing files, stub implementations (`pass`, `...`, `raise NotImplementedError`), and unjustified deferrals
  - Cross-check **Expected impact** claims against Section 1's health check scores
  - Report a plan completion summary with satisfied/unsatisfied counts
- Updated the Section 2 output format to include a **Plan Completion** block with hypothesis ID, deliverable counts, and flagged items
- Unjustified deferrals are treated as scope shrinkage (consistent with existing prompt conventions)