### PR TITLE
exp-20: Organize factory --help into command groups

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -24,7 +24,7 @@ You communicate directly with the user when running in foreground mode. You expl
 
 **Permitted Actions (exhaustive):**
 - `factory agent <role>` — spawn specialist agents
-- `factory begin/finalize/log/eval/guard/precheck/review/study/history/summary/backlog-*/refine-status/refine-begin/refine-complete` — CLI tools
+- `factory <cmd>` — full CLI reference via `factory --help`
 - `git log/diff/status/add/commit/checkout/branch` — version control
 - `gh issue/pr` — GitHub operations
 - `cat/ls/head/grep` — read files for review

--- a/factory/agents/prompts/refactory.md
+++ b/factory/agents/prompts/refactory.md
@@ -22,36 +22,10 @@ Use your slash commands to recall the detailed procedures for each capability.
 
 ## Factory CLI Reference
 
-You have access to the full factory CLI. Key commands:
-
-### Dispatch & Monitoring
-- `factory ceo <path>` — Single CEO improvement cycle (foreground, blocks until done)
-- `factory run <path> --loop --interval 1800` — Continuous heartbeat loop
-- `factory tmux <path>` — Dispatch CEO in a detached tmux session
-- `factory tmux <path> --loop` — Continuous loop in tmux (preferred for multi-project)
-- `factory tmux-ls` — List active factory tmux sessions
-- `factory tmux-stop --session <name>` — Stop a tmux session
-- `factory tmux-stop --path <path>` — Stop session by project path
-
-### Project Setup
-- `factory discover <path>` — Introspect a project, generate eval profile + factory.md automatically. **Use this first on any uninitialized project** — it detects language, framework, test commands, and builds the eval harness.
-- `factory init <path>` — Parse an existing factory.md into .factory/config.json. Only needed after manually editing factory.md.
-
-### Project Intelligence
-- `factory eval <path>` — Run eval, get current composite score
-- `factory history <path>` — Show experiment history (TSV)
-- `factory study <path>` — Analyze codebase, write observations
-- `factory status <path>` — Show project state and recent activity
-- `factory backlog-list <path>` — List pending backlog items
-- `factory backlog-add <path> "item"` — Add backlog item
-
-### Recovery & State
-- `factory checkpoint <path>` — Save CEO state for crash recovery
-- `factory resume <path>` — Resume from last checkpoint
-
-### Self-Evolution
-- `factory ace` — Evolve all agent playbooks from experiment data
-- `factory ace-stats` — Show playbook evolution statistics
+Run `factory --help` to see all available commands organized by category. Key patterns:
+- `factory ceo <path>` / `factory run <path>` / `factory tmux <path>` — dispatch CEO cycles
+- `factory agent <role> --task '...'` — invoke specialist agents
+- `factory <cmd> --help` — get detailed help for any command
 
 ## Session Persistence
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -4232,8 +4232,84 @@ def _emit_cli_event(project_path: Path, event_type: str, data: dict) -> None:
 # ── parser construction ────────────────────────────────────────
 
 
+_COMMAND_GROUPS: list[tuple[str, list[str]]] = [
+    ("Entry Points", [
+        "ceo", "run", "tmux", "tmux-ls", "tmux-capture", "tmux-stop", "refactory", "dashboard",
+        "agent",
+    ]),
+    ("Project Setup", ["home", "detect", "discover", "init"]),
+    ("Experiment Lifecycle", [
+        "begin", "finalize", "guard", "precheck", "log", "emit", "review",
+    ]),
+    ("Project Intelligence", [
+        "eval", "history", "study", "status", "summary", "diff", "explain", "export",
+        "research", "insights", "report-update", "baseline", "clean-pr",
+    ]),
+    ("Backlog & Refinement", [
+        "backlog-add", "backlog-list", "backlog-remove", "deferred-list", "deferred-remove",
+        "refine-status", "refine-begin", "refine-complete", "message",
+    ]),
+    ("Knowledge & Archive", [
+        "archive", "vault-init", "backfill-citations", "backfill-archive",
+    ]),
+    ("Self-Evolution", ["ace", "ace-stats", "digest", "workflow"]),
+    ("Configuration", [
+        "config", "profile", "install", "self-update", "runners", "usage", "serve-mcp",
+    ]),
+    ("Validation & Recovery", [
+        "leakage-check", "validate-research", "checkpoint", "resume", "notify", "registry-list",
+    ]),
+]
+
+
+class _GroupedHelpParser(argparse.ArgumentParser):
+    """ArgumentParser that renders subcommands in labelled groups."""
+
+    def format_help(self) -> str:
+        if self._subparsers is None:
+            return super().format_help()
+
+        sub_action: argparse._SubParsersAction | None = None  # type: ignore[type-arg]
+        for action in self._subparsers._group_actions:
+            if isinstance(action, argparse._SubParsersAction):
+                sub_action = action
+                break
+
+        if sub_action is None:
+            return super().format_help()
+
+        parts = [f"usage: {self.prog} [-h] <command> ...\n"]
+        if self.description:
+            parts.append(f"{self.description}\n")
+
+        help_map: dict[str, str] = {}
+        for sub_act in sub_action._choices_actions:
+            help_map[sub_act.dest] = sub_act.help or ""
+
+        grouped_cmds: set[str] = set()
+        for group_name, cmds in _COMMAND_GROUPS:
+            lines = []
+            for cmd in cmds:
+                if cmd in sub_action._name_parser_map and cmd in help_map:
+                    lines.append(f"  {cmd:25s}{help_map[cmd]}")
+                    grouped_cmds.add(cmd)
+            if lines:
+                parts.append(f"\n{group_name}:\n" + "\n".join(lines))
+
+        ungrouped = [
+            c for c in help_map
+            if c not in grouped_cmds and c in sub_action._name_parser_map
+        ]
+        if ungrouped:
+            lines = [f"  {cmd:25s}{help_map[cmd]}" for cmd in ungrouped]
+            parts.append("\nOther:\n" + "\n".join(lines))
+
+        parts.append("")
+        return "\n".join(parts)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = _GroupedHelpParser(
         prog="factory",
         description="Remote Factory — domain-agnostic multi-agent software evolution loop",
     )
