### PR TITLE
Fix Langfuse tracing: suppress dual traces, respect CLAUDE_CONFIG_DIR, support LANGFUSE_BASE_URL, forward env in Harbor

### DIFF
--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -124,6 +124,7 @@ class FactoryCeo(BaseInstalledAgent):
             "LANGFUSE_HOST",
             "LANGFUSE_PUBLIC_KEY",
             "LANGFUSE_SECRET_KEY",
+            "LANGFUSE_BASE_URL",
         ):
             val = self._get_env(var) or os.environ.get(var)
             if val and var not in env:

--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -121,6 +121,9 @@ class FactoryCeo(BaseInstalledAgent):
             "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING",
             "MAX_THINKING_TOKENS",
             "CLAUDE_CODE_EFFORT_LEVEL",
+            "LANGFUSE_HOST",
+            "LANGFUSE_PUBLIC_KEY",
+            "LANGFUSE_SECRET_KEY",
         ):
             val = self._get_env(var) or os.environ.get(var)
             if val and var not in env:

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -114,7 +114,6 @@ class ClaudeRunner:
             cmd.extend(["--name", request.session_name])
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-        env["TELEMETRY_PLATFORM"] = ""
         if request.model:
             env["FACTORY_MODEL"] = request.model
 
@@ -223,7 +222,6 @@ class ClaudeRunner:
             cmd.extend(["--name", request.session_name])
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-        env["TELEMETRY_PLATFORM"] = ""
         if request.model:
             env["FACTORY_MODEL"] = request.model
 

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -114,6 +114,7 @@ class ClaudeRunner:
             cmd.extend(["--name", request.session_name])
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        env["TELEMETRY_PLATFORM"] = ""
         if request.model:
             env["FACTORY_MODEL"] = request.model
 
@@ -222,6 +223,7 @@ class ClaudeRunner:
             cmd.extend(["--name", request.session_name])
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        env["TELEMETRY_PLATFORM"] = ""
         if request.model:
             env["FACTORY_MODEL"] = request.model
 

--- a/factory/telemetry.py
+++ b/factory/telemetry.py
@@ -28,11 +28,12 @@ def is_enabled() -> bool:
         return True
     if not _HAS_LANGFUSE:
         return False
-    if not os.environ.get("LANGFUSE_HOST"):
+    host = os.environ.get("LANGFUSE_BASE_URL") or os.environ.get("LANGFUSE_HOST")
+    if not host:
         return False
     try:
         _client = Langfuse()
-        log.debug("langfuse_initialized", host=os.environ["LANGFUSE_HOST"])
+        log.debug("langfuse_initialized", host=host)
         return True
     except Exception as exc:
         log.warning("langfuse_init_failed", error=str(exc))
@@ -192,9 +193,17 @@ def flush() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _get_claude_projects_dir() -> Path:
+    """Return the Claude Code projects directory, respecting CLAUDE_CONFIG_DIR."""
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if config_dir:
+        return Path(config_dir).expanduser() / "projects"
+    return Path.home() / ".claude" / "projects"
+
+
 def _find_transcript(claude_session_id: str, project_path: Path) -> Path | None:
     """Locate a Claude Code transcript JSONL, trying multiple path patterns."""
-    claude_dir = Path.home() / ".claude" / "projects"
+    claude_dir = _get_claude_projects_dir()
     dir_name = str(project_path.resolve()).replace("/", "-").replace(".", "-")
     direct = claude_dir / dir_name / f"{claude_session_id}.jsonl"
     if direct.exists():
