### PR TITLE
fix: set git identity in FeatureBench workspace for CI runners

### DIFF
--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -177,6 +177,8 @@ echo "    Cloning https://github.com/${REPO}..."
 git clone --quiet "https://github.com/${REPO}.git" "${WORKSPACE}/repo"
 cd "${WORKSPACE}/repo"
 git checkout --quiet "${BASE_COMMIT}"
+git config user.name 'benchmark'
+git config user.email 'benchmark@ci'
 
 echo "    Checked out ${BASE_COMMIT:0:12}"
 echo "    Working directory: ${WORKSPACE}/repo"


### PR DESCRIPTION
## Summary

- Adds `git config user.name` and `git config user.email` in the FeatureBench workspace repo after checkout, before the mask patch `git commit --amend` that requires a git identity
- Fixes CI failure: `fatal: empty ident name (for <runner@...>) not allowed` on GitHub Actions runners that lack default git identity

## Changes

- `benchmarks/run-featurebench.sh`: Added 2 lines of local git config (`user.name 'benchmark'`, `user.email 'benchmark@ci'`) after `git checkout` of the base commit (line 180-181)

## Test plan

- [ ] Verify `bash -n benchmarks/run-featurebench.sh` passes (syntax check) — done locally
- [ ] Run FeatureBench in CI to confirm the `git commit --amend` step no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)