### PR TITLE
fix: define shared CEO_MODES/RUN_MODES constants, fix tmux mode choices

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -24,6 +24,9 @@ from typing import TYPE_CHECKING
 log = structlog.get_logger()
 _WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
 
+CEO_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "research", "review", "qa", "create"]
+RUN_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "research"]
+
 if TYPE_CHECKING:
     from factory.messages import Message
 
@@ -4511,7 +4514,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "research", "review", "qa", "create"],
+        choices=CEO_MODES,
         default="auto",
         help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
              "build, discover, improve, meta, design (research + brainstorm → spec → build), "
@@ -4587,7 +4590,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--mode",
-        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "research"],
+        choices=RUN_MODES,
         default="auto",
         help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
              "build, discover, improve, meta, or research",
@@ -4650,7 +4653,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--session", default=None, help="Custom tmux session name")
     p.add_argument(
         "--mode",
-        choices=["auto", "auto-fresh", "build", "discover", "improve", "meta", "research", "qa"],
+        choices=CEO_MODES,
         default="auto",
         help="Run mode (default: auto, respects in-flight cycle)",
     )

--- a/tests/test_tmux_cli.py
+++ b/tests/test_tmux_cli.py
@@ -7,9 +7,13 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from factory.cli import (
+    CEO_MODES,
     _build_tmux_run_args,
     _tmux_session_name,
+    build_parser,
     cmd_tmux,
     cmd_tmux_ls,
     cmd_tmux_stop,
@@ -317,3 +321,17 @@ class TestTmuxSessionMapping:
         printed = mock_print.call_args[0][0]
         data = json.loads(printed)
         assert data[0]["project"] == "/home/user/app"
+
+
+class TestTmuxModeChoices:
+    @pytest.mark.parametrize("mode", ["design", "interactive", "review", "create"])
+    def test_tmux_accepts_ceo_only_modes(self, mode: str) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["tmux", "/tmp/project", "--mode", mode])
+        assert args.mode == mode
+
+    def test_tmux_accepts_all_ceo_modes(self) -> None:
+        parser = build_parser()
+        for mode in CEO_MODES:
+            args = parser.parse_args(["tmux", "/tmp/project", "--mode", mode])
+            assert args.mode == mode


### PR DESCRIPTION
Closes #835

## Changes

- Defined `CEO_MODES` (11 modes) and `RUN_MODES` (7 headless-safe modes) as module-level constants in `factory/cli.py`
- Replaced 3 hardcoded `choices` lists in `ceo`, `run`, and `tmux` subcommand `--mode` arguments with references to the shared constants
- Fixed `tmux --mode` to use `CEO_MODES` instead of `RUN_MODES` — tmux wraps `factory ceo` internally, so it should accept all CEO modes (design, interactive, review, create were previously rejected)
- Added parametrized tests in `tests/test_tmux_cli.py` verifying tmux accepts the 4 previously rejected modes

No runtime behavior changes — only argparse validation was modified. `_build_tmux_run_args()` was not touched.