@@ -4843,7 +4919,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # workflow — graph engine commands
     from factory.workflow.cli import add_workflow_parser
-    add_workflow_parser(sub)
+    add_workflow_parser(sub)  # type: ignore[arg-type]
 
     return parser
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for factory.cli — CLI subcommand routing."""
 
+import argparse
 import asyncio
 import contextlib
 import json
@@ -139,6 +140,60 @@ class TestParser:
         parser = build_parser()
         args = parser.parse_args(["agent", "failure_analyst", "--task", "test", "--project", "/p"])
         assert args.role == "failure_analyst"
+
+
+class TestGroupedHelp:
+    """Tests for _GroupedHelpParser and _COMMAND_GROUPS completeness."""
+
+    EXPECTED_GROUPS = [
+        "Entry Points:",
+        "Project Setup:",
+        "Experiment Lifecycle:",
+        "Project Intelligence:",
+        "Backlog & Refinement:",
+        "Knowledge & Archive:",
+        "Self-Evolution:",
+        "Configuration:",
+        "Validation & Recovery:",
+    ]
+
+    def test_help_output_contains_all_group_headers(self):
+        help_text = build_parser().format_help()
+        for header in self.EXPECTED_GROUPS:
+            assert header in help_text, f"Missing group header: {header}"
+
+    def test_all_subcommands_covered_by_groups(self):
+        from factory.cli import _COMMAND_GROUPS
+        grouped = {cmd for _, cmds in _COMMAND_GROUPS for cmd in cmds}
+        parser = build_parser()
+        sub_action = None
+        for action in parser._subparsers._group_actions:
+            if isinstance(action, argparse._SubParsersAction):
+                sub_action = action
+                break
+        assert sub_action is not None
+        registered = set(sub_action._name_parser_map.keys())
+        orphans = registered - grouped
+        assert orphans == set(), f"Commands not in any group: {orphans}"
+
+    def test_no_command_in_multiple_groups(self):
+        from factory.cli import _COMMAND_GROUPS
+        seen: dict[str, str] = {}
+        duplicates: list[str] = []
+        for group_name, cmds in _COMMAND_GROUPS:
+            for cmd in cmds:
+                if cmd in seen:
+                    duplicates.append(f"{cmd!r} in both {seen[cmd]!r} and {group_name!r}")
+                seen[cmd] = group_name
+        assert duplicates == [], f"Commands in multiple groups: {duplicates}"
+
+    def test_no_ungrouped_other_section(self):
+        help_text = build_parser().format_help()
+        assert "\nOther:\n" not in help_text, "Help has an 'Other' section — some commands are ungrouped"
+
+    def test_group_count_is_nine(self):
+        from factory.cli import _COMMAND_GROUPS
+        assert len(_COMMAND_GROUPS) == 9
 
 
 class TestCmdCeoDesign:


### PR DESCRIPTION
Closes #876

## Changes

- **factory/cli.py**: Added `_GroupedHelpParser` subclass and `_COMMAND_GROUPS` mapping that organizes 61 subcommands into 9 labelled categories (Entry Points, Project Setup, Experiment Lifecycle, Project Intelligence, Backlog & Refinement, Knowledge & Archive, Self-Evolution, Configuration, Validation & Recovery). The usage line is simplified from a flat command list to `factory [-h] <command> ...`. All existing command registration and parsing behavior is preserved — only the `--help` display changes.
- **factory/agents/prompts/ceo.md**: Replaced hardcoded command enumeration in Permitted Actions with `factory <cmd>` referencing `factory --help`
- **factory/agents/prompts/refactory.md**: Replaced 34-line CLI reference section with 4-line directive to use `factory --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)