### PR TITLE
fix: use 7200s timeout for scheduled benchmark runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -161,7 +161,7 @@ jobs:
           if [ '${{ github.event_name }}' = 'workflow_dispatch' ]; then
             echo "value=$BENCHMARK_TIMEOUT" >> "$GITHUB_OUTPUT"
           elif [ '${{ github.event_name }}' = 'schedule' ]; then
-            echo 'value=3600' >> "$GITHUB_OUTPUT"
+            echo 'value=7200' >> "$GITHUB_OUTPUT"
           else
             echo 'value=7200' >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary
- Scheduled benchmark runs were using a 3600s (1h) solver timeout while push/PR runs used 7200s (2h)
- Aligns the scheduled timeout to 7200s so all non-manual runs use the same value

## Test plan
- [ ] Trigger a manual workflow_dispatch run to confirm the timeout step still resolves correctly
- [ ] Verify next scheduled run uses the 7200s timeout in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)