### PR TITLE
feat: session recovery — preserve branches, add run index and CLI commands

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1870,6 +1870,172 @@ def cmd_resume(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sessions(args: argparse.Namespace) -> int:
+    """Dispatch sessions subcommand."""
+    sub = getattr(args, "sessions_command", None)
+    if not sub:
+        print("Usage: factory sessions {list,prune,resume}")
+        return 1
+    session_handlers = {
+        "list": cmd_sessions_list,
+        "prune": cmd_sessions_prune,
+        "resume": cmd_sessions_resume,
+    }
+    handler = session_handlers.get(sub)
+    if handler is None:
+        print(f"Unknown sessions subcommand: {sub}", file=sys.stderr)
+        return 1
+    return handler(args)
+
+
+def cmd_sessions_list(args: argparse.Namespace) -> int:
+    """List factory sessions from the run index."""
+    from factory.run_index import list_runs
+
+    project_path = Path(args.path).resolve()
+    runs = list_runs(project_path)
+
+    status_filter = getattr(args, "status", None)
+    if status_filter:
+        runs = [r for r in runs if r.status == status_filter]
+
+    if not runs:
+        print("No sessions found.")
+        return 0
+
+    header = f"{'Run ID':<20} {'Mode':<12} {'Status':<12} {'Created':<26} {'Branch'}"
+    print(header)
+    print("-" * len(header))
+    for r in runs:
+        print(f"{r.run_id:<20} {r.mode:<12} {r.status:<12} {r.created_at:<26} {r.branch}")
+    return 0
+
+
+def cmd_sessions_prune(args: argparse.Namespace) -> int:
+    """Delete run metadata and git branches for completed/crashed sessions."""
+    from factory.run_index import delete_run, list_runs
+
+    project_path = Path(args.path).resolve()
+    runs = list_runs(project_path)
+    dry_run = getattr(args, "dry_run", False)
+
+    status_filter = getattr(args, "status", None)
+    if status_filter:
+        prune_statuses = {status_filter}
+    else:
+        prune_statuses = {"completed", "crashed"}
+
+    runs = [r for r in runs if r.status in prune_statuses]
+
+    older_than = getattr(args, "older_than", None)
+    if older_than:
+        from datetime import datetime, timedelta
+
+        if older_than.endswith("d"):
+            days = int(older_than[:-1])
+        elif older_than.endswith("h"):
+            days = 0
+            hours = int(older_than[:-1])
+            cutoff = datetime.now() - timedelta(hours=hours)
+        else:
+            days = int(older_than)
+
+        if older_than.endswith("d") or not older_than.endswith("h"):
+            cutoff = datetime.now() - timedelta(days=days)
+
+        runs = [
+            r for r in runs
+            if datetime.fromisoformat(r.created_at) < cutoff
+        ]
+
+    if not runs:
+        print("Nothing to prune.")
+        return 0
+
+    for r in runs:
+        if dry_run:
+            print(f"Would prune: {r.run_id} (branch={r.branch}, status={r.status})")
+        else:
+            subprocess.run(
+                ["git", "branch", "-D", r.branch],
+                cwd=project_path,
+                capture_output=True,
+            )
+            delete_run(project_path, r.run_id)
+            print(f"Pruned: {r.run_id} (branch={r.branch})")
+
+    if dry_run:
+        print(f"\n{len(runs)} session(s) would be pruned. Pass without --dry-run to execute.")
+    else:
+        print(f"\n{len(runs)} session(s) pruned.")
+    return 0
+
+
+def cmd_sessions_resume(args: argparse.Namespace) -> int:
+    """Reconstruct a worktree from a preserved branch and resume."""
+    from factory.run_index import read_run, update_status
+
+    project_path = Path(args.path).resolve()
+    run_id = args.run_id
+
+    meta = read_run(project_path, run_id)
+    if meta is None:
+        print(f"No session found with run_id={run_id}", file=sys.stderr)
+        return 1
+
+    if meta.status == "active":
+        print(f"Session {run_id} is already active.")
+
+    wt_path = Path(meta.worktree_path)
+    if not wt_path.exists():
+        result = subprocess.run(
+            ["git", "branch", "--list", meta.branch],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+        )
+        if meta.branch not in result.stdout:
+            print(f"Branch {meta.branch} no longer exists. Cannot resume.", file=sys.stderr)
+            return 1
+
+        wt_path.parent.mkdir(parents=True, exist_ok=True)
+        result = subprocess.run(
+            ["git", "worktree", "add", str(wt_path), meta.branch],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print(f"Failed to reconstruct worktree: {result.stderr.strip()}", file=sys.stderr)
+            return 1
+
+        factory_dir = project_path / ".factory"
+        wt_factory = wt_path / ".factory"
+        if wt_factory.exists() or wt_factory.is_symlink():
+            if wt_factory.is_dir() and not wt_factory.is_symlink():
+                import shutil
+                shutil.rmtree(wt_factory)
+            else:
+                wt_factory.unlink()
+        wt_factory.symlink_to(factory_dir)
+
+        print(f"Reconstructed worktree at {wt_path}")
+    else:
+        print(f"Worktree already exists at {wt_path}")
+
+    update_status(project_path, run_id, "active")
+
+    from factory.checkpoint import format_checkpoint, load_checkpoint
+    checkpoint = load_checkpoint(project_path)
+    if checkpoint:
+        print("\n=== Resume Context ===")
+        print(format_checkpoint(checkpoint))
+    else:
+        print(f"\nSession {run_id} is active. No checkpoint found — start fresh from branch {meta.branch}.")
+
+    return 0
+
+
 def cmd_research(args: argparse.Namespace) -> int:
     """Print citation index table and coverage summary."""
     from factory.research_index import build_citation_index, citation_coverage
@@ -4311,6 +4477,28 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("resume", help="Load checkpoint and display resume context")
     p.add_argument("path", help="Path to the project")
 
+    # sessions — session management
+    sessions_parser = sub.add_parser("sessions", help="Manage factory sessions (list, prune, resume)")
+    sessions_sub = sessions_parser.add_subparsers(dest="sessions_command")
+
+    p_sess_list = sessions_sub.add_parser("list", help="List factory sessions")
+    p_sess_list.add_argument("path", help="Path to the project")
+    p_sess_list.add_argument("--status", choices=["active", "completed", "crashed"],
+                              default=None, help="Filter by status")
+
+    p_sess_prune = sessions_sub.add_parser("prune", help="Prune completed/crashed sessions")
+    p_sess_prune.add_argument("path", help="Path to the project")
+    p_sess_prune.add_argument("--older-than", default=None,
+                               help="Only prune sessions older than this (e.g. 7d, 24h)")
+    p_sess_prune.add_argument("--status", choices=["active", "completed", "crashed"],
+                               default=None, help="Prune only sessions with this status")
+    p_sess_prune.add_argument("--dry-run", action="store_true", default=False,
+                               help="Show what would be pruned without deleting")
+
+    p_sess_resume = sessions_sub.add_parser("resume", help="Resume a previous session")
+    p_sess_resume.add_argument("path", help="Path to the project")
+    p_sess_resume.add_argument("run_id", help="Run ID to resume")
+
     # log
     p = sub.add_parser("log", help="Append a structured event to .factory/events.jsonl")
     p.add_argument("path", help="Path to the project")
@@ -4720,6 +4908,7 @@ def main(argv: list[str] | None = None) -> int:
         "review": cmd_review,
         "checkpoint": cmd_checkpoint,
         "resume": cmd_resume,
+        "sessions": cmd_sessions,
         "log": cmd_log,
         "vault-init": cmd_vault_init,
         "message": cmd_message,

--- a/factory/run_index.py
+++ b/factory/run_index.py
@@ -1,0 +1,96 @@
+"""Run index — tracks factory session metadata in .factory/runs/<run-id>.json."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Literal
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+
+log = structlog.get_logger()
+
+
+class RunMetadata(BaseModel):
+    """Metadata for a single factory run / session."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    run_id: str
+    branch: str
+    worktree_path: str
+    created_at: str
+    mode: str
+    status: Literal["active", "completed", "crashed"]
+
+
+def _runs_dir(project_path: Path) -> Path:
+    return project_path / ".factory" / "runs"
+
+
+def write_run(project_path: Path, metadata: RunMetadata) -> None:
+    """Write run metadata atomically to .factory/runs/<run-id>.json."""
+    runs = _runs_dir(project_path)
+    runs.mkdir(parents=True, exist_ok=True)
+    target = runs / f"{metadata.run_id}.json"
+    data = json.dumps(metadata.model_dump(), indent=2) + "\n"
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=runs, suffix=".tmp")
+    try:
+        with open(tmp_fd, "w") as f:
+            f.write(data)
+        Path(tmp_path).replace(target)
+    except Exception:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
+    log.debug("run_index.write", run_id=metadata.run_id, status=metadata.status)
+
+
+def read_run(project_path: Path, run_id: str) -> RunMetadata | None:
+    """Load one run's metadata, or None if not found."""
+    path = _runs_dir(project_path) / f"{run_id}.json"
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return RunMetadata.model_validate(data)
+
+
+def list_runs(project_path: Path) -> list[RunMetadata]:
+    """List all runs sorted by created_at descending."""
+    runs = _runs_dir(project_path)
+    if not runs.is_dir():
+        return []
+    results: list[RunMetadata] = []
+    for p in runs.glob("*.json"):
+        try:
+            data = json.loads(p.read_text())
+            results.append(RunMetadata.model_validate(data))
+        except Exception:
+            log.warning("run_index.skip_corrupt", path=str(p))
+    results.sort(key=lambda r: r.created_at, reverse=True)
+    return results
+
+
+def update_status(
+    project_path: Path,
+    run_id: str,
+    status: Literal["active", "completed", "crashed"],
+) -> bool:
+    """Update the status field of an existing run. Returns True if updated."""
+    meta = read_run(project_path, run_id)
+    if meta is None:
+        return False
+    meta = meta.model_copy(update={"status": status})
+    write_run(project_path, meta)
+    log.debug("run_index.update_status", run_id=run_id, status=status)
+    return True
+
+
+def delete_run(project_path: Path, run_id: str) -> bool:
+    """Delete a run metadata file. Returns True if deleted."""
+    path = _runs_dir(project_path) / f"{run_id}.json"
+    if not path.exists():
+        return False
+    path.unlink()
+    return True

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -55,6 +55,22 @@ def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path
     except Exception:
         pass
 
+    try:
+        from factory.run_index import RunMetadata, write_run
+        from datetime import datetime
+
+        meta = RunMetadata(
+            run_id=run_id,
+            branch=branch,
+            worktree_path=str(wt_dir),
+            created_at=datetime.now().isoformat(),
+            mode="unknown",
+            status="active",
+        )
+        write_run(project_path, meta)
+    except Exception:
+        pass
+
     return wt_dir, branch
 
 
@@ -81,11 +97,11 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
         capture_output=True,
     )
 
