### PR TITLE
fix: pass Vertex AI credentials to failure analysis step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -211,6 +211,9 @@ jobs:
         if: always() && steps.gate.outputs.run == 'true'
         continue-on-error: true
         env:
+          CLAUDE_CODE_USE_VERTEX: "1"
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
+          CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}
           LANGFUSE_HOST: ${{ secrets.LANGFUSE_BENCH_HOST }}
           LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BENCH_HOST }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_BENCH_PUBLIC_KEY }}


### PR DESCRIPTION
## Summary

The `Analyze failures` step in benchmark CI was missing Vertex AI auth env vars, so `claude -p` returned "Not logged in."

Adds `CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, and `CLOUD_ML_REGION` to the step's env — same credentials the benchmark run step uses. GCP service account credentials are already available from the `google-github-actions/auth` step earlier in the job.

## Test plan

- [ ] Next benchmark failure should produce a real claude analysis instead of "Not logged in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)