### PR TITLE
feat: add --refactory-agent flag to filter help output

### DIFF
--- a/factory/agents/prompts/refactory.md
+++ b/factory/agents/prompts/refactory.md
@@ -22,10 +22,7 @@ Use your slash commands to recall the detailed procedures for each capability.
 
 ## Factory CLI Reference
 
-Run `factory --help` to see all available commands organized by category. Key patterns:
-- `factory ceo <path>` / `factory run <path>` / `factory tmux <path>` — dispatch CEO cycles
-- `factory agent <role> --task '...'` — invoke specialist agents
-- `factory <cmd> --help` — get detailed help for any command
+Run `factory --help --refactory-agent` to see commands relevant to your role. For any command's full options, run `factory <cmd> --help`.
 
 ## Session Persistence
 

--- a/factory/cli.py
+++ b/factory/cli.py
@@ -4232,6 +4232,14 @@ def _emit_cli_event(project_path: Path, event_type: str, data: dict) -> None:
 # ── parser construction ────────────────────────────────────────
 
 
+_REFACTORY_AGENT_COMMANDS: frozenset[str] = frozenset({
+    "ceo", "run", "tmux", "tmux-ls", "tmux-stop", "tmux-capture",
+    "discover", "init", "detect",
+    "eval", "history", "study", "status", "backlog-list", "backlog-add",
+    "checkpoint", "resume",
+    "ace", "ace-stats",
+})
+
 _COMMAND_GROUPS: list[tuple[str, list[str]]] = [
     ("Entry Points", [
         "ceo", "run", "tmux", "tmux-ls", "tmux-capture", "tmux-stop", "refactory", "dashboard",
@@ -4286,23 +4294,28 @@ class _GroupedHelpParser(argparse.ArgumentParser):
         for sub_act in sub_action._choices_actions:
             help_map[sub_act.dest] = sub_act.help or ""
 
+        refactory_filter = "--refactory-agent" in sys.argv
+
         grouped_cmds: set[str] = set()
         for group_name, cmds in _COMMAND_GROUPS:
             lines = []
             for cmd in cmds:
                 if cmd in sub_action._name_parser_map and cmd in help_map:
+                    if refactory_filter and cmd not in _REFACTORY_AGENT_COMMANDS:
+                        continue
                     lines.append(f"  {cmd:25s}{help_map[cmd]}")
                     grouped_cmds.add(cmd)
             if lines:
                 parts.append(f"\n{group_name}:\n" + "\n".join(lines))
 
-        ungrouped = [
-            c for c in help_map
-            if c not in grouped_cmds and c in sub_action._name_parser_map
-        ]
-        if ungrouped:
-            lines = [f"  {cmd:25s}{help_map[cmd]}" for cmd in ungrouped]
-            parts.append("\nOther:\n" + "\n".join(lines))
+        if not refactory_filter:
+            ungrouped = [
+                c for c in help_map
+                if c not in grouped_cmds and c in sub_action._name_parser_map
+            ]
+            if ungrouped:
+                lines = [f"  {cmd:25s}{help_map[cmd]}" for cmd in ungrouped]
+                parts.append("\nOther:\n" + "\n".join(lines))
 
         parts.append("")
         return "\n".join(parts)
@@ -4312,6 +4325,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser = _GroupedHelpParser(
         prog="factory",
         description="Remote Factory — domain-agnostic multi-agent software evolution loop",
+    )
+    parser.add_argument(
+        "--refactory-agent", action="store_true",
+        help="Show only commands used by the re:factory agent",
     )
     sub = parser.add_subparsers(dest="command")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import contextlib
 import json
 import signal
 import subprocess
+import sys
 import threading
 from datetime import datetime
 from pathlib import Path
@@ -194,6 +195,50 @@ class TestGroupedHelp:
     def test_group_count_is_nine(self):
         from factory.cli import _COMMAND_GROUPS
         assert len(_COMMAND_GROUPS) == 9
+
+
+class TestRefactoryAgentFilter:
+    """Tests for --refactory-agent help filtering."""
+
+    EXPECTED_COMMANDS = {
+        "ceo", "run", "tmux", "tmux-ls", "tmux-stop", "tmux-capture",
+        "discover", "init", "detect",
+        "eval", "history", "study", "status", "backlog-list", "backlog-add",
+        "checkpoint", "resume",
+        "ace", "ace-stats",
+    }
+
+    def test_filtered_help_shows_only_expected_commands(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["factory", "--help", "--refactory-agent"])
+        parser = build_parser()
+        help_text = parser.format_help()
+        import re as _re
+        displayed = set(_re.findall(r"^  (\S+)", help_text, _re.MULTILINE))
+        assert displayed == self.EXPECTED_COMMANDS
+
+    def test_filtered_help_has_group_headers(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["factory", "--help", "--refactory-agent"])
+        help_text = build_parser().format_help()
+        for header in ("Entry Points:", "Project Setup:", "Project Intelligence:",
+                       "Validation & Recovery:", "Self-Evolution:"):
+            assert header in help_text, f"Missing group header: {header}"
+
+    def test_filtered_help_omits_empty_groups(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["factory", "--help", "--refactory-agent"])
+        help_text = build_parser().format_help()
+        for header in ("Experiment Lifecycle:", "Knowledge & Archive:", "Configuration:"):
+            assert header not in help_text, f"Group should be hidden: {header}"
+
+    def test_filtered_help_no_other_section(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["factory", "--help", "--refactory-agent"])
+        help_text = build_parser().format_help()
+        assert "\nOther:\n" not in help_text
+
+    def test_unfiltered_help_unaffected(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["factory", "--help"])
+        help_text = build_parser().format_help()
+        assert "Experiment Lifecycle:" in help_text
+        assert "begin" in help_text
 
 
 class TestCmdCeoDesign:


### PR DESCRIPTION
Closes #21

## Changes

- Added `_REFACTORY_AGENT_COMMANDS` frozenset (20 commands) to `factory/cli.py`
- `format_help()` in `_GroupedHelpParser` checks `sys.argv` for `--refactory-agent` and filters commands/groups accordingly
- Registered `--refactory-agent` as a `store_true` argument on the parser for discoverability
- Updated `factory/agents/prompts/refactory.md` CLI reference to point to `factory --help --refactory-agent`
- Added 5 tests covering filtered output correctness, group header presence/absence, and no regression on unfiltered help