### PR TITLE
fix: restore Langfuse trace analysis for benchmark runs

### DIFF
--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -9,6 +9,26 @@ from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
 
 
+COMMON_ENV_VARS = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_MODEL",
+    "CLAUDE_CODE_USE_VERTEX",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLOUD_ML_REGION",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING",
+    "MAX_THINKING_TOKENS",
+    "CLAUDE_CODE_EFFORT_LEVEL",
+    "LANGFUSE_HOST",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_BASE_URL",
+)
+
+
 class ProgramBenchFactoryCeo(BaseInstalledAgent):
     """Runs ``factory ceo`` for ProgramBench tasks.
 
@@ -66,20 +86,7 @@ class ProgramBenchFactoryCeo(BaseInstalledAgent):
         if self.model_name:
             env["ANTHROPIC_MODEL"] = self.model_name.split("/")[-1]
 
-        for var in (
-            "ANTHROPIC_BASE_URL",
-            "ANTHROPIC_MODEL",
-            "CLAUDE_CODE_USE_VERTEX",
-            "ANTHROPIC_VERTEX_PROJECT_ID",
-            "CLOUD_ML_REGION",
-            "GOOGLE_APPLICATION_CREDENTIALS",
-            "CLAUDE_CODE_SUBAGENT_MODEL",
-            "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
-            "ANTHROPIC_DEFAULT_OPUS_MODEL",
-            "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING",
-            "MAX_THINKING_TOKENS",
-            "CLAUDE_CODE_EFFORT_LEVEL",
-        ):
+        for var in COMMON_ENV_VARS:
             val = self._get_env(var) or os.environ.get(var)
             if val and var not in env:
                 env[var] = val
@@ -292,23 +299,7 @@ class FactoryCeo(BaseInstalledAgent):
         if self.model_name:
             env["ANTHROPIC_MODEL"] = self.model_name.split("/")[-1]
 
-        for var in (
-            "ANTHROPIC_BASE_URL",
-            "ANTHROPIC_MODEL",
-            "CLAUDE_CODE_USE_VERTEX",
-            "ANTHROPIC_VERTEX_PROJECT_ID",
-            "CLOUD_ML_REGION",
-            "GOOGLE_APPLICATION_CREDENTIALS",
-            "CLAUDE_CODE_SUBAGENT_MODEL",
-            "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS",
-            "ANTHROPIC_DEFAULT_OPUS_MODEL",
-            "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING",
-            "MAX_THINKING_TOKENS",
-            "CLAUDE_CODE_EFFORT_LEVEL",
-            "LANGFUSE_HOST",
-            "LANGFUSE_PUBLIC_KEY",
-            "LANGFUSE_SECRET_KEY",
-        ):
+        for var in COMMON_ENV_VARS:
             val = self._get_env(var) or os.environ.get(var)
             if val and var not in env:
                 env[var] = val

--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -46,7 +46,14 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
-    DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"', "solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"'}'
+    LANGFUSE_TRACE_ID=""
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
+            LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"', "solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0

--- a/benchmarks/run-legacybench.sh
+++ b/benchmarks/run-legacybench.sh
@@ -37,7 +37,14 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
-    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"'}'
+    LANGFUSE_TRACE_ID=""
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
+            LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0

--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -66,7 +66,14 @@ cleanup() {
             rm -rf "${RESULTS_DIR}"
         fi
     fi
-    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"'}'
+    LANGFUSE_TRACE_ID=""
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
+            LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0

--- a/benchmarks/run-swebench.sh
+++ b/benchmarks/run-swebench.sh
@@ -38,7 +38,14 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
-    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"'}'
+    LANGFUSE_TRACE_ID=""
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
+            LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -38,7 +38,14 @@ cleanup() {
         fi
     fi
     PASSED="${RESOLVED}"
-    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"'}'
+    LANGFUSE_TRACE_ID=""
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
+            LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
     write_result
     if [ "${STATUS}" = "success" ]; then
         exit 0

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -427,6 +427,12 @@ def begin_cycle_session(
         trace_id, span_id = result
         os.environ["FACTORY_TRACE_ID"] = trace_id
         os.environ["FACTORY_PARENT_SPAN_ID"] = span_id
+        try:
+            factory_dir = project_path / ".factory"
+            factory_dir.mkdir(parents=True, exist_ok=True)
+            (factory_dir / "trace_id.txt").write_text(trace_id)
+        except OSError:
+            logger.debug("Failed to write trace_id.txt", exc_info=True)
         return span_id
     except Exception:
         logger.debug("Failed to begin cycle trace", exc_info=True)

--- a/scripts/langfuse/analyze_failure.py
+++ b/scripts/langfuse/analyze_failure.py
@@ -29,11 +29,17 @@ def find_matching_trace(
     instance_id: str,
     timestamp: datetime,
     duration_seconds: int,
+    verbose: bool = False,
 ) -> dict | None:
     from_ts = timestamp - timedelta(minutes=5)
     to_ts = timestamp + timedelta(seconds=duration_seconds) + timedelta(minutes=5)
 
+    if verbose:
+        print(f"[verbose] Searching traces from {from_ts} to {to_ts}", file=sys.stderr)
+
     traces = list_traces(from_ts, to_ts)
+    if verbose:
+        print(f"[verbose] Found {len(traces)} traces in window", file=sys.stderr)
     if not traces:
         return None
 
@@ -45,10 +51,19 @@ def find_matching_trace(
         if benchmark.lower() in text or instance_id.lower() in text:
             candidates.append(t)
 
+    if verbose:
+        print(f"[verbose] Filtered to {len(candidates)} candidates", file=sys.stderr)
+
     if not candidates:
         candidates = traces
 
-    return max(candidates, key=lambda t: t.get("latency", 0) or 0)
+    selected = max(candidates, key=lambda t: t.get("latency", 0) or 0)
+    if verbose:
+        print(
+            f"[verbose] Selected trace: {selected['id']} (latency={selected.get('latency', 0)}s)",
+            file=sys.stderr,
+        )
+    return selected
 
 
 def format_trace_dump(trace: dict) -> str:
@@ -183,6 +198,24 @@ def main() -> int:
             print("[verbose] Benchmark resolved — nothing to diagnose.", file=sys.stderr)
         return 0
 
+    solver = result_data.get("solver", "")
+    if solver == "claude-code":
+        if args.summary:
+            report = "Trace analysis not available for claude-code solver."
+        else:
+            benchmark = result_data.get("benchmark", "unknown")
+            instance_id = result_data.get("instance_id", "unknown")
+            duration = result_data.get("duration_seconds", 0)
+            report = (
+                f"### Failure Analysis: {benchmark} / {instance_id}\n\n"
+                f"**Solver:** {solver}\n"
+                f"**Duration:** {duration}s\n\n"
+                "Trace analysis not available — claude-code solver does not create "
+                "factory-managed Langfuse traces.\n"
+            )
+        _write_output(report, args.output)
+        return 0
+
     try:
         host, _, _ = load_creds()
     except (KeyError, Exception) as e:
@@ -192,25 +225,37 @@ def main() -> int:
         return 0
 
     trace, trace_id = None, None
-    try:
-        ts_str = result_data.get("timestamp", "")
-        benchmark = result_data.get("benchmark", "")
-        instance_id = result_data.get("instance_id", "")
-        timestamp = parse_benchmark_timestamp(ts_str)
-        matched = find_matching_trace(
-            benchmark, instance_id, timestamp, result_data.get("duration_seconds", 0),
-        )
-        if matched:
-            trace_id = matched.get("id")
-            if args.verbose:
-                print(f"[verbose] Matched trace: {trace_id}", file=sys.stderr)
+
+    direct_trace_id = (result_data.get("details") or {}).get("trace_id", "")
+    if direct_trace_id:
+        print(f"Using direct trace ID: {direct_trace_id}", file=sys.stderr)
+        trace_id = direct_trace_id
+        try:
             trace = fetch_trace(trace_id, use_cache=False)
-        else:
-            print(f"WARNING: No matching trace for {benchmark}/{instance_id}", file=sys.stderr)
-    except (ValueError, KeyError) as e:
-        print(f"WARNING: Could not search for trace: {e}", file=sys.stderr)
-    except Exception as e:
-        print(f"WARNING: Trace fetch failed: {e}", file=sys.stderr)
+        except Exception as e:
+            print(f"WARNING: Failed to fetch direct trace {trace_id}: {e}", file=sys.stderr)
+    else:
+        try:
+            ts_str = result_data.get("timestamp", "")
+            benchmark = result_data.get("benchmark", "")
+            instance_id = result_data.get("instance_id", "")
+            timestamp = parse_benchmark_timestamp(ts_str)
+            matched = find_matching_trace(
+                benchmark, instance_id, timestamp,
+                result_data.get("duration_seconds", 0),
+                verbose=args.verbose,
+            )
+            if matched:
+                trace_id = matched.get("id")
+                if args.verbose:
+                    print(f"[verbose] Matched trace: {trace_id}", file=sys.stderr)
+                trace = fetch_trace(trace_id, use_cache=False)
+            else:
+                print(f"WARNING: No matching trace for {benchmark}/{instance_id}", file=sys.stderr)
+        except (ValueError, KeyError) as e:
+            print(f"WARNING: Could not search for trace: {e}", file=sys.stderr)
+        except Exception as e:
+            print(f"WARNING: Trace fetch failed: {e}", file=sys.stderr)
 
     report = generate_report(
         result_data, trace=trace, trace_id=trace_id, host=host,


### PR DESCRIPTION
Closes #954

## Changes

- **Fix env var forwarding (root cause):** `ProgramBenchFactoryCeo` in `factory_harbor_agent.py` forwarded zero Langfuse env vars, causing `telemetry.is_enabled()` to return `False` and no traces to be created. `FactoryCeo` was also missing `LANGFUSE_BASE_URL`. Extracted a shared `COMMON_ENV_VARS` tuple used by both classes to prevent future divergence.

- **Direct trace ID propagation:** `begin_cycle_session()` in `runner.py` now writes the trace ID to `.factory/trace_id.txt`. All 5 benchmark run scripts (`run-swebench.sh`, `run-programbench.sh`, `run-featurebench.sh`, `run-terminalbench.sh`, `run-legacybench.sh`) extract this file after the Harbor run and include `trace_id` in `DETAILS_JSON`. `analyze_failure.py` checks for this direct trace ID first, falling back to time-window search only when absent.

- **Solver-aware analysis:** `analyze_failure.py` now skips trace lookup entirely for `claude-code` solver runs (which never produce factory-managed Langfuse traces), eliminating misleading "No trace found" warnings.

- **Verbose logging:** `find_matching_trace()` now logs the search time window, raw trace count, filtered candidate count, and selected trace ID to stderr when `--verbose` is used.