### PR TITLE
fix: build completion tracking + Sacred Rules 4-5 enforcement (issues #783, #796)

### DIFF
--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -190,6 +190,8 @@ def _count_build_phases_done(project_path: Path) -> int:
         return 0
     try:
         data = json.loads(phases_path.read_text())
+        if not isinstance(data, dict):
+            return 0
         return len(data.get("completed", []))
     except (json.JSONDecodeError, ValueError):
         return 0

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -126,9 +126,9 @@ def _count_hypotheses(project_path: Path) -> int:
         return 0
 
     content = strategy_file.read_text()
-    # Match headings like "#### H1:" or "### H2:" etc.
-    matches = re.findall(r"^#{2,4}\s+H(\d+):", content, re.MULTILINE)
-    return len(matches)
+    h_matches = re.findall(r"^#{2,4}\s+H(\d+):", content, re.MULTILINE)
+    phase_matches = re.findall(r"^#{2,4}\s+Phase\s+(\d+):", content, re.MULTILINE)
+    return len(h_matches) + len(phase_matches)
 
 
 def _count_verdicts(project_path: Path, since_ts: datetime | None = None) -> int:
@@ -181,6 +181,18 @@ def _count_verdicts(project_path: Path, since_ts: datetime | None = None) -> int
         if exp_dir.is_dir() and (exp_dir / "verdict.json").exists():
             count += 1
     return count
+
+
+def _count_build_phases_done(project_path: Path) -> int:
+    """Count completed phases from .factory/build_phases_done.json."""
+    phases_path = project_path / ".factory" / "build_phases_done.json"
+    if not phases_path.exists():
+        return 0
+    try:
+        data = json.loads(phases_path.read_text())
+        return len(data.get("completed", []))
+    except (json.JSONDecodeError, ValueError):
+        return 0
 
 
 def _has_eval_profile(project_path: Path) -> bool:
@@ -249,13 +261,10 @@ def _detect_incomplete(
         )
 
     elif mode == "build":
-        # For build mode, check if Builder completed at least one hypothesis
-        # In build mode, the strategy file should have phases marked as hypotheses
         planned = _count_hypotheses(project_path)
         completed = _count_verdicts(project_path, since_ts=cycle_started_at)
 
         if planned == 0:
-            # No strategy means we're in scaffold phase — check for eval profile
             if not _has_eval_profile(project_path):
                 return IncompleteGap(
                     mode=mode,
@@ -268,6 +277,20 @@ def _detect_incomplete(
 
         if completed >= planned:
             return None
+
+        if completed == 0:
+            phases_done = _count_build_phases_done(project_path)
+            if phases_done >= planned:
+                return None
+            if phases_done > 0:
+                next_phase = phases_done + 1
+                return IncompleteGap(
+                    mode=mode,
+                    planned=planned,
+                    completed=phases_done,
+                    next_item=f"Phase{next_phase}",
+                    reason=f"build.incomplete: {phases_done}/{planned} phases recorded in build_phases_done.json",
+                )
 
         next_h = completed + 1
         return IncompleteGap(

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -855,8 +855,20 @@ def cmd_guard(args: argparse.Namespace) -> int:
         if args.check_surfaces:
             fixed_surfaces = config.fixed_surfaces
 
+    cycle_started_at = None
+    cycle_path = project_path / ".factory" / "state" / "cycle.json"
+    if cycle_path.is_file():
+        try:
+            cycle_data = json.loads(cycle_path.read_text())
+            started_at_str = cycle_data.get("started_at")
+            if started_at_str:
+                cycle_started_at = datetime.fromisoformat(started_at_str)
+        except (json.JSONDecodeError, OSError, ValueError):
+            pass
+
     violations = check_all(
         project_path, args.baseline, allowed_scope=scope, fixed_surfaces=fixed_surfaces,
+        cycle_started_at=cycle_started_at,
     )
     _emit_cli_event(project_path, "guard.completed", {
         "violations": len(violations),

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -979,6 +979,22 @@ def cmd_finalize(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_record_phase(args: argparse.Namespace) -> int:
+    """Record a completed build phase in build_phases_done.json."""
+    from factory.store import ExperimentStore
+
+    project_path = Path(args.path).resolve()
+    store = ExperimentStore(project_path)
+    pr_number = getattr(args, "pr", None)
+    store.record_build_phase(args.phase, pr_number=pr_number)
+    _emit_cli_event(project_path, "build.phase_recorded", {
+        "phase": args.phase,
+        "pr": pr_number,
+    })
+    print(f"Recorded build phase {args.phase}")
+    return 0
+
+
 def cmd_message(args: argparse.Namespace) -> int:
     """Queue a message for the CEO agent."""
     from factory.messages import write_message
@@ -4002,6 +4018,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--force", action="store_true", default=False,
                     help="Bypass precheck gate (for pre-existing failures)")
 
+    # record-phase
+    p = sub.add_parser("record-phase", help="Record a completed build phase")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("phase", type=int, help="Phase number that was completed")
+    p.add_argument("--pr", type=int, default=None, help="PR number for this phase")
+
     # history
     p = sub.add_parser("history", help="Print formatted experiment history table")
     p.add_argument("path", help="Path to the project")
@@ -4566,6 +4588,7 @@ def main(argv: list[str] | None = None) -> int:
         "guard": cmd_guard,
         "begin": cmd_begin,
         "finalize": cmd_finalize,
+        "record-phase": cmd_record_phase,
         "history": cmd_history,
         "notify": cmd_notify,
         "study": cmd_study,

--- a/factory/eval/guards.py
+++ b/factory/eval/guards.py
@@ -2,6 +2,7 @@
 
 import fnmatch
 import subprocess
+from datetime import datetime
 from pathlib import Path, PurePath
 
 
@@ -171,6 +172,80 @@ def check_fixed_surfaces(
     return None
 
 
+_TEST_FILE_PATTERNS = ("test_", "_test.", "/tests/")
+
+
+def _is_test_file(filepath: str) -> bool:
+    """Check if a filepath looks like a test file."""
+    basename = filepath.split("/")[-1]
+    return (
+        basename.startswith("test_")
+        or "_test." in basename
+        or "/tests/" in ("/" + filepath)
+    )
+
+
+def check_test_deletion(project_path: Path, baseline_sha: str) -> str | None:
+    """Guard: test files must not be deleted.
+
+    Runs ``git diff --name-status`` between baseline and HEAD, filters for
+    deleted (D) entries that match test file patterns. Returns a violation
+    string listing deleted test files, or None if clean.
+    """
+    try:
+        diff_output = _run_git(
+            ["diff", "--name-status", f"{baseline_sha}..HEAD"], project_path,
+        )
+    except subprocess.CalledProcessError:
+        return "Cannot determine deleted files (git diff failed)"
+
+    if not diff_output.strip():
+        return None
+
+    deleted_tests: list[str] = []
+    for line in diff_output.strip().splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) != 2:
+            continue
+        status, filepath = parts
+        if status != "D":
+            continue
+        basename = filepath.split("/")[-1]
+        if basename in _AUTO_GENERATED_FILES:
+            continue
+        if _is_test_file(filepath):
+            deleted_tests.append(filepath)
+
+    if deleted_tests:
+        return f"Test files deleted: {', '.join(deleted_tests)}"
+    return None
+
+
+def check_eval_not_skipped(
+    project_path: Path,
+    cycle_started_at: datetime | None = None,
+) -> str | None:
+    """Guard: eval must have been run during the current cycle.
+
+    Checks that ``.factory/last_eval.json`` exists and its modification time
+    is after ``cycle_started_at``. If ``cycle_started_at`` is None, only
+    checks existence.
+    """
+    last_eval = project_path / ".factory" / "last_eval.json"
+    if not last_eval.is_file():
+        return "Eval was skipped: .factory/last_eval.json does not exist"
+
+    if cycle_started_at is not None:
+        mtime = datetime.fromtimestamp(last_eval.stat().st_mtime)
+        if mtime < cycle_started_at:
+            return (
+                f"Eval was skipped: .factory/last_eval.json is stale "
+                f"(modified {mtime.isoformat()}, cycle started {cycle_started_at.isoformat()})"
+            )
+
+    return None
+
+
 def snapshot_eval_tree(project_path: Path) -> str:
     """Take a snapshot of eval/ tree for later comparison."""
     try:
@@ -185,6 +260,7 @@ def check_all(
     eval_tree_before: str | None = None,
     allowed_scope: list[str] | None = None,
     fixed_surfaces: list[str] | None = None,
+    cycle_started_at: datetime | None = None,
 ) -> list[str]:
     """Run all guards, return list of violation strings (empty = pass)."""
     violations: list[str] = []
@@ -209,6 +285,15 @@ def check_all(
 
     if fixed_surfaces:
         v = check_fixed_surfaces(project_path, baseline_sha, fixed_surfaces)
+        if v:
+            violations.append(v)
+
+    v = check_test_deletion(project_path, baseline_sha)
+    if v:
+        violations.append(v)
+
+    if cycle_started_at is not None:
+        v = check_eval_not_skipped(project_path, cycle_started_at)
         if v:
             violations.append(v)
 

--- a/factory/eval/guards.py
+++ b/factory/eval/guards.py
@@ -2,7 +2,7 @@
 
 import fnmatch
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path, PurePath
 
 
@@ -236,7 +236,7 @@ def check_eval_not_skipped(
         return "Eval was skipped: .factory/last_eval.json does not exist"
 
     if cycle_started_at is not None:
-        mtime = datetime.fromtimestamp(last_eval.stat().st_mtime)
+        mtime = datetime.fromtimestamp(last_eval.stat().st_mtime, tz=timezone.utc)
         if mtime < cycle_started_at:
             return (
                 f"Eval was skipped: .factory/last_eval.json is stale "

--- a/factory/store.py
+++ b/factory/store.py
@@ -635,18 +635,29 @@ class ExperimentStore:
 
     def record_build_phase(self, phase_num: int, pr_number: int | None = None) -> None:
         """Record a completed build phase in build_phases_done.json."""
+        self.factory_dir.mkdir(parents=True, exist_ok=True)
         phases_path = self.factory_dir / "build_phases_done.json"
         if phases_path.exists():
-            data = json.loads(phases_path.read_text())
+            try:
+                data = json.loads(phases_path.read_text())
+            except (json.JSONDecodeError, ValueError):
+                data = {"completed": []}
+            if not isinstance(data, dict):
+                data = {"completed": []}
         else:
             data = {"completed": []}
+
+        existing_phases = {e["phase"] for e in data.get("completed", []) if isinstance(e, dict)}
+        if phase_num in existing_phases:
+            log.info("record_build_phase_duplicate", phase=phase_num)
+            return
 
         entry: dict[str, int | str | None] = {
             "phase": phase_num,
             "pr": pr_number,
             "timestamp": datetime.now().isoformat(),
         }
-        data["completed"].append(entry)
+        data.setdefault("completed", []).append(entry)
 
         phases_path.write_text(json.dumps(data, indent=2) + "\n")
         log.info("record_build_phase", phase=phase_num, pr=pr_number)

--- a/factory/store.py
+++ b/factory/store.py
@@ -633,6 +633,24 @@ class ExperimentStore:
         log.debug("read_eval_profile_loaded", dimension_count=len(data.get("dimensions", [])))
         return EvalProfile(**data)
 
+    def record_build_phase(self, phase_num: int, pr_number: int | None = None) -> None:
+        """Record a completed build phase in build_phases_done.json."""
+        phases_path = self.factory_dir / "build_phases_done.json"
+        if phases_path.exists():
+            data = json.loads(phases_path.read_text())
+        else:
+            data = {"completed": []}
+
+        entry: dict[str, int | str | None] = {
+            "phase": phase_num,
+            "pr": pr_number,
+            "timestamp": datetime.now().isoformat(),
+        }
+        data["completed"].append(entry)
+
+        phases_path.write_text(json.dumps(data, indent=2) + "\n")
+        log.info("record_build_phase", phase=phase_num, pr=pr_number)
+
     async def read_strategy(self) -> str | None:
         """Read strategy/current.md, return None if missing."""
         strategy_path = self.factory_dir / "strategy" / "current.md"

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -127,6 +127,49 @@ class TestBudgetAllowsRespawn:
         assert _budget_allows_respawn(None, tmp_path) is True
 
 
+class TestCountHypotheses:
+    """Tests for _count_hypotheses() with both H and Phase heading formats."""
+
+    def test_count_hypotheses_matches_phase_headings(self, tmp_path: Path) -> None:
+        """Strategy file with Phase headings returns correct count."""
+        from factory.ceo_completion import _count_hypotheses
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "## Build Plan\n\n### Phase 1: Scaffold\n\n### Phase 2: Core logic\n"
+        )
+
+        assert _count_hypotheses(tmp_path) == 2
+
+    def test_count_hypotheses_matches_h_headings(self, tmp_path: Path) -> None:
+        """Strategy file with H-style headings still returns correct count."""
+        from factory.ceo_completion import _count_hypotheses
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "### Hypotheses\n\n#### H1: Improve caching\n\n#### H2: Add retry logic\n"
+        )
+
+        assert _count_hypotheses(tmp_path) == 2
+
+    def test_count_hypotheses_mixed_headings(self, tmp_path: Path) -> None:
+        """Strategy file with both Phase and H markers counts both."""
+        from factory.ceo_completion import _count_hypotheses
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "## Plan\n\n"
+            "### Phase 1: Setup\n\n"
+            "### Phase 2: Build\n\n"
+            "#### H1: Fix edge case\n\n"
+        )
+
+        assert _count_hypotheses(tmp_path) == 3
+
+
 class TestDetectIncomplete:
     """Tests for _detect_incomplete()."""
 
@@ -193,6 +236,56 @@ class TestDetectIncomplete:
 
         gap = _detect_incomplete(tmp_path, "improve")
         assert gap is None
+
+    def test_build_completion_via_phases_done_json(self, tmp_path: Path) -> None:
+        """Build mode is complete when build_phases_done.json has all phases."""
+        from factory.ceo_completion import _detect_incomplete
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "### Phase 1: Scaffold\n\n### Phase 2: Core\n\n### Phase 3: Tests\n"
+        )
+
+        phases_data = {
+            "completed": [
+                {"phase": 1, "pr": 10, "timestamp": "2026-06-26T10:00:00"},
+                {"phase": 2, "pr": 11, "timestamp": "2026-06-26T11:00:00"},
+                {"phase": 3, "pr": 12, "timestamp": "2026-06-26T12:00:00"},
+            ]
+        }
+        (tmp_path / ".factory" / "build_phases_done.json").write_text(
+            json.dumps(phases_data)
+        )
+
+        gap = _detect_incomplete(tmp_path, "build")
+        assert gap is None
+
+    def test_build_incomplete_when_phases_missing(self, tmp_path: Path) -> None:
+        """Build mode is incomplete when build_phases_done.json has fewer phases than planned."""
+        from factory.ceo_completion import _detect_incomplete
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "### Phase 1: Scaffold\n\n### Phase 2: Core\n\n### Phase 3: Tests\n"
+        )
+
+        phases_data = {
+            "completed": [
+                {"phase": 1, "pr": 10, "timestamp": "2026-06-26T10:00:00"},
+            ]
+        }
+        (tmp_path / ".factory" / "build_phases_done.json").write_text(
+            json.dumps(phases_data)
+        )
+
+        gap = _detect_incomplete(tmp_path, "build")
+        assert gap is not None
+        assert gap.planned == 3
+        assert gap.completed == 1
+        assert gap.next_item == "Phase2"
+        assert "build_phases_done.json" in gap.reason
 
     def test_discover_complete_when_profile_exists(self, tmp_path: Path) -> None:
         """Discover mode is complete when eval_profile.json exists."""

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -1268,6 +1268,74 @@ class TestCeoPromptResearchMode:
         assert "workflow-research" in ceo_prompt
 
 
+class TestRecordBuildPhase:
+    """Tests for ExperimentStore.record_build_phase() write path."""
+
+    def test_record_build_phase_basic(self, tmp_path: Path) -> None:
+        """Record a phase, verify JSON content."""
+        from factory.store import ExperimentStore
+
+        store = ExperimentStore(tmp_path)
+        (tmp_path / ".factory").mkdir()
+        store.record_build_phase(1, pr_number=42)
+
+        phases_path = tmp_path / ".factory" / "build_phases_done.json"
+        data = json.loads(phases_path.read_text())
+        assert len(data["completed"]) == 1
+        assert data["completed"][0]["phase"] == 1
+        assert data["completed"][0]["pr"] == 42
+
+    def test_record_build_phase_deduplicates(self, tmp_path: Path) -> None:
+        """Recording the same phase twice results in only 1 entry."""
+        from factory.store import ExperimentStore
+
+        store = ExperimentStore(tmp_path)
+        (tmp_path / ".factory").mkdir()
+        store.record_build_phase(1, pr_number=10)
+        store.record_build_phase(1, pr_number=10)
+
+        phases_path = tmp_path / ".factory" / "build_phases_done.json"
+        data = json.loads(phases_path.read_text())
+        assert len(data["completed"]) == 1
+
+    def test_record_build_phase_handles_malformed_json(self, tmp_path: Path) -> None:
+        """Corrupt file is recovered gracefully."""
+        from factory.store import ExperimentStore
+
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "build_phases_done.json").write_text("NOT VALID JSON {{{")
+
+        store = ExperimentStore(tmp_path)
+        store.record_build_phase(1, pr_number=5)
+
+        data = json.loads((factory_dir / "build_phases_done.json").read_text())
+        assert len(data["completed"]) == 1
+        assert data["completed"][0]["phase"] == 1
+
+    def test_count_build_phases_done_non_dict_json(self, tmp_path: Path) -> None:
+        """A JSON array in build_phases_done.json returns 0."""
+        from factory.ceo_completion import _count_build_phases_done
+
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "build_phases_done.json").write_text("[1, 2, 3]")
+
+        assert _count_build_phases_done(tmp_path) == 0
+
+    def test_record_build_phase_creates_factory_dir(self, tmp_path: Path) -> None:
+        """record_build_phase creates .factory/ if it doesn't exist."""
+        from factory.store import ExperimentStore
+
+        store = ExperimentStore(tmp_path)
+        store.record_build_phase(1, pr_number=7)
+
+        phases_path = tmp_path / ".factory" / "build_phases_done.json"
+        assert phases_path.exists()
+        data = json.loads(phases_path.read_text())
+        assert len(data["completed"]) == 1
+
+
 class TestCeoCompletionBackgroundBypass:
     """Tests for background=True bypassing the respawn loop."""
 

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -2,7 +2,7 @@
 
 import json
 import subprocess
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -285,7 +285,7 @@ class TestCheckEvalNotSkipped:
         factory_dir.mkdir()
         last_eval = factory_dir / "last_eval.json"
         last_eval.write_text(json.dumps({"total": 0.8}))
-        cycle_started_at = datetime.now() - timedelta(minutes=5)
+        cycle_started_at = datetime.now(timezone.utc) - timedelta(minutes=5)
         result = check_eval_not_skipped(git_project, cycle_started_at)
         assert result is None
 
@@ -294,15 +294,24 @@ class TestCheckEvalNotSkipped:
         assert result is not None
         assert "does not exist" in result
 
+    def test_check_eval_not_skipped_with_tz_aware_cycle(self, git_project):
+        factory_dir = git_project / ".factory"
+        factory_dir.mkdir()
+        last_eval = factory_dir / "last_eval.json"
+        last_eval.write_text(json.dumps({"total": 0.8}))
+        cycle_started_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+        result = check_eval_not_skipped(git_project, cycle_started_at)
+        assert result is None
+
     def test_fails_when_stale(self, git_project):
         factory_dir = git_project / ".factory"
         factory_dir.mkdir()
         last_eval = factory_dir / "last_eval.json"
         last_eval.write_text(json.dumps({"total": 0.8}))
         import os
-        stale_time = (datetime.now() - timedelta(hours=2)).timestamp()
+        stale_time = (datetime.now(timezone.utc) - timedelta(hours=2)).timestamp()
         os.utime(last_eval, (stale_time, stale_time))
-        cycle_started_at = datetime.now() - timedelta(minutes=5)
+        cycle_started_at = datetime.now(timezone.utc) - timedelta(minutes=5)
         result = check_eval_not_skipped(git_project, cycle_started_at)
         assert result is not None
         assert "stale" in result

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -1,6 +1,8 @@
 """Tests for factory.eval.guards — safety checks."""
 
+import json
 import subprocess
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -8,10 +10,12 @@ import pytest
 from factory.eval.guards import (
     _glob_match,
     check_eval_immutable,
+    check_eval_not_skipped,
     check_experiment_branch,
     check_fixed_surfaces,
     check_git_clean,
     check_scope,
+    check_test_deletion,
     snapshot_eval_tree,
     check_all,
 )
@@ -225,3 +229,80 @@ class TestCheckAll:
             fixed_surfaces=["truth.json"],
         )
         assert any("Fixed surface" in v for v in violations)
+
+
+class TestCheckTestDeletion:
+    def test_detects_deleted_test_file(self, git_project):
+        (git_project / "tests").mkdir()
+        (git_project / "tests" / "test_foo.py").write_text("def test_x(): pass\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "add test"], git_project)
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "tests" / "test_foo.py").unlink()
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "delete test"], git_project)
+        result = check_test_deletion(git_project, baseline)
+        assert result is not None
+        assert "test_foo.py" in result
+
+    def test_ignores_non_test_files(self, git_project):
+        (git_project / "src" / "utils.py").write_text("x = 1\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "add utils"], git_project)
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "src" / "utils.py").unlink()
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "delete utils"], git_project)
+        result = check_test_deletion(git_project, baseline)
+        assert result is None
+
+    def test_detects_test_in_nested_dir(self, git_project):
+        (git_project / "tests").mkdir()
+        (git_project / "tests" / "unit").mkdir()
+        (git_project / "tests" / "unit" / "test_bar.py").write_text("def test_y(): pass\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "add nested test"], git_project)
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "tests" / "unit" / "test_bar.py").unlink()
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "delete nested test"], git_project)
+        result = check_test_deletion(git_project, baseline)
+        assert result is not None
+        assert "test_bar.py" in result
+
+    def test_clean_when_no_deletions(self, git_project):
+        baseline = _git(["rev-parse", "HEAD"], git_project).stdout.strip()
+        (git_project / "src" / "new.py").write_text("new\n")
+        _git(["add", "."], git_project)
+        _git(["commit", "-m", "add file"], git_project)
+        result = check_test_deletion(git_project, baseline)
+        assert result is None
+
+
+class TestCheckEvalNotSkipped:
+    def test_passes_when_recent(self, git_project):
+        factory_dir = git_project / ".factory"
+        factory_dir.mkdir()
+        last_eval = factory_dir / "last_eval.json"
+        last_eval.write_text(json.dumps({"total": 0.8}))
+        cycle_started_at = datetime.now() - timedelta(minutes=5)
+        result = check_eval_not_skipped(git_project, cycle_started_at)
+        assert result is None
+
+    def test_fails_when_missing(self, git_project):
+        result = check_eval_not_skipped(git_project)
+        assert result is not None
+        assert "does not exist" in result
+
+    def test_fails_when_stale(self, git_project):
+        factory_dir = git_project / ".factory"
+        factory_dir.mkdir()
+        last_eval = factory_dir / "last_eval.json"
+        last_eval.write_text(json.dumps({"total": 0.8}))
+        import os
+        stale_time = (datetime.now() - timedelta(hours=2)).timestamp()
+        os.utime(last_eval, (stale_time, stale_time))
+        cycle_started_at = datetime.now() - timedelta(minutes=5)
+        result = check_eval_not_skipped(git_project, cycle_started_at)
+        assert result is not None
+        assert "stale" in result


