### PR TITLE
fix: include solver name in benchmark result filenames to prevent collision (#905)

### DIFF
--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -17,7 +17,7 @@ SPLIT="${3:-full}"
 
 BENCHMARK="featurebench"
 RUN_ID="ci-featurebench-${TIMESTAMP}"
-RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-featurebench.json"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-featurebench-${BENCHMARK_SOLVER:-factory}.json"
 
 # Map split name to Harbor dataset
 case "${SPLIT}" in

--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -18,7 +18,7 @@ SOLVER_TIMEOUT="${2:-3600}"
 
 BENCHMARK="programbench"
 RUN_ID="ci-programbench-${TIMESTAMP}"
-RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-programbench.json"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-programbench-${BENCHMARK_SOLVER:-factory}.json"
 
 # Task-specific mapping
 case "${TASK_NAME}" in

--- a/benchmarks/run-swebench.sh
+++ b/benchmarks/run-swebench.sh
@@ -17,7 +17,7 @@ HARBOR_DATASET="${3:-swe-bench/swe-bench-verified}"
 
 BENCHMARK="swebench"
 RUN_ID="ci-swebench-${TIMESTAMP}"
-RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-swebench.json"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-swebench-${BENCHMARK_SOLVER:-factory}.json"
 
 JOBS_DIR=""
 

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -17,7 +17,7 @@ SOLVER_TIMEOUT="${2:-1800}"
 BENCHMARK="terminalbench"
 INSTANCE_ID="${TASK_NAME}"
 RUN_ID="ci-terminalbench-${TIMESTAMP}"
-RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-terminalbench.json"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-terminalbench-${BENCHMARK_SOLVER:-factory}.json"
 
 JOBS_DIR=""
 


### PR DESCRIPTION
## Summary

- Include `${BENCHMARK_SOLVER:-factory}` suffix in benchmark result filenames across all 4 runner scripts to prevent filename collisions when two solvers start in the same second

## Problem

Each benchmark runner named its result JSON as `${TIMESTAMP}-${benchmark}.json` — without the solver name. When the CI matrix runs factory and claude-code solvers in parallel for the same benchmark and they start in the same second, they produce identical filenames. During `download-artifact` with `merge-multiple: true`, one file overwrites the other.

**Impact:** Lost results inflate dashboard accuracy — e.g., run `28490416319` shows claude-code at 100% because 2 of 4 results were lost (both surviving ones happened to pass), so `computeRunAccuracy()` computes 2/2 = 100% instead of 2/4 = 50%.

## Fix

Result filenames now include the solver: `${TIMESTAMP}-${benchmark}-${BENCHMARK_SOLVER:-factory}.json`

No downstream code references filenames — `append_results.py`, the dashboard, and the PR comment script all key on JSON content fields (`data.benchmark`, `data.solver`).

Closes #905

## Test plan

- [ ] Verify next CI run produces 8 distinct result JSON files (was 6-8 depending on timing)
- [ ] Verify dashboard accuracy reflects all benchmarks, including failures
- [ ] Verify standalone benchmark runs still work (BENCHMARK_SOLVER defaults to `factory`)