### PR TITLE
feat: parallelize 'all' mode and add usage docs to full-eval dashboard

### DIFF
--- a/benchmarks/commit-full-eval.sh
+++ b/benchmarks/commit-full-eval.sh
@@ -21,7 +21,7 @@ usage() {
     echo "  --results-dir DIR   Directory containing *-full.json files (default: benchmarks/results)"
     echo "  --run-id ID         Run identifier (default: auto-generated from timestamp)"
     echo "  -h, --help          Show this help message"
-    exit 0
+    exit "${1:-0}"
 }
 
 # ── Argument parsing ──
@@ -31,7 +31,7 @@ while [ $# -gt 0 ]; do
         --results-dir) RESULTS_DIR="$2"; shift 2 ;;
         --run-id)      RUN_ID="$2"; shift 2 ;;
         -h|--help)     usage ;;
-        *)             echo "ERROR: Unknown option '$1'"; usage ;;
+        *)             echo "ERROR: Unknown option '$1'"; usage 1 ;;
     esac
 done
 

--- a/benchmarks/commit-full-eval.sh
+++ b/benchmarks/commit-full-eval.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# benchmarks/commit-full-eval.sh — Commit full eval results to the benchmark-data branch.
+# Mirrors the CI workflow's commit pattern (benchmark.yml lines 220-293) but runs
+# from any machine with git push access.
+
+# ── Defaults ──
+
+RESULTS_DIR="${RESULTS_DIR:-benchmarks/results}"
+RUN_ID=""
+REPO_URL=""
+TEMP_DIR=""
+
+# ── Usage ──
+
+usage() {
+    echo "Usage: $(basename "$0") [options]"
+    echo ""
+    echo "Options:"
+    echo "  --results-dir DIR   Directory containing *-full.json files (default: benchmarks/results)"
+    echo "  --run-id ID         Run identifier (default: auto-generated from timestamp)"
+    echo "  -h, --help          Show this help message"
+    exit 0
+}
+
+# ── Argument parsing ──
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --results-dir) RESULTS_DIR="$2"; shift 2 ;;
+        --run-id)      RUN_ID="$2"; shift 2 ;;
+        -h|--help)     usage ;;
+        *)             echo "ERROR: Unknown option '$1'"; usage ;;
+    esac
+done
+
+if [ -z "${RUN_ID}" ]; then
+    RUN_ID="full-$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+
+# ── Cleanup ──
+
+cleanup() {
+    if [ -n "${TEMP_DIR}" ] && [ -d "${TEMP_DIR}" ]; then
+        rm -rf "${TEMP_DIR}"
+    fi
+}
+
+trap cleanup EXIT
+
+# ── Validate inputs ──
+
+if [ ! -d "${RESULTS_DIR}" ]; then
+    echo "ERROR: Results directory not found: ${RESULTS_DIR}"
+    exit 1
+fi
+
+FULL_JSON_FILES=()
+while IFS= read -r -d '' f; do
+    FULL_JSON_FILES+=("$f")
+done < <(find "${RESULTS_DIR}" -maxdepth 1 -name '*-full.json' -print0 2>/dev/null)
+
+if [ ${#FULL_JSON_FILES[@]} -eq 0 ]; then
+    echo "ERROR: No *-full.json files found in ${RESULTS_DIR}"
+    exit 1
+fi
+
+echo "==> Found ${#FULL_JSON_FILES[@]} full eval result file(s)"
+for f in "${FULL_JSON_FILES[@]}"; do
+    echo "    $(basename "${f}")"
+done
+
+# ── Resolve repo URL ──
+
+REPO_URL=$(git remote get-url origin 2>/dev/null || echo "")
+if [ -z "${REPO_URL}" ]; then
+    echo "ERROR: Could not determine git remote URL"
+    exit 1
+fi
+
+# ── Get current commit info ──
+
+CURRENT_COMMIT=$(git rev-parse HEAD 2>/dev/null || echo "")
+CURRENT_REF=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+GIT_USER_NAME=$(git config user.name 2>/dev/null || echo "")
+GIT_USER_EMAIL=$(git config user.email 2>/dev/null || echo "")
+
+echo "==> Current state"
+echo "    Commit: ${CURRENT_COMMIT:-unknown}"
+echo "    Ref:    ${CURRENT_REF:-unknown}"
+echo "    Run ID: ${RUN_ID}"
+echo ""
+
+# ── Clone benchmark-data branch ──
+
+echo "==> Setting up benchmark-data branch"
+
+TEMP_DIR="$(mktemp -d /tmp/benchmark-data-XXXXXX)"
+
+if git ls-remote --exit-code --heads "${REPO_URL}" benchmark-data >/dev/null 2>&1; then
+    echo "    Cloning existing benchmark-data branch..."
+    git clone --single-branch --branch benchmark-data --depth 1 "${REPO_URL}" "${TEMP_DIR}/benchmark-data"
+else
+    echo "    Creating new benchmark-data branch..."
+    mkdir -p "${TEMP_DIR}/benchmark-data"
+    cd "${TEMP_DIR}/benchmark-data"
+    git init
+    git checkout -b benchmark-data
+    git remote add origin "${REPO_URL}"
+    touch results.jsonl full-eval-results.jsonl
+    git add .
+    if [ -n "${GIT_USER_NAME}" ]; then
+        git config user.name "${GIT_USER_NAME}"
+        git config user.email "${GIT_USER_EMAIL}"
+    fi
+    git commit -m "Initialize benchmark data branch"
+    git push -u origin benchmark-data
+fi
+
+BENCHMARK_DATA_DIR="${TEMP_DIR}/benchmark-data"
+
+# ── Enrich and append results ──
+
+echo "==> Enriching and appending results"
+
+python3 << PYEOF
+import json, os, sys
+
+results_dir = "${RESULTS_DIR}"
+output = "${BENCHMARK_DATA_DIR}/full-eval-results.jsonl"
+run_id = "${RUN_ID}"
+commit = "${CURRENT_COMMIT}"
+ref = "${CURRENT_REF}"
+
+files = sorted([
+    os.path.join(results_dir, f)
+    for f in os.listdir(results_dir)
+    if f.endswith("-full.json")
+])
+
+count = 0
+for fpath in files:
+    print(f"  Processing: {os.path.basename(fpath)}", file=sys.stderr)
+    with open(fpath) as fh:
+        data = json.load(fh)
+    data["run_id"] = run_id
+    data["commit"] = commit
+    data["ref"] = ref
+    data["trigger"] = "manual"
+    with open(output, "a") as out:
+        out.write(json.dumps(data) + "\n")
+    count += 1
+
+size = os.path.getsize(output) if os.path.exists(output) else 0
+print(f"  Appended {count} result(s). File size: {size} bytes", file=sys.stderr)
+PYEOF
+
+echo ""
+
+# ── Commit and push ──
+
+echo "==> Committing results"
+
+cd "${BENCHMARK_DATA_DIR}"
+
+if [ -n "${GIT_USER_NAME}" ]; then
+    git config user.name "${GIT_USER_NAME}"
+    git config user.email "${GIT_USER_EMAIL}"
+fi
+
+git add full-eval-results.jsonl
+
+if git diff --cached --quiet; then
+    echo "    No changes to commit."
+    exit 0
+fi
+
+git commit -m "benchmark: add full eval results from run ${RUN_ID} [skip ci]"
+
+echo "==> Pushing to benchmark-data branch"
+git push origin benchmark-data || (
+    echo "    Push failed, retrying with rebase..."
+    git pull --rebase origin benchmark-data && git push origin benchmark-data
+)
+
+echo ""
+echo "==> Done. Full eval results committed to benchmark-data branch."

--- a/benchmarks/run-full-eval.sh
+++ b/benchmarks/run-full-eval.sh
@@ -32,7 +32,7 @@ usage() {
     echo "  --split S                      Dataset split (featurebench only: full, lite)"
     echo "  --preserve                     Preserve Harbor jobs directory after completion"
     echo "  -h, --help                     Show this help message"
-    exit 0
+    exit "${1:-0}"
 }
 
 # ── Argument parsing ──
@@ -52,7 +52,7 @@ while [ $# -gt 0 ]; do
         --split)       SPLIT="$2"; shift 2 ;;
         --preserve)    PRESERVE_WORKSPACE="1"; shift ;;
         -h|--help)     usage ;;
-        *)             echo "ERROR: Unknown option '$1'"; usage ;;
+        *)             echo "ERROR: Unknown option '$1'"; usage 1 ;;
     esac
 done
 

--- a/benchmarks/run-full-eval.sh
+++ b/benchmarks/run-full-eval.sh
@@ -16,6 +16,7 @@ BENCHMARK_SOLVER="${BENCHMARK_SOLVER:-factory}"
 CONCURRENCY="${CONCURRENCY:-5}"
 SOLVER_TIMEOUT="${SOLVER_TIMEOUT:-3600}"
 SPLIT=""
