### PR TITLE
feat: add create mode dispatch to re:factory agent

### DIFF
--- a/factory/agents/prompts/refactory.md
+++ b/factory/agents/prompts/refactory.md
@@ -116,6 +116,9 @@ When the user says "work on X":
    - `factory tmux <path> --focus "item"` for targeted single-item work
    - `factory tmux <path> --mode design` for brainstorming what to work on
    - `factory tmux <path> --mode research` for research-driven improvement
+   - `factory tmux <path> --mode create --focus "mode description"` for creating new factory modes
+
+   Create mode is a meta-mode: it requires the factory project path (not a target project), uses `--focus` to provide the mode description, and generates new workflow definitions, CLI wiring, and tests for a new factory mode.
 
 ### 5. Monitor Proactively
 

--- a/factory/agents/skills/factory-run.md
+++ b/factory/agents/skills/factory-run.md
@@ -31,6 +31,7 @@ factory tmux <project_path> --mode improve   # default — score-driven improvem
 factory tmux <project_path> --mode design    # brainstorm what to work on first
 factory tmux <project_path> --mode research  # research-driven improvement
 factory tmux <project_path> --mode meta      # improve the factory itself + ACE evolution
+factory tmux <factory_project_path> --mode create --focus "mode description"  # create new factory mode
 ```
 
 ## Monitor Running Sessions
@@ -62,5 +63,6 @@ factory tmux-stop --path <project_path>
 | User asks "work on this project" | `factory tmux <path>` |
 | User asks to build one specific thing | `factory tmux <path> --focus "<item>"` |
 | User wants to discuss what to work on | `factory tmux <path> --mode design` |
+| User wants to create a new factory mode | `factory tmux /path/to/factory --mode create --focus "description"` |
 
 Always check `factory tmux-ls` before dispatching to avoid launching duplicate sessions for the same project.


### PR DESCRIPTION
Closes #864

## Changes

- Added create mode (`--mode create --focus "mode description"`) to the dispatch mode list in `factory/agents/prompts/refactory.md` (Section 4: Dispatch Based on Intent), with a note explaining it's a meta-mode that targets the factory project path
- Added create mode to the mode selection examples and "When to Use Which" scenario table in `factory/agents/skills/factory-run.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)