### PR TITLE
feat: add --no-worktree flag to factory ceo and factory run

### DIFF
--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -1,4 +1,5 @@
 """CLI parser construction and main dispatch."""
+
 from __future__ import annotations
 
 import argparse
@@ -7,43 +8,126 @@ import sys
 from factory.cli._helpers import CEO_MODES, RUN_MODES, _load_env_local
 
 
-_REFACTORY_AGENT_COMMANDS: frozenset[str] = frozenset({
-    "ceo", "run", "tmux", "tmux-ls", "tmux-stop", "tmux-capture",
-    "discover", "init", "detect",
-    "eval", "history", "study", "status", "backlog-list", "backlog-add",
-    "checkpoint", "resume",
-    "ace", "ace-stats",
-})
+_REFACTORY_AGENT_COMMANDS: frozenset[str] = frozenset(
+    {
+        "ceo",
+        "run",
+        "tmux",
+        "tmux-ls",
+        "tmux-stop",
+        "tmux-capture",
+        "discover",
+        "init",
+        "detect",
+        "eval",
+        "history",
+        "study",
+        "status",
+        "backlog-list",
+        "backlog-add",
+        "checkpoint",
+        "resume",
+        "ace",
+        "ace-stats",
+    }
+)
 
 
 _COMMAND_GROUPS: list[tuple[str, list[str]]] = [
-    ("Entry Points", [
-        "ceo", "run", "tmux", "tmux-ls", "tmux-capture", "tmux-stop", "refactory", "dashboard",
-        "agent",
-    ]),
+    (
+        "Entry Points",
+        [
+            "ceo",
+            "run",
+            "tmux",
+            "tmux-ls",
+            "tmux-capture",
+            "tmux-stop",
+            "refactory",
+            "dashboard",
+            "agent",
+        ],
+    ),
     ("Project Setup", ["home", "detect", "discover", "init"]),
-    ("Experiment Lifecycle", [
-        "begin", "finalize", "guard", "precheck", "log", "emit", "review",
-    ]),
-    ("Project Intelligence", [
-        "eval", "history", "study", "status", "summary", "diff", "explain", "export",
-        "research", "insights", "report-update", "baseline", "clean-pr", "spec",
-        "adversarial-state",
-    ]),
-    ("Backlog & Refinement", [
-        "backlog-add", "backlog-list", "backlog-remove", "deferred-list", "deferred-remove",
-        "refine-status", "refine-begin", "refine-complete", "message",
-    ]),
-    ("Knowledge & Archive", [
-        "archive", "vault-init", "backfill-citations", "backfill-archive",
-    ]),
+    (
+        "Experiment Lifecycle",
+        [
+            "begin",
+            "finalize",
+            "guard",
+            "precheck",
+            "log",
+            "emit",
+            "review",
+        ],
+    ),
+    (
+        "Project Intelligence",
+        [
+            "eval",
+            "history",
+            "study",
+            "status",
+            "summary",
+            "diff",
+            "explain",
+            "export",
+            "research",
+            "insights",
+            "report-update",
+            "baseline",
+            "clean-pr",
+            "spec",
+            "adversarial-state",
+        ],
+    ),
+    (
+        "Backlog & Refinement",
+        [
+            "backlog-add",
+            "backlog-list",
+            "backlog-remove",
+            "deferred-list",
+            "deferred-remove",
+            "refine-status",
+            "refine-begin",
+            "refine-complete",
+            "message",
+        ],
+    ),
+    (
+        "Knowledge & Archive",
+        [
+            "archive",
+            "vault-init",
+            "backfill-citations",
+            "backfill-archive",
+        ],
+    ),
     ("Self-Evolution", ["ace", "ace-stats", "digest", "workflow"]),
-    ("Configuration", [
-        "config", "profile", "install", "self-update", "runners", "usage", "serve-mcp",
-    ]),
-    ("Validation & Recovery", [
-        "leakage-check", "validate-research", "checkpoint", "resume", "notify", "registry-list",
-    ]),
+    (
+        "Configuration",
+        [
+            "config",
+            "profile",
+            "install",
+            "self-update",
+            "runners",
+            "usage",
+            "serve-mcp",
+        ],
+    ),
+    (
+        "Validation & Recovery",
+        [
+            "leakage-check",
+            "validate-research",
+            "checkpoint",
+            "resume",
+            "notify",
+            "registry-list",
+        ],
+    ),
 ]
 
 
@@ -87,8 +171,7 @@ class _GroupedHelpParser(argparse.ArgumentParser):
 
         if not refactory_filter:
             ungrouped = [
-                c for c in help_map
-                if c not in grouped_cmds and c in sub_action._name_parser_map
+                c for c in help_map if c not in grouped_cmds and c in sub_action._name_parser_map
             ]
             if ungrouped:
                 lines = [f"  {cmd:25s}{help_map[cmd]}" for cmd in ungrouped]
@@ -104,7 +187,8 @@ def build_parser() -> argparse.ArgumentParser:
         description="Remote Factory — domain-agnostic multi-agent software evolution loop",
     )
     parser.add_argument(
-        "--refactory-agent", action="store_true",
+        "--refactory-agent",
+        action="store_true",
         help="Show only commands used by the re:factory agent",
     )
     sub = parser.add_subparsers(dest="command")
@@ -128,16 +212,23 @@ def build_parser() -> argparse.ArgumentParser:
     # eval
     p = sub.add_parser("eval", help="Run project evals, print JSON CompositeScore")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--skip-project-eval", action="store_true", default=False,
-                    help="Skip user-defined project eval dimensions (run only hygiene + growth)")
+    p.add_argument(
+        "--skip-project-eval",
+        action="store_true",
+        default=False,
+        help="Skip user-defined project eval dimensions (run only hygiene + growth)",
+    )
 
     # guard
     p = sub.add_parser("guard", help="Check guard rules, print violations or 'clean'")
     p.add_argument("path", help="Path to the project")
     p.add_argument("--baseline", required=True, help="Baseline commit SHA")
     p.add_argument("--check-scope", action="store_true", help="Also check file scope")
-    p.add_argument("--check-surfaces", action="store_true",
-                    help="Also check fixed surface constraints (research mode)")
+    p.add_argument(
+        "--check-surfaces",
+        action="store_true",
+        help="Also check fixed surface constraints (research mode)",
+    )
 
     # begin
     p = sub.add_parser("begin", help="Start experiment, print ID")
@@ -148,8 +239,9 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("finalize", help="Finalize experiment with verdict")
     p.add_argument("path", help="Path to the project")
     p.add_argument("--id", required=True, type=int, help="Experiment ID")
-    p.add_argument("--verdict", required=True, choices=["keep", "revert", "error"],
-                    help="Experiment verdict")
+    p.add_argument(
+        "--verdict", required=True, choices=["keep", "revert", "error"], help="Experiment verdict"
+    )
     p.add_argument("--hypothesis", default=None, help="Hypothesis text")
     p.add_argument("--summary", default=None, help="Change summary")
     p.add_argument("--cost", default=None, type=float, help="Cost in USD")
@@ -158,8 +250,12 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--notes", default=None, help="Additional notes")
     p.add_argument("--score-before", type=float, default=None, help="Eval score before change")
     p.add_argument("--score-after", type=float, default=None, help="Eval score after change")
-    p.add_argument("--force", action="store_true", default=False,
-                    help="Bypass precheck gate (for pre-existing failures)")
+    p.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Bypass precheck gate (for pre-existing failures)",
+    )
 
     # history
     p = sub.add_parser("history", help="Print formatted experiment history table")
@@ -173,16 +269,20 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("study", help="Read interaction logs and write observations")
     p.add_argument("path", help="Path to the project")
     p.add_argument(
-        "--projects-dir", default=None,
+        "--projects-dir",
+        default=None,
         help="Directory containing factory-managed projects for cross-project insights",
     )
     p.add_argument(
-        "--focus", default=None,
+        "--focus",
+        default=None,
         help="Targeted mode: filter observations to a single backlog item",
     )
 
     # backlog-remove (alias: deferred-remove)
-    p = sub.add_parser("backlog-remove", aliases=["deferred-remove"], help="Remove a completed backlog item")
+    p = sub.add_parser(
+        "backlog-remove", aliases=["deferred-remove"], help="Remove a completed backlog item"
+    )
     p.add_argument("path", help="Path to the project")
     p.add_argument("item", help="Exact text of the backlog item to remove")
 
@@ -204,29 +304,48 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("path", help="Path to the project")
 
     # leakage-check
-    p = sub.add_parser("leakage-check", help="Scan text for ground truth leakage against fixed surfaces")
+    p = sub.add_parser(
+        "leakage-check", help="Scan text for ground truth leakage against fixed surfaces"
+    )
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--text", default=None, help="Text to scan for leakage (hypothesis, strategy, etc.)")
-    p.add_argument("--text-file", default=None, help="Path to file containing text to scan (safer for large diffs)")
-    p.add_argument("--sensitivity", choices=["low", "medium", "high"], default="medium",
-                    help="Sensitivity level (default: medium)")
+    p.add_argument(
+        "--text", default=None, help="Text to scan for leakage (hypothesis, strategy, etc.)"
+    )
+    p.add_argument(
+        "--text-file",
+        default=None,
+        help="Path to file containing text to scan (safer for large diffs)",
+    )
+    p.add_argument(
+        "--sensitivity",
+        choices=["low", "medium", "high"],
+        default="medium",
+        help="Sensitivity level (default: medium)",
+    )
 
     # validate-research
-    p = sub.add_parser("validate-research", help="Validate research mode configuration for ground truth isolation")
+    p = sub.add_parser(
+        "validate-research", help="Validate research mode configuration for ground truth isolation"
+    )
     p.add_argument("path", help="Path to the project")
 
     # adversarial-state
     p = sub.add_parser("adversarial-state", help="Inspect or reset adversarial eval loop state")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--reset", action="store_true", default=False,
-                    help="Reset adversarial state to defaults")
+    p.add_argument(
+        "--reset", action="store_true", default=False, help="Reset adversarial state to defaults"
+    )
 
     # backfill-citations
-    p = sub.add_parser("backfill-citations", help="Extract citations from experiment text into citations.json")
+    p = sub.add_parser(
+        "backfill-citations", help="Extract citations from experiment text into citations.json"
+    )
     p.add_argument("path", help="Path to the project")
 
     # backfill-archive
-    p = sub.add_parser("backfill-archive", help="Generate archive notes for experiments missing from archive")
+    p = sub.add_parser(
+        "backfill-archive", help="Generate archive notes for experiments missing from archive"
+    )
     p.add_argument("path", help="Path to the project")
 
     # research
@@ -252,7 +371,8 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("insights", help="Cross-project analysis of experiment histories")
     p.add_argument("path", help="Path to the project (insights.md written here)")
     p.add_argument(
-        "--projects-dir", default=None,
+        "--projects-dir",
+        default=None,
         help="Directory containing factory-managed projects (default: from registry or ~/factory-projects)",
     )
 
@@ -267,11 +387,14 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("ace", help="Run ACE self-improvement on agent playbooks")
     p.add_argument("path", help="Path to the project")
     p.add_argument(
-        "--projects-dir", default=None,
+        "--projects-dir",
+        default=None,
         help="Directory containing factory-managed projects (default: from registry or ~/factory-projects)",
     )
     p.add_argument(
-        "--dry-run", action="store_true", default=False,
+        "--dry-run",
+        action="store_true",
+        default=False,
         help="Print candidates without writing playbooks",
     )
 
@@ -294,19 +417,28 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--score-after", type=float, default=None, help="Eval score after change")
     p.add_argument("--hypothesis", default=None, help="Current experiment hypothesis")
     p.add_argument("--baseline", default=None, help="Baseline commit SHA for scope check")
-    p.add_argument("--similarity-threshold", type=float, default=0.6,
-                    help="Similarity threshold for anti-pattern detection (default: 0.6)")
+    p.add_argument(
+        "--similarity-threshold",
+        type=float,
+        default=0.6,
+        help="Similarity threshold for anti-pattern detection (default: 0.6)",
+    )
 
     # clean-pr
     p = sub.add_parser("clean-pr", help="Strip non-essential artifacts from a PR diff")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--exp", type=int, default=None, help="Experiment ID (archives full diff before stripping)")
+    p.add_argument(
+        "--exp", type=int, default=None, help="Experiment ID (archives full diff before stripping)"
+    )
 
     # baseline
     p = sub.add_parser("baseline", help="Fetch stored eval baseline from eval-data branch")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--commit", default=None,
-                    help="Commit SHA to look up (default: git merge-base HEAD <target-branch>)")
+    p.add_argument(
+        "--commit",
+        default=None,
+        help="Commit SHA to look up (default: git merge-base HEAD <target-branch>)",
+    )
 
     # refine-status
     p = sub.add_parser("refine-status", help="Print refinement state and regrounding output")
@@ -320,49 +452,66 @@ def build_parser() -> argparse.ArgumentParser:
     # refine-complete
     p = sub.add_parser("refine-complete", help="Complete the current refinement with a verdict")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--verdict", required=True, choices=["keep", "revert", "error", "tier3_exit"],
-                    help="Refinement verdict")
+    p.add_argument(
+        "--verdict",
+        required=True,
+        choices=["keep", "revert", "error", "tier3_exit"],
+        help="Refinement verdict",
+    )
 
     # review
     p = sub.add_parser("review", help="Format and post a structured review on a GitHub PR")
-    p.add_argument("--verdict", required=True, choices=["keep", "revert", "KEEP", "REVERT"],
-                    help="Review verdict")
+    p.add_argument(
+        "--verdict",
+        required=True,
+        choices=["keep", "revert", "KEEP", "REVERT"],
+        help="Review verdict",
+    )
     p.add_argument("--reason", default=None, help="One-sentence reason for the verdict")
     p.add_argument("--score-before", type=float, default=None, help="Score before change")
     p.add_argument("--score-after", type=float, default=None, help="Score after change")
     p.add_argument("--threshold", type=float, default=0.8, help="Eval threshold")
-    p.add_argument("--guards", default=None,
-                    help="Guard results as 'check:PASS,check:FAIL' pairs")
+    p.add_argument("--guards", default=None, help="Guard results as 'check:PASS,check:FAIL' pairs")
     p.add_argument("--precheck-summary", default=None, help="Precheck gate output summary")
-    p.add_argument("--code-notes", default=None,
-                    help="Code review notes separated by | (pipe)")
+    p.add_argument("--code-notes", default=None, help="Code review notes separated by | (pipe)")
     p.add_argument("--experiment-id", type=int, default=None, help="Experiment ID")
     p.add_argument("--hypothesis", default=None, help="Experiment hypothesis text")
     p.add_argument("--pr", type=int, default=None, help="PR number to post review on")
     p.add_argument("--repo", default=None, help="GitHub repo (owner/name) for the PR")
-    p.add_argument("--qa-body-file", default=None,
-                    help="Path to file containing QA analysis to include in review")
-    p.add_argument("--dry-run", action="store_true", default=False,
-                    help="Print review without posting")
+    p.add_argument(
+        "--qa-body-file",
+        default=None,
+        help="Path to file containing QA analysis to include in review",
+    )
+    p.add_argument(
+        "--dry-run", action="store_true", default=False, help="Print review without posting"
+    )
 
     # checkpoint
-    p = sub.add_parser("checkpoint", help="Show or save a CEO checkpoint for crash-resilient resume")
+    p = sub.add_parser(
+        "checkpoint", help="Show or save a CEO checkpoint for crash-resilient resume"
+    )
     p.add_argument("path", help="Path to the project")
     ckpt_action = p.add_mutually_exclusive_group()
     ckpt_action.add_argument("--save", action="store_true", default=False, help="Save a checkpoint")
-    ckpt_action.add_argument("--clear", action="store_true", default=False,
-                              help="Clear the checkpoint file")
+    ckpt_action.add_argument(
+        "--clear", action="store_true", default=False, help="Clear the checkpoint file"
+    )
     p.add_argument("--mode", default=None, help="CEO mode (e.g. improve, build)")
     p.add_argument("--experiment", type=int, default=None, help="Active experiment ID")
-    p.add_argument("--completed", default=None,
-                    help="Comma-separated list of completed agent roles")
-    p.add_argument("--pending", default=None,
-                    help="Comma-separated list of pending agent roles")
-    p.add_argument("--scores", default=None,
-                    help="JSON dict of eval scores (e.g. '{\"tests\": 0.9}')")
+    p.add_argument(
+        "--completed", default=None, help="Comma-separated list of completed agent roles"
+    )
+    p.add_argument("--pending", default=None, help="Comma-separated list of pending agent roles")
+    p.add_argument(
+        "--scores", default=None, help="JSON dict of eval scores (e.g. '{\"tests\": 0.9}')"
+    )
     p.add_argument("--hypothesis", default=None, help="Current hypothesis text")
-    p.add_argument("--completed-hypotheses", default=None,
-                    help="Comma-separated list of completed experiment IDs (e.g. '1,2,3')")
+    p.add_argument(
+        "--completed-hypotheses",
+        default=None,
+        help="Comma-separated list of completed experiment IDs (e.g. '1,2,3')",
+    )
 
     # resume
     p = sub.add_parser("resume", help="Load checkpoint and display resume context")
@@ -387,7 +536,10 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("self-update", help="Upgrade the factory CLI to the latest version")
 
     # install — install Factory agents as Claude Code or Codex CLI agents
-    p = sub.add_parser("install", help="Install Factory agents as CLI agents (~/.claude/agents/ or ~/.codex/agents/)")
+    p = sub.add_parser(
+        "install",
+        help="Install Factory agents as CLI agents (~/.claude/agents/ or ~/.codex/agents/)",
+    )
     p.add_argument(
         "--role",
         default=None,
@@ -403,15 +555,15 @@ def build_parser() -> argparse.ArgumentParser:
     # usage — token usage breakdown
     p = sub.add_parser("usage", help="Show per-agent token usage and cost breakdown")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--json", action="store_true", default=False,
-                    help="Output as JSON instead of table")
+    p.add_argument(
+        "--json", action="store_true", default=False, help="Output as JSON instead of table"
+    )
 
     # runners — runner management
     runners_parser = sub.add_parser("runners", help="Manage factory runners")
     runners_sub = runners_parser.add_subparsers(dest="runners_command")
     p_runners_list = runners_sub.add_parser("list", help="List all registered runners")
