### PR TITLE
fix: switch swebench to deterministic executor + fix trace_id

### DIFF
--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -156,8 +156,8 @@ class ProgramBenchFactoryCeo(BaseInstalledAgent):
         await self.exec_as_agent(
             environment,
             command=(
-                "mkdir -p /logs/.factory && "
-                "cp .factory/trace_id.txt /logs/.factory/trace_id.txt 2>/dev/null; "
+                "cp /testbed/.factory/trace_id.txt /logs/agent/trace_id.txt 2>/dev/null || "
+                "cp .factory/trace_id.txt /logs/agent/trace_id.txt 2>/dev/null; "
                 "exit 0"
             ),
             env=env,
@@ -369,14 +369,12 @@ class FactoryCeo(BaseInstalledAgent):
             env=env,
         )
 
-        # Run factory ceo in headless mode
+        # Run swebench workflow via deterministic executor
         await self.exec_as_agent(
             environment,
             command=(
                 'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; '
-                'export FACTORY_CEO_RESPAWN_DISABLED=1; '
-                "factory ceo . --headless --mode swebench --no-github "
-                "--prompt /tmp/task-instruction.md "
+                "factory workflow run swebench . "
                 "2>&1 </dev/null | tee /logs/agent/factory-ceo.txt"
                 "; exit 0"
             ),
@@ -386,8 +384,8 @@ class FactoryCeo(BaseInstalledAgent):
         await self.exec_as_agent(
             environment,
             command=(
-                "mkdir -p /logs/.factory && "
-                "cp .factory/trace_id.txt /logs/.factory/trace_id.txt 2>/dev/null; "
+                "cp /testbed/.factory/trace_id.txt /logs/agent/trace_id.txt 2>/dev/null || "
+                "cp .factory/trace_id.txt /logs/agent/trace_id.txt 2>/dev/null; "
                 "exit 0"
             ),
             env=env,

--- a/benchmarks/run-featurebench.sh
+++ b/benchmarks/run-featurebench.sh
@@ -40,7 +40,7 @@ cleanup() {
     PASSED="${RESOLVED}"
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -name 'trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
         fi

--- a/benchmarks/run-legacybench.sh
+++ b/benchmarks/run-legacybench.sh
@@ -31,7 +31,7 @@ cleanup() {
     PASSED="${RESOLVED}"
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -name 'trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
         fi

--- a/benchmarks/run-programbench.sh
+++ b/benchmarks/run-programbench.sh
@@ -52,7 +52,7 @@ cleanup() {
     local exit_code=$?
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -name 'trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
         fi

--- a/benchmarks/run-swebench.sh
+++ b/benchmarks/run-swebench.sh
@@ -32,7 +32,7 @@ cleanup() {
     PASSED="${RESOLVED}"
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -name 'trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
         fi

--- a/benchmarks/run-terminalbench.sh
+++ b/benchmarks/run-terminalbench.sh
@@ -32,7 +32,7 @@ cleanup() {
     PASSED="${RESOLVED}"
     LANGFUSE_TRACE_ID=""
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
-        TRACE_ID_FILE=$(find "${JOBS_DIR}" -path '*/.factory/trace_id.txt' -type f 2>/dev/null | head -1)
+        TRACE_ID_FILE=$(find "${JOBS_DIR}" -name 'trace_id.txt' -type f 2>/dev/null | head -1)
         if [ -n "${TRACE_ID_FILE}" ] && [ -f "${TRACE_ID_FILE}" ]; then
             LANGFUSE_TRACE_ID=$(cat "${TRACE_ID_FILE}" | tr -d '[:space:]')
         fi

--- a/factory/workflow/contributed/swebench.py
+++ b/factory/workflow/contributed/swebench.py
@@ -124,13 +124,20 @@ def workflow() -> Workflow:
         command=(
             "cd {project_path} && "
             "CURRENT=$(git rev-parse --abbrev-ref HEAD) && "
-            "if [ \"$CURRENT\" = 'main' ] || [ \"$CURRENT\" = 'master' ]; then "
-            "echo 'Already on main/master branch — no merge needed'; "
+            "COMMON=$(git rev-parse --git-common-dir) && "
+            "BASE=$(git --git-dir=\"$COMMON\" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main) && "
+            "if [ \"$CURRENT\" = \"$BASE\" ]; then "
+            "echo \"Already on $BASE — no merge needed\"; "
             "exit 0; fi && "
-            "BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null "
-            "| sed 's|refs/remotes/origin/||' || echo main) && "
-            "git branch -f \"$BASE\" HEAD && "
-            "echo \"Fast-forwarded $BASE to $(git rev-parse --short HEAD)\""
+            "git update-ref refs/heads/\"$BASE\" HEAD && "
+            "PARENT_WT=$(cd \"$COMMON/..\" && pwd) && "
+            "git diff-tree --no-commit-id --name-only -r HEAD HEAD~1 | "
+            "while read file; do "
+            "if [ -f \"$file\" ]; then "
+            "mkdir -p \"$PARENT_WT/$(dirname $file)\" && "
+            "cp \"$file\" \"$PARENT_WT/$file\"; "
+            "fi; done && "
+            "echo \"Updated $BASE to $(git rev-parse --short HEAD)\""
         ),
         reads={".factory/reviews/builder-latest.md"},
     )

--- a/tests/test_workflow_swebench.py
+++ b/tests/test_workflow_swebench.py
@@ -75,7 +75,7 @@ class TestSwebenchWorkflow:
         wf = workflow()
         node = wf.nodes["auto_merge"]
         assert isinstance(node, FnNode)
-        assert "git branch -f" in node.command
+        assert "git update-ref" in node.command
 
     def test_proceed_edge_to_merge(self) -> None:
         """gate_verify has a PROCEED edge to auto_merge."""


### PR DESCRIPTION
## Summary

Fixes swebench benchmark failures caused by the CEO paraphrasing shell commands.

1. **`factory workflow run swebench .`** replaces `factory ceo --mode swebench` — executor runs commands verbatim
2. **`git update-ref` + `git-common-dir`** — detects actual parent branch (e.g. `1.7`), not hardcoded `main`; copies changed files to parent working tree
3. **trace_id to `/logs/agent/`** — Harbor exports this path; scripts search by `-name`

## Evidence

5/5 local Harbor runs RESOLVED with trace_id `da6a64b8...` captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)