+LIMIT_TASKS=""
 PRESERVE_WORKSPACE="${PRESERVE_WORKSPACE:-}"
 
 # ── Usage ──
@@ -30,6 +31,7 @@ usage() {
     echo "  --concurrency N                Number of concurrent tasks (default: 5)"
     echo "  --timeout N                    Per-task solver timeout in seconds (default: 3600)"
     echo "  --split S                      Dataset split (featurebench only: full, lite)"
+    echo "  --limit N                      Maximum number of tasks to run (optional)"
     echo "  --preserve                     Preserve Harbor jobs directory after completion"
     echo "  -h, --help                     Show this help message"
     exit "${1:-0}"
@@ -50,6 +52,7 @@ while [ $# -gt 0 ]; do
         --concurrency) CONCURRENCY="$2"; shift 2 ;;
         --timeout)     SOLVER_TIMEOUT="$2"; shift 2 ;;
         --split)       SPLIT="$2"; shift 2 ;;
+        --limit)       LIMIT_TASKS="$2"; shift 2 ;;
         --preserve)    PRESERVE_WORKSPACE="1"; shift ;;
         -h|--help)     usage ;;
         *)             echo "ERROR: Unknown option '$1'"; usage 1 ;;
@@ -301,6 +304,8 @@ if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
         --agent-timeout-multiplier "${TIMEOUT_MULTIPLIER}"
     )
 
+    [ -n "${LIMIT_TASKS}" ] && HARBOR_CMD+=(--n-tasks "${LIMIT_TASKS}")
+
     if [ "${BENCHMARK}" = "programbench" ]; then
         HARBOR_CMD+=(
             --allow-agent-host api.anthropic.com
@@ -350,6 +355,8 @@ else
         --jobs-dir "${JOBS_DIR}"
         --agent-timeout-multiplier "${TIMEOUT_MULTIPLIER}"
     )
+
+    [ -n "${LIMIT_TASKS}" ] && HARBOR_CMD+=(--n-tasks "${LIMIT_TASKS}")
 
     if [ "${BENCHMARK}" = "programbench" ]; then
         HARBOR_CMD+=(

--- a/benchmarks/run-full-eval.sh
+++ b/benchmarks/run-full-eval.sh
@@ -62,23 +62,56 @@ done
 # ── Handle 'all' — re-invoke for each benchmark ──
 
 if [ "${BENCHMARK}" = "all" ]; then
-    log "Running full eval for ALL benchmarks"
+    log "Running full eval for ALL benchmarks (parallel)"
     echo ""
     FAILED=0
+    FAILED_NAMES=()
+    declare -A PIDS
+
+    "${BASH_SOURCE[0]}" swebench \
+        --solver "${BENCHMARK_SOLVER}" \
+        --concurrency "${CONCURRENCY}" \
+        --timeout "${SOLVER_TIMEOUT}" \
+        ${LIMIT_TASKS:+--limit "${LIMIT_TASKS}"} \
+        ${PRESERVE_WORKSPACE:+--preserve} &
+    PIDS[swebench]=$!
+
+    "${BASH_SOURCE[0]}" featurebench \
+        --solver "${BENCHMARK_SOLVER}" \
+        --concurrency "${CONCURRENCY}" \
+        --timeout "${SOLVER_TIMEOUT}" \
+        ${LIMIT_TASKS:+--limit "${LIMIT_TASKS}"} \
+        ${SPLIT:+--split "${SPLIT}"} \
+        ${PRESERVE_WORKSPACE:+--preserve} &
+    PIDS[featurebench]=$!
+
+    "${BASH_SOURCE[0]}" terminalbench \
+        --solver "${BENCHMARK_SOLVER}" \
+        --concurrency "${CONCURRENCY}" \
+        --timeout "${SOLVER_TIMEOUT}" \
+        ${LIMIT_TASKS:+--limit "${LIMIT_TASKS}"} \
+        ${PRESERVE_WORKSPACE:+--preserve} &
+    PIDS[terminalbench]=$!
+
+    "${BASH_SOURCE[0]}" programbench \
+        --solver "${BENCHMARK_SOLVER}" \
+        --concurrency "${CONCURRENCY}" \
+        --timeout "${SOLVER_TIMEOUT}" \
+        ${LIMIT_TASKS:+--limit "${LIMIT_TASKS}"} \
+        ${PRESERVE_WORKSPACE:+--preserve} &
+    PIDS[programbench]=$!
+
     for BENCH in swebench featurebench terminalbench programbench; do
-        log "Starting: ${BENCH}"
-        "${BASH_SOURCE[0]}" "${BENCH}" \
-            --solver "${BENCHMARK_SOLVER}" \
-            --concurrency "${CONCURRENCY}" \
-            --timeout "${SOLVER_TIMEOUT}" \
-            ${LIMIT_TASKS:+--limit "${LIMIT_TASKS}"} \
-            ${SPLIT:+--split "${SPLIT}"} \
-            ${PRESERVE_WORKSPACE:+--preserve} \
-            || { log "FAILED: ${BENCH}"; FAILED=$((FAILED + 1)); }
-        echo ""
+        if ! wait "${PIDS[${BENCH}]}"; then
+            log "FAILED: ${BENCH}"
+            FAILED=$((FAILED + 1))
+            FAILED_NAMES+=("${BENCH}")
+        fi
     done
+
+    echo ""
     if [ "${FAILED}" -gt 0 ]; then
-        log "${FAILED} benchmark(s) failed"
+        log "${FAILED} benchmark(s) failed: ${FAILED_NAMES[*]}"
         exit 1
     fi
     log "All benchmarks complete"

--- a/benchmarks/run-full-eval.sh
+++ b/benchmarks/run-full-eval.sh
@@ -263,6 +263,7 @@ echo ""
 log "Step 3: Running Harbor evaluation (full dataset)"
 
 JOBS_DIR="$(mktemp -d /tmp/full-eval-${BENCHMARK}-jobs-XXXXXX)"
+export JOBS_DIR
 echo "    Jobs directory: ${JOBS_DIR}"
 echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 

--- a/benchmarks/run-full-eval.sh
+++ b/benchmarks/run-full-eval.sh
@@ -24,7 +24,7 @@ PRESERVE_WORKSPACE="${PRESERVE_WORKSPACE:-}"
 usage() {
     echo "Usage: $(basename "$0") <benchmark> [options]"
     echo ""
-    echo "Benchmarks: swebench, featurebench, terminalbench, programbench"
+    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, all"
     echo ""
     echo "Options:"
     echo "  --solver factory|claude-code   Solver to use (default: factory)"
@@ -59,6 +59,32 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# ── Handle 'all' — re-invoke for each benchmark ──
+
+if [ "${BENCHMARK}" = "all" ]; then
+    log "Running full eval for ALL benchmarks"
+    echo ""
+    FAILED=0
+    for BENCH in swebench featurebench terminalbench programbench; do
+        log "Starting: ${BENCH}"
+        "${BASH_SOURCE[0]}" "${BENCH}" \
+            --solver "${BENCHMARK_SOLVER}" \
+            --concurrency "${CONCURRENCY}" \
+            --timeout "${SOLVER_TIMEOUT}" \
+            ${LIMIT_TASKS:+--limit "${LIMIT_TASKS}"} \
+            ${SPLIT:+--split "${SPLIT}"} \
+            ${PRESERVE_WORKSPACE:+--preserve} \
+            || { log "FAILED: ${BENCH}"; FAILED=$((FAILED + 1)); }
+        echo ""
+    done
+    if [ "${FAILED}" -gt 0 ]; then
+        log "${FAILED} benchmark(s) failed"
+        exit 1
+    fi
+    log "All benchmarks complete"
+    exit 0
+fi
+
 # ── Map benchmark to Harbor dataset ──
 
 HARBOR_DATASET=""
@@ -86,9 +112,12 @@ case "${BENCHMARK}" in
             exit 1
         fi
         ;;
+    all)
+        # Handled below — runs each benchmark sequentially
+        ;;
     *)
         echo "ERROR: Unknown benchmark '${BENCHMARK}'"
-        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench"
+        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, all"
         exit 1
         ;;
 esac

