### PR TITLE
ci: route benchmarks to dedicated Langfuse project

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -176,9 +176,10 @@ jobs:
           CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
           MAX_THINKING_TOKENS: "128000"
           CLAUDE_CODE_EFFORT_LEVEL: "XHIGH"
-          LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
-          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
-          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_HOST: ${{ secrets.LANGFUSE_BENCH_HOST }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BENCH_HOST }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_BENCH_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_BENCH_SECRET_KEY }}
         run: |
           chmod +x benchmarks/run.sh benchmarks/lib.sh benchmarks/run-*.sh
           benchmarks/run.sh ${{ matrix.benchmark }} ${{ steps.config.outputs.instance }} --timeout ${{ steps.timeout.outputs.value }} --solver ${{ matrix.solver }}


### PR DESCRIPTION
Closes #883

## Changes

- Replaced shared Langfuse secrets (`LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`) with benchmark-specific secrets (`LANGFUSE_BENCH_HOST`, `LANGFUSE_BENCH_PUBLIC_KEY`, `LANGFUSE_BENCH_SECRET_KEY`) in `.github/workflows/benchmark.yml`
- Added `LANGFUSE_BASE_URL` env var (set to `LANGFUSE_BENCH_HOST`) for SDK compatibility

Benchmark telemetry is now routed to a dedicated Langfuse project, separate from eval-baseline and ceo-review workflows which continue using the shared secrets.