### PR TITLE
Propagate --no-github flag to sub-agents via env var + prompt injection

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -154,6 +154,16 @@ async def invoke_agent(
 
     prompt = resolve_prompt(role, project_path, use_profile=use_profile)
 
+    if os.environ.get("FACTORY_NO_GITHUB") == "1":
+        prompt += (
+            "\n\n## GitHub Disabled\n\n"
+            "GitHub integration is disabled for this session (--no-github). "
+            "Do NOT run any gh CLI commands (gh issue, gh pr, gh api, etc.). "
+            "Do NOT create pull requests or reference GitHub issues. "
+            "Work locally only — create commits, run tests, but skip all GitHub operations. "
+            "When a step would normally involve GitHub, skip it and note that it was skipped.\n"
+        )
+
     logger.info("Invoking %s agent for %s", role, project_path.name)
 
     started_data: dict[str, object] = {"task": task[:200]}

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2374,6 +2374,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         return 1
 
     no_github = getattr(args, "no_github", False)
+    if no_github:
+        os.environ["FACTORY_NO_GITHUB"] = "1"
     refine_request = getattr(args, "refine", None)
 
     if refine_request:
@@ -3670,6 +3672,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     focus = getattr(args, "focus", None)
     discover_only = getattr(args, "discover_only", False)
     no_github = getattr(args, "no_github", False)
+    if no_github:
+        os.environ["FACTORY_NO_GITHUB"] = "1"
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,6 +1,7 @@
 """Tests for factory.agents — prompt loading and resolution."""
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -711,4 +712,67 @@ class TestBgAgents:
             bg = False
         assert bg is False
         assert bg_agents is True
+
+
+class TestNoGithubPropagation:
+    """Tests for --no-github env var propagation to sub-agents."""
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_appends_no_github_directive(self, tmp_path, monkeypatch):
+        """When FACTORY_NO_GITHUB=1, invoke_agent appends GitHub Disabled section."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        monkeypatch.setenv("FACTORY_NO_GITHUB", "1")
+        (tmp_path / ".factory").mkdir(exist_ok=True)
+
+        captured_prompt: list[str] = []
+
+        class MockRunner:
+            name = "claude"
+            async def headless(self, request):
+                captured_prompt.append(request.prompt)
+                from factory.models import AgentRunResult
+                return AgentRunResult(stdout="ok", return_code=0)
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
+
+        await invoke_agent("researcher", "test task", tmp_path)
+        assert len(captured_prompt) == 1
+        assert "## GitHub Disabled" in captured_prompt[0]
+        assert "Do NOT run any gh CLI commands" in captured_prompt[0]
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_no_directive_when_unset(self, tmp_path, monkeypatch):
+        """When FACTORY_NO_GITHUB is not set, no GitHub Disabled section is appended."""
+        import factory.agents.runner as runner_module
+        from factory.agents.runner import invoke_agent
+
+        monkeypatch.delenv("FACTORY_NO_GITHUB", raising=False)
+        (tmp_path / ".factory").mkdir(exist_ok=True)
+
+        captured_prompt: list[str] = []
+
+        class MockRunner:
+            name = "claude"
+            async def headless(self, request):
+                captured_prompt.append(request.prompt)
+                from factory.models import AgentRunResult
+                return AgentRunResult(stdout="ok", return_code=0)
+
+        monkeypatch.setattr(runner_module, "get_runner", lambda *args, **kwargs: MockRunner())
+
+        await invoke_agent("researcher", "test task", tmp_path)
+        assert len(captured_prompt) == 1
+        assert "## GitHub Disabled" not in captured_prompt[0]
+
+    def test_env_var_propagates_to_subprocess_env(self, monkeypatch):
+        """FACTORY_NO_GITHUB=1 is visible in os.environ for child processes."""
+        monkeypatch.setenv("FACTORY_NO_GITHUB", "1")
+        assert os.environ.get("FACTORY_NO_GITHUB") == "1"
+
+    def test_env_var_absent_by_default(self, monkeypatch):
+        """FACTORY_NO_GITHUB is not set when --no-github is not passed."""
+        monkeypatch.delenv("FACTORY_NO_GITHUB", raising=False)
+        assert os.environ.get("FACTORY_NO_GITHUB") is None
 


### PR DESCRIPTION
Closes #787

## Changes

- **factory/cli.py**: Set `FACTORY_NO_GITHUB=1` env var in `cmd_ceo()` and `cmd_run()` when `--no-github` is passed, so the flag propagates to all subprocess environments
- **factory/agents/runner.py**: In `invoke_agent()`, after resolving the prompt, check `FACTORY_NO_GITHUB` env var and append a "GitHub Disabled" directive instructing sub-agents to skip all `gh` CLI commands and GitHub operations
- **tests/test_agents.py**: Added `TestNoGithubPropagation` test class with 4 tests verifying prompt injection when env var is set/unset and env var propagation behavior