### PR TITLE
fix: use OTel span attributes for Langfuse trace naming

### DIFF
--- a/factory/telemetry.py
+++ b/factory/telemetry.py
@@ -24,7 +24,6 @@ except ImportError:
 
 _client: object | None = None
 _observations: dict[str, Any] = {}
-_trace_names: dict[str, tuple[str, Any]] = {}  # trace_id -> (name, input)
 
 def is_enabled() -> bool:
     """Check if Langfuse is configured and lazily initialise the client."""
@@ -50,53 +49,23 @@ def _get_client() -> Any:
     return _client
 
 
-_trace_name_counter: int = 0
+def _set_trace_name_on_span(obs: Any, name: str, input_data: object | None = None) -> None:
+    """Set trace-level name and input via OTel span attributes.
 
-
-def _update_trace_via_api(
-    trace_id: str,
-    name: str,
-    input_data: object | None = None,
-) -> None:
-    """Set trace name and input via the Langfuse ingestion API.
-
-    The v4 Python SDK derives trace names from observations, so we use
-    the public ingestion batch endpoint to override it. Each call uses
-    a unique event ID to avoid deduplication.
+    The v4 SDK reads ``langfuse.trace.name`` / ``langfuse.trace.input``
+    from span attributes and applies them to the parent trace on export.
     """
-    global _trace_name_counter
-    import urllib.request
-    from datetime import datetime, timezone
-
-    host = os.environ.get("LANGFUSE_HOST", "")
-    pub_key = os.environ.get("LANGFUSE_PUBLIC_KEY", "")
-    sec_key = os.environ.get("LANGFUSE_SECRET_KEY", "")
-    if not host or not pub_key:
-        return
     try:
-        import base64
-        _trace_name_counter += 1
-        auth = base64.b64encode(f"{pub_key}:{sec_key}".encode()).decode()
-        inner: dict[str, Any] = {"id": trace_id, "name": name}
+        from langfuse._client.attributes import LangfuseOtelSpanAttributes
+        otel_span = getattr(obs, "_otel_span", None)
+        if otel_span is None or not otel_span.is_recording():
+            return
+        otel_span.set_attribute(LangfuseOtelSpanAttributes.TRACE_NAME, name)
         if input_data is not None:
-            inner["input"] = input_data
-        body = {
-            "batch": [{
-                "id": f"trace-name-{trace_id[:8]}-{_trace_name_counter}",
-                "type": "trace-create",
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "body": inner,
-            }],
-        }
-        req = urllib.request.Request(
-            f"{host}/api/public/ingestion",
-            data=json.dumps(body).encode(),
-            headers={"Authorization": f"Basic {auth}", "Content-Type": "application/json"},
-            method="POST",
-        )
-        urllib.request.urlopen(req, timeout=5)
+            serialized = json.dumps(input_data) if not isinstance(input_data, str) else input_data
+            otel_span.set_attribute(LangfuseOtelSpanAttributes.TRACE_INPUT, serialized)
     except Exception:
-        log.debug("langfuse_trace_update_failed", trace_id=trace_id, exc_info=True)
+        log.debug("langfuse_set_trace_name_failed", exc_info=True)
 
 
 def begin_trace(
@@ -117,8 +86,7 @@ def begin_trace(
         metadata={"model": model, "project": project_name},
     )
     _observations[obs.id] = obs
-    _trace_names[obs.trace_id] = (trace_name, trace_input)
-    _update_trace_via_api(obs.trace_id, trace_name, trace_input)
+    _set_trace_name_on_span(obs, trace_name, trace_input)
     log.debug("langfuse_trace_started", trace_id=obs.trace_id, span_id=obs.id)
     return (obs.trace_id, obs.id)
 
@@ -204,7 +172,7 @@ def end_span(
 
 
 def end_trace(trace_id: str, span_id: str | None = None, output: str | None = None) -> None:
-    """Mark a root trace span as finished and re-assert trace name."""
+    """Mark a root trace span as finished."""
     if not is_enabled():
         return
     sid = span_id or trace_id
@@ -213,28 +181,14 @@ def end_trace(trace_id: str, span_id: str | None = None, output: str | None = No
         obs.update(output=output or {"status": "completed"})
         obs.end()
         _observations.pop(sid, None)
-    saved = _trace_names.pop(trace_id, None)
-    if saved:
-        name, input_data = saved
-        _update_trace_via_api(trace_id, name, input_data)
     log.debug("langfuse_trace_ended", trace_id=trace_id)
 
 
 def flush() -> None:
-    """Flush any buffered Langfuse events and re-assert trace names.
-
-    The SDK derives trace names from observations, so we flush twice:
-    first to drain the SDK's queue, then reassert names via the API,
-    then flush again to ensure our name update is the final write.
-    """
+    """Flush any buffered Langfuse events."""
     if _client is not None:
         client = _get_client()
         client.flush()
-        _time.sleep(1.0)
-        for trace_id, (name, input_data) in list(_trace_names.items()):
-            _update_trace_via_api(trace_id, name, input_data)
-        client.flush()
-        _time.sleep(0.3)
 
 
 # ---------------------------------------------------------------------------
@@ -533,10 +487,6 @@ class TranscriptTailer:
             while not self._stop_event.is_set():
                 try:
                     self._ingest_new_lines()
-                    if self.trace_id:
-                        saved = _trace_names.get(self.trace_id)
-                        if saved:
-                            _update_trace_via_api(self.trace_id, saved[0], saved[1])
                 except Exception:
                     log.debug("tailer_ingest_error", exc_info=True)
                 self._stop_event.wait(self.POLL_INTERVAL)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -16,16 +16,12 @@ def _reset_telemetry():
     """Reset telemetry module state between tests."""
     old_client = telemetry_mod._client
     old_obs = telemetry_mod._observations.copy()
-    old_names = telemetry_mod._trace_names.copy()
     telemetry_mod._client = None
     telemetry_mod._observations.clear()
-    telemetry_mod._trace_names.clear()
     yield
     telemetry_mod._client = old_client
     telemetry_mod._observations.clear()
     telemetry_mod._observations.update(old_obs)
-    telemetry_mod._trace_names.clear()
-    telemetry_mod._trace_names.update(old_names)
 
 
 class TestIsEnabled:
@@ -61,7 +57,7 @@ class TestBeginTrace:
         mock_client.start_observation.return_value = mock_obs
         telemetry_mod._client = mock_client
 
-        with patch.object(telemetry_mod, "_update_trace_via_api"):
+        with patch.object(telemetry_mod, "_set_trace_name_on_span"):
             result = telemetry_mod.begin_trace("my-project", "cycle-1", model="opus")
 
         assert result == ("trace-abc", "span-abc")
@@ -80,7 +76,7 @@ class TestBeginTrace:
         mock_client.start_observation.return_value = mock_obs
         telemetry_mod._client = mock_client
 
-        with patch.object(telemetry_mod, "_update_trace_via_api"):
+        with patch.object(telemetry_mod, "_set_trace_name_on_span"):
             telemetry_mod.begin_trace("proj", "c1")
 
         mock_client.start_observation.assert_called_once_with(
@@ -175,10 +171,8 @@ class TestEndTrace:
         mock_obs = MagicMock()
         telemetry_mod._client = mock_client
         telemetry_mod._observations["span-1"] = mock_obs
-        telemetry_mod._trace_names["trace-1"] = ("factory:proj/c1", {"project": "proj"})
 
-        with patch.object(telemetry_mod, "_update_trace_via_api"):
-            telemetry_mod.end_trace("trace-1", span_id="span-1")
+        telemetry_mod.end_trace("trace-1", span_id="span-1")
 
         mock_obs.update.assert_called_once_with(output={"status": "completed"})
         mock_obs.end.assert_called_once()
@@ -189,9 +183,8 @@ class TestFlush:
     def test_flushes_when_client_exists(self) -> None:
         mock_client = MagicMock()
         telemetry_mod._client = mock_client
-        with patch.object(telemetry_mod, "_update_trace_via_api"):
-            telemetry_mod.flush()
-        assert mock_client.flush.call_count == 2
+        telemetry_mod.flush()
+        mock_client.flush.assert_called_once()
 
     def test_noop_when_no_client(self) -> None:
         telemetry_mod._client = None


### PR DESCRIPTION
## Summary
- Replaced raw `urllib` calls to the legacy `/api/public/ingestion` Langfuse endpoint with OTel span attributes (`langfuse.trace.name` / `langfuse.trace.input`) for setting trace names
- The legacy endpoint returns 403 on some self-hosted Langfuse instances while the SDK's OTLP export path works fine — this was causing noisy error logs on every trace
- Removed the `flush()` sleep/retry loop and periodic re-assertion in `TranscriptTailer` since trace naming is now baked into span data at creation time

## Test plan
- [x] All 15 telemetry tests pass
- [x] `ruff check` passes
- [x] Manually verified traces appear with correct names in Langfuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)