--- a/benchmarks/run-full-eval.sh
+++ b/benchmarks/run-full-eval.sh
@@ -1,0 +1,497 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# benchmarks/run-full-eval.sh — Run ALL tasks in a benchmark dataset through Harbor.
+# Unlike the per-benchmark CI scripts (which run a single task via --include-task-name),
+# this runs the full dataset with configurable concurrency and aggregates multi-task results.
+
+# ── Shared library ──
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# ── Defaults ──
+
+BENCHMARK=""
+BENCHMARK_SOLVER="${BENCHMARK_SOLVER:-factory}"
+CONCURRENCY="${CONCURRENCY:-5}"
+SOLVER_TIMEOUT="${SOLVER_TIMEOUT:-3600}"
+SPLIT=""
+PRESERVE_WORKSPACE="${PRESERVE_WORKSPACE:-}"
+
+# ── Usage ──
+
+usage() {
+    echo "Usage: $(basename "$0") <benchmark> [options]"
+    echo ""
+    echo "Benchmarks: swebench, featurebench, terminalbench, programbench"
+    echo ""
+    echo "Options:"
+    echo "  --solver factory|claude-code   Solver to use (default: factory)"
+    echo "  --concurrency N                Number of concurrent tasks (default: 5)"
+    echo "  --timeout N                    Per-task solver timeout in seconds (default: 3600)"
+    echo "  --split S                      Dataset split (featurebench only: full, lite)"
+    echo "  --preserve                     Preserve Harbor jobs directory after completion"
+    echo "  -h, --help                     Show this help message"
+    exit 0
+}
+
+# ── Argument parsing ──
+
+if [ $# -lt 1 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    usage
+fi
+
+BENCHMARK="$1"
+shift
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --solver)      BENCHMARK_SOLVER="$2"; shift 2 ;;
+        --concurrency) CONCURRENCY="$2"; shift 2 ;;
+        --timeout)     SOLVER_TIMEOUT="$2"; shift 2 ;;
+        --split)       SPLIT="$2"; shift 2 ;;
+        --preserve)    PRESERVE_WORKSPACE="1"; shift ;;
+        -h|--help)     usage ;;
+        *)             echo "ERROR: Unknown option '$1'"; usage ;;
+    esac
+done
+
+# ── Map benchmark to Harbor dataset ──
+
+HARBOR_DATASET=""
+PROGRAMBENCH_LOCAL=""
+EXTRA_HARBOR_ARGS=()
+
+case "${BENCHMARK}" in
+    swebench)
+        HARBOR_DATASET="swe-bench/swe-bench-verified"
+        ;;
+    featurebench)
+        case "${SPLIT:-full}" in
+            lite)       HARBOR_DATASET="featurebench-lite" ;;
+            full|fast)  HARBOR_DATASET="featurebench" ;;
+            *)          HARBOR_DATASET="featurebench-${SPLIT}" ;;
+        esac
+        ;;
+    terminalbench)
+        HARBOR_DATASET="terminal-bench@2.0"
+        ;;
+    programbench)
+        PROGRAMBENCH_LOCAL="${HARNESS_DIR}/benchmarks/programbench-harbor"
+        if [ ! -d "${PROGRAMBENCH_LOCAL}" ]; then
+            echo "ERROR: ProgramBench task directory not found: ${PROGRAMBENCH_LOCAL}"
+            exit 1
+        fi
+        ;;
+    *)
+        echo "ERROR: Unknown benchmark '${BENCHMARK}'"
+        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench"
+        exit 1
+        ;;
+esac
+
+# ── Configuration ──
+
+RUN_ID="full-${BENCHMARK}-${TIMESTAMP}"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-${BENCHMARK}-full.json"
+INSTANCE_ID="full-eval"
+
+JOBS_DIR=""
+
+PASSED=0
+RESOLVED=0
+TOTAL=0
+
+# ── Helpers ──
+
+cleanup() {
+    local exit_code=$?
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        if [ "${PRESERVE_WORKSPACE}" = "1" ]; then
+            log "Preserving harbor jobs at ${JOBS_DIR} (--preserve)"
+        else
+            log "Cleaning up harbor jobs directory"
+            rm -rf "${JOBS_DIR}"
+        fi
+    fi
+
+    local end_time duration
+    end_time="$(date +%s)"
+    duration=$(( end_time - START_TIME ))
+    mkdir -p "${CI_RESULTS_DIR}"
+
+    python3 -c "
+import json, sys
+
+tasks = json.loads('${TASKS_JSON:-[]}')
+passed = sum(1 for t in tasks if t.get('resolved'))
+total = len(tasks)
+cost = sum(t.get('cost_usd', 0) for t in tasks)
+
+result = {
+    'benchmark': '${BENCHMARK}',
+    'eval_type': 'full',
+    'solver': '${BENCHMARK_SOLVER}',
+    'passed': passed,
+    'total': total,
+    'score': round(passed / max(total, 1), 4),
+    'duration_seconds': ${duration:-0},
+    'status': '${STATUS}',
+    'timestamp': '${TIMESTAMP}',
+    'details': {
+        'cost_usd': round(cost, 4),
+        'concurrency': ${CONCURRENCY},
+        'dataset': '${HARBOR_DATASET:-local}'
+    },
+    'tasks': tasks
+}
+json.dump(result, sys.stdout, indent=2)
+print()
+" > "${RESULT_FILE}" 2>/dev/null || true
+
+    if [ -f "${RESULT_FILE}" ]; then
+        echo ""
+        log "Results written to ${RESULT_FILE}"
+        cat "${RESULT_FILE}"
+    fi
+
+    if [ "${STATUS}" = "success" ]; then
+        exit 0
+    else
+        exit "${exit_code:-1}"
+    fi
+}
+
+trap cleanup EXIT
+
+TASKS_JSON="[]"
+
+# ── Step 1: Parse and display configuration ──
+
+show_banner "Full Eval — ${BENCHMARK}"
+log "Step 1: Configuration"
+echo "    Benchmark:       ${BENCHMARK}"
+echo "    Dataset:         ${HARBOR_DATASET:-${PROGRAMBENCH_LOCAL}}"
+echo "    Solver:          ${BENCHMARK_SOLVER}"
+echo "    Concurrency:     ${CONCURRENCY}"
+echo "    Solver timeout:  ${SOLVER_TIMEOUT}s ($(( SOLVER_TIMEOUT / 3600 ))h $(( (SOLVER_TIMEOUT % 3600) / 60 ))m)"
+echo "    Run ID:          ${RUN_ID}"
+echo "    Timestamp:       ${TIMESTAMP}"
+echo ""
+
+# ── Step 2: Validate prerequisites ──
+
+log "Step 2: Validating prerequisites"
+
+MISSING=()
+
+if ! command -v docker &>/dev/null && [ ! -x /usr/bin/docker ]; then
+    MISSING+=("docker (install from https://docs.docker.com/get-docker/)")
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "    ERROR: Missing prerequisites:"
+    for m in "${MISSING[@]}"; do
+        echo "      - ${m}"
+    done
+    exit 1
+fi
+
+echo "    docker: found"
+
+ensure_uvx
+
+echo "    harbor: checking availability via uvx..."
+if ! uvx harbor --version &>/dev/null 2>&1; then
+    echo "    harbor: installing via uvx..."
+    uvx harbor --version || {
+        echo "    ERROR: Failed to install/run harbor via uvx"
+        exit 1
+    }
+fi
+echo "    harbor: available"
+
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "    ANTHROPIC_API_KEY: set"
+else
+    setup_vertex_env
+    if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+        echo "    Vertex AI: configured (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
+    else
+        echo "    WARNING: No ANTHROPIC_API_KEY or Vertex AI configuration found."
+        echo "    Harbor's agent requires API access."
+    fi
+fi
+
+echo "    All prerequisites satisfied."
+echo ""
+
+# ── Step 3: Run Harbor evaluation ──
+
+log "Step 3: Running Harbor evaluation (full dataset)"
+
+JOBS_DIR="$(mktemp -d /tmp/full-eval-${BENCHMARK}-jobs-XXXXXX)"
+echo "    Jobs directory: ${JOBS_DIR}"
+echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+TIMEOUT_MULTIPLIER=$(( SOLVER_TIMEOUT / 120 ))
+[ "${TIMEOUT_MULTIPLIER}" -lt 1 ] && TIMEOUT_MULTIPLIER=1
+
+MODEL="anthropic/claude-opus-4-6"
+
+echo "    Model:           ${MODEL}"
+echo "    Timeout mult:    ${TIMEOUT_MULTIPLIER}x"
+echo "    Concurrency:     ${CONCURRENCY}"
+echo ""
+
+cd "${HARNESS_DIR}"
+
+HARBOR_EXIT=0
+
+if [ "${BENCHMARK_SOLVER}" = "claude-code" ]; then
+    AGENT_ARGS=(--agent claude-code)
+    if [ "${BENCHMARK}" = "featurebench" ]; then
+        AGENT_ARGS+=(--extra-instruction-path "${HARNESS_DIR}/benchmarks/featurebench-extra-instructions.md")
+    elif [ "${BENCHMARK}" = "terminalbench" ]; then
+        AGENT_ARGS+=(--extra-instruction-path "${HARNESS_DIR}/benchmarks/terminalbench-extra-instructions.md")
+    fi
+    echo "    Agent:           claude-code (Harbor built-in)"
+else
+    AGENT_MODULE="${HARNESS_DIR}/benchmarks/factory_harbor_agent.py"
+    export PYTHONPATH="$(dirname "${AGENT_MODULE}"):${PYTHONPATH:-}"
+    if [ "${BENCHMARK}" = "programbench" ]; then
+        AGENT_ARGS=(--agent factory_harbor_agent:ProgramBenchFactoryCeo)
+    else
+        AGENT_ARGS=(--agent-import-path factory_harbor_agent:FactoryCeo)
+    fi
+    echo "    Agent:           factory (FactoryCeo)"
+fi
+
+# Build dataset args — ProgramBench uses local path via -p
+DATASET_ARGS=()
+if [ -n "${PROGRAMBENCH_LOCAL}" ]; then
+    DATASET_ARGS=(-p "${PROGRAMBENCH_LOCAL}")
+else
+    DATASET_ARGS=(--dataset "${HARBOR_DATASET}")
+fi
+
+# Build --allow-agent-host flags for ProgramBench (matching run-programbench.sh)
+AGENT_ALLOW_HOSTS=()
+if [ "${BENCHMARK}" = "programbench" ]; then
+    if [ -n "${LANGFUSE_HOST:-}" ]; then
+        LANGFUSE_HOSTNAME=$(echo "${LANGFUSE_HOST}" | sed 's|https\?://||' | sed 's|/.*||')
+        AGENT_ALLOW_HOSTS+=(--allow-agent-host "${LANGFUSE_HOSTNAME}")
+    elif [ -n "${LANGFUSE_BASE_URL:-}" ]; then
+        LANGFUSE_HOSTNAME=$(echo "${LANGFUSE_BASE_URL}" | sed 's|https\?://||' | sed 's|/.*||')
+        AGENT_ALLOW_HOSTS+=(--allow-agent-host "${LANGFUSE_HOSTNAME}")
+    fi
+fi
+
+if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+    GCLOUD_ADC="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
+    echo "    Auth mode:       Vertex AI (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
+
+    HARBOR_CMD=(
+        uvx harbor run
+        "${DATASET_ARGS[@]}"
+        "${AGENT_ARGS[@]}"
+        --model "${MODEL}"
+        --n-concurrent "${CONCURRENCY}"
+        --jobs-dir "${JOBS_DIR}"
+        --agent-timeout-multiplier "${TIMEOUT_MULTIPLIER}"
+    )
+
+    if [ "${BENCHMARK}" = "programbench" ]; then
+        HARBOR_CMD+=(
+            --allow-agent-host api.anthropic.com
+            --allow-agent-host us-east5-aiplatform.googleapis.com
+            --allow-agent-host us-central1-aiplatform.googleapis.com
+            --allow-agent-host europe-west1-aiplatform.googleapis.com
+            --allow-agent-host oauth2.googleapis.com
+            --allow-agent-host www.googleapis.com
+            --allow-agent-host storage.googleapis.com
+            --allow-agent-host metadata.google.internal
+            --allow-agent-host sentry.io
+            --allow-agent-host statsig.anthropic.com
+            "${AGENT_ALLOW_HOSTS[@]}"
+        )
+    fi
+
+    HARBOR_CMD+=(
+        --ae "CLAUDE_CODE_USE_VERTEX=1"
+        --ae "ANTHROPIC_VERTEX_PROJECT_ID=${ANTHROPIC_VERTEX_PROJECT_ID}"
+        --ae "CLOUD_ML_REGION=${CLOUD_ML_REGION:-us-east5}"
+        --ae "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-opus-4-6[1m]}"
+        --ae "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcloud-adc.json"
+        --ae "CLAUDE_CODE_SUBAGENT_MODEL=${CLAUDE_CODE_SUBAGENT_MODEL:-claude-opus-4-6[1m]}"
+        --ae "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}"
+        --ae "ANTHROPIC_DEFAULT_OPUS_MODEL=${ANTHROPIC_DEFAULT_OPUS_MODEL:-claude-opus-4-6[1m]}"
+        --ae "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=${CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING:-1}"
+        --ae "MAX_THINKING_TOKENS=${MAX_THINKING_TOKENS:-128000}"
+        --ae "CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL:-XHIGH}"
+        --ae "LANGFUSE_HOST=${LANGFUSE_HOST:-}"
+        --ae "LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}"
+        --ae "LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}"
+        --ae "LANGFUSE_BASE_URL=${LANGFUSE_BASE_URL:-}"
+        --ae "TELEMETRY_PLATFORM=${TELEMETRY_PLATFORM:-}"
+        --mounts '[{"type": "bind", "source": "'"${GCLOUD_ADC}"'", "target": "/tmp/gcloud-adc.json", "read_only": true}]'
+    )
+
+    "${HARBOR_CMD[@]}" 2>&1 || HARBOR_EXIT=$?
+else
+    echo "    Auth mode:       Direct API (ANTHROPIC_API_KEY)"
+
+    HARBOR_CMD=(
+        uvx harbor run
+        "${DATASET_ARGS[@]}"
+        "${AGENT_ARGS[@]}"
+        --model "${MODEL}"
+        --n-concurrent "${CONCURRENCY}"
+        --jobs-dir "${JOBS_DIR}"
+        --agent-timeout-multiplier "${TIMEOUT_MULTIPLIER}"
+    )
+
+    if [ "${BENCHMARK}" = "programbench" ]; then
+        HARBOR_CMD+=(
+            --allow-agent-host api.anthropic.com
+            --allow-agent-host sentry.io
+            --allow-agent-host statsig.anthropic.com
+            "${AGENT_ALLOW_HOSTS[@]}"
+        )
+    fi
+
+    HARBOR_CMD+=(
+        --ae "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-opus-4-6[1m]}"
+        --ae "CLAUDE_CODE_SUBAGENT_MODEL=${CLAUDE_CODE_SUBAGENT_MODEL:-claude-opus-4-6[1m]}"
+        --ae "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}"
+        --ae "ANTHROPIC_DEFAULT_OPUS_MODEL=${ANTHROPIC_DEFAULT_OPUS_MODEL:-claude-opus-4-6[1m]}"
+        --ae "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=${CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING:-1}"
+        --ae "MAX_THINKING_TOKENS=${MAX_THINKING_TOKENS:-128000}"
+        --ae "CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL:-XHIGH}"
+        --ae "LANGFUSE_HOST=${LANGFUSE_HOST:-}"
+        --ae "LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}"
+        --ae "LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}"
+        --ae "LANGFUSE_BASE_URL=${LANGFUSE_BASE_URL:-}"
+        --ae "TELEMETRY_PLATFORM=${TELEMETRY_PLATFORM:-}"
+    )
+
+    "${HARBOR_CMD[@]}" 2>&1 || HARBOR_EXIT=$?
+fi
+
+if [ "${HARBOR_EXIT}" -ne 0 ]; then
+    echo "    Harbor exited with code ${HARBOR_EXIT}"
+fi
+
+set +e
+
+echo "    Finished at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# ── Step 4: Extract per-task results ──
+
+log "Step 4: Extracting per-task results"
+
+TASKS_JSON=$(python3 << 'PYEOF'
+import json, os, sys, glob
+
+jobs_dir = os.environ.get("JOBS_DIR", "")
+if not jobs_dir or not os.path.isdir(jobs_dir):
+    print("[]")
+    sys.exit(0)
+
+tasks = {}
+
+for reward_path in sorted(glob.glob(os.path.join(jobs_dir, "**", "reward.json"), recursive=True)):
+    parts = reward_path.split(os.sep)
+    instance_id = None
+    for i, p in enumerate(parts):
+        if p == "trials" and i + 1 < len(parts):
+            instance_id = parts[i + 1]
+            break
+    if not instance_id:
+        continue
+
+    try:
+        with open(reward_path) as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            values = [v for v in data.values() if isinstance(v, (int, float))]
+            score = sum(values) / len(values) if values else 0.0
+            resolved = score > 0.5
+        elif isinstance(data, (int, float)):
+            resolved = float(data) > 0.5
+        else:
+            resolved = False
+    except Exception:
+        resolved = False
+
+    if instance_id not in tasks:
+        tasks[instance_id] = {"instance_id": instance_id, "resolved": resolved, "cost_usd": 0, "duration_seconds": 0}
+    else:
+        tasks[instance_id]["resolved"] = resolved
+
+for reward_path in sorted(glob.glob(os.path.join(jobs_dir, "**", "reward.txt"), recursive=True)):
+    parts = reward_path.split(os.sep)
+    instance_id = None
+    for i, p in enumerate(parts):
+        if p == "trials" and i + 1 < len(parts):
+            instance_id = parts[i + 1]
+            break
+    if not instance_id or instance_id in tasks:
+        continue
+
+    try:
+        with open(reward_path) as f:
+            val = f.read().strip()
+        resolved = val in ("1", "1.0")
+    except Exception:
+        resolved = False
+
+    tasks[instance_id] = {"instance_id": instance_id, "resolved": resolved, "cost_usd": 0, "duration_seconds": 0}
+
+result_files = sorted(glob.glob(os.path.join(jobs_dir, "**", "result.json"), recursive=True))
+for rpath in result_files:
+    try:
+        with open(rpath) as f:
+            data = json.load(f)
+        for trial_name, trial_data in data.get("trials", {}).items():
+            if trial_name in tasks:
+                tasks[trial_name]["cost_usd"] = trial_data.get("cost_usd", 0) or 0
+                tasks[trial_name]["duration_seconds"] = trial_data.get("duration_seconds", 0) or 0
+    except Exception:
+        pass
+
+    try:
+        stats = data.get("stats", {})
+        cost = stats.get("cost_usd", 0) or 0
+        if cost > 0 and len(tasks) > 0:
+            uncosted = [t for t in tasks.values() if t["cost_usd"] == 0]
+            if len(uncosted) == len(tasks):
+                per_task = cost / len(tasks)
+                for t in tasks.values():
+                    t["cost_usd"] = round(per_task, 4)
+    except Exception:
+        pass
+
+task_list = sorted(tasks.values(), key=lambda t: t["instance_id"])
+print(json.dumps(task_list))
+PYEOF
+)
+
+PASSED=$(python3 -c "import json; tasks=json.loads('${TASKS_JSON}'); print(sum(1 for t in tasks if t.get('resolved')))")
+TOTAL=$(python3 -c "import json; tasks=json.loads('${TASKS_JSON}'); print(len(tasks))")
+
+echo ""
+echo "============================================"
+echo "  Full Eval Results: ${BENCHMARK}"
+echo "  Resolved: ${PASSED}/${TOTAL}"
+if [ "${TOTAL}" -gt 0 ]; then
+    SCORE=$(python3 -c "print(round(${PASSED} / ${TOTAL} * 100, 1))")
+    echo "  Accuracy: ${SCORE}%"
+fi
+echo "============================================"
+echo ""
+
+set -e
+
+STATUS="success"

