### PR TITLE
fix: include solver name in benchmark result filenames to prevent collision (#905)

### DIFF
--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -17,7 +17,7 @@ SPLIT="${3:-full}"
 
 BENCHMARK="featurebench"
 RUN_ID="ci-featurebench-${TIMESTAMP}"
-RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-featurebench.json"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-featurebench-${BENCHMARK_SOLVER:-factory}.json"
 
 # Map split name to Harbor dataset
 case "${SPLIT}" in

--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -18,7 +18,7 @@ SOLVER_TIMEOUT="${2:-3600}"
 
 BENCHMARK="programbench"
 RUN_ID="ci-programbench-${TIMESTAMP}"
-RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-programbench.json"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-programbench-${BENCHMARK_SOLVER:-factory}.json"
 
 # Task-specific mapping
 case "${TASK_NAME}" in

--- a/benchmarks/run-swebench.sh
+++ b/benchmarks/run-swebench.sh
@@ -17,7 +17,7 @@ HARBOR_DATASET="${3:-swe-bench/swe-bench-verified}"
 
 BENCHMARK="swebench"
 RUN_ID="ci-swebench-${TIMESTAMP}"
-RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-swebench.json"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-swebench-${BENCHMARK_SOLVER:-factory}.json"
 
 JOBS_DIR=""
 

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -17,7 +17,7 @@ SOLVER_TIMEOUT="${2:-1800}"
 BENCHMARK="terminalbench"
 INSTANCE_ID="${TASK_NAME}"
 RUN_ID="ci-terminalbench-${TIMESTAMP}"
-RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-terminalbench.json"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-terminalbench-${BENCHMARK_SOLVER:-factory}.json"
 
 JOBS_DIR=""
 


### PR DESCRIPTION
Closes #905

## Changes

- Appended `-${BENCHMARK_SOLVER:-factory}` to `RESULT_FILE` in all four benchmark runner scripts (`run-programbench.sh`, `run-swebench.sh`, `run-featurebench.sh`, `run-terminalbench.sh`)
- When two solvers (e.g. `factory` and `claude-code`) run the same benchmark in the same second, their result JSON files now have distinct names, preventing overwrites during CI artifact merging (`download-artifact` with `merge-multiple: true`)
- Default suffix is `-factory` for standalone runs where `BENCHMARK_SOLVER` is unset