### PR TITLE
fix: pin @ceo-review to main branch code (issue #944)

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -34,11 +34,18 @@ jobs:
         id: pr
         run: echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout PR merge ref
+      - name: Checkout default branch (trusted factory)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: factory-trusted
+
+      - name: Checkout PR merge ref (code under review)
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ steps.pr.outputs.number }}/merge
           fetch-depth: 0
+          path: pr-code
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -49,6 +56,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install factory
+        working-directory: factory-trusted
         run: uv sync --extra telemetry
 
       - name: Set up Node.js
@@ -66,6 +74,7 @@ jobs:
           claude --version
 
       - name: Run CEO review
+        working-directory: factory-trusted
         env:
           CLAUDE_CODE_USE_VERTEX: "1"
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
@@ -76,7 +85,7 @@ jobs:
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
         run: |
-          uv run factory ceo . --mode qa --pr ${{ steps.pr.outputs.number }} --headless
+          uv run factory ceo ${{ github.workspace }}/pr-code --mode qa --pr ${{ steps.pr.outputs.number }} --headless
 
       - name: Approve PR if verdict is KEEP
         if: success()


### PR DESCRIPTION
Closes #944

## Changes

- Split the single checkout step into two: one for the default branch (trusted factory code) and one for the PR merge ref (code under review)
- Install and run the factory from `factory-trusted/` (the default branch checkout), ensuring a PR cannot tamper with the reviewer
- Point the `factory ceo` command at `${{ github.workspace }}/pr-code` so the review still targets the PR's code
- All env vars, approval logic, and failure-comment steps remain unchanged