### PR TITLE
feat: Workflow Composition API — compose_serial, trim_nodes, describe_nodes

### DIFF
--- a/factory/workflow/README.md
+++ b/factory/workflow/README.md
@@ -172,6 +172,108 @@ nodes["archivist"] = AgentNode(
 )
 ```
 
+## Composition
+
+The `factory/workflow/composition.py` module provides functions for building
+new workflows from existing ones without copying code.
+
+### Inspecting workflows
+
+Before composing, inspect the workflows to find node IDs:
+
+```python
+from factory.workflow.composition import describe_nodes
+from factory.workflow.definitions import improve_workflow
+
+# Fast mode (default) — deterministic extraction
+nodes = describe_nodes(improve_workflow())
+
+# Rich mode — LLM-powered one-liner summaries
+nodes = describe_nodes(improve_workflow(), use_llm=True)
+
+for node in nodes:
+    print(f"{node['id']:20s} {node['type']:16s} {node['description']}")
+```
+
+Example output:
+
+```
+study                Study            factory study {project_path}
+researcher           Agent(researcher) Deep research for the project...
+gate_research        Gate(agent)       Are observations grounded in data?...
+strategist           Agent(strategist) Generate prioritized hypotheses...
+...
+```
+
+### API
+
+| Function | Purpose |
+|----------|---------|
+| `describe_nodes(wf, *, use_llm=False)` | List all nodes with ID, type, and description (topo-sorted). Fast extraction by default; `use_llm=True` for LLM-powered rich summaries |
+| `compose_serial(w1, w2, ...)` | Chain two workflows end-to-end |
+| `trim_nodes(wf, node_ids)` | Remove nodes and reconnect (linear only) |
+| `prefix_nodes(wf, prefix)` | Namespace all node IDs with a prefix |
+| `find_terminal_nodes(wf)` | List nodes with no unconditional outgoing edges |
+| `validate_composition(wf)` | Run graph + composition-specific validation |
+
+### Example: chaining discover → review
+
+```python
+from factory.workflow.composition import compose_serial
+from factory.workflow.definitions import discover_workflow, review_workflow
+
+def discover_then_review() -> Workflow:
+    return compose_serial(
+        discover_workflow(),
+        review_workflow(),
+        end_node_w1="redetect",
+        name="discover-then-review",
+    )
+```
+
+### Example: extracting and trimming
+
+```python
+from factory.workflow.composition import trim_nodes
+
+wf = improve_workflow()
+# Extract the QA subgraph
+qa = wf.subgraph(
+    {"health_checker", "code_reviewer", "gate_review",
+     "adversarial_tester", "gate_qa"},
+    name="qa-only",
+    start_node="health_checker",
+)
+```
+
+### ID conflict resolution
+
+When composing workflows with overlapping node IDs, provide an explicit
+`rename` dict:
+
+```python
+composed = compose_serial(
+    discover_workflow(),
+    discover_workflow(),
+    end_node_w1="redetect",
+    name="double-discover",
+    rename={"discover": "discover2", "gate_discover": "gate_discover2",
+            "redetect": "redetect2"},
+)
+```
+
+Without a rename dict, `compose_serial` raises `ValueError` listing conflicts.
+
+### Constraints
+
+- **trim_nodes**: MVP supports linear nodes only (1 unconditional in-edge,
+  1 unconditional out-edge). Raises `ValueError` for GateNodes with conditional
+  edges, ForkNodes, JoinNodes, or nodes whose writes are read by downstream nodes.
+- **compose_parallel**: Deferred to future work.
+- All composition functions return new `Workflow` objects (immutable pattern)
+  and call `validate_graph()` before returning. `describe_nodes` is a read-only
+  introspection function returning `list[dict]`, not a `Workflow`.
+
 ## Validation
 
 The graph validator (`validation.py`) checks:
@@ -281,6 +383,7 @@ factory/workflow/
 ├── __init__.py          # Public API: re-exports all primitives + executor
 ├── primitives.py        # Pydantic models: Node types, Edge, Verdict, Workflow
 ├── definitions.py       # 8 workflow functions returning Workflow objects
+├── composition.py       # Composition: compose_serial, trim_nodes, describe_nodes, helpers
 ├── executor.py          # WorkflowExecutor — async graph walker
 ├── validation.py        # NetworkX-based graph validator
 ├── events.py            # Structured event types for .factory/events.jsonl

--- a/factory/workflow/composition.py
+++ b/factory/workflow/composition.py
@@ -1,0 +1,570 @@
+"""Workflow composition — functions for building new workflows from existing ones.
+
+Provides prefix_nodes, find_terminal_nodes, compose_serial, trim_nodes,
+validate_composition, and describe_nodes. All mutating functions return new
+Workflow objects and call validate_graph() before returning.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.workflow.primitives import (
+    AgentNode,
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    Study,
+    VerdictType,
+    Workflow,
+)
+
+log = structlog.get_logger()
+
+
+def prefix_nodes(wf: Workflow, prefix: str) -> Workflow:
+    """Return a new Workflow with all node IDs prefixed as ``{prefix}_{id}``.
+
+    Deep-copies all nodes. Rewrites edge sources/targets, start_node,
+    ForkNode.targets, and JoinNode.sources. Sets trigger to None.
+    Calls validate_graph() before returning.
+    """
+    rename = {nid: f"{prefix}_{nid}" for nid in wf.nodes}
+    return _apply_rename(wf, rename, name=wf.name)
+
+
+def find_terminal_nodes(wf: Workflow) -> list[str]:
+    """Return node IDs that have no outgoing unconditional edges."""
+    nodes_with_unconditional_out: set[str] = set()
+    for edge in wf.edges:
+        if edge.condition is None:
+            nodes_with_unconditional_out.add(edge.source)
+    return [nid for nid in wf.nodes if nid not in nodes_with_unconditional_out]
+
+
+def compose_serial(
+    w1: Workflow,
+    w2: Workflow,
+    *,
+    end_node_w1: str,
+    start_node_w2: str | None = None,
+    name: str,
+    rename: dict[str, str] | None = None,
+) -> Workflow:
+    """Chain two workflows end-to-end.
+
+    Deep-copies all nodes from both workflows. Applies ``rename`` dict to w2's
+    node IDs, detects remaining ID conflicts, adds a bridge edge from
+    ``end_node_w1`` to ``start_node_w2``, and validates the result.
+
+    Raises ValueError if ID conflicts remain after rename or if the graph
+    is invalid.
+    """
+    if end_node_w1 not in w1.nodes:
+        raise ValueError(f"end_node_w1 '{end_node_w1}' not in w1 nodes")
+
+    actual_start_w2 = start_node_w2 or w2.start_node
+    rename = rename or {}
+
+    # Build the rename mapping for w2
+    def _renamed(nid: str) -> str:
+        return rename.get(nid, nid)
+
+    # Detect ID conflicts after rename
+    w2_renamed_ids = {_renamed(nid) for nid in w2.nodes}
+    conflicts = set(w1.nodes.keys()) & w2_renamed_ids
+    if conflicts:
+        raise ValueError(
+            f"ID conflicts between w1 and w2 (after rename): {sorted(conflicts)}"
+        )
+
+    # Deep-copy w1 nodes
+    nodes: dict[str, Any] = {}
+    for nid, node in w1.nodes.items():
+        nodes[nid] = node.model_copy(deep=True)
+
+    # Deep-copy w2 nodes with rename
+    for nid, node in w2.nodes.items():
+        new_id = _renamed(nid)
+        copied = node.model_copy(deep=True)
+        copied = _rename_node(copied, nid, new_id, rename)
+        nodes[new_id] = copied
+
+    # Merge edges
+    edges: list[Edge] = [e.model_copy(deep=True) for e in w1.edges]
+    for e in w2.edges:
+        edges.append(Edge(
+            source=_renamed(e.source),
+            target=_renamed(e.target),
+            condition=e.condition,
+        ))
+
+    # Bridge edge
+    renamed_start_w2 = _renamed(actual_start_w2)
+    edges.append(Edge(source=end_node_w1, target=renamed_start_w2))
+
+    result = Workflow(
+        name=name,
+        nodes=nodes,
+        edges=edges,
+        start_node=w1.start_node,
+        trigger=None,
+    )
+
+    issues = result.validate_graph()
+    if issues:
+        raise ValueError(f"Composed workflow validation failed: {issues}")
+
+    return result
+
+
+def trim_nodes(wf: Workflow, node_ids: set[str]) -> Workflow:
+    """Remove specified nodes and reconnect predecessors to successors.
+
+    MVP scope: linear only (1 unconditional in-edge, 1 unconditional out-edge).
+    Raises ValueError for ForkNode, JoinNode, nodes with conditional edges,
+    or data flow breaks.
+    """
+    for nid in node_ids:
+        if nid not in wf.nodes:
+            raise ValueError(f"node '{nid}' not in workflow")
+        node = wf.nodes[nid]
+
+        if isinstance(node, ForkNode):
+            raise ValueError(f"structural nodes cannot be trimmed: '{nid}' is a ForkNode")
+        if isinstance(node, JoinNode):
+            raise ValueError(f"structural nodes cannot be trimmed: '{nid}' is a JoinNode")
+
+        # Check conditional edges
+        in_edges = [e for e in wf.edges if e.target == nid]
+        out_edges = [e for e in wf.edges if e.source == nid]
+
+        conditional_in = [e for e in in_edges if e.condition is not None]
+        conditional_out = [e for e in out_edges if e.condition is not None]
+        if conditional_in or conditional_out:
+            raise ValueError(
+                f"nodes with conditional edges cannot be trimmed: '{nid}'; "
+                "use subgraph() instead"
+            )
+
+        unconditional_in = [e for e in in_edges if e.condition is None]
+        unconditional_out = [e for e in out_edges if e.condition is None]
+
+        if len(unconditional_in) != 1:
+            raise ValueError(
+                f"node '{nid}' has {len(unconditional_in)} unconditional in-edges "
+                "(expected exactly 1)"
+            )
+        if len(unconditional_out) != 1:
+            raise ValueError(
+                f"node '{nid}' has {len(unconditional_out)} unconditional out-edges "
+                "(expected exactly 1)"
+            )
+
+        # Check data flow: if trimmed node writes files that downstream nodes
+        # read exclusively from this node
+        if node.writes:
+            successor_id = unconditional_out[0].target
+            _check_data_flow(wf, nid, successor_id, node_ids)
+
+    # Build new edges: remove edges touching trimmed nodes, add bridge edges
+    new_edges: list[Edge] = []
+    bridge_edges: list[Edge] = []
+
+    for nid in node_ids:
+        in_edges = [e for e in wf.edges if e.target == nid and e.condition is None]
+        out_edges = [e for e in wf.edges if e.source == nid and e.condition is None]
+        predecessor = in_edges[0].source
+        successor = out_edges[0].target
+        bridge_edges.append(Edge(source=predecessor, target=successor))
+
+    for e in wf.edges:
+        if e.source not in node_ids and e.target not in node_ids:
+            new_edges.append(e.model_copy(deep=True))
+
+    new_edges.extend(bridge_edges)
+
+    # Deep-copy nodes minus trimmed
+    nodes: dict[str, Any] = {}
+    for nid, node in wf.nodes.items():
+        if nid not in node_ids:
+            nodes[nid] = node.model_copy(deep=True)
+
+    # Determine start_node
+    start = wf.start_node
+    if start in node_ids:
+        out_edges = [e for e in wf.edges if e.source == start and e.condition is None]
+        start = out_edges[0].target
+
+    result = Workflow(
+        name=wf.name,
+        nodes=nodes,
+        edges=new_edges,
+        start_node=start,
+        trigger=None,
+    )
+
+    issues = result.validate_graph()
+    if issues:
+        raise ValueError(f"Trimmed workflow validation failed: {issues}")
+
+    return result
+
+
+def validate_composition(wf: Workflow) -> list[str]:
+    """Run graph validation plus composition-specific checks.
+
+    Returns combined list of issues (empty = valid).
+    """
+    issues = wf.validate_graph()
+
+    for nid, node in wf.nodes.items():
+        if isinstance(node, ForkNode):
+            for t in node.targets:
+                if t not in wf.nodes:
+                    issues.append(f"ForkNode '{nid}' target '{t}' not in nodes")
+        if isinstance(node, JoinNode):
+            for s in node.sources:
+                if s not in wf.nodes:
+                    issues.append(f"JoinNode '{nid}' source '{s}' not in nodes")
+
+    return issues
+
+
+def describe_nodes(
+    wf: Workflow,
+    *,
+    use_llm: bool = False,
+) -> list[dict[str, str]]:
+    """Return a list of {id, type, description} dicts for every node, topo-sorted.
+
+    Default mode extracts descriptions from node metadata. LLM mode makes a
+    single runner call for richer summaries.
+    """
+    sorted_ids = _topological_sort(wf)
+
+    if use_llm:
+        return _describe_nodes_llm(wf, sorted_ids)
+    return _describe_nodes_fast(wf, sorted_ids)
+
+
+# ── internal helpers ─────────────────────────────────────────────
+
+
+def _rename_node(
+    node: Any,
+    old_id: str,
+    new_id: str,
+    rename: dict[str, str],
+) -> Any:
+    """Rename a node's ID and update internal references."""
+    def _r(nid: str) -> str:
+        return rename.get(nid, nid)
+
+    updates: dict[str, Any] = {"id": new_id}
+
+    if isinstance(node, ForkNode):
+        updates["targets"] = [_r(t) for t in node.targets]
+    elif isinstance(node, JoinNode):
+        updates["sources"] = [_r(s) for s in node.sources]
+
+    return node.model_copy(update=updates)
+
+
+def _apply_rename(
+    wf: Workflow,
+    rename: dict[str, str],
+    *,
+    name: str,
+) -> Workflow:
+    """Apply a rename mapping to an entire workflow."""
+    def _r(nid: str) -> str:
+        return rename.get(nid, nid)
+
+    nodes: dict[str, Any] = {}
+    for nid, node in wf.nodes.items():
+        new_id = _r(nid)
+        copied = node.model_copy(deep=True)
+        copied = _rename_node(copied, nid, new_id, rename)
+        nodes[new_id] = copied
+
+    edges = [
+        Edge(source=_r(e.source), target=_r(e.target), condition=e.condition)
+        for e in wf.edges
+    ]
+
+    result = Workflow(
+        name=name,
+        nodes=nodes,
+        edges=edges,
+        start_node=_r(wf.start_node),
+        trigger=None,
+    )
+
+    issues = result.validate_graph()
+    if issues:
+        raise ValueError(f"Renamed workflow validation failed: {issues}")
+
+    return result
+
+
+def _check_data_flow(
+    wf: Workflow,
+    trimmed_id: str,
+    successor_id: str,
+    all_trimmed: set[str],
+) -> None:
+    """Check that trimming a node doesn't break data flow.
+
+    For each file the trimmed node writes, check if any non-trimmed successor
+    reads it and no other non-trimmed predecessor writes it.
+    """
+    import networkx as nx
+
+    trimmed_node = wf.nodes[trimmed_id]
+
+    g: nx.DiGraph[str] = nx.DiGraph()
+    for nid in wf.nodes:
+        g.add_node(nid)
+    for edge in wf.edges:
+        g.add_edge(edge.source, edge.target)
+
+    for written_file in trimmed_node.writes:
+        # Find all non-trimmed descendants that read this file
+        descendants = nx.descendants(g, trimmed_id)
+        readers = [
+            nid for nid in descendants
+            if nid not in all_trimmed and written_file in wf.nodes[nid].reads
+        ]
+        if not readers:
+            continue
+
+        # Check if any other non-trimmed predecessor writes this file
+        other_writers = [
+            nid for nid, node in wf.nodes.items()
+            if nid != trimmed_id
+            and nid not in all_trimmed
+            and written_file in node.writes
+        ]
+
+        # For each reader, check if at least one other writer is an ancestor
+        for reader_id in readers:
+            reader_ancestors = nx.ancestors(g, reader_id)
+            has_other_source = any(
+                w in reader_ancestors for w in other_writers
+            )
+            if not has_other_source:
+                raise ValueError(
+                    f"trimming '{trimmed_id}' breaks data flow: '{reader_id}' "
+                    f"reads '{written_file}' which only '{trimmed_id}' writes"
+                )
+
+
+def _topological_sort(wf: Workflow) -> list[str]:
+    """Topological sort of node IDs, ignoring RELOOP back-edges."""
+    adj: dict[str, list[str]] = defaultdict(list)
+    in_degree: dict[str, int] = {nid: 0 for nid in wf.nodes}
+
+    for edge in wf.edges:
+        if edge.condition == VerdictType.RELOOP:
+            continue
+        adj[edge.source].append(edge.target)
+        in_degree[edge.target] = in_degree.get(edge.target, 0) + 1
+
+    queue: deque[str] = deque()
+    for nid in wf.nodes:
+        if in_degree.get(nid, 0) == 0:
+            queue.append(nid)
+
+    if not queue:
+        queue.append(wf.start_node)
+
+    ordered: list[str] = []
+    visited: set[str] = set()
+
+    while queue:
+        nid = queue.popleft()
+        if nid in visited:
+            continue
+        visited.add(nid)
+        ordered.append(nid)
+
+        for target in adj.get(nid, []):
+            in_degree[target] -= 1
+            if in_degree[target] <= 0 and target not in visited:
+                queue.append(target)
+
+    for nid in wf.nodes:
+        if nid not in visited:
+            ordered.append(nid)
+
+    return ordered
+
+
+def _node_type_str(node: Any) -> str:
+    """Return a descriptive type string for a node."""
+    if isinstance(node, Study):
+        return "Study"
+    if isinstance(node, AgentNode):
+        return f"Agent({node.role.value})"
+    if isinstance(node, GateNode):
+        return f"Gate({node.evaluator_type})"
+    if isinstance(node, ForkNode):
+        return f"Fork({len(node.targets)})"
+    if isinstance(node, JoinNode):
+        return f"Join({len(node.sources)})"
+    if isinstance(node, FnNode):
+        return "Fn"
+    return "Unknown"
+
+
+def _first_sentence(text: str) -> str:
+    """Extract the first sentence from a text block."""
+    if not text:
+        return ""
+    text = text.strip()
+    for sep in (". ", ".\n", ".\t"):
+        idx = text.find(sep)
+        if idx != -1:
+            return text[: idx + 1]
+    if text.endswith("."):
+        return text
+    # No period found — return whole text truncated
+    if len(text) > 100:
+        return text[:97] + "..."
+    return text
+
+
+def _describe_nodes_fast(
+    wf: Workflow,
+    sorted_ids: list[str],
+) -> list[dict[str, str]]:
+    """Fast extraction mode — derive descriptions from node metadata."""
+    result: list[dict[str, str]] = []
+
+    for nid in sorted_ids:
+        node = wf.nodes[nid]
+        type_str = _node_type_str(node)
+
+        if isinstance(node, Study):
+            desc = node.command[:80] if node.command else nid
+        elif isinstance(node, AgentNode):
+            if node.prompt_template:
+                desc = _first_sentence(node.prompt_template)
+            else:
+                desc = node.role.value
+        elif isinstance(node, GateNode):
+            if node.gate_prompt:
+                desc = _first_sentence(node.gate_prompt)
+            elif node.evaluator_command:
+                desc = node.evaluator_command[:80]
+            else:
+                desc = node.evaluator_type
+        elif isinstance(node, ForkNode):
+            desc = "Fork to: " + ", ".join(node.targets)
+        elif isinstance(node, JoinNode):
+            desc = "Join from: " + ", ".join(node.sources)
+        elif isinstance(node, FnNode):
+            desc = node.command[:80] if node.command else nid
+        else:
+            desc = nid
+
+        result.append({"id": nid, "type": type_str, "description": desc})
+
+    return result
+
+
+def _describe_nodes_llm(
+    wf: Workflow,
+    sorted_ids: list[str],
+) -> list[dict[str, str]]:
+    """LLM mode — make a single runner call for rich node descriptions."""
+    from factory.models import AgentRunRequest
+    from factory.runners import get_runner
+
+    # Build the batch prompt
+    node_specs: list[dict[str, Any]] = []
+    for nid in sorted_ids:
+        node = wf.nodes[nid]
+        spec: dict[str, Any] = {
+            "id": nid,
+            "type": _node_type_str(node),
+        }
+
+        if isinstance(node, AgentNode):
+            if node.prompt_template:
+                spec["prompt_template"] = node.prompt_template[:200]
+            spec["role"] = node.role.value
+        elif isinstance(node, GateNode):
+            if node.gate_prompt:
+                spec["gate_prompt"] = node.gate_prompt[:200]
+            spec["evaluator_type"] = node.evaluator_type
+        elif isinstance(node, FnNode):
+            if node.command:
+                spec["command"] = node.command[:200]
+        elif isinstance(node, ForkNode):
+            spec["targets"] = node.targets
+        elif isinstance(node, JoinNode):
+            spec["sources"] = node.sources
+
+        if node.reads:
+            spec["reads"] = sorted(node.reads)
+        if node.writes:
+            spec["writes"] = sorted(node.writes)
+
+        node_specs.append(spec)
+
+    prompt = (
+        "You are describing nodes in a workflow graph. "
+        "For each node below, write a clean one-line description of what it does. "
+        "Do NOT include raw template syntax like {project_path}. "
+        "Return valid JSON: a list of objects with 'id' and 'description' keys.\n\n"
+        f"Nodes:\n{json.dumps(node_specs, indent=2)}"
+    )
+
+    runner = get_runner()
+    request = AgentRunRequest(
+        prompt="Describe workflow nodes concisely.",
+        task=prompt,
+        cwd=Path.cwd(),
+        timeout=60.0,
+        role="describe_nodes",
+    )
+
+    result = asyncio.run(runner.headless(request))
+
+    # Parse the LLM response
+    try:
+        raw = result.stdout.strip()
+        # Extract JSON from the response (may be wrapped in markdown code block)
+        if "```json" in raw:
+            raw = raw.split("```json")[1].split("```")[0].strip()
+        elif "```" in raw:
+            raw = raw.split("```")[1].split("```")[0].strip()
+
+        descriptions: list[dict[str, str]] = json.loads(raw)
+        desc_map = {d["id"]: d["description"] for d in descriptions}
+    except (json.JSONDecodeError, KeyError, IndexError):
+        log.warning("describe_nodes.llm_parse_failed", stdout=result.stdout[:200])
+        return _describe_nodes_fast(wf, sorted_ids)
+
+    # Build result with type info and fallback to fast extraction
+    output: list[dict[str, str]] = []
+    for nid in sorted_ids:
+        node = wf.nodes[nid]
+        type_str = _node_type_str(node)
+        desc = desc_map.get(nid, "")
+        if not desc:
+            fast = _describe_nodes_fast(wf, [nid])
+            desc = fast[0]["description"] if fast else nid
+        output.append({"id": nid, "type": type_str, "description": desc})
+
+    return output

