### PR TITLE
fix: swebench workflow fixes — auto_merge removal, terminal flag, trace persistence (#963, #964, #965)

### DIFF
--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -156,6 +156,16 @@ class ProgramBenchFactoryCeo(BaseInstalledAgent):
         await self.exec_as_agent(
             environment,
             command=(
+                "mkdir -p /logs/.factory && "
+                "cp .factory/trace_id.txt /logs/.factory/trace_id.txt 2>/dev/null; "
+                "exit 0"
+            ),
+            env=env,
+        )
+
+        await self.exec_as_agent(
+            environment,
+            command=(
                 "set +e; "
                 'FACTORY_BRANCH=$(git branch --list "factory/*" | head -1 | tr -d " *"); '
                 'if [ -n "$FACTORY_BRANCH" ]; then '
@@ -369,6 +379,16 @@ class FactoryCeo(BaseInstalledAgent):
                 "--prompt /tmp/task-instruction.md "
                 "2>&1 </dev/null | tee /logs/agent/factory-ceo.txt"
                 "; exit 0"
+            ),
+            env=env,
+        )
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "mkdir -p /logs/.factory && "
+                "cp .factory/trace_id.txt /logs/.factory/trace_id.txt 2>/dev/null; "
+                "exit 0"
             ),
             env=env,
         )

