### PR TITLE
fix: enforce QA verification in all workflows (Sacred Rule 9)

### DIFF
--- a/factory/agents/playbooks/ceo.md
+++ b/factory/agents/playbooks/ceo.md
@@ -1,7 +1,7 @@
 ---
 role: ceo
-updated: 2026-04-26
-item_count: 9
+updated: 2026-06-27
+item_count: 10
 ---
 
 ## Behavioral Playbook — Ceo
@@ -13,6 +13,8 @@ item_count: 9
 - [ceo-00004] helpful=0 harmful=0 :: When reviewing the Strategist's hypotheses, HARD-REJECT if all hypotheses are hygiene-only (tests, lint, cleanup). The eval is 50% hygiene + 50% growth — always include at least one hypothesis that adds real functionality.
 - [ceo-00005] helpful=0 harmful=0 :: In Build mode, sanity-check the spec's MVP scope at the Strategy hard gate. If the product IS an external integration and the build plan defers that integration entirely, flag it. The CEO's job is to catch scope gaps, not rubber-stamp.
 - [ceo-00006] helpful=0 harmful=0 :: At the end of Build mode (before transitioning to Discover/Improve), extract all deferred items from the build plan into .factory/strategy/deferred.md via `factory deferred-list`. The Strategist's $DEFERRED_DIRECTIVE checks for this file.
+
+- [ceo-00016] helpful=0 harmful=0 :: Before calling factory finalize on any experiment that produced a PR, verify qa.completed exists in .factory/events.jsonl. If QA was not invoked, spawn it NOW — do not finalize without QA. If the workflow SKILL.md doesn't include a QA step, spawn QA manually. No exceptions.
 
 ### DON'T
 - [ceo-00007] helpful=0 harmful=0 :: NEVER exit Build mode between phases with a self-judged "stopping point" rationale. Phrases like "This is a good stopping point" or "Phase 1 is complete and documented" are FORBIDDEN exit reasons. A scaffold without implementation is not a deliverable — complete ALL planned phases before exiting.

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -917,6 +917,7 @@ def cmd_finalize(args: argparse.Namespace) -> int:
                 history=history_dicts,
                 project_path=project_path,
                 hard_constraints=config.hard_constraints,
+                exp_id=args.id,
             )
 
             if not precheck_result.passed:

