### PR TITLE
Require documentation updates in every factory PR

### DIFF
--- a/factory/agents/prompts/builder.md
+++ b/factory/agents/prompts/builder.md
@@ -22,8 +22,9 @@ You will be given:
 3. **Verify your branch**: `git branch --show-current` (already set up by the worktree — do NOT create a new branch)
 4. **Implement**: Make the changes described in the issue — only modify files within the declared scope
 5. **Test**: Run tests, lint, and type checks to verify your changes work
-6. **Commit**: `git add <changed files> && git commit -m "<descriptive message>"`
-7. **Open a PR**: `gh pr create --base $TARGET_BRANCH --title "<issue title>" --body "Closes #$ISSUE_NUM\n\n## Changes\n<summary>"`
+6. **Update documentation**: After tests pass, scan for documentation files (README.md, CLAUDE.md, AGENTS.md, CHANGELOG.md, docs/*.md, SPEC.md) that reference changed modules, functions, CLI commands, configuration, or architecture. Update those docs to reflect the implementation changes. Include doc changes in the same commit and PR. If no docs are affected, state so in the PR body.
+7. **Commit**: `git add <changed files> && git commit -m "<descriptive message>"`
+8. **Open a PR**: `gh pr create --base $TARGET_BRANCH --title "<issue title>" --body "Closes #$ISSUE_NUM\n\n## Changes\n<summary>"`
 
 ## Constraints
 

--- a/factory/agents/prompts/qa.md
+++ b/factory/agents/prompts/qa.md
@@ -65,7 +65,7 @@ Read the full PR diff and evaluate against a structured checklist. This section 
    git diff <baseline>..HEAD -- <file2>
    ```
    For each file, read its diff hunk by hunk.
-3. **Evaluate against the 7-category checklist** — for each category, cite specific evidence from the diff:
+3. **Evaluate against the 8-category checklist** — for each category, cite specific evidence from the diff:
 
 | # | Category | What to check |
 |---|----------|---------------|
@@ -76,6 +76,7 @@ Read the full PR diff and evaluate against a structured checklist. This section 
 | 5 | **Style & consistency** | Naming conventions, code duplication, dead code, import organization |
 | 6 | **Scope compliance** | PR implements what the hypothesis asked — no scope creep, no unrelated changes |
 | 7 | **Guardrail compliance** | No file exceeds 500 lines, all modified files within declared scope, no fixed_surfaces modified |
+| 8 | **Documentation freshness** | Changed public APIs/CLI/config/architecture without updating README, CLAUDE.md, AGENTS.md, docs/*.md, or other project docs |
 
 4. **Spec fidelity check:** Read the GitHub issue (`gh issue view <issue_number>`) and verify the PR implements ALL acceptance criteria. Flag any scope shrinkage.
 
@@ -100,7 +101,7 @@ Read the full PR diff and evaluate against a structured checklist. This section 
 ### Issue Severity
 
 - **Critical** — blocks merge: bugs causing runtime failure, security vulnerabilities, data corruption, fixed surface violation.
-- **Important** — should fix: edge cases not handled, missing error handling, logic gaps.
+- **Important** — should fix: edge cases not handled, missing error handling, logic gaps, missing documentation updates for functional changes.
 - **Minor** — nice to fix: style, naming, minor duplication.
 
 Output format:
@@ -115,6 +116,7 @@ Output format:
 - Style: PASS | FAIL — <evidence>
 - Scope: PASS | FAIL — <evidence>
 - Guardrails: PASS | FAIL — <evidence>
+- Documentation: PASS | FAIL — <evidence>
 
 ### Spec Fidelity
 - Acceptance criteria met: N/M


### PR DESCRIPTION
Closes #892

## Changes

- **Builder prompt**: Added Step 6 (Update documentation) between Test and Commit. After tests pass, the Builder must scan documentation files (README.md, CLAUDE.md, AGENTS.md, CHANGELOG.md, docs/*.md, SPEC.md) for references to changed modules, functions, CLI commands, configuration, or architecture — and update them in the same commit/PR. If no docs are affected, this is stated in the PR body.
- **QA prompt**: Added 8th code review category "Documentation freshness" to the checklist table, checking whether PRs that change public APIs/CLI/config/architecture also update relevant docs. Added corresponding `Documentation: PASS | FAIL` line to the output format template. Missing documentation updates for functional changes are flagged as Important severity.