### PR TITLE
feat: support adversarial (GAN-style) eval loops (#935)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,13 @@ mypy factory/                    # Type check
 
 The factory is a three-layer system:
 
-1. **Python CLI** (`factory/`): Pure tools that don't make decisions. Entry point is `factory/cli.py`.
+1. **Python CLI** (`factory/cli/`): Pure tools that don't make decisions. Entry point is `factory/cli/_main.py`.
 2. **CEO Agent** (`factory/agents/prompts/ceo.md`): Orchestrates the full workflow. Spawned via `factory ceo /path`.
 3. **Specialist Agents** (`factory/agents/`): Eight subprocesses spawned by the CEO via `factory agent <role>`.
 
 Agent roles: Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Distiller, Failure Analyst, CEO.
+
+Key modules: `factory/adversarial.py` (GAN-style adversarial eval loops — phase transitions with hysteresis, convergence detection, state at `.factory/adversarial_state.json`).
 
 ## MCP Server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- **Adversarial eval loops** — First-class GAN-style alternating generator/discriminator optimization. Configure in `factory.md` with `## Adversarial` section using dot-notation for per-component eval commands, metrics, and thresholds. Hysteresis prevents oscillation (N consecutive above-threshold rounds before switching). Convergence detection when both sides sustain above-threshold performance. State persisted at `.factory/adversarial_state.json` for crash-resilient resume. New `factory adversarial-state` CLI command for inspection and reset. 80 new tests
 - **Post-cycle refinement loop** — After build/improve cycles complete in foreground mode, the CEO stays active and routes follow-up requests through the Refiner → Builder → full review pipeline. New `--refine` flag for direct refinement entry. Three CLI commands (`refine-status`, `refine-begin`, `refine-complete`) provide identity regrounding and state tracking. No hard cap on refinements; advisory warnings at 5 and 10
 - **Refiner agent** — New specialist that classifies refinement requests into tiers (T1: prompt/config, T2: code changes, T3: architectural — requires `--focus`) and scopes the implementation for the Builder
 - **Inner/outer loop controls** — Configure multi-run aggregation, plateau detection, and automatic scope expansion for research mode via `## Inner Loop` and `## Outer Loop Surfaces` in `factory.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent 
 7. **Report** (`factory/report.py`): Performance report generation — consolidates experiment records, CEO verdicts, and observations into `.factory/performance_report.json` for ACE consumption
 8. **Checkpoint** (`factory/checkpoint.py`): Saves and loads CEO state for crash-resilient resume
 9. **Analysis** (`factory/analysis.py`): Experiment comparison (`diff`) and FEEC analysis (`explain`)
+10. **Adversarial** (`factory/adversarial.py`): GAN-style adversarial eval loop state machine — phase transitions with hysteresis, per-role streak counters, convergence detection. State persisted at `.factory/adversarial_state.json`
 
 ### Target project's `.factory/` layout
 
@@ -93,6 +94,7 @@ Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent 
 ├── reviews/                  # Agent output capture + CEO review verdicts
 │   ├── <role>-latest.md      # Auto-saved stdout from each agent invocation
 │   └── ceo-verdict-<role>.md # CEO's review verdict (PROCEED/REDIRECT/ABORT)
+├── adversarial_state.json    # Adversarial loop state (phase, streaks, history)
 ├── archive/                  # Long-term knowledge store (Archivist notes)
 │   ├── experiments/          # Per-experiment learnings and decision rationale
 │   ├── patterns/             # Recurring patterns and anti-patterns
@@ -102,7 +104,7 @@ Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent 
 
 ### Models
 
-All domain models live in `factory/models.py` as strict Pydantic v2 models. Key types: `ProjectState` (enum), `FactoryConfig`, `EvalProfile` / `EvalDimension`, `CompositeScore` / `EvalResult`, `ExperimentRecord`, `CrossProjectInsights`, `AgentVerdict`, `Observation`, `PerformanceReport`, `ProjectEntry` / `ProjectRegistry`. The `Notifier` protocol defines the async notification interface. `FactoryConfig` includes `clean_pr` (bool), `clean_pr_include` (list[str]), and `clean_pr_exclude` (list[str]) for Clean PR Mode — stripping non-essential artifacts from PRs before pushing to external repos.
+All domain models live in `factory/models.py` as strict Pydantic v2 models. Key types: `ProjectState` (enum), `FactoryConfig`, `EvalProfile` / `EvalDimension`, `CompositeScore` / `EvalResult`, `ExperimentRecord`, `CrossProjectInsights`, `AgentVerdict`, `Observation`, `PerformanceReport`, `ProjectEntry` / `ProjectRegistry`, `AdversarialConfig` / `AdversarialComponent` / `AdversarialState` / `AdversarialPhaseRecord`. The `Notifier` protocol defines the async notification interface. `FactoryConfig` includes `clean_pr` (bool), `clean_pr_include` (list[str]), and `clean_pr_exclude` (list[str]) for Clean PR Mode — stripping non-essential artifacts from PRs before pushing to external repos. `FactoryConfig.adversarial` (`AdversarialConfig | None`) holds the GAN-style adversarial eval loop configuration parsed from `factory.md`.
 
 ## Environment
 
@@ -214,6 +216,10 @@ factory explain /path --exp N                   # Explain experiment with FEEC a
 factory backlog-list /path                      # List pending backlog items
 factory backlog-add /path "item text"           # Add a new item to the backlog
 factory backlog-remove /path "item text"        # Remove a completed backlog item
+
+# Adversarial eval loops
+factory adversarial-state /path/to/project           # Inspect adversarial loop state
+factory adversarial-state /path/to/project --reset   # Reset to defaults
 
 # Operations
 factory dashboard --projects-dir ~/factory-projects    # Live web dashboard on :8420

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,6 +125,26 @@ Key differences from Improve mode:
 6. Archivist records    → .factory/archive/ notes, performance report
 ```
 
+### Adversarial Pipeline
+
+For projects with an `## Adversarial` section in `factory.md`, re:factory alternates between optimizing two competing components (generator and discriminator):
+
+```
+1. Check active phase  → load .factory/adversarial_state.json
+2. Run active eval     → generator or discriminator eval_command
+3. Record result       → update streak counters, check hysteresis
+4. Phase switch?       → if consecutive_above >= hysteresis, flip active role
+5. Convergence?        → if both per-role streaks >= convergence_window, mark converged
+6. Save state          → persist to .factory/adversarial_state.json
+```
+
+Key properties:
+- **Hysteresis** prevents oscillation — N consecutive above-threshold rounds required before switching (default 3)
+- **Per-role streak counters freeze** when that role is inactive — only the active role's counter changes
+- **Convergence** requires both sides to independently sustain above-threshold performance
+
+State management: `factory/adversarial.py`. Configuration: [Adversarial](configuration.md#adversarial).
+
 ### Eval Pipeline
 
 ```
@@ -188,6 +208,7 @@ Stuck detection activates after 3+ consecutive same-category reverts, forcing ca
 | `factory/analysis.py` | Experiment comparison (diff, explain) |
 | `factory/registry.py` | Global project registry (`~/.factory/registry.json`) |
 | `factory/report.py` | Performance report generation and loading |
+| `factory/adversarial.py` | GAN-style adversarial eval loop state machine |
 | `factory/agents/runner.py` | Agent subprocess spawner + event emission |
 
 ## `.factory/` Directory
@@ -216,6 +237,7 @@ Generated at runtime — not checked into version control:
 ├── reviews/
 │   ├── <role>-latest.md
 │   └── ceo-verdict-<role>.md
+├── adversarial_state.json   # Adversarial loop state (phase, streaks, history)
 ├── archive/                 # Archivist notes (institutional memory)
 │   ├── experiments/         # Per-experiment notes
 │   ├── strategies/          # Strategy snapshots

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,6 +272,58 @@ Per-cycle or total budget constraints for research experiments.
 $5/cycle, $50 total
 ```
 
+### `## Adversarial`
+
+GAN-style adversarial eval loop configuration. Alternates between optimizing a generator and discriminator, switching phases when a component exceeds its threshold for N consecutive rounds (hysteresis). Convergence is detected when both sides sustain above-threshold performance.
+
+```markdown
+## Adversarial
+- generator.eval_command: python eval/score_gen.py
+- generator.metric_name: evasion_rate
+- generator.threshold: 0.4
+- generator.scope: src/generator/, eval/gen_data/
+- generator.timeout: 600
+- discriminator.eval_command: python eval/score_disc.py
+- discriminator.metric_name: recall_specificity
+- discriminator.threshold: 0.8
+- discriminator.scope: src/discriminator/, eval/disc_data/
+- discriminator.timeout: 600
+- hysteresis: 3
+- max_rounds: 50
+- convergence_window: 5
+```
+
+Uses dot-notation to separate generator and discriminator settings. Each eval command should print JSON to stdout with a numeric score (e.g., `{"score": 0.72}`).
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `generator.eval_command` | Shell command to score the generator | *(required)* |
+| `generator.metric_name` | Label for the generator metric | `generator_score` |
+| `generator.threshold` | Score at which the generator is "good enough" to switch phases | `0.5` |
+| `generator.scope` | Comma-separated file paths the generator may modify | `[]` |
+| `generator.timeout` | Eval timeout in seconds | `300` |
+| `discriminator.*` | Same fields as generator, for the discriminator side | *(required)* |
+| `hysteresis` | Consecutive above-threshold rounds required before switching phases | `3` |
+| `max_rounds` | Hard cap on total rounds (`null` = unlimited) | `null` |
+| `convergence_window` | Both sides must sustain this many consecutive above-threshold rounds to converge | `5` |
+
+**Phase transition algorithm:**
+1. Active component's eval command runs and produces a score
+2. Score >= threshold: increment `consecutive_above` and the active role's per-role streak counter
+3. Score < threshold: reset both `consecutive_above` and the active role's streak to 0
+4. If `consecutive_above >= hysteresis`: switch active role, reset `consecutive_above` to 0
+5. Per-role streak counters freeze when that role is inactive (neither increment nor reset)
+6. Convergence: both per-role streaks independently reach `convergence_window`
+
+State is persisted at `.factory/adversarial_state.json` and survives CEO crashes and restarts.
+
+Inspect or reset state via CLI:
+
+```bash
+factory adversarial-state /path/to/project           # View current state
+factory adversarial-state /path/to/project --reset    # Reset to defaults
+```
+
 ## `.factory/` Directory
 
 Generated at runtime by re:factory. Add to `.gitignore` — do not edit manually:
@@ -298,6 +350,7 @@ Generated at runtime by re:factory. Add to `.gitignore` — do not edit manually
 ├── reviews/
 │   ├── <role>-latest.md
 │   └── ceo-verdict-<role>.md
+├── adversarial_state.json   # Adversarial loop state (phase, streaks, history)
 ├── archive/                 # Archivist notes
 │   ├── experiments/
 │   ├── strategies/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,15 +96,16 @@ If you're interested in any of these, open an issue to discuss the approach befo
 
 ```
 factory/
-├── cli.py                  # CLI entry point (argparse subcommands)
+├── cli/                    # CLI package (argparse subcommands)
 ├── models.py               # Pydantic v2 domain models
 ├── state.py                # Project state detection
 ├── store.py                # .factory/ filesystem store
 ├── events.py               # Event system (JSONL log)
 ├── strategy.py             # FEEC priority heuristic
+├── adversarial.py          # GAN-style adversarial eval loop state machine
 ├── study.py                # Code analysis + observations
 ├── insights.py             # Cross-project patterns
-├── checkpoint.py            # CEO checkpoint save/load (legacy, debugging)
+├── checkpoint.py           # CEO checkpoint save/load (legacy, debugging)
 ├── analysis.py             # Experiment comparison
 ├── agents/
 │   ├── runner.py           # Agent subprocess spawner
@@ -118,15 +119,17 @@ factory/
 ├── eval/                   # Three-tier eval system
 └── notify/                 # Telegram notifications
 
-tests/                      # 1350+ tests mirroring factory/ structure
+tests/                      # 3000+ tests mirroring factory/ structure
 ```
 
 ## Adding a New CLI Command
 
-1. Add `cmd_<name>` function in `factory/cli.py`
-2. Register it in the `COMMANDS` handler dict
-3. Add argument parsing in the `build_parser` function
-4. Write tests in `tests/test_cli.py`
+1. Add `cmd_<name>` function in the appropriate `factory/cli/<module>.py` file
+2. Export it from `factory/cli/__init__.py`
+3. Register it in the `handlers` dict in `factory/cli/_main.py`
+4. Add argument parsing in the `build_parser` function in `factory/cli/_main.py`
+5. Add the command name to `_COMMAND_GROUPS` for grouped help display
+6. Write tests in `tests/test_cli.py`
 
 ## Adding a New Agent Role
 

--- a/docs/eval.md
+++ b/docs/eval.md
@@ -147,6 +147,37 @@ The research target metric must satisfy `metric_after >= previous_best` for ever
 
 If a change improves the metric on some instances but regresses on others, the aggregate must still be at or above the previous best. The CEO cannot override a monotonic improvement violation.
 
+## Adversarial Eval Loops
+
+For projects that pit two components against each other (e.g., a generator creating test cases vs. a discriminator catching them), re:factory supports GAN-style adversarial eval loops as a first-class pattern.
+
+Unlike the standard three-tier eval, adversarial loops use **two separate eval commands** — one per component — and alternate between them. Each side has its own threshold, and the loop switches focus when one side consistently exceeds its target.
+
+### How it works
+
+1. The **generator** starts as the active phase
+2. Each round runs the active component's eval command and records the score
+3. When a component scores at or above its threshold for N consecutive rounds (hysteresis), the loop switches to the other component
+4. Per-role streak counters freeze when inactive — the generator's counter doesn't change during discriminator rounds
+5. **Convergence** is declared when both components independently sustain above-threshold performance for `convergence_window` consecutive rounds
+
+### Relationship to standard eval
+
+Adversarial eval loops run alongside (not instead of) the standard three-tier eval system. The standard hygiene/growth/project eval still gates keep/revert decisions. The adversarial loop provides an additional signal about which component to focus improvement efforts on.
+
+### Configuration
+
+Configure in `factory.md` with dot-notation. See [Configuration — Adversarial](configuration.md#adversarial) for the full reference.
+
+### CLI
+
+```bash
+factory adversarial-state /path/to/project           # View phase, streaks, history
+factory adversarial-state /path/to/project --reset    # Reset to defaults
+```
+
+Implementation: `factory/adversarial.py`. State persisted at `.factory/adversarial_state.json`.
+
 ## Running Evals
 
 ```bash

--- a/factory/adversarial.py
+++ b/factory/adversarial.py
@@ -1,0 +1,215 @@
+"""Adversarial (GAN-style) eval loop — phase-aware state management.
+
+Alternates between optimizing a generator and discriminator, each scored
+by its own metric.  Automatic phase switching when a component exceeds
+its threshold for N consecutive rounds (hysteresis).  Convergence is
+detected when both sides sustain above-threshold performance.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+import structlog
+
+from factory.models import (
+    AdversarialComponent,
+    AdversarialConfig,
+    AdversarialPhaseRecord,
+    AdversarialState,
+)
+
+log = structlog.get_logger()
+
+_STATE_FILE = "adversarial_state.json"
+
+
+def _state_path(project_path: Path) -> Path:
+    return project_path / ".factory" / _STATE_FILE
+
+
+# ── state persistence ───────────────────────────────────────────
+
+
+def load_adversarial_state(project_path: Path) -> AdversarialState:
+    """Load state from .factory/adversarial_state.json, returning defaults if missing."""
+    path = _state_path(project_path)
+    if not path.exists():
+        return AdversarialState()
+    try:
+        data = json.loads(path.read_text())
+        return AdversarialState(**data)
+    except (json.JSONDecodeError, TypeError, KeyError, ValueError) as exc:
+        log.warning("adversarial_state_corrupt", path=str(path), error=str(exc))
+        return AdversarialState()
+
+
+def save_adversarial_state(project_path: Path, state: AdversarialState) -> None:
+    """Persist state to .factory/adversarial_state.json."""
+    path = _state_path(project_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state.model_dump(), indent=2) + "\n")
+    log.debug("adversarial_state_saved", round=state.current_round, active=state.active_role)
+
+
+def reset_adversarial_state(project_path: Path) -> None:
+    """Delete the state file, resetting to defaults."""
+    path = _state_path(project_path)
+    if path.exists():
+        path.unlink()
+        log.info("adversarial_state_reset", path=str(path))
+
+
+# ── phase queries ───────────────────────────────────────────────
+
+
+def get_active_phase(state: AdversarialState) -> Literal["generator", "discriminator"]:
+    """Return the currently active role."""
+    return state.active_role
+
+
+def get_active_component(
+    config: AdversarialConfig,
+    state: AdversarialState,
+) -> AdversarialComponent:
+    """Return the AdversarialComponent for the currently active phase."""
+    if state.active_role == "generator":
+        return config.generator
+    return config.discriminator
+
+
+# ── phase transition ────────────────────────────────────────────
+
+
+def should_switch_phase(
+    state: AdversarialState,
+    config: AdversarialConfig,
+    current_score: float,
+) -> bool:
+    """Check whether the active phase should switch.
+
+    Returns True when the active component has scored at or above its
+    threshold for ``config.hysteresis`` consecutive rounds.
+
+    Does NOT mutate state — the caller updates counters.
+    """
+    component = get_active_component(config, state)
+    if current_score < component.threshold:
+        return False
+    return (state.consecutive_above + 1) >= config.hysteresis
+
+
+# ── convergence ─────────────────────────────────────────────────
+
+
+def detect_convergence(
+    state: AdversarialState,
+    config: AdversarialConfig,
+) -> bool:
+    """Check if both sides have sustained above-threshold performance.
+
+    Convergence requires both per-role consecutive counters to
+    independently reach ``config.convergence_window``.
+    """
+    return (
+        state.generator_consecutive_above >= config.convergence_window
+        and state.discriminator_consecutive_above >= config.convergence_window
+    )
+
+
+# ── record + transition ────────────────────────────────────────
+
+
+def record_phase_result(
+    project_path: Path,
+    config: AdversarialConfig,
+    score: float,
+) -> AdversarialPhaseRecord:
+    """Record a phase result, potentially transitioning phases.
+
+    1. Load state, increment round
+    2. Update consecutive counters for the active role
+    3. Switch phase if hysteresis threshold met
+    4. Check convergence
+    5. Save state and return the record
+    """
+    state = load_adversarial_state(project_path)
+    state.current_round += 1
+
+    component = get_active_component(config, state)
+    active_role = state.active_role
+
+    # Update counters
+    if score >= component.threshold:
+        state.consecutive_above += 1
+        if active_role == "generator":
+            state.generator_consecutive_above += 1
+        else:
+            state.discriminator_consecutive_above += 1
+    else:
+        state.consecutive_above = 0
+        if active_role == "generator":
+            state.generator_consecutive_above = 0
+        else:
+            state.discriminator_consecutive_above = 0
+
+    # Phase switch check
+    switched = state.consecutive_above >= config.hysteresis
+    if switched:
+        state.active_role = "discriminator" if active_role == "generator" else "generator"
+        state.consecutive_above = 0
+        log.info(
+            "adversarial_phase_switch",
+            from_role=active_role,
+            to_role=state.active_role,
+            round=state.current_round,
+        )
+
+    # Convergence check
+    if not state.converged and detect_convergence(state, config):
+        state.converged = True
+        log.info("adversarial_converged", round=state.current_round)
+
+    record = AdversarialPhaseRecord(
+        round=state.current_round,
+        active_role=active_role,
+        score=score,
+        metric_name=component.metric_name,
+        timestamp=datetime.now().isoformat(),
+        switched=switched,
+    )
+    state.history.append(record)
+
+    save_adversarial_state(project_path, state)
+    return record
+
+
+# ── formatting ──────────────────────────────────────────────────
+
+
+def format_adversarial_state(state: AdversarialState) -> str:
+    """Human-readable summary for CLI output."""
+    lines = [
+        f"Active phase: {state.active_role}",
+        f"Current round: {state.current_round}",
+        f"Consecutive above threshold: {state.consecutive_above}",
+        f"Generator streak: {state.generator_consecutive_above}",
+        f"Discriminator streak: {state.discriminator_consecutive_above}",
+        f"Converged: {state.converged}",
+    ]
+
+    if state.history:
+        lines.append(f"\nHistory ({len(state.history)} entries):")
+        for rec in state.history[-10:]:
+            switch_marker = " [SWITCH]" if rec.switched else ""
+            lines.append(
+                f"  Round {rec.round}: {rec.active_role} "
+                f"score={rec.score:.4f} ({rec.metric_name}){switch_marker}"
+            )
+        if len(state.history) > 10:
+            lines.append(f"  ... ({len(state.history) - 10} earlier entries omitted)")
+
+    return "\n".join(lines)

--- a/factory/cli/__init__.py
+++ b/factory/cli/__init__.py
@@ -76,6 +76,7 @@ from factory.cli.ceo import (
     cmd_tmux_stop as cmd_tmux_stop,
 )
 from factory.cli.eval_cmds import (
+    cmd_adversarial_state as cmd_adversarial_state,
     cmd_baseline as cmd_baseline,
     cmd_eval as cmd_eval,
     cmd_guard as cmd_guard,

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -28,6 +28,7 @@ _COMMAND_GROUPS: list[tuple[str, list[str]]] = [
     ("Project Intelligence", [
         "eval", "history", "study", "status", "summary", "diff", "explain", "export",
         "research", "insights", "report-update", "baseline", "clean-pr", "spec",
+        "adversarial-state",
     ]),
     ("Backlog & Refinement", [
         "backlog-add", "backlog-list", "backlog-remove", "deferred-list", "deferred-remove",
@@ -213,6 +214,12 @@ def build_parser() -> argparse.ArgumentParser:
     # validate-research
     p = sub.add_parser("validate-research", help="Validate research mode configuration for ground truth isolation")
     p.add_argument("path", help="Path to the project")
+
+    # adversarial-state
+    p = sub.add_parser("adversarial-state", help="Inspect or reset adversarial eval loop state")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--reset", action="store_true", default=False,
+                    help="Reset adversarial state to defaults")
 
     # backfill-citations
     p = sub.add_parser("backfill-citations", help="Extract citations from experiment text into citations.json")
@@ -786,6 +793,7 @@ def main(argv: list[str] | None = None) -> int:
         "baseline": _cli.cmd_baseline,
         "leakage-check": _cli.cmd_leakage_check,
         "validate-research": _cli.cmd_validate_research,
+        "adversarial-state": _cli.cmd_adversarial_state,
         "refine-status": _cli.cmd_refine_status,
         "refine-begin": _cli.cmd_refine_begin,
         "refine-complete": _cli.cmd_refine_complete,

--- a/factory/cli/eval_cmds.py
+++ b/factory/cli/eval_cmds.py
@@ -149,3 +149,23 @@ def cmd_baseline(args: argparse.Namespace) -> int:
     print(json.dumps(baseline, indent=2, default=str))
     return 0
 
+
+def cmd_adversarial_state(args: argparse.Namespace) -> int:
+    """Inspect or reset adversarial eval loop state."""
+    from factory.adversarial import (
+        format_adversarial_state,
+        load_adversarial_state,
+        reset_adversarial_state,
+    )
+
+    project_path = Path(args.path).resolve()
+
+    if args.reset:
+        reset_adversarial_state(project_path)
+        print("Adversarial state reset.")
+        return 0
+
+    state = load_adversarial_state(project_path)
+    print(format_adversarial_state(state))
+    return 0
+

--- a/factory/models.py
+++ b/factory/models.py
@@ -179,6 +179,58 @@ class TierWeights(BaseModel):
     spec_compliance: float | None = None
 
 
+class AdversarialComponent(BaseModel):
+    """One side of an adversarial eval loop (generator or discriminator)."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    role: Literal["generator", "discriminator"]
+    eval_command: str
+    metric_name: str
+    threshold: float
+    scope: list[str] = []
+    timeout: float = 300.0
+
+
+class AdversarialConfig(BaseModel):
+    """GAN-style adversarial eval loop configuration from factory.md."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    generator: AdversarialComponent
+    discriminator: AdversarialComponent
+    hysteresis: int = 3
+    max_rounds: int | None = None
+    convergence_window: int = 5
+
+
+class AdversarialPhaseRecord(BaseModel):
+    """One entry in the adversarial phase history."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    round: int
+    active_role: Literal["generator", "discriminator"]
+    score: float
+    metric_name: str
+    timestamp: str
+    switched: bool
+
+
+class AdversarialState(BaseModel):
+    """Persisted adversarial loop state at .factory/adversarial_state.json."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    active_role: Literal["generator", "discriminator"] = "generator"
+    current_round: int = 0
+    consecutive_above: int = 0
+    generator_consecutive_above: int = 0
+    discriminator_consecutive_above: int = 0
+    converged: bool = False
+    history: list[AdversarialPhaseRecord] = []
+
+
 class FactoryConfig(BaseModel):
     """Machine-readable config stored at .factory/config.json."""
 
@@ -206,6 +258,7 @@ class FactoryConfig(BaseModel):
     eval_spec: list[str] = []
     hygiene_weights: TierWeights | None = None
     growth_weights: TierWeights | None = None
+    adversarial: AdversarialConfig | None = None
     clean_pr: bool = False
     clean_pr_include: list[str] = []
     clean_pr_exclude: list[str] = []

--- a/factory/store.py
+++ b/factory/store.py
@@ -13,6 +13,8 @@ from filelock import FileLock
 from pydantic import ValidationError
 
 from factory.models import (
+    AdversarialComponent,
+    AdversarialConfig,
     AggregateMethod,
     CompositeScore,
     CostBudgetConfig,
@@ -237,6 +239,79 @@ def _parse_tier_weights(items: str | list[str] | float) -> TierWeights | None:
     return TierWeights(**filtered)
 
 
+def _parse_adversarial(items: str | list[str] | float) -> AdversarialConfig | None:
+    """Parse adversarial config from factory.md.
+
+    Expects dot-notation key-value pairs like:
+      - generator.eval_command: python eval/score_gen.py
+      - generator.metric_name: evasion_rate
+      - generator.threshold: 0.4
+      - discriminator.eval_command: python eval/score_disc.py
+      - discriminator.metric_name: recall_specificity
+      - discriminator.threshold: 0.8
+      - hysteresis: 3
+      - convergence_window: 5
+    """
+    if not isinstance(items, list):
+        return None
+
+    gen_kv: dict[str, str] = {}
+    disc_kv: dict[str, str] = {}
+    top_kv: dict[str, str] = {}
+
+    for item in items:
+        s = str(item).strip()
+        if ":" not in s:
+            continue
+        key, val = s.split(":", 1)
+        key = key.strip()
+        val = val.strip()
+        if key.startswith("generator."):
+            gen_kv[key.removeprefix("generator.")] = val
+        elif key.startswith("discriminator."):
+            disc_kv[key.removeprefix("discriminator.")] = val
+        else:
+            top_kv[key] = val
+
+    if not gen_kv.get("eval_command") or not disc_kv.get("eval_command"):
+        return None
+
+    try:
+        generator = AdversarialComponent(
+            role="generator",
+            eval_command=gen_kv["eval_command"],
+            metric_name=gen_kv.get("metric_name", "generator_score"),
+            threshold=float(gen_kv.get("threshold", "0.5")),
+            scope=[s.strip() for s in gen_kv.get("scope", "").split(",") if s.strip()],
+            timeout=float(gen_kv.get("timeout", "300")),
+        )
+        discriminator = AdversarialComponent(
+            role="discriminator",
+            eval_command=disc_kv["eval_command"],
+            metric_name=disc_kv.get("metric_name", "discriminator_score"),
+            threshold=float(disc_kv.get("threshold", "0.5")),
+            scope=[s.strip() for s in disc_kv.get("scope", "").split(",") if s.strip()],
+            timeout=float(disc_kv.get("timeout", "300")),
+        )
+        config = AdversarialConfig(
+            generator=generator,
+            discriminator=discriminator,
+            hysteresis=int(top_kv.get("hysteresis", "3")),
+            max_rounds=int(top_kv["max_rounds"]) if "max_rounds" in top_kv else None,
+            convergence_window=int(top_kv.get("convergence_window", "5")),
+        )
+        log.debug(
+            "adversarial_parsed",
+            gen_cmd=generator.eval_command,
+            disc_cmd=discriminator.eval_command,
+            hysteresis=config.hysteresis,
+        )
+        return config
+    except (ValueError, KeyError, TypeError) as exc:
+        log.warning("adversarial_parse_failed", error=str(exc))
+        return None
+
+
 class ExperimentStore:
     """Manages the .factory/ directory for a project."""
 
@@ -355,6 +430,7 @@ class ExperimentStore:
         eval_spec = list(es_raw) if isinstance(es_raw, list) else []
         hygiene_tier_weights = _parse_tier_weights(parsed.get("hygiene_weights", []))
         growth_tier_weights = _parse_tier_weights(parsed.get("growth_weights", []))
+        adversarial = _parse_adversarial(parsed.get("adversarial", []))
 
         clean_pr_raw = parsed.get("clean_pr", "")
         clean_pr = str(clean_pr_raw).strip().lower() in ("true", "yes", "1") if clean_pr_raw else False
@@ -395,6 +471,7 @@ class ExperimentStore:
             eval_spec=eval_spec,
             hygiene_weights=hygiene_tier_weights,
             growth_weights=growth_tier_weights,
+            adversarial=adversarial,
             clean_pr=clean_pr,
             clean_pr_include=clean_pr_include,
             clean_pr_exclude=clean_pr_exclude,

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -1,0 +1,835 @@
+"""Tests for adversarial (GAN-style) eval loop support."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from factory.adversarial import (
+    detect_convergence,
+    format_adversarial_state,
+    get_active_component,
+    get_active_phase,
+    load_adversarial_state,
+    record_phase_result,
+    reset_adversarial_state,
+    save_adversarial_state,
+    should_switch_phase,
+)
+from factory.models import (
+    AdversarialComponent,
+    AdversarialConfig,
+    AdversarialPhaseRecord,
+    AdversarialState,
+    FactoryConfig,
+)
+from factory.store import _parse_adversarial
+
+
+# ── fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def gen_component() -> AdversarialComponent:
+    return AdversarialComponent(
+        role="generator",
+        eval_command="python eval/gen.py",
+        metric_name="evasion_rate",
+        threshold=0.4,
+        scope=["src/gen.py"],
+    )
+
+
+@pytest.fixture
+def disc_component() -> AdversarialComponent:
+    return AdversarialComponent(
+        role="discriminator",
+        eval_command="python eval/disc.py",
+        metric_name="recall_specificity",
+        threshold=0.8,
+        scope=["src/disc.py"],
+    )
+
+
+@pytest.fixture
+def adv_config(gen_component, disc_component) -> AdversarialConfig:
+    return AdversarialConfig(
+        generator=gen_component,
+        discriminator=disc_component,
+        hysteresis=3,
+        convergence_window=5,
+    )
+
+
+@pytest.fixture
+def adv_project(tmp_path: Path) -> Path:
+    """Create a minimal project with .factory/ directory."""
+    project = tmp_path / "adv-project"
+    project.mkdir()
+    (project / ".factory").mkdir()
+    return project
+
+
+# ── model tests ─────────────────────────────────────────────────
+
+
+class TestAdversarialComponentModel:
+    def test_valid_generator(self):
+        c = AdversarialComponent(
+            role="generator",
+            eval_command="python eval.py",
+            metric_name="score",
+            threshold=0.5,
+        )
+        assert c.role == "generator"
+        assert c.threshold == 0.5
+
+    def test_valid_discriminator(self):
+        c = AdversarialComponent(
+            role="discriminator",
+            eval_command="python eval.py",
+            metric_name="accuracy",
+            threshold=0.9,
+        )
+        assert c.role == "discriminator"
+
+    def test_defaults(self):
+        c = AdversarialComponent(
+            role="generator",
+            eval_command="echo ok",
+            metric_name="m",
+            threshold=0.5,
+        )
+        assert c.scope == []
+        assert c.timeout == 300.0
+
+    def test_strict_rejects_extras(self):
+        with pytest.raises(Exception):
+            AdversarialComponent(
+                role="generator",
+                eval_command="echo ok",
+                metric_name="m",
+                threshold=0.5,
+                extra_field="bad",
+            )
+
+    def test_invalid_role_rejected(self):
+        with pytest.raises(Exception):
+            AdversarialComponent(
+                role="attacker",
+                eval_command="echo ok",
+                metric_name="m",
+                threshold=0.5,
+            )
+
+
+class TestAdversarialConfigModel:
+    def test_valid_config(self, adv_config):
+        assert adv_config.hysteresis == 3
+        assert adv_config.generator.role == "generator"
+        assert adv_config.discriminator.role == "discriminator"
+
+    def test_defaults(self, gen_component, disc_component):
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+        )
+        assert config.hysteresis == 3
+        assert config.max_rounds is None
+        assert config.convergence_window == 5
+
+    def test_strict_rejects_extras(self, gen_component, disc_component):
+        with pytest.raises(Exception):
+            AdversarialConfig(
+                generator=gen_component,
+                discriminator=disc_component,
+                extra="bad",
+            )
+
+    def test_with_max_rounds(self, gen_component, disc_component):
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+            max_rounds=50,
+        )
+        assert config.max_rounds == 50
+
+
+class TestAdversarialPhaseRecordModel:
+    def test_valid_record(self):
+        r = AdversarialPhaseRecord(
+            round=1,
+            active_role="generator",
+            score=0.45,
+            metric_name="evasion_rate",
+            timestamp="2026-07-02T10:00:00",
+            switched=False,
+        )
+        assert r.round == 1
+        assert not r.switched
+
+    def test_switched_flag(self):
+        r = AdversarialPhaseRecord(
+            round=3,
+            active_role="generator",
+            score=0.5,
+            metric_name="evasion_rate",
+            timestamp="2026-07-02T10:00:00",
+            switched=True,
+        )
+        assert r.switched
+
+
+class TestAdversarialStateModel:
+    def test_default_state(self):
+        state = AdversarialState()
+        assert state.active_role == "generator"
+        assert state.current_round == 0
+        assert state.consecutive_above == 0
+        assert state.generator_consecutive_above == 0
+        assert state.discriminator_consecutive_above == 0
+        assert not state.converged
+        assert state.history == []
+
+    def test_state_with_history(self):
+        rec = AdversarialPhaseRecord(
+            round=1, active_role="generator", score=0.3,
+            metric_name="m", timestamp="2026-01-01T00:00:00", switched=False,
+        )
+        state = AdversarialState(history=[rec])
+        assert len(state.history) == 1
+
+    def test_strict_rejects_extras(self):
+        with pytest.raises(Exception):
+            AdversarialState(extra="bad")
+
+
+# ── state persistence tests ────────────────────────────────────
+
+
+class TestLoadAdversarialState:
+    def test_missing_file_returns_default(self, adv_project):
+        state = load_adversarial_state(adv_project)
+        assert state.active_role == "generator"
+        assert state.current_round == 0
+
+    def test_reads_existing_file(self, adv_project):
+        state = AdversarialState(active_role="discriminator", current_round=5)
+        (adv_project / ".factory" / "adversarial_state.json").write_text(
+            json.dumps(state.model_dump(), indent=2)
+        )
+        loaded = load_adversarial_state(adv_project)
+        assert loaded.active_role == "discriminator"
+        assert loaded.current_round == 5
+
+    def test_corrupt_file_returns_default(self, adv_project):
+        (adv_project / ".factory" / "adversarial_state.json").write_text("not json")
+        state = load_adversarial_state(adv_project)
+        assert state.active_role == "generator"
+        assert state.current_round == 0
+
+    def test_invalid_fields_returns_default(self, adv_project):
+        (adv_project / ".factory" / "adversarial_state.json").write_text(
+            '{"active_role": "invalid_role"}'
+        )
+        state = load_adversarial_state(adv_project)
+        assert state.active_role == "generator"
+
+
+class TestSaveAdversarialState:
+    def test_creates_file(self, adv_project):
+        state = AdversarialState(active_role="discriminator", current_round=3)
+        save_adversarial_state(adv_project, state)
+        path = adv_project / ".factory" / "adversarial_state.json"
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["active_role"] == "discriminator"
+        assert data["current_round"] == 3
+
+    def test_roundtrip(self, adv_project):
+        original = AdversarialState(
+            active_role="discriminator",
+            current_round=7,
+            consecutive_above=2,
+            generator_consecutive_above=4,
+            discriminator_consecutive_above=2,
+        )
+        save_adversarial_state(adv_project, original)
+        loaded = load_adversarial_state(adv_project)
+        assert loaded == original
+
+    def test_creates_parent_dirs(self, tmp_path):
+        project = tmp_path / "new-project"
+        project.mkdir()
+        state = AdversarialState()
+        save_adversarial_state(project, state)
+        assert (project / ".factory" / "adversarial_state.json").exists()
+
+
+class TestResetAdversarialState:
+    def test_deletes_file(self, adv_project):
+        save_adversarial_state(adv_project, AdversarialState(current_round=5))
+        path = adv_project / ".factory" / "adversarial_state.json"
+        assert path.exists()
+        reset_adversarial_state(adv_project)
+        assert not path.exists()
+
+    def test_noop_when_missing(self, adv_project):
+        reset_adversarial_state(adv_project)
+
+
+# ── phase transition tests ──────────────────────────────────────
+
+
+class TestShouldSwitchPhase:
+    def test_below_threshold_no_switch(self, adv_config):
+        state = AdversarialState(consecutive_above=0)
+        assert not should_switch_phase(state, adv_config, 0.2)
+
+    def test_above_threshold_once_no_switch_with_hysteresis(self, adv_config):
+        state = AdversarialState(consecutive_above=0)
+        assert not should_switch_phase(state, adv_config, 0.5)
+
+    def test_above_threshold_consecutive_triggers_switch(self, adv_config):
+        state = AdversarialState(consecutive_above=2)
+        assert should_switch_phase(state, adv_config, 0.5)
+
+    def test_score_dip_resets_counter(self, adv_config):
+        state = AdversarialState(consecutive_above=2)
+        assert not should_switch_phase(state, adv_config, 0.1)
+
+    def test_hysteresis_of_one(self, gen_component, disc_component):
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+            hysteresis=1,
+        )
+        state = AdversarialState(consecutive_above=0)
+        assert should_switch_phase(state, config, 0.5)
+
+    def test_exactly_at_threshold_counts_as_above(self, adv_config):
+        state = AdversarialState(consecutive_above=2)
+        assert should_switch_phase(state, adv_config, 0.4)
+
+    def test_discriminator_threshold(self, adv_config):
+        state = AdversarialState(
+            active_role="discriminator",
+            consecutive_above=2,
+        )
+        assert should_switch_phase(state, adv_config, 0.8)
+        assert not should_switch_phase(state, adv_config, 0.79)
+
+
+# ── convergence tests ───────────────────────────────────────────
+
+
+class TestDetectConvergence:
+    def test_not_converged_initially(self, adv_config):
+        state = AdversarialState()
+        assert not detect_convergence(state, adv_config)
+
+    def test_converged_when_both_above(self, adv_config):
+        state = AdversarialState(
+            generator_consecutive_above=5,
+            discriminator_consecutive_above=5,
+        )
+        assert detect_convergence(state, adv_config)
+
+    def test_not_converged_when_only_generator_above(self, adv_config):
+        state = AdversarialState(
+            generator_consecutive_above=5,
+            discriminator_consecutive_above=3,
+        )
+        assert not detect_convergence(state, adv_config)
+
+    def test_not_converged_when_only_discriminator_above(self, adv_config):
+        state = AdversarialState(
+            generator_consecutive_above=2,
+            discriminator_consecutive_above=5,
+        )
+        assert not detect_convergence(state, adv_config)
+
+    def test_convergence_window_zero_converges_immediately(self, gen_component, disc_component):
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+            convergence_window=0,
+        )
+        state = AdversarialState()
+        assert detect_convergence(state, config)
+
+    def test_above_threshold_converges(self, gen_component, disc_component):
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+            convergence_window=2,
+        )
+        state = AdversarialState(
+            generator_consecutive_above=3,
+            discriminator_consecutive_above=2,
+        )
+        assert detect_convergence(state, config)
+
+
+# ── active phase query tests ────────────────────────────────────
+
+
+class TestGetActivePhase:
+    def test_default_is_generator(self):
+        state = AdversarialState()
+        assert get_active_phase(state) == "generator"
+
+    def test_returns_discriminator(self):
+        state = AdversarialState(active_role="discriminator")
+        assert get_active_phase(state) == "discriminator"
+
+
+class TestGetActiveComponent:
+    def test_generator_active(self, adv_config):
+        state = AdversarialState(active_role="generator")
+        component = get_active_component(adv_config, state)
+        assert component.role == "generator"
+        assert component.eval_command == "python eval/gen.py"
+
+    def test_discriminator_active(self, adv_config):
+        state = AdversarialState(active_role="discriminator")
+        component = get_active_component(adv_config, state)
+        assert component.role == "discriminator"
+        assert component.eval_command == "python eval/disc.py"
+
+
+# ── record phase result tests ──────────────────────────────────
+
+
+class TestRecordPhaseResult:
+    def test_records_round_and_increments(self, adv_project, adv_config):
+        record = record_phase_result(adv_project, adv_config, 0.2)
+        assert record.round == 1
+        assert record.active_role == "generator"
+        assert record.score == 0.2
+        assert not record.switched
+
+        state = load_adversarial_state(adv_project)
+        assert state.current_round == 1
+        assert state.consecutive_above == 0
+        assert len(state.history) == 1
+
+    def test_increments_consecutive_above(self, adv_project, adv_config):
+        record_phase_result(adv_project, adv_config, 0.5)
+        state = load_adversarial_state(adv_project)
+        assert state.consecutive_above == 1
+        assert state.generator_consecutive_above == 1
+
+    def test_resets_consecutive_on_dip(self, adv_project, adv_config):
+        record_phase_result(adv_project, adv_config, 0.5)
+        record_phase_result(adv_project, adv_config, 0.5)
+        record_phase_result(adv_project, adv_config, 0.1)
+        state = load_adversarial_state(adv_project)
+        assert state.consecutive_above == 0
+        assert state.generator_consecutive_above == 0
+
+    def test_switches_phase_after_hysteresis(self, adv_project, adv_config):
+        record_phase_result(adv_project, adv_config, 0.5)
+        record_phase_result(adv_project, adv_config, 0.5)
+        record = record_phase_result(adv_project, adv_config, 0.5)
+        assert record.switched
+
+        state = load_adversarial_state(adv_project)
+        assert state.active_role == "discriminator"
+        assert state.consecutive_above == 0
+
+    def test_generator_streak_preserved_after_switch(self, adv_project, adv_config):
+        for _ in range(3):
+            record_phase_result(adv_project, adv_config, 0.5)
+        state = load_adversarial_state(adv_project)
+        assert state.generator_consecutive_above == 3
+        assert state.active_role == "discriminator"
+
+    def test_discriminator_phase_scoring(self, adv_project, adv_config):
+        for _ in range(3):
+            record_phase_result(adv_project, adv_config, 0.5)
+        record = record_phase_result(adv_project, adv_config, 0.9)
+        assert record.active_role == "discriminator"
+        state = load_adversarial_state(adv_project)
+        assert state.discriminator_consecutive_above == 1
+
+    def test_full_cycle_both_phases(self, adv_project, adv_config):
+        for _ in range(3):
+            record_phase_result(adv_project, adv_config, 0.5)
+        for _ in range(3):
+            record_phase_result(adv_project, adv_config, 0.9)
+
+        state = load_adversarial_state(adv_project)
+        assert state.active_role == "generator"
+        assert state.current_round == 6
+        assert state.generator_consecutive_above == 3
+        assert state.discriminator_consecutive_above == 3
+
+    def test_detects_convergence(self, adv_project, gen_component, disc_component):
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+            hysteresis=2,
+            convergence_window=2,
+        )
+        record_phase_result(adv_project, config, 0.5)
+        record_phase_result(adv_project, config, 0.5)
+        record_phase_result(adv_project, config, 0.9)
+        record_phase_result(adv_project, config, 0.9)
+
+        state = load_adversarial_state(adv_project)
+        assert state.converged
+        assert state.generator_consecutive_above == 2
+        assert state.discriminator_consecutive_above == 2
+
+    def test_convergence_stays_true(self, adv_project, gen_component, disc_component):
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+            hysteresis=2,
+            convergence_window=2,
+        )
+        for _ in range(2):
+            record_phase_result(adv_project, config, 0.5)
+        for _ in range(2):
+            record_phase_result(adv_project, config, 0.9)
+        record_phase_result(adv_project, config, 0.1)
+
+        state = load_adversarial_state(adv_project)
+        assert state.converged
+
+    def test_history_appended(self, adv_project, adv_config):
+        record_phase_result(adv_project, adv_config, 0.3)
+        record_phase_result(adv_project, adv_config, 0.5)
+        state = load_adversarial_state(adv_project)
+        assert len(state.history) == 2
+        assert state.history[0].score == 0.3
+        assert state.history[1].score == 0.5
+
+    def test_metric_name_recorded(self, adv_project, adv_config):
+        record = record_phase_result(adv_project, adv_config, 0.3)
+        assert record.metric_name == "evasion_rate"
+
+    def test_timestamp_recorded(self, adv_project, adv_config):
+        record = record_phase_result(adv_project, adv_config, 0.3)
+        assert record.timestamp
+
+
+# ── format tests ────────────────────────────────────────────────
+
+
+class TestFormatAdversarialState:
+    def test_default_state_output(self):
+        state = AdversarialState()
+        output = format_adversarial_state(state)
+        assert "Active phase: generator" in output
+        assert "Current round: 0" in output
+        assert "Converged: False" in output
+
+    def test_with_history_shows_entries(self):
+        rec = AdversarialPhaseRecord(
+            round=1, active_role="generator", score=0.35,
+            metric_name="evasion_rate", timestamp="2026-07-02T10:00:00",
+            switched=False,
+        )
+        state = AdversarialState(current_round=1, history=[rec])
+        output = format_adversarial_state(state)
+        assert "History (1 entries)" in output
+        assert "Round 1" in output
+        assert "0.3500" in output
+
+    def test_converged_state_shows_converged(self):
+        state = AdversarialState(converged=True)
+        output = format_adversarial_state(state)
+        assert "Converged: True" in output
+
+    def test_switch_marker(self):
+        rec = AdversarialPhaseRecord(
+            round=3, active_role="generator", score=0.5,
+            metric_name="evasion_rate", timestamp="2026-07-02T10:00:00",
+            switched=True,
+        )
+        state = AdversarialState(current_round=3, history=[rec])
+        output = format_adversarial_state(state)
+        assert "[SWITCH]" in output
+
+    def test_truncates_long_history(self):
+        records = [
+            AdversarialPhaseRecord(
+                round=i, active_role="generator", score=0.3,
+                metric_name="m", timestamp="2026-07-02T10:00:00",
+                switched=False,
+            )
+            for i in range(15)
+        ]
+        state = AdversarialState(current_round=15, history=records)
+        output = format_adversarial_state(state)
+        assert "5 earlier entries omitted" in output
+
+
+# ── FactoryConfig integration ───────────────────────────────────
+
+
+class TestFactoryConfigAdversarial:
+    def test_adversarial_defaults_to_none(self, sample_config):
+        assert sample_config.adversarial is None
+
+    def test_adversarial_accepts_config(self, adv_config):
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            adversarial=adv_config,
+        )
+        assert config.adversarial is not None
+        assert config.adversarial.generator.role == "generator"
+
+    def test_roundtrip_through_json(self, adv_config):
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            adversarial=adv_config,
+        )
+        data = config.model_dump()
+        restored = FactoryConfig(**data)
+        assert restored.adversarial is not None
+        assert restored.adversarial.hysteresis == 3
+        assert restored.adversarial.generator.threshold == 0.4
+
+    def test_json_serialization(self, adv_config):
+        config = FactoryConfig(
+            goal="test",
+            scope=[],
+            guards=[],
+            eval_command="echo ok",
+            eval_threshold=0.8,
+            constraints=[],
+            adversarial=adv_config,
+        )
+        text = json.dumps(config.model_dump(), indent=2)
+        data = json.loads(text)
+        restored = FactoryConfig(**data)
+        assert restored.adversarial == adv_config
+
+
+# ── store parser tests ──────────────────────────────────────────
+
+
+class TestParseAdversarial:
+    def test_valid_dot_notation(self):
+        items = [
+            "generator.eval_command: python eval/gen.py",
+            "generator.metric_name: evasion_rate",
+            "generator.threshold: 0.4",
+            "generator.scope: src/gen.py, src/utils.py",
+            "discriminator.eval_command: python eval/disc.py",
+            "discriminator.metric_name: recall_specificity",
+            "discriminator.threshold: 0.8",
+            "hysteresis: 3",
+            "convergence_window: 5",
+        ]
+        config = _parse_adversarial(items)
+        assert config is not None
+        assert config.generator.eval_command == "python eval/gen.py"
+        assert config.generator.metric_name == "evasion_rate"
+        assert config.generator.threshold == 0.4
+        assert config.generator.scope == ["src/gen.py", "src/utils.py"]
+        assert config.discriminator.eval_command == "python eval/disc.py"
+        assert config.discriminator.threshold == 0.8
+        assert config.hysteresis == 3
+        assert config.convergence_window == 5
+
+    def test_missing_generator_returns_none(self):
+        items = [
+            "discriminator.eval_command: python eval/disc.py",
+            "discriminator.metric_name: accuracy",
+            "discriminator.threshold: 0.8",
+        ]
+        assert _parse_adversarial(items) is None
+
+    def test_missing_discriminator_returns_none(self):
+        items = [
+            "generator.eval_command: python eval/gen.py",
+            "generator.metric_name: score",
+            "generator.threshold: 0.5",
+        ]
+        assert _parse_adversarial(items) is None
+
+    def test_empty_list_returns_none(self):
+        assert _parse_adversarial([]) is None
+
+    def test_non_list_returns_none(self):
+        assert _parse_adversarial("not a list") is None
+        assert _parse_adversarial(42.0) is None
+
+    def test_defaults_applied(self):
+        items = [
+            "generator.eval_command: python gen.py",
+            "discriminator.eval_command: python disc.py",
+        ]
+        config = _parse_adversarial(items)
+        assert config is not None
+        assert config.generator.metric_name == "generator_score"
+        assert config.discriminator.metric_name == "discriminator_score"
+        assert config.generator.threshold == 0.5
+        assert config.hysteresis == 3
+        assert config.convergence_window == 5
+        assert config.max_rounds is None
+
+    def test_max_rounds_parsed(self):
+        items = [
+            "generator.eval_command: python gen.py",
+            "discriminator.eval_command: python disc.py",
+            "max_rounds: 50",
+        ]
+        config = _parse_adversarial(items)
+        assert config is not None
+        assert config.max_rounds == 50
+
+    def test_empty_scope_gives_empty_list(self):
+        items = [
+            "generator.eval_command: python gen.py",
+            "discriminator.eval_command: python disc.py",
+        ]
+        config = _parse_adversarial(items)
+        assert config is not None
+        assert config.generator.scope == []
+
+
+# ── CLI integration tests ───────────────────────────────────────
+
+
+class TestCLIAdversarialState:
+    def test_subcommand_registered(self):
+        from factory.cli import build_parser
+        parser = build_parser()
+        ns = parser.parse_args(["adversarial-state", "/tmp/test"])
+        assert ns.command == "adversarial-state"
+        assert ns.path == "/tmp/test"
+
+    def test_reset_flag(self):
+        from factory.cli import build_parser
+        parser = build_parser()
+        ns = parser.parse_args(["adversarial-state", "/tmp/test", "--reset"])
+        assert ns.reset is True
+
+    def test_reset_defaults_false(self):
+        from factory.cli import build_parser
+        parser = build_parser()
+        ns = parser.parse_args(["adversarial-state", "/tmp/test"])
+        assert ns.reset is False
+
+    def test_handler_in_dispatch(self):
+        from factory.cli import cmd_adversarial_state
+        assert callable(cmd_adversarial_state)
+
+    def test_cmd_adversarial_state_inspect(self, adv_project):
+        import argparse
+        from factory.cli import cmd_adversarial_state
+
+        ns = argparse.Namespace(path=str(adv_project), reset=False)
+        code = cmd_adversarial_state(ns)
+        assert code == 0
+
+    def test_cmd_adversarial_state_reset(self, adv_project):
+        import argparse
+        from factory.cli import cmd_adversarial_state
+
+        save_adversarial_state(adv_project, AdversarialState(current_round=5))
+        ns = argparse.Namespace(path=str(adv_project), reset=True)
+        code = cmd_adversarial_state(ns)
+        assert code == 0
+        assert not (adv_project / ".factory" / "adversarial_state.json").exists()
+
+    def test_handlers_dict_contains_entry(self):
+        from factory.cli import main
+        import inspect
+        source = inspect.getsource(main)
+        assert '"adversarial-state"' in source
+
+
+# ── edge case tests ─────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_multiple_full_cycles(self, adv_project, gen_component, disc_component):
+        """Run through multiple complete generator/discriminator cycles."""
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+            hysteresis=2,
+            convergence_window=4,
+        )
+        # Generator phase: 2 rounds above threshold → switch
+        for _ in range(2):
+            record_phase_result(adv_project, config, 0.5)
+        state = load_adversarial_state(adv_project)
+        assert state.active_role == "discriminator"
+
+        # Discriminator phase: 2 rounds above threshold → switch
+        for _ in range(2):
+            record_phase_result(adv_project, config, 0.9)
+        state = load_adversarial_state(adv_project)
+        assert state.active_role == "generator"
+
+        # Generator phase again: 2 more above → switch
+        for _ in range(2):
+            record_phase_result(adv_project, config, 0.5)
+        state = load_adversarial_state(adv_project)
+        assert state.active_role == "discriminator"
+        assert state.generator_consecutive_above == 4
+        assert state.discriminator_consecutive_above == 2
+        assert not state.converged  # disc only at 2, need 4
+
+        # Discriminator phase: 2 more above → switch, disc now at 4
+        for _ in range(2):
+            record_phase_result(adv_project, config, 0.9)
+        state = load_adversarial_state(adv_project)
+        assert state.discriminator_consecutive_above == 4
+        assert state.converged
+
+    def test_failure_resets_per_role_counter(self, adv_project, adv_config):
+        """Scoring below threshold resets the active role's per-role counter."""
+        record_phase_result(adv_project, adv_config, 0.5)
+        record_phase_result(adv_project, adv_config, 0.5)
+        state = load_adversarial_state(adv_project)
+        assert state.generator_consecutive_above == 2
+
+        record_phase_result(adv_project, adv_config, 0.1)
+        state = load_adversarial_state(adv_project)
+        assert state.generator_consecutive_above == 0
+        assert state.consecutive_above == 0
+
+    def test_inactive_role_counter_frozen(self, adv_project, gen_component, disc_component):
+        """Per-role counters don't change when the role is inactive."""
+        config = AdversarialConfig(
+            generator=gen_component,
+            discriminator=disc_component,
+            hysteresis=2,
+            convergence_window=10,
+        )
+        for _ in range(2):
+            record_phase_result(adv_project, config, 0.5)
+        state = load_adversarial_state(adv_project)
+        assert state.generator_consecutive_above == 2
+        assert state.discriminator_consecutive_above == 0
+
+        record_phase_result(adv_project, config, 0.1)
+        state = load_adversarial_state(adv_project)
+        assert state.generator_consecutive_above == 2
+        assert state.discriminator_consecutive_above == 0
+
+    def test_convergence_not_possible_without_both_active(self, adv_project, adv_config):
+        """If only the generator ever runs, convergence can't happen."""
+        for _ in range(10):
+            record_phase_result(adv_project, adv_config, 0.2)
+        state = load_adversarial_state(adv_project)
+        assert not state.converged
+        assert state.active_role == "generator"


### PR DESCRIPTION
## Summary

- Adds first-class support for GAN-style adversarial eval loops with automatic phase switching, hysteresis to prevent oscillation, and convergence detection
- New `AdversarialConfig`, `AdversarialState`, and related Pydantic models in `factory/models.py`
- Core state machine in `factory/adversarial.py` — phase transitions, per-role consecutive counters that freeze when inactive, convergence when both sides sustain above-threshold performance
- Config parsing via dot-notation in `factory/store.py` (e.g., `generator.eval_command: ...`)
- CLI command `factory adversarial-state <path> [--reset]` for inspecting/resetting loop state
- 80 new tests covering all models, state I/O, phase transitions, convergence, CLI integration, and edge cases

Closes #935

## Usage

### 1. Configure in `factory.md`

Add an `adversarial` section to your project's `factory.md` using dot-notation:

```markdown
## adversarial

- generator.eval_command: python eval/score_gen.py
- generator.metric_name: evasion_rate
- generator.threshold: 0.4
- generator.scope: src/generator/, eval/gen_data/
- generator.timeout: 600
- discriminator.eval_command: python eval/score_disc.py
- discriminator.metric_name: recall_specificity
- discriminator.threshold: 0.8
- discriminator.scope: src/discriminator/, eval/disc_data/
- discriminator.timeout: 600
- hysteresis: 3
- max_rounds: 50
- convergence_window: 5
```

Each eval command should print JSON to stdout with a numeric score (e.g., `{"score": 0.72}`).

**Config fields:**

| Field | Description | Default |
|---|---|---|
| `generator.eval_command` | Shell command to score the generator | *(required)* |
| `generator.metric_name` | Label for the generator metric | `generator_score` |
| `generator.threshold` | Score at which the generator is "good enough" to switch | `0.5` |
| `generator.scope` | Comma-separated file paths the generator may modify | `[]` |
| `generator.timeout` | Eval timeout in seconds | `300` |
| `discriminator.*` | Same fields as generator, for the discriminator side | *(required)* |
| `hysteresis` | Consecutive above-threshold rounds needed before switching | `3` |
| `max_rounds` | Hard cap on total rounds (null = unlimited) | `null` |
| `convergence_window` | Both sides must sustain this many consecutive above-threshold rounds to converge | `5` |

### 2. How the loop works

The adversarial loop alternates between optimizing two competing components. The **generator** starts as the active phase.

```
                    ┌──────────────────────────────────┐
                    │          Round N begins           │
                    │   Active role = generator         │
                    └──────────────┬───────────────────┘
                                   │
                    ┌──────────────▼───────────────────┐
                    │  Run generator eval_command       │
                    │  Score = 0.45 (threshold = 0.4)   │
                    └──────────────┬───────────────────┘
                                   │
                         score >= threshold?
                        /                    \
                      yes                     no
                       │                       │
              increment streak           reset streak
              (consecutive_above++)      (consecutive_above=0)
              (gen_streak++)             (gen_streak=0)
                       │                       │
              streak >= hysteresis?             │
                /            \                 │
              yes             no               │
               │               │               │
        ┌──────▼─────┐        │               │
        │ SWITCH to  │        │               │
        │discriminator│        │               │
        │reset consec.│        │               │
        └──────┬─────┘        │               │
               │               │               │
               └───────┬───────┘───────────────┘
                       │
              ┌────────▼────────────────────┐
              │ Convergence check:          │
              │ gen_streak >= window AND    │
              │ disc_streak >= window?      │
              │ If yes → converged = true   │
              └────────┬────────────────────┘
                       │
                 Save state, emit record
```

**Key behaviors:**
- **Hysteresis prevents thrashing**: A phase only switches after N *consecutive* above-threshold rounds (default 3), not on a single good score
- **Per-role counters freeze when inactive**: The generator's streak counter only changes during generator rounds — it is untouched while the discriminator is active, and vice versa
- **Score dips reset counters**: A single below-threshold score resets both `consecutive_above` and the active role's per-role counter to 0
- **Convergence requires both sides**: The loop converges only when *both* `generator_consecutive_above` and `discriminator_consecutive_above` independently reach `convergence_window`

### 3. Recording results programmatically

```python
from pathlib import Path
from factory.adversarial import (
    record_phase_result,
    get_active_phase,
    get_active_component,
    load_adversarial_state,
)
from factory.store import ExperimentStore

project = Path("/path/to/project")
store = ExperimentStore(project)
config = await store.read_config()

# Check what phase we're in
state = load_adversarial_state(project)
phase = get_active_phase(state)           # "generator"
component = get_active_component(config.adversarial, state)
print(f"Run: {component.eval_command}")   # "python eval/score_gen.py"

# After running the eval and getting a score:
record = record_phase_result(project, config.adversarial, score=0.72)
# record.switched == True if phase just flipped
# record.round == current round number

# Check if we've converged
state = load_adversarial_state(project)
if state.converged:
    print("Both sides have converged!")
```

### 4. Inspecting state via CLI

```bash
# View current adversarial loop state
$ factory adversarial-state /path/to/project
Active phase: discriminator
Current round: 12
Consecutive above threshold: 2
Generator streak: 5
Discriminator streak: 2
Converged: False

History (10 entries):
  Round 3: generator score=0.4200 (evasion_rate)
  Round 4: generator score=0.5100 (evasion_rate)
  Round 5: generator score=0.4800 (evasion_rate) [SWITCH]
  Round 6: discriminator score=0.7500 (recall_specificity)
  Round 7: discriminator score=0.8200 (recall_specificity)
  ...

# Reset state to start fresh
$ factory adversarial-state /path/to/project --reset
Adversarial state reset.
```

### 5. State persistence

State is persisted at `.factory/adversarial_state.json`:

```json
{
  "active_role": "discriminator",
  "current_round": 12,
  "consecutive_above": 2,
  "generator_consecutive_above": 5,
  "discriminator_consecutive_above": 2,
  "converged": false,
  "history": [
    {
      "round": 1,
      "active_role": "generator",
      "score": 0.32,
      "metric_name": "evasion_rate",
      "timestamp": "2026-07-02T14:30:00",
      "switched": false
    }
  ]
}
```

The state survives CEO crashes and restarts — the loop picks up exactly where it left off.

## Test plan

- [x] All 80 new tests pass (`pytest tests/test_adversarial.py -v`)
- [x] Full test suite passes (3001 passed, 12 skipped)
- [x] Lint clean (`ruff check`)
- [x] Rebased on latest upstream main

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