-    subprocess.run(
-        ["git", "branch", "-D", branch],
-        cwd=project_path,
-        capture_output=True,
-    )
+    try:
+        from factory.run_index import update_status
+        update_status(project_path, run_id, "completed")
+    except Exception:
+        pass
 
 
 def prune_stale(project_path: Path) -> list[str]:

--- a/tests/test_cli_sessions.py
+++ b/tests/test_cli_sessions.py
@@ -1,0 +1,164 @@
+"""Tests for factory sessions CLI commands (list, prune, resume)."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from factory.cli import main
+from factory.run_index import RunMetadata, list_runs, read_run, write_run
+
+pytestmark = pytest.mark.real_worktree
+
+
+@pytest.fixture
+def git_project(tmp_path: Path) -> Path:
+    """Create a minimal git project with .factory/ directory."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    env = {
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+        "HOME": str(tmp_path),
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+    }
+
+    subprocess.run(["git", "init", "-b", "main"], cwd=project, capture_output=True, check=True)
+    (project / ".gitignore").write_text(".factory/\n")
+    (project / "README.md").write_text("hello")
+    subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "initial"],
+        cwd=project, capture_output=True, check=True, env=env,
+    )
+
+    factory_dir = project / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "config.json").write_text("{}")
+
+    return project
+
+
+def _seed_run(project: Path, run_id: str, status: str = "completed", created_at: str = "2026-06-28T12:00:00") -> None:
+    """Seed a run metadata entry and create the corresponding git branch."""
+    branch = f"factory/run-{run_id}"
+    env = {
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@test.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@test.com",
+        "HOME": str(project.parent),
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+    }
+    subprocess.run(
+        ["git", "branch", branch],
+        cwd=project, capture_output=True, check=True, env=env,
+    )
+    write_run(project, RunMetadata(
+        run_id=run_id,
+        branch=branch,
+        worktree_path=str(project / ".factory-worktrees" / f"run-{run_id}"),
+        created_at=created_at,
+        mode="improve",
+        status=status,
+    ))
+
+
+class TestSessionsList:
+    def test_no_sessions(self, git_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        ret = main(["sessions", "list", str(git_project)])
+        assert ret == 0
+        assert "No sessions found" in capsys.readouterr().out
+
+    def test_lists_sessions(self, git_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_run(git_project, "aabb1122", status="completed")
+        _seed_run(git_project, "ccdd3344", status="active")
+
+        ret = main(["sessions", "list", str(git_project)])
+        assert ret == 0
+        output = capsys.readouterr().out
+        assert "aabb1122" in output
+        assert "ccdd3344" in output
+
+    def test_filter_by_status(self, git_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_run(git_project, "aabb1122", status="completed")
+        _seed_run(git_project, "ccdd3344", status="active")
+
+        ret = main(["sessions", "list", str(git_project), "--status", "active"])
+        assert ret == 0
+        output = capsys.readouterr().out
+        assert "ccdd3344" in output
+        assert "aabb1122" not in output
+
+
+class TestSessionsPrune:
+    def test_prune_completed(self, git_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_run(git_project, "aabb1122", status="completed")
+
+        ret = main(["sessions", "prune", str(git_project)])
+        assert ret == 0
+        output = capsys.readouterr().out
+        assert "Pruned" in output
+
+        assert read_run(git_project, "aabb1122") is None
+
+        result = subprocess.run(
+            ["git", "branch", "--list", "factory/run-aabb1122"],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert "factory/run-aabb1122" not in result.stdout
+
+    def test_prune_dry_run(self, git_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _seed_run(git_project, "aabb1122", status="completed")
+
+        ret = main(["sessions", "prune", str(git_project), "--dry-run"])
+        assert ret == 0
+        output = capsys.readouterr().out
+        assert "Would prune" in output
+
+        assert read_run(git_project, "aabb1122") is not None
+
+    def test_prune_nothing(self, git_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        ret = main(["sessions", "prune", str(git_project)])
+        assert ret == 0
+        assert "Nothing to prune" in capsys.readouterr().out
+
+    def test_prune_does_not_touch_active(self, git_project: Path) -> None:
+        _seed_run(git_project, "active01", status="active")
+        _seed_run(git_project, "done0001", status="completed")
+
+        main(["sessions", "prune", str(git_project)])
+
+        assert read_run(git_project, "active01") is not None
+        assert read_run(git_project, "done0001") is None
+
+
+class TestSessionsResume:
+    def test_resume_reconstructs_worktree(self, git_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        from factory.worktree import create_worktree, remove_worktree
+
+        wt_path, branch = create_worktree(git_project)
+        runs = list_runs(git_project)
+        run_id = runs[0].run_id
+
+        remove_worktree(git_project, wt_path, branch)
+        assert not wt_path.exists()
+
+        ret = main(["sessions", "resume", str(git_project), run_id])
+        assert ret == 0
+        output = capsys.readouterr().out
+        assert "Reconstructed worktree" in output
+
+        assert wt_path.exists()
+
+        meta = read_run(git_project, run_id)
+        assert meta is not None
+        assert meta.status == "active"
+
+    def test_resume_nonexistent_session(self, git_project: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        ret = main(["sessions", "resume", str(git_project), "nonexistent"])
+        assert ret == 1
+        assert "No session found" in capsys.readouterr().err

--- a/tests/test_run_index.py
+++ b/tests/test_run_index.py
@@ -1,0 +1,170 @@
+"""Tests for factory/run_index.py — run metadata CRUD operations."""
+
+from pathlib import Path
+
+import pytest
+
+from factory.run_index import (
+    RunMetadata,
+    delete_run,
+    list_runs,
+    read_run,
+    update_status,
+    write_run,
+)
+
+
+@pytest.fixture
+def project_with_factory(tmp_path: Path) -> Path:
+    """Create a minimal project directory with .factory/."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".factory").mkdir()
+    return project
+
+
+def _make_meta(
+    run_id: str = "abcd1234",
+    branch: str = "factory/run-abcd1234",
+    status: str = "active",
+    mode: str = "improve",
+) -> RunMetadata:
+    return RunMetadata(
+        run_id=run_id,
+        branch=branch,
+        worktree_path=f"/tmp/worktrees/run-{run_id}",
+        created_at="2026-06-28T12:00:00",
+        mode=mode,
+        status=status,
+    )
+
+
+class TestRunMetadataModel:
+    def test_valid_model(self) -> None:
+        meta = _make_meta()
+        assert meta.run_id == "abcd1234"
+        assert meta.status == "active"
+
+    def test_rejects_invalid_status(self) -> None:
+        with pytest.raises(Exception):
+            _make_meta(status="invalid")
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(Exception):
+            RunMetadata(
+                run_id="x",
+                branch="b",
+                worktree_path="/tmp",
+                created_at="2026-01-01T00:00:00",
+                mode="improve",
+                status="active",
+                extra_field="bad",
+            )
+
+
+class TestWriteAndRead:
+    def test_write_creates_file(self, project_with_factory: Path) -> None:
+        meta = _make_meta()
+        write_run(project_with_factory, meta)
+
+        run_file = project_with_factory / ".factory" / "runs" / "abcd1234.json"
+        assert run_file.exists()
+
+    def test_read_returns_written_data(self, project_with_factory: Path) -> None:
+        meta = _make_meta()
+        write_run(project_with_factory, meta)
+
+        loaded = read_run(project_with_factory, "abcd1234")
+        assert loaded is not None
+        assert loaded.run_id == "abcd1234"
+        assert loaded.branch == "factory/run-abcd1234"
+        assert loaded.status == "active"
+        assert loaded.mode == "improve"
+
+    def test_read_nonexistent_returns_none(self, project_with_factory: Path) -> None:
+        assert read_run(project_with_factory, "nonexistent") is None
+
+    def test_write_is_idempotent(self, project_with_factory: Path) -> None:
+        meta = _make_meta()
+        write_run(project_with_factory, meta)
+        write_run(project_with_factory, meta)
+
+        loaded = read_run(project_with_factory, "abcd1234")
+        assert loaded is not None
+
+    def test_creates_runs_directory(self, project_with_factory: Path) -> None:
+        runs_dir = project_with_factory / ".factory" / "runs"
+        assert not runs_dir.exists()
+
+        write_run(project_with_factory, _make_meta())
+        assert runs_dir.is_dir()
+
+
+class TestListRuns:
+    def test_empty_when_no_runs(self, project_with_factory: Path) -> None:
+        assert list_runs(project_with_factory) == []
+
+    def test_lists_all_runs(self, project_with_factory: Path) -> None:
+        write_run(project_with_factory, _make_meta(run_id="aaaa1111", branch="factory/run-aaaa1111"))
+        write_run(project_with_factory, _make_meta(run_id="bbbb2222", branch="factory/run-bbbb2222"))
+
+        runs = list_runs(project_with_factory)
+        assert len(runs) == 2
+        ids = {r.run_id for r in runs}
+        assert ids == {"aaaa1111", "bbbb2222"}
+
+    def test_sorted_by_created_at_desc(self, project_with_factory: Path) -> None:
+        write_run(project_with_factory, RunMetadata(
+            run_id="old",
+            branch="factory/run-old",
+            worktree_path="/tmp/old",
+            created_at="2026-01-01T00:00:00",
+            mode="improve",
+            status="completed",
+        ))
+        write_run(project_with_factory, RunMetadata(
+            run_id="new",
+            branch="factory/run-new",
+            worktree_path="/tmp/new",
+            created_at="2026-06-28T12:00:00",
+            mode="improve",
+            status="active",
+        ))
+
+        runs = list_runs(project_with_factory)
+        assert runs[0].run_id == "new"
+        assert runs[1].run_id == "old"
+
+    def test_skips_corrupt_files(self, project_with_factory: Path) -> None:
+        write_run(project_with_factory, _make_meta())
+        runs_dir = project_with_factory / ".factory" / "runs"
+        (runs_dir / "corrupt.json").write_text("not json{{{")
+
+        runs = list_runs(project_with_factory)
+        assert len(runs) == 1
+
+
+class TestUpdateStatus:
+    def test_updates_status(self, project_with_factory: Path) -> None:
+        write_run(project_with_factory, _make_meta(status="active"))
+
+        result = update_status(project_with_factory, "abcd1234", "completed")
+        assert result is True
+
+        loaded = read_run(project_with_factory, "abcd1234")
+        assert loaded is not None
+        assert loaded.status == "completed"
+
+    def test_returns_false_for_nonexistent(self, project_with_factory: Path) -> None:
+        result = update_status(project_with_factory, "nonexistent", "crashed")
+        assert result is False
+
+
+class TestDeleteRun:
+    def test_deletes_run(self, project_with_factory: Path) -> None:
+        write_run(project_with_factory, _make_meta())
+        assert delete_run(project_with_factory, "abcd1234") is True
+        assert read_run(project_with_factory, "abcd1234") is None
+
+    def test_returns_false_for_nonexistent(self, project_with_factory: Path) -> None:
+        assert delete_run(project_with_factory, "nonexistent") is False

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -111,7 +111,7 @@ class TestCreateWorktree:
 
 
 class TestRemoveWorktree:
-    def test_removes_worktree_completely(self, git_project: Path) -> None:
+    def test_removes_worktree_dir_but_preserves_branch(self, git_project: Path) -> None:
         wt_path, branch = create_worktree(git_project)
         assert wt_path.exists()
 
@@ -123,7 +123,7 @@ class TestRemoveWorktree:
             ["git", "branch", "--list", branch],
             cwd=git_project, capture_output=True, text=True,
         )
-        assert branch not in result.stdout
+        assert branch in result.stdout
 
     def test_safe_on_already_removed_path(self, git_project: Path) -> None:
         wt_path, branch = create_worktree(git_project)
@@ -283,6 +283,28 @@ class TestSymlinkResolution:
         config_via_symlink = (wt_path / ".factory" / "config.json").read_text()
         config_direct = (git_project / ".factory" / "config.json").read_text()
         assert config_via_symlink == config_direct
+
+
+class TestRunIndexIntegration:
+    def test_create_worktree_writes_run_metadata(self, git_project: Path) -> None:
+        from factory.run_index import list_runs
+
+        wt_path, branch = create_worktree(git_project)
+
+        runs = list_runs(git_project)
+        assert len(runs) == 1
+        assert runs[0].branch == branch
+        assert runs[0].status == "active"
+
+    def test_remove_worktree_marks_completed(self, git_project: Path) -> None:
+        from factory.run_index import list_runs
+
+        wt_path, branch = create_worktree(git_project)
+        remove_worktree(git_project, wt_path, branch)
+
+        runs = list_runs(git_project)
+        assert len(runs) == 1
+        assert runs[0].status == "completed"
 
 
 class TestFilelockConcurrency:


### PR DESCRIPTION
Closes #698

## Changes

- **Preserve git branches**: Removed `git branch -D` from `remove_worktree()`. Branches are the key artifact for session reconstruction and cost kilobytes. Worktree directory cleanup and `git worktree prune` remain.
- **Add run index** (`factory/run_index.py`): New module with `RunMetadata` Pydantic model and CRUD functions (`write_run`, `read_run`, `list_runs`, `update_status`, `delete_run`). Writes `.factory/runs/<run-id>.json` atomically via tempfile+rename.
- **Hook worktree lifecycle**: `create_worktree()` now writes run metadata (status=active) after creating the worktree. `remove_worktree()` updates run status to completed.
- **Add CLI commands**:
  - `factory sessions list [--status active|completed|crashed]` — tabular listing of all sessions
  - `factory sessions prune [--older-than 7d] [--dry-run]` — delete metadata + branches for completed/crashed sessions
  - `factory sessions resume <run-id>` — reconstruct worktree from preserved branch, restore .factory symlink, update status to active, show checkpoint if available
- **Tests**: 16 unit tests for run_index, 9 CLI integration tests, 2 worktree integration tests verifying branch preservation and status updates