### PR TITLE
ci: add LANGFUSE_BASE_URL to benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -177,6 +177,7 @@ jobs:
           MAX_THINKING_TOKENS: "128000"
           CLAUDE_CODE_EFFORT_LEVEL: "XHIGH"
           LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_HOST }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
         run: |


### PR DESCRIPTION
Closes the gap where benchmark scripts forward `LANGFUSE_BASE_URL` to Claude Code subprocesses but the workflow never set it.

## Changes
- Add `LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_HOST }}` to the "Run benchmark" step's env block, right after `LANGFUSE_HOST`

## Notes
The GH secrets (`LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`) were also updated to point to the CI-specific Langfuse project at langfuse-ci.ai-innovation.team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)