--- a/benchmarks/run-full-eval.sh
+++ b/benchmarks/run-full-eval.sh
@@ -428,7 +428,7 @@ echo ""
 log "Step 4: Extracting per-task results"
 
 TASKS_JSON=$(python3 << 'PYEOF'
-import json, os, sys, glob
+import json, os, re, sys, glob
 
 jobs_dir = os.environ.get("JOBS_DIR", "")
 if not jobs_dir or not os.path.isdir(jobs_dir):
@@ -437,13 +437,21 @@ if not jobs_dir or not os.path.isdir(jobs_dir):
 
 tasks = {}
 
+def extract_instance_id(reward_path):
+    """Extract instance_id from a reward file path.
+
+    Harbor structure: $JOBS_DIR/<job>/<trial-name>/verifier/reward.{json,txt}
+    Trial name format: <instance_id>__<7-char-suffix> e.g. matplotlib__matplotlib-14623__ff4rTkg
+    """
+    reward_dir = os.path.dirname(reward_path)
+    if os.path.basename(reward_dir) == "verifier":
+        trial_dir = os.path.basename(os.path.dirname(reward_dir))
+    else:
+        trial_dir = os.path.basename(reward_dir)
+    return re.sub(r'__[A-Za-z0-9]{7}$', '', trial_dir)
+
 for reward_path in sorted(glob.glob(os.path.join(jobs_dir, "**", "reward.json"), recursive=True)):
-    parts = reward_path.split(os.sep)
-    instance_id = None
-    for i, p in enumerate(parts):
-        if p == "trials" and i + 1 < len(parts):
-            instance_id = parts[i + 1]
-            break
+    instance_id = extract_instance_id(reward_path)
     if not instance_id:
         continue
 
@@ -467,12 +475,7 @@ for reward_path in sorted(glob.glob(os.path.join(jobs_dir, "**", "reward.json"),
         tasks[instance_id]["resolved"] = resolved
 
 for reward_path in sorted(glob.glob(os.path.join(jobs_dir, "**", "reward.txt"), recursive=True)):
-    parts = reward_path.split(os.sep)
-    instance_id = None
-    for i, p in enumerate(parts):
-        if p == "trials" and i + 1 < len(parts):
-            instance_id = parts[i + 1]
-            break
+    instance_id = extract_instance_id(reward_path)
     if not instance_id or instance_id in tasks:
         continue
 
@@ -485,19 +488,25 @@ for reward_path in sorted(glob.glob(os.path.join(jobs_dir, "**", "reward.txt"), 
 
     tasks[instance_id] = {"instance_id": instance_id, "resolved": resolved, "cost_usd": 0, "duration_seconds": 0}
 
-result_files = sorted(glob.glob(os.path.join(jobs_dir, "**", "result.json"), recursive=True))
-for rpath in result_files:
+# Extract per-trial cost/duration from per-trial result.json files
+for rpath in sorted(glob.glob(os.path.join(jobs_dir, "**", "result.json"), recursive=True)):
     try:
-        with open(rpath) as f:
-            data = json.load(f)
-        for trial_name, trial_data in data.get("trials", {}).items():
-            if trial_name in tasks:
-                tasks[trial_name]["cost_usd"] = trial_data.get("cost_usd", 0) or 0
-                tasks[trial_name]["duration_seconds"] = trial_data.get("duration_seconds", 0) or 0
+        rdir = os.path.dirname(rpath)
+        trial_id = extract_instance_id(rpath + "/dummy")
+        if os.path.isdir(os.path.join(rdir, "verifier")) or os.path.isdir(os.path.join(rdir, "agent")):
+            with open(rpath) as f:
+                data = json.load(f)
+            if trial_id in tasks:
+                tasks[trial_id]["cost_usd"] = data.get("cost_usd", 0) or 0
+                tasks[trial_id]["duration_seconds"] = data.get("duration_seconds", 0) or 0
     except Exception:
         pass
 
+# Extract aggregate cost from job-level result.json and distribute evenly if no per-task costs
+for rpath in sorted(glob.glob(os.path.join(jobs_dir, "*/result.json"))):
     try:
+        with open(rpath) as f:
+            data = json.load(f)
         stats = data.get("stats", {})
         cost = stats.get("cost_usd", 0) or 0
         if cost > 0 and len(tasks) > 0:

--- a/docs/full-eval.md
+++ b/docs/full-eval.md
@@ -1,0 +1,665 @@
+# Full Eval Dashboard
+
+<div id="full-eval-dashboard">
+  <p>Loading full eval results...</p>
+</div>
+
+<style>
+#full-eval-dashboard table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+#full-eval-dashboard th {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 2px solid var(--md-default-fg-color--lightest);
+  white-space: nowrap;
+}
+#full-eval-dashboard td {
+  padding: 0.5rem 0.8rem;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  vertical-align: top;
+}
+#full-eval-dashboard tr:hover td {
+  background: var(--md-default-fg-color--lightest);
+}
+#full-eval-dashboard .status-success { color: #22863a; }
+#full-eval-dashboard .status-failure { color: #cb2431; }
+#full-eval-dashboard .error-msg {
+  color: var(--md-default-fg-color--light);
+  font-style: italic;
+}
+#full-eval-dashboard .section-title {
+  margin-top: 2.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+#full-eval-dashboard .section-explanation {
+  font-size: 0.85rem;
+  opacity: 0.6;
+  margin: 0.3rem 0 1.5rem 0;
+  font-style: italic;
+}
+
+/* Hero section */
+#full-eval-dashboard .hero-section { text-align: center; margin: 1rem 0 2.5rem 0; }
+#full-eval-dashboard .hero-cards { display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap; margin: 1.5rem 0; }
+#full-eval-dashboard .hero-card { flex: 0 1 220px; text-align: center; padding: 1.5rem 1rem; border-radius: 12px; background: var(--md-default-bg-color--light, #f5f5f5); border: 2px solid; }
+#full-eval-dashboard .hero-card.factory { border-color: #4285f4; }
+#full-eval-dashboard .hero-card.claude-code { border-color: #ff7043; }
+#full-eval-dashboard .hero-score { font-size: 2.4rem; font-weight: 800; line-height: 1.1; }
+#full-eval-dashboard .hero-label { font-size: 0.85rem; color: var(--md-default-fg-color--light); margin-bottom: 0.3rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+#full-eval-dashboard .hero-sublabel { font-size: 0.75rem; color: var(--md-default-fg-color--light); opacity: 0.7; }
+#full-eval-dashboard .hero-trend { font-size: 0.85rem; margin-top: 0.4rem; }
+#full-eval-dashboard .hero-explanation { font-size: 0.85rem; opacity: 0.6; max-width: 700px; margin: 0 auto; }
+
+/* Filter bar */
+#full-eval-dashboard .filter-bar {
+  display: flex;
+  gap: 1rem;
+  margin: 0.5rem 0 1rem 0;
+  align-items: center;
+  flex-wrap: wrap;
+}
+#full-eval-dashboard .filter-bar select {
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+  font-size: 0.85rem;
+}
+#full-eval-dashboard .filter-bar label {
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+/* Expandable rows */
+#full-eval-dashboard .run-detail { background: rgba(255,255,255,0.02); }
+#full-eval-dashboard .run-detail td:first-child { padding-left: 2rem; font-size: 0.85rem; opacity: 0.85; }
+#full-eval-dashboard .run-detail.hidden { display: none; }
+#full-eval-dashboard .toggle-details {
+  background: none;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.8rem;
+  color: var(--md-default-fg-color);
+}
+#full-eval-dashboard .toggle-details:hover {
+  background: var(--md-default-fg-color--lightest);
+}
+
+/* Task detail rows */
+#full-eval-dashboard .task-row { font-size: 0.82rem; }
+#full-eval-dashboard .task-row td { padding: 0.3rem 0.8rem; opacity: 0.9; }
+#full-eval-dashboard .task-row.hidden { display: none; }
+
+/* Trend indicators */
+#full-eval-dashboard .trend-up { color: #22863a; }
+#full-eval-dashboard .trend-down { color: #cb2431; }
+#full-eval-dashboard .trend-neutral { color: #888; }
+
+/* Pagination controls */
+#full-eval-dashboard .pagination { display: flex; justify-content: center; align-items: center; gap: 8px; margin: 16px 0; flex-wrap: wrap; }
+#full-eval-dashboard .pagination button { background: #2a2a3e; color: #e0e0e0; border: 1px solid #444; border-radius: 6px; padding: 6px 12px; cursor: pointer; font-size: 0.85rem; }
+#full-eval-dashboard .pagination button:hover:not(:disabled) { background: #3a3a5e; }
+#full-eval-dashboard .pagination button:disabled { opacity: 0.4; cursor: not-allowed; }
+#full-eval-dashboard .pagination button.active { background: #667eea; border-color: #667eea; }
+#full-eval-dashboard .pagination .page-info { color: #aaa; font-size: 0.85em; }
+
+/* Cost analytics */
+#full-eval-dashboard .cost-grid { display: flex; gap: 1.5rem; flex-wrap: wrap; margin: 1rem 0; }
+#full-eval-dashboard .cost-card { flex: 1; min-width: 200px; padding: 1.2rem; border-radius: 8px; background: var(--md-default-bg-color--light, #f5f5f5); border: 1px solid var(--md-default-fg-color--lightest); }
+#full-eval-dashboard .cost-card .cost-value { font-size: 1.8rem; font-weight: 700; }
+#full-eval-dashboard .cost-card .cost-label { font-size: 0.8rem; color: var(--md-default-fg-color--light); text-transform: uppercase; letter-spacing: 0.04em; }
+</style>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+<script>
+const FE_REPO = 'akashgit/remote-factory';
+const FE_JSONL_URL = `https://raw.githubusercontent.com/${FE_REPO}/benchmark-data/full-eval-results.jsonl`;
+
+function feIsDarkMode() {
+  return document.body.getAttribute('data-md-color-scheme') === 'slate';
+}
+
+function feChartColors() {
+  const dark = feIsDarkMode();
+  return {
+    text: dark ? '#ccc' : '#333',
+    grid: dark ? '#444' : '#e0e0e0',
+  };
+}
+
+function feFormatDuration(seconds) {
+  if (seconds == null) return '—';
+  if (seconds >= 3600) {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    return h + 'h ' + m + 'm';
+  }
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return m > 0 ? m + 'm ' + s + 's' : s + 's';
+}
+
+function feFormatCost(usd) {
+  if (usd == null) return '—';
+  return '$' + usd.toFixed(2);
+}
+
+function feFormatDate(ts) {
+  if (!ts) return '—';
+  const d = feParseTimestamp(ts);
+  if (!d) return ts;
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    + ' ' + d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+}
+
+function feParseTimestamp(ts) {
+  if (!ts) return null;
+  const iso = ts.replace(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/,
+    '$1-$2-$3T$4:$5:$6Z'
+  );
+  const d = new Date(iso);
+  return isNaN(d) ? null : d;
+}
+
+function feStatusIcon(resolved) {
+  return resolved
+    ? '<span class="status-success">&#10003;</span>'
+    : '<span class="status-failure">&#10007;</span>';
+}
+
+async function feFetchJsonl() {
+  const resp = await fetch(FE_JSONL_URL);
+  if (!resp.ok) return null;
+  const text = await resp.text();
+  const lines = text.trim().split('\n').filter(Boolean);
+  return lines.map(l => {
+    try { return JSON.parse(l); }
+    catch { return null; }
+  }).filter(Boolean);
+}
+
+// Section 1: Hero — Latest accuracy per benchmark x solver
+function feRenderHero(results) {
+  const latest = {};
+  for (const r of results) {
+    const key = r.benchmark + '|' + r.solver;
+    if (!latest[key] || (r.timestamp > latest[key].timestamp)) {
+      latest[key] = r;
+    }
+  }
+
+  const priorByKey = {};
+  for (const r of results) {
+    const key = r.benchmark + '|' + r.solver;
+    const cur = latest[key];
+    if (r.timestamp < cur.timestamp) {
+      if (!priorByKey[key] || r.timestamp > priorByKey[key].timestamp) {
+        priorByKey[key] = r;
+      }
+    }
+  }
+
+  const entries = Object.entries(latest).sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return '';
+
+  let html = '<div class="hero-section">';
+  html += '<div class="hero-cards">';
+
+  for (const [key, r] of entries) {
+    const acc = r.total > 0 ? (r.passed / r.total * 100) : null;
+    const solverClass = r.solver === 'claude-code' ? 'claude-code' : 'factory';
+    const prior = priorByKey[key];
+    const prevAcc = prior && prior.total > 0 ? (prior.passed / prior.total * 100) : null;
+
+    let trendHtml = '';
+    if (acc != null && prevAcc != null) {
+      const delta = acc - prevAcc;
+      if (Math.abs(delta) < 0.5) {
+        trendHtml = '<div class="hero-trend trend-neutral">= no change</div>';
+      } else {
+        const sign = delta > 0 ? '+' : '';
+        const cls = delta > 0 ? 'trend-up' : 'trend-down';
+        const arrow = delta > 0 ? '&#9650;' : '&#9660;';
+        trendHtml = `<div class="hero-trend ${cls}">${arrow} ${sign}${delta.toFixed(1)}% vs prior</div>`;
+      }
+    } else if (acc != null) {
+      trendHtml = '<div class="hero-trend trend-neutral">first run</div>';
+    }
+
+    html += `<div class="hero-card ${solverClass}">`;
+    html += `<div class="hero-label">${r.benchmark}</div>`;
+    html += `<div class="hero-sublabel">${r.solver}</div>`;
+    html += `<div class="hero-score">${acc != null ? acc.toFixed(1) + '%' : '—'}</div>`;
+    html += `<div class="hero-sublabel">${r.passed}/${r.total} tasks</div>`;
+    html += trendHtml;
+    html += '</div>';
+  }
+
+  html += '</div>';
+  html += '<div class="hero-explanation">Latest full eval accuracy per benchmark and solver. Accuracy = percentage of all tasks in the dataset solved correctly.</div>';
+  html += '</div>';
+  return html;
+}
+
+// Section 2: Accuracy Trend Chart
+function feRenderAccuracyTrend(results) {
+  const benchmarks = [...new Set(results.map(r => r.benchmark))].sort();
+  const solvers = [...new Set(results.map(r => r.solver))].sort();
+
+  const datasets = [];
+  const colorMap = { factory: '#4285f4', 'claude-code': '#ff7043' };
+  const dashMap = { factory: [], 'claude-code': [5, 5] };
+  const benchColors = ['#4285f4', '#ff7043', '#66bb6a', '#ab47bc', '#ffa726', '#26c6da'];
+
+  let colorIdx = 0;
+  for (const bench of benchmarks) {
+    for (const solver of solvers) {
+      const subset = results
+        .filter(r => r.benchmark === bench && r.solver === solver)
+        .sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+
+      if (subset.length === 0) continue;
+
+      const points = subset
+        .map(r => {
+          const d = feParseTimestamp(r.timestamp);
+          if (!d || r.total === 0) return null;
+          return { x: d, y: (r.passed / r.total) * 100 };
+        })
+        .filter(Boolean);
+
+      if (points.length === 0) continue;
+
+      const color = benchmarks.length === 1
+        ? (colorMap[solver] || benchColors[colorIdx % benchColors.length])
+        : benchColors[colorIdx % benchColors.length];
+
+      datasets.push({
+        label: bench + ' / ' + solver,
+        data: points,
+        borderColor: color,
+        backgroundColor: color,
+        tension: 0.2,
+        pointRadius: 4,
+        borderDash: solvers.length > 1 && solver === 'claude-code' ? [5, 5] : [],
+      });
+      colorIdx++;
+    }
+  }
+
+  if (datasets.length === 0) return '';
+
+  let html = '<div class="section-title">Accuracy Over Time</div>';
+  html += '<p class="section-explanation">Solve rate across the full dataset for each benchmark/solver combination.</p>';
+
+  html += '<div class="filter-bar">';
+  html += '<label>Benchmark: <select id="fe-filter-trend-bench"><option value="">All</option>';
+  for (const b of benchmarks) html += `<option value="${b}">${b}</option>`;
+  html += '</select></label>';
+  html += '<label>Solver: <select id="fe-filter-trend-solver"><option value="">All</option>';
+  for (const s of solvers) html += `<option value="${s}">${s}</option>`;
+  html += '</select></label>';
+  html += '</div>';
+
+  html += '<div style="width:100%;margin:1rem 0 2rem 0"><canvas id="fe-accuracy-chart" style="width:100%!important;height:400px!important"></canvas></div>';
+
+  setTimeout(() => {
+    const ctx = document.getElementById('fe-accuracy-chart');
+    if (!ctx) return;
+    const colors = feChartColors();
+
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: { datasets: datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { labels: { color: colors.text } },
+          tooltip: {
+            callbacks: {
+              label: (item) => item.dataset.label + ': ' + item.raw.y.toFixed(1) + '%',
+            },
+          },
+        },
+        scales: {
+          x: {
+            type: 'time',
+            time: { unit: 'day', tooltipFormat: 'MMM d, yyyy HH:mm' },
+            title: { display: true, text: 'Date', color: colors.text },
+            ticks: { color: colors.text },
+            grid: { color: colors.grid },
+          },
+          y: {
+            min: 0,
+            max: 100,
+            title: { display: true, text: 'Accuracy (%)', color: colors.text },
+            ticks: { color: colors.text },
+            grid: { color: colors.grid },
+          },
+        },
+      },
+    });
+
+    const benchSelect = document.getElementById('fe-filter-trend-bench');
+    const solverSelect = document.getElementById('fe-filter-trend-solver');
+
+    function updateChart() {
+      const bv = benchSelect?.value || '';
+      const sv = solverSelect?.value || '';
+      chart.data.datasets.forEach(ds => {
+        const [dsBench, dsSolver] = ds.label.split(' / ');
+        const matchB = !bv || dsBench === bv;
+        const matchS = !sv || dsSolver === sv;
+        ds.hidden = !(matchB && matchS);
+      });
+      chart.update();
+    }
+
+    if (benchSelect) benchSelect.addEventListener('change', updateChart);
+    if (solverSelect) solverSelect.addEventListener('change', updateChart);
+  }, 0);
+
+  return html;
+}
+
+// Section 3: Per-task results table with expandable rows
+let feCurrentPage = 1;
+const FE_RUNS_PER_PAGE = 15;
+let feAllRuns = [];
+let feFilteredRuns = [];
+
+function feGetFilteredRuns() {
+  const bv = document.getElementById('fe-filter-bench')?.value || '';
+  const sv = document.getElementById('fe-filter-solver')?.value || '';
+  return feAllRuns.filter(r => {
+    return (!bv || r.benchmark === bv) && (!sv || r.solver === sv);
+  });
+}
+
+function feRenderPaginationControls(current, total, totalItems, startIdx, endIdx) {
+  if (totalItems === 0) return '<span class="page-info">No matching runs</span>';
+  if (total <= 1) return `<span class="page-info">Showing all ${totalItems} runs</span>`;
+
+  let html = `<span class="page-info">Showing ${startIdx + 1}–${endIdx} of ${totalItems}</span>`;
+  html += `<button class="fe-page-btn" data-page="${current - 1}" ${current === 1 ? 'disabled' : ''}>&#8592; Prev</button>`;
+
+  const pages = [];
+  pages.push(1);
+  if (current > 3) pages.push('...');
+  for (let p = Math.max(2, current - 1); p <= Math.min(total - 1, current + 1); p++) pages.push(p);
+  if (current < total - 2) pages.push('...');
+  if (total > 1) pages.push(total);
+
+  for (const p of pages) {
+    if (p === '...') {
+      html += '<span class="page-info">&#8230;</span>';
+    } else {
+      html += `<button class="fe-page-btn${p === current ? ' active' : ''}" data-page="${p}">${p}</button>`;
+    }
+  }
+
+  html += `<button class="fe-page-btn" data-page="${current + 1}" ${current === total ? 'disabled' : ''}>Next &#8594;</button>`;
+  return html;
+}
+
+function feUpdateTable() {
+  feFilteredRuns = feGetFilteredRuns();
+  const totalPages = Math.max(1, Math.ceil(feFilteredRuns.length / FE_RUNS_PER_PAGE));
+  if (feCurrentPage > totalPages) feCurrentPage = totalPages;
+
+  const start = (feCurrentPage - 1) * FE_RUNS_PER_PAGE;
+  const pageRuns = feFilteredRuns.slice(start, start + FE_RUNS_PER_PAGE);
+
+  let rowsHtml = '';
+  for (let i = 0; i < pageRuns.length; i++) {
+    const r = pageRuns[i];
+    const rid = 'fe-run-' + (start + i);
+    const acc = r.total > 0 ? (r.passed / r.total * 100).toFixed(1) + '%' : '—';
+    const cost = r.details?.cost_usd;
+    const tasks = r.tasks || [];
+
+    rowsHtml += `<tr class="run-summary">`;
+    rowsHtml += `<td style="white-space:nowrap">${feFormatDate(r.timestamp)}</td>`;
+    rowsHtml += `<td>${r.benchmark}</td>`;
+    rowsHtml += `<td>${r.solver}</td>`;
+    rowsHtml += `<td>${r.passed}/${r.total}</td>`;
+    rowsHtml += `<td>${acc}</td>`;
+    rowsHtml += `<td>${feFormatCost(cost)}</td>`;
+    rowsHtml += `<td>${feFormatDuration(r.duration_seconds)}</td>`;
+    if (tasks.length > 0) {
+      rowsHtml += `<td><button class="toggle-details" data-target="${rid}">+ ${tasks.length} tasks</button></td>`;
+    } else {
+      rowsHtml += '<td></td>';
+    }
+    rowsHtml += '</tr>';
+
+    for (const t of tasks) {
+      rowsHtml += `<tr class="task-row hidden" data-parent="${rid}">`;
+      rowsHtml += `<td></td>`;
+      rowsHtml += `<td colspan="2" style="padding-left:2rem;font-family:monospace;font-size:0.78rem">${t.instance_id}</td>`;
+      rowsHtml += `<td>${feStatusIcon(t.resolved)}</td>`;
+      rowsHtml += `<td>${t.resolved ? '<span class="status-success">PASS</span>' : '<span class="status-failure">FAIL</span>'}</td>`;
+      rowsHtml += `<td>${feFormatCost(t.cost_usd)}</td>`;
+      rowsHtml += `<td>${feFormatDuration(t.duration_seconds)}</td>`;
+      rowsHtml += '<td></td>';
+      rowsHtml += '</tr>';
+    }
+  }
+
+  const tbody = document.getElementById('fe-tbody');
+  if (tbody) tbody.innerHTML = rowsHtml;
+
+  const endIdx = start + pageRuns.length;
+  const pHtml = feRenderPaginationControls(feCurrentPage, totalPages, feFilteredRuns.length, start, endIdx);
+  const pTop = document.getElementById('fe-pagination-top');
+  const pBottom = document.getElementById('fe-pagination-bottom');
+  if (pTop) pTop.innerHTML = pHtml;
+  if (pBottom) pBottom.innerHTML = pHtml;
+}
+
+function feRenderResultsTable(results) {
+  feAllRuns = [...results].sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''));
+  feCurrentPage = 1;
+
+  const benchmarks = [...new Set(results.map(r => r.benchmark))].sort();
+  const solvers = [...new Set(results.map(r => r.solver))].sort();
+
+  let html = '<div class="section-title">Run History</div>';
+  html += '<p class="section-explanation">All full eval runs, newest first. Click a row to see per-task breakdown.</p>';
+
+  html += '<div class="filter-bar">';
+  html += '<label>Benchmark: <select id="fe-filter-bench"><option value="">All</option>';
+  for (const b of benchmarks) html += `<option value="${b}">${b}</option>`;
+  html += '</select></label>';
+  html += '<label>Solver: <select id="fe-filter-solver"><option value="">All</option>';
+  for (const s of solvers) html += `<option value="${s}">${s}</option>`;
+  html += '</select></label>';
+  html += '</div>';
+
+  html += '<div id="fe-pagination-top" class="pagination"></div>';
+  html += '<table><thead><tr>';
+  html += '<th>Date</th><th>Benchmark</th><th>Solver</th><th>Passed</th><th>Score</th><th>Cost</th><th>Duration</th><th></th>';
+  html += '</tr></thead><tbody id="fe-tbody"></tbody></table>';
+  html += '<div id="fe-pagination-bottom" class="pagination"></div>';
+
+  setTimeout(() => {
+    feUpdateTable();
+
+    document.addEventListener('click', (e) => {
+      const btn = e.target.closest('.toggle-details');
+      if (!btn || !btn.dataset.target?.startsWith('fe-run-')) return;
+      const rid = btn.dataset.target;
+      const details = document.querySelectorAll(`.task-row[data-parent="${rid}"]`);
+      const isHidden = details[0]?.classList.contains('hidden');
+      details.forEach(row => row.classList.toggle('hidden'));
+      const count = details.length;
+      btn.textContent = isHidden ? `− ${count} tasks` : `+ ${count} tasks`;
+    });
+
+    document.addEventListener('click', (e) => {
+      const btn = e.target.closest('.fe-page-btn');
+      if (!btn || btn.disabled) return;
+      const page = parseInt(btn.dataset.page);
+      if (page && page !== feCurrentPage) {
+        feCurrentPage = page;
+        feUpdateTable();
+      }
+    });
+
+    const benchSelect = document.getElementById('fe-filter-bench');
+    const solverSelect = document.getElementById('fe-filter-solver');
+    if (benchSelect) benchSelect.addEventListener('change', () => { feCurrentPage = 1; feUpdateTable(); });
+    if (solverSelect) solverSelect.addEventListener('change', () => { feCurrentPage = 1; feUpdateTable(); });
+  }, 0);
+
+  return html;
+}
+
+// Section 4: Cost & Duration Analytics
+function feRenderCostAnalytics(results) {
+  if (results.length === 0) return '';
+
+  const totalCost = results.reduce((s, r) => s + (r.details?.cost_usd || 0), 0);
+  const totalTasks = results.reduce((s, r) => s + (r.total || 0), 0);
+  const avgCostPerTask = totalTasks > 0 ? totalCost / totalTasks : 0;
+  const totalDuration = results.reduce((s, r) => s + (r.duration_seconds || 0), 0);
+  const avgDuration = results.length > 0 ? totalDuration / results.length : 0;
+  const totalRuns = results.length;
+
+  let html = '<div class="section-title">Cost &amp; Duration Analytics</div>';
+  html += '<p class="section-explanation">Aggregate cost and duration statistics across all full eval runs. Vertex AI runs may show $0 when billing is at the platform level.</p>';
+
+  html += '<div class="cost-grid">';
+  html += '<div class="cost-card">';
+  html += `<div class="cost-value">${feFormatCost(totalCost)}</div>`;
+  html += `<div class="cost-label">Total Spend (${totalRuns} runs)</div>`;
+  html += '</div>';
+  html += '<div class="cost-card">';
+  html += `<div class="cost-value">${feFormatCost(avgCostPerTask)}</div>`;
+  html += `<div class="cost-label">Avg Cost / Task (${totalTasks} tasks)</div>`;
+  html += '</div>';
+  html += '<div class="cost-card">';
+  html += `<div class="cost-value">${feFormatDuration(avgDuration)}</div>`;
+  html += '<div class="cost-label">Avg Duration / Run</div>';
+  html += '</div>';
+  html += '</div>';
+
+  html += '<div style="width:100%;margin:1.5rem 0"><canvas id="fe-cost-chart" style="width:100%!important;height:300px!important"></canvas></div>';
+
+  setTimeout(() => {
+    const ctx = document.getElementById('fe-cost-chart');
+    if (!ctx) return;
+    const colors = feChartColors();
+
+    const sortedByDate = [...results].sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+    const costPoints = sortedByDate
+      .map(r => {
+        const d = feParseTimestamp(r.timestamp);
+        return d ? { x: d, y: r.details?.cost_usd || 0, label: r.benchmark + ' / ' + r.solver } : null;
+      })
+      .filter(Boolean);
+
+    const durationPoints = sortedByDate
+      .map(r => {
+        const d = feParseTimestamp(r.timestamp);
+        return d ? { x: d, y: (r.duration_seconds || 0) / 3600, label: r.benchmark + ' / ' + r.solver } : null;
+      })
+      .filter(Boolean);
+
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        datasets: [
+          {
+            label: 'Cost (USD)',
+            data: costPoints,
+            backgroundColor: '#4285f4aa',
+            yAxisID: 'y',
+          },
+          {
+            label: 'Duration (hours)',
+            data: durationPoints,
+            backgroundColor: '#ff704388',
+            yAxisID: 'y1',
+          },
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { labels: { color: colors.text } },
+          tooltip: {
+            callbacks: {
+              title: (items) => items[0]?.raw?.label || '',
+              label: (item) => {
+                if (item.datasetIndex === 0) return 'Cost: ' + feFormatCost(item.raw.y);
+                return 'Duration: ' + (item.raw.y).toFixed(1) + 'h';
+              },
+            },
+          },
+        },
+        scales: {
+          x: {
+            type: 'time',
+            time: { unit: 'day', tooltipFormat: 'MMM d, yyyy' },
+            ticks: { color: colors.text },
+            grid: { color: colors.grid },
+          },
+          y: {
+            position: 'left',
+            title: { display: true, text: 'Cost (USD)', color: colors.text },
+            ticks: { color: colors.text },
+            grid: { color: colors.grid },
+          },
+          y1: {
+            position: 'right',
+            title: { display: true, text: 'Duration (hours)', color: colors.text },
+            ticks: { color: colors.text },
+            grid: { drawOnChartArea: false },
+          },
+        },
+      },
+    });
+  }, 0);
+
+  return html;
+}
+
+async function feRenderDashboard() {
+  const container = document.getElementById('full-eval-dashboard');
+
+  try {
+    const results = await feFetchJsonl();
+
+    if (results && results.length > 0) {
+      let html = '';
+      html += feRenderHero(results);
+      html += feRenderAccuracyTrend(results);
+      html += feRenderResultsTable(results);
+      html += feRenderCostAnalytics(results);
+      container.innerHTML = html;
+      return;
+    }
+
+    container.innerHTML = '<p class="error-msg">No full eval results available yet.<br>'
+      + 'Run a full benchmark evaluation to generate data:<br>'
+      + '<code>benchmarks/run-full-eval.sh swebench --solver factory</code></p>';
+  } catch (err) {
+    container.innerHTML = `<p class="error-msg">${err.message}</p>`;
+  }
+}
+
+feRenderDashboard();
+</script>

