### PR TITLE
feat: factory session recovery — preserve branches, run index, and session commands

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1933,7 +1933,10 @@ def cmd_sessions_resume(args: argparse.Namespace) -> int:
     project_path = Path(args.path).resolve()
     run_id = args.run_id
 
-    meta = load_run(project_path, run_id)
+    try:
+        meta = load_run(project_path, run_id)
+    except ValueError:
+        meta = None
     if meta is None:
         print(f"Error: no session found with run ID '{run_id}'.", file=sys.stderr)
         print("Use 'factory sessions-list <path>' to see available sessions.", file=sys.stderr)

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1870,6 +1870,124 @@ def cmd_resume(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_sessions_list(args: argparse.Namespace) -> int:
+    """List past factory sessions from the run index."""
+    from factory.runs import SessionRunStatus, list_runs
+
+    project_path = Path(args.path).resolve()
+    runs = list_runs(project_path)
+
+    status_filter = getattr(args, "status", None)
+    if status_filter:
+        runs = [r for r in runs if r.status == SessionRunStatus(status_filter)]
+
+    if getattr(args, "json", False):
+        print(json.dumps([r.model_dump() for r in runs], indent=2))
+        return 0
+
+    if not runs:
+        print("No sessions found.")
+        return 0
+
+    header = f"{'RUN ID':<12} {'STATUS':<12} {'MODE':<10} {'BRANCH':<30} {'CREATED':<26} {'EXPERIMENTS'}"
+    print(header)
+    print("-" * len(header))
+    for r in runs:
+        exp_ids = ",".join(str(e) for e in r.experiment_ids) if r.experiment_ids else "-"
+        mode = r.mode or "-"
+        print(f"{r.run_id:<12} {r.status.value:<12} {mode:<10} {r.branch:<30} {r.created_at:<26} {exp_ids}")
+
+    return 0
+
+
+def cmd_sessions_prune(args: argparse.Namespace) -> int:
+    """Prune old session metadata and branches."""
+    from factory.runs import prune_runs
+
+    project_path = Path(args.path).resolve()
+    older_than = getattr(args, "older_than", 30)
+    dry_run = getattr(args, "dry_run", False)
+    prune_all = getattr(args, "all", False)
+
+    pruned = prune_runs(
+        project_path,
+        older_than_days=older_than,
+        dry_run=dry_run,
+        prune_all=prune_all,
+    )
+
+    if not pruned:
+        print("Nothing to prune.")
+    else:
+        for msg in pruned:
+            print(msg)
+        print(f"\n{len(pruned)} session(s) {'would be pruned' if dry_run else 'pruned'}.")
+
+    return 0
+
+
+def cmd_sessions_resume(args: argparse.Namespace) -> int:
+    """Reconstruct a worktree from a preserved session branch."""
+    from factory.runs import load_run
+
+    project_path = Path(args.path).resolve()
+    run_id = args.run_id
+
+    meta = load_run(project_path, run_id)
+    if meta is None:
+        print(f"Error: no session found with run ID '{run_id}'.", file=sys.stderr)
+        print("Use 'factory sessions-list <path>' to see available sessions.", file=sys.stderr)
+        return 1
+
+    branch_check = subprocess.run(
+        ["git", "rev-parse", "--verify", meta.branch],
+        cwd=project_path,
+        capture_output=True,
+    )
+    if branch_check.returncode != 0:
+        print(f"Error: branch '{meta.branch}' no longer exists.", file=sys.stderr)
+        print("It may have been pruned. Use 'factory sessions-list' to check.", file=sys.stderr)
+        return 1
+
+    wt_path = Path(meta.worktree_path)
+    if wt_path.exists():
+        print(f"Error: worktree path already exists: {wt_path}", file=sys.stderr)
+        print("Remove it first or use a different session.", file=sys.stderr)
+        return 1
+
+    wt_path.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        ["git", "worktree", "add", str(wt_path), meta.branch],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error reconstructing worktree: {result.stderr.strip()}", file=sys.stderr)
+        return 1
+
+    factory_dir = project_path / ".factory"
+    wt_factory = wt_path / ".factory"
+    if wt_factory.exists() or wt_factory.is_symlink():
+        import shutil
+        if wt_factory.is_dir() and not wt_factory.is_symlink():
+            shutil.rmtree(wt_factory)
+        else:
+            wt_factory.unlink()
+    wt_factory.symlink_to(factory_dir)
+
+    print(f"Worktree reconstructed at: {wt_path}")
+    print(f"Branch: {meta.branch}")
+    if meta.claude_session_id:
+        print("\nTo resume the Claude session:")
+        print(f"  cd {wt_path} && claude --resume --session-id {meta.claude_session_id}")
+    else:
+        print("\nNo Claude session ID recorded. To work in the restored worktree:")
+        print(f"  cd {wt_path}")
+
+    return 0
+
+
 def cmd_research(args: argparse.Namespace) -> int:
     """Print citation index table and coverage summary."""
     from factory.research_index import build_citation_index, citation_coverage
@@ -4344,6 +4462,28 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("resume", help="Load checkpoint and display resume context")
     p.add_argument("path", help="Path to the project")
 
+    # sessions-list
+    p = sub.add_parser("sessions-list", help="List past factory sessions")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--status", choices=["running", "completed", "error"],
+                   help="Filter by session status")
+    p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # sessions-prune
+    p = sub.add_parser("sessions-prune", help="Clean up old session branches and metadata")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--older-than", type=int, default=30,
+                   help="Prune sessions older than N days (default: 30)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Show what would be pruned without acting")
+    p.add_argument("--all", action="store_true",
+                   help="Prune all completed sessions regardless of age")
+
+    # sessions-resume
+    p = sub.add_parser("sessions-resume", help="Reconstruct worktree from a past session")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("run_id", help="Run ID of the session to resume")
+
     # log
     p = sub.add_parser("log", help="Append a structured event to .factory/events.jsonl")
     p.add_argument("path", help="Path to the project")
