### PR TITLE
feat: add nightly release workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,8 +3,6 @@ name: Benchmark CI
 on:
   push:
     branches: [main]
-  schedule:
-    - cron: '17 6 * * 1-5'
   workflow_dispatch:
     inputs:
       benchmark:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -86,8 +86,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           KEEP=7
-          NIGHTLIES=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 \
-            | grep 'nightly-' | awk '{print $1}')
+          NIGHTLIES=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName \
+            -q '[.[] | select(.tagName | startswith("nightly-"))][].tagName')
 
           COUNT=0
           for TAG in $NIGHTLIES; do

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,99 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for new commits since last nightly
+        id: check
+        run: |
+          LAST_NIGHTLY=$(git tag --list 'nightly-*' --sort=-creatordate | head -n1)
+          if [ -n "$LAST_NIGHTLY" ]; then
+            NEW_COMMITS=$(git rev-list "$LAST_NIGHTLY"..HEAD --count)
+            if [ "$NEW_COMMITS" -eq 0 ]; then
+              echo "No new commits since $LAST_NIGHTLY — skipping release."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Set release variables
+        if: steps.check.outputs.skip != 'true'
+        id: vars
+        run: |
+          TAG="nightly-$(date -u +%Y-%m-%d)"
+          TITLE="Nightly $(date -u +%Y-%m-%d)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
+      - name: Delete existing release for today if re-running
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.vars.outputs.tag }}"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Deleting existing release $TAG"
+            gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
+          fi
+
+      - name: Find latest stable tag for notes
+        if: steps.check.outputs.skip != 'true'
+        id: stable
+        run: |
+          STABLE_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n1)
+          if [ -n "$STABLE_TAG" ]; then
+            echo "tag=$STABLE_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create nightly release
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.vars.outputs.tag }}"
+          TITLE="${{ steps.vars.outputs.title }}"
+          STABLE="${{ steps.stable.outputs.tag }}"
+
+          NOTES_ARGS=""
+          if [ -n "$STABLE" ]; then
+            NOTES_ARGS="--notes-start-tag $STABLE"
+          fi
+
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TITLE" \
+            --prerelease \
+            --generate-notes \
+            $NOTES_ARGS
+
+      - name: Cleanup old nightly releases
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          KEEP=7
+          NIGHTLIES=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 \
+            | grep 'nightly-' | awk '{print $1}')
+
+          COUNT=0
+          for TAG in $NIGHTLIES; do
+            COUNT=$((COUNT + 1))
+            if [ "$COUNT" -gt "$KEEP" ]; then
+              echo "Deleting old nightly release: $TAG"
+              gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
+            fi
+          done


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/nightly-release.yml` — creates a `nightly-YYYY-MM-DD` pre-release daily at 05:00 UTC with auto-generated release notes
- Removes the `schedule` trigger from `benchmark.yml` — benchmarks now fire via the nightly release's `release: [created]` event instead of a separate cron, eliminating duplicate runs
- Skips release creation when there are no new commits since the last nightly
- Idempotent: re-running on the same day replaces today's release
- Cleans up old nightly releases, keeping the 7 most recent

## How it works

1. Nightly release workflow fires daily at 05:00 UTC
2. Checks for new commits since the last `nightly-*` tag — skips if none
3. Creates a GitHub pre-release with `--generate-notes` from the latest stable `v*` tag
4. The release event automatically triggers `benchmark.yml` (which already listens for `release: [created]`)
5. Old nightly releases beyond 7 are cleaned up (both release and tag)

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify a nightly release is created
- [ ] Verify the release is marked as pre-release
- [ ] Verify benchmark workflow is triggered by the release event
- [ ] Re-run the workflow on the same day and confirm it replaces (not duplicates) today's release
- [ ] Verify no release is created when there are no new commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)