### PR TITLE
fix: re-add auto_merge to swebench workflow using git branch -f

### DIFF
--- a/factory/workflow/contributed/swebench.py
+++ b/factory/workflow/contributed/swebench.py
@@ -1,6 +1,6 @@
 """SWE-bench benchmark workflow — minimal bug-fix pipeline for containerized evaluation.
 
-3-node pipeline: study → builder → gate_verify
+4-node pipeline: study → builder → gate_verify → auto_merge
 RELOOP from gate_verify back to builder (max 3 iterations) on test failure.
 
 Designed for Harbor containers where:
@@ -26,9 +26,9 @@ from factory.workflow.primitives import (
 meta = {
     "name": "swebench",
     "description": (
-        "SWE-bench benchmark mode — minimal 3-node pipeline for solving "
+        "SWE-bench benchmark mode — minimal 4-node pipeline for solving "
         "GitHub issues in containerized evaluation. study → builder → "
-        "gate_verify with RELOOP on test failure."
+        "gate_verify → auto_merge with RELOOP on test failure."
     ),
 }
 
@@ -118,11 +118,29 @@ def workflow() -> Workflow:
         reads={".factory/reviews/builder-latest.md"},
     )
 
+    # ── Node 4: Auto Merge ─────────────────────────────────────────
+    nodes["auto_merge"] = FnNode(
+        id="auto_merge",
+        command=(
+            "cd {project_path} && "
+            "CURRENT=$(git rev-parse --abbrev-ref HEAD) && "
+            "if [ \"$CURRENT\" = 'main' ] || [ \"$CURRENT\" = 'master' ]; then "
+            "echo 'Already on main/master branch — no merge needed'; "
+            "exit 0; fi && "
+            "BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null "
+            "| sed 's|refs/remotes/origin/||' || echo main) && "
+            "git branch -f \"$BASE\" HEAD && "
+            "echo \"Fast-forwarded $BASE to $(git rev-parse --short HEAD)\""
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
     # ── Edges ──────────────────────────────────────────────────────
 
     edges = [
         Edge(source="study", target="builder"),
         Edge(source="builder", target="gate_verify"),
+        Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
         Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),
     ]
 

--- a/tests/test_workflow_swebench.py
+++ b/tests/test_workflow_swebench.py
@@ -22,10 +22,10 @@ class TestSwebenchWorkflow:
         assert wf.name == "swebench"
 
     def test_node_count(self) -> None:
-        """Workflow has exactly 3 nodes: study, builder, gate_verify."""
+        """Workflow has exactly 4 nodes: study, builder, gate_verify, auto_merge."""
         wf = workflow()
-        assert len(wf.nodes) == 3
-        assert set(wf.nodes.keys()) == {"study", "builder", "gate_verify"}
+        assert len(wf.nodes) == 4
+        assert set(wf.nodes.keys()) == {"study", "builder", "gate_verify", "auto_merge"}
 
     def test_start_node(self) -> None:
         wf = workflow()
@@ -38,9 +38,9 @@ class TestSwebenchWorkflow:
         assert issues == [], f"Workflow has validation issues: {issues}"
 
     def test_edge_count(self) -> None:
-        """3 edges: study->builder, builder->gate, gate->builder RELOOP."""
+        """4 edges: study->builder, builder->gate, gate->merge, gate->builder RELOOP."""
         wf = workflow()
-        assert len(wf.edges) == 3
+        assert len(wf.edges) == 4
 
     def test_study_node_is_fn(self) -> None:
         wf = workflow()
@@ -70,6 +70,23 @@ class TestSwebenchWorkflow:
         assert "pass:" in node.evaluator_command
         assert "reloop:" in node.evaluator_command
         assert "fail:" in node.evaluator_command
+
+    def test_auto_merge_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["auto_merge"]
+        assert isinstance(node, FnNode)
+        assert "git branch -f" in node.command
+
+    def test_proceed_edge_to_merge(self) -> None:
+        """gate_verify has a PROCEED edge to auto_merge."""
+        wf = workflow()
+        proceed_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "auto_merge"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(proceed_edges) == 1
 
     def test_reloop_edge_exists(self) -> None:
         """gate_verify has a RELOOP edge back to builder."""


### PR DESCRIPTION
## Summary

Re-adds `auto_merge` FnNode to the swebench workflow. Without it, the Builder's fix stays on the worktree branch which the factory deletes on exit — Harbor can't find the changes and the benchmark fails despite a correct solution.

Uses `git branch -f $BASE HEAD` instead of `git checkout && git merge` — updates main's ref without checking it out, which works inside worktrees.

## Evidence

[Benchmark run 28759321348](https://github.com/akashgit/remote-factory/actions/runs/28759321348): Builder made the correct `Printable.__slots__` fix in 95s ([trace](https://langfuse-ci.ai-innovation.team/trace/08f5568ce347a3d0a59b3a14e0263c45)), but `passed: 0` because changes never landed on main.

## Test plan

- [x] 161 tests pass
- [x] `factory workflow validate swebench` → VALID (4 nodes, 4 edges)
- [x] E2E clean-room test confirmed `git branch -f` fast-forwards main from inside worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)