### PR TITLE
re:factory agent: improve tmux session interaction and monitoring reliability

### DIFF
--- a/factory/agents/prompts/refactory.md
+++ b/factory/agents/prompts/refactory.md
@@ -147,6 +147,41 @@ Use `factory checkpoint <path>` before long runs and `factory resume <path>` aft
 
 Periodically trigger playbook evolution via `factory ace` to distill experiment outcomes into agent behavior rules. Review with `factory ace-stats`. This is how the factory's agents improve over time.
 
+## Tmux Session Interaction Rules
+
+### Input Submission
+
+Always use `C-m` (not `Enter`) when sending keys to tmux sessions running Claude Code:
+```bash
+tmux send-keys -t <session> "your input" C-m
+```
+`Enter` is unreliable inside Claude Code sessions — `C-m` is the canonical carriage return and works consistently.
+
+### Post-Dispatch Verification
+
+After every `factory tmux` dispatch, verify the session actually started before reporting success:
+1. `tmux has-session -t <session>` — confirm the session exists
+2. `factory tmux-capture <path>` or `tmux capture-pane -t <session> -p | tail -5` — check for error strings (`Error:`, `exited`, `no server`)
+
+If the session exited immediately, report the failure to the user right away. Never report a dispatch as successful without verification.
+
+### Session Cleanup Scope
+
+Never kill a tmux session unless it was created in the current task scope. Before killing any session:
+1. Run `factory tmux-ls` to see all active sessions
+2. Cross-reference against sessions you dispatched in this conversation
+3. If a session was not created by you, do not kill it — even if the name looks related
+
+When in doubt, ask the user before killing a session.
+
+### Transcript Before Judgment
+
+Never characterize CEO behavior (e.g., "going rogue", "deviated from instructions") without reading the transcript first. Use `factory tmux-capture <path>` or read `.factory/reviews/ceo-latest.md` before making any assessment of what the CEO did or didn't do.
+
+### Proactive Monitoring
+
+After dispatching CEO sessions, set up periodic monitoring using `ScheduleWakeup` to check session status every 5–10 minutes until completion. Report results proactively — the user should not have to ask "is it done yet?"
+
 ## Hierarchy
 
 ```

--- a/factory/agents/skills/factory-run.md
+++ b/factory/agents/skills/factory-run.md
@@ -33,6 +33,17 @@ factory tmux <project_path> --mode research  # research-driven improvement
 factory tmux <project_path> --mode meta      # improve the factory itself + ACE evolution
 ```
 
+## Post-Dispatch Verification
+
+After every `factory tmux <path>` dispatch, always verify the session started successfully before reporting to the user:
+
+```bash
+tmux has-session -t <session_name> 2>/dev/null && echo "alive" || echo "dead"
+factory tmux-capture <path>     # or: tmux capture-pane -t <session_name> -p | tail -20
+```
+
+If the session exited or shows error output (`Error:`, `exited`, `no server`), report the failure immediately. Never assume a dispatch succeeded without checking.
+
 ## Monitor Running Sessions
 
 ```bash

--- a/factory/agents/skills/sessions.md
+++ b/factory/agents/skills/sessions.md
@@ -18,6 +18,22 @@ tmux list-panes -t <session_name> -F '#{pane_pid}' 2>/dev/null
 ```
 If the session exists but the CEO process has exited, the session is stale — stop it and dispatch a fresh one if needed.
 
+### Sending Input to Sessions
+
+Always use `C-m` (not `Enter`) when sending keys to tmux sessions running Claude Code:
+```bash
+tmux send-keys -t <session_name> "your input" C-m
+```
+`Enter` is unreliable inside Claude Code sessions — `C-m` is the canonical carriage return.
+
+### Capturing Output
+
+Use `factory tmux-capture` to inspect session output:
+```bash
+factory tmux-capture <project_path>                 # last 100 lines
+factory tmux-capture --session <name> --lines -200  # custom line count
+```
+
 ## User Attach Guidance
 
 If the user wants to watch or interact with a running CEO session:
@@ -47,3 +63,21 @@ You can have multiple CEO sessions running simultaneously across different proje
 - When a session completes, review results before deciding whether to launch another cycle
 - Stagger launches to avoid resource contention on the host machine
 - If multiple sessions are running, check each project's results systematically — don't let completed sessions go unreviewed
