### PR TITLE
fix: restore navigation sidebar on docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,3 @@
----
-hide:
-  - navigation
----
-
 <p align="center">
   <img src="assets/refactory_logo.png" alt="re:factory" width="480">
 </p>


### PR DESCRIPTION
## Summary
- Removes `hide: - navigation` frontmatter from `docs/index.md` so the sidebar appears on the main docs page
- Fixes #943

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Built `index.html` contains `md-sidebar--primary` div with 15 cross-page nav links
- [x] No leftover frontmatter markers in the file

🤖 Generated with [Claude Code](https://claude.ai/claude-code)