-    p_runners_list.add_argument("--json", action="store_true", default=False,
-                                help="Output as JSON")
+    p_runners_list.add_argument("--json", action="store_true", default=False, help="Output as JSON")
 
     # serve-mcp — MCP stdio server
     sub.add_parser("serve-mcp", help="Start the Factory MCP stdio server")
@@ -419,7 +571,8 @@ def build_parser() -> argparse.ArgumentParser:
     # dashboard — live web dashboard
     p = sub.add_parser("dashboard", help="Launch the live Factory dashboard")
     p.add_argument(
-        "--projects-dir", default="~/factory-projects",
+        "--projects-dir",
+        default="~/factory-projects",
         help="Directory containing factory-managed projects (default: ~/factory-projects)",
     )
     p.add_argument("--port", type=int, default=8420, help="Server port (default: 8420)")
@@ -429,21 +582,34 @@ def build_parser() -> argparse.ArgumentParser:
     config_parser = sub.add_parser("config", help="Manage ~/.factory/config.toml")
     config_sub = config_parser.add_subparsers(dest="config_command")
     p_show = config_sub.add_parser("show", help="Show resolved config (secrets masked)")
-    p_show.add_argument("--reveal", action="store_true", default=False,
-                        help="Show full secret values instead of masking")
+    p_show.add_argument(
+        "--reveal",
+        action="store_true",
+        default=False,
+        help="Show full secret values instead of masking",
+    )
     config_sub.add_parser("edit", help="Open config.toml in $EDITOR")
     config_sub.add_parser("migrate", help="Create starter config.toml from current env vars")
 
     # profile — user profile management
-    profile_parser = sub.add_parser("profile", help="Manage the user profile at ~/.factory/profile.md")
+    profile_parser = sub.add_parser(
+        "profile", help="Manage the user profile at ~/.factory/profile.md"
+    )
     profile_sub = profile_parser.add_subparsers(dest="profile_command")
     p_build = profile_sub.add_parser("build", help="Collect evidence and synthesize user profile")
-    p_build.add_argument("paths", nargs="*", default=None,
-                         help="Project paths to collect evidence from (default: all registered)")
-    p_build.add_argument("--dry-run", action="store_true", default=False,
-                         help="Print collected evidence without running LLM synthesis")
-    p_build.add_argument("--runner", default=None,
-                         help="CLI backend to use for synthesis")
+    p_build.add_argument(
+        "paths",
+        nargs="*",
+        default=None,
+        help="Project paths to collect evidence from (default: all registered)",
+    )
+    p_build.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Print collected evidence without running LLM synthesis",
+    )
+    p_build.add_argument("--runner", default=None, help="CLI backend to use for synthesis")
     profile_sub.add_parser("show", help="Print the current user profile")
 
     # emit — emit a structured event to .factory/events.jsonl
@@ -455,183 +621,350 @@ def build_parser() -> argparse.ArgumentParser:
 
     # agent — invoke a specialist agent directly
     p = sub.add_parser("agent", help="Invoke a specialist agent with a task")
-    p.add_argument("role", choices=["researcher", "strategist", "builder", "qa",
-                                     "health_checker", "code_reviewer",
-                                     "adversarial_tester",
-                                     "archivist", "ceo",
-                                     "failure_analyst", "refiner"],
-                    help="Agent role to invoke")
+    p.add_argument(
+        "role",
+        choices=[
+            "researcher",
+            "strategist",
+            "builder",
+            "qa",
+            "health_checker",
+            "code_reviewer",
+            "adversarial_tester",
+            "archivist",
+            "ceo",
+            "failure_analyst",
+            "refiner",
+        ],
+        help="Agent role to invoke",
+    )
     p.add_argument("--task", required=True, help="Task description for the agent")
     p.add_argument("--project", required=True, help="Path to the project")
-    p.add_argument("--timeout", type=float, default=600.0,
-                    help="Timeout in seconds (default: 600)")
-    p.add_argument("--model", default=None,
-                    help="Claude model for agent subprocess (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", default=None,
-                    help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
-    p.add_argument("--profile", default=None,
-                    help="Credential profile from ~/.factory/config.toml")
-    p.add_argument("--use-profile", action="store_true", default=False,
-                    help="Inject user profile (~/.factory/profile.md) into the agent prompt")
-    p.add_argument("--tmux-persist", action="store_true", default=False,
-                    help="Run agent interactively in a tmux window instead of headless (claude only)")
-    p.add_argument("--bg", action="store_true", default=False,
-                    help="Dispatch agent as a background session via claude agent view (claude only)")
-    p.add_argument("--review-tag", default=None,
-                    help="Tag for distinct review output files (writes <role>-<tag>-latest.md)")
-    p.add_argument("--parent-session", default=None,
-                    help="Parent session ID for linking specialist sessions to a CEO cycle session")
+    p.add_argument("--timeout", type=float, default=600.0, help="Timeout in seconds (default: 600)")
+    p.add_argument(
+        "--model",
+        default=None,
+        help="Claude model for agent subprocess (default: FACTORY_MODEL env var, or claude CLI default)",
+    )
+    p.add_argument(
+        "--runner",
+        default=None,
+        help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')",
+    )
+    p.add_argument("--profile", default=None, help="Credential profile from ~/.factory/config.toml")
+    p.add_argument(
+        "--use-profile",
+        action="store_true",
+        default=False,
+        help="Inject user profile (~/.factory/profile.md) into the agent prompt",
+    )
+    p.add_argument(
+        "--tmux-persist",
+        action="store_true",
+        default=False,
+        help="Run agent interactively in a tmux window instead of headless (claude only)",
+    )
+    p.add_argument(
+        "--bg",
+        action="store_true",
+        default=False,
+        help="Dispatch agent as a background session via claude agent view (claude only)",
+    )
+    p.add_argument(
+        "--review-tag",
+        default=None,
+        help="Tag for distinct review output files (writes <role>-<tag>-latest.md)",
+    )
+    p.add_argument(
+        "--parent-session",
+        default=None,
+        help="Parent session ID for linking specialist sessions to a CEO cycle session",
+    )
 
     # ceo — launch the Factory CEO agent directly
     p = sub.add_parser("ceo", help="Launch the Factory CEO agent (interactive by default)")
-    p.add_argument("path", nargs="?", default=None,
-                    help="Project path, GitHub URL, idea file path, or prompt. "
-                         "In design mode, pass a raw idea string")
     p.add_argument(
-        "--prompt", default=None,
+        "path",
+        nargs="?",
+        default=None,
+        help="Project path, GitHub URL, idea file path, or prompt. "
+        "In design mode, pass a raw idea string",
+    )
+    p.add_argument(
+        "--prompt",
+        default=None,
         help="Path to a prompt/spec file (absolute or relative to project). "
-             "Loaded as the build spec into .factory/strategy/current.md",
+        "Loaded as the build spec into .factory/strategy/current.md",
     )
     p.add_argument(
         "--mode",
         choices=CEO_MODES,
         default="auto",
         help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
-             "build, discover, improve, meta, design (research + brainstorm → spec → build), "
-             "research (autonomous research optimization), review (on-demand PR review), "
-             "qa (QA verification pipeline for PRs), "
-             "or create (meta-mode for creating new factory modes)",
+        "build, discover, improve, meta, design (research + brainstorm → spec → build), "
+        "research (autonomous research optimization), review (on-demand PR review), "
+        "qa (QA verification pipeline for PRs), "
+        "or create (meta-mode for creating new factory modes)",
     )
     p.add_argument(
-        "--focus", default=None,
+        "--focus",
+        default=None,
         help="Target a specific item: backlog name ('dashboard UI'), issue number (42), "
-             "URL (https://github.com/o/r/issues/42), or shorthand (owner/repo#42). "
-             "Issue refs are auto-detected and fetched via gh/glab CLI",
+        "URL (https://github.com/o/r/issues/42), or shorthand (owner/repo#42). "
+        "Issue refs are auto-detected and fetched via gh/glab CLI",
     )
     p.add_argument(
-        "--dir", default=None,
+        "--dir",
+        default=None,
         help="Working directory name for the new project (overrides auto-derived name from prompt or idea file). "
-             "Ignored when pointing at an existing directory or GitHub URL.",
+        "Ignored when pointing at an existing directory or GitHub URL.",
     )
     p.add_argument(
-        "--headless", action="store_true", default=False,
+        "--headless",
+        action="store_true",
+        default=False,
         help="Run in pipe mode (non-interactive) instead of foreground",
     )
     p.add_argument(
-        "--discover-only", action="store_true", default=False,
+        "--discover-only",
+        action="store_true",
+        default=False,
         help="Only run discovery and review — do not chain into improve",
     )
     p.add_argument(
-        "--no-github", action="store_true", default=False,
+        "--no-github",
+        action="store_true",
+        default=False,
         help="Disable GitHub operations (issue creation, PR posting, cloning)",
     )
-    p.add_argument("--min-growth", type=int, default=None,
-                    help="Minimum guaranteed growth hypotheses (default: 2)")
-    p.add_argument("--max-new", type=int, default=None,
-                    help="Max new items added to backlog per cycle (default: 2)")
-    p.add_argument("--branch", default=None,
-                    help="Target branch for PRs (default: from factory.md, fallback: main)")
-    p.add_argument("--model", default=None,
-                    help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", default=None,
-                    help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
-    p.add_argument("--profile", default=None,
-                    help="Credential profile from ~/.factory/config.toml")
     p.add_argument(
-        "--refine", default=None, metavar="REQUEST",
-        help="Refinement mode: classify and implement a user-directed change. "
-             "Mutually exclusive with --mode design, --mode research, --mode meta, --prompt, --focus",
+        "--min-growth",
+        type=int,
+        default=None,
+        help="Minimum guaranteed growth hypotheses (default: 2)",
     )
-    p.add_argument("--use-profile", action="store_true", default=False,
-                    help="Inject user profile (~/.factory/profile.md) into agent prompts")
+    p.add_argument(
+        "--max-new",
+        type=int,
+        default=None,
+        help="Max new items added to backlog per cycle (default: 2)",
+    )
+    p.add_argument(
+        "--branch",
+        default=None,
+        help="Target branch for PRs (default: from factory.md, fallback: main)",
+    )
+    p.add_argument(
+        "--model",
+        default=None,
+        help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)",
+    )
+    p.add_argument(
+        "--runner",
+        default=None,
+        help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')",
+    )
+    p.add_argument("--profile", default=None, help="Credential profile from ~/.factory/config.toml")
+    p.add_argument(
+        "--refine",
+        default=None,
+        metavar="REQUEST",
+        help="Refinement mode: classify and implement a user-directed change. "
+        "Mutually exclusive with --mode design, --mode research, --mode meta, --prompt, --focus",
+    )
+    p.add_argument(
+        "--use-profile",
+        action="store_true",
+        default=False,
+        help="Inject user profile (~/.factory/profile.md) into agent prompts",
+    )
     clean_pr_group = p.add_mutually_exclusive_group()
-    clean_pr_group.add_argument("--clean-pr", action="store_true", default=None, dest="clean_pr",
-                                help="Enable clean PR mode: strip non-essential artifacts before PR")
-    clean_pr_group.add_argument("--no-clean-pr", action="store_false", dest="clean_pr",
-                                help="Disable clean PR mode")
-    p.add_argument("--tmux-persist", action="store_true", default=False,
-                    help="Run agent interactively in a tmux window instead of headless (claude only)")
-    p.add_argument("--bg", action="store_true", default=False,
-                    help="Dispatch agent as a background session via claude agent view (claude only)")
-    p.add_argument("--bg-agents", action="store_true", default=False,
-                    help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground")
-    p.add_argument("--pr", type=int, default=None,
-                    help="PR number for --mode review or --mode deep-qa (required when mode=review or mode=deep-qa)")
-    p.add_argument("--repo", default=None,
-                    help="Repository (owner/repo) for --mode review or --mode deep-qa (optional, defaults to current repo)")
-    p.add_argument("--run-id", default=None, dest="run_id",
-                    help="Use a specific run ID (e.g., UUID from external orchestrator). "
-                         "First 8 chars are used for worktree naming")
+    clean_pr_group.add_argument(
+        "--clean-pr",
+        action="store_true",
+        default=None,
+        dest="clean_pr",
+        help="Enable clean PR mode: strip non-essential artifacts before PR",
+    )
+    clean_pr_group.add_argument(
+        "--no-clean-pr", action="store_false", dest="clean_pr", help="Disable clean PR mode"
+    )
+    p.add_argument(
+        "--tmux-persist",
+        action="store_true",
+        default=False,
+        help="Run agent interactively in a tmux window instead of headless (claude only)",
+    )
+    p.add_argument(
+        "--bg",
+        action="store_true",
+        default=False,
+        help="Dispatch agent as a background session via claude agent view (claude only)",
+    )
+    p.add_argument(
+        "--bg-agents",
+        action="store_true",
+        default=False,
+        help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground",
+    )
+    p.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="PR number for --mode review or --mode deep-qa (required when mode=review or mode=deep-qa)",
+    )
+    p.add_argument(
+        "--repo",
+        default=None,
+        help="Repository (owner/repo) for --mode review or --mode deep-qa (optional, defaults to current repo)",
+    )
+    p.add_argument(
+        "--run-id",
+        default=None,
+        dest="run_id",
+        help="Use a specific run ID (e.g., UUID from external orchestrator). "
+        "First 8 chars are used for worktree naming",
+    )
+    p.add_argument(
+        "--no-worktree",
+        action="store_true",
+        default=False,
+        dest="no_worktree",
+        help="Run directly in the project directory without creating a worktree "
+        "(useful for testing in-flight branch changes)",
+    )
 
     # run
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
     p.add_argument("path", help="Project path, GitHub URL, idea file path, or prompt")
     p.add_argument(
-        "--prompt", default=None,
+        "--prompt",
+        default=None,
         help="Path to a prompt/spec file (absolute or relative to project). "
-             "Loaded as the build spec into .factory/strategy/current.md",
+        "Loaded as the build spec into .factory/strategy/current.md",
     )
     p.add_argument(
         "--mode",
         choices=RUN_MODES,
         default="auto",
         help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
-             "build, discover, improve, meta, or research",
+        "build, discover, improve, meta, or research",
     )
     p.add_argument(
-        "--focus", default=None,
+        "--focus",
+        default=None,
         help="Target a specific item: backlog name ('dashboard UI'), issue number (42), "
-             "URL (https://github.com/o/r/issues/42), or shorthand (owner/repo#42). "
-             "Issue refs are auto-detected and fetched via gh/glab CLI",
+        "URL (https://github.com/o/r/issues/42), or shorthand (owner/repo#42). "
+        "Issue refs are auto-detected and fetched via gh/glab CLI",
     )
     p.add_argument(
-        "--discover-only", action="store_true", default=False,
+        "--discover-only",
+        action="store_true",
+        default=False,
         help="Only run discovery and review — do not chain into improve",
     )
     p.add_argument(
-        "--no-github", action="store_true", default=False,
+        "--no-github",
+        action="store_true",
+        default=False,
         help="Disable GitHub operations (issue creation, PR posting, cloning)",
     )
     p.add_argument(
-        "--loop", action="store_true", default=False,
+        "--loop",
+        action="store_true",
+        default=False,
         help="Enable heartbeat mode: run continuously with sleep between cycles",
     )
     p.add_argument(
-        "--interval", type=int, default=1800,
+        "--interval",
+        type=int,
+        default=1800,
         help="Seconds to sleep between cycles (default: 1800)",
     )
     p.add_argument(
-        "--max-cycles", type=int, default=None,
+        "--max-cycles",
+        type=int,
+        default=None,
         help="Maximum number of cycles (default: unlimited)",
     )
-    p.add_argument("--min-growth", type=int, default=None,
-                    help="Minimum guaranteed growth hypotheses (default: 2)")
-    p.add_argument("--max-new", type=int, default=None,
-                    help="Max new items added to backlog per cycle (default: 2)")
-    p.add_argument("--branch", default=None,
-                    help="Target branch for PRs (default: from factory.md, fallback: main)")
-    p.add_argument("--model", default=None,
-                    help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", default=None,
-                    help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
-    p.add_argument("--profile", default=None,
-                    help="Credential profile from ~/.factory/config.toml")
-    p.add_argument("--use-profile", action="store_true", default=False,
-                    help="Inject user profile (~/.factory/profile.md) into agent prompts")
+    p.add_argument(
+        "--min-growth",
+        type=int,
+        default=None,
+        help="Minimum guaranteed growth hypotheses (default: 2)",
+    )
+    p.add_argument(
+        "--max-new",
+        type=int,
+        default=None,
+        help="Max new items added to backlog per cycle (default: 2)",
+    )
+    p.add_argument(
+        "--branch",
+        default=None,
+        help="Target branch for PRs (default: from factory.md, fallback: main)",
+    )
+    p.add_argument(
+        "--model",
+        default=None,
+        help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)",
+    )
+    p.add_argument(
+        "--runner",
+        default=None,
+        help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')",
+    )
+    p.add_argument("--profile", default=None, help="Credential profile from ~/.factory/config.toml")
+    p.add_argument(
+        "--use-profile",
+        action="store_true",
+        default=False,
+        help="Inject user profile (~/.factory/profile.md) into agent prompts",
+    )
     run_clean_pr_group = p.add_mutually_exclusive_group()
-    run_clean_pr_group.add_argument("--clean-pr", action="store_true", default=None, dest="clean_pr",
-                                    help="Enable clean PR mode: strip non-essential artifacts before PR")
-    run_clean_pr_group.add_argument("--no-clean-pr", action="store_false", dest="clean_pr",
-                                    help="Disable clean PR mode")
-    p.add_argument("--tmux-persist", action="store_true", default=False,
-                    help="Run agent interactively in a tmux window instead of headless (claude only)")
-    p.add_argument("--bg", action="store_true", default=False,
-                    help="Dispatch agent as a background session via claude agent view (claude only)")
-    p.add_argument("--bg-agents", action="store_true", default=False,
-                    help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground")
-    p.add_argument("--run-id", default=None, dest="run_id",
-                    help="Use a specific run ID (e.g., UUID from external orchestrator). "
-                         "First 8 chars are used for worktree naming")
+    run_clean_pr_group.add_argument(
+        "--clean-pr",
+        action="store_true",
+        default=None,
+        dest="clean_pr",
+        help="Enable clean PR mode: strip non-essential artifacts before PR",
+    )
+    run_clean_pr_group.add_argument(
+        "--no-clean-pr", action="store_false", dest="clean_pr", help="Disable clean PR mode"
+    )
+    p.add_argument(
+        "--tmux-persist",
+        action="store_true",
+        default=False,
+        help="Run agent interactively in a tmux window instead of headless (claude only)",
+    )
+    p.add_argument(
+        "--bg",
+        action="store_true",
+        default=False,
+        help="Dispatch agent as a background session via claude agent view (claude only)",
+    )
+    p.add_argument(
+        "--bg-agents",
+        action="store_true",
+        default=False,
+        help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground",
+    )
+    p.add_argument(
+        "--run-id",
+        default=None,
+        dest="run_id",
+        help="Use a specific run ID (e.g., UUID from external orchestrator). "
+        "First 8 chars are used for worktree naming",
+    )
+    p.add_argument(
+        "--no-worktree",
+        action="store_true",
+        default=False,
+        dest="no_worktree",
+        help="Run directly in the project directory without creating a worktree "
+        "(useful for testing in-flight branch changes)",
+    )
 
     # tmux — launch factory run in a detached tmux session
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")
@@ -646,70 +979,120 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--loop", action="store_true", default=False, help="Enable loop mode")
     p.add_argument("--interval", type=int, default=1800, help="Loop interval in seconds")
     p.add_argument("--max-cycles", type=int, default=None, help="Max cycles for loop mode")
-    p.add_argument("--attach", action="store_true", default=False,
-                    help="Attach to session after creating")
     p.add_argument(
-        "--no-github", action="store_true", default=False,
+        "--attach", action="store_true", default=False, help="Attach to session after creating"
+    )
+    p.add_argument(
+        "--no-github",
+        action="store_true",
+        default=False,
         help="Disable GitHub operations (issue creation, PR posting, cloning)",
     )
-    p.add_argument("--model", default=None,
-                    help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)")
-    p.add_argument("--runner", default=None,
-                    help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')")
-    p.add_argument("--profile", default=None,
-                    help="Credential profile from ~/.factory/config.toml")
     p.add_argument(
-        "--focus", default=None,
+        "--model",
+        default=None,
+        help="Claude model for agent subprocesses (default: FACTORY_MODEL env var, or claude CLI default)",
+    )
+    p.add_argument(
+        "--runner",
+        default=None,
+        help="CLI backend to use (default: FACTORY_RUNNER env var, or 'claude')",
+    )
+    p.add_argument("--profile", default=None, help="Credential profile from ~/.factory/config.toml")
+    p.add_argument(
+        "--focus",
+        default=None,
         help="Target a specific item: backlog name, issue number, URL, or shorthand",
     )
     p.add_argument(
-        "--refine", default=None, metavar="REQUEST",
+        "--refine",
+        default=None,
+        metavar="REQUEST",
         help="Refinement mode: classify and implement a user-directed change",
     )
     tmux_clean_pr = p.add_mutually_exclusive_group()
-    tmux_clean_pr.add_argument("--clean-pr", action="store_true", default=None, dest="clean_pr",
-                                help="Enable clean PR mode")
-    tmux_clean_pr.add_argument("--no-clean-pr", action="store_false", dest="clean_pr",
-                                help="Disable clean PR mode")
+    tmux_clean_pr.add_argument(
+        "--clean-pr",
+        action="store_true",
+        default=None,
+        dest="clean_pr",
+        help="Enable clean PR mode",
+    )
+    tmux_clean_pr.add_argument(
+        "--no-clean-pr", action="store_false", dest="clean_pr", help="Disable clean PR mode"
+    )
     p.add_argument(
-        "--prompt", default=None,
+        "--prompt",
+        default=None,
         help="Path to a prompt/spec file",
     )
-    p.add_argument("--branch", default=None,
-                    help="Target branch for PRs")
-    p.add_argument("--min-growth", type=int, default=None,
-                    help="Minimum guaranteed growth hypotheses")
-    p.add_argument("--max-new", type=int, default=None,
-                    help="Max new items added to backlog per cycle")
-    p.add_argument("--discover-only", action="store_true", default=False,
-                    help="Only run discovery and review — do not chain into improve")
-    p.add_argument("--bg-agents", action="store_true", default=False,
-                    help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground")
-    p.add_argument("--tmux-persist", action="store_true", default=False,
-                    help="Run agent interactively in a tmux window instead of headless (claude only)")
-    p.add_argument("--use-profile", action="store_true", default=False,
-                    help="Inject user profile (~/.factory/profile.md) into agent prompts")
+    p.add_argument("--branch", default=None, help="Target branch for PRs")
+    p.add_argument(
+        "--min-growth", type=int, default=None, help="Minimum guaranteed growth hypotheses"
+    )
+    p.add_argument(
+        "--max-new", type=int, default=None, help="Max new items added to backlog per cycle"
+    )
+    p.add_argument(
+        "--discover-only",
+        action="store_true",
+        default=False,
+        help="Only run discovery and review — do not chain into improve",
+    )
+    p.add_argument(
+        "--bg-agents",
+        action="store_true",
+        default=False,
+        help="Background sub-agents (via FACTORY_BG=1) while CEO runs in foreground",
+    )
+    p.add_argument(
+        "--tmux-persist",
+        action="store_true",
+        default=False,
+        help="Run agent interactively in a tmux window instead of headless (claude only)",
+    )
+    p.add_argument(
+        "--use-profile",
+        action="store_true",
+        default=False,
+        help="Inject user profile (~/.factory/profile.md) into agent prompts",
+    )
 
     # tmux-ls — list factory tmux sessions
     p = sub.add_parser("tmux-ls", help="List running factory tmux sessions")
-    p.add_argument("--json", action="store_true", default=False, dest="json_output",
-                    help="Output as JSON array for programmatic consumption")
+    p.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        dest="json_output",
+        help="Output as JSON array for programmatic consumption",
+    )
 
     # tmux-capture — capture output from a factory tmux session
     p = sub.add_parser("tmux-capture", help="Capture recent output from a factory tmux session")
     p.add_argument("path", nargs="?", default=None, help="Project path (derives session name)")
     p.add_argument("--session", default=None, help="Session name to capture from")
-    p.add_argument("--lines", type=int, default=-100, help="Number of lines to capture (default: -100)")
+    p.add_argument(
+        "--lines", type=int, default=-100, help="Number of lines to capture (default: -100)"
+    )
 
     # tmux-stop — stop factory tmux sessions
     p = sub.add_parser("tmux-stop", help="Stop factory tmux session(s)")
     p.add_argument("--session", default=None, help="Session name to stop")
     p.add_argument("--path", default=None, help="Project path (derives session name)")
-    p.add_argument("--all", action="store_true", default=False, dest="stop_all",
-                    help="Stop ALL factory tmux sessions (required when no --session/--path given)")
-    p.add_argument("--force", action="store_true", default=False,
-                    help="Force-kill a session even if it's not in the factory registry")
-
+    p.add_argument(
+        "--all",
+        action="store_true",
+        default=False,
+        dest="stop_all",
+        help="Stop ALL factory tmux sessions (required when no --session/--path given)",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Force-kill a session even if it's not in the factory registry",
+    )
 
     # spec — repo spec generation and analysis
     spec_parser = sub.add_parser("spec", help="Repo spec generation and analysis")
@@ -729,15 +1112,23 @@ def build_parser() -> argparse.ArgumentParser:
 
     # refactory — persistent supervisor agent
     p = sub.add_parser("refactory", help="Launch the re:factory persistent supervisor agent")
-    p.add_argument("path", nargs="?", default=None,
-                    help="Project directory (default: current working directory)")
-    p.add_argument("--reset", action="store_true", default=False,
-                    help="Reset session (new session ID, fresh start)")
-    p.add_argument("--model", default=None,
-                    help="Claude model override")
+    p.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        help="Project directory (default: current working directory)",
+    )
+    p.add_argument(
+        "--reset",
+        action="store_true",
+        default=False,
+        help="Reset session (new session ID, fresh start)",
+    )
+    p.add_argument("--model", default=None, help="Claude model override")
 
     # workflow — graph engine commands
     from factory.workflow.cli import add_workflow_parser
+
     add_workflow_parser(sub)  # type: ignore[arg-type]
 
     return parser
@@ -830,7 +1221,9 @@ def main(argv: list[str] | None = None) -> int:
             str(getattr(a, "spec_command", "")),
             lambda args: print("Usage: factory spec {generate,validate,scope,update,impact}") or 1,
         )(a),
-        "workflow": lambda a: __import__("factory.workflow.cli", fromlist=["cmd_workflow"]).cmd_workflow(a),
+        "workflow": lambda a: __import__(
+            "factory.workflow.cli", fromlist=["cmd_workflow"]
+        ).cmd_workflow(a),
     }
 
     try:

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -1,4 +1,5 @@
 """CLI ceo commands."""