--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -37,20 +37,20 @@ TOTAL=1
 
 cleanup() {
     local exit_code=$?
-    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
-            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
-        else
-            log "Cleaning up harbor jobs directory"
-            rm -rf "${JOBS_DIR}"
-        fi
-    fi
     PASSED="${RESOLVED}"
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
         TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
+            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
+        else
+            log "Cleaning up harbor jobs directory"
+            rm -rf "${JOBS_DIR}"
         fi
     fi
     DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"', "solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'

--- a/benchmarks/run-legacybench.sh
+++ b/benchmarks/run-legacybench.sh
@@ -28,20 +28,20 @@ TOTAL=1
 
 cleanup() {
     local exit_code=$?
-    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
-            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
-        else
-            log "Cleaning up harbor jobs directory"
-            rm -rf "${JOBS_DIR}"
-        fi
-    fi
     PASSED="${RESOLVED}"
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
         TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
+            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
+        else
+            log "Cleaning up harbor jobs directory"
+            rm -rf "${JOBS_DIR}"
         fi
     fi
     DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'

--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -50,6 +50,13 @@ TOTAL=1
 
 cleanup() {
     local exit_code=$?
+    LANGFUSE_TRACE_ID=""
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
+            LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
         if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
             log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
@@ -64,13 +71,6 @@ cleanup() {
         else
             log "Cleaning up results directory"
             rm -rf "${RESULTS_DIR}"
-        fi
-    fi
-    LANGFUSE_TRACE_ID=""
-    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
-        if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
-            LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
         fi
     fi
     DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'

--- a/benchmarks/run-swebench.sh
+++ b/benchmarks/run-swebench.sh
@@ -29,20 +29,20 @@ TOTAL=1
 
 cleanup() {
     local exit_code=$?
-    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
-            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
-        else
-            log "Cleaning up harbor jobs directory"
-            rm -rf "${JOBS_DIR}"
-        fi
-    fi
     PASSED="${RESOLVED}"
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
         TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
+            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
+        else
+            log "Cleaning up harbor jobs directory"
+            rm -rf "${JOBS_DIR}"
         fi
     fi
     DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -29,20 +29,20 @@ TOTAL=1
 
 cleanup() {
     local exit_code=$?
-    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
-            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
-        else
-            log "Cleaning up harbor jobs directory"
-            rm -rf "${JOBS_DIR}"
-        fi
-    fi
     PASSED="${RESOLVED}"
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
         TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
+        fi
+    fi
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
+            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
+        else
+            log "Cleaning up harbor jobs directory"
+            rm -rf "${JOBS_DIR}"
         fi
     fi
     DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -1624,6 +1624,12 @@ def _build_ceo_task(
             "step-by-step playbook. This mode creates a new factory mode (workflow + skill + "
             "CLI wiring + tests) from the user's description above."
         )
+    else:
+        task += (
+            f"\n\nRun {mode} mode: read `skills/workflow-{mode}/SKILL.md` for the full "
+            f"step-by-step playbook. Follow the instructions exactly as written — "
+            f"do not add additional steps, research, or ceremony beyond what the SKILL.md describes."
+        )
 
     if no_github:
         task += (

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -572,6 +572,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 model=model, no_github=no_github, use_profile=use_profile,
                 tmux_persist=tmux_persist,
                 background=background,
+                completed_mode=mode,
             )
         finally:
             _stop_ceo_tailer(ceo_tailer)
@@ -1688,6 +1689,7 @@ def _chain_modes(
     use_profile: bool = False,
     tmux_persist: bool = False,
     background: bool = False,
+    completed_mode: str | None = None,
 ) -> int:
     """After a cycle completes, re-detect state and chain into the next mode.
 
@@ -1695,9 +1697,24 @@ def _chain_modes(
     automatically — Build → Discover → Review → Improve — without manual
     re-invocation. Returns 0 when one Improve cycle completes (or all
     chains are exhausted).
+
+    If *completed_mode* names a terminal workflow, returns 0 immediately
+    without chaining.
     """
     from factory.models import ProjectState
     from factory.state import detect_state
+
+    if completed_mode:
+        from factory.workflow.definitions import register_all
+
+        workflows = register_all()
+        if completed_mode in workflows and workflows[completed_mode].terminal:
+            print(
+                f"[factory] Terminal mode completed: {completed_mode} "
+                "— skipping post-completion chaining",
+                file=sys.stderr,
+            )
+            return 0
 
     for i in range(max_chains):
         state = detect_state(project_path)
@@ -1915,6 +1932,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             model=model, no_github=no_github, use_profile=use_profile_flag,
             tmux_persist=tmux_persist,
             background=background,
+            completed_mode=mode,
         )
 
     # Heartbeat loop mode
@@ -1956,6 +1974,7 @@ def cmd_run(args: argparse.Namespace) -> int:
                 model=model, no_github=no_github, use_profile=use_profile_flag,
                 tmux_persist=tmux_persist,
                 background=background,
+                completed_mode=mode,
             )
             _emit_cli_event(project_path, "cycle.completed", {"cycle": cycle, "mode": mode})
 

--- a/factory/workflow/contributed/swebench.py
+++ b/factory/workflow/contributed/swebench.py
@@ -136,5 +136,6 @@ def workflow() -> Workflow:
         nodes=nodes,
         edges=edges,
         start_node="study",
+        terminal=True,
         trigger=trigger,
     )

--- a/factory/workflow/contributed/swebench.py
+++ b/factory/workflow/contributed/swebench.py
@@ -1,6 +1,6 @@
 """SWE-bench benchmark workflow — minimal bug-fix pipeline for containerized evaluation.
 
-4-node pipeline: study → builder → gate_verify → auto_merge
+3-node pipeline: study → builder → gate_verify
 RELOOP from gate_verify back to builder (max 3 iterations) on test failure.
 
 Designed for Harbor containers where:
@@ -26,9 +26,9 @@ from factory.workflow.primitives import (
 meta = {
     "name": "swebench",
     "description": (
-        "SWE-bench benchmark mode — minimal 4-node pipeline for solving "
+        "SWE-bench benchmark mode — minimal 3-node pipeline for solving "
         "GitHub issues in containerized evaluation. study → builder → "
-        "gate_verify → auto_merge with RELOOP on test failure."
+        "gate_verify with RELOOP on test failure."
     ),
 }
 
@@ -118,29 +118,11 @@ def workflow() -> Workflow:
         reads={".factory/reviews/builder-latest.md"},
     )
 
-    # ── Node 4: Auto Merge ─────────────────────────────────────────
-    nodes["auto_merge"] = FnNode(
-        id="auto_merge",
-        command=(
-            "cd {project_path} && "
-            "CURRENT=$(git rev-parse --abbrev-ref HEAD) && "
-            "if [ \"$CURRENT\" = 'main' ] || [ \"$CURRENT\" = 'master' ]; then "
-            "echo 'Already on main/master branch — no merge needed'; "
-            "exit 0; fi && "
-            "BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null "
-            "| sed 's|refs/remotes/origin/||' || echo main) && "
-            "git checkout \"$BASE\" && "
-            "git merge --no-edit \"$CURRENT\""
-        ),
-        reads={".factory/reviews/builder-latest.md"},
-    )
-
     # ── Edges ──────────────────────────────────────────────────────
 
     edges = [
         Edge(source="study", target="builder"),
         Edge(source="builder", target="gate_verify"),
-        Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
         Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),
     ]
 

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -204,6 +204,7 @@ class Workflow(BaseModel):
     nodes: dict[str, NodeType]
     edges: list[Edge]
     start_node: str
+    terminal: bool = False
     trigger: TriggerFn | None = Field(default=None, exclude=True)
 
     def validate_graph(self) -> list[str]:

--- a/tests/test_chain_modes_terminal.py
+++ b/tests/test_chain_modes_terminal.py
@@ -1,0 +1,77 @@
+"""Tests for _chain_modes terminal workflow behaviour."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from factory.models import ProjectState
+from factory.workflow.primitives import FnNode, Workflow
+
+
+def _terminal_workflow() -> Workflow:
+    return Workflow(
+        name="swebench",
+        nodes={"start": FnNode(id="start", command="true")},
+        edges=[],
+        start_node="start",
+        terminal=True,
+    )
+
+
+def _non_terminal_workflow() -> Workflow:
+    return Workflow(
+        name="improve",
+        nodes={"start": FnNode(id="start", command="true")},
+        edges=[],
+        start_node="start",
+        terminal=False,
+    )
+
+
+class TestChainModesTerminal:
+    def test_returns_zero_for_terminal_mode(self, tmp_path: Path) -> None:
+        """_chain_modes exits immediately when completed_mode is terminal."""
+        from factory.cli.ceo import _chain_modes
+
+        registry = {
+            "swebench": _terminal_workflow(),
+            "improve": _non_terminal_workflow(),
+        }
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            result = _chain_modes(tmp_path, completed_mode="swebench")
+        assert result == 0
+
+    def test_does_not_call_run_single_cycle_for_terminal(self, tmp_path: Path) -> None:
+        """Terminal mode prevents any further cycle execution."""
+        from factory.cli.ceo import _chain_modes
+
+        registry = {"swebench": _terminal_workflow()}
+        with patch("factory.workflow.definitions.register_all", return_value=registry), \
+             patch("factory.cli.ceo._run_single_cycle") as mock_run:
+            _chain_modes(tmp_path, completed_mode="swebench")
+        mock_run.assert_not_called()
+
+    def test_non_terminal_mode_proceeds(self, tmp_path: Path) -> None:
+        """Non-terminal completed_mode does not short-circuit."""
+        from factory.cli.ceo import _chain_modes
+
+        registry = {"improve": _non_terminal_workflow()}
+        with patch("factory.workflow.definitions.register_all", return_value=registry), \
+             patch("factory.state.detect_state", return_value=ProjectState.HAS_FACTORY), \
+             patch("factory.cli.ceo._auto_detect_mode", return_value="improve"), \
+             patch("factory.cli.ceo._run_single_cycle", return_value=0):
+            result = _chain_modes(
+                tmp_path, completed_mode="improve", already_improved=True,
+            )
+        assert result == 0
+
+    def test_no_completed_mode_proceeds(self, tmp_path: Path) -> None:
+        """Without completed_mode, _chain_modes runs normally."""
+        from factory.cli.ceo import _chain_modes
+
+        with patch("factory.state.detect_state", return_value=ProjectState.HAS_FACTORY), \
+             patch("factory.cli.ceo._auto_detect_mode", return_value="improve"), \
+             patch("factory.cli.ceo._run_single_cycle", return_value=0):
+            result = _chain_modes(tmp_path, already_improved=True)
+        assert result == 0

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -494,3 +494,25 @@ class TestContributedWorkflows:
             wf = workflows[name]
             issues = wf.validate_graph()
             assert issues == [], f"{name} workflow has issues: {issues}"
+
+
+# ── Terminal flag defaults ──────────────────────────────────────
+
+
+class TestTerminalFlagDefaults:
+    """Standard workflows default to terminal=False."""
+
+    def test_build_not_terminal(self) -> None:
+        assert build_workflow().terminal is False
+
+    def test_improve_not_terminal(self) -> None:
+        assert improve_workflow().terminal is False
+
+    def test_research_not_terminal(self) -> None:
+        assert research_workflow().terminal is False
+
+    def test_meta_not_terminal(self) -> None:
+        assert meta_workflow().terminal is False
+
+    def test_design_not_terminal(self) -> None:
+        assert design_workflow().terminal is False

--- a/tests/test_workflow_swebench.py
+++ b/tests/test_workflow_swebench.py
@@ -22,10 +22,10 @@ class TestSwebenchWorkflow:
         assert wf.name == "swebench"
 
     def test_node_count(self) -> None:
-        """Workflow has exactly 4 nodes: study, builder, gate_verify, auto_merge."""
+        """Workflow has exactly 3 nodes: study, builder, gate_verify."""
         wf = workflow()
-        assert len(wf.nodes) == 4
-        assert set(wf.nodes.keys()) == {"study", "builder", "gate_verify", "auto_merge"}
+        assert len(wf.nodes) == 3
+        assert set(wf.nodes.keys()) == {"study", "builder", "gate_verify"}
 
     def test_start_node(self) -> None:
         wf = workflow()
@@ -38,9 +38,9 @@ class TestSwebenchWorkflow:
         assert issues == [], f"Workflow has validation issues: {issues}"
 
     def test_edge_count(self) -> None:
-        """4 edges: study->builder, builder->gate, gate->merge, gate->builder."""
+        """3 edges: study->builder, builder->gate, gate->builder RELOOP."""
         wf = workflow()
-        assert len(wf.edges) == 4
+        assert len(wf.edges) == 3
 
     def test_study_node_is_fn(self) -> None:
         wf = workflow()
@@ -71,13 +71,6 @@ class TestSwebenchWorkflow:
         assert "reloop:" in node.evaluator_command
         assert "fail:" in node.evaluator_command
 
-    def test_auto_merge_node(self) -> None:
-        wf = workflow()
-        node = wf.nodes["auto_merge"]
-        assert isinstance(node, FnNode)
-        assert "git merge" in node.command
-        assert "main" in node.command
-
     def test_reloop_edge_exists(self) -> None:
         """gate_verify has a RELOOP edge back to builder."""
         wf = workflow()
@@ -88,17 +81,6 @@ class TestSwebenchWorkflow:
             and e.condition == VerdictType.RELOOP
         ]
         assert len(reloop_edges) == 1
-
-    def test_proceed_edge_to_merge(self) -> None:
-        """gate_verify has a PROCEED edge to auto_merge."""
-        wf = workflow()
-        proceed_edges = [
-            e for e in wf.edges
-            if e.source == "gate_verify"
-            and e.target == "auto_merge"
-            and e.condition == VerdictType.PROCEED
-        ]
-        assert len(proceed_edges) == 1
 
     def test_no_eval_infrastructure(self) -> None:
         """No factory eval nodes (begin, finalize, precheck, study)."""

--- a/tests/test_workflow_swebench.py
+++ b/tests/test_workflow_swebench.py
@@ -115,6 +115,18 @@ class TestSwebenchWorkflow:
         assert "gate_strategy" not in node_ids
 
 
+class TestSwebenchTerminal:
+    """Tests for the terminal flag on swebench workflow."""
+
+    def test_workflow_is_terminal(self) -> None:
+        wf = workflow()
+        assert wf.terminal is True
+
+    def test_registered_workflow_is_terminal(self) -> None:
+        workflows = register_all()
+        assert workflows["swebench"].terminal is True
+
+
 class TestSwebenchTrigger:
     """Tests for the trigger function."""
 

--- a/workflow-swebench/SKILL.md
+++ b/workflow-swebench/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: workflow-swebench
+description: "SWE-bench benchmark mode — minimal 4-node pipeline for solving GitHub issues in containerized evaluation. Reads the task instruction, fixes the bug, runs tests, and merges to main. No eval infrastructure, no deep-QA, no research phases. Use when invoked with --mode swebench inside a Harbor benchmark container."
+disable-model-invocation: true
+argument-hint: "<project_path> --prompt /tmp/task-instruction.md"
+---
+
+# Swebench Workflow
+
+The user wants: **$ARGUMENTS**
+
+## Step: Study
+
+```bash
+mkdir -p $PROJECT_PATH/.factory/reviews && cd $PROJECT_PATH && (echo '=== Repository Structure ===' && find . -type f -name '*.py' | head -200 && echo '\n=== Test Files ===' && find . -type f -name 'test_*.py' -o -name '*_test.py' | head -50 && echo '\n=== Configuration Files ===' && ls -la setup.py setup.cfg pyproject.toml tox.ini conftest.py 2>/dev/null || true && echo '\n=== Task Instruction ===' && cat /tmp/task-instruction.md 2>/dev/null || echo 'No task instruction file found at /tmp/task-instruction.md') > .factory/reviews/study-output.md 2>&1
+```
+
+## Phase 1: Builder
+
+```bash
+factory agent builder --task "You are fixing a bug in an open-source project for the SWE-bench benchmark.
+
+## Your Task
+
+1. **Read the task instruction** — Read /tmp/task-instruction.md for the full bug description and task requirements.
+
+2. **Understand the codebase** — explore the repository structure. Read relevant source files, test files, and configuration. Identify the root cause of the bug described in the task.
+
+3. **Implement the fix** — make the MINIMAL change that resolves the issue. Do NOT refactor, modernize, or add unrelated improvements. Fix ONLY the described bug.
+
+4. **Run the project's own tests** — this is CRITICAL. Run the test suite to verify your fix works AND existing tests still pass. Use pytest, tox, or whatever test runner the project uses. If specific test files are mentioned in the task, run those first.
+
+5. **Commit your changes** — commit directly on the current branch with a descriptive message referencing the issue. Do NOT create a new branch. Do NOT create a PR.
+
+## Rules
+
+- MINIMAL fix only — smallest diff that resolves the issue
+- MUST run tests before committing — never commit untested code
+- Do NOT create branches or PRs — commit on current branch
+- Do NOT run factory commands (factory eval, factory study, etc.)
+- Do NOT modify test files unless the bug is IN the test infrastructure
+- If tests fail after your fix, investigate and fix the issue
+
+Read: .factory/reviews/study-output.md
+Write output to: .factory/reviews/builder-latest.md" --project "$PROJECT_PATH" --timeout 1200
+```
+
+### Gate — Verify (Automated)
+
+**MANDATORY:** Wait for the preceding agent to finish, then run this check BEFORE spawning the next agent. Do NOT run agents in parallel across this gate.
+
+```bash
+cd $PROJECT_PATH && CHANGES=$(git diff HEAD~1 --stat 2>/dev/null || echo 'NO_COMMITS') && if [ "$CHANGES" = 'NO_COMMITS' ] || [ -z "$CHANGES" ]; then echo 'fail: builder did not commit any changes'; exit 0; fi && BUILDER_OUTPUT=$(cat .factory/reviews/builder-latest.md 2>/dev/null || echo '') && if echo "$BUILDER_OUTPUT" | grep -qiE 'tests?.*(pass|succeed|ok|PASSED)'; then echo 'pass: builder reports tests passing'; elif echo "$BUILDER_OUTPUT" | grep -qiE 'tests?.*(fail|error|FAILED)'; then echo 'reloop: builder needs to retry — tests did not pass'; else echo 'pass: changes committed, no issues detected'; fi
+```
+
+*On RELOOP: return to `builder` (max 3 iterations)*


### PR DESCRIPTION
## Summary

Follow-up fixes to the swebench workflow (PR #960) based on E2E testing and adversarial research.

- **Remove auto_merge node (#963)** — `auto_merge` tried `git checkout main && git merge` from inside a worktree, which fails because main is locked by the parent repo. Harbor's 3-strategy recovery chain already handles merging. Workflow is now 3 nodes: `study → builder → gate_verify`.
- **Add CEO fallback for contributed workflows** — `_build_ceo_task()` had no handler for custom modes like `swebench`, causing the CEO to flounder for 4+ minutes before starting. Now any mode without a hardcoded block gets directed to read its `skills/workflow-{mode}/SKILL.md`. CEO startup went from 4+ min to 26 seconds.
- **Add terminal flag to Workflow model (#964)** — After a contributed workflow completes, the CLI auto-chained to discover mode (burning tokens on a benchmark container that will be destroyed). New `terminal: bool = False` field on `Workflow`; swebench sets `terminal=True`. `_chain_modes()` exits immediately for terminal workflows.
- **Fix trace_id.txt persistence (#965)** — Harbor agent now copies `.factory/trace_id.txt` to `/logs/.factory/` before container exit. Benchmark scripts reordered to extract trace_id before `rm -rf` cleanup (was a race condition).

## Test plan

- [x] 163/163 tests pass (swebench workflow, workflow definitions, skill export, chain modes terminal)
- [x] `factory workflow validate swebench` → VALID (3 nodes, 3 edges)
- [x] E2E clean-room test: CEO follows SKILL.md in 26s, Builder spawned and completes in ~2 min
- [x] Code review: all 7 categories PASS, no issues
- [x] Ruff + mypy clean

Closes #963, #964, #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)