--- a/docs/full-eval.md
+++ b/docs/full-eval.md
@@ -1,5 +1,29 @@
 # Full Eval Dashboard
 
+## How to Run
+
+Run a full evaluation of any benchmark through Harbor. Results appear on this dashboard after committing.
+
+**Run all benchmarks (parallel):**
+```bash
+benchmarks/run-full-eval.sh all --solver factory --concurrency 5 --timeout 36000
+```
+
+**Run individual benchmarks:**
+```bash
+benchmarks/run-full-eval.sh swebench --solver factory --concurrency 5 --timeout 36000
+benchmarks/run-full-eval.sh featurebench --solver factory --concurrency 5 --timeout 36000
+benchmarks/run-full-eval.sh terminalbench --solver factory --concurrency 5 --timeout 36000
+benchmarks/run-full-eval.sh programbench --solver factory --concurrency 5 --timeout 36000
+```
+
+**Commit results:**
+```bash
+benchmarks/commit-full-eval.sh
+```
+
+Use `--limit N` to run a subset of tasks (useful for testing).
+
 <div id="full-eval-dashboard">
   <p>Loading full eval results...</p>
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,5 +68,6 @@ nav:
       - Self-Improvement Loop: self-improvement.md
       - ACE Playbook Evolution: ace.md
   - Benchmarks: benchmarks.md
+  - Full Eval: full-eval.md
   - Contributing: contributing.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Changes

- **Parallel 'all' mode**: The `all` benchmark option in `benchmarks/run-full-eval.sh` now runs all 4 benchmarks (swebench, featurebench, terminalbench, programbench) in parallel using background processes with PID tracking, instead of sequentially. Failed benchmarks are collected and reported by name.
- **Usage docs**: Added a concise "How to Run" section at the top of `docs/full-eval.md` showing commands for running all/individual benchmarks, committing results, and using `--limit N`.
- **JSONL URL**: Verified the dashboard already uses the correct production URL (`https://raw.githubusercontent.com/akashgit/remote-factory/benchmark-data/full-eval-results.jsonl`) — no change needed.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>