+
 from __future__ import annotations
 
 import argparse
@@ -19,7 +20,17 @@ from pathlib import Path
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from factory.cli._helpers import _emit_cli_event, _ensure_dashboard, _is_github_url, _print_banner, _read_target_branch, _resolve_runner, _run, _safe_is_dir, _safe_is_file
+from factory.cli._helpers import (
+    _emit_cli_event,
+    _ensure_dashboard,
+    _is_github_url,
+    _print_banner,
+    _read_target_branch,
+    _resolve_runner,
+    _run,
+    _safe_is_dir,
+    _safe_is_file,
+)
 from factory.cli._wizard import (
     _CLI_REF as _CLI_REF,
     _ask_follow_ups as _ask_follow_ups,
@@ -67,8 +78,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     dir_name = getattr(args, "dir", None)
 
     if not raw_path:
-        print("Error: provide a project path, GitHub URL, idea file, or prompt",
-              file=sys.stderr)
+        print("Error: provide a project path, GitHub URL, idea file, or prompt", file=sys.stderr)
         return 1
 
     no_github = getattr(args, "no_github", False)
@@ -78,20 +88,19 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     if refine_request:
         if mode and mode != "auto":
-            print(f"Error: --refine and --mode {mode} are mutually exclusive.",
-                  file=sys.stderr)
+            print(f"Error: --refine and --mode {mode} are mutually exclusive.", file=sys.stderr)
             return 1
         if prompt_file:
-            print("Error: --refine and --prompt are mutually exclusive.",
-                  file=sys.stderr)
+            print("Error: --refine and --prompt are mutually exclusive.", file=sys.stderr)
             return 1
         if focus:
-            print("Error: --refine and --focus are mutually exclusive.",
-                  file=sys.stderr)
+            print("Error: --refine and --focus are mutually exclusive.", file=sys.stderr)
             return 1
         if not Path(raw_path).expanduser().resolve().is_dir():
-            print("Error: --refine requires an existing project directory, not a URL or idea.",
-                  file=sys.stderr)
+            print(
+                "Error: --refine requires an existing project directory, not a URL or idea.",
+                file=sys.stderr,
+            )
             return 1
 
     # ── review mode early exit ────────────────────────────────
@@ -107,8 +116,10 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
         project_path = Path(raw_path).expanduser().resolve()
         if not project_path.is_dir():
-            print(f"Error: project path must be an existing directory for review mode: {raw_path}",
-                  file=sys.stderr)
+            print(
+                f"Error: project path must be an existing directory for review mode: {raw_path}",
+                file=sys.stderr,
+            )
             return 1
 
         _print_banner("review")
@@ -127,7 +138,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             f"3. Run Hard Precheck Gate\n"
             f"4. Post verdict via "
             f"factory review --verdict <KEEP|REVERT> --pr {pr_number} "
-            f"--reason \"$REASON\" "
+            f'--reason "$REASON" '
             f"--qa-body-file .factory/reviews/adversarial-qa.md"
             f"{repo_flag}\n"
             f"\nSet $REASON to the QA verdict summary (e.g. 'QA: CLEAN — 2854 tests pass, 0 issues' "
@@ -139,21 +150,30 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
             prompt = resolve_prompt("ceo", project_path)
             runner = get_runner(runner_name)
-            return runner.interactive_run(AgentRunRequest(
-                prompt=prompt, task=task, cwd=project_path,
-                model=model, role="ceo", skip_permissions=True,
-            ))
+            return runner.interactive_run(
+                AgentRunRequest(
+                    prompt=prompt,
+                    task=task,
+                    cwd=project_path,
+                    model=model,
+                    role="ceo",
+                    skip_permissions=True,
+                )
+            )
 
         from factory.ceo_completion import run_ceo_with_completion_guard
-        result, code = _run(run_ceo_with_completion_guard(
-            project_path,
-            task,
-            mode="review",
-            runner_name=runner_name,
-            model=model,
-            timeout=7200.0,
-            max_respawns=1,
-        ))
+
+        result, code = _run(
+            run_ceo_with_completion_guard(
+                project_path,
+                task,
+                mode="review",
+                runner_name=runner_name,
+                model=model,
+                timeout=7200.0,
+                max_respawns=1,
+            )
+        )
         print(result)
         return code
 
@@ -170,8 +190,10 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
         project_path = Path(raw_path).expanduser().resolve()
         if not project_path.is_dir():
-            print(f"Error: project path must be an existing directory for qa mode: {raw_path}",
-                  file=sys.stderr)
+            print(
+                f"Error: project path must be an existing directory for qa mode: {raw_path}",
+                file=sys.stderr,
+            )
             return 1
 
         _print_banner("qa")
@@ -179,27 +201,28 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         repo_flag = f" --repo {repo}" if repo else ""
         repo_clause = f" in repo `{repo}`" if repo else ""
         task = (
-            f'Project: {project_path}\nMode: qa\n\n'
-            f'## QA Verification Directive\n\n'
-            f'Run the QA verification pipeline for PR #{pr_number}{repo_clause}.\n\n'
-            f'Read and follow the workflow-qa SKILL.md playbook at '
-            f'skills/workflow-qa/SKILL.md.\n\n'
-            f'Key parameters:\n'
-            f'- PR_NUMBER={pr_number}\n'
-            f'- PROJECT_PATH={project_path}\n'
-            f'{f"- REPO={repo}" + chr(10) if repo else ""}'
-            f'\nPost the final verdict via:\n'
-            f'factory review --verdict <KEEP|REVERT> --pr {pr_number} '
+            f"Project: {project_path}\nMode: qa\n\n"
+            f"## QA Verification Directive\n\n"
+            f"Run the QA verification pipeline for PR #{pr_number}{repo_clause}.\n\n"
+            f"Read and follow the workflow-qa SKILL.md playbook at "
+            f"skills/workflow-qa/SKILL.md.\n\n"
+            f"Key parameters:\n"
+            f"- PR_NUMBER={pr_number}\n"
+            f"- PROJECT_PATH={project_path}\n"
+            f"{f'- REPO={repo}' + chr(10) if repo else ''}"
+            f"\nPost the final verdict via:\n"
+            f"factory review --verdict <KEEP|REVERT> --pr {pr_number} "
             f'--reason "$REASON" '
-            f'--qa-body-file .factory/reviews/qa-latest.md'
-            f'{repo_flag}\n'
+            f"--qa-body-file .factory/reviews/qa-latest.md"
+            f"{repo_flag}\n"
             f'\nSet $REASON to the QA verdict summary (e.g. "QA: CLEAN — 2854 tests pass, 0 issues" '
             f'or "QA: ISSUES_FOUND — 3 critical issues"). Set $VERDICT to KEEP if QA is CLEAN, REVERT otherwise.\n'
-            f'\nIMPORTANT: Do NOT post any PR comments (gh pr comment, gh issue comment). '
-            f'The factory review command above is the ONLY GitHub output artifact.\n'
+            f"\nIMPORTANT: Do NOT post any PR comments (gh pr comment, gh issue comment). "
+            f"The factory review command above is the ONLY GitHub output artifact.\n"
         )
 
         from factory.agents.runner import begin_cycle_session, complete_cycle_session
+
         cycle_span_id = begin_cycle_session(project_path, cycle_id="qa", model=model)
 
         if not headless:
@@ -207,140 +230,86 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
             prompt = resolve_prompt("ceo", project_path)
             runner = get_runner(runner_name)
-            rc = runner.interactive_run(AgentRunRequest(
-                prompt=prompt, task=task, cwd=project_path,
-                model=model, role="ceo", skip_permissions=True,
-            ))
+            rc = runner.interactive_run(
+                AgentRunRequest(
+                    prompt=prompt,
+                    task=task,
+                    cwd=project_path,
+                    model=model,
+                    role="ceo",
+                    skip_permissions=True,
+                )
+            )
             complete_cycle_session(project_path, cycle_span_id)
             return rc
 
         from factory.ceo_completion import run_ceo_with_completion_guard
-        result, code = _run(run_ceo_with_completion_guard(
-            project_path,
-            task,
-            mode="qa",
-            runner_name=runner_name,
-            model=model,
-            timeout=7200.0,
-            max_respawns=1,
-        ))
-        complete_cycle_session(project_path, cycle_span_id)
-        print(result)
-        return code
 
-    # ── deep-qa mode early exit ───────────────────────────────
-    if mode == "deep-qa":
-        pr_number = getattr(args, "pr", None)
-        if pr_number is None:
-            print("Error: --mode deep-qa requires --pr <number>", file=sys.stderr)
-            return 1
-
-        repo = getattr(args, "repo", None)
-        model = _resolve_model(args)
-        runner_name = _resolve_runner(args)
-
-        project_path = Path(raw_path).expanduser().resolve()
-        if not project_path.is_dir():
-            print(f"Error: project path must be an existing directory for deep-qa mode: {raw_path}",
-                  file=sys.stderr)
-            return 1
-
-        _print_banner("deep-qa")
-
-        repo_flag = f" --repo {repo}" if repo else ""
-        repo_clause = f" in repo `{repo}`" if repo else ""
-        task = (
-            f"Project: {project_path}\nMode: deep-qa\n\n"
-            f"## Deep-QA Verification Directive\n\n"
-            f"Run the deep-QA verification pipeline for PR #{pr_number}{repo_clause}.\n\n"
-            f"Execute the 3-specialist pipeline:\n"
-            f"1. health_checker — run eval, compare scores, write health-check.md\n"
-            f"2. code_reviewer — 7-category code review, write code-review.md\n"
-            f"3. adversarial_tester — skeptical feature testing, write adversarial-qa.md\n\n"
-            f"Key parameters:\n"
-            f"- PR_NUMBER={pr_number}\n"
-            f"- PROJECT_PATH={project_path}\n"
-            f"{f'- REPO={repo}' + chr(10) if repo else ''}"
-            f"\nPost the final verdict via:\n"
-            f"factory review --verdict <KEEP|REVERT> --pr {pr_number} "
-            f"--reason \"$REASON\" "
-            f"--qa-body-file .factory/reviews/adversarial-qa.md"
-            f"{repo_flag}\n"
-            f"\nSet $REASON to the QA verdict summary (e.g. 'QA: CLEAN — 2854 tests pass, 0 issues' "
-            f"or 'QA: ISSUES_FOUND — 3 critical issues'). Set $VERDICT to KEEP if QA is CLEAN, REVERT otherwise.\n"
-            f"\nIMPORTANT: Do NOT post any PR comments (gh pr comment, gh issue comment). "
-            f"The factory review command above is the ONLY GitHub output artifact.\n"
+        result, code = _run(
+            run_ceo_with_completion_guard(
+                project_path,
+                task,
+                mode="qa",
+                runner_name=runner_name,
+                model=model,
+                timeout=7200.0,
+                max_respawns=1,
+            )
         )
-
-        from factory.agents.runner import begin_cycle_session, complete_cycle_session
-        cycle_span_id = begin_cycle_session(project_path, cycle_id="deep-qa", model=model)
-
-        if not headless:
-            from factory.models import AgentRunRequest
-
-            prompt = resolve_prompt("ceo", project_path)
-            runner = get_runner(runner_name)
-            rc = runner.interactive_run(AgentRunRequest(
-                prompt=prompt, task=task, cwd=project_path,
-                model=model, role="ceo", skip_permissions=True,
-            ))
-            complete_cycle_session(project_path, cycle_span_id)
-            return rc
-
-        from factory.ceo_completion import run_ceo_with_completion_guard
-        result, code = _run(run_ceo_with_completion_guard(
-            project_path,
-            task,
-            mode="deep-qa",
-            runner_name=runner_name,
-            model=model,
-            timeout=7200.0,
-            max_respawns=1,
-        ))
         complete_cycle_session(project_path, cycle_span_id)
         print(result)
         return code
 
     _design_is_existing = (
-        mode == "design"
-        and raw_path
-        and _safe_is_dir(Path(raw_path).expanduser().resolve())
+        mode == "design" and raw_path and _safe_is_dir(Path(raw_path).expanduser().resolve())
     )
 
     if mode == "design":
         if headless:
             flag = "--bg" if bg else "--headless"
-            print(f"Error: --mode design requires foreground mode "
-                  f"(incompatible with {flag})", file=sys.stderr)
+            print(
+                f"Error: --mode design requires foreground mode (incompatible with {flag})",
+                file=sys.stderr,
+            )
             return 1
         if prompt_file:
-            print("Error: --mode design and --prompt are mutually exclusive. "
-                  "Design mode generates the spec; --prompt provides one.",
-                  file=sys.stderr)
+            print(
+                "Error: --mode design and --prompt are mutually exclusive. "
+                "Design mode generates the spec; --prompt provides one.",
+                file=sys.stderr,
+            )
             return 1
         if focus and not _design_is_existing:
-            print("Error: --mode design and --focus are mutually exclusive "
-                  "for new ideas. To discuss a topic on an existing project, "
-                  "pass the project path: factory ceo /path --mode design --focus \"topic\"",
-                  file=sys.stderr)
+            print(
+                "Error: --mode design and --focus are mutually exclusive "
+                "for new ideas. To discuss a topic on an existing project, "
+                'pass the project path: factory ceo /path --mode design --focus "topic"',
+                file=sys.stderr,
+            )
             return 1
 
     if mode == "create":
         if headless:
             flag = "--bg" if bg else "--headless"
-            print(f"Error: --mode create requires foreground mode "
-                  f"(incompatible with {flag})", file=sys.stderr)
+            print(
+                f"Error: --mode create requires foreground mode (incompatible with {flag})",
+                file=sys.stderr,
+            )
             return 1
         if prompt_file:
-            print("Error: --mode create and --prompt are mutually exclusive. "
-                  "Create mode generates the workflow from a description.",
-                  file=sys.stderr)
+            print(
+                "Error: --mode create and --prompt are mutually exclusive. "
+                "Create mode generates the workflow from a description.",
+                file=sys.stderr,
+            )
             return 1
     if mode == "research":
         if prompt_file:
-            print("Error: --mode research and --prompt are mutually exclusive. "
-                  "Research ideation generates the spec; --prompt provides one.",
-                  file=sys.stderr)
+            print(
+                "Error: --mode research and --prompt are mutually exclusive. "
+                "Research ideation generates the spec; --prompt provides one.",
+                file=sys.stderr,
+            )
             return 1
 
     create_description: str | None = None
@@ -352,9 +321,11 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     if mode == "create":
         resolved_path = Path(raw_path).expanduser().resolve()
         if not _safe_is_dir(resolved_path):
-            print("Error: --mode create requires an existing project directory. "
-                  "Pass the factory project path: factory ceo /path/to/factory --mode create",
-                  file=sys.stderr)
+            print(
+                "Error: --mode create requires an existing project directory. "
+                "Pass the factory project path: factory ceo /path/to/factory --mode create",
+                file=sys.stderr,
+            )
             return 1
         project_path, context = _resolve_input(raw_path, dir_name=dir_name)
         create_description = focus if focus else context
@@ -365,7 +336,11 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         resolved_file = Path(raw_path).expanduser()
         if resolved_file.is_file():
             design_idea = resolved_file.read_text()
-            slug = _slugify(dir_name) if dir_name else _slugify(resolved_file.stem.split("—")[0].strip())
+            slug = (
+                _slugify(dir_name)
+                if dir_name
+                else _slugify(resolved_file.stem.split("—")[0].strip())
+            )
             project_path = _dedupe_project_path(_get_projects_dir() / slug, design_idea)
             deferred_spec = design_idea
             needs_materialize = True
@@ -378,16 +353,26 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             deferred_spec = raw_path
             needs_materialize = True
         context = None
-    elif mode == "research" and not _safe_is_dir(resolved := Path(raw_path).expanduser()) and not _safe_is_file(resolved):
+    elif (
+        mode == "research"
+        and not _safe_is_dir(resolved := Path(raw_path).expanduser())
+        and not _safe_is_file(resolved)
+    ):
         # New research project from idea — enter research ideation
         if headless:
             flag = "--bg" if bg else "--headless"
-            print("Error: --mode research for new projects requires foreground mode "
-                  f"(incompatible with {flag})", file=sys.stderr)
+            print(
+                "Error: --mode research for new projects requires foreground mode "
+                f"(incompatible with {flag})",
+                file=sys.stderr,
+            )
             return 1
         if focus:
-            print("Error: --focus cannot be used with research ideation for new projects. "
-                  "--focus targets existing backlog items.", file=sys.stderr)
+            print(
+                "Error: --focus cannot be used with research ideation for new projects. "
+                "--focus targets existing backlog items.",
+                file=sys.stderr,
+            )
             return 1
         research_ideation = raw_path
         slug = _slugify(dir_name) if dir_name else _extract_project_name(raw_path)
@@ -405,9 +390,13 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     issue_url: str | None = None
     if focus:
         from factory.issue import is_issue_ref
+
         if is_issue_ref(focus) and no_github:
-            print("Error: --focus resolved to an issue reference, but --no-github is set. "
-                  "Issue fetching requires GitHub/GitLab CLI access.", file=sys.stderr)
+            print(
+                "Error: --focus resolved to an issue reference, but --no-github is set. "
+                "Issue fetching requires GitHub/GitLab CLI access.",
+                file=sys.stderr,
+            )
             return 1
         issue_resolved = _resolve_focus_issue(focus, project_path)
         if issue_resolved:
@@ -416,7 +405,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     force_fresh = mode == "auto-fresh"
     if mode in ("auto", "auto-fresh"):
         mode = _auto_detect_mode(
-            project_path, has_prompt=bool(prompt_file or context),
+            project_path,
+            has_prompt=bool(prompt_file or context),
             force_fresh=force_fresh,
         )
     discover_only = getattr(args, "discover_only", False)
@@ -435,21 +425,30 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         print("Error: --bg and --tmux-persist are mutually exclusive.", file=sys.stderr)
         return 1
     clean_pr_flag = getattr(args, "clean_pr", None)
+    no_worktree = getattr(args, "no_worktree", False)
 
     if mode == "research" and not research_ideation and not _has_research_target(project_path):
-        print("Error: --mode research requires research_target in factory.md. "
-              "Either configure research_target manually, or pass an idea string "
-              "to start research ideation: factory ceo \"your idea\" --mode research",
-              file=sys.stderr)
+        print(
+            "Error: --mode research requires research_target in factory.md. "
+            "Either configure research_target manually, or pass an idea string "
+            'to start research ideation: factory ceo "your idea" --mode research',
+            file=sys.stderr,
+        )
         return 1
 
     if focus and prompt_file:
-        print("Error: --focus (targeted mode) and --prompt are mutually exclusive. "
-              "--focus builds one backlog item; --prompt executes a spec file.", file=sys.stderr)
+        print(
+            "Error: --focus (targeted mode) and --prompt are mutually exclusive. "
+            "--focus builds one backlog item; --prompt executes a spec file.",
+            file=sys.stderr,
+        )
         return 1
     if focus and mode not in ("improve", "research", "create") and not design_existing:
-        print(f"Error: --focus (targeted mode) only works in improve, research, or create mode, got '{mode}'. "
-              "The project must already be built before targeting specific items.", file=sys.stderr)
+        print(
+            f"Error: --focus (targeted mode) only works in improve, research, or create mode, got '{mode}'. "
+            "The project must already be built before targeting specific items.",
+            file=sys.stderr,
+        )
         return 1
 
     if design_existing:
@@ -465,25 +464,34 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         _materialize_project(project_path, deferred_spec)
 
     from factory.worktree import create_worktree, prune_stale, remove_worktree
+
     pruned = prune_stale(project_path)
     if pruned:
         print(f"  Cleaned {len(pruned)} stale worktree(s)", file=sys.stderr)
 
     if focus:
         from factory.study import add_backlog_item
+
         add_backlog_item(project_path, focus)
 
     from factory.messages import mark_read, read_pending
 
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
-    base_branch = branch or _read_target_branch(project_path)
-    wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
+    if no_worktree:
+        wt_path = project_path
+        wt_branch = None
+    else:
+        base_branch = branch or _read_target_branch(project_path)
+        wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
 
     from factory.skill_cache import ensure_skills
+
     ensure_skills(wt_path)
 
-    interactive = design_existing or bool(design_idea) or bool(research_ideation) or mode == "create"
+    interactive = (
+        design_existing or bool(design_idea) or bool(research_ideation) or mode == "create"
+    )
     ceo_mode = "create" if mode == "create" else ("build" if interactive else mode)
     if clean_pr_flag is not None:
         clean_pr_resolved = clean_pr_flag
@@ -499,9 +507,16 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             clean_pr_resolved = False
 
     task = _build_ceo_task(
-        wt_path, ceo_mode, context, focus=focus, prompt_file=prompt_file,
-        min_growth=min_growth, max_new=max_new, branch=branch,
-        discover_only=discover_only, no_github=no_github,
+        wt_path,
+        ceo_mode,
+        context,
+        focus=focus,
+        prompt_file=prompt_file,
+        min_growth=min_growth,
+        max_new=max_new,
+        branch=branch,
+        discover_only=discover_only,
+        no_github=no_github,
         design_idea=design_idea,
         design_existing=design_existing,
         research_ideation=research_ideation,
@@ -527,6 +542,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         os.environ["FACTORY_BG"] = "1"
 
     from factory.agents.runner import begin_cycle_session, complete_cycle_session
+
     cycle_span_id = begin_cycle_session(project_path, cycle_id=mode, model=model)
 
     import time as _time
@@ -536,7 +552,9 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     from factory.runners.claude import _make_ceo_message_emitter
 
     ceo_tailer = _start_ceo_tailer(
-        wt_path, cycle_span_id, _ceo_start,
+        wt_path,
+        cycle_span_id,
+        _ceo_start,
         on_line=_make_ceo_message_emitter(wt_path),
         is_headless=headless,
     )
@@ -547,18 +565,20 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         from factory.ceo_completion import run_ceo_with_completion_guard
 
         try:
-            result, code = _run(run_ceo_with_completion_guard(
-                wt_path,
-                task,
-                mode=mode,
-                runner_name=runner_name,
-                model=model,
-                timeout=7200.0,
-                session_name=session_name,
-                use_profile=use_profile,
-                tmux_persist=tmux_persist,
-                background=background,
-            ))
+            result, code = _run(
+                run_ceo_with_completion_guard(
+                    wt_path,
+                    task,
+                    mode=mode,
+                    runner_name=runner_name,
+                    model=model,
+                    timeout=7200.0,
+                    session_name=session_name,
+                    use_profile=use_profile,
+                    tmux_persist=tmux_persist,
+                    background=background,
+                )
+            )
             print(result)
             if code == 0:
                 if pending_ids:
@@ -566,20 +586,28 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             if code != 0:
                 return code
             return _chain_modes(
-                project_path, focus=focus,
-                min_growth=min_growth, max_new=max_new, branch=branch,
+                project_path,
+                focus=focus,
+                min_growth=min_growth,
+                max_new=max_new,
+                branch=branch,
                 already_improved=mode in ("improve", "meta") or discover_only,
-                model=model, no_github=no_github, use_profile=use_profile,
+                model=model,
+                no_github=no_github,
+                use_profile=use_profile,
                 tmux_persist=tmux_persist,
                 background=background,
                 completed_mode=mode,
+                no_worktree=no_worktree,
             )
         finally:
             _stop_ceo_tailer(ceo_tailer)
             complete_cycle_session(project_path, cycle_span_id)
-            remove_worktree(project_path, wt_path, wt_branch)
+            if not no_worktree:
+                remove_worktree(project_path, wt_path, wt_branch)
             if needs_materialize and _is_scaffold_only(project_path):
                 import shutil
+
                 shutil.rmtree(project_path, ignore_errors=True)
 
     # Interactive foreground mode: use subprocess.run so we can clean up the worktree.
@@ -594,22 +622,32 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
         prompt = resolve_prompt("ceo", wt_path, use_profile=use_profile)
         runner = get_runner(runner_name)
-        return runner.interactive_run(_RunReq(
-            prompt=prompt, task=task, cwd=wt_path,
-            model=model, role="ceo", skip_permissions=True,
-            session_name=session_name,
-        ))
+        return runner.interactive_run(
+            _RunReq(
+                prompt=prompt,
+                task=task,
+                cwd=wt_path,
+                model=model,
+                role="ceo",
+                skip_permissions=True,
+                session_name=session_name,
+            )
+        )
     finally:
         _stop_ceo_tailer(ceo_tailer)
         complete_cycle_session(project_path, cycle_span_id)
-        remove_worktree(project_path, wt_path, wt_branch)
+        if not no_worktree:
+            remove_worktree(project_path, wt_path, wt_branch)
         if needs_materialize and _is_scaffold_only(project_path):
             import shutil
+
             shutil.rmtree(project_path, ignore_errors=True)
 
 
 def _start_ceo_tailer(
-    wt_path: Path, cycle_span_id: str | None, start_time: float,
+    wt_path: Path,
+    cycle_span_id: str | None,
+    start_time: float,
     on_line: Callable[[bytes], None] | None = None,
     is_headless: bool = False,
 ) -> object | None:
@@ -695,7 +733,9 @@ def _resolve_tmux_persist(args: argparse.Namespace) -> bool:
 
     cli_flag = getattr(args, "tmux_persist", False)
     cli_value = "true" if cli_flag else None
-    val = resolve("tmux_persist", cli_value=cli_value, env_var="FACTORY_TMUX_PERSIST", default="false")
+    val = resolve(
+        "tmux_persist", cli_value=cli_value, env_var="FACTORY_TMUX_PERSIST", default="false"
+    )
     return bool(val and val.lower() in ("1", "true", "yes"))
 
 
@@ -722,7 +762,11 @@ def _resolve_bg_agents(args: argparse.Namespace) -> bool:
 def _get_projects_dir() -> Path:
     from factory.user_config import resolve
 
-    raw = resolve("projects_dir", env_var="FACTORY_PROJECTS_DIR", default=str(Path.home() / "factory-projects"))
+    raw = resolve(
+        "projects_dir",
+        env_var="FACTORY_PROJECTS_DIR",
+        default=str(Path.home() / "factory-projects"),
+    )
     return Path(raw).expanduser() if raw else Path.home() / "factory-projects"
 
 
@@ -732,6 +776,7 @@ _ORIGINAL_GET_PROJECTS_DIR = _get_projects_dir
 def _resolve_projects_dir() -> Path:
     """Resolve _get_projects_dir with support for test monkeypatching on factory.cli."""
     import factory.cli as _cli
+
     cli_fn = getattr(_cli, "_get_projects_dir", _ORIGINAL_GET_PROJECTS_DIR)
     if cli_fn is not _ORIGINAL_GET_PROJECTS_DIR:
         return cli_fn()
@@ -755,7 +800,9 @@ def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | N
     # 2. Existing file (e.g. path to an idea/spec .md file)
     if _safe_is_file(expanded):
         idea_content = expanded.read_text()
-        slug = _slugify(dir_name) if dir_name else _slugify(expanded.stem.split("\u2014")[0].strip())
+        slug = (
+            _slugify(dir_name) if dir_name else _slugify(expanded.stem.split("\u2014")[0].strip())
+        )
         project_path = _dedupe_project_path(_resolve_projects_dir() / slug, idea_content)
         print(f"Idea file: {expanded.name}")
         print(f"Project directory: {project_path}")
@@ -775,12 +822,38 @@ def _resolve_input(raw: str, dir_name: str | None = None) -> tuple[Path, str | N
     return project_path, raw
 
 
-_FILLER_WORDS = frozenset({
-    "a", "an", "the", "that", "which", "with", "for", "and", "or", "to", "using",
-    "comprehensive", "simple", "basic", "advanced", "new", "custom", "full",
-    "complete", "modern", "robust", "scalable", "lightweight", "minimal",
-    "fully", "featured", "production", "ready",
-})
+_FILLER_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "that",
+        "which",
+        "with",
+        "for",
+        "and",
+        "or",
+        "to",
+        "using",
+        "comprehensive",
+        "simple",
+        "basic",
+        "advanced",
+        "new",
+        "custom",
+        "full",
+        "complete",
+        "modern",
+        "robust",
+        "scalable",
+        "lightweight",
+        "minimal",
+        "fully",
+        "featured",
+        "production",
+        "ready",
+    }
+)
 
 
 _VERB_RE = re.compile(
@@ -834,7 +907,7 @@ def _derive_session_name(
     max_len = 60
 
     if focus:
-        label = focus.lower()[:max_len - len(prefix)]
+        label = focus.lower()[: max_len - len(prefix)]
         return f"{prefix}{label}"
 
     idea = design_idea or research_ideation
@@ -843,9 +916,12 @@ def _derive_session_name(
         if desc:
             return f"{prefix}{desc}"[:max_len]
 
-    if raw_path and not _safe_is_dir(Path(raw_path).expanduser()) \
-            and not _safe_is_file(Path(raw_path).expanduser()) \
-            and not _is_github_url(raw_path):
+    if (
+        raw_path
+        and not _safe_is_dir(Path(raw_path).expanduser())
+        and not _safe_is_file(Path(raw_path).expanduser())
+        and not _is_github_url(raw_path)
+    ):
         desc = _extract_short_description(raw_path)
         if desc:
             return f"{prefix}{desc}"[:max_len]
@@ -887,9 +963,20 @@ def _ensure_repo(project_path: Path) -> None:
     if not (project_path / ".git").is_dir():
         subprocess.run(["git", "init"], cwd=project_path, capture_output=True, check=True)
         subprocess.run(
-            ["git", "-c", "user.name=Factory", "-c", "user.email=factory@localhost",
-             "commit", "--allow-empty", "-m", "Initial commit"],
-            cwd=project_path, capture_output=True, check=True,
+            [
+                "git",
+                "-c",
+                "user.name=Factory",
+                "-c",
+                "user.email=factory@localhost",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "Initial commit",
+            ],
+            cwd=project_path,
+            capture_output=True,
+            check=True,
         )
 
 
@@ -914,7 +1001,8 @@ def _read_prompt_file(project_path: Path, prompt_file: str) -> str:
 
 
 def _resolve_focus_issue(
-    focus: str, project_path: Path,
+    focus: str,
+    project_path: Path,
 ) -> tuple[str, str, int, str] | None:
     """If *focus* looks like an issue ref, fetch it and return (title, context, number, url).
 
@@ -933,9 +1021,7 @@ def _resolve_focus_issue(
 
     strategy_dir = project_path / ".factory" / "strategy"
     strategy_dir.mkdir(parents=True, exist_ok=True)
-    (strategy_dir / "current.md").write_text(
-        f"## Project Specification\n\n{context}\n"
-    )
+    (strategy_dir / "current.md").write_text(f"## Project Specification\n\n{context}\n")
     print(
         f"  Issue: #{issue_spec.number} → .factory/strategy/current.md",
         file=sys.stderr,
@@ -964,14 +1050,13 @@ def _is_scaffold_only(project_path: Path) -> bool:
         return False
     result = subprocess.run(
         ["git", "rev-list", "--count", "HEAD"],
-        cwd=project_path, capture_output=True, text=True,
+        cwd=project_path,
+        capture_output=True,
+        text=True,
     )
     if result.returncode != 0 or result.stdout.strip() != "1":
         return False
-    non_git = [
-        p for p in project_path.rglob("*")
-        if p.is_file() and ".git" not in p.parts
-    ]
+    non_git = [p for p in project_path.rglob("*") if p.is_file() and ".git" not in p.parts]
     allowed = {project_path / ".factory" / "strategy" / "current.md"}
     return all(p in allowed for p in non_git)
 
@@ -1033,10 +1118,13 @@ def _tmux_available() -> bool:
 
 def _tmux_session_alive(session: str) -> bool:
     """Check if a tmux session exists and is alive."""
-    return subprocess.run(
-        ["tmux", "has-session", "-t", session],
-        capture_output=True,
-    ).returncode == 0
+    return (
+        subprocess.run(
+            ["tmux", "has-session", "-t", session],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
 
 
 def _build_tmux_run_args(args: argparse.Namespace, project_path: Path, model: str | None) -> str:
@@ -1108,7 +1196,15 @@ def cmd_tmux(args: argparse.Namespace) -> int:
         return 0
 
     # Build the factory run command — propagate env vars, use bare `factory`
-    _ENV_PREFIXES = ("FACTORY_", "ANTHROPIC_", "BOBSHELL_", "OPENAI_", "CODEX_", "CLAUDE_CODE_", "CLOUD_ML_")
+    _ENV_PREFIXES = (
+        "FACTORY_",
+        "ANTHROPIC_",
+        "BOBSHELL_",
+        "OPENAI_",
+        "CODEX_",
+        "CLAUDE_CODE_",
+        "CLOUD_ML_",
+    )
     run_cmd_parts = []
     for key, val in sorted(os.environ.items()):
         if key.startswith(_ENV_PREFIXES):
@@ -1181,7 +1277,11 @@ def cmd_tmux_ls(args: argparse.Namespace) -> int:
         parts = line.split("\t")
         name = parts[0]
         if name.startswith(_TMUX_SESSION_PREFIX):
-            created = datetime.fromtimestamp(int(parts[1])).strftime("%Y-%m-%d %H:%M") if len(parts) > 1 else "?"
+            created = (
+                datetime.fromtimestamp(int(parts[1])).strftime("%Y-%m-%d %H:%M")
+                if len(parts) > 1
+                else "?"
+            )
             project = mapping.get(name, "?")
             factory_sessions.append({"session": name, "started": created, "project": project})
 
@@ -1308,7 +1408,10 @@ def cmd_tmux_stop(args: argparse.Namespace) -> int:
             f"Warning: session '{session}' is not in the factory session registry.",
             file=sys.stderr,
         )
-        print("It may not be a factory-managed session. Use --force to kill it anyway.", file=sys.stderr)
+        print(
+            "It may not be a factory-managed session. Use --force to kill it anyway.",
+            file=sys.stderr,
+        )
         return 1
 
     subprocess.run(["tmux", "kill-session", "-t", session])
@@ -1343,7 +1446,10 @@ def cmd_refactory(args: argparse.Namespace) -> int:
 
     prompt = resolve_prompt("refactory")
     prompt_file = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".md", prefix="refactory-prompt-", delete=False,
+        mode="w",
+        suffix=".md",
+        prefix="refactory-prompt-",
+        delete=False,
     )
     prompt_file.write(prompt)
     prompt_file.close()
@@ -1351,15 +1457,19 @@ def cmd_refactory(args: argparse.Namespace) -> int:
     if is_new_session:
         cmd = [
             "claude",
-            "--session-id", session_id,
-            "--append-system-prompt-file", prompt_file.name,
+            "--session-id",
+            session_id,
+            "--append-system-prompt-file",
+            prompt_file.name,
             "--dangerously-skip-permissions",
         ]
     else:
         cmd = [
             "claude",
-            "--resume", session_id,
-            "--append-system-prompt-file", prompt_file.name,
+            "--resume",
+            session_id,
+            "--append-system-prompt-file",
+            prompt_file.name,
             "--dangerously-skip-permissions",
         ]
 
@@ -1375,13 +1485,16 @@ def _has_research_target(project_path: Path) -> bool:
     """Check if project already has research_target configured."""
     try:
         from factory.store import ExperimentStore
+
         config = _run(ExperimentStore(project_path).read_config())
         return config.research_target is not None
     except (FileNotFoundError, json.JSONDecodeError, ValueError, KeyError):
         return False
 
 
-def _auto_detect_mode(project_path: Path, has_prompt: bool = False, force_fresh: bool = False) -> str:
+def _auto_detect_mode(
+    project_path: Path, has_prompt: bool = False, force_fresh: bool = False
+) -> str:
     """Detect the right mode based on project state.
 
     Checks for an in-flight cycle first — if one exists, returns its mode
@@ -1574,10 +1687,14 @@ def _build_ceo_task(
         if min_growth is not None:
             budget_lines.append(f"- **min_growth:** {min_growth} (guaranteed growth hypotheses)")
         if max_new is not None:
-            budget_lines.append(f"- **max_new:** {max_new} (max new items added to backlog per cycle)")
+            budget_lines.append(
+                f"- **max_new:** {max_new} (max new items added to backlog per cycle)"
+            )
         budget_lines.append("")
-        budget_lines.append("Pass these overrides to the Strategist. They take precedence over "
-                           "factory.md defaults and study-computed values.")
+        budget_lines.append(
+            "Pass these overrides to the Strategist. They take precedence over "
+            "factory.md defaults and study-computed values."
+        )
         task += "\n".join(budget_lines)
 
     if context:
@@ -1690,6 +1807,7 @@ def _chain_modes(
     tmux_persist: bool = False,
     background: bool = False,
     completed_mode: str | None = None,
+    no_worktree: bool = False,
 ) -> int:
     """After a cycle completes, re-detect state and chain into the next mode.
 
@@ -1729,10 +1847,18 @@ def _chain_modes(
             file=sys.stderr,
         )
         code = _run_single_cycle(
-            project_path, next_mode, focus=focus,
-            min_growth=min_growth, max_new=max_new, branch=branch,
-            no_github=no_github, model=model, use_profile=use_profile,
-            tmux_persist=tmux_persist, background=background,
+            project_path,
+            next_mode,
+            focus=focus,
+            min_growth=min_growth,
+            max_new=max_new,
+            branch=branch,
+            no_github=no_github,
+            model=model,
+            use_profile=use_profile,
+            tmux_persist=tmux_persist,
+            background=background,
+            no_worktree=no_worktree,
         )
         if code != 0:
             return code
@@ -1758,6 +1884,7 @@ def _run_single_cycle(
     tmux_persist: bool = False,
     background: bool = False,
     run_id: str | None = None,
+    no_worktree: bool = False,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
     from factory.agents.runner import invoke_agent
@@ -1765,6 +1892,7 @@ def _run_single_cycle(
 
     if focus:
         from factory.study import add_backlog_item
+
         add_backlog_item(project_path, focus)
 
     from factory.messages import mark_read, read_pending
@@ -1772,34 +1900,48 @@ def _run_single_cycle(
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
 
-    base_branch = branch or _read_target_branch(project_path)
-    wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
+    if no_worktree:
+        wt_path = project_path
+        wt_branch = None
+    else:
+        base_branch = branch or _read_target_branch(project_path)
+        wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
 
     from factory.skill_cache import ensure_skills
+
     ensure_skills(wt_path)
 
     try:
         task = _build_ceo_task(
-            wt_path, mode, context, focus=focus, prompt_file=prompt_file,
-            min_growth=min_growth, max_new=max_new, branch=branch,
-            discover_only=discover_only, no_github=no_github,
+            wt_path,
+            mode,
+            context,
+            focus=focus,
+            prompt_file=prompt_file,
+            min_growth=min_growth,
+            max_new=max_new,
+            branch=branch,
+            discover_only=discover_only,
+            no_github=no_github,
             messages=pending,
             issue_number=issue_number,
             issue_url=issue_url,
             clean_pr=clean_pr,
         )
 
-        result, code = _run(invoke_agent(
-            "ceo",
-            task,
-            wt_path,
-            timeout=7200.0,
-            dangerously_skip_permissions=True,
-            model=model,
-            use_profile=use_profile,
-            tmux_persist=tmux_persist,
-            background=background,
-        ))
+        result, code = _run(
+            invoke_agent(
+                "ceo",
+                task,
+                wt_path,
+                timeout=7200.0,
+                dangerously_skip_permissions=True,
+                model=model,
+                use_profile=use_profile,
+                tmux_persist=tmux_persist,
+                background=background,
+            )
+        )
 
         if code == 0:
             if pending_ids:
@@ -1808,7 +1950,8 @@ def _run_single_cycle(
         print(result)
         return code
     finally:
-        remove_worktree(project_path, wt_path, wt_branch)
+        if not no_worktree:
+            remove_worktree(project_path, wt_path, wt_branch)
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -1853,9 +1996,13 @@ def cmd_run(args: argparse.Namespace) -> int:
     issue_url: str | None = None
     if focus:
         from factory.issue import is_issue_ref
+
         if is_issue_ref(focus) and no_github:
-            print("Error: --focus resolved to an issue reference, but --no-github is set. "
-                  "Issue fetching requires GitHub/GitLab CLI access.", file=sys.stderr)
+            print(
+                "Error: --focus resolved to an issue reference, but --no-github is set. "
+                "Issue fetching requires GitHub/GitLab CLI access.",
+                file=sys.stderr,
+            )
             return 1
         issue_resolved = _resolve_focus_issue(focus, project_path)
         if issue_resolved:
@@ -1865,24 +2012,35 @@ def cmd_run(args: argparse.Namespace) -> int:
     force_fresh = mode == "auto-fresh"
     if mode in ("auto", "auto-fresh"):
         mode = _auto_detect_mode(
-            project_path, has_prompt=bool(prompt_file or context),
+            project_path,
+            has_prompt=bool(prompt_file or context),
             force_fresh=force_fresh,
         )
 
     if focus and loop:
-        print("Error: --focus (targeted mode) and --loop are mutually exclusive. "
-              "Targeted mode builds exactly one item and exits.", file=sys.stderr)
+        print(
+            "Error: --focus (targeted mode) and --loop are mutually exclusive. "
+            "Targeted mode builds exactly one item and exits.",
+            file=sys.stderr,
+        )
         return 1
     if focus and prompt_file:
-        print("Error: --focus (targeted mode) and --prompt are mutually exclusive. "
-              "--focus builds one backlog item; --prompt executes a spec file.", file=sys.stderr)
+        print(
+            "Error: --focus (targeted mode) and --prompt are mutually exclusive. "
+            "--focus builds one backlog item; --prompt executes a spec file.",
+            file=sys.stderr,
+        )
         return 1
     if focus and mode not in ("improve", "research"):
-        print(f"Error: --focus (targeted mode) only works in improve or research mode, got '{mode}'. "
-              "The project must already be built before targeting specific items.", file=sys.stderr)
+        print(
+            f"Error: --focus (targeted mode) only works in improve or research mode, got '{mode}'. "
+            "The project must already be built before targeting specific items.",
+            file=sys.stderr,
+        )
         return 1
 
     clean_pr_flag = getattr(args, "clean_pr", None)
+    no_worktree = getattr(args, "no_worktree", False)
     if clean_pr_flag is not None:
         clean_pr_resolved = clean_pr_flag
     else:
@@ -1903,6 +2061,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         _materialize_project(project_path, context)
 
     from factory.worktree import prune_stale
+
     if project_path.is_dir():
         pruned = prune_stale(project_path)
         if pruned:
@@ -1913,8 +2072,14 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     if not loop:
         code = _run_single_cycle(
-            project_path, mode, context, focus=focus, prompt_file=prompt_file,
-            discover_only=discover_only, no_github=no_github, model=model,
+            project_path,
+            mode,
+            context,
+            focus=focus,
+            prompt_file=prompt_file,
+            discover_only=discover_only,
+            no_github=no_github,
+            model=model,
             issue_number=issue_number,
             issue_url=issue_url,
             use_profile=use_profile_flag,
@@ -1922,17 +2087,25 @@ def cmd_run(args: argparse.Namespace) -> int:
             tmux_persist=tmux_persist,
             background=background,
             run_id=run_id,
+            no_worktree=no_worktree,
             **budget_kwargs,
         )
         if code != 0:
             return code
         return _chain_modes(
-            project_path, focus=focus, already_improved=skip_improve,
-            min_growth=min_growth, max_new=max_new, branch=branch,
-            model=model, no_github=no_github, use_profile=use_profile_flag,
+            project_path,
+            focus=focus,
+            already_improved=skip_improve,
+            min_growth=min_growth,
+            max_new=max_new,
+            branch=branch,
+            model=model,
+            no_github=no_github,
+            use_profile=use_profile_flag,
             tmux_persist=tmux_persist,
             background=background,
             completed_mode=mode,
+            no_worktree=no_worktree,
         )
 
     # Heartbeat loop mode
@@ -1957,8 +2130,14 @@ def cmd_run(args: argparse.Namespace) -> int:
             _emit_cli_event(project_path, "cycle.started", {"cycle": cycle, "mode": mode})
 
             _run_single_cycle(
-                project_path, mode, context, focus=focus, prompt_file=prompt_file,
-                discover_only=discover_only, no_github=no_github, model=model,
+                project_path,
+                mode,
+                context,
+                focus=focus,
+                prompt_file=prompt_file,
+                discover_only=discover_only,
+                no_github=no_github,
+                model=model,
                 issue_number=issue_number,
                 issue_url=issue_url,
                 use_profile=use_profile_flag,
@@ -1966,15 +2145,23 @@ def cmd_run(args: argparse.Namespace) -> int:
                 tmux_persist=tmux_persist,
                 background=background,
                 run_id=run_id,
+                no_worktree=no_worktree,
                 **budget_kwargs,
             )
             _chain_modes(
-                project_path, focus=focus, already_improved=skip_improve,
-                min_growth=min_growth, max_new=max_new, branch=branch,
-                model=model, no_github=no_github, use_profile=use_profile_flag,
+                project_path,
+                focus=focus,
+                already_improved=skip_improve,
+                min_growth=min_growth,
+                max_new=max_new,
+                branch=branch,
+                model=model,
+                no_github=no_github,
+                use_profile=use_profile_flag,
                 tmux_persist=tmux_persist,
                 background=background,
                 completed_mode=mode,
+                no_worktree=no_worktree,
             )
             _emit_cli_event(project_path, "cycle.completed", {"cycle": cycle, "mode": mode})
 
@@ -1998,9 +2185,5 @@ def cmd_run(args: argparse.Namespace) -> int:
         signal.signal(signal.SIGINT, old_sigint)
 
     elapsed = time.monotonic() - start_time
-    print(
-        f"[factory] Shutting down gracefully after {cycle} cycles."
-        f" Total runtime: {elapsed:.0f}s"
-    )
+    print(f"[factory] Shutting down gracefully after {cycle} cycles. Total runtime: {elapsed:.0f}s")
     return 0
-

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -260,6 +260,91 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         print(result)
         return code
 
+    # ── deep-qa mode early exit ───────────────────────────────
+    if mode == "deep-qa":
+        pr_number = getattr(args, "pr", None)
+        if pr_number is None:
+            print("Error: --mode deep-qa requires --pr <number>", file=sys.stderr)
+            return 1
+
+        repo = getattr(args, "repo", None)
+        model = _resolve_model(args)
+        runner_name = _resolve_runner(args)
+
+        project_path = Path(raw_path).expanduser().resolve()
+        if not project_path.is_dir():
+            print(
+                f"Error: project path must be an existing directory for deep-qa mode: {raw_path}",
+                file=sys.stderr,
+            )
+            return 1
+
+        _print_banner("deep-qa")
+
+        repo_flag = f" --repo {repo}" if repo else ""
+        repo_clause = f" in repo `{repo}`" if repo else ""
+        task = (
+            f"Project: {project_path}\nMode: deep-qa\n\n"
+            f"## Deep-QA Verification Directive\n\n"
+            f"Run the deep-QA verification pipeline for PR #{pr_number}{repo_clause}.\n\n"
+            f"Execute the 3-specialist pipeline:\n"
+            f"1. health_checker — run eval, compare scores, write health-check.md\n"
+            f"2. code_reviewer — 7-category code review, write code-review.md\n"
+            f"3. adversarial_tester — skeptical feature testing, write adversarial-qa.md\n\n"
+            f"Key parameters:\n"
+            f"- PR_NUMBER={pr_number}\n"
+            f"- PROJECT_PATH={project_path}\n"
+            f"{f'- REPO={repo}' + chr(10) if repo else ''}"
+            f"\nPost the final verdict via:\n"
+            f"factory review --verdict <KEEP|REVERT> --pr {pr_number} "
+            f'--reason "$REASON" '
+            f"--qa-body-file .factory/reviews/adversarial-qa.md"
+            f"{repo_flag}\n"
+            f"\nSet $REASON to the QA verdict summary (e.g. 'QA: CLEAN — 2854 tests pass, 0 issues' "
+            f"or 'QA: ISSUES_FOUND — 3 critical issues'). Set $VERDICT to KEEP if QA is CLEAN, REVERT otherwise.\n"
+            f"\nIMPORTANT: Do NOT post any PR comments (gh pr comment, gh issue comment). "
+            f"The factory review command above is the ONLY GitHub output artifact.\n"
+        )
+
+        from factory.agents.runner import begin_cycle_session, complete_cycle_session
+
+        cycle_span_id = begin_cycle_session(project_path, cycle_id="deep-qa", model=model)
+
+        if not headless:
+            from factory.models import AgentRunRequest
+
+            prompt = resolve_prompt("ceo", project_path)
+            runner = get_runner(runner_name)
+            rc = runner.interactive_run(
+                AgentRunRequest(
+                    prompt=prompt,
+                    task=task,
+                    cwd=project_path,
+                    model=model,
+                    role="ceo",
+                    skip_permissions=True,
+                )
+            )
+            complete_cycle_session(project_path, cycle_span_id)
+            return rc
+
+        from factory.ceo_completion import run_ceo_with_completion_guard
+
+        result, code = _run(
+            run_ceo_with_completion_guard(
+                project_path,
+                task,
+                mode="deep-qa",
+                runner_name=runner_name,
+                model=model,
+                timeout=7200.0,
+                max_respawns=1,
+            )
+        )
+        complete_cycle_session(project_path, cycle_span_id)
+        print(result)
+        return code
+
     _design_is_existing = (
         mode == "design" and raw_path and _safe_is_dir(Path(raw_path).expanduser().resolve())
     )

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -604,6 +604,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             _stop_ceo_tailer(ceo_tailer)
             complete_cycle_session(project_path, cycle_span_id)
             if not no_worktree:
+                assert wt_branch is not None
                 remove_worktree(project_path, wt_path, wt_branch)
             if needs_materialize and _is_scaffold_only(project_path):
                 import shutil
@@ -637,6 +638,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         _stop_ceo_tailer(ceo_tailer)
         complete_cycle_session(project_path, cycle_span_id)
         if not no_worktree:
+            assert wt_branch is not None
             remove_worktree(project_path, wt_path, wt_branch)
         if needs_materialize and _is_scaffold_only(project_path):
             import shutil
@@ -1951,6 +1953,7 @@ def _run_single_cycle(
         return code
     finally:
         if not no_worktree:
+            assert wt_branch is not None
             remove_worktree(project_path, wt_path, wt_branch)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,23 @@ from unittest.mock import patch, AsyncMock, MagicMock
 
 import pytest
 
-from factory.cli import main, build_parser, _is_github_url, _slugify, _extract_project_name, _dedupe_project_path, _resolve_input, _persist_spec, _has_research_target, _build_ceo_task, _ensure_repo, _materialize_project, _is_scaffold_only, _quick_classify, _welcome_wizard
+from factory.cli import (
+    main,
+    build_parser,
+    _is_github_url,
+    _slugify,
+    _extract_project_name,
+    _dedupe_project_path,
+    _resolve_input,
+    _persist_spec,
+    _has_research_target,
+    _build_ceo_task,
+    _ensure_repo,
+    _materialize_project,
+    _is_scaffold_only,
+    _quick_classify,
+    _welcome_wizard,
+)
 from factory.models import ExperimentRecord
 from factory.store import ExperimentStore
 
@@ -33,14 +49,18 @@ def _mock_foreground():
     """Mock the interactive foreground path: subprocess.run inside ClaudeRunner,
     worktree lifecycle, and dashboard.  Yields the subprocess.run mock."""
     mock_run = MagicMock(return_value=MagicMock(returncode=0))
-    with patch("factory.runners.claude.subprocess.run", mock_run), \
-         patch("factory.worktree.create_worktree",
-               side_effect=lambda p, b="main", run_id=None: (p, "factory/run-test")), \
-         patch("factory.worktree.remove_worktree"), \
-         patch("factory.worktree.prune_stale", return_value=[]), \
-         patch("factory.cli.ceo._read_target_branch", return_value="main"), \
-         patch("factory.cli.ceo._is_scaffold_only", return_value=False), \
-         patch("factory.cli.ceo._ensure_dashboard"):
+    with (
+        patch("factory.runners.claude.subprocess.run", mock_run),
+        patch(
+            "factory.worktree.create_worktree",
+            side_effect=lambda p, b="main", run_id=None: (p, "factory/run-test"),
+        ),
+        patch("factory.worktree.remove_worktree"),
+        patch("factory.worktree.prune_stale", return_value=[]),
+        patch("factory.cli.ceo._read_target_branch", return_value="main"),
+        patch("factory.cli.ceo._is_scaffold_only", return_value=False),
+        patch("factory.cli.ceo._ensure_dashboard"),
+    ):
         yield mock_run
 
 
@@ -80,20 +100,43 @@ class TestParser:
 
     def test_finalize_subcommand(self):
         parser = build_parser()
-        args = parser.parse_args([
-            "finalize", "/path", "--id", "1", "--verdict", "keep",
-            "--hypothesis", "h", "--summary", "s",
-        ])
+        args = parser.parse_args(
+            [
+                "finalize",
+                "/path",
+                "--id",
+                "1",
+                "--verdict",
+                "keep",
+                "--hypothesis",
+                "h",
+                "--summary",
+                "s",
+            ]
+        )
         assert args.id == 1
         assert args.verdict == "keep"
 
     def test_finalize_with_scores(self):
         parser = build_parser()
-        args = parser.parse_args([
-            "finalize", "/path", "--id", "1", "--verdict", "keep",
-            "--hypothesis", "h", "--summary", "s",
-            "--score-before", "0.80", "--score-after", "0.85",
-        ])
+        args = parser.parse_args(
+            [
+                "finalize",
+                "/path",
+                "--id",
+                "1",
+                "--verdict",
+                "keep",
+                "--hypothesis",
+                "h",
+                "--summary",
+                "s",
+                "--score-before",
+                "0.80",
+                "--score-after",
+                "0.85",
+            ]
+        )
         assert args.score_before == 0.80
         assert args.score_after == 0.85
 
@@ -102,7 +145,9 @@ class TestParser:
 
     def test_emit_subcommand(self):
         parser = build_parser()
-        args = parser.parse_args(["emit", "agent.started", "--agent", "researcher", "--project", "/p"])
+        args = parser.parse_args(
+            ["emit", "agent.started", "--agent", "researcher", "--project", "/p"]
+        )
         assert args.command == "emit"
         assert args.event_type == "agent.started"
         assert args.agent == "researcher"
@@ -165,6 +210,7 @@ class TestGroupedHelp:
 
     def test_all_subcommands_covered_by_groups(self):
         from factory.cli import _COMMAND_GROUPS
+
         grouped = {cmd for _, cmds in _COMMAND_GROUPS for cmd in cmds}
         parser = build_parser()
         sub_action = None
@@ -179,6 +225,7 @@ class TestGroupedHelp:
 
     def test_no_command_in_multiple_groups(self):
         from factory.cli import _COMMAND_GROUPS
+
         seen: dict[str, str] = {}
         duplicates: list[str] = []
         for group_name, cmds in _COMMAND_GROUPS:
@@ -190,10 +237,13 @@ class TestGroupedHelp:
 
     def test_no_ungrouped_other_section(self):
         help_text = build_parser().format_help()
-        assert "\nOther:\n" not in help_text, "Help has an 'Other' section — some commands are ungrouped"
+        assert "\nOther:\n" not in help_text, (
+            "Help has an 'Other' section — some commands are ungrouped"
+        )
 
     def test_group_count_is_nine(self):
         from factory.cli import _COMMAND_GROUPS
+
         assert len(_COMMAND_GROUPS) == 9
 
 
@@ -201,11 +251,25 @@ class TestRefactoryAgentFilter:
     """Tests for --refactory-agent help filtering."""
 
     EXPECTED_COMMANDS = {
-        "ceo", "run", "tmux", "tmux-ls", "tmux-stop", "tmux-capture",
-        "discover", "init", "detect",
-        "eval", "history", "study", "status", "backlog-list", "backlog-add",
-        "checkpoint", "resume",
-        "ace", "ace-stats",
+        "ceo",
+        "run",
+        "tmux",
+        "tmux-ls",
+        "tmux-stop",
+        "tmux-capture",
+        "discover",
+        "init",
+        "detect",
+        "eval",
+        "history",
+        "study",
+        "status",
+        "backlog-list",
+        "backlog-add",
+        "checkpoint",
+        "resume",
+        "ace",
+        "ace-stats",
     }
 
     def test_filtered_help_shows_only_expected_commands(self, monkeypatch):
@@ -213,14 +277,20 @@ class TestRefactoryAgentFilter:
         parser = build_parser()
         help_text = parser.format_help()
         import re as _re
+
         displayed = set(_re.findall(r"^  (\S+)", help_text, _re.MULTILINE))
         assert displayed == self.EXPECTED_COMMANDS
 
     def test_filtered_help_has_group_headers(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["factory", "--help", "--refactory-agent"])
         help_text = build_parser().format_help()
-        for header in ("Entry Points:", "Project Setup:", "Project Intelligence:",
-                       "Validation & Recovery:", "Self-Evolution:"):
+        for header in (
+            "Entry Points:",
+            "Project Setup:",
+            "Project Intelligence:",
+            "Validation & Recovery:",
+            "Self-Evolution:",
+        ):
             assert header in help_text, f"Missing group header: {header}"
 
     def test_filtered_help_omits_empty_groups(self, monkeypatch):
@@ -374,9 +444,13 @@ class TestHasResearchTarget:
         (tmp_path / ".git").mkdir()
         factory_dir = tmp_path / ".factory"
         factory_dir.mkdir()
-        rt = {"objective": "maximize accuracy", "metric": "accuracy",
-              "target": 0.9, "run_command": "python run.py",
-              "result_path": "results.json"}
+        rt = {
+            "objective": "maximize accuracy",
+            "metric": "accuracy",
+            "target": 0.9,
+            "run_command": "python run.py",
+            "result_path": "results.json",
+        }
         (factory_dir / "config.json").write_text(json.dumps(_make_config(research_target=rt)))
         assert _has_research_target(tmp_path) is True
 
@@ -397,9 +471,13 @@ class TestCmdCeoResearchIdeation:
         (tmp_path / ".git").mkdir()
         factory_dir = tmp_path / ".factory"
         factory_dir.mkdir()
-        rt = {"objective": "maximize accuracy", "metric": "accuracy",
-              "target": 0.9, "run_command": "python run.py",
-              "result_path": "results.json"}
+        rt = {
+            "objective": "maximize accuracy",
+            "metric": "accuracy",
+            "target": 0.9,
+            "run_command": "python run.py",
+            "result_path": "results.json",
+        }
         (factory_dir / "config.json").write_text(json.dumps(_make_config(research_target=rt)))
         with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "research", "--focus", "tokenizer"])
@@ -486,9 +564,13 @@ class TestCmdCeoResearchIdeation:
         (tmp_path / ".git").mkdir()
         factory_dir = tmp_path / ".factory"
         factory_dir.mkdir()
-        rt = {"objective": "maximize accuracy", "metric": "accuracy",
-              "target": 0.9, "run_command": "python run.py",
-              "result_path": "results.json"}
+        rt = {
+            "objective": "maximize accuracy",
+            "metric": "accuracy",
+            "target": 0.9,
+            "run_command": "python run.py",
+            "result_path": "results.json",
+        }
         (factory_dir / "config.json").write_text(json.dumps(_make_config(research_target=rt)))
         with _mock_foreground() as mock_run:
             main(["ceo", str(tmp_path), "--mode", "research"])
@@ -538,12 +620,18 @@ class TestCmdStatus:
         asyncio.run(store.init(sample_config))
         exp_id = asyncio.run(store.begin("Improve performance"))
         record = ExperimentRecord(
-            id=exp_id, timestamp=datetime.now(),
+            id=exp_id,
+            timestamp=datetime.now(),
             hypothesis="Improve performance",
             change_summary="Optimized hot path",
-            issue_number=None, pr_number=None,
-            score_before=0.8, score_after=0.95, delta=0.15,
-            verdict="keep", cost_usd=None, notes="",
+            issue_number=None,
+            pr_number=None,
+            score_before=0.8,
+            score_after=0.95,
+            delta=0.15,
+            verdict="keep",
+            cost_usd=None,
+            notes="",
         )
         asyncio.run(store.finalize(exp_id, record))
 
@@ -573,6 +661,7 @@ class TestCmdHistory:
     def test_history_no_experiments(self, tmp_project, capsys, sample_config):
         import asyncio
         from factory.store import ExperimentStore
+
         store = ExperimentStore(tmp_project)
         asyncio.run(store.init(sample_config))
         result = main(["history", str(tmp_project)])
@@ -693,21 +782,28 @@ class TestCmdArchive:
         asyncio.run(store.init(sample_config))
         exp_id = asyncio.run(store.begin("Improve throughput"))
         record = ExperimentRecord(
-            id=exp_id, timestamp=datetime.now(),
+            id=exp_id,
+            timestamp=datetime.now(),
             hypothesis="Improve throughput",
             change_summary="Optimized pipeline",
-            issue_number=None, pr_number=None,
-            score_before=0.7, score_after=0.85, delta=0.15,
-            verdict="keep", cost_usd=0.5, notes="",
+            issue_number=None,
+            pr_number=None,
+            score_before=0.7,
+            score_after=0.85,
+            delta=0.15,
+            verdict="keep",
+            cost_usd=0.5,
+            notes="",
         )
         asyncio.run(store.finalize(exp_id, record))
 
-        with patch("factory.obsidian.notes.write_experiment_note") as mock_exp, \
-             patch("factory.obsidian.notes.write_project_dashboard") as mock_dash, \
-             patch("factory.obsidian.notes.write_strategy_note") as mock_strat, \
-             patch("factory.obsidian.notes.update_memory_index"), \
-             patch("factory.obsidian.notes._get_vault_path",
-                   return_value=tmp_project / "vault"):
+        with (
+            patch("factory.obsidian.notes.write_experiment_note") as mock_exp,
+            patch("factory.obsidian.notes.write_project_dashboard") as mock_dash,
+            patch("factory.obsidian.notes.write_strategy_note") as mock_strat,
+            patch("factory.obsidian.notes.update_memory_index"),
+            patch("factory.obsidian.notes._get_vault_path", return_value=tmp_project / "vault"),
+        ):
             result = main(["archive", str(tmp_project)])
 
         assert result == 0
@@ -722,29 +818,35 @@ class TestCmdArchive:
         asyncio.run(store.init(sample_config))
         exp_id = asyncio.run(store.begin("Test hypothesis"))
         record = ExperimentRecord(
-            id=exp_id, timestamp=datetime.now(),
+            id=exp_id,
+            timestamp=datetime.now(),
             hypothesis="Test hypothesis",
             change_summary="Changed stuff",
-            issue_number=None, pr_number=None,
-            score_before=0.8, score_after=0.85, delta=0.05,
-            verdict="keep", cost_usd=None, notes="",
+            issue_number=None,
+            pr_number=None,
+            score_before=0.8,
+            score_after=0.85,
+            delta=0.05,
+            verdict="keep",
+            cost_usd=None,
+            notes="",
         )
         asyncio.run(store.finalize(exp_id, record))
         asyncio.run(store.write_strategy("Focus on reliability."))
 
-        with patch("factory.obsidian.notes.write_experiment_note") as mock_exp, \
-             patch("factory.obsidian.notes.write_project_dashboard") as mock_dash, \
-             patch("factory.obsidian.notes.write_strategy_note") as mock_strat, \
-             patch("factory.obsidian.notes.update_memory_index"), \
-             patch("factory.obsidian.notes._get_vault_path",
-                   return_value=tmp_project / "vault"):
+        with (
+            patch("factory.obsidian.notes.write_experiment_note") as mock_exp,
+            patch("factory.obsidian.notes.write_project_dashboard") as mock_dash,
+            patch("factory.obsidian.notes.write_strategy_note") as mock_strat,
+            patch("factory.obsidian.notes.update_memory_index"),
+            patch("factory.obsidian.notes._get_vault_path", return_value=tmp_project / "vault"),
+        ):
             result = main(["archive", str(tmp_project)])
 
         assert result == 0
         mock_exp.assert_called_once()
         mock_dash.assert_called_once()
         mock_strat.assert_called_once()
-
 
 
 class TestCmdVaultInit:
@@ -809,15 +911,18 @@ class TestRunWithGitHubUrl:
     def test_run_clones_https_url(self, capsys):
         """cmd_run clones a GitHub HTTPS URL into a temp dir and invokes CEO."""
         url = "https://github.com/user/repo"
-        with patch("factory.cli.ceo.subprocess.run") as mock_clone, \
-             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.cli.ceo.tempfile.mkdtemp", return_value="/tmp/factory-abc"), \
-             patch("factory.cli.ceo._read_target_branch", return_value="main"):
+        with (
+            patch("factory.cli.ceo.subprocess.run") as mock_clone,
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.cli.ceo.tempfile.mkdtemp", return_value="/tmp/factory-abc"),
+            patch("factory.cli.ceo._read_target_branch", return_value="main"),
+        ):
             result = main(["run", url])
 
         assert result == 0
         mock_clone.assert_called_once_with(
-            ["git", "clone", url, "/tmp/factory-abc"], check=True,
+            ["git", "clone", url, "/tmp/factory-abc"],
+            check=True,
         )
         out = capsys.readouterr().out
         assert "Cloned https://github.com/user/repo" in out
@@ -825,23 +930,28 @@ class TestRunWithGitHubUrl:
     def test_run_clones_ssh_url(self, capsys):
         """cmd_run clones a GitHub SSH URL into a temp dir."""
         url = "git@github.com:user/repo.git"
-        with patch("factory.cli.ceo.subprocess.run") as mock_clone, \
-             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.cli.ceo.tempfile.mkdtemp", return_value="/tmp/factory-xyz"), \
-             patch("factory.cli.ceo._read_target_branch", return_value="main"):
+        with (
+            patch("factory.cli.ceo.subprocess.run") as mock_clone,
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.cli.ceo.tempfile.mkdtemp", return_value="/tmp/factory-xyz"),
+            patch("factory.cli.ceo._read_target_branch", return_value="main"),
+        ):
             result = main(["run", url])
 
         assert result == 0
         mock_clone.assert_called_once_with(
-            ["git", "clone", url, "/tmp/factory-xyz"], check=True,
+            ["git", "clone", url, "/tmp/factory-xyz"],
+            check=True,
         )
         out = capsys.readouterr().out
         assert f"Cloned {url}" in out
 
     def test_run_local_path_no_clone(self, tmp_path):
         """cmd_run with a local path does not clone — just invokes CEO."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["run", str(tmp_path)])
 
         assert result == 0
@@ -849,8 +959,10 @@ class TestRunWithGitHubUrl:
 
     def test_run_discover_mode(self, tmp_path):
         """cmd_run with --mode=discover passes discover task to CEO."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["run", str(tmp_path), "--mode", "discover"])
 
         assert result == 0
@@ -860,8 +972,10 @@ class TestRunWithGitHubUrl:
 
     def test_run_meta_mode(self, tmp_path):
         """cmd_run with --mode=meta passes meta task to CEO."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["run", str(tmp_path), "--mode", "meta"])
 
         assert result == 0
@@ -914,19 +1028,31 @@ class TestHeartbeatParserFlags:
 class TestHeartbeatLoop:
     def test_no_loop_single_run(self, tmp_path):
         """Without --loop, cmd_run executes exactly one cycle."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["run", str(tmp_path)])
         assert result == 0
         mock_agent.assert_called_once()
 
     def test_loop_exits_after_max_cycles(self, tmp_path, capsys):
         """With --loop --max-cycles=3, runs exactly 3 cycles then exits."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
-            result = main([
-                "run", str(tmp_path), "--loop", "--max-cycles", "3", "--interval", "0",
-            ])
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
+            result = main(
+                [
+                    "run",
+                    str(tmp_path),
+                    "--loop",
+                    "--max-cycles",
+                    "3",
+                    "--interval",
+                    "0",
+                ]
+            )
         assert result == 0
         assert mock_agent.call_count == 3
 
@@ -938,11 +1064,19 @@ class TestHeartbeatLoop:
 
     def test_loop_single_cycle(self, tmp_path, capsys):
         """--max-cycles=1 runs one cycle, no sleep, then exits."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
-            result = main([
-                "run", str(tmp_path), "--loop", "--max-cycles", "1",
-            ])
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
+            result = main(
+                [
+                    "run",
+                    str(tmp_path),
+                    "--loop",
+                    "--max-cycles",
+                    "1",
+                ]
+            )
         assert result == 0
         out = capsys.readouterr().out
         assert "[factory] Cycle 1 started at" in out
@@ -963,9 +1097,14 @@ class TestHeartbeatLoop:
                 threading.Timer(0.05, handler, args=(signal.SIGTERM, None)).start()
             return ("ok", 0)
 
-        with patch("signal.signal", side_effect=_capture_signal), \
-             patch("factory.agents.runner.invoke_agent", AsyncMock(side_effect=_trigger_sigterm_after_cycle)), \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("signal.signal", side_effect=_capture_signal),
+            patch(
+                "factory.agents.runner.invoke_agent",
+                AsyncMock(side_effect=_trigger_sigterm_after_cycle),
+            ),
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["run", str(tmp_path), "--loop", "--interval", "30"])
 
         assert result == 0
@@ -987,9 +1126,14 @@ class TestHeartbeatLoop:
                 threading.Timer(0.05, handler, args=(signal.SIGINT, None)).start()
             return ("ok", 0)
 
-        with patch("signal.signal", side_effect=_capture_signal), \
-             patch("factory.agents.runner.invoke_agent", AsyncMock(side_effect=_trigger_sigint_after_cycle)), \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("signal.signal", side_effect=_capture_signal),
+            patch(
+                "factory.agents.runner.invoke_agent",
+                AsyncMock(side_effect=_trigger_sigint_after_cycle),
+            ),
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["run", str(tmp_path), "--loop", "--interval", "30"])
 
         assert result == 0
@@ -998,11 +1142,21 @@ class TestHeartbeatLoop:
 
     def test_loop_logs_sleep_message(self, tmp_path, capsys):
         """Verify the sleep log message appears between cycles."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
-            result = main([
-                "run", str(tmp_path), "--loop", "--max-cycles", "2", "--interval", "0",
-            ])
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
+            result = main(
+                [
+                    "run",
+                    str(tmp_path),
+                    "--loop",
+                    "--max-cycles",
+                    "2",
+                    "--interval",
+                    "0",
+                ]
+            )
         assert result == 0
         out = capsys.readouterr().out
         assert "[factory] Cycle 1 completed. Sleeping for 0s..." in out
@@ -1014,9 +1168,16 @@ class TestHeartbeatLoop:
 class TestCmdAgentParser:
     def test_agent_subcommand(self):
         parser = build_parser()
-        args = parser.parse_args([
-            "agent", "researcher", "--task", "Research the project", "--project", "/some/path",
-        ])
+        args = parser.parse_args(
+            [
+                "agent",
+                "researcher",
+                "--task",
+                "Research the project",
+                "--project",
+                "/some/path",
+            ]
+        )
         assert args.command == "agent"
         assert args.role == "researcher"
         assert args.task == "Research the project"
@@ -1024,16 +1185,32 @@ class TestCmdAgentParser:
 
     def test_agent_default_timeout(self):
         parser = build_parser()
-        args = parser.parse_args([
-            "agent", "builder", "--task", "Build it", "--project", "/path",
-        ])
+        args = parser.parse_args(
+            [
+                "agent",
+                "builder",
+                "--task",
+                "Build it",
+                "--project",
+                "/path",
+            ]
+        )
         assert args.timeout == 600.0
 
     def test_agent_custom_timeout(self):
         parser = build_parser()
-        args = parser.parse_args([
-            "agent", "qa", "--task", "Eval", "--project", "/path", "--timeout", "300",
-        ])
+        args = parser.parse_args(
+            [
+                "agent",
+                "qa",
+                "--task",
+                "Eval",
+                "--project",
+                "/path",
+                "--timeout",
+                "300",
+            ]
+        )
         assert args.timeout == 300.0
 
     def test_agent_all_roles_valid(self):
@@ -1047,9 +1224,16 @@ class TestCmdAgent:
     def test_agent_invokes_invoke_agent(self, tmp_path, capsys):
         """cmd_agent delegates to invoke_agent with correct args."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            result = main([
-                "agent", "researcher", "--task", "Research", "--project", str(tmp_path),
-            ])
+            result = main(
+                [
+                    "agent",
+                    "researcher",
+                    "--task",
+                    "Research",
+                    "--project",
+                    str(tmp_path),
+                ]
+            )
         assert result == 0
         mock_agent.assert_called_once()
         call_args = mock_agent.call_args
@@ -1061,9 +1245,16 @@ class TestCmdAgent:
     def test_agent_returns_nonzero_on_failure(self, tmp_path):
         """cmd_agent returns agent exit code on failure."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_fail()):
-            result = main([
-                "agent", "builder", "--task", "Build", "--project", str(tmp_path),
-            ])
+            result = main(
+                [
+                    "agent",
+                    "builder",
+                    "--task",
+                    "Build",
+                    "--project",
+                    str(tmp_path),
+                ]
+            )
         assert result == 1
 
 
@@ -1092,7 +1283,9 @@ class TestCmdCeoParser:
 
     def test_ceo_review_mode_with_repo(self):
         parser = build_parser()
-        args = parser.parse_args(["ceo", "/some/path", "--mode", "review", "--pr", "42", "--repo", "owner/repo"])
+        args = parser.parse_args(
+            ["ceo", "/some/path", "--mode", "review", "--pr", "42", "--repo", "owner/repo"]
+        )
         assert args.repo == "owner/repo"
 
     def test_ceo_pr_default_none(self):
@@ -1139,8 +1332,19 @@ class TestCmdCeoReview:
     def test_review_mode_headless_with_repo(self, tmp_path, capsys):
         """--mode review --pr 42 --repo owner/repo includes repo in task."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            result = main(["ceo", str(tmp_path), "--mode", "review", "--pr", "42",
-                           "--repo", "owner/repo", "--headless"])
+            result = main(
+                [
+                    "ceo",
+                    str(tmp_path),
+                    "--mode",
+                    "review",
+                    "--pr",
+                    "42",
+                    "--repo",
+                    "owner/repo",
+                    "--headless",
+                ]
+            )
         assert result == 0
         task = mock_agent.call_args[0][1]
         assert "owner/repo" in task
@@ -1149,16 +1353,20 @@ class TestCmdCeoReview:
 
     def test_review_mode_skips_worktree(self, tmp_path):
         """Review mode does not create worktrees or touch experiment store."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.worktree.create_worktree") as mock_wt:
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.worktree.create_worktree") as mock_wt,
+        ):
             main(["ceo", str(tmp_path), "--mode", "review", "--pr", "42", "--headless"])
         mock_wt.assert_not_called()
 
     def test_review_mode_foreground(self, tmp_path):
         """Review mode without --headless launches interactively."""
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        with patch("factory.runners.claude.subprocess.run", mock_run), \
-             patch("factory.cli.ceo._ensure_dashboard"):
+        with (
+            patch("factory.runners.claude.subprocess.run", mock_run),
+            patch("factory.cli.ceo._ensure_dashboard"),
+        ):
             main(["ceo", str(tmp_path), "--mode", "review", "--pr", "42"])
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
@@ -1207,8 +1415,19 @@ class TestCmdCeoQa:
     def test_qa_mode_headless_with_repo(self, tmp_path, capsys):
         """--mode qa --pr 42 --repo owner/repo includes repo in task."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            result = main(["ceo", str(tmp_path), "--mode", "qa", "--pr", "42",
-                           "--repo", "owner/repo", "--headless"])
+            result = main(
+                [
+                    "ceo",
+                    str(tmp_path),
+                    "--mode",
+                    "qa",
+                    "--pr",
+                    "42",
+                    "--repo",
+                    "owner/repo",
+                    "--headless",
+                ]
+            )
         assert result == 0
         task = mock_agent.call_args[0][1]
         assert "owner/repo" in task
@@ -1216,16 +1435,20 @@ class TestCmdCeoQa:
 
     def test_qa_mode_skips_worktree(self, tmp_path):
         """QA mode does not create worktrees or touch experiment store."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.worktree.create_worktree") as mock_wt:
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.worktree.create_worktree") as mock_wt,
+        ):
             main(["ceo", str(tmp_path), "--mode", "qa", "--pr", "42", "--headless"])
         mock_wt.assert_not_called()
 
     def test_qa_mode_foreground(self, tmp_path):
         """QA mode without --headless launches interactively."""
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        with patch("factory.runners.claude.subprocess.run", mock_run), \
-             patch("factory.cli.ceo._ensure_dashboard"):
+        with (
+            patch("factory.runners.claude.subprocess.run", mock_run),
+            patch("factory.cli.ceo._ensure_dashboard"),
+        ):
             main(["ceo", str(tmp_path), "--mode", "qa", "--pr", "42"])
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
@@ -1306,8 +1529,10 @@ class TestCmdCeoDeepQa:
 class TestCmdCeo:
     def test_ceo_headless_invokes_ceo_agent(self, tmp_path, capsys):
         """cmd_ceo --headless spawns CEO agent via invoke_agent."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["ceo", str(tmp_path), "--headless"])
         assert result == 0
         mock_agent.assert_called_once()
@@ -1317,8 +1542,10 @@ class TestCmdCeo:
 
     def test_ceo_headless_meta_mode_task(self, tmp_path):
         """cmd_ceo --headless with --mode=meta includes meta instructions."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["ceo", str(tmp_path), "--mode", "meta", "--headless"])
         assert result == 0
         task = mock_agent.call_args[0][1]
@@ -1327,21 +1554,26 @@ class TestCmdCeo:
     def test_ceo_headless_clones_github_url(self, capsys):
         """cmd_ceo --headless clones a GitHub URL then invokes CEO."""
         url = "https://github.com/user/repo"
-        with patch("factory.cli.ceo.subprocess.run") as mock_clone, \
-             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.cli.ceo._chain_modes", return_value=0), \
-             patch("factory.cli.ceo.tempfile.mkdtemp", return_value="/tmp/factory-ceo"), \
-             patch("factory.cli.ceo._read_target_branch", return_value="main"):
+        with (
+            patch("factory.cli.ceo.subprocess.run") as mock_clone,
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+            patch("factory.cli.ceo.tempfile.mkdtemp", return_value="/tmp/factory-ceo"),
+            patch("factory.cli.ceo._read_target_branch", return_value="main"),
+        ):
             result = main(["ceo", url, "--headless"])
         assert result == 0
         mock_clone.assert_called_once_with(
-            ["git", "clone", url, "/tmp/factory-ceo"], check=True,
+            ["git", "clone", url, "/tmp/factory-ceo"],
+            check=True,
         )
 
     def test_ceo_headless_timeout_is_2_hours(self, tmp_path):
         """CEO agent gets 7200s timeout in headless mode."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             main(["ceo", str(tmp_path), "--headless"])
         call_kwargs = mock_agent.call_args[1]
         assert call_kwargs["timeout"] == 7200.0
@@ -1401,8 +1633,6 @@ class TestSlugify:
         assert _slugify("!!!") == "factory-project"
 
 
-
-
 class TestExtractProjectName:
     def test_strips_build_verb(self):
         assert _extract_project_name("Build a weather CLI tool") == "weather-cli-tool"
@@ -1411,7 +1641,10 @@ class TestExtractProjectName:
         assert _extract_project_name("Create an API server") == "api-server"
 
     def test_strips_filler_adjectives(self):
-        assert _extract_project_name("Build a comprehensive e-commerce platform with payments") == "e-commerce-platform-payments"
+        assert (
+            _extract_project_name("Build a comprehensive e-commerce platform with payments")
+            == "e-commerce-platform-payments"
+        )
 
     def test_caps_at_four_words(self):
         result = _extract_project_name("distributed eval runner for multi-node benchmarks on GPUs")
@@ -1455,7 +1688,9 @@ class TestDedupeProjectPath:
         path = tmp_path / "projects" / "rest-api"
         spec_dir = path / ".factory" / "strategy"
         spec_dir.mkdir(parents=True)
-        (spec_dir / "current.md").write_text("## Project Specification\n\nBuild a REST API for users\n")
+        (spec_dir / "current.md").write_text(
+            "## Project Specification\n\nBuild a REST API for users\n"
+        )
         result = _dedupe_project_path(path, "Build a REST API for payments")
         assert result == tmp_path / "projects" / "rest-api-2"
 
@@ -1539,8 +1774,10 @@ class TestResolveInput:
         bin_file = tmp_path / "data.bin"
         bin_file.write_bytes(b"\x00\x01\x02\xff")
 
-        with patch("factory.cli.ceo._get_projects_dir", return_value=tmp_path / "projects"), \
-             pytest.raises(UnicodeDecodeError):
+        with (
+            patch("factory.cli.ceo._get_projects_dir", return_value=tmp_path / "projects"),
+            pytest.raises(UnicodeDecodeError),
+        ):
             _resolve_input(str(bin_file))
 
     def test_ceo_receives_context(self, tmp_path):
@@ -1548,9 +1785,11 @@ class TestResolveInput:
         idea_file = tmp_path / "Test Idea \u2014 Details.md"
         idea_file.write_text("# Test Idea\nBuild X that does Y")
 
-        with patch("factory.cli.ceo._get_projects_dir", return_value=tmp_path / "projects"), \
-             patch("factory.cli.ceo._chain_modes", return_value=0), \
-             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
+        with (
+            patch("factory.cli.ceo._get_projects_dir", return_value=tmp_path / "projects"),
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+        ):
             main(["ceo", str(idea_file), "--headless"])
 
         task_arg = mock_agent.call_args[0][1]  # second positional = task
@@ -1559,7 +1798,9 @@ class TestResolveInput:
 
     def test_dir_overrides_slug_for_raw_prompt(self, tmp_path):
         with patch("factory.cli.ceo._get_projects_dir", return_value=tmp_path / "projects"):
-            project_path, context = _resolve_input("Build a todo app with FastAPI", dir_name="my-todo")
+            project_path, context = _resolve_input(
+                "Build a todo app with FastAPI", dir_name="my-todo"
+            )
 
         assert project_path.name == "my-todo"
         assert not (project_path / ".git").is_dir()
@@ -1613,12 +1854,18 @@ class TestResearchMode:
         (tmp_path / ".git").mkdir()
         factory_dir = tmp_path / ".factory"
         factory_dir.mkdir()
-        rt = {"objective": "maximize accuracy", "metric": "accuracy",
-              "target": 0.9, "run_command": "python run.py",
-              "result_path": "results.json"}
+        rt = {
+            "objective": "maximize accuracy",
+            "metric": "accuracy",
+            "target": 0.9,
+            "run_command": "python run.py",
+            "result_path": "results.json",
+        }
         (factory_dir / "config.json").write_text(json.dumps(_make_config(research_target=rt)))
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent, \
-             patch("factory.cli.ceo._chain_modes", return_value=0):
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
             result = main(["ceo", str(tmp_path), "--mode", "research", "--headless"])
         assert result == 0
         task = mock_agent.call_args[0][1]
@@ -1642,6 +1889,7 @@ class TestResearchMode:
         asyncio.run(store.init(config_with_research))
 
         from factory.cli import _auto_detect_mode
+
         mode = _auto_detect_mode(tmp_project, force_fresh=True)
         assert mode == "research"
 
@@ -1651,6 +1899,7 @@ class TestResearchMode:
         asyncio.run(store.init(sample_config))
 
         from factory.cli import _auto_detect_mode
+
         mode = _auto_detect_mode(tmp_project, force_fresh=True)
         assert mode == "improve"
 
@@ -1776,9 +2025,17 @@ class TestProfileParser:
 
     def test_use_profile_flag_on_agent(self):
         parser = build_parser()
-        args = parser.parse_args([
-            "agent", "researcher", "--task", "test", "--project", "/p", "--use-profile",
-        ])
+        args = parser.parse_args(
+            [
+                "agent",
+                "researcher",
+                "--task",
+                "test",
+                "--project",
+                "/p",
+                "--use-profile",
+            ]
+        )
         assert args.use_profile is True
 
 
@@ -1818,6 +2075,7 @@ class TestCmdHomeReturnsFactoryDir:
     def test_cmd_home_returns_package_root(self, capsys):
         from factory.cli import cmd_home
         import argparse
+
         result = cmd_home(argparse.Namespace())
         assert result == 0
         output = capsys.readouterr().out.strip()
@@ -1832,14 +2090,16 @@ class TestCmdTmuxBareCLI:
         from factory.cli import cmd_tmux
         import argparse
 
-        with patch("factory.cli.ceo._tmux_available", return_value=True), \
-             patch("factory.cli.ceo._tmux_session_alive", return_value=True), \
-             patch("factory.cli.ceo.time.sleep"), \
-             patch("subprocess.run") as mock_run:
+        with (
+            patch("factory.cli.ceo._tmux_available", return_value=True),
+            patch("factory.cli.ceo._tmux_session_alive", return_value=True),
+            patch("factory.cli.ceo.time.sleep"),
+            patch("subprocess.run") as mock_run,
+        ):
             mock_run.return_value = type("R", (), {"returncode": 1})()  # has-session fails
             mock_run.side_effect = [
                 type("R", (), {"returncode": 1})(),  # has-session → no existing session
-                type("R", (), {"returncode": 0})(),   # new-session → success
+                type("R", (), {"returncode": 0})(),  # new-session → success
                 type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),  # capture-pane
             ]
             args = argparse.Namespace(
@@ -1870,6 +2130,7 @@ class TestPluginAgentsDirGuard:
     def test_plugin_agents_dir_none_when_missing(self, tmp_path):
         """_PLUGIN_AGENTS_DIR is None when the agents/ dir doesn't exist."""
         from factory.agents import plugin
+
         original = plugin._PLUGIN_AGENTS_DIR
         try:
             plugin._PLUGIN_AGENTS_DIR = None
@@ -1885,8 +2146,10 @@ class TestResolveProjectPath:
         from factory.cli import cmd_notify
         import argparse
 
-        with patch("factory.cli.admin._run", side_effect=lambda c: []), \
-             patch("factory.notify.telegram.TelegramNotifier") as MockNotifier:
+        with (
+            patch("factory.cli.admin._run", side_effect=lambda c: []),
+            patch("factory.notify.telegram.TelegramNotifier") as MockNotifier,
+        ):
             mock_instance = MockNotifier.return_value
             mock_instance.send_digest = AsyncMock()
             args = argparse.Namespace(path=str(tmp_path))
@@ -1924,6 +2187,7 @@ class TestNoBareUvRunPythonMFactory:
 
     def test_no_hardcoded_uv_run_python_m_factory(self):
         import glob
+
         repo_root = Path(__file__).resolve().parent.parent
         violations: list[str] = []
         for pattern in self.SCAN_GLOBS:
@@ -1960,7 +2224,7 @@ class TestSacredRule8Present:
         """Rule 8 must be in the numbered Sacred Rules list, not just mentioned elsewhere."""
         repo_root = Path(__file__).resolve().parent.parent
         ceo_prompt = (repo_root / "factory" / "agents" / "prompts" / "ceo.md").read_text()
-        assert '8. **Do not do another agent\'s job**' in ceo_prompt, (
+        assert "8. **Do not do another agent's job**" in ceo_prompt, (
             "Sacred Rule 8 must be a numbered item (8.) in the Sacred Rules section"
         )
 
@@ -1974,7 +2238,9 @@ class TestEnsureRepo:
         _ensure_repo(project)
         result = subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
-            cwd=project, capture_output=True, text=True,
+            cwd=project,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         assert int(result.stdout.strip()) >= 1
@@ -1985,7 +2251,9 @@ class TestEnsureRepo:
         _ensure_repo(project)
         result = subprocess.run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            cwd=project, capture_output=True, text=True,
+            cwd=project,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
         branch = result.stdout.strip()
@@ -1997,12 +2265,16 @@ class TestEnsureRepo:
         _ensure_repo(project)
         count_before = subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
-            cwd=project, capture_output=True, text=True,
+            cwd=project,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
         _ensure_repo(project)
         count_after = subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
-            cwd=project, capture_output=True, text=True,
+            cwd=project,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
         assert count_before == count_after
 
@@ -2033,8 +2305,7 @@ class TestDesignFileInput:
 
     def test_raw_idea_persists_spec(self, tmp_path):
         """When --mode design receives a raw string, the spec should be persisted."""
-        with _mock_foreground(), \
-             patch("factory.cli.ceo._get_projects_dir", return_value=tmp_path):
+        with _mock_foreground(), patch("factory.cli.ceo._get_projects_dir", return_value=tmp_path):
             main(["ceo", "Build a CLI todo app", "--mode", "design"])
         matches = [p for p in tmp_path.iterdir() if p.is_dir()]
         assert len(matches) == 1
@@ -2078,7 +2349,9 @@ class TestRefineFlag:
         prompt_file = tmp_path / "spec.md"
         prompt_file.write_text("some spec")
         with _mock_foreground():
-            result = main(["ceo", str(tmp_path), "--refine", "fix bug", "--prompt", str(prompt_file)])
+            result = main(
+                ["ceo", str(tmp_path), "--refine", "fix bug", "--prompt", str(prompt_file)]
+            )
         assert result == 1
         assert "mutually exclusive" in capsys.readouterr().err
 
@@ -2130,7 +2403,11 @@ class TestRefinerPromptExists:
         prompt_path = Path(__file__).parent.parent / "factory" / "agents" / "prompts" / "refiner.md"
         content = prompt_path.read_text()
         assert "Tier" in content, "refiner.md should reference Tier classification"
-        assert "Builder" in content or "builder" in content, "refiner.md should reference the Builder agent"
+        assert "Builder" in content or "builder" in content, (
+            "refiner.md should reference the Builder agent"
+        )
+
+
 class TestWizardLongInputRedirect:
     """Tests for wizard long-input redirect to ~/.factory/wizard_input.md."""
 
@@ -2172,9 +2449,19 @@ class TestWizardLongInputRedirect:
         short_input = "Build a weather CLI"
         monkeypatch.setattr("builtins.input", self._make_input_fn(short_input))
 
-        with patch("factory.cli.ceo._classify_with_llm", return_value=([], [
-            {"label": "Build", "explanation": "Build it.", "command": "factory ceo 'Build a weather CLI' --mode build"},
-        ])):
+        with patch(
+            "factory.cli.ceo._classify_with_llm",
+            return_value=(
+                [],
+                [
+                    {
+                        "label": "Build",
+                        "explanation": "Build it.",
+                        "command": "factory ceo 'Build a weather CLI' --mode build",
+                    },
+                ],
+            ),
+        ):
             _welcome_wizard()
 
         assert not wizard_file.exists()
@@ -2289,12 +2576,16 @@ class TestMaterializeProject:
         _materialize_project(project, "first spec")
         count_before = subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
-            cwd=project, capture_output=True, text=True,
+            cwd=project,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
         _materialize_project(project, "second spec")
         count_after = subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
-            cwd=project, capture_output=True, text=True,
+            cwd=project,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
         assert count_before == count_after
 
@@ -2324,9 +2615,9 @@ class TestIsScaffoldOnly:
         (project / "README.md").write_text("# Hello")
         subprocess.run(["git", "add", "README.md"], cwd=project, capture_output=True)
         subprocess.run(
-            ["git", "-c", "user.name=Test", "-c", "user.email=t@t",
-             "commit", "-m", "second"],
-            cwd=project, capture_output=True,
+            ["git", "-c", "user.name=Test", "-c", "user.email=t@t", "commit", "-m", "second"],
+            cwd=project,
+            capture_output=True,
         )
         assert _is_scaffold_only(project) is False
 
@@ -2361,9 +2652,10 @@ class TestDeferredCreationFlow:
         assert not project_path.exists()
         _materialize_project(project_path, context)
         assert (project_path / ".git").is_dir()
-        assert "Build a weather CLI" in (
-            project_path / ".factory" / "strategy" / "current.md"
-        ).read_text()
+        assert (
+            "Build a weather CLI"
+            in (project_path / ".factory" / "strategy" / "current.md").read_text()
+        )
 
     def test_existing_dir_not_affected(self, tmp_path):
         """_resolve_input on existing dir returns it unchanged, _materialize_project is no-op."""
@@ -2371,3 +2663,92 @@ class TestDeferredCreationFlow:
         project_path, context = _resolve_input(str(tmp_path))
         assert project_path == tmp_path
         assert context is None
+
+
+class TestNoWorktreeFlag:
+    """Tests for --no-worktree flag on ceo and run commands."""
+
+    def test_ceo_parser_accepts_no_worktree(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path", "--no-worktree"])
+        assert args.no_worktree is True
+
+    def test_ceo_parser_default_no_worktree_false(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path"])
+        assert args.no_worktree is False
+
+    def test_run_parser_accepts_no_worktree(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path", "--no-worktree"])
+        assert args.no_worktree is True
+
+    def test_run_parser_default_no_worktree_false(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "/some/path"])
+        assert args.no_worktree is False
+
+    def test_ceo_no_worktree_skips_create_worktree(self, tmp_path):
+        """--no-worktree prevents create_worktree from being called."""
+        with (
+            patch("factory.worktree.create_worktree") as mock_create,
+            patch("factory.worktree.remove_worktree") as mock_remove,
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("factory.cli.ceo._read_target_branch", return_value="main"),
+            patch("factory.cli.ceo._is_scaffold_only", return_value=False),
+            patch("factory.cli.ceo._ensure_dashboard"),
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
+            result = main(["ceo", str(tmp_path), "--headless", "--no-worktree"])
+        assert result == 0
+        mock_create.assert_not_called()
+        mock_remove.assert_not_called()
+
+    def test_ceo_no_worktree_uses_project_path(self, tmp_path):
+        """--no-worktree makes the CEO run in the project directory itself."""
+        with (
+            patch("factory.worktree.create_worktree") as mock_create,
+            patch("factory.worktree.remove_worktree") as mock_remove,
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("factory.cli.ceo._read_target_branch", return_value="main"),
+            patch("factory.cli.ceo._is_scaffold_only", return_value=False),
+            patch("factory.cli.ceo._ensure_dashboard"),
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
+            result = main(["ceo", str(tmp_path), "--headless", "--no-worktree"])
+        assert result == 0
+        mock_create.assert_not_called()
+        mock_remove.assert_not_called()
+        task = mock_agent.call_args[0][1]
+        assert str(tmp_path) in task
+
+    def test_run_no_worktree_skips_create_worktree(self, tmp_path):
+        """--no-worktree on run command prevents create_worktree from being called."""
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.worktree.create_worktree") as mock_create,
+            patch("factory.worktree.remove_worktree") as mock_remove,
+            patch("factory.cli.ceo._chain_modes", return_value=0),
+        ):
+            result = main(["run", str(tmp_path), "--no-worktree"])
+        assert result == 0
+        mock_create.assert_not_called()
+        mock_remove.assert_not_called()
+
+    def test_ceo_foreground_no_worktree_skips_worktree(self, tmp_path):
+        """--no-worktree in foreground mode skips worktree create and remove."""
+        mock_run = MagicMock(return_value=MagicMock(returncode=0))
+        with (
+            patch("factory.runners.claude.subprocess.run", mock_run),
+            patch("factory.worktree.create_worktree") as mock_create,
+            patch("factory.worktree.remove_worktree") as mock_remove,
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("factory.cli.ceo._read_target_branch", return_value="main"),
+            patch("factory.cli.ceo._is_scaffold_only", return_value=False),
+            patch("factory.cli.ceo._ensure_dashboard"),
+        ):
+            main(["ceo", str(tmp_path), "--no-worktree"])
+        mock_create.assert_not_called()
+        mock_remove.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1490,8 +1490,19 @@ class TestCmdCeoDeepQa:
     def test_deep_qa_mode_headless_with_repo(self, tmp_path, capsys):
         """--mode deep-qa --pr 42 --repo owner/repo includes repo in task."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            result = main(["ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42",
-                           "--repo", "owner/repo", "--headless"])
+            result = main(
+                [
+                    "ceo",
+                    str(tmp_path),
+                    "--mode",
+                    "deep-qa",
+                    "--pr",
+                    "42",
+                    "--repo",
+                    "owner/repo",
+                    "--headless",
+                ]
+            )
         assert result == 0
         task = mock_agent.call_args[0][1]
         assert "owner/repo" in task
@@ -1499,16 +1510,20 @@ class TestCmdCeoDeepQa:
 
     def test_deep_qa_mode_skips_worktree(self, tmp_path):
         """Deep-QA mode does not create worktrees or touch experiment store."""
-        with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()), \
-             patch("factory.worktree.create_worktree") as mock_wt:
+        with (
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
+            patch("factory.worktree.create_worktree") as mock_wt,
+        ):
             main(["ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42", "--headless"])
         mock_wt.assert_not_called()
 
     def test_deep_qa_mode_foreground(self, tmp_path):
         """Deep-QA mode without --headless launches interactively."""
         mock_run = MagicMock(return_value=MagicMock(returncode=0))
-        with patch("factory.runners.claude.subprocess.run", mock_run), \
-             patch("factory.cli.ceo._ensure_dashboard"):
+        with (
+            patch("factory.runners.claude.subprocess.run", mock_run),
+            patch("factory.cli.ceo._ensure_dashboard"),
+        ):
             main(["ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42"])
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
@@ -2727,7 +2742,7 @@ class TestNoWorktreeFlag:
     def test_run_no_worktree_skips_create_worktree(self, tmp_path):
         """--no-worktree on run command prevents create_worktree from being called."""
         with (
-            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
+            patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
             patch("factory.worktree.create_worktree") as mock_create,
             patch("factory.worktree.remove_worktree") as mock_remove,
             patch("factory.cli.ceo._chain_modes", return_value=0),


### PR DESCRIPTION
Closes #937

## Changes

- Added `--no-worktree` (`store_true`, default `False`) argument to both `ceo` and `run` subparsers in `factory/cli/_main.py`
- When `--no-worktree` is set in `cmd_ceo()`: sets `wt_path = project_path` and `wt_branch = None` instead of calling `create_worktree()`, guards both `finally` blocks so `remove_worktree()` is only called when not `no_worktree`
- Threaded `no_worktree` parameter through `_run_single_cycle()`, `_chain_modes()`, and `cmd_run()` (single-shot and heartbeat loop paths)
- Added 8 tests covering parser flag parsing, `create_worktree` skip verification, `remove_worktree` guard verification, and foreground mode behavior

## Safety

- `remove_worktree()` is never called when `--no-worktree` is set — prevents `shutil.rmtree()` on the actual project directory
- `wt_branch` is set to `None` to prevent branch deletion in cleanup
- `prune_stale()` runs regardless of the flag