### PR TITLE
docs: remove Build as separate entry point — fold into Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ See the [full setup guide](docs/setup.md) for authentication and environment var
 |---|---|
 | **Start from a raw idea** | `uv run factory ceo "my idea" --mode design` |
 | **Improve an existing project** | `uv run factory ceo /path/to/project --mode improve` |
-| **Fix or add one thing** | `uv run factory ceo /path --focus "add dark mode"` |
-| **Target a GitHub issue** | `uv run factory ceo /path --focus 42` |
 
 ---
 
@@ -77,9 +75,9 @@ You can also pass a spec file or URL directly — `uv run factory ceo spec.md` �
 
 ---
 
-## Improve + Focus Workflow
+## Improve Workflow
 
-Point re:factory at an existing project for continuous improvement:
+Improve mode is re:factory's continuous improvement loop for existing projects. Point it at a codebase and it autonomously observes the project state, generates hypotheses for improvements, builds and tests changes, and keeps or reverts each experiment based on eval scores.
 
 ```bash
 uv run factory ceo ~/factory-projects/my-app --mode improve
@@ -90,9 +88,9 @@ Each cycle: **observe** → **hypothesize** → **build** → **review** → **m
 When you know exactly what you want, `--focus` pins a single target — one hypothesis, one experiment, done:
 
 ```bash
-uv run factory ceo ~/my-app --focus "add dark mode toggle"
-uv run factory ceo ~/my-app --focus 42                       # GitHub issue
-uv run factory ceo ~/my-app --focus "owner/repo#42"          # Issue shorthand
+uv run factory ceo ~/my-app --mode improve --focus "add dark mode toggle"
+uv run factory ceo ~/my-app --mode improve --focus 42                       # GitHub issue
+uv run factory ceo ~/my-app --mode improve --focus "owner/repo#42"          # Issue shorthand
 ```
 
 Other ways to steer: file GitHub issues (the Strategist reads them), add to the backlog manually, or pass a spec file with `--prompt`.
@@ -148,7 +146,6 @@ Built something with re:factory? Open a PR to add it here.
 # Core workflow
 uv run factory ceo "idea" --mode design         # Design from a raw idea
 uv run factory ceo <path> --mode improve        # Improve an existing project
-uv run factory ceo <path> --focus "..."         # One target, one experiment
 uv run factory ceo <path> --refine "..."        # Single targeted refinement
 uv run factory ceo <path> --loop                # Continuous improvement loop
 uv run factory tmux <path> --loop               # Loop in detached tmux session

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ See the [full setup guide](docs/setup.md) for authentication and environment var
 | I want to… | Command |
 |---|---|
 | **Start from a raw idea** | `uv run factory ceo "my idea" --mode design` |
-| **Build from a spec or repo** | `uv run factory ceo spec.md` |
 | **Improve an existing project** | `uv run factory ceo /path/to/project` |
 | **Fix or add one thing** | `uv run factory ceo /path --focus "add dark mode"` |
 | **Target a GitHub issue** | `uv run factory ceo /path --focus 42` |
@@ -78,21 +77,7 @@ uv run factory ceo ~/factory-projects/my-app --mode design
 uv run factory ceo ~/factory-projects/my-app --mode design --focus "auth layer"
 ```
 
----
-
-## Build Workflow
-
-When you already have a spec file, a GitHub repo, or a clear description, re:factory builds directly — no design step needed:
-
-```bash
-uv run factory ceo ~/ideas/spec.md
-uv run factory ceo https://github.com/user/repo
-uv run factory ceo "Build a personal homepage with a blog"
-```
-
-The pipeline: **Researcher** surveys best practices → **Strategist** creates a plan → **Builder** implements and commits → **E2E gate** confirms it runs. Override the output directory with `--dir my-site`. (If you start with a raw idea via `--mode design`, the CEO refines it into a spec first, then transitions into this same build pipeline automatically. `--mode interactive` remains accepted as an alias.)
-
-After the first build, a backlog appears at `.factory/strategy/backlog.md` — deferred features that feed future improvement cycles. Manage it with `uv run factory backlog-list`, `uv run factory backlog-add`, and `uv run factory backlog-remove`.
+You can also pass a spec file or URL directly — `uv run factory ceo spec.md` — and re:factory builds without the design conversation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,18 +27,14 @@ cd remote-factory
 uv sync
 ```
 
-Then just run:
+Then start with one of the two main workflows:
 
 ```bash
-uv run factory
-```
+# Design — brainstorm an idea, refine it, then build
+uv run factory ceo "my idea" --mode design
 
-The **welcome wizard** launches automatically — a conversational agent that asks what you want to do, classifies your input (an idea, a file path, a GitHub URL, or a description), and presents the right command. No flags to memorize. Paste an idea and the wizard handles the rest.
-
-You can also skip the wizard and call commands directly:
-
-```bash
-uv run factory ceo "Build a personal homepage with a blog" --mode design
+# Improve — point at an existing project for continuous improvement
+uv run factory ceo /path/to/project --mode improve
 ```
 
 See the [full setup guide](docs/setup.md) for authentication and environment variables.
@@ -50,7 +46,7 @@ See the [full setup guide](docs/setup.md) for authentication and environment var
 | I want to… | Command |
 |---|---|
 | **Start from a raw idea** | `uv run factory ceo "my idea" --mode design` |
-| **Improve an existing project** | `uv run factory ceo /path/to/project` |
+| **Improve an existing project** | `uv run factory ceo /path/to/project --mode improve` |
 | **Fix or add one thing** | `uv run factory ceo /path --focus "add dark mode"` |
 | **Target a GitHub issue** | `uv run factory ceo /path --focus 42` |
 
@@ -83,10 +79,10 @@ You can also pass a spec file or URL directly — `uv run factory ceo spec.md` �
 
 ## Improve + Focus Workflow
 
-Point re:factory at an existing project and it enters Improve mode automatically:
+Point re:factory at an existing project for continuous improvement:
 
 ```bash
-uv run factory ceo ~/factory-projects/my-app
+uv run factory ceo ~/factory-projects/my-app --mode improve
 ```
 
 Each cycle: **observe** → **hypothesize** → **build** → **review** → **measure** → **decide** (keep or revert) → **archive**. The Strategist picks work from the backlog using FEEC priority (Fix > Exploit > Explore > Combine).
@@ -150,8 +146,8 @@ Built something with re:factory? Open a PR to add it here.
 
 ```bash
 # Core workflow
-uv run factory ceo <path|url|idea>              # Build or improve
-uv run factory ceo <path> --mode design         # Discuss, then execute
+uv run factory ceo "idea" --mode design         # Design from a raw idea
+uv run factory ceo <path> --mode improve        # Improve an existing project
 uv run factory ceo <path> --focus "..."         # One target, one experiment
 uv run factory ceo <path> --refine "..."        # Single targeted refinement
 uv run factory ceo <path> --loop                # Continuous improvement loop


### PR DESCRIPTION
Closes #807

## Changes

- Removed the standalone **Build Workflow** section (lines 83–96) — build is what happens after Design, not a separate entry point
- Removed the "Build from a spec or repo" row from the "What Do You Want to Do?" table
- Added a note at the end of the Design Workflow section mentioning that spec files and URLs can be passed directly for building without the design conversation