### PR TITLE
fix: auto-detect PR number in experiment.finalize event

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -33,6 +33,21 @@ def _run(coro):  # noqa: ANN001, ANN202
     return asyncio.run(coro)
 
 
+def _detect_pr_number(project_path: Path) -> int | None:
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", "--json", "number", "-q", ".number"],
+            capture_output=True,
+            timeout=10,
+            cwd=project_path,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.decode().strip())
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError, OSError):
+        pass
+    return None
+
+
 def _read_target_branch(project_path: Path) -> str:
     """Read target branch from .factory/config.json, falling back to git detection."""
     config_path = project_path / ".factory" / "config.json"
@@ -938,6 +953,10 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         })
         print("Finalize gate: precheck SKIPPED (--force)")
 
+    pr_number = args.pr
+    if pr_number is None:
+        pr_number = _detect_pr_number(project_path)
+
     cost = args.cost
     if cost is None:
         from factory.events import load_events, sum_agent_costs
@@ -957,7 +976,7 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         hypothesis=args.hypothesis or "",
         change_summary=args.summary or "",
         issue_number=args.issue,
-        pr_number=args.pr,
+        pr_number=pr_number,
         score_before=score_before,
         score_after=score_after,
         delta=None,
@@ -973,7 +992,7 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         "exp_id": args.id,
         "verdict": verdict,
         "hypothesis": (args.hypothesis or "")[:200],
-        "pr_number": args.pr,
+        "pr_number": pr_number,
         "issue_number": args.issue,
         "score_before": score_before,
         "score_after": score_after,

--- a/tests/test_event_enrichment.py
+++ b/tests/test_event_enrichment.py
@@ -202,6 +202,42 @@ def test_cmd_finalize_emits_enriched_event(tmp_path: Path) -> None:
     assert data["cost_usd"] == 2.50
 
 
+def test_finalize_autodetects_pr_number(tmp_path: Path) -> None:
+    """cmd_finalize auto-detects PR number via gh when args.pr is None."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    _setup_factory_dir(project)
+
+    ns = argparse.Namespace(
+        path=str(project),
+        id=1,
+        verdict="keep",
+        hypothesis="Auto PR detection",
+        summary="Testing auto PR",
+        cost=1.00,
+        issue=42,
+        pr=None,
+        score_before=0.50,
+        score_after=0.60,
+        notes="",
+        force=True,
+    )
+
+    mock_store = MagicMock()
+    fake_gh_result = MagicMock(returncode=0, stdout=b"123\n")
+
+    with patch("factory.store.ExperimentStore", return_value=mock_store), \
+         patch("factory.cli._run", return_value=None), \
+         patch("subprocess.run", return_value=fake_gh_result):
+        from factory.cli import cmd_finalize
+        cmd_finalize(ns)
+
+    events = load_events(project)
+    finalize_events = [e for e in events if e["type"] == "experiment.finalize"]
+    assert len(finalize_events) == 1
+    assert finalize_events[0]["data"]["pr_number"] == 123
+
+
 def test_finalize_event_with_null_scores(tmp_path: Path) -> None:
     project = tmp_path / "proj"
     project.mkdir()


### PR DESCRIPTION
Closes #828

## Changes

- Added `_detect_pr_number(project_path)` helper in `factory/cli.py` that runs `gh pr view --json number -q .number` to find the PR for the current branch
- Updated `cmd_finalize` to call `_detect_pr_number` when `--pr` is not explicitly provided, so the `experiment.finalize` event and `ExperimentRecord` get the correct `pr_number`
- Added `test_finalize_autodetects_pr_number` test that mocks `subprocess.run` to return a PR number and verifies it appears in the emitted event
- Gracefully handles `gh` failures (timeout, not installed, no PR) by returning `None`
- No behavior change when `--pr` is explicitly passed

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>