### PR TITLE
feat: add programbench discovery-first workflow

### DIFF
--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -30,187 +30,6 @@ COMMON_ENV_VARS = (
 )
 
 
-class ProgramBenchFactoryCeo(BaseInstalledAgent):
-    """Runs ``factory ceo`` for ProgramBench tasks.
-
-    Assumes Claude Code and Factory CLI are pre-installed in the Docker
-    image (via the task Dockerfile), so install() only verifies they exist.
-    """
-
-    @staticmethod
-    @override
-    def name() -> str:
-        return "programbench-factory-ceo"
-
-    @override
-    def get_version_command(self) -> str | None:
-        return (
-            'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; '
-            'which factory 2>/dev/null || echo "unknown"'
-        )
-
-    @override
-    def parse_version(self, stdout: str) -> str:
-        match = re.search(r"(\d+\.\d+\.\d+)", stdout.strip())
-        return match.group(1) if match else stdout.strip()
-
-    @override
-    async def install(self, environment: BaseEnvironment) -> None:
-        await self.exec_as_agent(
-            environment,
-            command=(
-                'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; '
-                "claude --version && factory --help >/dev/null"
-            ),
-        )
-
-    @override
-    async def run(
-        self,
-        instruction: str,
-        environment: BaseEnvironment,
-        context: AgentContext,
-    ) -> None:
-        """Run factory ceo to solve the task described in *instruction*."""
-        api_key = (
-            self._get_env("ANTHROPIC_API_KEY")
-            or self._get_env("ANTHROPIC_AUTH_TOKEN")
-            or ""
-        )
-
-        env: dict[str, str] = {
-            "ANTHROPIC_API_KEY": api_key,
-            "IS_SANDBOX": "1",
-            "CLAUDE_CONFIG_DIR": "/logs/agent/sessions",
-        }
-
-        if self.model_name:
-            env["ANTHROPIC_MODEL"] = self.model_name.split("/")[-1]
-
-        for var in COMMON_ENV_VARS:
-            val = self._get_env(var) or os.environ.get(var)
-            if val and var not in env:
-                env[var] = val
-
-        env = {k: v for k, v in env.items() if v}
-
-        await self.exec_as_agent(
-            environment,
-            command=(
-                "mkdir -p $CLAUDE_CONFIG_DIR/debug "
-                "$CLAUDE_CONFIG_DIR/projects "
-                "$CLAUDE_CONFIG_DIR/shell-snapshots "
-                "$CLAUDE_CONFIG_DIR/statsig "
-                "$CLAUDE_CONFIG_DIR/todos "
-                "$CLAUDE_CONFIG_DIR/skills"
-            ),
-            env=env,
-        )
-
-        await self.exec_as_agent(
-            environment,
-            command=(
-                "cat > ./factory.md << 'FACTORYEOF'\n"
-                "---\n"
-                "goal: Reverse-engineer the compiled binary and produce equivalent source code\n"
-                "---\n"
-                "FACTORYEOF"
-            ),
-            env=env,
-        )
-
-        await self.exec_as_agent(
-            environment,
-            command=(
-                'set -e; '
-                'if [ ! -d .git ]; then git init -b main; fi && '
-                'git config user.name "Factory Agent" && '
-                'git config user.email "factory@agent.local" && '
-                'printf "/proc\\n/sys\\n/dev\\n/run\\n/tmp\\n/var\\n/root\\n'
-                '/home\\n/usr\\n/bin\\n/sbin\\n/lib\\n/lib64\\n/etc\\n'
-                '/boot\\n/mnt\\n/opt\\n/srv\\n/media\\n/logs\\n" > .gitignore && '
-                'git add -A && '
-                'git commit -m "initial state" --allow-empty'
-            ),
-            env=env,
-        )
-
-        await self.exec_as_agent(
-            environment,
-            command=f"cat > /tmp/task-instruction.md << 'INSTREOF'\n{instruction}\nINSTREOF",
-            env=env,
-        )
-
-        await self.exec_as_agent(
-            environment,
-            command=(
-                'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; '
-                'export FACTORY_CEO_RESPAWN_DISABLED=1; '
-                "factory ceo . --headless --mode build --no-github "
-                "--prompt /tmp/task-instruction.md "
-                "2>&1 </dev/null | tee /logs/agent/factory-ceo.txt"
-                "; exit 0"
-            ),
-            env=env,
-        )
-
-        await self.exec_as_agent(
-            environment,
-            command=(
-                "cp /testbed/.factory/trace_id.txt /logs/agent/trace_id.txt 2>/dev/null || "
-                "cp .factory/trace_id.txt /logs/agent/trace_id.txt 2>/dev/null; "
-                "exit 0"
-            ),
-            env=env,
-        )
-
-        await self.exec_as_agent(
-            environment,
-            command=(
-                "set +e; "
-                'FACTORY_BRANCH=$(git branch --list "factory/*" | head -1 | tr -d " *"); '
-                'if [ -n "$FACTORY_BRANCH" ]; then '
-                '  echo "Merging factory branch: $FACTORY_BRANCH"; '
-                '  git merge "$FACTORY_BRANCH" --no-edit 2>/dev/null '
-                '    || git cherry-pick "$FACTORY_BRANCH" --no-edit 2>/dev/null '
-                "    || true; "
-                "fi; "
-                'if [ -z "$FACTORY_BRANCH" ]; then '
-                '  echo "No factory branch, finding orphaned commits..."; '
-                "  ORPHAN_COMMITS=$(git fsck --unreachable --no-reflogs 2>/dev/null "
-                "    | grep 'unreachable commit' | awk '{print \\$3}'); "
-                '  if [ -n "$ORPHAN_COMMITS" ]; then '
-                '    BEST_COMMIT=""; '
-                "    BEST_TIME=0; "
-                "    for SHA in $ORPHAN_COMMITS; do "
-                '      COMMIT_TIME=$(git show -s --format=\'%ct\' "$SHA" 2>/dev/null || echo 0); '
-                '      if [ "$COMMIT_TIME" -gt "$BEST_TIME" ]; then '
-                "        BEST_TIME=$COMMIT_TIME; "
-                "        BEST_COMMIT=$SHA; "
-                "      fi; "
-                "    done; "
-                '    if [ -n "$BEST_COMMIT" ]; then '
-                '      echo "Recovering from orphan tip: $BEST_COMMIT"; '
-                '      echo "  Message: $(git log -1 --format=\'%%s\' $BEST_COMMIT 2>/dev/null)"; '
-                '      git checkout "$BEST_COMMIT" -- . 2>/dev/null || true; '
-                "      git checkout HEAD -- .factory/ eval/ factory.md 2>/dev/null || true; "
-                "      rm -rf .factory/ eval/ factory.md 2>/dev/null || true; "
-                "    fi; "
-                "  fi; "
-                "fi; "
-                'for wt in .factory-worktrees/*/; do '
-                '  if [ -d "$wt" ]; then '
-                '    echo "Recovering files from worktree: $wt"; '
-                "    rsync -a --exclude='.git' --exclude='.factory' "
-                '      "$wt" ./ 2>/dev/null || true; '
-                "  fi; "
-                "done; "
-                "exit 0"
-            ),
-            env=env,
-        )
-
-
 class FactoryCeo(BaseInstalledAgent):
     """Runs ``factory ceo`` to solve benchmark tasks.
 
@@ -465,6 +284,24 @@ class FactoryCeo(BaseInstalledAgent):
                 "exit 0"
             ),
             env=env,
+        )
+
+
+class ProgramBenchFactoryCeo(FactoryCeo):
+    """Runs the deterministic programbench workflow."""
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "programbench-factory-ceo"
+
+    @override
+    def _get_factory_command(self) -> str:
+        return (
+            'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; '
+            'factory workflow run programbench . '
+            '2>&1 </dev/null | tee /logs/agent/factory-ceo.txt'
+            '; exit 0'
         )
 
 

--- a/factory/workflow/contributed/programbench.py
+++ b/factory/workflow/contributed/programbench.py
@@ -1,0 +1,237 @@
+"""ProgramBench benchmark workflow — discovery-first reverse engineering pipeline.
+
+5-node pipeline: discover → plan → builder → gate_verify → auto_merge
+RELOOP from gate_verify back to builder (max 3 iterations) on failure.
+
+Designed for Harbor containers where:
+- A compiled binary exists at /workspace/executable
+- The agent must reverse-engineer its behavior and produce equivalent source
+- Discovery phase probes the binary exhaustively before any code is written
+- Harbor's verifier is the FINAL authority on pass/fail
+- Harbor checks the MAIN branch for changes
+- No .factory/ infrastructure (no eval, no experiments, no deep-QA)
+"""
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Edge,
+    FnNode,
+    GateNode,
+    VerdictType,
+    Workflow,
+)
+
+meta = {
+    "name": "programbench",
+    "description": (
+        "ProgramBench benchmark mode — discovery-first reverse engineering "
+        "pipeline. discover → plan → builder → gate_verify → auto_merge "
+        "with RELOOP on failure."
+    ),
+}
+
+
+def workflow() -> Workflow:
+    """Build the ProgramBench workflow — discovery-first reverse engineering."""
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # ── Node 1: Discover ──────────────────────────────────────────
+    nodes["discover"] = AgentNode(
+        id="discover",
+        role=AgentRole.RESEARCHER,
+        model="opus",
+        timeout=900,
+        max_iterations=1,
+        prompt_template=(
+            "You are a reverse-engineering researcher. Your job is to probe a "
+            "compiled binary at /workspace/executable and document EVERYTHING "
+            "you discover about its behavior.\n\n"
+            "## Your Task\n\n"
+            "1. **Read the task instruction** — Read /tmp/task-instruction.md "
+            "for context on what the binary does.\n\n"
+            "2. **Check the workspace** — List all files in /workspace/. Look "
+            "for README files, man pages, documentation, data files, or any "
+            "other clues about the binary's purpose.\n\n"
+            "3. **Read any documentation found** — If there is a README.md or "
+            "other docs, read them thoroughly.\n\n"
+            "4. **Probe the binary systematically** — Run the binary with:\n"
+            "   - No arguments\n"
+            "   - --help, -h\n"
+            "   - --version, -V, -v\n"
+            "   - Invalid/unknown flags to see error messages\n"
+            "   - Single-letter flags: -a through -z, -A through -Z\n"
+            "   - Common long flags: --verbose, --debug, --output, --input, "
+            "--format, --config, --list, --all, --recursive, --quiet\n"
+            "   - Flags that take arguments — try them with various values\n"
+            "   - Pipe input via stdin\n"
+            "   - Provide sample files as arguments\n\n"
+            "5. **Record exact outputs** — For EVERY invocation, capture:\n"
+            "   - The exact command run\n"
+            "   - stdout (exact text)\n"
+            "   - stderr (exact text)\n"
+            "   - Exit code ($?)\n\n"
+            "6. **Note special behaviors** — Document:\n"
+            "   - The exact version string from -V or --version output\n"
+            "   - How the binary behaves with no terminal (e.g. 'Error opening "
+            "terminal' messages)\n"
+            "   - Any environment variables it reads\n"
+            "   - Any files it creates, reads, or modifies\n"
+            "   - Interactive vs non-interactive behavior differences\n\n"
+            "7. **Write ALL findings** — Save your complete findings to "
+            ".factory/reviews/discovery.md. Be EXHAUSTIVE — the builder agent "
+            "will use this as its sole reference for implementation.\n\n"
+            "## Rules\n\n"
+            "- Act AUTONOMOUSLY — do NOT ask for confirmation or input\n"
+            "- Be THOROUGH — try every flag combination you can think of\n"
+            "- Record EXACT outputs, not summaries\n"
+            "- Note exit codes for each invocation\n"
+            "- The binary is execute-only — you cannot read its contents\n"
+            "- Do NOT attempt to implement anything — only discover and document\n"
+            "- Do NOT run factory commands\n"
+            "- Do NOT create branches or PRs\n"
+        ),
+        reads=set(),
+        writes={".factory/reviews/discovery.md"},
+    )
+
+    # ── Node 2: Plan ──────────────────────────────────────────────
+    nodes["plan"] = FnNode(
+        id="plan",
+        command=(
+            "cd {project_path} && "
+            "echo 'pass: discovery complete'"
+        ),
+        reads={".factory/reviews/discovery.md"},
+        writes=set(),
+    )
+
+    # ── Node 3: Builder ───────────────────────────────────────────
+    nodes["builder"] = AgentNode(
+        id="builder",
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=1200,
+        max_iterations=3,
+        prompt_template=(
+            "You are reverse-engineering a compiled binary and producing "
+            "equivalent source code for the ProgramBench benchmark.\n\n"
+            "## Your Task\n\n"
+            "1. **Read the discovery findings** — Read "
+            ".factory/reviews/discovery.md thoroughly. This contains the "
+            "complete behavioral profile of the target binary gathered by "
+            "a discovery agent. It has exact outputs, exit codes, and flag "
+            "behaviors for every invocation tested.\n\n"
+            "2. **Read any documentation** — Check /workspace/ for README.md, "
+            "man pages, or other docs. Read /tmp/task-instruction.md for the "
+            "task description.\n\n"
+            "3. **Write the source code** — Implement C source code that "
+            "reproduces ALL discovered behaviors:\n"
+            "   - Match every flag and option exactly\n"
+            "   - Match output format exactly (spacing, newlines, field widths)\n"
+            "   - Match exit codes exactly\n"
+            "   - Match error messages exactly\n"
+            "   - CRITICAL: Hardcode the exact version string from -V output. "
+            "Do NOT use __DATE__ or __TIME__ macros — these produce different "
+            "values on every build and will fail verification.\n\n"
+            "4. **Create compile.sh** — Write a build script that:\n"
+            "   - Backs up the original: cp /workspace/executable "
+            "/workspace/executable.bak\n"
+            "   - Compiles the source to /workspace/executable\n"
+            "   - Is executable (chmod +x)\n\n"
+            "5. **Differential testing** — After compiling, compare your "
+            "implementation against the original:\n"
+            "   - Run both /workspace/executable.bak and /workspace/executable "
+            "with the same flags\n"
+            "   - Compare stdout, stderr, and exit codes\n"
+            "   - Fix ANY differences found\n"
+            "   - Test with at least 10 different flag combinations\n\n"
+            "6. **Commit your changes** — Commit directly on the current "
+            "branch with a descriptive message. Do NOT create a new branch. "
+            "Do NOT create a PR.\n\n"
+            "## Rules\n\n"
+            "- Act AUTONOMOUSLY — do NOT ask for confirmation or input\n"
+            "- The discovery findings are your primary reference — trust them\n"
+            "- Match behavior EXACTLY — even minor output differences cause "
+            "verification failure\n"
+            "- Do NOT use __DATE__, __TIME__, or other non-deterministic macros\n"
+            "- Do NOT create branches or PRs — commit on current branch\n"
+            "- Do NOT run factory commands (factory eval, factory study, etc.)\n"
+            "- If differential testing reveals mismatches, fix them before "
+            "committing\n"
+        ),
+        reads={".factory/reviews/discovery.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Node 4: Gate Verify ───────────────────────────────────────
+    nodes["gate_verify"] = GateNode(
+        id="gate_verify",
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            "if ! test -f compile.sh; then "
+            "echo 'reloop: compile.sh missing'; "
+            "exit 0; fi && "
+            "if ! bash compile.sh 2>&1; then "
+            "echo 'reloop: compile.sh failed'; "
+            "exit 0; fi && "
+            "if ! test -f /workspace/executable; then "
+            "echo 'reloop: /workspace/executable not found after compilation'; "
+            "exit 0; fi && "
+            "echo 'pass: compile.sh succeeded and executable exists'"
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Node 5: Auto Merge ────────────────────────────────────────
+    nodes["auto_merge"] = FnNode(
+        id="auto_merge",
+        command=(
+            "cd {project_path} && "
+            "CURRENT=$(git rev-parse --abbrev-ref HEAD) && "
+            "COMMON=$(git rev-parse --git-common-dir) && "
+            "BASE=$(git --git-dir=\"$COMMON\" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main) && "
+            "if [ \"$CURRENT\" = \"$BASE\" ]; then "
+            "echo \"Already on $BASE — no merge needed\"; "
+            "exit 0; fi && "
+            "git update-ref refs/heads/\"$BASE\" HEAD && "
+            "PARENT_WT=$(cd \"$COMMON/..\" && pwd) && "
+            "git diff-tree --no-commit-id --name-only -r HEAD HEAD~1 | "
+            "while read file; do "
+            "if [ -f \"$file\" ]; then "
+            "mkdir -p \"$PARENT_WT/$(dirname $file)\" && "
+            "cp \"$file\" \"$PARENT_WT/$file\"; "
+            "fi; done && "
+            "echo \"Updated $BASE to $(git rev-parse --short HEAD)\""
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Edges ─────────────────────────────────────────────────────
+
+    edges = [
+        Edge(source="discover", target="plan"),
+        Edge(source="plan", target="builder"),
+        Edge(source="builder", target="gate_verify"),
+        Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
+        Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),
+    ]
+
+    # ── Trigger ───────────────────────────────────────────────────
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "programbench"
+
+    return Workflow(
+        name="programbench",
+        nodes=nodes,
+        edges=edges,
+        start_node="discover",
+        terminal=True,
+        trigger=trigger,
+    )

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -1991,6 +1991,7 @@ def register_all() -> dict[str, Workflow]:
     from factory.workflow.contributed.legacybench import workflow as legacybench_workflow
     from factory.workflow.contributed.swebench import workflow as swebench_workflow
     from factory.workflow.contributed.featurebench import workflow as featurebench_workflow
+    from factory.workflow.contributed.programbench import workflow as programbench_workflow
     from factory.workflow.contributed.terminalbench import workflow as terminalbench_workflow
 
     return {
@@ -2003,6 +2004,7 @@ def register_all() -> dict[str, Workflow]:
         "deep-qa": deep_qa_workflow(),
         "legacybench": legacybench_workflow(),
         "featurebench": featurebench_workflow(),
+        "programbench": programbench_workflow(),
         "swebench": swebench_workflow(),
         "terminalbench": terminalbench_workflow(),
         "research": research_workflow(),

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -496,7 +496,7 @@ class TestRealWorkflowSkills:
 # ── QA phase enforcement ──────────────────────────────────────────
 
 
-QA_EXEMPT_WORKFLOWS = {"featurebench", "legacybench", "swebench", "terminalbench"}
+QA_EXEMPT_WORKFLOWS = {"featurebench", "legacybench", "programbench", "swebench", "terminalbench"}
 
 
 def _workflows_with_builder() -> list[str]:

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -388,7 +388,7 @@ class TestDocFreshnessGate:
 # ── Builder → QA reachability audit ────────────────────────────
 
 
-QA_EXEMPT_WORKFLOWS = {"featurebench", "legacybench", "swebench", "terminalbench"}  # Benchmark workflows use external verifiers
+QA_EXEMPT_WORKFLOWS = {"featurebench", "legacybench", "programbench", "swebench", "terminalbench"}  # Benchmark workflows use external verifiers
 
 
 def _workflows_with_builder() -> list[str]:

--- a/tests/test_workflow_programbench.py
+++ b/tests/test_workflow_programbench.py
@@ -1,0 +1,186 @@
+"""Tests for the ProgramBench contributed workflow."""
+
+from __future__ import annotations
+
+from factory.models import ProjectState
+from factory.workflow.contributed.programbench import meta, workflow
+from factory.workflow.definitions import register_all
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    FnNode,
+    GateNode,
+    VerdictType,
+)
+
+
+class TestProgrambenchWorkflow:
+    """Tests for programbench workflow graph structure."""
+
+    def test_workflow_name(self) -> None:
+        wf = workflow()
+        assert wf.name == "programbench"
+
+    def test_node_count(self) -> None:
+        """Workflow has exactly 5 nodes: discover, plan, builder, gate_verify, auto_merge."""
+        wf = workflow()
+        assert len(wf.nodes) == 5
+        assert set(wf.nodes.keys()) == {"discover", "plan", "builder", "gate_verify", "auto_merge"}
+
+    def test_start_node(self) -> None:
+        wf = workflow()
+        assert wf.start_node == "discover"
+
+    def test_graph_validates(self) -> None:
+        """Graph passes structural validation (DAG check, edge consistency)."""
+        wf = workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Workflow has validation issues: {issues}"
+
+    def test_edge_count(self) -> None:
+        """5 edges: discover->plan, plan->builder, builder->gate, gate->merge, gate->builder RELOOP."""
+        wf = workflow()
+        assert len(wf.edges) == 5
+
+    def test_discover_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["discover"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.RESEARCHER
+        assert "reverse-engineering" in node.prompt_template.lower()
+        assert "autonomous" in node.prompt_template.lower()
+        assert "discovery.md" in node.prompt_template
+
+    def test_plan_node_is_fn(self) -> None:
+        wf = workflow()
+        node = wf.nodes["plan"]
+        assert isinstance(node, FnNode)
+        assert "discovery complete" in node.command
+
+    def test_builder_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.BUILDER
+        assert node.max_iterations == 3
+        assert node.timeout == 1200
+        assert "discovery.md" in node.prompt_template
+        assert "autonomous" in node.prompt_template.lower()
+        assert "__DATE__" in node.prompt_template
+
+    def test_gate_verify_is_fn_evaluator(self) -> None:
+        """Gate uses fn evaluator (not agent) for speed and determinism."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert node.evaluator_command is not None
+        assert "pass:" in node.evaluator_command
+        assert "reloop:" in node.evaluator_command
+        assert "compile.sh" in node.evaluator_command
+
+    def test_auto_merge_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["auto_merge"]
+        assert isinstance(node, FnNode)
+        assert "git update-ref" in node.command
+
+    def test_proceed_edge_to_merge(self) -> None:
+        """gate_verify has a PROCEED edge to auto_merge."""
+        wf = workflow()
+        proceed_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "auto_merge"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(proceed_edges) == 1
+
+    def test_reloop_edge_exists(self) -> None:
+        """gate_verify has a RELOOP edge back to builder."""
+        wf = workflow()
+        reloop_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "builder"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(reloop_edges) == 1
+
+    def test_no_eval_infrastructure(self) -> None:
+        """No factory eval nodes (begin, finalize, precheck, study)."""
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "begin" not in node_ids
+        assert "finalize" not in node_ids
+        assert "gate_precheck" not in node_ids
+        for node in wf.nodes.values():
+            if isinstance(node, FnNode):
+                assert "factory eval" not in node.command
+                assert "factory finalize" not in node.command
+                assert "factory precheck" not in node.command
+                assert "factory begin" not in node.command
+
+
+class TestProgrambenchTerminal:
+    """Tests for the terminal flag on programbench workflow."""
+
+    def test_workflow_is_terminal(self) -> None:
+        wf = workflow()
+        assert wf.terminal is True
+
+    def test_registered_workflow_is_terminal(self) -> None:
+        workflows = register_all()
+        assert workflows["programbench"].terminal is True
+
+
+class TestProgrambenchTrigger:
+    """Tests for the trigger function."""
+
+    def test_trigger_matches_programbench_mode(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "programbench"})
+
+    def test_trigger_matches_without_factory(self) -> None:
+        """Trigger fires on mode alone, regardless of project state."""
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.NO_REPO, {"mode": "programbench"})
+        assert wf.trigger(ProjectState.NO_FACTORY, {"mode": "programbench"})
+
+    def test_trigger_rejects_other_modes(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "terminalbench"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+class TestProgrambenchRegistration:
+    """Tests for registration in the global workflow registry."""
+
+    def test_registered_in_register_all(self) -> None:
+        workflows = register_all()
+        assert "programbench" in workflows
+
+    def test_registered_workflow_valid(self) -> None:
+        workflows = register_all()
+        wf = workflows["programbench"]
+        issues = wf.validate_graph()
+        assert issues == [], f"Registered programbench workflow has issues: {issues}"
+
+    def test_registered_workflow_has_trigger(self) -> None:
+        workflows = register_all()
+        wf = workflows["programbench"]
+        assert wf.trigger is not None
+
+
+class TestProgrambenchMeta:
+    """Tests for the module-level meta dict."""
+
+    def test_meta_has_name(self) -> None:
+        assert meta["name"] == "programbench"
+
+    def test_meta_has_description(self) -> None:
+        assert "programbench" in meta["description"].lower() or "ProgramBench" in meta["description"]


### PR DESCRIPTION
## Summary
- Adds `factory/workflow/contributed/programbench.py` — discovery-first reverse engineering pipeline: `discover → plan → builder → gate_verify → auto_merge`
- Replaces the standalone `ProgramBenchFactoryCeo` class (180+ lines) with a 15-line subclass of `FactoryCeo` that runs `factory workflow run programbench .`
- Registered in `register_all()`, QA exemptions added, 23 new tests

## Results
Validated end-to-end through Harbor on the `cmatrix` task:
- **768/769 tests passed (99.87%)** — matches claude-code solver
- **25 minutes** — down from 100+ min with the old `factory ceo --mode build` approach
- Trace: [`2a4e9caf`](https://langfuse-ci.ai-innovation.team/trace/2a4e9caf62e9d4957a76fdf98820803b)

## Test plan
- [x] `pytest tests/` — 3136 tests pass
- [x] Harbor E2E: `BENCHMARK_SOLVER=factory benchmarks/run-programbench.sh cmatrix 3600` → 768/769

🤖 Generated with [Claude Code](https://claude.com/claude-code)