### PR TITLE
feat: make langfuse a core dependency

### DIFF
--- a/factory/telemetry.py
+++ b/factory/telemetry.py
@@ -11,16 +11,12 @@ from pathlib import Path
 from typing import Any
 
 import structlog
+from langfuse import Langfuse
+from langfuse.types import TraceContext
 
 log = structlog.get_logger()
 
-try:
-    from langfuse import Langfuse  # type: ignore[import-not-found]
-    from langfuse.types import TraceContext  # type: ignore[import-not-found]
-
-    _HAS_LANGFUSE = True
-except ImportError:
-    _HAS_LANGFUSE = False
+_HAS_LANGFUSE = True
 
 _client: object | None = None
 _observations: dict[str, Any] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pyyaml>=6.0",
     "filelock>=3.0",
     "networkx>=3.6.1",
+    "langfuse>=3.0",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -31,7 +32,7 @@ Issues = "https://github.com/akashgit/remote-factory/issues"
 
 [project.optional-dependencies]
 migrate = ["tomli_w>=1.0"]
-telemetry = ["langfuse>=3.0"]
+telemetry = ["langfuse>=3.0"]  # kept for backward compat; langfuse is now a core dep
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -1531,6 +1531,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "filelock" },
+    { name = "langfuse" },
     { name = "mcp" },
     { name = "networkx" },
     { name = "pydantic" },
@@ -1566,6 +1567,7 @@ docs = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "filelock", specifier = ">=3.0" },
+    { name = "langfuse", specifier = ">=3.0" },
     { name = "langfuse", marker = "extra == 'telemetry'", specifier = ">=3.0" },
     { name = "mcp", specifier = ">=1.27.0" },
     { name = "networkx", specifier = ">=3.6.1" },


### PR DESCRIPTION
## Summary

- Move `langfuse>=3.0` from `[telemetry]` optional extra to core dependencies
- Remove try/except import guard in `factory/telemetry.py` — langfuse is now always importable
- Keep `[telemetry]` extra for backward compat (commented as such)

Langfuse is lightweight (~4 MB package + ~1 MB otel deps), and most of its dependencies (`pydantic`, `httpx`, `wrapt`, `packaging`) are already in the dependency tree. Making it a core dep ensures tracing works by default — previously, agents would silently produce no traces when the extra wasn't installed.

## Test plan
- [x] `ruff check factory/telemetry.py` — clean
- [x] `pytest tests/ -x` — 1525 passed (1 pre-existing failure in `verification.md`)
- [x] Verified all 3 deep-qa agents produce Langfuse traces with observations

🤖 Generated with [Claude Code](https://claude.com/claude-code)