--- a/factory/workflow/composition.py
+++ b/factory/workflow/composition.py
@@ -8,6 +8,7 @@ Workflow objects and call validate_graph() before returning.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 from collections import defaultdict, deque
 from pathlib import Path
@@ -539,7 +540,16 @@ def _describe_nodes_llm(
         role="describe_nodes",
     )
 
-    result = asyncio.run(runner.headless(request))
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            result = pool.submit(asyncio.run, runner.headless(request)).result()
+    else:
+        result = asyncio.run(runner.headless(request))
 
     # Parse the LLM response
     try:

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -1460,6 +1460,10 @@ def create_workflow() -> Workflow:
             "7) Interactive vs headless behavior "
             "Follow conventions from existing workflows — use the same patterns for "
             "builder→gate→QA→gate loops, archivist placement, and research forks. "
+            "When the new mode reuses parts of existing workflows, reference composition "
+            "functions (compose_serial, trim_nodes, subgraph, prefix_nodes, describe_nodes) "
+            "from factory/workflow/composition.py in the specification. Use "
+            "describe_nodes(workflow()) programmatically to discover node IDs. "
             "Write the specification to .factory/strategy/current.md."
         ),
         reads={".factory/strategy/research-combined.md"},
@@ -1501,7 +1505,17 @@ def create_workflow() -> Workflow:
             "6) Run factory workflow export-skills to generate the SKILL.md "
             "7) Write tests in tests/ "
             "8) Run pytest and ruff check to verify "
