### PR TITLE
ci: route benchmarks to dedicated Langfuse project

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -176,9 +176,10 @@ jobs:
           CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
           MAX_THINKING_TOKENS: "128000"
           CLAUDE_CODE_EFFORT_LEVEL: "XHIGH"
-          LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
-          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
-          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_HOST: ${{ secrets.LANGFUSE_BENCH_HOST }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BENCH_HOST }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_BENCH_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_BENCH_SECRET_KEY }}
         run: |
           chmod +x benchmarks/run.sh benchmarks/lib.sh benchmarks/run-*.sh
           benchmarks/run.sh ${{ matrix.benchmark }} ${{ steps.config.outputs.instance }} --timeout ${{ steps.timeout.outputs.value }} --solver ${{ matrix.solver }}


### PR DESCRIPTION
## Summary
- Route benchmark CI telemetry to a dedicated Langfuse project, separate from other CI workflows (eval-baseline, ceo-review)
- New GH secrets created: `LANGFUSE_BENCH_HOST`, `LANGFUSE_BENCH_PUBLIC_KEY`, `LANGFUSE_BENCH_SECRET_KEY`
- Added `LANGFUSE_BASE_URL` so Claude Code's native Langfuse integration also picks up the base URL

## Changes
- `.github/workflows/benchmark.yml`: swap shared `LANGFUSE_*` secrets for benchmark-specific `LANGFUSE_BENCH_*` secrets, add `LANGFUSE_BASE_URL`

## What's unchanged
- `eval-baseline.yml` and `ceo-review.yml` continue using the shared `LANGFUSE_*` secrets
- No benchmark script changes needed — they already forward both `LANGFUSE_HOST` and `LANGFUSE_BASE_URL`