### PR TITLE
fix: restore navigation sidebar on docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,3 @@
----
-hide:
-  - navigation
----
-
 <p align="center">
   <img src="assets/refactory_logo.png" alt="re:factory" width="480">
 </p>


### PR DESCRIPTION
Closes #943

## Changes
- Removed the `hide: - navigation` frontmatter from `docs/index.md` that was suppressing the documentation sidebar on the main docs page
- The file now starts directly with the HTML content, restoring the default MkDocs navigation sidebar behavior