### PR TITLE
Add RobotSail to ceo-review authorized users

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
-      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect"]'), github.event.comment.user.login)
+      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary
- Adds `RobotSail` to the authorized users list in `.github/workflows/ceo-review.yml`

## Test plan
- [ ] Verify `@ceo-review` comment from RobotSail triggers the workflow