### PR TITLE
feat: add create mode (W₉) for building new factory modes

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -310,6 +310,7 @@ Each mode's full instructions live in a workflow skill under `skills/workflow-<n
 - `--mode research` (with `research_target` configured) → read `skills/workflow-research/SKILL.md`
 - `--mode meta` → read `skills/workflow-meta/SKILL.md`
 - `--refine "<request>"` → read `skills/workflow-refine/SKILL.md`
+- `--mode create` or `## Create Mode` → read `skills/workflow-create/SKILL.md`
 
 **Invocation:** Read the selected SKILL.md file, then follow its instructions as your mode-specific playbook. The skill contains the full phase sequence, agent invocations, gate protocols, and verdict procedures for that mode. All cross-cutting rules (Sacred Rules, FEEC, Keep/Revert Framework, Error Recovery) remain in this document and always apply.
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -214,6 +214,7 @@ Given the user's input, return a JSON object with two keys: "follow_ups" and "su
 | `factory ceo {path} --mode improve --focus {issue}` | Target a specific GitHub issue number |
 | `factory ceo {path} --mode design` | Discuss what to work on in an existing project |
 | `factory ceo {path} --mode meta` | Self-improve the factory's own agents |
+| `factory ceo {path} --mode create` | Create a new factory mode (workflow + skill) |
 
 ## Information requirements per mode
 
@@ -288,7 +289,7 @@ Return ONLY a JSON object (no markdown, no explanation):
 6. For new ideas, commands should use the literal user text in quotes — no placeholders
 7. For existing projects, use {path} placeholder and add a path follow-up
 8. If the user mentions fixing/improving an EXISTING project, do NOT wrap input as a new idea
-9. Every generated command MUST include an explicit `--mode` flag (improve, design, research, meta, or build)
+9. Every generated command MUST include an explicit `--mode` flag (improve, design, research, meta, build, or create)
 10. When the input is a GitHub URL (clone scenario), always append `--clean-pr` to the generated command
 
 User input: """
@@ -411,7 +412,10 @@ _CLI_REF = """\
     factory ceo ~/projects/my-app --mode design
 
   Self-improve the factory:
-    factory ceo /path/to/factory --mode meta\
+    factory ceo /path/to/factory --mode meta
+
+  Create a new factory mode:
+    factory ceo /path/to/factory --mode create\
 """
 
 
@@ -2481,6 +2485,22 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                   file=sys.stderr)
             return 1
 
+    if mode == "create":
+        if headless:
+            flag = "--bg" if bg else "--headless"
+            print(f"Error: --mode create requires foreground mode "
+                  f"(incompatible with {flag})", file=sys.stderr)
+            return 1
+        if prompt_file:
+            print("Error: --mode create and --prompt are mutually exclusive. "
+                  "Create mode generates the workflow from a description.",
+                  file=sys.stderr)
+            return 1
+        if focus:
+            print("Error: --mode create and --focus are mutually exclusive.",
+                  file=sys.stderr)
+            return 1
+
     if mode == "research":
         if prompt_file:
             print("Error: --mode research and --prompt are mutually exclusive. "
@@ -2488,12 +2508,22 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                   file=sys.stderr)
             return 1
 
+    create_description: str | None = None
     design_idea: str | None = None
     design_existing: bool = False
     research_ideation: str | None = None
     deferred_spec: str | None = None
     needs_materialize = False
-    if mode == "design" and _design_is_existing:
+    if mode == "create":
+        resolved_path = Path(raw_path).expanduser().resolve()
+        if not _safe_is_dir(resolved_path):
+            print("Error: --mode create requires an existing project directory. "
+                  "Pass the factory project path: factory ceo /path/to/factory --mode create",
+                  file=sys.stderr)
+            return 1
+        project_path, context = _resolve_input(raw_path, dir_name=dir_name)
+        create_description = context
+    elif mode == "design" and _design_is_existing:
         project_path, context = _resolve_input(raw_path, dir_name=dir_name)
         design_existing = True
     elif mode == "design":
@@ -2614,8 +2644,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     base_branch = branch or _read_target_branch(project_path)
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
-    interactive = design_existing or bool(design_idea) or bool(research_ideation)
-    ceo_mode = "build" if interactive else mode
+    interactive = design_existing or bool(design_idea) or bool(research_ideation) or mode == "create"
+    ceo_mode = "create" if mode == "create" else ("build" if interactive else mode)
     if clean_pr_flag is not None:
         clean_pr_resolved = clean_pr_flag
     else:
@@ -2642,6 +2672,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         refine_request=refine_request,
         clean_pr=clean_pr_resolved,
         display_mode=banner_mode,
+        create_description=create_description,
     )
 
     session_name = _derive_session_name(
@@ -3481,6 +3512,7 @@ def _build_ceo_task(
     refine_request: str | None = None,
     clean_pr: bool = False,
     display_mode: str | None = None,
+    create_description: str | None = None,
 ) -> str:
     """Build the CEO agent task string from mode and optional context."""
     shown_mode = display_mode if display_mode is not None else mode
@@ -3541,6 +3573,23 @@ def _build_ceo_task(
             f"config to .factory/strategy/current.md, then proceed to Build mode. "
             f"During Review mode (factory.md creation), populate the research sections "
             f"from the approved spec.\n"
+        )
+
+    if create_description:
+        task += (
+            f"\n\n## Create Mode (New Factory Mode)\n\n"
+            f"**Mode description from user:**\n{create_description}\n\n"
+            f"You are in Create mode — a meta-mode for creating new factory modes.\n\n"
+            f"Follow the Create workflow (skills/workflow-create/SKILL.md):\n"
+            f"1. Research existing workflow patterns and the user's intent\n"
+            f"2. Synthesize a complete workflow specification\n"
+            f"3. Present the spec to the user for interactive approval\n"
+            f"4. Implement: workflow definition, SKILL.md, CLI wiring, tests\n"
+            f"5. QA verification (graph validates, SKILL.md generates, CLI recognizes mode)\n"
+            f"6. Open PR for review\n\n"
+            f"The implementation targets THIS project (the factory codebase). "
+            f"Key files to modify: factory/workflow/definitions.py, "
+            f"factory/workflow/skill_export.py, factory/cli.py, tests/.\n"
         )
 
     if prompt_file:
@@ -3634,6 +3683,12 @@ def _build_ceo_task(
             "metric, implement the change within mutable_surfaces only (leave fixed_surfaces "
             "untouched), run the research command, compare results against the target, and "
             "make a keep/revert decision. Respect research_constraints and cost_budget."
+        )
+    elif mode == "create":
+        task += (
+            "\n\nRun Create mode: read `skills/workflow-create/SKILL.md` for the full "
+            "step-by-step playbook. This mode creates a new factory mode (workflow + skill + "
+            "CLI wiring + tests) from the user's description above."
         )
 
     if no_github:
@@ -4379,11 +4434,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "research", "review"],
+        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "research", "review", "create"],
         default="auto",
         help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
              "build, discover, improve, meta, design (research + brainstorm → spec → build), "
-             "research (autonomous research optimization), or review (on-demand PR review)",
+             "research (autonomous research optimization), review (on-demand PR review), "
+             "or create (meta-mode for creating new factory modes)",
     )
     p.add_argument(
         "--focus", default=None,

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -1,4 +1,4 @@
-"""All 8 workflow definitions as Python functions returning Workflow objects.
+"""All 9 workflow definitions as Python functions returning Workflow objects.
 
 W₁: Build Mode
 W₂: Design Mode (= W₁ with user gate at strategy approval)
@@ -8,6 +8,7 @@ W₅: Meta Mode
 W₆: Discover Mode
 W₇: Review Mode
 W₈: Refine Mode
+W₉: Create Mode (meta-mode for creating new factory modes)
 """
 
 from __future__ import annotations
@@ -38,6 +39,7 @@ __all__ = [
     "discover_workflow",
     "review_workflow",
     "refine_workflow",
+    "create_workflow",
     "register_all",
 ]
 
@@ -1190,11 +1192,288 @@ def refine_workflow() -> Workflow:
     )
 
 
