### PR TITLE
fix: use straight line segments in benchmark charts

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -418,7 +418,7 @@ function renderAccuracyTrend(mainResults) {
             data: factoryPoints,
             borderColor: '#4285f4',
             backgroundColor: '#4285f4',
-            tension: 0.2,
+            tension: 0,
             pointRadius: 4,
           },
           {
@@ -426,7 +426,7 @@ function renderAccuracyTrend(mainResults) {
             data: claudePoints,
             borderColor: '#ff7043',
             backgroundColor: '#ff7043',
-            tension: 0.2,
+            tension: 0,
             pointRadius: 4,
           },
         ]
@@ -488,7 +488,7 @@ function renderDurationTrend(mainResults) {
             data: runAvgs.factoryDurationPoints,
             borderColor: '#4285f4',
             backgroundColor: '#4285f4',
-            tension: 0.2,
+            tension: 0,
             pointRadius: 4,
           },
           {
@@ -496,7 +496,7 @@ function renderDurationTrend(mainResults) {
             data: runAvgs.claudeDurationPoints,
             borderColor: '#ff7043',
             backgroundColor: '#ff7043',
-            tension: 0.2,
+            tension: 0,
             pointRadius: 4,
           },
         ]
@@ -562,7 +562,7 @@ function renderCostTrend(mainResults) {
             data: runAvgs.factoryCostPoints,
             borderColor: '#4285f4',
             backgroundColor: '#4285f4',
-            tension: 0.2,
+            tension: 0,
             pointRadius: 4,
           },
           {
@@ -570,7 +570,7 @@ function renderCostTrend(mainResults) {
             data: runAvgs.claudeCostPoints,
             borderColor: '#ff7043',
             backgroundColor: '#ff7043',
-            tension: 0.2,
+            tension: 0,
             pointRadius: 4,
           },
         ]


### PR DESCRIPTION
Closes #971

## Changes

- Changed `tension: 0.2` to `tension: 0` in all 6 Chart.js dataset configurations across the 3 benchmark charts (Accuracy Trend, Duration Trend, Cost Trend)
- `tension: 0.2` caused Chart.js to render bezier curve interpolation between data points, making trends appear smoother than the actual data
- `tension: 0` renders straight line segments connecting each data point directly, giving an accurate representation of the underlying data