### PR TITLE
Fix Node.js eval: detect vitest, auto-detect language for observability

### DIFF
--- a/factory/eval/growth.py
+++ b/factory/eval/growth.py
@@ -164,7 +164,7 @@ def eval_observability(project_path: Path) -> dict:
     try:
         from factory.study import _analyze_observability
 
-        result = _analyze_observability(project_path, "python")
+        result = _analyze_observability(project_path, "unknown")
         score = result.get("observability_score", 0.0)
         fn_cov = result.get("function_coverage", 0.0)
         structured = result.get("structured_logging", False)

--- a/factory/eval/languages/node.py
+++ b/factory/eval/languages/node.py
@@ -2,10 +2,28 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
 from factory.eval.languages.base import EvalFragment, _run_cmd
+
+
+def _detect_test_runner(project_path: Path) -> str:
+    """Detect the test runner from package.json devDependencies and scripts."""
+    pkg_path = project_path / "package.json"
+    if not pkg_path.exists():
+        return "jest"
+    try:
+        pkg = json.loads(pkg_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return "jest"
+    deps = {**pkg.get("devDependencies", {}), **pkg.get("dependencies", {})}
+    scripts = pkg.get("scripts", {})
+    test_script = scripts.get("test", "")
+    if "vitest" in deps or "vitest" in test_script:
+        return "vitest"
+    return "jest"
 
 
 class NodeEvaluator:
@@ -16,7 +34,7 @@ class NodeEvaluator:
     def detect(self, project_path: Path) -> bool:
         return (project_path / "package.json").exists()
 
-    def run_tests_with_coverage(
+    def _run_jest_with_coverage(
         self, project_path: Path, timeout: int = 300,
     ) -> tuple[EvalFragment | None, EvalFragment | None]:
         rc, stdout, stderr = _run_cmd(
@@ -26,8 +44,20 @@ class NodeEvaluator:
             ],
             project_path, timeout=timeout,
         )
-        output = stdout + stderr
+        return self._parse_test_output(project_path, stdout + stderr)
 
+    def _run_vitest_with_coverage(
+        self, project_path: Path, timeout: int = 300,
+    ) -> tuple[EvalFragment | None, EvalFragment | None]:
+        rc, stdout, stderr = _run_cmd(
+            ["npx", "vitest", "run", "--coverage"],
+            project_path, timeout=timeout,
+        )
+        return self._parse_test_output(project_path, stdout + stderr)
+
+    def _parse_test_output(
+        self, project_path: Path, output: str,
+    ) -> tuple[EvalFragment | None, EvalFragment | None]:
         test_frag: EvalFragment | None = None
         p_match = re.search(r"(\d+)\s+passed", output)
         f_match = re.search(r"(\d+)\s+failed", output)
@@ -44,6 +74,8 @@ class NodeEvaluator:
 
         cov_frag: EvalFragment | None = None
         cov_match = re.search(r"Statements\s*:\s*([\d.]+)%", output)
+        if not cov_match:
+            cov_match = re.search(r"All files\s*\|\s*([\d.]+)", output)
         if cov_match:
             pct = float(cov_match.group(1))
             cov_frag = EvalFragment(
@@ -55,6 +87,14 @@ class NodeEvaluator:
             )
 
         return test_frag, cov_frag
+
+    def run_tests_with_coverage(
+        self, project_path: Path, timeout: int = 300,
+    ) -> tuple[EvalFragment | None, EvalFragment | None]:
+        runner = _detect_test_runner(project_path)
+        if runner == "vitest":
+            return self._run_vitest_with_coverage(project_path, timeout=timeout)
+        return self._run_jest_with_coverage(project_path, timeout=timeout)
 
     def run_tests(self, project_path: Path, timeout: int = 300) -> EvalFragment | None:
         test_frag, _ = self.run_tests_with_coverage(project_path, timeout=timeout)


### PR DESCRIPTION
## Summary

- **NodeEvaluator detects vitest vs jest** from `package.json` (devDependencies and scripts.test). Projects with vitest run `npx vitest run --coverage` instead of hardcoded `npx jest`. Coverage parsing handles both Jest text-summary and Vitest table formats.
- **Observability auto-detects language** instead of hardcoding `"python"`. TypeScript projects now score correctly (was always 0.0 because it looked for `.py` files).

## Impact

Tested on a Next.js/TypeScript project (Slipstream):
| Dimension | Before | After |
|-----------|--------|-------|
| tests | 0.0 | 1.0 |
| coverage | 0.5 (default) | 0.32 (real) |
| observability | 0.0 | 0.357 |
| composite | 0.458 | 0.612 |
| passed | false | true |

## Files changed

- `factory/eval/languages/node.py`: Added `_detect_test_runner()`, split test execution into jest/vitest paths, extracted `_parse_test_output()` shared parser
- `factory/eval/growth.py`: Changed `"python"` to `"unknown"` on line 167 to trigger language auto-detection