### PR TITLE
feat: add summary mode to failure analysis (closes #950)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -225,13 +225,19 @@ jobs:
             resolved=$(python3 -c "import json; print(json.load(open('$result_file')).get('resolved', False))")
             if [ "$resolved" = "False" ]; then
               echo "Analyzing failure: $result_file"
+              base="$(basename "$result_file" .json)"
               python3 scripts/langfuse/analyze_failure.py "$result_file" \
-                --output "benchmarks/results/$(basename "$result_file" .json)-analysis.md" \
+                --summary --output "benchmarks/results/${base}-summary.md" \
+                || echo "Summary failed for $result_file (non-fatal)"
+              python3 scripts/langfuse/analyze_failure.py "$result_file" \
+                --output "benchmarks/results/${base}-analysis.md" \
                 || echo "Analysis failed for $result_file (non-fatal)"
-              analysis_file="benchmarks/results/$(basename "$result_file" .json)-analysis.md"
-              if [ -f "$analysis_file" ]; then
-                cat "$analysis_file" >> $GITHUB_STEP_SUMMARY
-              fi
+              for suffix in summary analysis; do
+                f="benchmarks/results/${base}-${suffix}.md"
+                if [ -f "$f" ]; then
+                  cat "$f" >> $GITHUB_STEP_SUMMARY
+                fi
+              done
             fi
           done
 
@@ -393,8 +399,22 @@ jobs:
               body += '_No benchmark results found._\n';
             }
 
+            const summaryFiles = new Set();
             for (const file of files) {
-              if (file.endsWith('-analysis.md')) {
+              if (file.endsWith('-summary.md')) {
+                summaryFiles.add(file);
+                const benchName = file.replace('-summary.md', '').replace(/^\d{8}T\d{6}Z-/, '');
+                const summaryText = fs.readFileSync('results/' + file, 'utf8').trim();
+                const analysisFile = file.replace('-summary.md', '-analysis.md');
+                body += '**' + benchName + ':** ' + summaryText + '\n';
+                if (fs.existsSync('results/' + analysisFile)) {
+                  const analysis = fs.readFileSync('results/' + analysisFile, 'utf8');
+                  body += '<details><summary>Detailed analysis</summary>\n\n' + analysis + '\n</details>\n\n';
+                }
+              }
+            }
+            for (const file of files) {
+              if (file.endsWith('-analysis.md') && !summaryFiles.has(file.replace('-analysis.md', '-summary.md'))) {
                 const analysis = fs.readFileSync('results/' + file, 'utf8');
                 const benchName = file.replace('-analysis.md', '').replace(/^\d{8}T\d{6}Z-/, '');
                 body += '<details><summary>Failure Analysis: ' + benchName + '</summary>\n\n';

--- a/scripts/langfuse/analyze_failure.py
+++ b/scripts/langfuse/analyze_failure.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Analyze a failed benchmark run using its Langfuse trace and claude -p.
 
-Usage: python scripts/langfuse/analyze_failure.py <result.json> [--output FILE] [--no-llm] [--verbose]
+Usage: python scripts/langfuse/analyze_failure.py <result.json> [--output FILE] [--no-llm] [--summary] [--verbose]
 """
 from __future__ import annotations
 
@@ -59,6 +59,30 @@ def format_trace_dump(trace: dict) -> str:
     return buf.getvalue()
 
 
+def run_llm_summary(trace_dump: str, benchmark: str, instance_id: str) -> str | None:
+    if not shutil.which("claude"):
+        return None
+
+    prompt = (
+        f"Benchmark: {benchmark}, Instance: {instance_id}. "
+        "Summarize why this benchmark failed in at most 2 sentences. "
+        f"Keep it under 140 characters total. Here is the trace: {trace_dump}"
+    )
+
+    try:
+        result = subprocess.run(
+            ["claude", "-p", prompt, "--max-turns", "1"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return None
+
+
 def run_llm_analysis(trace_dump: str, benchmark: str, instance_id: str) -> str | None:
     if not shutil.which("claude"):
         return None
@@ -91,11 +115,23 @@ def generate_report(
     host: str | None,
     use_llm: bool = True,
     verbose: bool = False,
+    summary: bool = False,
 ) -> str:
     benchmark = result_data["benchmark"]
     instance_id = result_data["instance_id"]
     solver = result_data.get("solver", "unknown")
     duration = result_data.get("duration_seconds", 0)
+
+    if summary:
+        if trace is None or not use_llm:
+            return "No trace available for summary."
+        trace_dump = format_trace_dump(trace)
+        if verbose:
+            print(f"[verbose] Summary trace dump: {len(trace_dump)} chars", file=sys.stderr)
+        text = run_llm_summary(trace_dump, benchmark, instance_id)
+        if text:
+            return text
+        return "No trace available for summary."
 
     header = (
         f"### Failure Analysis: {benchmark} / {instance_id}\n\n"
@@ -127,6 +163,7 @@ def main() -> int:
     parser.add_argument("result_json", help="Path to benchmark result JSON file")
     parser.add_argument("--output", "-o", help="Output file (default: stdout)")
     parser.add_argument("--no-llm", action="store_true", help="Skip LLM analysis, output raw trace")
+    parser.add_argument("--summary", action="store_true", help="Output a short 1-2 sentence summary instead of full analysis")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output to stderr")
     args = parser.parse_args()
 
@@ -178,6 +215,7 @@ def main() -> int:
     report = generate_report(
         result_data, trace=trace, trace_id=trace_id, host=host,
         use_llm=not args.no_llm, verbose=args.verbose,
+        summary=args.summary,
     )
     _write_output(report, args.output)
     return 0


### PR DESCRIPTION
## Summary

- Adds `--summary` flag to `analyze_failure.py` — produces a 2-sentence / 140-char max diagnosis
- CI runs the script twice per failure: summary first, then detailed
- PR comment shows summary inline, detailed analysis in collapsible `<details>`

Closes #950

## Test plan

- [ ] Next CI benchmark failure shows inline summary + collapsible detailed analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)