@@ -387,7 +396,7 @@ def ingest_transcript_to_span(
 
 def _find_recent_transcript(project_path: Path, session_start: float) -> Path | None:
     """Find the most recently modified JSONL transcript after *session_start*."""
-    claude_dir = Path.home() / ".claude" / "projects"
+    claude_dir = _get_claude_projects_dir()
     dir_name = str(project_path.resolve()).replace("/", "-").replace(".", "-")
     proj_dir = claude_dir / dir_name
     if not proj_dir.exists():

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -134,30 +134,6 @@ class TestClaudeRunner:
             assert "--append-system-prompt" not in [c for c in cmd if c != "--append-system-prompt-file"]
 
 
-    def test_build_command_suppresses_telemetry_platform(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setenv("TELEMETRY_PLATFORM", "langfuse")
-        runner = ClaudeRunner()
-        cmd, env, temp_files = runner.build_command(AgentRunRequest(
-            prompt="Test", task="Test", cwd=tmp_path,
-        ))
-        assert env["TELEMETRY_PLATFORM"] == ""
-        for f in temp_files:
-            f.unlink(missing_ok=True)
-
-    def test_build_interactive_command_suppresses_telemetry_platform(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setenv("TELEMETRY_PLATFORM", "langfuse")
-        runner = ClaudeRunner()
-        cmd, env, temp_files = runner.build_interactive_command(AgentRunRequest(
-            prompt="Test", task="Test", cwd=tmp_path,
-        ))
-        assert env["TELEMETRY_PLATFORM"] == ""
-        for f in temp_files:
-            f.unlink(missing_ok=True)
-
 
 class TestBobRunner:
     def test_is_dry_run_true(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -134,6 +134,31 @@ class TestClaudeRunner:
             assert "--append-system-prompt" not in [c for c in cmd if c != "--append-system-prompt-file"]
 
 
+    def test_build_command_suppresses_telemetry_platform(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TELEMETRY_PLATFORM", "langfuse")
+        runner = ClaudeRunner()
+        cmd, env, temp_files = runner.build_command(AgentRunRequest(
+            prompt="Test", task="Test", cwd=tmp_path,
+        ))
+        assert env["TELEMETRY_PLATFORM"] == ""
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_build_interactive_command_suppresses_telemetry_platform(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("TELEMETRY_PLATFORM", "langfuse")
+        runner = ClaudeRunner()
+        cmd, env, temp_files = runner.build_interactive_command(AgentRunRequest(
+            prompt="Test", task="Test", cwd=tmp_path,
+        ))
+        assert env["TELEMETRY_PLATFORM"] == ""
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+
 class TestBobRunner:
     def test_is_dry_run_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("FACTORY_BOB_DRY_RUN", "1")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -31,6 +31,7 @@ class TestIsEnabled:
 
     def test_returns_false_without_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
         with patch.object(telemetry_mod, "_HAS_LANGFUSE", True):
             assert telemetry_mod.is_enabled() is False
 
@@ -46,6 +47,36 @@ class TestIsEnabled:
     def test_returns_true_on_subsequent_calls(self) -> None:
         telemetry_mod._client = MagicMock()
         assert telemetry_mod.is_enabled() is True
+
+    def test_returns_true_with_base_url_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANGFUSE_BASE_URL", "http://localhost:3000")
+        monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        mock_client = MagicMock()
+        mock_langfuse_cls = MagicMock(return_value=mock_client)
+        monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
+        monkeypatch.setattr(telemetry_mod, "Langfuse", mock_langfuse_cls, raising=False)
+        assert telemetry_mod.is_enabled() is True
+        assert telemetry_mod._client is mock_client
+
+
+class TestFindTranscript:
+    def test_find_transcript_respects_claude_config_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        config_dir = tmp_path / "custom-claude"
+        project_path = tmp_path / "my-project"
+        project_path.mkdir()
+        dir_name = str(project_path.resolve()).replace("/", "-").replace(".", "-")
+        transcript_dir = config_dir / "projects" / dir_name
+        transcript_dir.mkdir(parents=True)
+        transcript_file = transcript_dir / "sess-abc.jsonl"
+        transcript_file.write_text('{"type":"user"}\n')
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+        result = telemetry_mod._find_transcript("sess-abc", project_path)
+        assert result is not None
+        assert result == transcript_file
 
 
 class TestBeginTrace:


### PR DESCRIPTION
Closes #896

## Changes

- **Fix 1 — Suppress dual tracing:** Add `TELEMETRY_PLATFORM=''` to subprocess env in `factory/runners/claude.py` (`build_command()` and `build_interactive_command()`), preventing Claude Code native tracing from creating 163+ extra observations that mix into the factory's clean trace hierarchy
- **Fix 2 — Respect CLAUDE_CONFIG_DIR:** Add `_get_claude_projects_dir()` helper in `factory/telemetry.py` that checks `CLAUDE_CONFIG_DIR` env var before falling back to `~/.claude/projects`, fixing transcript lookup in Harbor containers
- **Fix 3 — Support LANGFUSE_BASE_URL:** Update `is_enabled()` in `factory/telemetry.py` to check `LANGFUSE_BASE_URL` (SDK v4 preferred) in addition to deprecated `LANGFUSE_HOST`
- **Fix 4 — Harbor env forwarding:** Add `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY` to the env forwarding tuple in `benchmarks/factory_harbor_agent.py`

## Test plan

- [x] `test_build_command_suppresses_telemetry_platform` — verifies env dict has `TELEMETRY_PLATFORM=''`
- [x] `test_build_interactive_command_suppresses_telemetry_platform` — same for interactive commands
- [x] `test_find_transcript_respects_claude_config_dir` — verifies transcript lookup uses custom config dir
- [x] `test_returns_true_with_base_url_only` — verifies `is_enabled()` works with only `LANGFUSE_BASE_URL`
- [x] `test_returns_false_without_host` — updated to also clear `LANGFUSE_BASE_URL`
- [x] All 17 telemetry tests pass, all runner tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)