-            "Commit changes and open a draft PR."
+            "Commit changes and open a draft PR. "
+            "When the new mode is a variant of an existing workflow (e.g., a specialized "
+            "improve loop, a subset of the build pipeline, or a chain of existing stages), "
+            "use composition functions from factory.workflow.composition instead of copying: "
+            "- compose_serial(w1, w2, end_node_w1=..., name=...) to chain workflows "
+            "- trim_nodes(wf, node_ids) to remove nodes and auto-reconnect (linear-only) "
+            "- Workflow.subgraph(node_ids, name=..., start_node=...) to extract a subset "
+            "- prefix_nodes(wf, prefix) to namespace node IDs before composing "
+            "- describe_nodes(wf) to inspect node IDs, types, and descriptions programmatically "
+            "See factory/workflow/composition.py for the full API and "
+            "factory/workflow/README.md 'Composition' section for examples."
         ),
         reads={".factory/strategy/current.md"},
         writes={".factory/reviews/builder-latest.md"},

--- a/tests/test_workflow_composition.py
+++ b/tests/test_workflow_composition.py
@@ -1,0 +1,370 @@
+"""Tests for factory.workflow.composition — uses real workflows from definitions.py."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from factory.workflow.composition import (
+    compose_serial,
+    describe_nodes,
+    find_terminal_nodes,
+    prefix_nodes,
+    trim_nodes,
+    validate_composition,
+)
+from factory.workflow.definitions import (
+    build_workflow,
+    discover_workflow,
+    improve_workflow,
+    register_all,
+    review_workflow,
+)
+from factory.workflow.primitives import (
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    VerdictType,
+    Workflow,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def _linear_workflow(node_ids: list[str], name: str = "linear") -> Workflow:
+    """Build a simple linear workflow of FnNodes for testing."""
+    nodes: dict[str, FnNode] = {}
+    edges: list[Edge] = []
+    for nid in node_ids:
+        nodes[nid] = FnNode(id=nid, command=f"echo {nid}")
+    for i in range(len(node_ids) - 1):
+        edges.append(Edge(source=node_ids[i], target=node_ids[i + 1]))
+    return Workflow(
+        name=name,
+        nodes=nodes,
+        edges=edges,
+        start_node=node_ids[0],
+        trigger=None,
+    )
+
+
+# ── 1. prefix_nodes ─────────────────────────────────────────────
+
+
+def test_prefix_nodes_discover():
+    """Prefix discover_workflow with 'd'. All IDs, edges, start_node should be prefixed."""
+    wf = discover_workflow()
+    prefixed = prefix_nodes(wf, "d")
+
+    for nid in prefixed.nodes:
+        assert nid.startswith("d_"), f"node '{nid}' missing prefix"
+    for edge in prefixed.edges:
+        assert edge.source.startswith("d_"), f"edge source '{edge.source}' missing prefix"
+        assert edge.target.startswith("d_"), f"edge target '{edge.target}' missing prefix"
+    assert prefixed.start_node == "d_discover"
+    assert not prefixed.validate_graph()
+
+
+def test_prefix_nodes_preserves_fork_join():
+    """Prefix build_workflow (has ForkNode/JoinNode). Fork targets and Join sources are prefixed."""
+    wf = build_workflow()
+    prefixed = prefix_nodes(wf, "b")
+
+    fork = None
+    join = None
+    for nid, node in prefixed.nodes.items():
+        if isinstance(node, ForkNode):
+            fork = node
+        elif isinstance(node, JoinNode):
+            join = node
+
+    assert fork is not None, "build_workflow should have a ForkNode"
+    assert join is not None, "build_workflow should have a JoinNode"
+
+    for t in fork.targets:
+        assert t.startswith("b_"), f"ForkNode target '{t}' missing prefix"
+    for s in join.sources:
+        assert s.startswith("b_"), f"JoinNode source '{s}' missing prefix"
+
+    assert not prefixed.validate_graph()
+
+
+# ── 2. find_terminal_nodes ───────────────────────────────────────
+
+
+def test_find_terminal_nodes_discover():
+    """discover_workflow terminal nodes should include 'redetect'."""
+    wf = discover_workflow()
+    terminals = find_terminal_nodes(wf)
+    assert isinstance(terminals, list)
+    assert "redetect" in terminals
+
+
+# ── 3. compose_serial ────────────────────────────────────────────
+
+
+def test_compose_serial_discover_review():
+    """Chain discover → review. Bridge edge, all nodes present, valid graph."""
+    d = discover_workflow()
+    r = review_workflow()
+    composed = compose_serial(
+        d, r,
+        end_node_w1="redetect",
+        name="discover-then-review",
+    )
+
+    assert not composed.validate_graph()
+    assert len(composed.nodes) == len(d.nodes) + len(r.nodes)
+
+    # Bridge edge exists
+    bridge = [
+        e for e in composed.edges
+        if e.source == "redetect" and e.target == r.start_node
+    ]
+    assert len(bridge) == 1
+    assert composed.start_node == d.start_node
+
+
+def test_compose_serial_id_conflict_raises():
+    """Composing improve with itself should raise ValueError listing conflicts."""
+    wf = improve_workflow()
+    with pytest.raises(ValueError, match="ID conflicts"):
+        compose_serial(
+            wf, wf,
+            end_node_w1="archivist",
+            name="double-improve",
+        )
+
+
+def test_compose_serial_with_rename():
+    """Compose discover with itself using rename dict. Both sets of nodes present."""
+    d = discover_workflow()
+    composed = compose_serial(
+        d, d,
+        end_node_w1="redetect",
+        name="double-discover",
+        rename={
+            "discover": "discover2",
+            "gate_discover": "gate_discover2",
+            "redetect": "redetect2",
+        },
+    )
+
+    assert not composed.validate_graph()
+    assert "discover" in composed.nodes
+    assert "discover2" in composed.nodes
+    assert "redetect" in composed.nodes
+    assert "redetect2" in composed.nodes
+    assert len(composed.nodes) == len(d.nodes) * 2
+
+
+def test_compose_serial_preserves_conditional_edges():
+    """Conditional edges (e.g. RELOOP) in w1 survive composition."""
+    d = discover_workflow()
+    r = review_workflow()
+
+    # discover has RELOOP edge: gate_discover → discover
+    reloop_edges_before = [
+        e for e in d.edges if e.condition == VerdictType.RELOOP
+    ]
+    assert len(reloop_edges_before) > 0
+
+    composed = compose_serial(
+        d, r,
+        end_node_w1="redetect",
+        name="discover-then-review",
+    )
+
+    reloop_edges_after = [
+        e for e in composed.edges if e.condition == VerdictType.RELOOP
+    ]
+    assert len(reloop_edges_after) >= len(reloop_edges_before)
+
+
+# ── 4. trim_nodes ────────────────────────────────────────────────
+
+
+def test_trim_linear_fn_node():
+    """Trim middle node from a 3-node linear chain."""
+    wf = _linear_workflow(["a", "b", "c"])
+    trimmed = trim_nodes(wf, {"b"})
+
+    assert len(trimmed.nodes) == 2
+    assert "a" in trimmed.nodes
+    assert "c" in trimmed.nodes
+    assert "b" not in trimmed.nodes
+
+    bridge = [e for e in trimmed.edges if e.source == "a" and e.target == "c"]
+    assert len(bridge) == 1
+    assert not trimmed.validate_graph()
+
+
+def test_trim_gate_node_raises():
+    """Trimming a GateNode with conditional edges raises ValueError."""
+    nodes: dict[str, FnNode | GateNode] = {
+        "a": FnNode(id="a", command="echo a"),
+        "gate": GateNode(
+            id="gate",
+            evaluator_type="fn",
+            evaluator_command="echo PROCEED",
+        ),
+        "b": FnNode(id="b", command="echo b"),
+        "c": FnNode(id="c", command="echo c"),
+    }
+    edges = [
+        Edge(source="a", target="gate"),
+        Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+        Edge(source="gate", target="a", condition=VerdictType.RELOOP),
+    ]
+    wf = Workflow(name="gate-test", nodes=nodes, edges=edges, start_node="a", trigger=None)
+
+    with pytest.raises(ValueError, match="conditional edges"):
+        trim_nodes(wf, {"gate"})
+
+
+def test_trim_fork_node_raises():
+    """Trimming a ForkNode raises ValueError about structural nodes."""
+    wf = build_workflow()
+    fork_ids = [nid for nid, n in wf.nodes.items() if isinstance(n, ForkNode)]
+    assert fork_ids, "build_workflow should have a ForkNode"
+
+    with pytest.raises(ValueError, match="structural nodes"):
+        trim_nodes(wf, {fork_ids[0]})
+
+
+def test_trim_data_flow_break_raises():
+    """Trimming a node that writes a file read by a successor raises ValueError."""
+    nodes: dict[str, FnNode] = {
+        "a": FnNode(id="a", command="echo a"),
+        "b": FnNode(id="b", command="echo b", writes={"output.md"}),
+        "c": FnNode(id="c", command="echo c", reads={"output.md"}),
+    }
+    edges = [
+        Edge(source="a", target="b"),
+        Edge(source="b", target="c"),
+    ]
+    wf = Workflow(name="data-flow", nodes=nodes, edges=edges, start_node="a", trigger=None)
+
+    with pytest.raises(ValueError, match="breaks data flow"):
+        trim_nodes(wf, {"b"})
+
+
+def test_trim_multiple_nodes():
+    """Trim 2 nodes from a 5-node linear chain."""
+    wf = _linear_workflow(["a", "b", "c", "d", "e"])
+    trimmed = trim_nodes(wf, {"b", "d"})
+
+    assert len(trimmed.nodes) == 3
+    assert set(trimmed.nodes.keys()) == {"a", "c", "e"}
+
+    # a → c and c → e should exist
+    edges_by_src = {e.source: e.target for e in trimmed.edges}
+    assert edges_by_src.get("a") == "c"
+    assert edges_by_src.get("c") == "e"
+    assert not trimmed.validate_graph()
+
+
+# ── 5. validate_composition ──────────────────────────────────────
+
+
+def test_validate_composition_clean():
+    """validate_composition on a freshly composed workflow returns no issues."""
+    d = discover_workflow()
+    r = review_workflow()
+    composed = compose_serial(
+        d, r,
+        end_node_w1="redetect",
+        name="discover-then-review",
+    )
+    issues = validate_composition(composed)
+    assert issues == []
+
+
+def test_validate_composition_on_all_registered():
+    """validate_composition on every registered workflow returns no issues."""
+    all_wf = register_all()
+    for name, wf in all_wf.items():
+        issues = validate_composition(wf)
+        assert issues == [], f"workflow '{name}' has composition issues: {issues}"
+
+
+# ── 6. describe_nodes ───────────────────────────────────────────
+
+
+def test_describe_nodes_improve():
+    """describe_nodes on improve_workflow returns all nodes with non-empty fields."""
+    wf = improve_workflow()
+    nodes = describe_nodes(wf)
+
+    assert len(nodes) == len(wf.nodes)
+    for entry in nodes:
+        assert entry["id"], "id should not be empty"
+        assert entry["type"], "type should not be empty"
+        assert entry["description"], "description should not be empty"
+
+    # Verify topological order: each node appears after its predecessors
+    id_order = {entry["id"]: i for i, entry in enumerate(nodes)}
+    for edge in wf.edges:
+        if edge.condition == VerdictType.RELOOP:
+            continue
+        if edge.source in id_order and edge.target in id_order:
+            assert id_order[edge.source] < id_order[edge.target], (
+                f"topo order violated: {edge.source} should come before {edge.target}"
+            )
+
+
+def test_describe_nodes_all_registered():
+    """describe_nodes on every registered workflow produces non-empty descriptions."""
+    all_wf = register_all()
+    for name, wf in all_wf.items():
+        nodes = describe_nodes(wf)
+        for entry in nodes:
+            assert entry["description"], (
+                f"workflow '{name}' node '{entry['id']}' has empty description"
+            )
+
+
+def test_describe_nodes_types_correct():
+    """Verify type strings match expected patterns for each node type."""
+    all_wf = register_all()
+
+    found_types: set[str] = set()
+    for wf in all_wf.values():
+        nodes = describe_nodes(wf)
+        for entry in nodes:
+            found_types.add(entry["type"].split("(")[0])
+
+    expected = {"Agent", "Gate", "Fn", "Fork", "Join", "Study"}
+    assert expected <= found_types, f"Missing types: {expected - found_types}"
+
+
+def test_describe_nodes_llm_mode():
+    """describe_nodes with use_llm=True returns structured output with clean descriptions."""
+    wf = discover_workflow()
+
+    mock_descriptions = [
+        {"id": "discover", "description": "Auto-discover eval dimensions for the project"},
+        {"id": "gate_discover", "description": "CEO verifies the discovered eval profile"},
+        {"id": "redetect", "description": "Re-detect project state after discovery"},
+    ]
+    mock_stdout = '```json\n' + __import__("json").dumps(mock_descriptions) + '\n```'
+
+    mock_result = AsyncMock()
+    mock_result.stdout = mock_stdout
+
+    mock_runner = AsyncMock()
+    mock_runner.headless = AsyncMock(return_value=mock_result)
+
+    with patch("factory.runners.get_runner", return_value=mock_runner):
+        nodes = describe_nodes(wf, use_llm=True)
+
+    assert len(nodes) == len(wf.nodes)
+    for entry in nodes:
+        assert entry["id"]
+        assert entry["type"]
+        assert entry["description"]
+        assert "{project_path}" not in entry["description"]


### PR DESCRIPTION
Closes #961

## Changes

- **New module `factory/workflow/composition.py`** with 6 functions:
  - `prefix_nodes(wf, prefix)` — namespace all node IDs with a prefix
  - `find_terminal_nodes(wf)` — discover nodes with no unconditional outgoing edges
  - `compose_serial(w1, w2, ...)` — chain two workflows end-to-end with ID conflict detection
  - `trim_nodes(wf, node_ids)` — remove linear nodes and auto-reconnect predecessors to successors
  - `validate_composition(wf)` — graph validation + composition-specific checks (fork targets, join sources)
  - `describe_nodes(wf, use_llm=False)` — topo-sorted node introspection with fast extraction or LLM-powered summaries

- **18 comprehensive test cases** using real workflows (discover, build, improve, review) from `definitions.py`

- **Create mode integration** — updated Builder and Strategist `prompt_template` fields in `create_workflow()` to reference composition functions. SKILL.md files auto-regenerate at runtime via the Pydantic → export-skills pipeline

- **README documentation** — added Composition section with API table, chaining/trimming examples, ID conflict resolution, and constraints

## Test plan
- [x] All 18 composition tests pass (`pytest tests/test_workflow_composition.py -v`)
- [x] 202 workflow/model tests pass with no regressions
- [x] `ruff check` clean on all changed files
- [x] `mypy` clean on `factory/workflow/composition.py`
- [x] `validate_composition()` passes on all 13 registered workflows
- [x] Create mode SKILL.md regeneration verified — composition guidance propagates to Strategist and Builder steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)