### PR TITLE
ci: enable Langfuse tracing for eval, benchmark, and CEO review

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Install Factory CLI
         if: steps.gate.outputs.run == 'true' && matrix.solver == 'factory'
         run: |
-          uv tool install 'remote-factory @ git+https://github.com/akashgit/remote-factory.git'
+          uv tool install 'remote-factory[telemetry] @ git+https://github.com/akashgit/remote-factory.git'
           export PATH="$HOME/.local/bin:$PATH"
           echo "PATH=$HOME/.local/bin:$PATH" >> "$GITHUB_ENV"
           factory --help > /dev/null
@@ -176,6 +176,9 @@ jobs:
           CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
           MAX_THINKING_TOKENS: "128000"
           CLAUDE_CODE_EFFORT_LEVEL: "XHIGH"
+          LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
         run: |
           chmod +x benchmarks/run.sh benchmarks/lib.sh benchmarks/run-*.sh
           benchmarks/run.sh ${{ matrix.benchmark }} ${{ steps.config.outputs.instance }} --timeout ${{ steps.timeout.outputs.value }} --solver ${{ matrix.solver }}

--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -49,7 +49,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install factory
-        run: uv sync
+        run: uv sync --extra telemetry
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -71,6 +71,9 @@ jobs:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
           CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
         run: |
           uv run factory ceo . --mode qa --pr ${{ steps.pr.outputs.number }} --headless
 

--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -26,13 +26,17 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --all-groups --extra telemetry
 
       - name: Initialize factory config
         run: uv run factory init .
 
       - name: Run eval
         id: eval
+        env:
+          LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
         run: |
           uv run factory eval . > eval_output.json || true
           cat eval_output.json


### PR DESCRIPTION
## Summary
- Passes `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` from repo secrets to the three workflows that run factory code (eval-baseline, benchmark, ceo-review)
- Installs the `telemetry` optional extra so the `langfuse` SDK is available at runtime
- The factory codebase already has full Langfuse instrumentation in `factory/telemetry.py` and `factory/agents/runner.py` — it just needs these env vars to activate

## Workflows updated
- `eval-baseline.yml` — `uv sync --all-groups --extra telemetry`, Langfuse env vars on eval step
- `benchmark.yml` — `remote-factory[telemetry]` in tool install, Langfuse env vars on benchmark step
- `ceo-review.yml` — `uv sync --extra telemetry`, Langfuse env vars on CEO review step

## Test plan
- [ ] Verify secrets `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` are set on the repo
- [ ] Trigger eval-baseline manually and confirm traces appear in Langfuse
- [ ] Trigger a CEO review (`@ceo-review`) and confirm traces appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)