### PR TITLE
fix: make langfuse import optional to prevent OTel connection errors

### DIFF
--- a/factory/telemetry.py
+++ b/factory/telemetry.py
@@ -11,12 +11,17 @@ from pathlib import Path
 from typing import Any
 
 import structlog
-from langfuse import Langfuse
-from langfuse.types import TraceContext
 
 log = structlog.get_logger()
 
-_HAS_LANGFUSE = True
+try:
+    from langfuse import Langfuse
+    from langfuse.types import TraceContext
+    _HAS_LANGFUSE = True
+except ImportError:
+    Langfuse = None  # type: ignore[assignment,misc]
+    TraceContext = None  # type: ignore[assignment,misc]
+    _HAS_LANGFUSE = False
 
 _client: object | None = None
 _observations: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- Wraps `langfuse` imports in `try/except ImportError` so the SDK's OTel exporter doesn't initialize eagerly on module import
- Prevents `localhost:3200` connection refused errors when no Langfuse server is running
- All telemetry functions gracefully no-op when langfuse is unavailable

Closes #884

## Test plan
- [x] `tests/test_telemetry.py` — all 15 tests pass
- [x] `TranscriptTailer` imports successfully without langfuse configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)