### PR TITLE
fix: add telemetry kill switch and auth validation for CI resilience (#912)

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -16,7 +16,7 @@ jobs:
       contains(github.event.comment.body, '@ceo-review') &&
       contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: React with eyes
@@ -74,6 +74,7 @@ jobs:
           LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          FACTORY_DISABLE_TELEMETRY: '1'
         run: |
           uv run factory ceo . --mode qa --pr ${{ steps.pr.outputs.number }} --headless
 

--- a/factory/telemetry.py
+++ b/factory/telemetry.py
@@ -29,6 +29,8 @@ _observations: dict[str, Any] = {}
 def is_enabled() -> bool:
     """Check if Langfuse is configured and lazily initialise the client."""
     global _client
+    if os.environ.get("FACTORY_DISABLE_TELEMETRY", "").lower() in ("1", "true"):
+        return False
     if _client is not None:
         return True
     if not _HAS_LANGFUSE:
@@ -38,10 +40,15 @@ def is_enabled() -> bool:
         return False
     try:
         _client = Langfuse()
+        if not _client.auth_check():
+            log.warning("langfuse_auth_failed", host=host)
+            _client = None
+            return False
         log.debug("langfuse_initialized", host=host)
         return True
     except Exception as exc:
         log.warning("langfuse_init_failed", error=str(exc))
+        _client = None
         return False
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -37,7 +37,9 @@ class TestIsEnabled:
 
     def test_returns_true_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.delenv("FACTORY_DISABLE_TELEMETRY", raising=False)
         mock_client = MagicMock()
+        mock_client.auth_check.return_value = True
         mock_langfuse_cls = MagicMock(return_value=mock_client)
         monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
         monkeypatch.setattr(telemetry_mod, "Langfuse", mock_langfuse_cls, raising=False)
@@ -46,8 +48,55 @@ class TestIsEnabled:
 
     def test_returns_true_with_langfuse_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("LANGFUSE_HOST", raising=False)
+        monkeypatch.delenv("FACTORY_DISABLE_TELEMETRY", raising=False)
         monkeypatch.setenv("LANGFUSE_BASE_URL", "https://langfuse.example.com")
         mock_client = MagicMock()
+        mock_client.auth_check.return_value = True
+        mock_langfuse_cls = MagicMock(return_value=mock_client)
+        monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
+        monkeypatch.setattr(telemetry_mod, "Langfuse", mock_langfuse_cls, raising=False)
+        assert telemetry_mod.is_enabled() is True
+        assert telemetry_mod._client is mock_client
+
+    def test_returns_false_when_kill_switch_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setenv("FACTORY_DISABLE_TELEMETRY", "1")
+        monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
+        assert telemetry_mod.is_enabled() is False
+
+    def test_returns_false_when_kill_switch_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setenv("FACTORY_DISABLE_TELEMETRY", "true")
+        monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
+        assert telemetry_mod.is_enabled() is False
+
+    def test_returns_false_when_auth_check_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.delenv("FACTORY_DISABLE_TELEMETRY", raising=False)
+        mock_client = MagicMock()
+        mock_client.auth_check.return_value = False
+        mock_langfuse_cls = MagicMock(return_value=mock_client)
+        monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
+        monkeypatch.setattr(telemetry_mod, "Langfuse", mock_langfuse_cls, raising=False)
+        assert telemetry_mod.is_enabled() is False
+        assert telemetry_mod._client is None
+
+    def test_returns_false_when_auth_check_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.delenv("FACTORY_DISABLE_TELEMETRY", raising=False)
+        mock_client = MagicMock()
+        mock_client.auth_check.side_effect = RuntimeError("connection refused")
+        mock_langfuse_cls = MagicMock(return_value=mock_client)
+        monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
+        monkeypatch.setattr(telemetry_mod, "Langfuse", mock_langfuse_cls, raising=False)
+        assert telemetry_mod.is_enabled() is False
+        assert telemetry_mod._client is None
+
+    def test_returns_true_when_auth_check_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.delenv("FACTORY_DISABLE_TELEMETRY", raising=False)
+        mock_client = MagicMock()
+        mock_client.auth_check.return_value = True
         mock_langfuse_cls = MagicMock(return_value=mock_client)
         monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
         monkeypatch.setattr(telemetry_mod, "Langfuse", mock_langfuse_cls, raising=False)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -103,7 +103,8 @@ class TestIsEnabled:
         assert telemetry_mod.is_enabled() is True
         assert telemetry_mod._client is mock_client
 
-    def test_returns_true_on_subsequent_calls(self) -> None:
+    def test_returns_true_on_subsequent_calls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FACTORY_DISABLE_TELEMETRY", raising=False)
         telemetry_mod._client = MagicMock()
         assert telemetry_mod.is_enabled() is True
 


### PR DESCRIPTION
Closes #912

## Changes

- **`factory/telemetry.py`**: Added `FACTORY_DISABLE_TELEMETRY` env var kill switch — when set to `1` or `true`, `is_enabled()` returns `False` immediately before any Langfuse initialization. Added `auth_check()` validation after `Langfuse()` construction: if auth fails (returns `False` or raises), the client is set to `None` and `is_enabled()` returns `False` with a warning log.
- **`.github/workflows/ceo-review.yml`**: Increased job timeout from 30 to 60 minutes. Added `FACTORY_DISABLE_TELEMETRY: '1'` to the CEO review step's env block so CI runs skip Langfuse telemetry.
- **`tests/test_telemetry.py`**: Added 5 new tests covering: kill switch with `1` and `true` values, `auth_check()` returning `False`, `auth_check()` raising an exception, and successful `auth_check()`. Updated 2 existing tests to mock `auth_check()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)