@@ -4753,6 +4893,9 @@ def main(argv: list[str] | None = None) -> int:
         "review": cmd_review,
         "checkpoint": cmd_checkpoint,
         "resume": cmd_resume,
+        "sessions-list": cmd_sessions_list,
+        "sessions-prune": cmd_sessions_prune,
+        "sessions-resume": cmd_sessions_resume,
         "log": cmd_log,
         "vault-init": cmd_vault_init,
         "message": cmd_message,

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -1952,7 +1952,8 @@ def cmd_sessions_resume(args: argparse.Namespace) -> int:
         print("It may have been pruned. Use 'factory sessions-list' to check.", file=sys.stderr)
         return 1
 
-    wt_path = Path(meta.worktree_path)
+    target = getattr(args, "target", None)
+    wt_path = Path(target) if target else Path(meta.worktree_path)
     if wt_path.exists():
         print(f"Error: worktree path already exists: {wt_path}", file=sys.stderr)
         print("Remove it first or use a different session.", file=sys.stderr)
@@ -4486,6 +4487,7 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("sessions-resume", help="Reconstruct worktree from a past session")
     p.add_argument("path", help="Path to the project")
     p.add_argument("run_id", help="Run ID of the session to resume")
+    p.add_argument("--target", help="Override worktree path (use instead of stored path)")
 
     # log
     p = sub.add_parser("log", help="Append a structured event to .factory/events.jsonl")

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -16,7 +16,7 @@ import sys
 import tempfile
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -2645,6 +2645,18 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     base_branch = branch or _read_target_branch(project_path)
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
+    _run_id = wt_branch.removeprefix("factory/run-")
+    from factory.runs import RunMetadata, SessionRunStatus, save_run, update_run
+    save_run(project_path, RunMetadata(
+        run_id=_run_id,
+        branch=wt_branch,
+        worktree_path=str(wt_path),
+        base_branch=base_branch,
+        status=SessionRunStatus.running,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        mode=mode,
+    ))
+
     interactive = design_existing or bool(design_idea) or bool(research_ideation) or mode == "create"
     ceo_mode = "create" if mode == "create" else ("build" if interactive else mode)
     if clean_pr_flag is not None:
@@ -2737,7 +2749,10 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         finally:
             _stop_ceo_tailer(ceo_tailer)
             complete_cycle_session(project_path, cycle_span_id)
-            remove_worktree(project_path, wt_path, wt_branch)
+            _fin_status = SessionRunStatus.error if sys.exc_info()[1] else SessionRunStatus.completed
+            update_run(project_path, _run_id,
+                       status=_fin_status, completed_at=datetime.now(timezone.utc).isoformat())
+            remove_worktree(project_path, wt_path, wt_branch, preserve_branch=True)
             if needs_materialize and _is_scaffold_only(project_path):
                 import shutil
                 shutil.rmtree(project_path, ignore_errors=True)
@@ -2762,7 +2777,10 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     finally:
         _stop_ceo_tailer(ceo_tailer)
         complete_cycle_session(project_path, cycle_span_id)
-        remove_worktree(project_path, wt_path, wt_branch)
+        _fin_status = SessionRunStatus.error if sys.exc_info()[1] else SessionRunStatus.completed
+        update_run(project_path, _run_id,
+                   status=_fin_status, completed_at=datetime.now(timezone.utc).isoformat())
+        remove_worktree(project_path, wt_path, wt_branch, preserve_branch=True)
         if needs_materialize and _is_scaffold_only(project_path):
             import shutil
             shutil.rmtree(project_path, ignore_errors=True)
