### PR TITLE
fix: use vars instead of secrets for LANGFUSE_BENCH_HOST to prevent trace link masking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -185,8 +185,8 @@ jobs:
           CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1"
           MAX_THINKING_TOKENS: "128000"
           CLAUDE_CODE_EFFORT_LEVEL: "XHIGH"
-          LANGFUSE_HOST: ${{ secrets.LANGFUSE_BENCH_HOST }}
-          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BENCH_HOST }}
+          LANGFUSE_HOST: ${{ vars.LANGFUSE_BENCH_HOST }}
+          LANGFUSE_BASE_URL: ${{ vars.LANGFUSE_BENCH_HOST }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_BENCH_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_BENCH_SECRET_KEY }}
           FACTORY_GIT_REF: ${{ github.sha }}
@@ -215,8 +215,8 @@ jobs:
           CLAUDE_CODE_USE_VERTEX: "1"
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
           CLOUD_ML_REGION: ${{ secrets.GCP_REGION }}
-          LANGFUSE_HOST: ${{ secrets.LANGFUSE_BENCH_HOST }}
-          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BENCH_HOST }}
+          LANGFUSE_HOST: ${{ vars.LANGFUSE_BENCH_HOST }}
+          LANGFUSE_BASE_URL: ${{ vars.LANGFUSE_BENCH_HOST }}
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_BENCH_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_BENCH_SECRET_KEY }}
         run: |
@@ -332,7 +332,7 @@ jobs:
           REF="${{ github.ref }}" \
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           TRIGGER="${{ github.event_name }}" \
-          LANGFUSE_HOST="${{ secrets.LANGFUSE_BENCH_HOST }}" \
+          LANGFUSE_HOST="${{ vars.LANGFUSE_BENCH_HOST }}" \
           python3 /tmp/append_results.py
 
           echo 'DEBUG: results dir contents:'


### PR DESCRIPTION
## Summary

- Moves `LANGFUSE_BENCH_HOST` from `secrets` to `vars` in the benchmark workflow (5 references)
- GitHub Actions masks all secret values in step summaries and logs, which turns Langfuse trace URLs like `https://langfuse-host/trace/<id>` into `***/trace/<id>` — a relative path that the browser resolves against the GitHub Actions page URL, producing broken links
- The host URL is not a credential (unlike the public/secret keys, which remain as secrets) and doesn't need masking

## Required repo change

Add `LANGFUSE_BENCH_HOST` as a **repository variable** (Settings > Secrets and variables > Actions > Variables tab) with the same value currently in the secret. The secret can be removed afterward.

## Test plan

- [ ] Add `LANGFUSE_BENCH_HOST` as a repo variable with the Langfuse host URL
- [ ] Trigger a benchmark run and verify trace links in the step summary point to the Langfuse host, not GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)