### PR TITLE
feat: preserve git branches for session recovery (issue #698 phase 1)

### DIFF
--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -81,11 +81,7 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
         capture_output=True,
     )
 
-    subprocess.run(
-        ["git", "branch", "-D", branch],
-        cwd=project_path,
-        capture_output=True,
-    )
+    log.info("worktree_branch_preserved", branch=branch)
 
 
 def prune_stale(project_path: Path) -> list[str]:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -111,7 +111,7 @@ class TestCreateWorktree:
 
 
 class TestRemoveWorktree:
-    def test_removes_worktree_completely(self, git_project: Path) -> None:
+    def test_removes_worktree_preserves_branch(self, git_project: Path) -> None:
         wt_path, branch = create_worktree(git_project)
         assert wt_path.exists()
 
@@ -123,7 +123,7 @@ class TestRemoveWorktree:
             ["git", "branch", "--list", branch],
             cwd=git_project, capture_output=True, text=True,
         )
-        assert branch not in result.stdout
+        assert branch in result.stdout
 
     def test_safe_on_already_removed_path(self, git_project: Path) -> None:
         wt_path, branch = create_worktree(git_project)


### PR DESCRIPTION
Closes #698

## Changes

- Removed `git branch -D` from `remove_worktree()` in `factory/worktree.py` — worktree directories are still cleaned up, but the branch ref is preserved for future session recovery
- Added `log.info("worktree_branch_preserved")` after worktree prune to surface the preservation in structured logs
- Updated `test_removes_worktree_completely` → `test_removes_worktree_preserves_branch` to assert the branch **still exists** after removal
- `prune_stale()` is unchanged — it retains `git branch -D` for explicit cleanup of crashed/orphaned runs

This is Phase 1 of 4 for session recovery. Future phases add a run index (Phase 2), `factory resume` (Phase 3), and `factory sessions prune` (Phase 4).