### PR DESCRIPTION
Closes #783
Closes #796

## Changes

### H1: Fix build mode completion tracking (#783)
- **Updated `_count_hypotheses()` regex** in `factory/ceo_completion.py` to match both `H\d+:` and `Phase \d+:` headings — build mode uses Phase headings that were previously invisible to the completion guard
- **Added `_count_build_phases_done()` helper** in `factory/ceo_completion.py` to read `.factory/build_phases_done.json` as ground-truth completion tracking for build mode
- **Updated `_detect_incomplete()` build mode branch** to check `build_phases_done.json` when `_count_verdicts()` returns 0, breaking the infinite respawn loop
- **Added `record_build_phase()` method** on `ExperimentStore` in `factory/store.py` — writes/appends to `.factory/build_phases_done.json` with phase number, PR number, and timestamp
- **Added `record-phase` CLI subcommand** in `factory/cli.py` — enables builders to call `factory record-phase <path> <N> [--pr <PR>]` after opening a PR
- **Added 5 tests** in `tests/test_ceo_completion.py`

### H2: Enforce Sacred Rules 4-5 in factory guard (#796)
- **Added `check_test_deletion()`** to `factory/eval/guards.py` — detects deleted test files via `git diff --name-status`, matching `test_*`, `_test.`, and `/tests/` patterns. Always-on in `check_all()`.
- **Added `check_eval_not_skipped()`** to `factory/eval/guards.py` — verifies `.factory/last_eval.json` exists and mtime is after cycle start. Active when `cycle_started_at` is provided.
- **Wired both into `check_all()`** with new `cycle_started_at` parameter
- **Updated `cmd_guard`** in `factory/cli.py` to load `cycle_started_at` from `.factory/state/cycle.json`
- **Added 7 tests** in `tests/test_guards.py` for both new guards