@@ -3818,6 +3836,18 @@ def _run_single_cycle(
     base_branch = branch or _read_target_branch(project_path)
     wt_path, wt_branch = create_worktree(project_path, base_branch)
 
+    _run_id = wt_branch.removeprefix("factory/run-")
+    from factory.runs import RunMetadata, SessionRunStatus, save_run, update_run
+    save_run(project_path, RunMetadata(
+        run_id=_run_id,
+        branch=wt_branch,
+        worktree_path=str(wt_path),
+        base_branch=base_branch,
+        status=SessionRunStatus.running,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        mode=mode,
+    ))
+
     try:
         task = _build_ceo_task(
             wt_path, mode, context, focus=focus, prompt_file=prompt_file,
@@ -3848,7 +3878,10 @@ def _run_single_cycle(
         print(result)
         return code
     finally:
-        remove_worktree(project_path, wt_path, wt_branch)
+        _fin_status = SessionRunStatus.error if sys.exc_info()[1] else SessionRunStatus.completed
+        update_run(project_path, _run_id,
+                   status=_fin_status, completed_at=datetime.now(timezone.utc).isoformat())
+        remove_worktree(project_path, wt_path, wt_branch, preserve_branch=True)
 
 
 def cmd_run(args: argparse.Namespace) -> int:

--- a/factory/runs.py
+++ b/factory/runs.py
@@ -6,8 +6,10 @@ session listing, resumption, and reconstruction.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
+import tempfile
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -61,7 +63,15 @@ def save_run(project_path: Path, metadata: RunMetadata) -> None:
     runs = _runs_dir(project_path)
     runs.mkdir(parents=True, exist_ok=True)
     path = runs / f"{metadata.run_id}.json"
-    path.write_text(metadata.model_dump_json(indent=2) + "\n")
+    fd, tmp = tempfile.mkstemp(dir=runs, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(metadata.model_dump_json(indent=2) + "\n")
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
     log.info("run_saved", run_id=metadata.run_id, status=metadata.status.value)
 
     try:
@@ -111,8 +121,17 @@ def update_run(project_path: Path, run_id: str, **kwargs: object) -> RunMetadata
     data.update(kwargs)
     updated = RunMetadata.model_validate(data)
 
-    path = _runs_dir(project_path) / f"{run_id}.json"
-    path.write_text(updated.model_dump_json(indent=2) + "\n")
+    runs = _runs_dir(project_path)
+    path = runs / f"{run_id}.json"
+    fd, tmp = tempfile.mkstemp(dir=runs, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(updated.model_dump_json(indent=2) + "\n")
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
     log.info("run_updated", run_id=run_id, **{k: str(v) for k, v in kwargs.items()})
 
     try:
@@ -135,7 +154,30 @@ def delete_run(project_path: Path, run_id: str) -> bool:
         return False
     path.unlink()
     log.info("run_deleted", run_id=run_id)
+
+    try:
+        from factory.events import emit_event
+        emit_event(project_path, "run.deleted", data={"run_id": run_id})
+    except Exception:
+        pass
+
     return True
+
+
+def _branch_in_use_by_worktree(project_path: Path, branch: str) -> bool:
+    """Check if a branch is currently checked out in any git worktree."""
+    result = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        if line.startswith("branch ") and line.endswith(f"/{branch}"):
+            return True
+    return False
 
 
 def prune_runs(
@@ -147,6 +189,7 @@ def prune_runs(
 ) -> list[str]:
     """Delete run metadata and branches older than N days (or all completed runs).
 
+    Running sessions are always skipped, even with prune_all=True.
     Returns list of human-readable descriptions of pruned items.
     """
     runs = list_runs(project_path)
@@ -154,7 +197,7 @@ def prune_runs(
     pruned: list[str] = []
 
     for meta in runs:
-        if meta.status == SessionRunStatus.running and not prune_all:
+        if meta.status == SessionRunStatus.running:
             continue
 
         created = datetime.fromisoformat(meta.created_at)
@@ -171,11 +214,14 @@ def prune_runs(
 
         delete_run(project_path, meta.run_id)
 
-        subprocess.run(
-            ["git", "branch", "-D", meta.branch],
-            cwd=project_path,
-            capture_output=True,
-        )
+        if _branch_in_use_by_worktree(project_path, meta.branch):
+            log.warning("branch_in_use", branch=meta.branch, run_id=meta.run_id)
+        else:
+            subprocess.run(
+                ["git", "branch", "-D", meta.branch],
+                cwd=project_path,
+                capture_output=True,
+            )
         pruned.append(f"Pruned: {desc}")
         log.info("run_pruned", run_id=meta.run_id, branch=meta.branch)
 

--- a/factory/runs.py
+++ b/factory/runs.py
@@ -6,6 +6,7 @@ session listing, resumption, and reconstruction.
 
 from __future__ import annotations
 
+import re
 import subprocess
 from datetime import datetime, timezone
 from enum import Enum
@@ -15,6 +16,13 @@ import structlog
 from pydantic import BaseModel, ConfigDict
 
 log = structlog.get_logger()
+
+_RUN_ID_RE = re.compile(r"^[a-f0-9]{8}$")
+
+
+def _validate_run_id(run_id: str) -> None:
+    if not _RUN_ID_RE.match(run_id):
+        raise ValueError(f"Invalid run_id: {run_id!r} (must match ^[a-f0-9]{{8}}$)")
 
 
 class SessionRunStatus(str, Enum):
@@ -49,6 +57,7 @@ def _runs_dir(project_path: Path) -> Path:
 
 def save_run(project_path: Path, metadata: RunMetadata) -> None:
     """Write run metadata to .factory/runs/{run_id}.json and emit run.created event."""
+    _validate_run_id(metadata.run_id)
     runs = _runs_dir(project_path)
     runs.mkdir(parents=True, exist_ok=True)
     path = runs / f"{metadata.run_id}.json"
@@ -68,6 +77,7 @@ def save_run(project_path: Path, metadata: RunMetadata) -> None:
 
 def load_run(project_path: Path, run_id: str) -> RunMetadata | None:
     """Load run metadata by ID. Returns None if not found."""
+    _validate_run_id(run_id)
     path = _runs_dir(project_path) / f"{run_id}.json"
     if not path.exists():
         return None
@@ -92,6 +102,7 @@ def list_runs(project_path: Path) -> list[RunMetadata]:
 
 def update_run(project_path: Path, run_id: str, **kwargs: object) -> RunMetadata | None:
     """Partial update of run metadata. Returns updated metadata, or None if not found."""
+    _validate_run_id(run_id)
     meta = load_run(project_path, run_id)
     if meta is None:
         return None
@@ -118,6 +129,7 @@ def update_run(project_path: Path, run_id: str, **kwargs: object) -> RunMetadata
 
 def delete_run(project_path: Path, run_id: str) -> bool:
     """Delete run metadata file. Returns True if deleted, False if not found."""
+    _validate_run_id(run_id)
     path = _runs_dir(project_path) / f"{run_id}.json"
     if not path.exists():
         return False

--- a/factory/runs.py
+++ b/factory/runs.py
@@ -1,0 +1,170 @@
+"""Run metadata persistence for factory session recovery.
+
+Stores per-run metadata in .factory/runs/<run_id>.json to enable
+session listing, resumption, and reconstruction.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+
+import structlog
+from pydantic import BaseModel, ConfigDict
+
+log = structlog.get_logger()
+
+
+class SessionRunStatus(str, Enum):
+    """Lifecycle status of a factory run."""
+
+    running = "running"
+    completed = "completed"
+    error = "error"
+
+
+class RunMetadata(BaseModel):
+    """Metadata for a single factory CEO run, persisted as JSON."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    run_id: str
+    branch: str
+    worktree_path: str
+    base_branch: str
+    status: SessionRunStatus
+    claude_session_id: str | None = None
+    child_session_ids: list[str] = []
+    created_at: str
+    completed_at: str | None = None
+    mode: str | None = None
+    experiment_ids: list[int] = []
+
+
+def _runs_dir(project_path: Path) -> Path:
+    return project_path / ".factory" / "runs"
+
+
+def save_run(project_path: Path, metadata: RunMetadata) -> None:
+    """Write run metadata to .factory/runs/{run_id}.json and emit run.created event."""
+    runs = _runs_dir(project_path)
+    runs.mkdir(parents=True, exist_ok=True)
+    path = runs / f"{metadata.run_id}.json"
+    path.write_text(metadata.model_dump_json(indent=2) + "\n")
+    log.info("run_saved", run_id=metadata.run_id, status=metadata.status.value)
+
+    try:
+        from factory.events import emit_event
+        emit_event(project_path, "run.created", data={
+            "run_id": metadata.run_id,
+            "branch": metadata.branch,
+            "status": metadata.status.value,
+        })
+    except Exception:
+        pass
+
+
+def load_run(project_path: Path, run_id: str) -> RunMetadata | None:
+    """Load run metadata by ID. Returns None if not found."""
+    path = _runs_dir(project_path) / f"{run_id}.json"
+    if not path.exists():
+        return None
+    return RunMetadata.model_validate_json(path.read_text())
+
+
+def list_runs(project_path: Path) -> list[RunMetadata]:
+    """Load all run metadata files from .factory/runs/."""
+    runs = _runs_dir(project_path)
+    if not runs.is_dir():
+        return []
+    results: list[RunMetadata] = []
+    for f in sorted(runs.iterdir()):
+        if f.suffix != ".json":
+            continue
+        try:
+            results.append(RunMetadata.model_validate_json(f.read_text()))
+        except Exception:
+            log.warning("run_load_failed", path=str(f))
+    return results
+
+
+def update_run(project_path: Path, run_id: str, **kwargs: object) -> RunMetadata | None:
+    """Partial update of run metadata. Returns updated metadata, or None if not found."""
+    meta = load_run(project_path, run_id)
+    if meta is None:
+        return None
+
+    data = meta.model_dump()
+    data.update(kwargs)
+    updated = RunMetadata.model_validate(data)
+
+    path = _runs_dir(project_path) / f"{run_id}.json"
+    path.write_text(updated.model_dump_json(indent=2) + "\n")
+    log.info("run_updated", run_id=run_id, **{k: str(v) for k, v in kwargs.items()})
+
+    try:
+        from factory.events import emit_event
+        emit_event(project_path, "run.updated", data={
+            "run_id": run_id,
+            **{k: str(v) for k, v in kwargs.items()},
+        })
+    except Exception:
+        pass
+
+    return updated
+
+
+def delete_run(project_path: Path, run_id: str) -> bool:
+    """Delete run metadata file. Returns True if deleted, False if not found."""
+    path = _runs_dir(project_path) / f"{run_id}.json"
+    if not path.exists():
+        return False
+    path.unlink()
+    log.info("run_deleted", run_id=run_id)
+    return True
+
+
+def prune_runs(
+    project_path: Path,
+    older_than_days: int = 30,
+    *,
+    dry_run: bool = False,
+    prune_all: bool = False,
+) -> list[str]:
+    """Delete run metadata and branches older than N days (or all completed runs).
+
+    Returns list of human-readable descriptions of pruned items.
+    """
+    runs = list_runs(project_path)
+    now = datetime.now(timezone.utc)
+    pruned: list[str] = []
+
+    for meta in runs:
+        if meta.status == SessionRunStatus.running and not prune_all:
+            continue
+
+        created = datetime.fromisoformat(meta.created_at)
+        age_days = (now - created).days
+
+        if not prune_all and age_days < older_than_days:
+            continue
+
+        desc = f"run {meta.run_id} (branch={meta.branch}, age={age_days}d, status={meta.status.value})"
+
+        if dry_run:
+            pruned.append(f"Would prune: {desc}")
+            continue
+
+        delete_run(project_path, meta.run_id)
+
+        subprocess.run(
+            ["git", "branch", "-D", meta.branch],
+            cwd=project_path,
+            capture_output=True,
+        )
+        pruned.append(f"Pruned: {desc}")
+        log.info("run_pruned", run_id=meta.run_id, branch=meta.branch)
+
+    return pruned

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -58,9 +58,21 @@ def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path
     return wt_dir, branch
 
 
-def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> None:
-    """Remove a worktree and its branch. Safe to call on already-removed paths."""
-    log.info("worktree_remove", branch=branch, path=str(worktree_path))
+def remove_worktree(
+    project_path: Path,
+    worktree_path: Path,
+    branch: str,
+    *,
+    preserve_branch: bool = True,
+) -> None:
+    """Remove a worktree directory. Safe to call on already-removed paths.
+
+    When preserve_branch is True (default), the git branch is kept so the
+    session can be reconstructed later. Pass preserve_branch=False to also
+    delete the branch (used by explicit prune commands).
+    """
+    log.info("worktree_remove", branch=branch, path=str(worktree_path),
+             preserve_branch=preserve_branch)
 
     run_id = branch.removeprefix("factory/run-")
     try:
@@ -68,6 +80,7 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
         emit_event(project_path, "worktree.removed", data={
             "run_id": run_id,
             "branch": branch,
+            "preserve_branch": preserve_branch,
         })
     except Exception:
         pass
@@ -81,15 +94,21 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
         capture_output=True,
     )
 
-    subprocess.run(
-        ["git", "branch", "-D", branch],
-        cwd=project_path,
-        capture_output=True,
-    )
+    if not preserve_branch:
+        subprocess.run(
+            ["git", "branch", "-D", branch],
+            cwd=project_path,
+            capture_output=True,
+        )
 
 
-def prune_stale(project_path: Path) -> list[str]:
-    """Clean up stale worktrees from crashed runs. Returns list of pruned entries."""
+def prune_stale(project_path: Path, *, delete_branches: bool = False) -> list[str]:
+    """Clean up stale worktree directories from crashed runs.
+
+    Returns list of pruned entries. When delete_branches is False (default),
+    orphaned branches are preserved for session recovery. Use
+    ``runs.prune_runs()`` for explicit branch cleanup.
+    """
     project_path = project_path.resolve()
     if not project_path.exists():
         return []
@@ -119,12 +138,13 @@ def prune_stale(project_path: Path) -> list[str]:
                 shutil.rmtree(d)
                 pruned.append(f"Removed orphaned directory: {d.name}")
                 log.info("worktree_pruned_orphan", name=d.name)
-                branch = f"factory/run-{run_id}"
-                subprocess.run(
-                    ["git", "branch", "-D", branch],
-                    cwd=project_path,
-                    capture_output=True,
-                )
+                if delete_branches:
+                    branch = f"factory/run-{run_id}"
+                    subprocess.run(
+                        ["git", "branch", "-D", branch],
+                        cwd=project_path,
+                        capture_output=True,
+                    )
 
     if pruned:
         log.info("worktree_prune_complete", pruned_count=len(pruned))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def _mock_worktree(tmp_path: Path, request: pytest.FixtureRequest) -> None:
     def _fake_create(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
         return project_path, "factory/run-fake0000"
 
-    def _fake_remove(project_path: Path, worktree_path: Path, branch: str) -> None:
+    def _fake_remove(project_path: Path, worktree_path: Path, branch: str, *, preserve_branch: bool = True) -> None:
         pass
 
     def _fake_prune(project_path: Path) -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def _mock_worktree(tmp_path: Path, request: pytest.FixtureRequest) -> None:
         return
 
     def _fake_create(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
-        return project_path, "factory/run-fake0000"
+        return project_path, "factory/run-face0000"
 
     def _fake_remove(project_path: Path, worktree_path: Path, branch: str, *, preserve_branch: bool = True) -> None:
         pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ def _mock_foreground():
     mock_run = MagicMock(return_value=MagicMock(returncode=0))
     with patch("factory.runners.claude.subprocess.run", mock_run), \
          patch("factory.worktree.create_worktree",
-               side_effect=lambda p, b="main": (p, "factory/run-test")), \
+               side_effect=lambda p, b="main": (p, "factory/run-deadbeef")), \
          patch("factory.worktree.remove_worktree"), \
          patch("factory.worktree.prune_stale", return_value=[]), \
          patch("factory.cli._read_target_branch", return_value="main"), \

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -172,3 +172,19 @@ class TestPruneRuns:
         pruned = prune_runs(project, prune_all=True)
         assert len(pruned) == 2
         assert list_runs(project) == []
+
+    def test_prune_all_skips_running(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        recent_ts = datetime.now(timezone.utc).isoformat()
+        save_run(project, _make_run("00000001", created_at=recent_ts, status=SessionRunStatus.running))
+        save_run(project, _make_run("00000002", created_at=recent_ts, status=SessionRunStatus.completed))
+
+        pruned = prune_runs(project, prune_all=True)
+        assert len(pruned) == 1
+        assert "00000002" in pruned[0]
+
+        remaining = list_runs(project)
+        assert len(remaining) == 1
+        assert remaining[0].run_id == "00000001"

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,174 @@
+"""Tests for factory/runs.py — run metadata CRUD operations."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from factory.runs import (
+    RunMetadata,
+    SessionRunStatus,
+    delete_run,
+    list_runs,
+    load_run,
+    prune_runs,
+    save_run,
+    update_run,
+)
+
+
+def _make_run(run_id: str = "abcd1234", **overrides: object) -> RunMetadata:
+    defaults: dict[str, object] = {
+        "run_id": run_id,
+        "branch": f"factory/run-{run_id}",
+        "worktree_path": f"/tmp/wt/run-{run_id}",
+        "base_branch": "main",
+        "status": SessionRunStatus.running,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "mode": "improve",
+    }
+    defaults.update(overrides)
+    return RunMetadata.model_validate(defaults)
+
+
+class TestSaveAndLoad:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        meta = _make_run()
+        save_run(project, meta)
+
+        loaded = load_run(project, meta.run_id)
+        assert loaded is not None
+        assert loaded.run_id == meta.run_id
+        assert loaded.branch == meta.branch
+        assert loaded.status == SessionRunStatus.running
+
+    def test_load_nonexistent(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        assert load_run(project, "nonexistent") is None
+
+
+class TestListRuns:
+    def test_list_empty(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        assert list_runs(project) == []
+
+    def test_list_multiple(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        save_run(project, _make_run("aaaa1111"))
+        save_run(project, _make_run("bbbb2222"))
+        save_run(project, _make_run("cccc3333"))
+
+        runs = list_runs(project)
+        assert len(runs) == 3
+        ids = {r.run_id for r in runs}
+        assert ids == {"aaaa1111", "bbbb2222", "cccc3333"}
+
+    def test_list_no_runs_dir(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        project.mkdir()
+        assert list_runs(project) == []
+
+
+class TestUpdateRun:
+    def test_update_status(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        save_run(project, _make_run())
+        updated = update_run(
+            project, "abcd1234",
+            status=SessionRunStatus.completed,
+            completed_at=datetime.now(timezone.utc).isoformat(),
+        )
+        assert updated is not None
+        assert updated.status == SessionRunStatus.completed
+        assert updated.completed_at is not None
+
+        reloaded = load_run(project, "abcd1234")
+        assert reloaded is not None
+        assert reloaded.status == SessionRunStatus.completed
+
+    def test_update_nonexistent(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        assert update_run(project, "nope", status=SessionRunStatus.error) is None
+
+
+class TestDeleteRun:
+    def test_delete_existing(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        save_run(project, _make_run())
+        assert delete_run(project, "abcd1234") is True
+        assert load_run(project, "abcd1234") is None
+        assert list_runs(project) == []
+
+    def test_delete_nonexistent(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        assert delete_run(project, "nope") is False
+
+
+class TestPruneRuns:
+    def test_prune_old_runs(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+        recent_ts = datetime.now(timezone.utc).isoformat()
+
+        save_run(project, _make_run("old00001", created_at=old_ts, status=SessionRunStatus.completed))
+        save_run(project, _make_run("new00001", created_at=recent_ts, status=SessionRunStatus.completed))
+
+        pruned = prune_runs(project, older_than_days=30)
+        assert len(pruned) == 1
+        assert "old00001" in pruned[0]
+
+        remaining = list_runs(project)
+        assert len(remaining) == 1
+        assert remaining[0].run_id == "new00001"
+
+    def test_prune_dry_run(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+        save_run(project, _make_run("old00001", created_at=old_ts, status=SessionRunStatus.completed))
+
+        pruned = prune_runs(project, older_than_days=30, dry_run=True)
+        assert len(pruned) == 1
+        assert "Would prune" in pruned[0]
+        assert load_run(project, "old00001") is not None
+
+    def test_prune_skips_running(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+        save_run(project, _make_run("old00001", created_at=old_ts, status=SessionRunStatus.running))
+
+        pruned = prune_runs(project, older_than_days=30)
+        assert len(pruned) == 0
+        assert load_run(project, "old00001") is not None
+
+    def test_prune_all(self, tmp_path: Path) -> None:
+        project = tmp_path / "proj"
+        (project / ".factory").mkdir(parents=True)
+
+        recent_ts = datetime.now(timezone.utc).isoformat()
+        save_run(project, _make_run("run00001", created_at=recent_ts, status=SessionRunStatus.completed))
+        save_run(project, _make_run("run00002", created_at=recent_ts, status=SessionRunStatus.error))
+
+        pruned = prune_runs(project, prune_all=True)
+        assert len(pruned) == 2
+        assert list_runs(project) == []

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -47,7 +47,7 @@ class TestSaveAndLoad:
         project = tmp_path / "proj"
         (project / ".factory").mkdir(parents=True)
 
-        assert load_run(project, "nonexistent") is None
+        assert load_run(project, "dead0000") is None
 
 
 class TestListRuns:
@@ -99,7 +99,7 @@ class TestUpdateRun:
         project = tmp_path / "proj"
         (project / ".factory").mkdir(parents=True)
 
-        assert update_run(project, "nope", status=SessionRunStatus.error) is None
+        assert update_run(project, "dead0000", status=SessionRunStatus.error) is None
 
 
 class TestDeleteRun:
@@ -116,7 +116,7 @@ class TestDeleteRun:
         project = tmp_path / "proj"
         (project / ".factory").mkdir(parents=True)
 
-        assert delete_run(project, "nope") is False
+        assert delete_run(project, "dead0000") is False
 
 
 class TestPruneRuns:
@@ -127,47 +127,47 @@ class TestPruneRuns:
         old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
         recent_ts = datetime.now(timezone.utc).isoformat()
 
-        save_run(project, _make_run("old00001", created_at=old_ts, status=SessionRunStatus.completed))
-        save_run(project, _make_run("new00001", created_at=recent_ts, status=SessionRunStatus.completed))
+        save_run(project, _make_run("01d00001", created_at=old_ts, status=SessionRunStatus.completed))
+        save_run(project, _make_run("ee000001", created_at=recent_ts, status=SessionRunStatus.completed))
 
         pruned = prune_runs(project, older_than_days=30)
         assert len(pruned) == 1
-        assert "old00001" in pruned[0]
+        assert "01d00001" in pruned[0]
 
         remaining = list_runs(project)
         assert len(remaining) == 1
-        assert remaining[0].run_id == "new00001"
+        assert remaining[0].run_id == "ee000001"
 
     def test_prune_dry_run(self, tmp_path: Path) -> None:
         project = tmp_path / "proj"
         (project / ".factory").mkdir(parents=True)
 
         old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
-        save_run(project, _make_run("old00001", created_at=old_ts, status=SessionRunStatus.completed))
+        save_run(project, _make_run("01d00001", created_at=old_ts, status=SessionRunStatus.completed))
 
         pruned = prune_runs(project, older_than_days=30, dry_run=True)
         assert len(pruned) == 1
         assert "Would prune" in pruned[0]
-        assert load_run(project, "old00001") is not None
+        assert load_run(project, "01d00001") is not None
 
     def test_prune_skips_running(self, tmp_path: Path) -> None:
         project = tmp_path / "proj"
         (project / ".factory").mkdir(parents=True)
 
         old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
-        save_run(project, _make_run("old00001", created_at=old_ts, status=SessionRunStatus.running))
+        save_run(project, _make_run("01d00001", created_at=old_ts, status=SessionRunStatus.running))
 
         pruned = prune_runs(project, older_than_days=30)
         assert len(pruned) == 0
-        assert load_run(project, "old00001") is not None
+        assert load_run(project, "01d00001") is not None
 
     def test_prune_all(self, tmp_path: Path) -> None:
         project = tmp_path / "proj"
         (project / ".factory").mkdir(parents=True)
 
         recent_ts = datetime.now(timezone.utc).isoformat()
-        save_run(project, _make_run("run00001", created_at=recent_ts, status=SessionRunStatus.completed))
-        save_run(project, _make_run("run00002", created_at=recent_ts, status=SessionRunStatus.error))
+        save_run(project, _make_run("00000001", created_at=recent_ts, status=SessionRunStatus.completed))
+        save_run(project, _make_run("00000002", created_at=recent_ts, status=SessionRunStatus.error))
 
         pruned = prune_runs(project, prune_all=True)
         assert len(pruned) == 2

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,70 @@
+"""CLI smoke tests for sessions-list, sessions-prune, sessions-resume commands."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from factory.cli import main
+from factory.runs import RunMetadata, SessionRunStatus, save_run
+
+
+def _save_test_run(project: Path, run_id: str = "test0001") -> None:
+    save_run(project, RunMetadata(
+        run_id=run_id,
+        branch=f"factory/run-{run_id}",
+        worktree_path=str(project / ".factory-worktrees" / f"run-{run_id}"),
+        base_branch="main",
+        status=SessionRunStatus.completed,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        mode="improve",
+    ))
+
+
+def test_sessions_list_empty(tmp_project: Path) -> None:
+    (tmp_project / ".factory").mkdir(exist_ok=True)
+    code = main(["sessions-list", str(tmp_project)])
+    assert code == 0
+
+
+def test_sessions_list_with_runs(tmp_project: Path) -> None:
+    (tmp_project / ".factory").mkdir(exist_ok=True)
+    _save_test_run(tmp_project, "aaaa1111")
+    _save_test_run(tmp_project, "bbbb2222")
+
+    code = main(["sessions-list", str(tmp_project)])
+    assert code == 0
+
+
+def test_sessions_list_json(tmp_project: Path, capsys: object) -> None:
+    (tmp_project / ".factory").mkdir(exist_ok=True)
+    _save_test_run(tmp_project)
+
+    code = main(["sessions-list", str(tmp_project), "--json"])
+    assert code == 0
+
+
+def test_sessions_list_status_filter(tmp_project: Path) -> None:
+    (tmp_project / ".factory").mkdir(exist_ok=True)
+    _save_test_run(tmp_project)
+
+    code = main(["sessions-list", str(tmp_project), "--status", "running"])
+    assert code == 0
+
+
+def test_sessions_prune_dry_run(tmp_project: Path) -> None:
+    (tmp_project / ".factory").mkdir(exist_ok=True)
+    _save_test_run(tmp_project)
+
+    code = main(["sessions-prune", str(tmp_project), "--dry-run"])
+    assert code == 0
+
+
+def test_sessions_prune_nothing(tmp_project: Path) -> None:
+    (tmp_project / ".factory").mkdir(exist_ok=True)
+    code = main(["sessions-prune", str(tmp_project)])
+    assert code == 0
+
+
+def test_sessions_resume_missing_run(tmp_project: Path) -> None:
+    (tmp_project / ".factory").mkdir(exist_ok=True)
+    code = main(["sessions-resume", str(tmp_project), "nonexistent"])
+    assert code == 1

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -7,7 +7,7 @@ from factory.cli import main
 from factory.runs import RunMetadata, SessionRunStatus, save_run
 
 
-def _save_test_run(project: Path, run_id: str = "test0001") -> None:
+def _save_test_run(project: Path, run_id: str = "ae5f0001") -> None:
     save_run(project, RunMetadata(
         run_id=run_id,
         branch=f"factory/run-{run_id}",

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -111,7 +111,7 @@ class TestCreateWorktree:
 
 
 class TestRemoveWorktree:
-    def test_removes_worktree_completely(self, git_project: Path) -> None:
+    def test_removes_directory_preserves_branch(self, git_project: Path) -> None:
         wt_path, branch = create_worktree(git_project)
         assert wt_path.exists()
 
@@ -123,7 +123,7 @@ class TestRemoveWorktree:
             ["git", "branch", "--list", branch],
             cwd=git_project, capture_output=True, text=True,
         )
-        assert branch not in result.stdout
+        assert branch in result.stdout
 
     def test_safe_on_already_removed_path(self, git_project: Path) -> None:
         wt_path, branch = create_worktree(git_project)
@@ -139,6 +139,74 @@ class TestRemoveWorktree:
             cwd=git_project, capture_output=True, text=True,
         )
         assert str(wt_path) not in result.stdout
+
+
+class TestBranchPreservation:
+    def test_remove_worktree_preserves_branch_by_default(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+        remove_worktree(git_project, wt_path, branch)
+
+        assert not wt_path.exists()
+        result = subprocess.run(
+            ["git", "branch", "--list", branch],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert branch in result.stdout
+
+    def test_remove_worktree_deletes_branch_when_not_preserved(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+        remove_worktree(git_project, wt_path, branch, preserve_branch=False)
+
+        assert not wt_path.exists()
+        result = subprocess.run(
+            ["git", "branch", "--list", branch],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert branch not in result.stdout
+
+    def test_prune_stale_preserves_branches_by_default(self, git_project: Path) -> None:
+        run_id = "aabb0011"
+        branch = f"factory/run-{run_id}"
+        subprocess.run(
+            ["git", "branch", branch],
+            cwd=git_project, capture_output=True, check=True,
+        )
+        wt_dir = git_project / ".factory-worktrees"
+        wt_dir.mkdir(parents=True, exist_ok=True)
+        orphan = wt_dir / f"run-{run_id}"
+        orphan.mkdir()
+        (orphan / "file.txt").write_text("stale")
+
+        prune_stale(git_project)
+
+        assert not orphan.exists()
+        result = subprocess.run(
+            ["git", "branch", "--list", branch],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert branch in result.stdout
+
+    def test_prune_stale_deletes_branches_when_requested(self, git_project: Path) -> None:
+        run_id = "ccdd0022"
+        branch = f"factory/run-{run_id}"
+        subprocess.run(
+            ["git", "branch", branch],
+            cwd=git_project, capture_output=True, check=True,
+        )
+        wt_dir = git_project / ".factory-worktrees"
+        wt_dir.mkdir(parents=True, exist_ok=True)
+        orphan = wt_dir / f"run-{run_id}"
+        orphan.mkdir()
+        (orphan / "file.txt").write_text("stale")
+
+        prune_stale(git_project, delete_branches=True)
+
+        assert not orphan.exists()
+        result = subprocess.run(
+            ["git", "branch", "--list", branch],
+            cwd=git_project, capture_output=True, text=True,
+        )
+        assert branch not in result.stdout
 
 
 class TestPruneStale:


### PR DESCRIPTION
Closes #698

## Changes

- **New module `factory/runs.py`**: `RunMetadata` Pydantic model and CRUD functions (`save_run`, `load_run`, `list_runs`, `update_run`, `delete_run`, `prune_runs`) for persisting per-run metadata at `.factory/runs/<run_id>.json`. Emits `run.created` and `run.updated` events.

- **`factory/worktree.py`**: `remove_worktree()` now takes `preserve_branch=True` (default) — branches are preserved after worktree removal so sessions can be reconstructed. `prune_stale()` takes `delete_branches=False` (default) — orphaned branches are no longer deleted during stale worktree cleanup.

- **`factory/cli.py`**: `cmd_ceo()` and `_run_single_cycle()` now call `save_run()` after creating a worktree and `update_run()` in `finally` blocks to track run lifecycle. Three new CLI commands:
  - `factory sessions-list <path>` — list past sessions with `--status` filter and `--json` output
  - `factory sessions-prune <path>` — prune old sessions with `--older-than`, `--dry-run`, `--all`
  - `factory sessions-resume <path> <run-id>` — reconstruct worktree from a preserved branch

- **Tests**: 13 CRUD tests in `test_runs.py`, 4 branch preservation tests in `test_worktree.py`, 7 CLI smoke tests in `test_sessions.py` (41 total pass).

## Test plan

- [x] `pytest tests/test_runs.py -v` — all 13 pass
- [x] `pytest tests/test_sessions.py -v` — all 7 pass
- [x] `pytest tests/test_worktree.py -v -k "not Symlink and not Filelock"` — all 21 pass (4 pre-existing failures excluded)
- [ ] Manual: run `factory ceo /path` and verify `.factory/runs/<id>.json` is written
- [ ] Manual: verify branch persists after run completes (`git branch --list factory/run-*`)
- [ ] Manual: `factory sessions-list /path` shows the completed run
- [ ] Manual: `factory sessions-resume /path <id>` reconstructs the worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)