### PR TITLE
feat: add --run-id flag to factory run command

### DIFF
--- a/factory/cli.py
+++ b/factory/cli.py
@@ -2668,6 +2668,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)
+    run_id = getattr(args, "run_id", None)
     model = _resolve_model(args)
     runner_name = _resolve_runner(args)
     use_profile = getattr(args, "use_profile", False)
@@ -2722,7 +2723,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
     base_branch = branch or _read_target_branch(project_path)
-    wt_path, wt_branch = create_worktree(project_path, base_branch)
+    wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
 
     interactive = design_existing or bool(design_idea) or bool(research_ideation) or mode == "create"
     ceo_mode = "create" if mode == "create" else ("build" if interactive else mode)
@@ -3880,6 +3881,7 @@ def _run_single_cycle(
     clean_pr: bool = False,
     tmux_persist: bool = False,
     background: bool = False,
+    run_id: str | None = None,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
     from factory.agents.runner import invoke_agent
@@ -3895,7 +3897,7 @@ def _run_single_cycle(
     pending_ids = [m.id for m in pending]
 
     base_branch = branch or _read_target_branch(project_path)
-    wt_path, wt_branch = create_worktree(project_path, base_branch)
+    wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
 
     try:
         task = _build_ceo_task(
@@ -3948,6 +3950,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     min_growth = getattr(args, "min_growth", None)
     max_new = getattr(args, "max_new", None)
     branch = getattr(args, "branch", None)
+    run_id = getattr(args, "run_id", None)
     model = _resolve_model(args)
     use_profile_flag = getattr(args, "use_profile", False)
     tmux_persist = _resolve_tmux_persist(args)
@@ -4039,6 +4042,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             clean_pr=clean_pr_resolved,
             tmux_persist=tmux_persist,
             background=background,
+            run_id=run_id,
             **budget_kwargs,
         )
         if code != 0:
@@ -4081,6 +4085,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 clean_pr=clean_pr_resolved,
                 tmux_persist=tmux_persist,
                 background=background,
+                run_id=run_id,
                 **budget_kwargs,
             )
             _chain_modes(
@@ -4579,6 +4584,9 @@ def build_parser() -> argparse.ArgumentParser:
                     help="PR number for --mode review or --mode qa (required when mode=review or mode=qa)")
     p.add_argument("--repo", default=None,
                     help="Repository (owner/repo) for --mode review or --mode qa (optional, defaults to current repo)")
+    p.add_argument("--run-id", default=None, dest="run_id",
+                    help="Use a specific run ID (e.g., UUID from external orchestrator). "
+                         "First 8 chars are used for worktree naming")
 
     # run
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
@@ -4646,6 +4654,9 @@ def build_parser() -> argparse.ArgumentParser:
                     help="Dispatch agent as a background session via claude agent view (claude only)")
     p.add_argument("--bg-agents", action="store_true", default=False,
                     help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground")
+    p.add_argument("--run-id", default=None, dest="run_id",
+                    help="Use a specific run ID (e.g., UUID from external orchestrator). "
+                         "First 8 chars are used for worktree naming")
 
     # tmux — launch factory run in a detached tmux session
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -10,8 +10,18 @@ import structlog
 log = structlog.get_logger()
 
 
-def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
+def create_worktree(
+    project_path: Path,
+    base_branch: str = "main",
+    run_id: str | None = None,
+) -> tuple[Path, str]:
     """Create an isolated worktree for a factory run.
+
+    Args:
+        project_path: Path to the project root.
+        base_branch: Branch to create the worktree from.
+        run_id: Optional run identifier. If provided, uses the first 8 chars.
+                If None, generates a random 8-char hex ID.
 
     Returns (worktree_path, branch_name).
     """
@@ -29,7 +39,10 @@ def create_worktree(project_path: Path, base_branch: str = "main") -> tuple[Path
     )
     base_commit = result.stdout.strip()
 
-    run_id = secrets.token_hex(4)
+    if run_id is not None:
+        run_id = run_id[:8]
+    else:
+        run_id = secrets.token_hex(4)
     branch = f"factory/run-{run_id}"
     factory_dir = project_path / ".factory"
     wt_parent = project_path / ".factory-worktrees"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def _mock_worktree(tmp_path: Path, request: pytest.FixtureRequest) -> None:
         yield  # type: ignore[misc]
         return
 
-    def _fake_create(project_path: Path, base_branch: str = "main") -> tuple[Path, str]:
+    def _fake_create(project_path: Path, base_branch: str = "main", run_id: str | None = None) -> tuple[Path, str]:
         return project_path, "factory/run-fake0000"
 
     def _fake_remove(project_path: Path, worktree_path: Path, branch: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ def _mock_foreground():
     mock_run = MagicMock(return_value=MagicMock(returncode=0))
     with patch("factory.runners.claude.subprocess.run", mock_run), \
          patch("factory.worktree.create_worktree",
-               side_effect=lambda p, b="main": (p, "factory/run-test")), \
+               side_effect=lambda p, b="main", run_id=None: (p, "factory/run-test")), \
          patch("factory.worktree.remove_worktree"), \
          patch("factory.worktree.prune_stale", return_value=[]), \
          patch("factory.cli._read_target_branch", return_value="main"), \

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -100,6 +100,26 @@ class TestCreateWorktree:
         wt_path, _ = create_worktree(git_project, base_branch="develop")
         assert (wt_path / "extra.txt").exists()
 
+    def test_uses_provided_run_id(self, git_project: Path) -> None:
+        uuid_str = "d854881a-800d-44ff-beb5-b9fd77cc3fb9"
+        wt_path, branch = create_worktree(git_project, run_id=uuid_str)
+
+        # First 8 chars of UUID should be used
+        assert branch == "factory/run-d854881a"
+        assert wt_path.name == "run-d854881a"
+
+    def test_run_id_truncated_to_8_chars(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project, run_id="abcdef1234567890")
+
+        assert branch == "factory/run-abcdef12"
+        assert wt_path.name == "run-abcdef12"
+
+    def test_short_run_id_used_as_is(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project, run_id="abc")
+
+        assert branch == "factory/run-abc"
+        assert wt_path.name == "run-abc"
+
     def test_multiple_worktrees_coexist(self, git_project: Path) -> None:
         wt1, br1 = create_worktree(git_project)
         wt2, br2 = create_worktree(git_project)


### PR DESCRIPTION
## Summary

- Add `--run-id` flag to both `factory run` and `factory ceo` commands
- When provided, uses the first 8 characters as the worktree name/branch suffix
- Allows external orchestrators (refactory-server) to track runs with consistent IDs

Closes #843

## Test plan

- [x] Added unit tests for `run_id` parameter in `create_worktree`:
  - Tests full UUID truncation to 8 chars
  - Tests short IDs used as-is
  - Tests long IDs truncated correctly
- [x] Verified `--run-id` appears in `factory run --help` and `factory ceo --help`
- [x] All existing worktree tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)