### PR TITLE
feat: workflow registry + legacybench contributed workflow

### DIFF
--- a/factory/workflow/registry.py
+++ b/factory/workflow/registry.py
@@ -1,0 +1,240 @@
+"""Workflow registry for discovering and loading contributed workflows.
+
+Follows the same search-path pattern as sdg_hub's FlowRegistry:
+register directories, auto-discover workflow files within them.
+
+A workflow file is any .py file containing:
+  - A `meta` dict with at least `name` and `description`
+  - A `workflow()` function returning a Workflow object
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.workflow.primitives import Workflow
+
+log = structlog.get_logger()
+
+
+@dataclass
+class WorkflowEntry:
+    """A discovered workflow in the registry."""
+
+    name: str
+    description: str
+    path: str
+    source: str  # "builtin", "user", "project"
+    _workflow_fn: Any = field(default=None, repr=False)
+
+
+class WorkflowRegistry:
+    """Registry for discovering contributed workflows.
+
+    Search paths are scanned for .py files with a `meta` dict and
+    `workflow()` function. Built-in workflows from `definitions.py`
+    are always available as the lowest-priority source.
+    """
+
+    _entries: dict[str, WorkflowEntry] = {}
+    _search_paths: list[tuple[str, str]] = []  # (path, source_label)
+    _initialized: bool = False
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset registry state. Useful for testing."""
+        cls._entries.clear()
+        cls._search_paths.clear()
+        cls._initialized = False
+
+    @classmethod
+    def _ensure_initialized(cls) -> None:
+        """Register default search paths on first access."""
+        if cls._initialized:
+            return
+
+        # User-global workflows
+        user_dir = Path.home() / ".factory" / "workflows"
+        if user_dir.is_dir():
+            cls._search_paths.append((str(user_dir), "user"))
+            log.debug("workflow_registry.search_path", path=str(user_dir), source="user")
+
+        cls._initialized = True
+
+    @classmethod
+    def register_search_path(cls, path: str, source: str = "project") -> None:
+        """Add a directory to search for workflow files.
+
+        Parameters
+        ----------
+        path : str
+            Path to directory containing workflow .py files.
+        source : str
+            Label for provenance ("project", "user", etc.).
+        """
+        resolved = str(Path(path).resolve())
+        existing = {p for p, _ in cls._search_paths}
+        if resolved not in existing:
+            cls._search_paths.append((resolved, source))
+            log.debug("workflow_registry.search_path", path=resolved, source=source)
+
+    @classmethod
+    def discover(cls, project_path: Path | None = None) -> dict[str, WorkflowEntry]:
+        """Discover all workflows from search paths + built-ins.
+
+        Parameters
+        ----------
+        project_path : Path, optional
+            If provided, also searches .factory/workflows/ in this project.
+
+        Returns
+        -------
+        dict[str, WorkflowEntry]
+            Name → entry mapping. Project shadows user shadows built-in.
+        """
+        cls._ensure_initialized()
+        cls._entries.clear()
+
+        # Layer 1: built-in workflows (lowest priority)
+        cls._load_builtins()
+
+        # Layer 2: user-global workflows
+        for search_path, source in cls._search_paths:
+            if source == "user":
+                cls._discover_in_directory(search_path, source)
+
+        # Layer 3: project-local workflows (highest priority)
+        if project_path:
+            project_wf_dir = project_path / ".factory" / "workflows"
+            if project_wf_dir.is_dir():
+                cls._discover_in_directory(str(project_wf_dir), "project")
+
+        # Layer 4: any explicitly registered paths
+        for search_path, source in cls._search_paths:
+            if source not in ("user",):
+                cls._discover_in_directory(search_path, source)
+
+        log.info("workflow_registry.discovered", count=len(cls._entries))
+        return cls._entries
+
+    @classmethod
+    def _load_builtins(cls) -> None:
+        """Load built-in workflows from definitions.py."""
+        from factory.workflow.definitions import register_all
+
+        for name, wf in register_all().items():
+            cls._entries[name] = WorkflowEntry(
+                name=name,
+                description=_get_builtin_description(name),
+                path="<builtin>",
+                source="builtin",
+                _workflow_fn=lambda _wf=wf: _wf,
+            )
+
+    @classmethod
+    def _discover_in_directory(cls, directory: str, source: str) -> None:
+        """Discover workflow files in a directory."""
+        path = Path(directory)
+        if not path.is_dir():
+            return
+
+        for py_file in sorted(path.glob("*.py")):
+            if py_file.name.startswith("_"):
+                continue
+            try:
+                meta, workflow_fn = _load_workflow_file(py_file)
+                name = meta["name"]
+                prev = cls._entries.get(name)
+                if prev and prev.source != "builtin":
+                    log.warning(
+                        "workflow_registry.shadow",
+                        name=name,
+                        new_source=source,
+                        old_source=prev.source,
+                    )
+                cls._entries[name] = WorkflowEntry(
+                    name=name,
+                    description=meta.get("description", ""),
+                    path=str(py_file),
+                    source=source,
+                    _workflow_fn=workflow_fn,
+                )
+                log.debug(
+                    "workflow_registry.loaded",
+                    name=name,
+                    path=str(py_file),
+                    source=source,
+                )
+            except Exception as exc:
+                log.debug("workflow_registry.skip", path=str(py_file), reason=str(exc))
+
+    @classmethod
+    def get_workflow(cls, name: str, project_path: Path | None = None) -> Workflow | None:
+        """Get a workflow by name, discovering if needed.
+
+        Returns None if not found.
+        """
+        if not cls._entries:
+            cls.discover(project_path)
+
+        entry = cls._entries.get(name)
+        if entry is None:
+            return None
+
+        if entry._workflow_fn is None:
+            return None
+
+        return entry._workflow_fn()
+
+    @classmethod
+    def list_workflows(cls, project_path: Path | None = None) -> list[WorkflowEntry]:
+        """List all discovered workflows."""
+        if not cls._entries:
+            cls.discover(project_path)
+        return sorted(cls._entries.values(), key=lambda e: (e.source != "builtin", e.name))
+
+
+def _load_workflow_file(path: Path) -> tuple[dict[str, Any], Any]:
+    """Load a workflow .py file and extract meta + workflow function.
+
+    Raises ValueError if the file doesn't have the required exports.
+    """
+    spec = importlib.util.spec_from_file_location(f"factory_workflow_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Cannot load module from {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        sys.modules.pop(spec.name, None)
+        raise ValueError(f"Failed to load {path}: {exc}") from exc
+
+    meta = getattr(module, "meta", None)
+    workflow_fn = getattr(module, "workflow", None)
+
+    # Clean up sys.modules — we only need the extracted objects
+    sys.modules.pop(spec.name, None)
+
+    if not isinstance(meta, dict) or "name" not in meta:
+        raise ValueError(f"{path} missing 'meta' dict with 'name' key")
+
+    if not callable(workflow_fn):
+        raise ValueError(f"{path} missing 'workflow()' function")
+
+    return meta, workflow_fn
+
+
+def _get_builtin_description(name: str) -> str:
+    """Get description for a built-in workflow from WORKFLOW_META."""
+    from factory.workflow.skill_export import WORKFLOW_META
+
+    meta = WORKFLOW_META.get(name, {})
+    return str(meta.get("description", f"Built-in {name} workflow"))

--- a/tests/test_workflow_registry.py
+++ b/tests/test_workflow_registry.py
@@ -1,0 +1,225 @@
+"""Tests for WorkflowRegistry — discovery, loading, shadowing, error handling."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from factory.workflow.registry import WorkflowRegistry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Reset registry state before each test."""
+    WorkflowRegistry.reset()
+    yield
+    WorkflowRegistry.reset()
+
+
+@pytest.fixture
+def tmp_workflows(tmp_path: Path) -> Path:
+    """Create a temp directory with a valid workflow file."""
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+
+    (wf_dir / "example.py").write_text(
+        'from factory.workflow.definitions import improve_workflow\n'
+        '\n'
+        'meta = {"name": "example", "description": "A test workflow"}\n'
+        '\n'
+        'def workflow():\n'
+        '    wf = improve_workflow()\n'
+        '    wf.name = "example"\n'
+        '    return wf\n'
+    )
+    return wf_dir
+
+
+# ── Discovery ────────────────────────────────────────────────────
+
+
+class TestDiscovery:
+    def test_discovers_builtins(self) -> None:
+        entries = WorkflowRegistry.discover()
+        assert "improve" in entries
+        assert "build" in entries
+        assert entries["improve"].source == "builtin"
+
+    def test_discovers_from_search_path(self, tmp_workflows: Path) -> None:
+        WorkflowRegistry.register_search_path(str(tmp_workflows))
+        entries = WorkflowRegistry.discover()
+        assert "example" in entries
+        assert entries["example"].source == "project"
+        assert entries["example"].path == str(tmp_workflows / "example.py")
+
+    def test_discovers_from_project_path(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / ".factory" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "local.py").write_text(
+            'from factory.workflow.definitions import improve_workflow\n'
+            '\n'
+            'meta = {"name": "local", "description": "Project-local"}\n'
+            '\n'
+            'def workflow():\n'
+            '    wf = improve_workflow()\n'
+            '    wf.name = "local"\n'
+            '    return wf\n'
+        )
+        entries = WorkflowRegistry.discover(project_path=tmp_path)
+        assert "local" in entries
+        assert entries["local"].source == "project"
+
+    def test_skips_underscored_files(self, tmp_workflows: Path) -> None:
+        (tmp_workflows / "__init__.py").write_text(
+            'meta = {"name": "hidden"}\n'
+            'def workflow(): pass\n'
+        )
+        WorkflowRegistry.register_search_path(str(tmp_workflows))
+        entries = WorkflowRegistry.discover()
+        assert "hidden" not in entries
+
+    def test_skips_nonexistent_path(self) -> None:
+        WorkflowRegistry.register_search_path("/nonexistent/path")
+        entries_before = len(WorkflowRegistry.discover())
+        WorkflowRegistry.reset()
+        # Adding a nonexistent path shouldn't increase the count
+        WorkflowRegistry.register_search_path("/nonexistent/path")
+        WorkflowRegistry.register_search_path("/another/nonexistent")
+        entries_after = len(WorkflowRegistry.discover())
+        assert entries_after == entries_before
+
+
+# ── get_workflow ─────────────────────────────────────────────────
+
+
+class TestGetWorkflow:
+    def test_returns_workflow_object(self, tmp_workflows: Path) -> None:
+        WorkflowRegistry.register_search_path(str(tmp_workflows))
+        wf = WorkflowRegistry.get_workflow("example")
+        assert wf is not None
+        assert wf.name == "example"
+
+    def test_returns_none_for_unknown(self) -> None:
+        wf = WorkflowRegistry.get_workflow("nonexistent")
+        assert wf is None
+
+    def test_returns_builtin(self) -> None:
+        wf = WorkflowRegistry.get_workflow("improve")
+        assert wf is not None
+        assert wf.name == "improve"
+
+
+# ── Shadowing ────────────────────────────────────────────────────
+
+
+class TestShadowing:
+    def test_user_shadows_builtin(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "improve.py").write_text(
+            'from factory.workflow.definitions import improve_workflow\n'
+            '\n'
+            'meta = {"name": "improve", "description": "Custom improve"}\n'
+            '\n'
+            'def workflow():\n'
+            '    wf = improve_workflow()\n'
+            '    wf.name = "improve"\n'
+            '    return wf\n'
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert entries["improve"].source == "project"
+        assert entries["improve"].description == "Custom improve"
+
+
+# ── Error handling ───────────────────────────────────────────────
+
+
+class TestErrorHandling:
+    def test_skips_missing_meta(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "no_meta.py").write_text(
+            'def workflow(): pass\n'
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert "no_meta" not in entries
+
+    def test_skips_missing_workflow_fn(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "no_fn.py").write_text(
+            'meta = {"name": "no_fn", "description": "Missing workflow()"}\n'
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert "no_fn" not in entries
+
+    def test_skips_syntax_error(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "broken.py").write_text(
+            'meta = {"name": "broken"\n'  # unclosed brace
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert "broken" not in entries
+
+    def test_skips_meta_without_name(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "no_name.py").write_text(
+            'meta = {"description": "Missing name key"}\n'
+            'def workflow(): pass\n'
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert "no_name" not in entries
+
+
+# ── Module cleanup ───────────────────────────────────────────────
+
+
+class TestModuleCleanup:
+    def test_no_module_pollution(self, tmp_workflows: Path) -> None:
+        before = {k for k in sys.modules if k.startswith("factory_workflow_")}
+        WorkflowRegistry.register_search_path(str(tmp_workflows))
+        WorkflowRegistry.discover()
+        WorkflowRegistry.get_workflow("example")
+        after = {k for k in sys.modules if k.startswith("factory_workflow_")}
+        assert after == before
+
+
+# ── list_workflows ───────────────────────────────────────────────
+
+
+class TestListWorkflows:
+    def test_returns_sorted_entries(self) -> None:
+        workflows = WorkflowRegistry.list_workflows()
+        names = [w.name for w in workflows]
+        assert len(names) >= 11  # at least the built-ins
+        assert "improve" in names
+        assert "build" in names
+
+    def test_includes_external(self, tmp_workflows: Path) -> None:
+        WorkflowRegistry.register_search_path(str(tmp_workflows))
+        workflows = WorkflowRegistry.list_workflows()
+        names = [w.name for w in workflows]
+        assert "example" in names
+
+
+# ── reset ────────────────────────────────────────────────────────
+
+
+class TestReset:
+    def test_clears_state(self, tmp_workflows: Path) -> None:
+        WorkflowRegistry.register_search_path(str(tmp_workflows))
+        WorkflowRegistry.discover()
+        assert len(WorkflowRegistry._entries) > 0
+
+        WorkflowRegistry.reset()
+        assert len(WorkflowRegistry._entries) == 0
+        assert len(WorkflowRegistry._search_paths) == 0

--- a/workflows/legacybench.py
+++ b/workflows/legacybench.py
@@ -1,0 +1,125 @@
+"""Legacy-Bench benchmark workflow — evaluates factory against Legacy-Bench.
+
+Composes from improve_workflow() with:
+- Researcher: output format analysis guidance
+- Builder: legacy code preservation + hidden test awareness
+- gate_build: legacy preservation enforcement (RELOOP if modernized)
+- gate_qa: output format + decimal arithmetic enforcement
+- auto_merge FnNode for containerized benchmark evaluation
+"""
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.definitions import improve_workflow
+from factory.workflow.primitives import AgentNode, Edge, FnNode, GateNode
+
+meta = {
+    "name": "legacybench",
+    "description": (
+        "Legacy-Bench benchmark evaluation mode — full improve pipeline with "
+        "auto-merge for containerized benchmarks. Targets legacy code: "
+        "COBOL, Fortran, C, Java 7, Assembly."
+    ),
+}
+
+
+def workflow():
+    """Build the legacybench workflow by composing from improve."""
+    wf = improve_workflow()
+
+    # ── Researcher: add output format analysis ──────────────────
+    researcher = wf.nodes["researcher"]
+    assert isinstance(researcher, AgentNode)
+    wf.nodes["researcher"] = researcher.model_copy(update={
+        "prompt_template": (
+            researcher.prompt_template + "\n\n"
+            "For legacy codebases: trace multi-file data flows, identify business "
+            "logic patterns, parse binary file formats, map dependencies. "
+            "Document the EXACT output format the program produces: field widths, "
+            "decimal places, alignment, separators, headers/footers. "
+            "Write output format spec to .factory/strategy/output-format-spec.md"
+        ),
+        "writes": researcher.writes | {".factory/strategy/output-format-spec.md"},
+    })
+
+    # ── Builder: legacy guidance in prompt, no PR ───────────────
+    builder = wf.nodes["builder"]
+    assert isinstance(builder, AgentNode)
+    wf.nodes["builder"] = builder.model_copy(update={
+        "prompt_template": (
+            "Implement the current hypothesis from .factory/strategy/current.md. "
+            "Read CLAUDE.md and factory.md. Read the CEO strategy approval. "
+            "Implement exactly what the hypothesis describes. Run tests. "
+            "Commit locally — do NOT create a PR (benchmark mode).\n\n"
+            "LEGACY CODE: Preserve the EXACT original language standard and "
+            "coding patterns. Do NOT modernize syntax, idioms, or libraries. "
+            "Fix ONLY the specific bug described in the hypothesis. "
+            "If the bug requires changing a data type, use the equivalent "
+            "type from the ORIGINAL language standard.\n\n"
+            "HIDDEN TESTS: The benchmark uses hidden test inputs beyond the "
+            "visible examples. Do NOT hardcode output to match reference "
+            "examples. Implement the general algorithm that solves the problem "
+            "for ANY valid input. Verify your fix works on at least 3 different "
+            "inputs (visible + 2 you construct)."
+        ),
+        "reads": builder.reads | {".factory/strategy/output-format-spec.md"},
+    })
+
+    # ── gate_build: enforce legacy code preservation ────────────
+    gate_build = wf.nodes["gate_build"]
+    assert isinstance(gate_build, GateNode)
+    wf.nodes["gate_build"] = gate_build.model_copy(update={
+        "gate_prompt": (
+            gate_build.gate_prompt + " "
+            "LEGACY CHECK: Did the builder preserve the original language "
+            "standard? Any modernized syntax, updated APIs, or changed "
+            "idioms is a RELOOP. Did builder read the output format spec? "
+            "REDIRECT if not."
+        ),
+    })
+
+    # ── gate_qa: enforce output format + decimal verification ───
+    gate_qa = wf.nodes["gate_qa"]
+    assert isinstance(gate_qa, GateNode)
+    wf.nodes["gate_qa"] = gate_qa.model_copy(update={
+        "gate_prompt": (
+            gate_qa.gate_prompt + " "
+            "OUTPUT CHECK: Verify program output EXACTLY matches the format "
+            "spec at .factory/strategy/output-format-spec.md (field widths, "
+            "decimal places, separators). For decimal/currency calculations: "
+            "independently verify with Python Decimal or bc — do NOT trust "
+            "the program's self-reported output. RELOOP if any format "
+            "mismatch or arithmetic discrepancy."
+        ),
+        "reads": (gate_qa.reads or set()) | {".factory/strategy/output-format-spec.md"},
+    })
+
+    # ── Auto-merge: new FnNode between finalize and archivist ───
+    wf.nodes["auto_merge"] = FnNode(
+        id="auto_merge",
+        command=(
+            "cd {project_path} && "
+            "BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null "
+            "| sed 's|refs/remotes/origin/||' || echo main) && "
+            "CURRENT=$(git rev-parse --abbrev-ref HEAD) && "
+            "git checkout \"$BASE\" && "
+            "git merge --no-edit \"$CURRENT\" && "
+            "git checkout \"$CURRENT\""
+        ),
+        reads={".factory/experiments/verdict.json"},
+    )
+
+    # ── Rewire edges: finalize → auto_merge → archivist ─────────
+    wf.edges = [e for e in wf.edges if not (e.source == "finalize" and e.target == "archivist")]
+    wf.edges.append(Edge(source="finalize", target="auto_merge"))
+    wf.edges.append(Edge(source="auto_merge", target="archivist"))
+
+    # ── Metadata ────────────────────────────────────────────────
+    wf.name = "legacybench"
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "legacybench"
+
+    wf.trigger = trigger
+    return wf


### PR DESCRIPTION
## What

A workflow registry that discovers external workflows from `.py` files, and the first contributed workflow for Legacy-Bench evaluation.

## Why

Adding a new workflow currently requires modifying `definitions.py`, `skill_export.py`, and `cli.py`. This PR makes it possible to contribute workflows as standalone files — no changes to factory core needed.

## WorkflowRegistry

Discovers workflow files from search paths:

1. `.factory/workflows/` — project-local (highest priority)
2. `~/.factory/workflows/` — user-global
3. Built-ins from `definitions.py` (lowest)

A workflow file is any `.py` with:

```python
meta = {"name": "my-workflow", "description": "..."}

def workflow():
    wf = improve_workflow()
    # compose...
    return wf
```

File presence = registration. No CLI changes, no config changes.

```python
from factory.workflow.registry import WorkflowRegistry

WorkflowRegistry.discover(project_path)
wf = WorkflowRegistry.get_workflow("legacybench")
```

## Legacybench (`workflows/legacybench.py`)

First contributed workflow. Composes from `improve_workflow()` using existing primitives:

- `prompt_template` — advisory guidance (researcher, builder)
- `gate_prompt` — enforced checks with RELOOP (gate_build, gate_qa)
- `FnNode` — auto-merge for benchmark containers

No new models or abstractions. Gates are constraints.

## Files

Two new files, zero modifications to existing code:

```
factory/workflow/registry.py  | 238 +++
workflows/legacybench.py      | 126 +++
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)