+# ── W₉: Create Mode ──────────────────────────────────────────────
+
+
+def create_workflow() -> Workflow:
+    """W₉: Create Mode — meta-mode for creating new factory modes.
+
+    Takes a user description and produces a fully working workflow definition,
+    SKILL.md, CLI wiring, and tests.
+
+    Fork(3 researchers) → Join → CEO gate → Strategist → User gate →
+    Archivist(async) → Builder → CEO gate → QA → gate_qa(max 3) →
+    Precheck gate → Archivist(async)
+    """
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # Fork: 3 parallel researchers
+    nodes["fork_research"] = ForkNode(
+        id="fork_research",
+        targets=["researcher_existing", "researcher_intent", "researcher_practices"],
+    )
+
+    nodes["researcher_existing"] = AgentNode(
+        id="researcher_existing",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Existing workflow analysis. "
+            "Read factory/workflow/definitions.py and analyze all existing workflow "
+            "definitions (build, design, improve, research, meta, discover, review, refine). "
+            "Document common patterns: node sequences, gate conventions, fork/join patterns, "
+            "archivist placement, edge wiring, trigger functions, reads/writes declarations. "
+            "Read factory/workflow/primitives.py for available node types and their fields. "
+            "Read factory/workflow/skill_export.py for WORKFLOW_META format. "
+            "Write findings to .factory/strategy/research-existing.md covering: "
+            "node type usage patterns, common subgraphs (builder→gate→qa→gate loop), "
+            "trigger function conventions, data flow patterns."
+        ),
+        writes={".factory/strategy/research-existing.md"},
+    )
+
+    nodes["researcher_intent"] = AgentNode(
+        id="researcher_intent",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Mode description analysis. "
+            "Read the user's mode description from the CEO task. "
+            "Parse and structure it into a workflow specification: "
+            "- Purpose and trigger conditions "
+            "- Agent roles needed (which specialists) "
+            "- Gate logic (user vs agent vs fn evaluators) "
+            "- Data flow (what files are read/written) "
+            "- Interactive vs headless requirements "
+            "- Input format (text, file, drawing, flow) "
+            "Write findings to .factory/strategy/research-intent.md covering: "
+            "structured requirements, node candidates, suggested graph topology."
+        ),
+        writes={".factory/strategy/research-intent.md"},
+    )
+
+    nodes["researcher_practices"] = AgentNode(
+        id="researcher_practices",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Workflow design best practices. "
+            "Search the web for workflow and pipeline design patterns relevant "
+            "to the described mode. Look for: DAG design patterns, agent orchestration "
+            "patterns, quality gate strategies, error recovery approaches. "
+            "Check .factory/archive/ for lessons from past mode creation or workflow changes. "
+            "Write findings to .factory/strategy/research-practices.md covering: "
+            "relevant design patterns, pitfalls to avoid, testing strategies."
+        ),
+        writes={".factory/strategy/research-practices.md"},
+    )
+
+    # Join
+    nodes["join_research"] = JoinNode(
+        id="join_research",
+        sources=["researcher_existing", "researcher_intent", "researcher_practices"],
+        reads={
+            ".factory/strategy/research-existing.md",
+            ".factory/strategy/research-intent.md",
+            ".factory/strategy/research-practices.md",
+        },
+        writes={".factory/strategy/research-combined.md"},
+    )
+
+    # CEO gate on research quality
+    nodes["gate_research"] = GateNode(
+        id="gate_research",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Are the existing workflow patterns well-documented? "
+            "Is the user's intent clearly structured into workflow requirements? "
+            "Are best practices relevant to this type of mode? Any gaps?"
+        ),
+        reads={".factory/strategy/research-combined.md"},
+    )
+
+    # Strategist synthesizes workflow specification
+    nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Synthesize a complete workflow specification for a new factory mode. "
+            "Read ALL tagged research files at .factory/strategy/research-*.md. "
+            "Produce a complete specification including: "
+            "1) Python code for the workflow function (nodes dict, edges list, trigger) "
+            "2) WORKFLOW_META entry (description, argument_hint) "
+            "3) CLI wiring changes (build_parser mode choices, cmd_ceo routing, _build_ceo_task section) "
+            "4) Test cases (graph validation, skill export, trigger function, registration) "
+            "5) Node details: for each node, specify id, type, role, prompt_template, reads, writes "
+            "6) Edge details: for each edge, specify source, target, condition "
+            "7) Interactive vs headless behavior "
+            "Follow conventions from existing workflows — use the same patterns for "
+            "builder→gate→QA→gate loops, archivist placement, and research forks. "
+            "Write the specification to .factory/strategy/current.md."
+        ),
+        reads={".factory/strategy/research-combined.md"},
+        writes={".factory/strategy/current.md"},
+    )
+
+    # User gate for workflow spec approval — interactive
+    nodes["gate_strategy"] = GateNode(
+        id="gate_strategy",
+        evaluator_type="user",
+        reads={".factory/strategy/current.md"},
+    )
+
+    # Archivist (async, non-blocking)
+    nodes["archivist_plan"] = AgentNode(
+        id="archivist_plan",
+        role=AgentRole.ARCHIVIST,
+        prompt_template="Archive the approved workflow specification for the new mode.",
+        reads={".factory/strategy/current.md"},
+        writes={".factory/archive/create-plan.md"},
+        blocking=False,
+    )
+
+    # Builder implements everything
+    nodes["builder"] = AgentNode(
+        id="builder",
+        role=AgentRole.BUILDER,
+        prompt_template=(
+            "Implement the new factory mode from the approved workflow specification. "
+            "Read the approved spec at .factory/strategy/current.md. "
+            "Read CLAUDE.md for project conventions. "
+            "Implementation checklist: "
+            "1) Add the workflow function to factory/workflow/definitions.py "
+            "2) Register it in register_all() "
+            "3) Add WORKFLOW_META entry in factory/workflow/skill_export.py "
+            "4) Wire --mode in factory/cli.py (build_parser, cmd_ceo, _build_ceo_task) "
+            "5) Run factory workflow validate <name> to verify the graph "
+            "6) Run factory workflow export-skills to generate the SKILL.md "
+            "7) Write tests in tests/ "
+            "8) Run pytest and ruff check to verify "
+            "Commit changes and open a draft PR."
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    # CEO gate on build
+    nodes["gate_build"] = GateNode(
+        id="gate_build",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Read builder output and PR diff. Does work match the approved spec? "
+            "Verify: workflow function exists, registered in register_all(), "
+            "WORKFLOW_META entry added, CLI wiring complete, tests written. "
+            "REDIRECT if any component is missing."
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # QA verification
+    nodes["qa"] = AgentNode(
+        id="qa",
+        role=AgentRole.QA,
+        prompt_template=(
+            "Verify the new factory mode end-to-end. "
+            "1. Health Check — run pytest, ruff check, mypy. Report results. "
+            "2. Code Review — read PR diff, evaluate correctness, architecture, "
+            "edge cases, security. Verify workflow graph validates. "
+            "3. Adversarial QA — actually test the new mode: "
+            "   - Run: factory workflow validate <name> "
+            "   - Run: factory workflow show <name> "
+            "   - Run: factory workflow export-skills --verify "
+            "   - Verify SKILL.md was generated under skills/workflow-<name>/ "
+            "   - Check CLI recognizes --mode <name> (factory ceo --help) "
+            "   - Check the workflow handles both interactive and headless paths "
+            "Write results to .factory/reviews/qa-latest.md"
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+        writes={".factory/reviews/qa-latest.md"},
+    )
+
+    # CEO gate on QA (max 3 iterations)
+    nodes["gate_qa"] = GateNode(
+        id="gate_qa",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Review QA results for the new mode. PROCEED if all checks pass: "
+            "workflow validates, SKILL.md generated, tests pass, CLI recognizes mode. "
+            "RELOOP to builder (max 3 iterations) if issues found."
+        ),
+        reads={".factory/reviews/qa-latest.md"},
+    )
+
+    # Precheck gate
+    nodes["gate_precheck"] = GateNode(
+        id="gate_precheck",
+        evaluator_type="fn",
+        evaluator_command="factory precheck {project_path} --score-before 0 --score-after 0",
+        reads={".factory/reviews/qa-latest.md"},
+    )
+
+    # Archivist (async)
+    nodes["archivist_build"] = AgentNode(
+        id="archivist_build",
+        role=AgentRole.ARCHIVIST,
+        prompt_template="Archive the new mode build results and learnings.",
+        reads={".factory/reviews/qa-latest.md"},
+        writes={".factory/archive/create-build.md"},
+        blocking=False,
+    )
+
+    # Edges
+    edges = [
+        # Fork to researchers
+        Edge(source="fork_research", target="researcher_existing"),
+        Edge(source="fork_research", target="researcher_intent"),
+        Edge(source="fork_research", target="researcher_practices"),
+        # Researchers to join
+        Edge(source="researcher_existing", target="join_research"),
+        Edge(source="researcher_intent", target="join_research"),
+        Edge(source="researcher_practices", target="join_research"),
+        # Join → research gate
+        Edge(source="join_research", target="gate_research"),
+        # Research gate
+        Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+        Edge(source="gate_research", target="fork_research", condition=VerdictType.RELOOP),
+        # Strategist → user gate
+        Edge(source="strategist", target="gate_strategy"),
+        # User gate
+        Edge(source="gate_strategy", target="archivist_plan", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # Archivist → builder
+        Edge(source="archivist_plan", target="builder"),
+        # Builder → build gate
+        Edge(source="builder", target="gate_build"),
+        # Build gate
+        Edge(source="gate_build", target="qa", condition=VerdictType.PROCEED),
+        Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
+        # QA → gate_qa
+        Edge(source="qa", target="gate_qa"),
+        # gate_qa
+        Edge(source="gate_qa", target="gate_precheck", condition=VerdictType.PROCEED),
+        Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
+        # Precheck → archivist
+        Edge(source="gate_precheck", target="archivist_build", condition=VerdictType.PROCEED),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "create"
+
+    return Workflow(
+        name="create",
+        nodes=nodes,
+        edges=edges,
+        start_node="fork_research",
+        trigger=trigger,
+    )
+
+
 # ── Registry ─────────────────────────────────────────────────────
 
 
 def register_all() -> dict[str, Workflow]:
-    """Build and return all 8 workflow definitions."""
+    """Build and return all 9 workflow definitions."""
     return {
         "build": build_workflow(),
         "design": design_workflow(),
@@ -1204,4 +1483,5 @@ def register_all() -> dict[str, Workflow]:
         "research": research_workflow(),
         "meta": meta_workflow(),
         "refine": refine_workflow(),
+        "create": create_workflow(),
     }

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -101,6 +101,16 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
         ),
         "argument_hint": '<project_path> --refine "<request>"',
     },
+    "create": {
+        "description": (
+            "Create mode — meta-mode for creating new factory modes from user descriptions. "
+            "Takes a description (text, spec file, or flow) and produces a fully working "
+            "workflow definition, SKILL.md, CLI wiring, and tests. Use when the user says "
+            "'create a mode for X', 'add a new workflow', or wants to extend the factory "
+            "with a custom pipeline."
+        ),
+        "argument_hint": '"mode description" or /path/to/spec.md',
+    },
 }
 
 

--- a/skills/workflow-create/SKILL.md
+++ b/skills/workflow-create/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: workflow-create
+description: "Create mode — meta-mode for creating new factory modes from user descriptions. Takes a description (text, spec file, or flow) and produces a fully working workflow definition, SKILL.md, CLI wiring, and tests. Use when the user says 'create a mode for X', 'add a new workflow', or wants to extend the factory with a custom pipeline."
+disable-model-invocation: true
+argument-hint: ""mode description" or /path/to/spec.md"
+---
+
+# Create Workflow
+
+The user wants: **$ARGUMENTS**
+
+## Phase 1: Research (Parallel)
+
+
+Spawn 3 agents in parallel:
+
+```bash
+factory agent researcher --review-tag existing --task "Existing workflow analysis. Read factory/workflow/definitions.py and analyze all existing workflow definitions (build, design, improve, research, meta, discover, review, refine). Document common patterns: node sequences, gate conventions, fork/join patterns, archivist placement, edge wiring, trigger functions, reads/writes declarations. Read factory/workflow/primitives.py for available node types and their fields. Read factory/workflow/skill_export.py for WORKFLOW_META format. Write findings to .factory/strategy/research-existing.md covering: node type usage patterns, common subgraphs (builder→gate→qa→gate loop), trigger function conventions, data flow patterns.
+Write output to: .factory/strategy/research-existing.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+factory agent researcher --review-tag intent --task "Mode description analysis. Read the user's mode description from the CEO task. Parse and structure it into a workflow specification: - Purpose and trigger conditions - Agent roles needed (which specialists) - Gate logic (user vs agent vs fn evaluators) - Data flow (what files are read/written) - Interactive vs headless requirements - Input format (text, file, drawing, flow) Write findings to .factory/strategy/research-intent.md covering: structured requirements, node candidates, suggested graph topology.
+Write output to: .factory/strategy/research-intent.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+factory agent researcher --review-tag practices --task "Workflow design best practices. Search the web for workflow and pipeline design patterns relevant to the described mode. Look for: DAG design patterns, agent orchestration patterns, quality gate strategies, error recovery approaches. Check .factory/archive/ for lessons from past mode creation or workflow changes. Write findings to .factory/strategy/research-practices.md covering: relevant design patterns, pitfalls to avoid, testing strategies.
+Write output to: .factory/strategy/research-practices.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+wait
+```
+
+## Barrier: Research
+
+
+Wait for all parallel agents to complete: `researcher_existing`, `researcher_intent`, `researcher_practices`
+
+Read combined outputs: `.factory/strategy/research-existing.md`, `.factory/strategy/research-intent.md`, `.factory/strategy/research-practices.md`
+
+Write combined result to: `.factory/strategy/research-combined.md`
+
+### CEO Review — Research
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/strategy/research-combined.md`
+3. Assess: Are the existing workflow patterns well-documented? Is the user's intent clearly structured into workflow requirements? Are best practices relevant to this type of mode? Any gaps?
+4. Write verdict to `.factory/reviews/ceo-verdict-research.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `fork_research` (max 3 iterations)*
+
+## Phase 2: Strategist
+
+
+```bash
+factory agent strategist --task "Synthesize a complete workflow specification for a new factory mode. Read ALL tagged research files at .factory/strategy/research-*.md. Produce a complete specification including: 1) Python code for the workflow function (nodes dict, edges list, trigger) 2) WORKFLOW_META entry (description, argument_hint) 3) CLI wiring changes (build_parser mode choices, cmd_ceo routing, _build_ceo_task section) 4) Test cases (graph validation, skill export, trigger function, registration) 5) Node details: for each node, specify id, type, role, prompt_template, reads, writes 6) Edge details: for each edge, specify source, target, condition 7) Interactive vs headless behavior Follow conventions from existing workflows — use the same patterns for builder→gate→QA→gate loops, archivist placement, and research forks. Write the specification to .factory/strategy/current.md.
+Read: .factory/strategy/research-combined.md
+Write output to: .factory/strategy/current.md" --project "$PROJECT_PATH" --timeout 600
+```
+
+### Steering Point — Strategy (User Approval)
+
+Present findings to the user. Wait for approval or feedback.
+- **Approve** → proceed to next step
+- **Feedback** → re-run the previous step with corrections
+
+*On RELOOP: return to `strategist` (max 3 iterations)*
+
+## Phase 3: Archivist Plan
+
+
+```bash
+factory agent archivist --task "Archive the approved workflow specification for the new mode.
+Read: .factory/strategy/current.md
+Write output to: .factory/archive/create-plan.md" --project "$PROJECT_PATH" --timeout 300 --model haiku &
+```
+*(fire-and-forget — CEO continues immediately)*
+
+## Phase 4: Builder
+
+
+```bash
+factory agent builder --task "Implement the new factory mode from the approved workflow specification. Read the approved spec at .factory/strategy/current.md. Read CLAUDE.md for project conventions. Implementation checklist: 1) Add the workflow function to factory/workflow/definitions.py 2) Register it in register_all() 3) Add WORKFLOW_META entry in factory/workflow/skill_export.py 4) Wire --mode in factory/cli.py (build_parser, cmd_ceo, _build_ceo_task) 5) Run factory workflow validate <name> to verify the graph 6) Run factory workflow export-skills to generate the SKILL.md 7) Write tests in tests/ 8) Run pytest and ruff check to verify Commit changes and open a draft PR.
+Read: .factory/strategy/current.md
+Write output to: .factory/reviews/builder-latest.md" --project "$PROJECT_PATH" --timeout 600
+```
+
+### CEO Review — Build
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/builder-latest.md`
+3. Assess: Read builder output and PR diff. Does work match the approved spec? Verify: workflow function exists, registered in register_all(), WORKFLOW_META entry added, CLI wiring complete, tests written. REDIRECT if any component is missing.
+4. Write verdict to `.factory/reviews/ceo-verdict-build.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `builder` (max 3 iterations)*
+
+## Phase 5: Qa
+
+
+```bash
+factory agent qa --task "Verify the new factory mode end-to-end. 1. Health Check — run pytest, ruff check, mypy. Report results. 2. Code Review — read PR diff, evaluate correctness, architecture, edge cases, security. Verify workflow graph validates. 3. Adversarial QA — actually test the new mode:    - Run: factory workflow validate <name>    - Run: factory workflow show <name>    - Run: factory workflow export-skills --verify    - Verify SKILL.md was generated under skills/workflow-<name>/    - Check CLI recognizes --mode <name> (factory ceo --help)    - Check the workflow handles both interactive and headless paths Write results to .factory/reviews/qa-latest.md
+Read: .factory/reviews/builder-latest.md
+Write output to: .factory/reviews/qa-latest.md" --project "$PROJECT_PATH" --timeout 600
+```
+
+### CEO Review — Qa
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/qa-latest.md`
+3. Assess: Review QA results for the new mode. PROCEED if all checks pass: workflow validates, SKILL.md generated, tests pass, CLI recognizes mode. RELOOP to builder (max 3 iterations) if issues found.
+4. Write verdict to `.factory/reviews/ceo-verdict-qa.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `builder` (max 3 iterations)*
+
+### Gate — Precheck (Automated)
+
+```bash
+factory precheck $PROJECT_PATH --score-before 0 --score-after 0
+```
+
+## Phase 6: Archivist Build
+
+
+```bash
+factory agent archivist --task "Archive the new mode build results and learnings.
+Read: .factory/reviews/qa-latest.md
+Write output to: .factory/archive/create-build.md" --project "$PROJECT_PATH" --timeout 300 --model haiku &
+```
+*(fire-and-forget — CEO continues immediately)*

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -378,17 +378,17 @@ class TestRealWorkflowSkills:
         assert "workflow-refine" in content
         assert "refiner" in content.lower()
 
-    def test_all_eight_skills_exported(self, tmp_path: Path) -> None:
+    def test_all_nine_skills_exported(self, tmp_path: Path) -> None:
         from factory.workflow.definitions import register_all
 
         workflows = register_all()
         paths = export_all_skills(tmp_path, workflows=workflows)
-        assert len(paths) == 8, f"Expected 8 skills, got {len(paths)}"
+        assert len(paths) == 9, f"Expected 9 skills, got {len(paths)}"
         dirs = {p.parent.name for p in paths}
         expected = {
             "workflow-build", "workflow-design", "workflow-discover",
             "workflow-review", "workflow-improve", "workflow-research",
-            "workflow-meta", "workflow-refine",
+            "workflow-meta", "workflow-refine", "workflow-create",
         }
         assert dirs == expected, f"Missing: {expected - dirs}"
         for p in paths:

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -1,4 +1,4 @@
-"""Tier 3: Workflow definition tests — verify all 5 workflows pass validation."""
+"""Tier 3: Workflow definition tests — verify all workflows pass validation."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ from __future__ import annotations
 from factory.models import ProjectState
 from factory.workflow.definitions import (
     build_workflow,
+    create_workflow,
     design_workflow,
     improve_workflow,
     meta_workflow,
@@ -16,7 +17,9 @@ from factory.workflow.primitives import (
     AgentNode,
     AgentRole,
     FnNode,
+    ForkNode,
     GateNode,
+    JoinNode,
 )
 
 
@@ -216,12 +219,12 @@ class TestAgentPool:
 
 
 class TestRegisterAll:
-    def test_all_eight_workflows(self) -> None:
+    def test_all_nine_workflows(self) -> None:
         all_wf = register_all()
-        assert len(all_wf) == 8
+        assert len(all_wf) == 9
         assert set(all_wf.keys()) == {
             "build", "design", "improve", "research", "meta",
-            "discover", "review", "refine",
+            "discover", "review", "refine", "create",
         }
 
     def test_all_validate(self) -> None:
@@ -229,3 +232,81 @@ class TestRegisterAll:
         for name, wf in all_wf.items():
             issues = wf.validate_graph()
             assert issues == [], f"{name} has validation issues: {issues}"
+
+
+# ── W₉ Create structure ────────────────────────────────────────
+
+
+class TestCreateStructure:
+    def test_create_valid(self) -> None:
+        wf = create_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"create workflow has issues: {issues}"
+
+    def test_create_trigger(self) -> None:
+        wf = create_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "create"})
+        assert wf.trigger(ProjectState.NO_REPO, {"mode": "create"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+
+    def test_create_name(self) -> None:
+        wf = create_workflow()
+        assert wf.name == "create"
+
+    def test_create_has_parallel_research(self) -> None:
+        wf = create_workflow()
+        assert "fork_research" in wf.nodes
+        assert "join_research" in wf.nodes
+        fork = wf.nodes["fork_research"]
+        assert isinstance(fork, ForkNode)
+        assert len(fork.targets) == 3
+        join = wf.nodes["join_research"]
+        assert isinstance(join, JoinNode)
+        assert len(join.sources) == 3
+
+    def test_create_has_user_gate(self) -> None:
+        """Create mode has a user approval gate at strategy."""
+        wf = create_workflow()
+        gate = wf.nodes.get("gate_strategy")
+        assert isinstance(gate, GateNode)
+        assert gate.evaluator_type == "user"
+
+    def test_create_has_builder_qa_loop(self) -> None:
+        """Create mode has the standard builder → QA → gate loop."""
+        wf = create_workflow()
+        assert "builder" in wf.nodes
+        assert "qa" in wf.nodes
+        assert "gate_qa" in wf.nodes
+        assert "gate_build" in wf.nodes
+        reloop_edges = [e for e in wf.edges if e.source == "gate_qa" and e.target == "builder"]
+        assert len(reloop_edges) == 1
+
+    def test_create_has_precheck(self) -> None:
+        wf = create_workflow()
+        assert "gate_precheck" in wf.nodes
+        precheck = wf.nodes["gate_precheck"]
+        assert isinstance(precheck, GateNode)
+        assert precheck.evaluator_type == "fn"
+
+    def test_create_archivists_nonblocking(self) -> None:
+        wf = create_workflow()
+        for nid in ("archivist_plan", "archivist_build"):
+            node = wf.nodes.get(nid)
+            assert node is not None, f"missing {nid}"
+            assert node.blocking is False
+
+    def test_create_start_node(self) -> None:
+        wf = create_workflow()
+        assert wf.start_node == "fork_research"
+
+    def test_create_skill_export(self) -> None:
+        from factory.workflow.skill_export import validate_skill, workflow_to_skill_md
+
+        wf = create_workflow()
+        skill_md = workflow_to_skill_md(wf)
+        issues = validate_skill(skill_md)
+        assert issues == [], f"create skill has issues: {issues}"
+        assert "workflow-create" in skill_md
+        assert "User Approval" in skill_md


### PR DESCRIPTION
## Summary

- Adds `--mode create` (W₉) — a meta-mode that lets users create new factory modes from natural language descriptions, spec files, or flow diagrams
- Implements the full workflow graph: fork(3 researchers) → join → CEO gate → strategist → **user approval gate** → archivist(async) → builder → CEO gate → QA → gate_qa(max 3 RELOOP) → precheck → archivist(async)
- Wires into CLI with validation (interactive-only, no `--prompt`/`--focus`/`--headless`)

## What it does

Given `factory ceo /path/to/factory --mode create "a mode that does X"`, the CEO:
1. Researches existing workflow patterns, user intent, and best practices (3 parallel researchers)
2. Synthesizes a complete workflow specification (Strategist)
3. Presents spec for user approval (design-mode pattern)
4. Implements: workflow definition + SKILL.md + CLI wiring + tests (Builder)
5. Verifies end-to-end (QA with standard builder→QA loop, max 3 iterations)

## Files changed

| File | Change |
|------|--------|
| `factory/workflow/definitions.py` | `create_workflow()` — 15 nodes, 20 edges |
| `factory/workflow/skill_export.py` | WORKFLOW_META entry for create |
| `factory/cli.py` | Parser, validation, routing, task generation |
| `factory/agents/prompts/ceo.md` | CEO routing for `--mode create` |
| `skills/workflow-create/SKILL.md` | Auto-generated skill file (144 lines) |
| `tests/test_workflow_definitions.py` | 10 new tests (TestCreateStructure) |
| `tests/test_skill_export.py` | Updated count from 8 → 9 workflows |

## Test plan

- [x] All 67 workflow + skill export tests pass
- [x] Graph validates (15 nodes, 20 edges, no issues)
- [x] SKILL.md passes validation (frontmatter, length)
- [x] ruff check clean
- [x] mypy clean
- [ ] Manual: `factory ceo /path/to/factory --mode create "a mode that does X"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)