### PR TITLE
fix: add missing mode values to CycleState Literal (#955)

### DIFF
--- a/factory/models.py
+++ b/factory/models.py
@@ -454,7 +454,10 @@ class CycleState(BaseModel):
 
     cycle_id: str
     started_at: datetime
-    mode: Literal["build", "discover", "improve", "meta", "qa", "research", "review"]
+    mode: Literal[
+        "build", "create", "deep-qa", "design", "discover",
+        "improve", "meta", "qa", "refine", "research", "review",
+    ]
     initial_prompt: str = ""
     respawns: int = 0
     runner_name: str | None = None


### PR DESCRIPTION
## Summary

- Adds `"deep-qa"`, `"design"`, `"create"`, and `"refine"` to the `CycleState.mode` Literal type in `factory/models.py`
- Without this, `factory ceo --mode deep-qa` fails with a Pydantic validation error when the completion guard tries to persist cycle state

Follow-up to #958 — that fix landed before this commit was pushed.

Closes #955

## Test plan

- [x] `pytest -v` — all tests pass
- [x] `ruff check .` — clean
- [x] `mypy factory/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)