### PR TITLE
fix: use full FeatureBench dataset and restore original instance ID

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,7 +66,7 @@ jobs:
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: featurebench
             solver: factory
-            default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
+            default_instance: 'sympy__sympy.c1097516.test_nullspace.f14fc970.lv1'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: terminalbench
             solver: factory
@@ -83,7 +83,7 @@ jobs:
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: featurebench
             solver: claude-code
-            default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
+            default_instance: 'sympy__sympy.c1097516.test_nullspace.f14fc970.lv1'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: terminalbench
             solver: claude-code

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,7 +66,7 @@ jobs:
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: featurebench
             solver: factory
-            default_instance: 'sympy__sympy.c1097516.test_nullspace.f14fc970.lv1'
+            default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           - benchmark: terminalbench
             solver: factory
@@ -83,7 +83,7 @@ jobs:
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'swebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: featurebench
             solver: claude-code
-            default_instance: 'sympy__sympy.c1097516.test_nullspace.f14fc970.lv1'
+            default_instance: 'pypa__packaging.013f3b03.test_metadata.e00b5801.lv1'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'featurebench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
           - benchmark: terminalbench
             solver: claude-code

--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -11,9 +11,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 # ── Configuration ──
 
-INSTANCE_ID="${1:-sympy__sympy.c1097516.test_nullspace.f14fc970.lv1}"
+INSTANCE_ID="${1:-pypa__packaging.013f3b03.test_metadata.e00b5801.lv1}"
 SOLVER_TIMEOUT="${2:-3600}"
-SPLIT="${3:-lite}"
+SPLIT="${3:-full}"
 
 BENCHMARK="featurebench"
 RUN_ID="ci-featurebench-${TIMESTAMP}"

--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -11,7 +11,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 # ── Configuration ──
 
-INSTANCE_ID="${1:-pypa__packaging.013f3b03.test_metadata.e00b5801.lv1}"
+INSTANCE_ID="${1:-sympy__sympy.c1097516.test_nullspace.f14fc970.lv1}"
 SOLVER_TIMEOUT="${2:-3600}"
 SPLIT="${3:-lite}"
 


### PR DESCRIPTION
Closes the FeatureBench CI configuration to use the full dataset instead of the lite split, and restores the original instance ID that exists in the full dataset.

## Changes

- Switch default split from `lite` to `full` in `benchmarks/run-featurebench.sh`
- Restore default instance ID to `pypa__packaging.013f3b03.test_metadata.e00b5801.lv1` in both `benchmarks/run-featurebench.sh` and `.github/workflows/benchmark.yml`

## Test plan

- [x] `uv run pytest tests/ -x -q --tb=short` — 2808 passed, 12 skipped
- [x] `uv run ruff check .` — all checks passed
- [x] Verified Harbor finds the task with `BENCHMARK_SOLVER=claude-code benchmarks/run-featurebench.sh pypa__packaging.013f3b03.test_metadata.e00b5801.lv1 120 full` — no "No tasks matched" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)