### PR TITLE
fix: set FACTORY_MODEL to Opus in CEO review CI workflow

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -71,6 +71,7 @@ jobs:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
           CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FACTORY_MODEL: "claude-opus-4-6[1m]"
           LANGFUSE_HOST: ${{ secrets.LANGFUSE_HOST }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}


### PR DESCRIPTION
## Summary
- The `ceo-review.yml` workflow was running `factory ceo` without specifying a model, causing it to fall back to Claude Code's default (Sonnet on Vertex AI)
- Adds `FACTORY_MODEL: "claude-opus-4-6[1m]"` to the env block so CEO PR reviews always use Opus

## Test plan
- [ ] Trigger a `@ceo-review` on a test PR and verify the Langfuse trace shows `claude-opus-4-6` as the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)