--- a/factory/precheck.py
+++ b/factory/precheck.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 import structlog
@@ -237,6 +238,61 @@ def check_hard_constraints(
     return results
 
 
+def check_qa_execution(
+    project_path: Path,
+    exp_id: int,
+) -> CheckResult:
+    """Verify the QA agent was invoked for this experiment — Sacred Rule 9."""
+    from factory.events import load_events
+
+    events = load_events(project_path)
+
+    exp_start_ts: datetime | None = None
+    for ev in reversed(events):
+        if ev.get("type") == "experiment.begin":
+            ev_data = ev.get("data", {})
+            if ev_data.get("exp_id") == exp_id:
+                ts_str = ev.get("timestamp")
+                if ts_str:
+                    exp_start_ts = datetime.fromisoformat(ts_str)
+                break
+
+    if exp_start_ts is None:
+        return CheckResult(
+            name="qa_execution",
+            passed=True,
+            detail=f"No experiment.begin event found for exp_id={exp_id} — skipping QA check",
+        )
+
+    for ev in events:
+        ts_str = ev.get("timestamp")
+        if not ts_str:
+            continue
+        ev_ts = datetime.fromisoformat(ts_str)
+        if ev_ts <= exp_start_ts:
+            continue
+
+        ev_type = ev.get("type", "")
+        if ev_type == "qa.completed":
+            return CheckResult(
+                name="qa_execution",
+                passed=True,
+                detail="QA agent completed for this experiment",
+            )
+        if ev_type == "agent.completed" and ev.get("agent") == "qa":
+            return CheckResult(
+                name="qa_execution",
+                passed=True,
+                detail="QA agent completed for this experiment",
+            )
+
+    return CheckResult(
+        name="qa_execution",
+        passed=False,
+        detail="QA agent not invoked — Sacred Rule 9 violation",
+    )
+
+
 def run_precheck(
     *,
     score_before: float | None,
@@ -250,6 +306,7 @@ def run_precheck(
     similarity_threshold: float = 0.6,
     fixed_surfaces: list[str] | None = None,
     hard_constraints: list[HardConstraint] | None = None,
+    exp_id: int | None = None,
 ) -> PreCheckResult:
     """Run all prechecks and return aggregate result.
 
@@ -277,6 +334,10 @@ def run_precheck(
     # 5. Hard constraints (user-defined checks from factory.md)
     if hard_constraints:
         checks.extend(check_hard_constraints(hard_constraints, project_path))
+
+    # 6. QA execution check (only when exp_id is provided)
+    if exp_id is not None:
+        checks.append(check_qa_execution(project_path, exp_id))
 
     # Aggregate
     failures = [c.name for c in checks if not c.passed]

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -203,17 +203,8 @@ def _agent_to_instruction(node: AgentNode, *, is_parallel: bool = False) -> str:
 
 
 def _fn_to_instruction(node: FnNode) -> str:
-    """Convert an FnNode to a CLI command instruction.
-
-    Eval commands are delegated to the evaluator agent rather than
-    invoked directly — the QA pipeline requires agent-mediated eval.
-    """
+    """Convert an FnNode to a CLI command instruction."""
     cmd = node.command.replace("{project_path}", "$PROJECT_PATH")
-    if "factory eval" in cmd:
-        return (
-            '```bash\nfactory agent evaluator --task "Run eval and report results." '
-            '--project "$PROJECT_PATH" --timeout 300\n```'
-        )
     return f"```bash\n{cmd}\n```"
 
 

--- a/skills/workflow-build/SKILL.md
+++ b/skills/workflow-build/SKILL.md
@@ -12,14 +12,25 @@ The user wants: **$ARGUMENTS**
 ## Phase 1: Research (Parallel)
 
 
-Spawn 3 researchers in parallel using a SINGLE Bash tool call with shell `&` + `wait`. Do NOT use `run_in_background: True` or separate Bash calls — all commands must run in one shell:
+Spawn 3 agents in parallel:
 
 ```bash
-factory agent researcher --review-tag similar --task "Similar projects research. Search the web for similar projects, existing solutions, and prior art. Analyze their strengths, weaknesses, and market positioning. Check .factory/archive/ for prior knowledge on similar builds. Write findings to .factory/strategy/research-similar.md covering: similar projects found (with links), what they do well and what's missing, differentiation opportunities. Write output to: .factory/strategy/research-similar.md" --project "$PROJECT_PATH" --timeout 600 &
-factory agent researcher --review-tag techstack --task "Tech stack research. Identify the best technology stack for this type of project. Find architecture patterns and best practices. Evaluate framework/library options with trade-offs. Write findings to .factory/strategy/research-techstack.md covering: recommended tech stack with rationale, architecture patterns, framework comparisons. Write output to: .factory/strategy/research-techstack.md" --project "$PROJECT_PATH" --timeout 600 &
-factory agent researcher --review-tag pitfalls --task "Pitfalls and scope research. Identify potential pitfalls and common mistakes for this type of project. Research MVP scope best practices. Check .factory/archive/ for lessons from past builds. Write findings to .factory/strategy/research-pitfalls.md covering: potential pitfalls to avoid, MVP scope recommendation, lessons from similar past builds. Write output to: .factory/strategy/research-pitfalls.md" --project "$PROJECT_PATH" --timeout 600 &
+factory agent researcher --review-tag similar --task "Similar projects research. Search the web for similar projects, existing solutions, and prior art. Analyze their strengths, weaknesses, and market positioning. Check .factory/archive/ for prior knowledge on similar builds. Write findings to .factory/strategy/research-similar.md covering: similar projects found (with links), what they do well and what's missing, differentiation opportunities.
+Write output to: .factory/strategy/research-similar.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+factory agent researcher --review-tag techstack --task "Tech stack research. Identify the best technology stack for this type of project. Find architecture patterns and best practices. Evaluate framework/library options with trade-offs. Write findings to .factory/strategy/research-techstack.md covering: recommended tech stack with rationale, architecture patterns, framework comparisons.
+Write output to: .factory/strategy/research-techstack.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+factory agent researcher --review-tag pitfalls --task "Pitfalls and scope research. Identify potential pitfalls and common mistakes for this type of project. Research MVP scope best practices. Check .factory/archive/ for lessons from past builds. Write findings to .factory/strategy/research-pitfalls.md covering: potential pitfalls to avoid, MVP scope recommendation, lessons from similar past builds.
+Write output to: .factory/strategy/research-pitfalls.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
 wait
-echo "All researchers complete"
 ```
 
 ## Barrier: Research
@@ -98,12 +109,27 @@ Apply the CEO Review Gate protocol:
 
 *On RELOOP: return to `builder` (max 3 iterations)*
 
-## Step: Eval
+## Phase 5: Qa
 
 
 ```bash
-factory eval "$PROJECT_PATH"
+factory agent qa --task "Run health check (factory eval + score delta), code review (correctness, architecture, edge cases, security), and adversarial QA (run/test the built feature). Write results to .factory/reviews/qa-latest.md
+Read: .factory/reviews/builder-latest.md
+Write output to: .factory/reviews/qa-latest.md" --project "$PROJECT_PATH" --timeout 600
 ```
+
+### CEO Review — Qa
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/qa-latest.md`
+3. Assess: Review QA results. PROCEED if all checks pass. RELOOP to builder (max 3 iterations) if issues found.
+4. Write verdict to `.factory/reviews/ceo-verdict-qa.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `builder` (max 3 iterations)*
 
 ### Gate — Precheck (Automated)
 
@@ -116,7 +142,7 @@ factory precheck $PROJECT_PATH --score-before 0 --score-after 0
 
 ```bash
 factory agent archivist --task "Archive the build phase results.
-Read: .factory/reviews/evaluator-latest.md
+Read: .factory/reviews/qa-latest.md
 Write output to: .factory/archive/build.md" --project "$PROJECT_PATH" --timeout 300 --model haiku &
 ```
 *(fire-and-forget — CEO continues immediately)*

--- a/skills/workflow-design/SKILL.md
+++ b/skills/workflow-design/SKILL.md
@@ -12,14 +12,25 @@ The user wants: **$ARGUMENTS**
 ## Phase 1: Research (Parallel)
 
 
-Spawn 3 researchers in parallel using a SINGLE Bash tool call with shell `&` + `wait`. Do NOT use `run_in_background: True` or separate Bash calls — all commands must run in one shell:
+Spawn 3 agents in parallel:
 
 ```bash
-factory agent researcher --review-tag similar --task "Similar projects research. Search the web for similar projects, existing solutions, and prior art. Analyze their strengths, weaknesses, and market positioning. Check .factory/archive/ for prior knowledge on similar builds. Write findings to .factory/strategy/research-similar.md covering: similar projects found (with links), what they do well and what's missing, differentiation opportunities. Write output to: .factory/strategy/research-similar.md" --project "$PROJECT_PATH" --timeout 600 &
-factory agent researcher --review-tag techstack --task "Tech stack research. Identify the best technology stack for this type of project. Find architecture patterns and best practices. Evaluate framework/library options with trade-offs. Write findings to .factory/strategy/research-techstack.md covering: recommended tech stack with rationale, architecture patterns, framework comparisons. Write output to: .factory/strategy/research-techstack.md" --project "$PROJECT_PATH" --timeout 600 &
-factory agent researcher --review-tag pitfalls --task "Pitfalls and scope research. Identify potential pitfalls and common mistakes for this type of project. Research MVP scope best practices. Check .factory/archive/ for lessons from past builds. Write findings to .factory/strategy/research-pitfalls.md covering: potential pitfalls to avoid, MVP scope recommendation, lessons from similar past builds. Write output to: .factory/strategy/research-pitfalls.md" --project "$PROJECT_PATH" --timeout 600 &
+factory agent researcher --review-tag similar --task "Similar projects research. Search the web for similar projects, existing solutions, and prior art. Analyze their strengths, weaknesses, and market positioning. Check .factory/archive/ for prior knowledge on similar builds. Write findings to .factory/strategy/research-similar.md covering: similar projects found (with links), what they do well and what's missing, differentiation opportunities.
+Write output to: .factory/strategy/research-similar.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+factory agent researcher --review-tag techstack --task "Tech stack research. Identify the best technology stack for this type of project. Find architecture patterns and best practices. Evaluate framework/library options with trade-offs. Write findings to .factory/strategy/research-techstack.md covering: recommended tech stack with rationale, architecture patterns, framework comparisons.
+Write output to: .factory/strategy/research-techstack.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+factory agent researcher --review-tag pitfalls --task "Pitfalls and scope research. Identify potential pitfalls and common mistakes for this type of project. Research MVP scope best practices. Check .factory/archive/ for lessons from past builds. Write findings to .factory/strategy/research-pitfalls.md covering: potential pitfalls to avoid, MVP scope recommendation, lessons from similar past builds.
+Write output to: .factory/strategy/research-pitfalls.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
 wait
-echo "All researchers complete"
 ```
 
 ## Barrier: Research
@@ -93,12 +104,27 @@ Apply the CEO Review Gate protocol:
 
 *On RELOOP: return to `builder` (max 3 iterations)*
 
-## Step: Eval
+## Phase 5: Qa
 
 
 ```bash
-factory eval "$PROJECT_PATH"
+factory agent qa --task "Run health check (factory eval + score delta), code review (correctness, architecture, edge cases, security), and adversarial QA (run/test the built feature). Write results to .factory/reviews/qa-latest.md
+Read: .factory/reviews/builder-latest.md
+Write output to: .factory/reviews/qa-latest.md" --project "$PROJECT_PATH" --timeout 600
 ```
+
+### CEO Review — Qa
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/qa-latest.md`
+3. Assess: Review QA results. PROCEED if all checks pass. RELOOP to builder (max 3 iterations) if issues found.
+4. Write verdict to `.factory/reviews/ceo-verdict-qa.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `builder` (max 3 iterations)*
 
 ### Gate — Precheck (Automated)
 
@@ -111,7 +137,7 @@ factory precheck $PROJECT_PATH --score-before 0 --score-after 0
 
 ```bash
 factory agent archivist --task "Archive the build phase results.
-Read: .factory/reviews/evaluator-latest.md
+Read: .factory/reviews/qa-latest.md
 Write output to: .factory/archive/build.md" --project "$PROJECT_PATH" --timeout 300 --model haiku &
 ```
 *(fire-and-forget — CEO continues immediately)*

--- a/skills/workflow-improve/SKILL.md
+++ b/skills/workflow-improve/SKILL.md
@@ -93,12 +93,27 @@ Apply the CEO Review Gate protocol:
 
 *On RELOOP: return to `builder` (max 3 iterations)*
 
-## Step: Eval
+## Phase 5: Qa
 
 
 ```bash
-factory eval "$PROJECT_PATH"
+factory agent qa --task "Run health check (factory eval + score delta), code review (correctness, architecture, edge cases, security), and adversarial QA (run/test the built feature). Write results to .factory/reviews/qa-latest.md
+Read: .factory/reviews/builder-latest.md
+Write output to: .factory/reviews/qa-latest.md" --project "$PROJECT_PATH" --timeout 600
 ```
+
+### CEO Review — Qa
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/qa-latest.md`
+3. Assess: Review QA results. PROCEED if all checks pass. RELOOP to builder (max 3 iterations) if issues found.
+4. Write verdict to `.factory/reviews/ceo-verdict-qa.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `builder` (max 3 iterations)*
 
 ### Gate — Precheck (Automated)
 

--- a/skills/workflow-meta/SKILL.md
+++ b/skills/workflow-meta/SKILL.md
@@ -104,3 +104,25 @@ factory agent builder --task "Delete the approved redundant tests. Verify remain
 Read: .factory/strategy/test-analysis.md
 Write output to: .factory/reviews/test-pruning-latest.md" --project "$PROJECT_PATH" --timeout 600
 ```
+
+## Phase 6: Qa Verify
+
+
+```bash
+factory agent qa --task "Verify the test suite still passes after pruning. Run health check and confirm no regressions. Write results to .factory/reviews/qa-verify-latest.md
+Read: .factory/reviews/test-pruning-latest.md
+Write output to: .factory/reviews/qa-verify-latest.md" --project "$PROJECT_PATH" --timeout 600
+```
+
+### CEO Review — Qa Verify
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/qa-verify-latest.md`
+3. Assess: Review QA verification of test pruning. PROCEED if tests still pass. RELOOP to test_builder (max 3 iterations) if regressions found.
+4. Write verdict to `.factory/reviews/ceo-verdict-qa-verify.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `test_builder` (max 3 iterations)*

--- a/skills/workflow-refine/SKILL.md
+++ b/skills/workflow-refine/SKILL.md
@@ -14,7 +14,6 @@ The user wants: **$ARGUMENTS**
 
 ```bash
 factory agent refiner --task "Classify and scope a refinement request. Read CLAUDE.md and factory.md. Analyze the codebase to identify which files need to change, estimate scope, and classify the request as Tier 1, 2, or 3. Produce the structured classification output with a Builder task description.
-Read: CLAUDE.md, factory.md
 Write output to: .factory/reviews/refiner-latest.md" --project "$PROJECT_PATH" --timeout 600
 ```
 
@@ -60,7 +59,7 @@ Read: .factory/reviews/refiner-latest.md
 Write output to: .factory/reviews/builder-latest.md" --project "$PROJECT_PATH" --timeout 600
 ```
 
-## Phase 3: Reviewer — Qa
+## Phase 3: Qa
 
 
 ```bash

--- a/skills/workflow-research/SKILL.md
+++ b/skills/workflow-research/SKILL.md
@@ -13,7 +13,7 @@ The user wants: **$ARGUMENTS**
 
 
 ```bash
-factory eval "$PROJECT_PATH"
+factory eval $PROJECT_PATH
 ```
 
 ## Phase 1: Failure Analyst
@@ -98,12 +98,27 @@ Apply the CEO Review Gate protocol:
 
 *On RELOOP: return to `builder` (max 3 iterations)*
 
-## Step: Eval
+## Phase 5: Qa
 
 
 ```bash
-factory eval "$PROJECT_PATH"
+factory agent qa --task "Run health check (factory eval + score delta), code review (correctness, architecture, edge cases, security), adversarial QA (run/test the built feature), and verify mutable/fixed surface constraint compliance. Write results to .factory/reviews/qa-latest.md
+Read: .factory/reviews/builder-latest.md
+Write output to: .factory/reviews/qa-latest.md" --project "$PROJECT_PATH" --timeout 600
 ```
+
+### CEO Review — Qa
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/qa-latest.md`
+3. Assess: Review QA results. PROCEED if all checks pass. RELOOP to builder (max 3 iterations) if issues found.
+4. Write verdict to `.factory/reviews/ceo-verdict-qa.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `builder` (max 3 iterations)*
 
 ### Gate — Precheck (Automated)
 
@@ -118,7 +133,7 @@ factory precheck $PROJECT_PATH --score-before 0 --score-after 0
 factory finalize $PROJECT_PATH --id 1 --verdict keep --hypothesis 'hypothesis'
 ```
 
-## Phase 5: Archivist
+## Phase 6: Archivist
 
 
 ```bash

--- a/skills/workflow-review/SKILL.md
+++ b/skills/workflow-review/SKILL.md
@@ -56,7 +56,7 @@ factory init $PROJECT_PATH
 
 
 ```bash
-factory eval "$PROJECT_PATH"
+factory eval $PROJECT_PATH
 ```
 
 ## Step: Commit

--- a/tests/test_precheck.py
+++ b/tests/test_precheck.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -13,6 +14,7 @@ from factory.strategy import (
 )
 from factory.precheck import (
     check_anti_pattern,
+    check_qa_execution,
     check_score_direction,
     check_scope,
     check_surfaces,
@@ -239,6 +241,119 @@ class TestCheckSurfaces:
         r = check_surfaces(Path("/tmp/test"), "abc123")
         assert not r.passed
         assert "not found" in r.detail.lower()
+
+
+# ── precheck: check_qa_execution ─────────────────────────────
+
+
+def _write_events(tmp_path: Path, events: list[dict]) -> None:
+    """Helper to write events.jsonl in a .factory/ dir."""
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir(exist_ok=True)
+    lines = [json.dumps(e) for e in events]
+    (factory_dir / "events.jsonl").write_text("\n".join(lines) + "\n")
+
+
+class TestCheckQaExecution:
+    def test_qa_execution_guard_pass(self, tmp_path: Path) -> None:
+        """events.jsonl has qa.completed after experiment.begin → passes."""
+        _write_events(tmp_path, [
+            {
+                "type": "experiment.begin",
+                "timestamp": "2026-06-27T10:00:00+00:00",
+                "project": "test",
+                "agent": None,
+                "data": {"exp_id": 1},
+            },
+            {
+                "type": "agent.completed",
+                "timestamp": "2026-06-27T10:05:00+00:00",
+                "project": "test",
+                "agent": "builder",
+                "data": {},
+            },
+            {
+                "type": "agent.completed",
+                "timestamp": "2026-06-27T10:10:00+00:00",
+                "project": "test",
+                "agent": "qa",
+                "data": {},
+            },
+        ])
+        result = check_qa_execution(tmp_path, exp_id=1)
+        assert result.passed
+        assert result.name == "qa_execution"
+
+    def test_qa_execution_guard_pass_with_qa_completed_type(self, tmp_path: Path) -> None:
+        """qa.completed event type also satisfies the check."""
+        _write_events(tmp_path, [
+            {
+                "type": "experiment.begin",
+                "timestamp": "2026-06-27T10:00:00+00:00",
+                "project": "test",
+                "agent": None,
+                "data": {"exp_id": 1},
+            },
+            {
+                "type": "qa.completed",
+                "timestamp": "2026-06-27T10:10:00+00:00",
+                "project": "test",
+                "agent": "qa",
+                "data": {},
+            },
+        ])
+        result = check_qa_execution(tmp_path, exp_id=1)
+        assert result.passed
+
+    def test_qa_execution_guard_fail(self, tmp_path: Path) -> None:
+        """builder.completed without qa.completed → fails."""
+        _write_events(tmp_path, [
+            {
+                "type": "experiment.begin",
+                "timestamp": "2026-06-27T10:00:00+00:00",
+                "project": "test",
+                "agent": None,
+                "data": {"exp_id": 1},
+            },
+            {
+                "type": "agent.completed",
+                "timestamp": "2026-06-27T10:05:00+00:00",
+                "project": "test",
+                "agent": "builder",
+                "data": {},
+            },
+        ])
+        result = check_qa_execution(tmp_path, exp_id=1)
+        assert not result.passed
+        assert "Sacred Rule 9" in result.detail
+
+    def test_qa_execution_guard_no_exp_id(self, tmp_path: Path) -> None:
+        """When exp_id is None, QA check is skipped (backwards compatible)."""
+        _write_events(tmp_path, [
+            {
+                "type": "experiment.begin",
+                "timestamp": "2026-06-27T10:00:00+00:00",
+                "project": "test",
+                "agent": None,
+                "data": {"exp_id": 1},
+            },
+        ])
+        result = run_precheck(
+            score_before=0.7,
+            score_after=0.85,
+            threshold=0.8,
+            hypothesis="test",
+            history=[],
+            project_path=tmp_path,
+            exp_id=None,
+        )
+        check_names = [c.name for c in result.checks]
+        assert "qa_execution" not in check_names
+
+    def test_qa_execution_guard_no_events_file(self, tmp_path: Path) -> None:
+        """No events.jsonl → passes (no experiment.begin found)."""
+        result = check_qa_execution(tmp_path, exp_id=1)
+        assert result.passed
 
 
 # ── precheck: run_precheck ────────────────────────────────────

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from factory.workflow.primitives import (
     AgentNode,
     AgentRole,
@@ -395,3 +397,35 @@ class TestRealWorkflowSkills:
             content = p.read_text()
             issues = validate_skill(content)
             assert issues == [], f"{p.parent.name} validation: {issues}"
+
+
+# ── QA phase enforcement ──────────────────────────────────────────
+
+
+def _workflows_with_builder() -> list[str]:
+    """Return names of workflows containing a Builder AgentNode."""
+    from factory.workflow.definitions import register_all
+
+    names = []
+    for name, wf in register_all().items():
+        has_builder = any(
+            isinstance(n, AgentNode) and n.role == AgentRole.BUILDER
+            for n in wf.nodes.values()
+        )
+        if has_builder:
+            names.append(name)
+    return sorted(names)
+
+
+class TestSkillQaEnforcement:
+    """Every workflow with a Builder must include a QA phase in its exported SKILL.md."""
+
+    @pytest.mark.parametrize("workflow_name", _workflows_with_builder())
+    def test_builder_workflow_has_qa_in_skill(self, workflow_name: str) -> None:
+        from factory.workflow.definitions import register_all
+
+        wf = register_all()[workflow_name]
+        content = workflow_to_skill_md(wf)
+        assert "factory agent qa" in content, (
+            f"workflow-{workflow_name} SKILL.md is missing 'factory agent qa' invocation"
+        )

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections import defaultdict, deque
+
+import pytest
 
 from factory.models import ProjectState
 from factory.workflow.definitions import (
@@ -310,3 +313,74 @@ class TestCreateStructure:
         assert issues == [], f"create skill has issues: {issues}"
         assert "workflow-create" in skill_md
         assert "User Approval" in skill_md
+
+
+# ── Builder → QA reachability audit ────────────────────────────
+
+
+def _workflows_with_builder() -> list[str]:
+    """Return names of workflows containing a Builder AgentNode."""
+    names = []
+    for name, wf in register_all().items():
+        has_builder = any(
+            isinstance(n, AgentNode) and n.role == AgentRole.BUILDER
+            for n in wf.nodes.values()
+        )
+        if has_builder:
+            names.append(name)
+    return sorted(names)
+
+
+def _is_reachable(workflow_name: str, source_id: str, target_id: str) -> bool:
+    """Check if target_id is reachable from source_id via forward edges."""
+    wf = register_all()[workflow_name]
+    adj: dict[str, list[str]] = defaultdict(list)
+    for edge in wf.edges:
+        adj[edge.source].append(edge.target)
+
+    visited: set[str] = set()
+    queue: deque[str] = deque([source_id])
+    while queue:
+        nid = queue.popleft()
+        if nid == target_id:
+            return True
+        if nid in visited:
+            continue
+        visited.add(nid)
+        queue.extend(adj.get(nid, []))
+    return False
+
+
+class TestBuilderQaReachability:
+    """Every workflow with a Builder must also have a QA node reachable from it."""
+
+    @pytest.mark.parametrize("workflow_name", _workflows_with_builder())
+    def test_builder_has_qa_node(self, workflow_name: str) -> None:
+        wf = register_all()[workflow_name]
+        qa_nodes = [
+            nid for nid, n in wf.nodes.items()
+            if isinstance(n, AgentNode) and n.role == AgentRole.QA
+        ]
+        assert qa_nodes, (
+            f"workflow '{workflow_name}' has a Builder but no QA AgentNode"
+        )
+
+    @pytest.mark.parametrize("workflow_name", _workflows_with_builder())
+    def test_qa_reachable_from_builder(self, workflow_name: str) -> None:
+        wf = register_all()[workflow_name]
+        builder_ids = [
+            nid for nid, n in wf.nodes.items()
+            if isinstance(n, AgentNode) and n.role == AgentRole.BUILDER
+        ]
+        qa_ids = [
+            nid for nid, n in wf.nodes.items()
+            if isinstance(n, AgentNode) and n.role == AgentRole.QA
+        ]
+        for bid in builder_ids:
+            reachable = any(
+                _is_reachable(workflow_name, bid, qid) for qid in qa_ids
+            )
+            assert reachable, (
+                f"workflow '{workflow_name}': QA node is not reachable from "
+                f"Builder node '{bid}' via edges"
+            )


### PR DESCRIPTION
## Summary

Fixes #812 — CEO skips QA verification after Builder completes.

**Root cause:** SKILL.md files (the step-by-step playbooks the CEO follows) were stale — generated before QA nodes were added to workflow graph definitions. The precheck gate validated outcome (scores, scope) but not process (whether QA actually ran).

### Fix 1: Regenerate SKILL.md files with QA phases
- Ran `factory workflow export-skills` to regenerate all 8 SKILL.md files from current graph definitions
- `workflow-improve` and `workflow-build` now include `factory agent qa` invocations between Builder and Precheck/Finalize
- Bonus: Fixed `_fn_to_instruction` in `skill_export.py` which was incorrectly converting `factory eval` commands to an invalid `factory agent evaluator` role

### Fix 2: Precheck QA gate
- Added `check_qa_execution()` to `factory/precheck.py` — verifies `qa.completed` event exists in `events.jsonl` after `experiment.begin`
- If QA was skipped, precheck FAILS with "QA agent not invoked — Sacred Rule 9 violation"
- Backwards compatible: check only runs when `exp_id` is provided

### Fix 3: CEO playbook enforcement rule
- Added `[ceo-00016]` to factory default playbook: "verify qa.completed before finalize, spawn QA manually if missing"

### Fix 4: Workflow definition audit tests
- `TestBuilderQaReachability` — parametrized test verifying every workflow with a Builder node has a QA node reachable via edges
- `TestSkillQaEnforcement` — parametrized test verifying every workflow with a Builder includes `factory agent qa` in its exported SKILL.md

## Test plan
- [x] 17 new tests covering all 4 fixes
- [x] `pytest -v` — 1898 tests pass (1 pre-existing codex runner failure)
- [x] `ruff check .` — clean
- [x] `mypy factory/` — clean
- [x] `factory workflow export-skills --verify` — passes
- [x] QA Agent ran full verification (health check + code review + adversarial QA)
- [x] Precheck QA gate verified to block finalize when QA is skipped
- [x] Regenerated SKILL.md files contain QA phases

## Files changed (14 files, +418/-37)
- `factory/precheck.py` — `check_qa_execution()` + wired into `run_precheck()`
- `factory/cli.py` — Pass `exp_id` to precheck in `cmd_finalize()`
- `factory/workflow/skill_export.py` — Remove incorrect evaluator conversion
- `skills/workflow-{improve,build,design,meta,research,refine,review}/SKILL.md` — Regenerated
- `factory/agents/playbooks/ceo.md` — Added `[ceo-00016]`
- `tests/test_precheck.py` — 5 new QA execution tests
- `tests/test_skill_export.py` — Parametrized QA enforcement test
- `tests/test_workflow_definitions.py` — Builder→QA reachability tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)