+
+## Proactive Monitoring
+
+After dispatching CEO sessions, set up periodic monitoring using `ScheduleWakeup` to detect completion and report results without being asked:
+
+```
+ScheduleWakeup({
+  delaySeconds: 300,
+  reason: "checking CEO session status for <project>",
+  prompt: "<the /loop prompt>"
+})
+```
+
+Each monitoring check should:
+1. Run `factory tmux-ls` to see if the session is still active
+2. If active, use `factory tmux-capture <path>` to check for progress or errors
+3. If completed, review results via `.factory/reviews/` and `factory eval <path>`
+4. Report findings proactively to the user

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -3269,6 +3269,14 @@ def _tmux_available() -> bool:
         return False
 
 
+def _tmux_session_alive(session: str) -> bool:
+    """Check if a tmux session exists and is alive."""
+    return subprocess.run(
+        ["tmux", "has-session", "-t", session],
+        capture_output=True,
+    ).returncode == 0
+
+
 def _build_tmux_run_args(args: argparse.Namespace, project_path: Path, model: str | None) -> str:
     """Build the 'factory ceo ...' command string from parsed args.
 
@@ -3360,6 +3368,26 @@ def cmd_tmux(args: argparse.Namespace) -> int:
 
     _save_tmux_session_mapping(session, str(project_path))
 
+    time.sleep(3)
+
+    if not _tmux_session_alive(session):
+        print(f"Error: session '{session}' exited immediately after launch", file=sys.stderr)
+        return 1
+
+    capture = subprocess.run(
+        ["tmux", "capture-pane", "-t", session, "-p"],
+        capture_output=True,
+        text=True,
+    )
+    if capture.returncode == 0:
+        pane_text = capture.stdout
+        _error_markers = ("Error:", "exited", "no server")
+        if any(marker in pane_text for marker in _error_markers):
+            log.warning("tmux_post_dispatch_warning", session=session)
+            print(f"Warning: session '{session}' may have errors:", file=sys.stderr)
+            for line in pane_text.strip().splitlines()[-10:]:
+                print(f"  {line}", file=sys.stderr)
+
     print(f"Factory launched in tmux session: {session}")
     print(f"  tmux attach -t {session}    # attach")
     print(f"  tmux kill-session -t {session}  # stop")
@@ -3409,6 +3437,45 @@ def cmd_tmux_ls(args: argparse.Namespace) -> int:
         print("-" * 80)
         for s in factory_sessions:
             print(f"{s['session']:<35} {s['started']:<20} {s['project']}")
+    return 0
+
+
+def cmd_tmux_capture(args: argparse.Namespace) -> int:
+    """Capture recent output from a factory tmux session."""
+    if not _tmux_available():
+        print("Error: tmux is not installed.", file=sys.stderr)
+        return 1
+
+    session = getattr(args, "session", None)
+    if not session and getattr(args, "path", None):
+        project_path = Path(args.path).resolve()
+        mapping = _load_tmux_session_mapping()
+        for s, p in mapping.items():
+            if Path(p).resolve() == project_path:
+                session = s
+                break
+        if not session:
+            session = _tmux_session_name(project_path)
+
+    if not session:
+        print("Error: specify --session or path to identify the session", file=sys.stderr)
+        return 1
+
+    if not _tmux_session_alive(session):
+        print(f"Error: session '{session}' not found", file=sys.stderr)
+        return 1
+
+    lines = getattr(args, "lines", -100)
+    result = subprocess.run(
+        ["tmux", "capture-pane", "-t", session, "-p", "-S", str(lines)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error: failed to capture pane for '{session}'", file=sys.stderr)
+        return 1
+
+    print(result.stdout, end="")
     return 0
 
 
@@ -3471,6 +3538,15 @@ def cmd_tmux_stop(args: argparse.Namespace) -> int:
     )
     if check.returncode != 0:
         print(f"Session '{session}' not found.")
+        return 1
+
+    mapping = _load_tmux_session_mapping()
+    if session not in mapping and not getattr(args, "force", False):
+        print(
+            f"Warning: session '{session}' is not in the factory session registry.",
+            file=sys.stderr,
+        )
+        print("It may not be a factory-managed session. Use --force to kill it anyway.", file=sys.stderr)
         return 1
 
     subprocess.run(["tmux", "kill-session", "-t", session])
@@ -4741,12 +4817,20 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--json", action="store_true", default=False, dest="json_output",
                     help="Output as JSON array for programmatic consumption")
 
+    # tmux-capture — capture output from a factory tmux session
+    p = sub.add_parser("tmux-capture", help="Capture recent output from a factory tmux session")
+    p.add_argument("path", nargs="?", default=None, help="Project path (derives session name)")
+    p.add_argument("--session", default=None, help="Session name to capture from")
+    p.add_argument("--lines", type=int, default=-100, help="Number of lines to capture (default: -100)")
+
     # tmux-stop — stop factory tmux sessions
     p = sub.add_parser("tmux-stop", help="Stop factory tmux session(s)")
     p.add_argument("--session", default=None, help="Session name to stop")
     p.add_argument("--path", default=None, help="Project path (derives session name)")
     p.add_argument("--all", action="store_true", default=False, dest="stop_all",
                     help="Stop ALL factory tmux sessions (required when no --session/--path given)")
+    p.add_argument("--force", action="store_true", default=False,
+                    help="Force-kill a session even if it's not in the factory registry")
 
     # refactory — persistent supervisor agent
     p = sub.add_parser("refactory", help="Launch the re:factory persistent supervisor agent")
@@ -4849,6 +4933,7 @@ def main(argv: list[str] | None = None) -> int:
         "run": cmd_run,
         "tmux": cmd_tmux,
         "tmux-ls": cmd_tmux_ls,
+        "tmux-capture": cmd_tmux_capture,
         "tmux-stop": cmd_tmux_stop,
         "refactory": cmd_refactory,
         "workflow": lambda a: __import__("factory.workflow.cli", fromlist=["cmd_workflow"]).cmd_workflow(a),

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -230,7 +230,7 @@ async def run_in_tmux(
             return f"Agent timed out after {timeout}s", 1, None
 
         subprocess.run(
-            ["tmux", "send-keys", "-t", f"{session}:{window}", "/exit", "Enter"],
+            ["tmux", "send-keys", "-t", f"{session}:{window}", "/exit", "C-m"],
             capture_output=True,
         )
         await _wait_for_window_exit(session, window)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1671,11 +1671,14 @@ class TestCmdTmuxBareCLI:
         import argparse
 
         with patch("factory.cli._tmux_available", return_value=True), \
+             patch("factory.cli._tmux_session_alive", return_value=True), \
+             patch("factory.cli.time.sleep"), \
              patch("subprocess.run") as mock_run:
             mock_run.return_value = type("R", (), {"returncode": 1})()  # has-session fails
             mock_run.side_effect = [
                 type("R", (), {"returncode": 1})(),  # has-session → no existing session
                 type("R", (), {"returncode": 0})(),   # new-session → success
+                type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),  # capture-pane
             ]
             args = argparse.Namespace(
                 path="/tmp/test-project",

--- a/tests/test_tmux_cli.py
+++ b/tests/test_tmux_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -12,9 +13,11 @@ import pytest
 from factory.cli import (
     CEO_MODES,
     _build_tmux_run_args,
+    _tmux_session_alive,
     _tmux_session_name,
     build_parser,
     cmd_tmux,
+    cmd_tmux_capture,
     cmd_tmux_ls,
     cmd_tmux_stop,
 )
@@ -87,12 +90,15 @@ class TestEnvVarWhitelist:
             patch("factory.cli._tmux_available", return_value=True),
             patch("factory.cli._resolve_model", return_value=None),
             patch("factory.cli._save_tmux_session_mapping"),
+            patch("factory.cli._tmux_session_alive", return_value=True),
+            patch("factory.cli.time.sleep"),
             patch("subprocess.run") as mock_run,
             patch.dict("os.environ", env, clear=True),
         ):
             mock_run.side_effect = [
                 MagicMock(returncode=1),  # has-session (not found)
                 MagicMock(returncode=0),  # new-session
+                MagicMock(returncode=0, stdout="", stderr=""),  # capture-pane
             ]
             cmd_tmux(args)
 
@@ -286,12 +292,15 @@ class TestTmuxSessionMapping:
             patch("factory.cli._tmux_available", return_value=True),
             patch("factory.cli._resolve_model", return_value=None),
             patch("factory.cli._TMUX_SESSIONS_FILE", sessions_file),
+            patch("factory.cli._tmux_session_alive", return_value=True),
+            patch("factory.cli.time.sleep"),
             patch("subprocess.run") as mock_run,
             patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
         ):
             mock_run.side_effect = [
                 MagicMock(returncode=1),  # has-session
                 MagicMock(returncode=0),  # new-session
+                MagicMock(returncode=0, stdout="", stderr=""),  # capture-pane
             ]
             cmd_tmux(args)
 
@@ -335,3 +344,153 @@ class TestTmuxModeChoices:
         for mode in CEO_MODES:
             args = parser.parse_args(["tmux", "/tmp/project", "--mode", mode])
             assert args.mode == mode
+
+
+class TestTmuxSessionAlive:
+    def test_returns_true_when_session_exists(self) -> None:
+        with patch("factory.cli.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert _tmux_session_alive("factory-app-abc123") is True
+        mock_run.assert_called_once_with(
+            ["tmux", "has-session", "-t", "factory-app-abc123"],
+            capture_output=True,
+        )
+
+    def test_returns_false_when_session_missing(self) -> None:
+        with patch("factory.cli.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            assert _tmux_session_alive("factory-app-abc123") is False
+
+
+class TestCmdTmuxCapture:
+    def test_captures_with_session_name(self) -> None:
+        args = argparse.Namespace(session="factory-app-abc123", path=None, lines=-100)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._tmux_session_alive", return_value=True),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="line1\nline2\n",
+            )
+            rc = cmd_tmux_capture(args)
+
+        assert rc == 0
+        mock_run.assert_called_once_with(
+            ["tmux", "capture-pane", "-t", "factory-app-abc123", "-p", "-S", "-100"],
+            capture_output=True,
+            text=True,
+        )
+        mock_print.assert_called_once_with("line1\nline2\n", end="")
+
+    def test_session_not_found(self) -> None:
+        args = argparse.Namespace(session="factory-gone-abc123", path=None, lines=-100)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._tmux_session_alive", return_value=False),
+            patch("builtins.print") as mock_print,
+        ):
+            rc = cmd_tmux_capture(args)
+
+        assert rc == 1
+        mock_print.assert_called_once()
+        assert "not found" in mock_print.call_args[0][0]
+
+
+class TestCmdTmuxPostDispatchVerification:
+    def test_returns_error_when_session_dies_immediately(self) -> None:
+        args = argparse.Namespace(
+            path="/tmp/myproject",
+            session=None,
+            mode="auto",
+            loop=False,
+            interval=1800,
+            max_cycles=None,
+            attach=False,
+            no_github=False,
+            model=None,
+            runner=None,
+            profile=None,
+            focus=None,
+            refine=None,
+            clean_pr=None,
+            prompt=None,
+            branch=None,
+            min_growth=None,
+            max_new=None,
+            discover_only=False,
+            bg_agents=False,
+            tmux_persist=False,
+            use_profile=False,
+        )
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._resolve_model", return_value=None),
+            patch("factory.cli._save_tmux_session_mapping"),
+            patch("factory.cli._tmux_session_alive", return_value=False),
+            patch("factory.cli.time.sleep"),
+            patch("subprocess.run") as mock_run,
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+            patch("builtins.print") as mock_print,
+        ):
+            mock_run.side_effect = [
+                MagicMock(returncode=1),  # has-session (not found)
+                MagicMock(returncode=0),  # new-session
+            ]
+            rc = cmd_tmux(args)
+
+        assert rc == 1
+        stderr_calls = [c for c in mock_print.call_args_list if c[1].get("file") is sys.stderr]
+        assert any("exited immediately" in str(c) for c in stderr_calls)
+
+
+class TestCmdTmuxStopOwnership:
+    def test_warns_and_blocks_unregistered_session(self) -> None:
+        args = argparse.Namespace(session="factory-mystery-abc123", path=None, stop_all=False, force=False)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._load_tmux_session_mapping", return_value={}),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_run.return_value = MagicMock(returncode=0)  # has-session
+            rc = cmd_tmux_stop(args)
+
+        assert rc == 1
+        stderr_calls = [c for c in mock_print.call_args_list if c[1].get("file") is sys.stderr]
+        assert any("not in the factory session registry" in str(c) for c in stderr_calls)
+        kill_calls = [c for c in mock_run.call_args_list if "kill-session" in str(c)]
+        assert len(kill_calls) == 0
+
+    def test_force_kills_unregistered_session(self) -> None:
+        args = argparse.Namespace(session="factory-mystery-abc123", path=None, stop_all=False, force=True)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._load_tmux_session_mapping", return_value={}),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print"),
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            rc = cmd_tmux_stop(args)
+
+        assert rc == 0
+
+    def test_registered_session_killed_without_force(self) -> None:
+        args = argparse.Namespace(session="factory-app-abc123", path=None, stop_all=False, force=False)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._load_tmux_session_mapping", return_value={"factory-app-abc123": "/tmp/app"}),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print"),
+        ):
+            mock_run.return_value = MagicMock(returncode=0)
+            rc = cmd_tmux_stop(args)
+
+        assert rc == 0

--- a/tests/test_tmux_cli.py
+++ b/tests/test_tmux_cli.py
@@ -399,8 +399,129 @@ class TestCmdTmuxCapture:
         mock_print.assert_called_once()
         assert "not found" in mock_print.call_args[0][0]
 
+    def test_tmux_not_available(self) -> None:
+        args = argparse.Namespace(session="factory-app-abc123", path=None, lines=-100)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=False),
+            patch("builtins.print") as mock_print,
+        ):
+            rc = cmd_tmux_capture(args)
+
+        assert rc == 1
+        assert "not installed" in mock_print.call_args[0][0]
+
+    def test_no_session_or_path(self) -> None:
+        args = argparse.Namespace(session=None, path=None, lines=-100)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("builtins.print") as mock_print,
+        ):
+            rc = cmd_tmux_capture(args)
+
+        assert rc == 1
+        assert "specify" in mock_print.call_args[0][0]
+
+    def test_path_based_lookup_from_mapping(self) -> None:
+        args = argparse.Namespace(session=None, path="/tmp/myproject", lines=-100)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._load_tmux_session_mapping", return_value={"factory-myproject-abc123": "/tmp/myproject"}),
+            patch("factory.cli._tmux_session_alive", return_value=True),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print"),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="output\n")
+            rc = cmd_tmux_capture(args)
+
+        assert rc == 0
+        mock_run.assert_called_once_with(
+            ["tmux", "capture-pane", "-t", "factory-myproject-abc123", "-p", "-S", "-100"],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_path_based_fallback_to_session_name(self) -> None:
+        args = argparse.Namespace(session=None, path="/tmp/unmapped", lines=-100)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._load_tmux_session_mapping", return_value={}),
+            patch("factory.cli._tmux_session_alive", return_value=True),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print"),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="output\n")
+            rc = cmd_tmux_capture(args)
+
+        assert rc == 0
+
+    def test_capture_pane_failure(self) -> None:
+        args = argparse.Namespace(session="factory-app-abc123", path=None, lines=-100)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._tmux_session_alive", return_value=True),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="error")
+            rc = cmd_tmux_capture(args)
+
+        assert rc == 1
+        assert "failed to capture" in mock_print.call_args[0][0]
+
 
 class TestCmdTmuxPostDispatchVerification:
+    def test_warns_when_error_markers_in_pane_output(self) -> None:
+        args = argparse.Namespace(
+            path="/tmp/myproject",
+            session=None,
+            mode="auto",
+            loop=False,
+            interval=1800,
+            max_cycles=None,
+            attach=False,
+            no_github=False,
+            model=None,
+            runner=None,
+            profile=None,
+            focus=None,
+            refine=None,
+            clean_pr=None,
+            prompt=None,
+            branch=None,
+            min_growth=None,
+            max_new=None,
+            discover_only=False,
+            bg_agents=False,
+            tmux_persist=False,
+            use_profile=False,
+        )
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._resolve_model", return_value=None),
+            patch("factory.cli._save_tmux_session_mapping"),
+            patch("factory.cli._tmux_session_alive", return_value=True),
+            patch("factory.cli.time.sleep"),
+            patch("subprocess.run") as mock_run,
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+            patch("builtins.print") as mock_print,
+        ):
+            mock_run.side_effect = [
+                MagicMock(returncode=1),  # has-session (not found)
+                MagicMock(returncode=0),  # new-session
+                MagicMock(returncode=0, stdout="Error: something went wrong\n", stderr=""),  # capture-pane
+            ]
+            rc = cmd_tmux(args)
+
+        assert rc == 0
+        stderr_calls = [c for c in mock_print.call_args_list if c[1].get("file") is sys.stderr]
+        assert any("may have errors" in str(c) for c in stderr_calls)
+
     def test_returns_error_when_session_dies_immediately(self) -> None:
         args = argparse.Namespace(
             path="/tmp/myproject",
@@ -446,6 +567,49 @@ class TestCmdTmuxPostDispatchVerification:
         assert rc == 1
         stderr_calls = [c for c in mock_print.call_args_list if c[1].get("file") is sys.stderr]
         assert any("exited immediately" in str(c) for c in stderr_calls)
+
+
+class TestCmdTmuxStopEdgeCases:
+    def test_tmux_not_available(self) -> None:
+        args = argparse.Namespace(session="factory-app-abc123", path=None, stop_all=False, force=False)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=False),
+            patch("builtins.print") as mock_print,
+        ):
+            rc = cmd_tmux_stop(args)
+
+        assert rc == 1
+        assert "not installed" in mock_print.call_args[0][0]
+
+    def test_path_derives_session_name(self) -> None:
+        args = argparse.Namespace(session=None, path="/tmp/myproject", stop_all=False, force=False)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("factory.cli._load_tmux_session_mapping", return_value={}),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_run.return_value = MagicMock(returncode=1)  # has-session → not found
+            rc = cmd_tmux_stop(args)
+
+        assert rc == 1
+        assert any("not found" in str(c) for c in mock_print.call_args_list)
+
+    def test_session_not_found_in_tmux(self) -> None:
+        args = argparse.Namespace(session="factory-gone-abc123", path=None, stop_all=False, force=False)
+
+        with (
+            patch("factory.cli._tmux_available", return_value=True),
+            patch("subprocess.run") as mock_run,
+            patch("builtins.print") as mock_print,
+        ):
+            mock_run.return_value = MagicMock(returncode=1)  # has-session → not found
+            rc = cmd_tmux_stop(args)
+
+        assert rc == 1
+        assert any("not found" in str(c) for c in mock_print.call_args_list)
 
 
 class TestCmdTmuxStopOwnership:

--- a/tests/test_tmux_e2e.py
+++ b/tests/test_tmux_e2e.py
@@ -109,7 +109,7 @@ class TestTmuxStopE2E:
             assert check.returncode == 0
 
             result = subprocess.run(
-                [sys.executable, "-m", "factory.cli", "tmux-stop", "--session", session],
+                [sys.executable, "-m", "factory.cli", "tmux-stop", "--session", session, "--force"],
                 capture_output=True, text=True,
                 cwd=str(tmp_path),
             )


### PR DESCRIPTION
Closes #855

## Changes

- **Post-dispatch verification** (`cmd_tmux`): After creating a tmux session, waits 3s then verifies the session is alive and checks pane output for error markers. Success message only prints after verification passes.
- **New `tmux-capture` subcommand**: Wraps `tmux capture-pane` for easy session output inspection. Accepts `--session`, project path, and `--lines` (default: -100).
- **Ownership verification** (`cmd_tmux_stop`): Before killing a named session, checks it against the factory session registry. Unregistered sessions require `--force` to prevent accidentally killing user sessions.
- **`_tmux_session_alive()` helper**: Reusable wrapper around `tmux has-session` with proper error handling.
- **C-m consistency** (`_tmux_persist.py`): Changed `"Enter"` to `"C-m"` in the `send-keys` call for reliable input submission.
- **Refactory prompt** (`refactory.md`): Added `## Tmux Session Interaction Rules` section covering input submission (C-m), post-dispatch verification, session cleanup scope, transcript-before-judgment, and proactive monitoring.
- **Skills updates**: Added post-dispatch verification to `factory-run.md`; added C-m guidance, `tmux-capture` usage, and proactive monitoring section to `sessions.md`.
- **Tests**: 10 new tests covering `_tmux_session_alive`, `cmd_tmux_capture`, post-dispatch verification failure, and `cmd_tmux_stop` ownership checks (with and without `--force`).