### PR TITLE
fix: set --max-turns 1000 for headless Claude Code invocations

### DIFF
--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -105,6 +105,7 @@ class ClaudeRunner:
             "-p", request.task,
             "--output-format", "stream-json",
             "--verbose",
+            "--max-turns", "1000",
         ]
         if request.skip_permissions:
             cmd.append("--dangerously-skip-permissions")


### PR DESCRIPTION
## Summary
- Sets `--max-turns 1000` in the Claude runner's `build_command()` for `-p` mode invocations
- Without this, fresh CI installs use Claude Code's default max_turns (as low as 3), causing agents to be killed before finishing work
- Observed in terminalbench CI run where the builder hit `Error: Reached max turns (3)` after only 123s

## Test plan
- [x] Verified `--max-turns` flag is accepted by Claude Code CLI
- [x] `pytest tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)