### PR TITLE
refactor: programbench workflow — adversarial discovery verification loop

### DIFF
--- a/factory/workflow/contributed/programbench/test_workflow.py
+++ b/factory/workflow/contributed/programbench/test_workflow.py
@@ -56,27 +56,30 @@ class TestProgrambenchWorkflow:
     def test_builder_maintains_discoveries(self) -> None:
         """Builder prompt instructs maintaining a structured discoveries file."""
         wf = workflow()
-        prompt = wf.nodes["builder"].prompt_template
-        assert "discoveries.md" in prompt
-        assert "## Discovery:" in prompt
-        assert "verified" in prompt
-        assert "uncertain" in prompt
-        assert "unexplored" in prompt
-        assert "Evidence" in prompt
+        node = wf.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert "discoveries.md" in node.prompt_template
+        assert "## Discovery:" in node.prompt_template
+        assert "verified" in node.prompt_template
+        assert "uncertain" in node.prompt_template
+        assert "unexplored" in node.prompt_template
+        assert "Evidence" in node.prompt_template
 
     def test_builder_reads_todos(self) -> None:
         """Builder prompt instructs reading todos.md on RELOOP iterations."""
         wf = workflow()
-        prompt = wf.nodes["builder"].prompt_template
-        assert "todos.md" in prompt
-        assert "address EACH item" in prompt
+        node = wf.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert "todos.md" in node.prompt_template
+        assert "address EACH item" in node.prompt_template
 
     def test_builder_backs_up_binary(self) -> None:
         """Builder prompt instructs backing up executable to executable.bak."""
         wf = workflow()
-        prompt = wf.nodes["builder"].prompt_template
-        assert "executable.bak" in prompt
-        assert "cp /workspace/executable /workspace/executable.bak" in prompt
+        node = wf.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert "executable.bak" in node.prompt_template
+        assert "cp /workspace/executable /workspace/executable.bak" in node.prompt_template
 
     def test_reviewer_node(self) -> None:
         wf = workflow()
@@ -90,29 +93,32 @@ class TestProgrambenchWorkflow:
     def test_reviewer_validates_discoveries(self) -> None:
         """Reviewer compares builder output against ground truth binary."""
         wf = workflow()
-        prompt = wf.nodes["reviewer"].prompt_template
-        assert "executable.bak" in prompt
-        assert "executable" in prompt
-        assert "verified" in prompt
-        assert "incorrect" in prompt
-        assert "unexplored" in prompt
+        node = wf.nodes["reviewer"]
+        assert isinstance(node, AgentNode)
+        assert "executable.bak" in node.prompt_template
+        assert "executable" in node.prompt_template
+        assert "verified" in node.prompt_template
+        assert "incorrect" in node.prompt_template
+        assert "unexplored" in node.prompt_template
 
     def test_reviewer_writes_todos(self) -> None:
         """Reviewer writes todos.md with specific tasks for the builder."""
         wf = workflow()
-        prompt = wf.nodes["reviewer"].prompt_template
-        assert "todos.md" in prompt
-        assert "## TODO:" in prompt
-        assert "Expected" in prompt
-        assert "Actual" in prompt
-        assert "Action" in prompt
+        node = wf.nodes["reviewer"]
+        assert isinstance(node, AgentNode)
+        assert "todos.md" in node.prompt_template
+        assert "## TODO:" in node.prompt_template
+        assert "Expected" in node.prompt_template
+        assert "Actual" in node.prompt_template
+        assert "Action" in node.prompt_template
 
     def test_reviewer_probes_unknown_unknowns(self) -> None:
         """Reviewer probes for behaviors the builder didn't think of."""
         wf = workflow()
-        prompt = wf.nodes["reviewer"].prompt_template
-        assert "unknown" in prompt.lower()
-        assert "ADDITIONAL" in prompt
+        node = wf.nodes["reviewer"]
+        assert isinstance(node, AgentNode)
+        assert "unknown" in node.prompt_template.lower()
+        assert "ADDITIONAL" in node.prompt_template
 
     def test_gate_verify_is_fn_evaluator(self) -> None:
         """Gate uses fn evaluator (not agent) for speed and determinism."""
@@ -127,10 +133,11 @@ class TestProgrambenchWorkflow:
     def test_gate_verify_checks_todos(self) -> None:
         """Gate checks todos.md for remaining items."""
         wf = workflow()
-        cmd = wf.nodes["gate_verify"].evaluator_command
-        assert cmd is not None
-        assert "todos.md" in cmd
-        assert "## TODO" in cmd
+        node = wf.nodes["gate_verify"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_command is not None
+        assert "todos.md" in node.evaluator_command
+        assert "## TODO" in node.evaluator_command
 
     def test_auto_merge_node(self) -> None:
         wf = workflow()

--- a/factory/workflow/contributed/programbench/test_workflow.py
+++ b/factory/workflow/contributed/programbench/test_workflow.py
@@ -22,10 +22,10 @@ class TestProgrambenchWorkflow:
         assert wf.name == "programbench"
 
     def test_node_count(self) -> None:
-        """Workflow has exactly 5 nodes: discover, plan, builder, gate_verify, auto_merge."""
+        """Workflow has exactly 4 nodes: discover, builder, gate_verify, auto_merge."""
         wf = workflow()
-        assert len(wf.nodes) == 5
-        assert set(wf.nodes.keys()) == {"discover", "plan", "builder", "gate_verify", "auto_merge"}
+        assert len(wf.nodes) == 4
+        assert set(wf.nodes.keys()) == {"discover", "builder", "gate_verify", "auto_merge"}
 
     def test_start_node(self) -> None:
         wf = workflow()
@@ -38,9 +38,9 @@ class TestProgrambenchWorkflow:
         assert issues == [], f"Workflow has validation issues: {issues}"
 
     def test_edge_count(self) -> None:
-        """5 edges: discover->plan, plan->builder, builder->gate, gate->merge, gate->builder RELOOP."""
+        """4 edges: discover->builder, builder->gate, gate->merge, gate->builder RELOOP."""
         wf = workflow()
-        assert len(wf.edges) == 5
+        assert len(wf.edges) == 4
 
     def test_discover_node(self) -> None:
         wf = workflow()
@@ -50,12 +50,17 @@ class TestProgrambenchWorkflow:
         assert "reverse-engineering" in node.prompt_template.lower()
         assert "autonomous" in node.prompt_template.lower()
         assert "discovery.md" in node.prompt_template
+        assert "test_behavior.sh" in node.prompt_template
+        assert "executable.bak" in node.prompt_template
 
-    def test_plan_node_is_fn(self) -> None:
+    def test_discover_builds_test_scaffold(self) -> None:
+        """Discovery agent prompt instructs building a test harness, not just notes."""
         wf = workflow()
-        node = wf.nodes["plan"]
-        assert isinstance(node, FnNode)
-        assert "discovery complete" in node.command
+        prompt = wf.nodes["discover"].prompt_template
+        assert "run_test" in prompt
+        assert "/workspace/tests/" in prompt
+        assert "expected" in prompt
+        assert "chmod" in prompt
 
     def test_builder_node(self) -> None:
         wf = workflow()
@@ -65,8 +70,17 @@ class TestProgrambenchWorkflow:
         assert node.max_iterations == 3
         assert node.timeout == 1200
         assert "discovery.md" in node.prompt_template
+        assert "test_behavior.sh" in node.prompt_template
         assert "autonomous" in node.prompt_template.lower()
         assert "__DATE__" in node.prompt_template
+
+    def test_builder_uses_test_scaffold(self) -> None:
+        """Builder prompt instructs running the test scaffold for iteration."""
+        wf = workflow()
+        prompt = wf.nodes["builder"].prompt_template
+        assert "test scaffold" in prompt.lower()
+        assert "ITERATE" in prompt
+        assert "FREQUENTLY" in prompt
 
     def test_gate_verify_is_fn_evaluator(self) -> None:
         """Gate uses fn evaluator (not agent) for speed and determinism."""
@@ -78,6 +92,14 @@ class TestProgrambenchWorkflow:
         assert "pass:" in node.evaluator_command
         assert "reloop:" in node.evaluator_command
         assert "compile.sh" in node.evaluator_command
+
+    def test_gate_verify_runs_test_scaffold(self) -> None:
+        """Gate actually runs the test scaffold and checks for '0 failed'."""
+        wf = workflow()
+        cmd = wf.nodes["gate_verify"].evaluator_command
+        assert cmd is not None
+        assert "test_behavior.sh" in cmd
+        assert "0 failed" in cmd
 
     def test_auto_merge_node(self) -> None:
         wf = workflow()
@@ -120,6 +142,16 @@ class TestProgrambenchWorkflow:
                 assert "factory finalize" not in node.command
                 assert "factory precheck" not in node.command
                 assert "factory begin" not in node.command
+
+    def test_no_plan_node(self) -> None:
+        """Plan node was removed — discover feeds directly into builder."""
+        wf = workflow()
+        assert "plan" not in wf.nodes
+        discover_to_builder = [
+            e for e in wf.edges
+            if e.source == "discover" and e.target == "builder"
+        ]
+        assert len(discover_to_builder) == 1
 
 
 class TestProgrambenchTerminal:

--- a/factory/workflow/contributed/programbench/test_workflow.py
+++ b/factory/workflow/contributed/programbench/test_workflow.py
@@ -22,14 +22,14 @@ class TestProgrambenchWorkflow:
         assert wf.name == "programbench"
 
     def test_node_count(self) -> None:
-        """Workflow has exactly 4 nodes: discover, builder, gate_verify, auto_merge."""
+        """Workflow has exactly 4 nodes: builder, reviewer, gate_verify, auto_merge."""
         wf = workflow()
         assert len(wf.nodes) == 4
-        assert set(wf.nodes.keys()) == {"discover", "builder", "gate_verify", "auto_merge"}
+        assert set(wf.nodes.keys()) == {"builder", "reviewer", "gate_verify", "auto_merge"}
 
     def test_start_node(self) -> None:
         wf = workflow()
-        assert wf.start_node == "discover"
+        assert wf.start_node == "builder"
 
     def test_graph_validates(self) -> None:
         """Graph passes structural validation (DAG check, edge consistency)."""
@@ -38,29 +38,9 @@ class TestProgrambenchWorkflow:
         assert issues == [], f"Workflow has validation issues: {issues}"
 
     def test_edge_count(self) -> None:
-        """4 edges: discover->builder, builder->gate, gate->merge, gate->builder RELOOP."""
+        """4 edges: builder->reviewer, reviewer->gate, gate->merge, gate->builder RELOOP."""
         wf = workflow()
         assert len(wf.edges) == 4
-
-    def test_discover_node(self) -> None:
-        wf = workflow()
-        node = wf.nodes["discover"]
-        assert isinstance(node, AgentNode)
-        assert node.role == AgentRole.RESEARCHER
-        assert "reverse-engineering" in node.prompt_template.lower()
-        assert "autonomous" in node.prompt_template.lower()
-        assert "discovery.md" in node.prompt_template
-        assert "test_behavior.sh" in node.prompt_template
-        assert "executable.bak" in node.prompt_template
-
-    def test_discover_builds_test_scaffold(self) -> None:
-        """Discovery agent prompt instructs building a test harness, not just notes."""
-        wf = workflow()
-        prompt = wf.nodes["discover"].prompt_template
-        assert "run_test" in prompt
-        assert "/workspace/tests/" in prompt
-        assert "expected" in prompt
-        assert "chmod" in prompt
 
     def test_builder_node(self) -> None:
         wf = workflow()
@@ -69,18 +49,70 @@ class TestProgrambenchWorkflow:
         assert node.role == AgentRole.BUILDER
         assert node.max_iterations == 3
         assert node.timeout == 1200
-        assert "discovery.md" in node.prompt_template
-        assert "test_behavior.sh" in node.prompt_template
+        assert "discoveries.md" in node.prompt_template
         assert "autonomous" in node.prompt_template.lower()
         assert "__DATE__" in node.prompt_template
 
-    def test_builder_uses_test_scaffold(self) -> None:
-        """Builder prompt instructs running the test scaffold for iteration."""
+    def test_builder_maintains_discoveries(self) -> None:
+        """Builder prompt instructs maintaining a structured discoveries file."""
         wf = workflow()
         prompt = wf.nodes["builder"].prompt_template
-        assert "test scaffold" in prompt.lower()
-        assert "ITERATE" in prompt
-        assert "FREQUENTLY" in prompt
+        assert "discoveries.md" in prompt
+        assert "## Discovery:" in prompt
+        assert "verified" in prompt
+        assert "uncertain" in prompt
+        assert "unexplored" in prompt
+        assert "Evidence" in prompt
+
+    def test_builder_reads_todos(self) -> None:
+        """Builder prompt instructs reading todos.md on RELOOP iterations."""
+        wf = workflow()
+        prompt = wf.nodes["builder"].prompt_template
+        assert "todos.md" in prompt
+        assert "address EACH item" in prompt
+
+    def test_builder_backs_up_binary(self) -> None:
+        """Builder prompt instructs backing up executable to executable.bak."""
+        wf = workflow()
+        prompt = wf.nodes["builder"].prompt_template
+        assert "executable.bak" in prompt
+        assert "cp /workspace/executable /workspace/executable.bak" in prompt
+
+    def test_reviewer_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["reviewer"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.RESEARCHER
+        assert "adversarial" in node.prompt_template.lower()
+        assert "autonomous" in node.prompt_template.lower()
+        assert "discoveries.md" in node.prompt_template
+
+    def test_reviewer_validates_discoveries(self) -> None:
+        """Reviewer compares builder output against ground truth binary."""
+        wf = workflow()
+        prompt = wf.nodes["reviewer"].prompt_template
+        assert "executable.bak" in prompt
+        assert "executable" in prompt
+        assert "verified" in prompt
+        assert "incorrect" in prompt
+        assert "unexplored" in prompt
+
+    def test_reviewer_writes_todos(self) -> None:
+        """Reviewer writes todos.md with specific tasks for the builder."""
+        wf = workflow()
+        prompt = wf.nodes["reviewer"].prompt_template
+        assert "todos.md" in prompt
+        assert "## TODO:" in prompt
+        assert "Expected" in prompt
+        assert "Actual" in prompt
+        assert "Action" in prompt
+
+    def test_reviewer_probes_unknown_unknowns(self) -> None:
+        """Reviewer probes for behaviors the builder didn't think of."""
+        wf = workflow()
+        prompt = wf.nodes["reviewer"].prompt_template
+        assert "unknown" in prompt.lower()
+        assert "ADDITIONAL" in prompt
 
     def test_gate_verify_is_fn_evaluator(self) -> None:
         """Gate uses fn evaluator (not agent) for speed and determinism."""
@@ -91,15 +123,14 @@ class TestProgrambenchWorkflow:
         assert node.evaluator_command is not None
         assert "pass:" in node.evaluator_command
         assert "reloop:" in node.evaluator_command
-        assert "compile.sh" in node.evaluator_command
 
-    def test_gate_verify_runs_test_scaffold(self) -> None:
-        """Gate actually runs the test scaffold and checks for '0 failed'."""
+    def test_gate_verify_checks_todos(self) -> None:
+        """Gate checks todos.md for remaining items."""
         wf = workflow()
         cmd = wf.nodes["gate_verify"].evaluator_command
         assert cmd is not None
-        assert "test_behavior.sh" in cmd
-        assert "0 failed" in cmd
+        assert "todos.md" in cmd
+        assert "## TODO" in cmd
 
     def test_auto_merge_node(self) -> None:
         wf = workflow()
@@ -129,6 +160,24 @@ class TestProgrambenchWorkflow:
         ]
         assert len(reloop_edges) == 1
 
+    def test_builder_to_reviewer_edge(self) -> None:
+        """builder feeds into reviewer."""
+        wf = workflow()
+        edges = [
+            e for e in wf.edges
+            if e.source == "builder" and e.target == "reviewer"
+        ]
+        assert len(edges) == 1
+
+    def test_reviewer_to_gate_edge(self) -> None:
+        """reviewer feeds into gate_verify."""
+        wf = workflow()
+        edges = [
+            e for e in wf.edges
+            if e.source == "reviewer" and e.target == "gate_verify"
+        ]
+        assert len(edges) == 1
+
     def test_no_eval_infrastructure(self) -> None:
         """No factory eval nodes (begin, finalize, precheck, study)."""
         wf = workflow()
@@ -143,15 +192,10 @@ class TestProgrambenchWorkflow:
                 assert "factory precheck" not in node.command
                 assert "factory begin" not in node.command
 
-    def test_no_plan_node(self) -> None:
-        """Plan node was removed — discover feeds directly into builder."""
+    def test_no_discover_node(self) -> None:
+        """Discover node was removed — builder does its own discovery."""
         wf = workflow()
-        assert "plan" not in wf.nodes
-        discover_to_builder = [
-            e for e in wf.edges
-            if e.source == "discover" and e.target == "builder"
-        ]
-        assert len(discover_to_builder) == 1
+        assert "discover" not in wf.nodes
 
 
 class TestProgrambenchTerminal:

--- a/factory/workflow/contributed/programbench/workflow.py
+++ b/factory/workflow/contributed/programbench/workflow.py
@@ -1,12 +1,12 @@
-"""ProgramBench benchmark workflow — discovery-first reverse engineering pipeline.
+"""ProgramBench benchmark workflow — scaffold-first reverse engineering pipeline.
 
-5-node pipeline: discover → plan → builder → gate_verify → auto_merge
+4-node pipeline: discover → builder → gate_verify → auto_merge
 RELOOP from gate_verify back to builder (max 3 iterations) on failure.
 
 Designed for Harbor containers where:
 - A compiled binary exists at /workspace/executable
-- The agent must reverse-engineer its behavior and produce equivalent source
-- Discovery phase probes the binary exhaustively before any code is written
+- The discovery agent probes the binary AND builds a test harness
+- The builder uses the test scaffold as a tight feedback loop
 - Harbor's verifier is the FINAL authority on pass/fail
 - Harbor checks the MAIN branch for changes
 - No .factory/ infrastructure (no eval, no experiments, no deep-QA)
@@ -28,15 +28,15 @@ from factory.workflow.primitives import (
 meta = {
     "name": "programbench",
     "description": (
-        "ProgramBench benchmark mode — discovery-first reverse engineering "
-        "pipeline. discover → plan → builder → gate_verify → auto_merge "
+        "ProgramBench benchmark mode — scaffold-first reverse engineering "
+        "pipeline. discover → builder → gate_verify → auto_merge "
         "with RELOOP on failure."
     ),
 }
 
 
 def workflow() -> Workflow:
-    """Build the ProgramBench workflow — discovery-first reverse engineering."""
+    """Build the ProgramBench workflow — scaffold-first reverse engineering."""
     nodes: dict[str, Any] = {}
     edges: list[Edge] = []
 
@@ -49,8 +49,9 @@ def workflow() -> Workflow:
         max_iterations=1,
         prompt_template=(
             "You are a reverse-engineering researcher. Your job is to probe a "
-            "compiled binary at /workspace/executable and document EVERYTHING "
-            "you discover about its behavior.\n\n"
+            "compiled binary at /workspace/executable, document its behavior, "
+            "AND build a test harness that the builder agent will compile "
+            "against.\n\n"
             "## Your Task\n\n"
             "1. **Read the task instruction** — Read /tmp/task-instruction.md "
             "for context on what the binary does.\n\n"
@@ -59,7 +60,9 @@ def workflow() -> Workflow:
             "other clues about the binary's purpose.\n\n"
             "3. **Read any documentation found** — If there is a README.md or "
             "other docs, read them thoroughly.\n\n"
-            "4. **Probe the binary systematically** — Run the binary with:\n"
+            "4. **Back up the original binary** — Run: "
+            "cp /workspace/executable /workspace/executable.bak\n\n"
+            "5. **Probe the binary systematically** — Run the binary with:\n"
             "   - No arguments\n"
             "   - --help, -h\n"
             "   - --version, -V, -v\n"
@@ -69,48 +72,122 @@ def workflow() -> Workflow:
             "--format, --config, --list, --all, --recursive, --quiet\n"
             "   - Flags that take arguments — try them with various values\n"
             "   - Pipe input via stdin\n"
-            "   - Provide sample files as arguments\n\n"
-            "5. **Record exact outputs** — For EVERY invocation, capture:\n"
-            "   - The exact command run\n"
-            "   - stdout (exact text)\n"
-            "   - stderr (exact text)\n"
-            "   - Exit code ($?)\n\n"
-            "6. **Note special behaviors** — Document:\n"
-            "   - The exact version string from -V or --version output\n"
-            "   - How the binary behaves with no terminal (e.g. 'Error opening "
-            "terminal' messages)\n"
-            "   - Any environment variables it reads\n"
-            "   - Any files it creates, reads, or modifies\n"
-            "   - Interactive vs non-interactive behavior differences\n\n"
-            "7. **Write ALL findings** — Save your complete findings to "
-            ".factory/reviews/discovery.md. Be EXHAUSTIVE — the builder agent "
-            "will use this as its sole reference for implementation.\n\n"
+            "   - Provide sample files as arguments\n"
+            "   - Combinations of flags\n\n"
+            "6. **Build the test scaffold** — For EACH behavior discovered, "
+            "create a test case. Create these files:\n\n"
+            "   **`/workspace/tests/test_behavior.sh`** — a shell script that "
+            "tests the agent's build against the original binary. Structure:\n"
+            "   ```bash\n"
+            "   #!/bin/bash\n"
+            "   PASS=0; FAIL=0; TOTAL=0\n"
+            "   run_test() {\n"
+            '       name=$1; shift\n'
+            "       TOTAL=$((TOTAL+1))\n"
+            '       expected=$(/workspace/executable.bak "$@" 2>&1)\n'
+            "       expected_exit=$?\n"
+            '       actual=$(/workspace/executable "$@" 2>&1)\n'
+            "       actual_exit=$?\n"
+            '       if [ "$expected" = "$actual" ] && '
+            '[ "$expected_exit" = "$actual_exit" ]; then\n'
+            "           PASS=$((PASS+1))\n"
+            "       else\n"
+            "           FAIL=$((FAIL+1))\n"
+            '           echo "FAIL: $name"\n'
+            '           if [ "$expected" != "$actual" ]; then\n'
+            '               diff <(echo "$expected") <(echo "$actual") '
+            "| head -10\n"
+            "           fi\n"
+            '           if [ "$expected_exit" != "$actual_exit" ]; then\n'
+            '               echo "  exit code: expected=$expected_exit '
+            'actual=$actual_exit"\n'
+            "           fi\n"
+            "       fi\n"
+            "   }\n"
+            "   # Tests for stdin input:\n"
+            "   run_test_stdin() {\n"
+            '       name=$1; input=$2; shift 2\n'
+            "       TOTAL=$((TOTAL+1))\n"
+            '       expected=$(echo "$input" | '
+            '/workspace/executable.bak "$@" 2>&1)\n'
+            "       expected_exit=$?\n"
+            '       actual=$(echo "$input" | '
+            '/workspace/executable "$@" 2>&1)\n'
+            "       actual_exit=$?\n"
+            '       if [ "$expected" = "$actual" ] && '
+            '[ "$expected_exit" = "$actual_exit" ]; then\n'
+            "           PASS=$((PASS+1))\n"
+            "       else\n"
+            "           FAIL=$((FAIL+1))\n"
+            '           echo "FAIL: $name"\n'
+            '           if [ "$expected" != "$actual" ]; then\n'
+            '               diff <(echo "$expected") <(echo "$actual") '
+            "| head -10\n"
+            "           fi\n"
+            "       fi\n"
+            "   }\n"
+            "   # Tests for file input:\n"
+            "   run_test_file() {\n"
+            '       name=$1; file=$2; shift 2\n'
+            "       TOTAL=$((TOTAL+1))\n"
+            '       expected=$(/workspace/executable.bak "$@" "$file" 2>&1)\n'
+            "       expected_exit=$?\n"
+            '       actual=$(/workspace/executable "$@" "$file" 2>&1)\n'
+            "       actual_exit=$?\n"
+            '       if [ "$expected" = "$actual" ] && '
+            '[ "$expected_exit" = "$actual_exit" ]; then\n'
+            "           PASS=$((PASS+1))\n"
+            "       else\n"
+            "           FAIL=$((FAIL+1))\n"
+            '           echo "FAIL: $name"\n'
+            '           if [ "$expected" != "$actual" ]; then\n'
+            '               diff <(echo "$expected") <(echo "$actual") '
+            "| head -10\n"
+            "           fi\n"
+            "       fi\n"
+            "   }\n"
+            '   run_test "help_flag" --help\n'
+            '   run_test "version_flag" --version\n'
+            "   # ... add more test cases for every behavior discovered ...\n"
+            '   echo "$PASS/$TOTAL passed, $FAIL failed"\n'
+            "   ```\n\n"
+            "   **`/workspace/tests/expected/`** — directory of expected output "
+            "files (one per test case) for reference.\n\n"
+            "   Create test data files as needed (CSV, TSV, edge-case inputs) "
+            "in /workspace/tests/.\n\n"
+            "7. **Make the test script executable** — chmod +x "
+            "/workspace/tests/test_behavior.sh\n\n"
+            "8. **Write a summary** — Save your complete findings to "
+            ".factory/reviews/discovery.md. Include:\n"
+            "   - Binary purpose and capabilities\n"
+            "   - All flags and options discovered\n"
+            "   - Exact version strings\n"
+            "   - Key behavioral notes (error handling, edge cases, output "
+            "formatting)\n"
+            "   - List of all test cases created\n\n"
+            "9. **Commit the test scaffold** — git add and commit the test "
+            "files and discovery notes.\n\n"
             "## Rules\n\n"
             "- Act AUTONOMOUSLY — do NOT ask for confirmation or input\n"
             "- Be THOROUGH — try every flag combination you can think of\n"
             "- Record EXACT outputs, not summaries\n"
             "- Note exit codes for each invocation\n"
             "- The binary is execute-only — you cannot read its contents\n"
-            "- Do NOT attempt to implement anything — only discover and document\n"
+            "- Do NOT attempt to implement the binary — only discover and "
+            "build tests\n"
             "- Do NOT run factory commands\n"
             "- Do NOT create branches or PRs\n"
+            "- The test scaffold is your PRIMARY deliverable — the builder "
+            "will iterate against it\n"
         ),
         reads=set(),
-        writes={".factory/reviews/discovery.md"},
+        writes={
+            ".factory/reviews/discovery.md",
+            "/workspace/tests/test_behavior.sh",
+        },
     )
 
-    # ── Node 2: Plan ──────────────────────────────────────────────
-    nodes["plan"] = FnNode(
-        id="plan",
-        command=(
-            "cd {project_path} && "
-            "echo 'pass: discovery complete'"
-        ),
-        reads={".factory/reviews/discovery.md"},
-        writes=set(),
-    )
-
-    # ── Node 3: Builder ───────────────────────────────────────────
+    # ── Node 2: Builder ───────────────────────────────────────────
     nodes["builder"] = AgentNode(
         id="builder",
         role=AgentRole.BUILDER,
@@ -119,17 +196,22 @@ def workflow() -> Workflow:
         max_iterations=3,
         prompt_template=(
             "You are reverse-engineering a compiled binary and producing "
-            "equivalent source code for the ProgramBench benchmark.\n\n"
+            "equivalent source code for the ProgramBench benchmark. A "
+            "discovery agent has already probed the binary and built a test "
+            "harness for you.\n\n"
             "## Your Task\n\n"
             "1. **Read the discovery findings** — Read "
-            ".factory/reviews/discovery.md thoroughly. This contains the "
-            "complete behavioral profile of the target binary gathered by "
-            "a discovery agent. It has exact outputs, exit codes, and flag "
-            "behaviors for every invocation tested.\n\n"
-            "2. **Read any documentation** — Check /workspace/ for README.md, "
+            ".factory/reviews/discovery.md for the behavioral summary.\n\n"
+            "2. **Read the test scaffold** — Read "
+            "/workspace/tests/test_behavior.sh to understand what tests "
+            "exist and what behaviors are expected.\n\n"
+            "3. **Read any documentation** — Check /workspace/ for README.md, "
             "man pages, or other docs. Read /tmp/task-instruction.md for the "
             "task description.\n\n"
-            "3. **Write the source code** — Implement C source code that "
+            "4. **Examine the original binary** — Run /workspace/executable.bak "
+            "directly if you need to clarify any behavior not covered by the "
+            "test scaffold.\n\n"
+            "5. **Write the source code** — Implement C source code that "
             "reproduces ALL discovered behaviors:\n"
             "   - Match every flag and option exactly\n"
             "   - Match output format exactly (spacing, newlines, field widths)\n"
@@ -138,37 +220,38 @@ def workflow() -> Workflow:
             "   - CRITICAL: Hardcode the exact version string from -V output. "
             "Do NOT use __DATE__ or __TIME__ macros — these produce different "
             "values on every build and will fail verification.\n\n"
-            "4. **Create compile.sh** — Write a build script that:\n"
-            "   - Backs up the original: cp /workspace/executable "
-            "/workspace/executable.bak\n"
+            "6. **Create compile.sh** — Write a build script that:\n"
             "   - Compiles the source to /workspace/executable\n"
             "   - Is executable (chmod +x)\n\n"
-            "5. **Differential testing** — After compiling, compare your "
-            "implementation against the original:\n"
-            "   - Run both /workspace/executable.bak and /workspace/executable "
-            "with the same flags\n"
-            "   - Compare stdout, stderr, and exit codes\n"
-            "   - Fix ANY differences found\n"
-            "   - Test with at least 10 different flag combinations\n\n"
-            "6. **Commit your changes** — Commit directly on the current "
+            "7. **Run the test scaffold** — After compiling, run:\n"
+            "   cd /workspace && bash tests/test_behavior.sh\n"
+            "   This tests your build against the original binary.\n\n"
+            "8. **ITERATE** — Fix failures, recompile, re-test. Run the "
+            "test scaffold FREQUENTLY during development, not just at the "
+            "end. The test scaffold is your spec — make all tests pass.\n\n"
+            "9. **Commit your changes** — Commit directly on the current "
             "branch with a descriptive message. Do NOT create a new branch. "
             "Do NOT create a PR.\n\n"
             "## Rules\n\n"
             "- Act AUTONOMOUSLY — do NOT ask for confirmation or input\n"
-            "- The discovery findings are your primary reference — trust them\n"
+            "- The test scaffold is your primary spec — make all tests pass\n"
+            "- The discovery findings are your reference — trust them\n"
             "- Match behavior EXACTLY — even minor output differences cause "
             "verification failure\n"
             "- Do NOT use __DATE__, __TIME__, or other non-deterministic macros\n"
             "- Do NOT create branches or PRs — commit on current branch\n"
             "- Do NOT run factory commands (factory eval, factory study, etc.)\n"
-            "- If differential testing reveals mismatches, fix them before "
-            "committing\n"
+            "- Run the test scaffold FREQUENTLY during development\n"
+            "- If tests reveal mismatches, fix them before committing\n"
         ),
-        reads={".factory/reviews/discovery.md"},
+        reads={
+            ".factory/reviews/discovery.md",
+            "/workspace/tests/test_behavior.sh",
+        },
         writes={".factory/reviews/builder-latest.md"},
     )
 
-    # ── Node 4: Gate Verify ───────────────────────────────────────
+    # ── Node 3: Gate Verify ───────────────────────────────────────
     nodes["gate_verify"] = GateNode(
         id="gate_verify",
         evaluator_type="fn",
@@ -183,12 +266,23 @@ def workflow() -> Workflow:
             "if ! test -f /workspace/executable; then "
             "echo 'reloop: /workspace/executable not found after compilation'; "
             "exit 0; fi && "
-            "echo 'pass: compile.sh succeeded and executable exists'"
+            "if [ -f /workspace/tests/test_behavior.sh ]; then "
+            "cd /workspace && "
+            "RESULT=$(bash tests/test_behavior.sh 2>&1 | tail -1) && "
+            "echo \"$RESULT\" && "
+            "if echo \"$RESULT\" | grep -q '0 failed'; then "
+            "echo 'pass: all behavioral tests pass'; "
+            "else "
+            "echo \"reloop: $RESULT\"; "
+            "fi; "
+            "else "
+            "echo 'pass: compile.sh succeeded, no test scaffold found'; "
+            "fi"
         ),
         reads={".factory/reviews/builder-latest.md"},
     )
 
-    # ── Node 5: Auto Merge ────────────────────────────────────────
+    # ── Node 4: Auto Merge ────────────────────────────────────────
     nodes["auto_merge"] = FnNode(
         id="auto_merge",
         command=(
@@ -215,8 +309,7 @@ def workflow() -> Workflow:
     # ── Edges ─────────────────────────────────────────────────────
 
     edges = [
-        Edge(source="discover", target="plan"),
-        Edge(source="plan", target="builder"),
+        Edge(source="discover", target="builder"),
         Edge(source="builder", target="gate_verify"),
         Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
         Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),

--- a/factory/workflow/contributed/programbench/workflow.py
+++ b/factory/workflow/contributed/programbench/workflow.py
@@ -1,13 +1,14 @@
-"""ProgramBench benchmark workflow — scaffold-first reverse engineering pipeline.
+"""ProgramBench benchmark workflow — adversarial discovery verification loop.
 
-4-node pipeline: discover → builder → gate_verify → auto_merge
-RELOOP from gate_verify back to builder (max 3 iterations) on failure.
+4-node loop: builder → reviewer → gate_verify → auto_merge
+RELOOP from gate_verify back to builder (max 3 iterations) when the
+reviewer finds incorrect or unexplored discoveries.
 
 Designed for Harbor containers where:
 - A compiled binary exists at /workspace/executable
-- The discovery agent probes the binary AND builds a test harness
-- The builder uses the test scaffold as a tight feedback loop
-- Harbor's verifier is the FINAL authority on pass/fail
+- The builder probes, implements, AND maintains a structured discoveries file
+- The reviewer adversarially validates each discovery against the ground truth
+- Todos drive targeted fixes on RELOOP iterations
 - Harbor checks the MAIN branch for changes
 - No .factory/ infrastructure (no eval, no experiments, no deep-QA)
 """
@@ -28,41 +29,41 @@ from factory.workflow.primitives import (
 meta = {
     "name": "programbench",
     "description": (
-        "ProgramBench benchmark mode — scaffold-first reverse engineering "
-        "pipeline. discover → builder → gate_verify → auto_merge "
-        "with RELOOP on failure."
+        "ProgramBench benchmark mode — adversarial discovery verification "
+        "loop. builder → reviewer → gate_verify → auto_merge "
+        "with RELOOP on unverified discoveries."
     ),
 }
 
 
 def workflow() -> Workflow:
-    """Build the ProgramBench workflow — scaffold-first reverse engineering."""
+    """Build the ProgramBench workflow — adversarial discovery verification."""
     nodes: dict[str, Any] = {}
     edges: list[Edge] = []
 
-    # ── Node 1: Discover ──────────────────────────────────────────
-    nodes["discover"] = AgentNode(
-        id="discover",
-        role=AgentRole.RESEARCHER,
+    # ── Node 1: Builder ──────────────────────────────────────────
+    nodes["builder"] = AgentNode(
+        id="builder",
+        role=AgentRole.BUILDER,
         model="opus",
-        timeout=900,
-        max_iterations=1,
+        timeout=1200,
+        max_iterations=3,
         prompt_template=(
-            "You are a reverse-engineering researcher. Your job is to probe a "
-            "compiled binary at /workspace/executable, document its behavior, "
-            "AND build a test harness that the builder agent will compile "
-            "against.\n\n"
+            "You are reverse-engineering a compiled binary and producing "
+            "equivalent source code for the ProgramBench benchmark.\n\n"
             "## Your Task\n\n"
             "1. **Read the task instruction** — Read /tmp/task-instruction.md "
             "for context on what the binary does.\n\n"
-            "2. **Check the workspace** — List all files in /workspace/. Look "
-            "for README files, man pages, documentation, data files, or any "
-            "other clues about the binary's purpose.\n\n"
-            "3. **Read any documentation found** — If there is a README.md or "
-            "other docs, read them thoroughly.\n\n"
-            "4. **Back up the original binary** — Run: "
-            "cp /workspace/executable /workspace/executable.bak\n\n"
-            "5. **Probe the binary systematically** — Run the binary with:\n"
+            "2. **Back up the original binary** — Run: "
+            "cp /workspace/executable /workspace/executable.bak\n"
+            "   (Skip if executable.bak already exists from a previous "
+            "iteration.)\n\n"
+            "3. **Check for TODOs from a previous review** — If "
+            "/workspace/todos.md exists, read it and address EACH item "
+            "before doing anything else. These are specific issues found by "
+            "the reviewer that MUST be fixed. Update /workspace/discoveries.md "
+            "with corrected evidence as you fix each TODO.\n\n"
+            "4. **Probe the binary systematically** — Run the binary with:\n"
             "   - No arguments\n"
             "   - --help, -h\n"
             "   - --version, -V, -v\n"
@@ -74,144 +75,24 @@ def workflow() -> Workflow:
             "   - Pipe input via stdin\n"
             "   - Provide sample files as arguments\n"
             "   - Combinations of flags\n\n"
-            "6. **Build the test scaffold** — For EACH behavior discovered, "
-            "create a test case. Create these files:\n\n"
-            "   **`/workspace/tests/test_behavior.sh`** — a shell script that "
-            "tests the agent's build against the original binary. Structure:\n"
-            "   ```bash\n"
-            "   #!/bin/bash\n"
-            "   PASS=0; FAIL=0; TOTAL=0\n"
-            "   run_test() {\n"
-            '       name=$1; shift\n'
-            "       TOTAL=$((TOTAL+1))\n"
-            '       expected=$(/workspace/executable.bak "$@" 2>&1)\n'
-            "       expected_exit=$?\n"
-            '       actual=$(/workspace/executable "$@" 2>&1)\n'
-            "       actual_exit=$?\n"
-            '       if [ "$expected" = "$actual" ] && '
-            '[ "$expected_exit" = "$actual_exit" ]; then\n'
-            "           PASS=$((PASS+1))\n"
-            "       else\n"
-            "           FAIL=$((FAIL+1))\n"
-            '           echo "FAIL: $name"\n'
-            '           if [ "$expected" != "$actual" ]; then\n'
-            '               diff <(echo "$expected") <(echo "$actual") '
-            "| head -10\n"
-            "           fi\n"
-            '           if [ "$expected_exit" != "$actual_exit" ]; then\n'
-            '               echo "  exit code: expected=$expected_exit '
-            'actual=$actual_exit"\n'
-            "           fi\n"
-            "       fi\n"
-            "   }\n"
-            "   # Tests for stdin input:\n"
-            "   run_test_stdin() {\n"
-            '       name=$1; input=$2; shift 2\n'
-            "       TOTAL=$((TOTAL+1))\n"
-            '       expected=$(echo "$input" | '
-            '/workspace/executable.bak "$@" 2>&1)\n'
-            "       expected_exit=$?\n"
-            '       actual=$(echo "$input" | '
-            '/workspace/executable "$@" 2>&1)\n'
-            "       actual_exit=$?\n"
-            '       if [ "$expected" = "$actual" ] && '
-            '[ "$expected_exit" = "$actual_exit" ]; then\n'
-            "           PASS=$((PASS+1))\n"
-            "       else\n"
-            "           FAIL=$((FAIL+1))\n"
-            '           echo "FAIL: $name"\n'
-            '           if [ "$expected" != "$actual" ]; then\n'
-            '               diff <(echo "$expected") <(echo "$actual") '
-            "| head -10\n"
-            "           fi\n"
-            "       fi\n"
-            "   }\n"
-            "   # Tests for file input:\n"
-            "   run_test_file() {\n"
-            '       name=$1; file=$2; shift 2\n'
-            "       TOTAL=$((TOTAL+1))\n"
-            '       expected=$(/workspace/executable.bak "$@" "$file" 2>&1)\n'
-            "       expected_exit=$?\n"
-            '       actual=$(/workspace/executable "$@" "$file" 2>&1)\n'
-            "       actual_exit=$?\n"
-            '       if [ "$expected" = "$actual" ] && '
-            '[ "$expected_exit" = "$actual_exit" ]; then\n'
-            "           PASS=$((PASS+1))\n"
-            "       else\n"
-            "           FAIL=$((FAIL+1))\n"
-            '           echo "FAIL: $name"\n'
-            '           if [ "$expected" != "$actual" ]; then\n'
-            '               diff <(echo "$expected") <(echo "$actual") '
-            "| head -10\n"
-            "           fi\n"
-            "       fi\n"
-            "   }\n"
-            '   run_test "help_flag" --help\n'
-            '   run_test "version_flag" --version\n'
-            "   # ... add more test cases for every behavior discovered ...\n"
-            '   echo "$PASS/$TOTAL passed, $FAIL failed"\n'
+            "5. **Maintain the discoveries file** — For EVERY behavioral "
+            "discovery (flag behavior, output format, edge case, error "
+            "message, exit code, etc.), add an entry to "
+            "/workspace/discoveries.md with this format:\n\n"
+            "   ```markdown\n"
+            "   ## Discovery: <short title>\n"
+            "   - **What:** <what was discovered>\n"
+            "   - **Evidence:** <command run and output observed>\n"
+            "   - **Status:** verified | uncertain | unexplored\n"
+            "   - **Notes:** <any additional context>\n"
             "   ```\n\n"
-            "   **`/workspace/tests/expected/`** — directory of expected output "
-            "files (one per test case) for reference.\n\n"
-            "   Create test data files as needed (CSV, TSV, edge-case inputs) "
-            "in /workspace/tests/.\n\n"
-            "7. **Make the test script executable** — chmod +x "
-            "/workspace/tests/test_behavior.sh\n\n"
-            "8. **Write a summary** — Save your complete findings to "
-            ".factory/reviews/discovery.md. Include:\n"
-            "   - Binary purpose and capabilities\n"
-            "   - All flags and options discovered\n"
-            "   - Exact version strings\n"
-            "   - Key behavioral notes (error handling, edge cases, output "
-            "formatting)\n"
-            "   - List of all test cases created\n\n"
-            "9. **Commit the test scaffold** — git add and commit the test "
-            "files and discovery notes.\n\n"
-            "## Rules\n\n"
-            "- Act AUTONOMOUSLY — do NOT ask for confirmation or input\n"
-            "- Be THOROUGH — try every flag combination you can think of\n"
-            "- Record EXACT outputs, not summaries\n"
-            "- Note exit codes for each invocation\n"
-            "- The binary is execute-only — you cannot read its contents\n"
-            "- Do NOT attempt to implement the binary — only discover and "
-            "build tests\n"
-            "- Do NOT run factory commands\n"
-            "- Do NOT create branches or PRs\n"
-            "- The test scaffold is your PRIMARY deliverable — the builder "
-            "will iterate against it\n"
-        ),
-        reads=set(),
-        writes={
-            ".factory/reviews/discovery.md",
-            "/workspace/tests/test_behavior.sh",
-        },
-    )
-
-    # ── Node 2: Builder ───────────────────────────────────────────
-    nodes["builder"] = AgentNode(
-        id="builder",
-        role=AgentRole.BUILDER,
-        model="opus",
-        timeout=1200,
-        max_iterations=3,
-        prompt_template=(
-            "You are reverse-engineering a compiled binary and producing "
-            "equivalent source code for the ProgramBench benchmark. A "
-            "discovery agent has already probed the binary and built a test "
-            "harness for you.\n\n"
-            "## Your Task\n\n"
-            "1. **Read the discovery findings** — Read "
-            ".factory/reviews/discovery.md for the behavioral summary.\n\n"
-            "2. **Read the test scaffold** — Read "
-            "/workspace/tests/test_behavior.sh to understand what tests "
-            "exist and what behaviors are expected.\n\n"
-            "3. **Read any documentation** — Check /workspace/ for README.md, "
-            "man pages, or other docs. Read /tmp/task-instruction.md for the "
-            "task description.\n\n"
-            "4. **Examine the original binary** — Run /workspace/executable.bak "
-            "directly if you need to clarify any behavior not covered by the "
-            "test scaffold.\n\n"
-            "5. **Write the source code** — Implement C source code that "
+            "   Record EVERY discovery, not just the ones you're confident "
+            "about. Mark discoveries as 'uncertain' if you're not 100%% sure. "
+            "Mark discoveries as 'unexplored' if you found something but "
+            "didn't dig into it yet.\n\n"
+            "6. **Read any documentation** — Check /workspace/ for README.md, "
+            "man pages, or other docs.\n\n"
+            "7. **Write the source code** — Implement C source code that "
             "reproduces ALL discovered behaviors:\n"
             "   - Match every flag and option exactly\n"
             "   - Match output format exactly (spacing, newlines, field widths)\n"
@@ -220,69 +101,123 @@ def workflow() -> Workflow:
             "   - CRITICAL: Hardcode the exact version string from -V output. "
             "Do NOT use __DATE__ or __TIME__ macros — these produce different "
             "values on every build and will fail verification.\n\n"
-            "6. **Create compile.sh** — Write a build script that:\n"
+            "8. **Create compile.sh** — Write a build script that:\n"
             "   - Compiles the source to /workspace/executable\n"
             "   - Is executable (chmod +x)\n\n"
-            "7. **Run the test scaffold** — After compiling, run:\n"
-            "   cd /workspace && bash tests/test_behavior.sh\n"
-            "   This tests your build against the original binary.\n\n"
-            "8. **ITERATE** — Fix failures, recompile, re-test. Run the "
-            "test scaffold FREQUENTLY during development, not just at the "
-            "end. The test scaffold is your spec — make all tests pass.\n\n"
-            "9. **Commit your changes** — Commit directly on the current "
-            "branch with a descriptive message. Do NOT create a new branch. "
-            "Do NOT create a PR.\n\n"
+            "9. **Test by diffing** — After compiling, test your build "
+            "against executable.bak by running the same commands on both and "
+            "comparing outputs. Fix any mismatches.\n\n"
+            "10. **Commit your changes** — Commit directly on the current "
+            "branch with a descriptive message.\n\n"
             "## Rules\n\n"
             "- Act AUTONOMOUSLY — do NOT ask for confirmation or input\n"
-            "- The test scaffold is your primary spec — make all tests pass\n"
-            "- The discovery findings are your reference — trust them\n"
-            "- Match behavior EXACTLY — even minor output differences cause "
-            "verification failure\n"
-            "- Do NOT use __DATE__, __TIME__, or other non-deterministic macros\n"
+            "- Record EVERY discovery, not just the ones you're confident "
+            "about\n"
+            "- Mark discoveries as 'uncertain' if you're not 100%% sure\n"
+            "- Mark discoveries as 'unexplored' if you found something but "
+            "didn't dig into it\n"
+            "- Do NOT skip the discoveries file — it is required\n"
+            "- Do NOT use __DATE__, __TIME__, or other non-deterministic "
+            "macros\n"
             "- Do NOT create branches or PRs — commit on current branch\n"
             "- Do NOT run factory commands (factory eval, factory study, etc.)\n"
-            "- Run the test scaffold FREQUENTLY during development\n"
-            "- If tests reveal mismatches, fix them before committing\n"
         ),
-        reads={
-            ".factory/reviews/discovery.md",
-            "/workspace/tests/test_behavior.sh",
-        },
-        writes={".factory/reviews/builder-latest.md"},
+        reads=set(),
+        writes={"/workspace/discoveries.md"},
     )
 
-    # ── Node 3: Gate Verify ───────────────────────────────────────
+    # ── Node 2: Reviewer ─────────────────────────────────────────
+    nodes["reviewer"] = AgentNode(
+        id="reviewer",
+        role=AgentRole.RESEARCHER,
+        model="opus",
+        timeout=900,
+        max_iterations=1,
+        prompt_template=(
+            "You are an adversarial reviewer for the ProgramBench benchmark. "
+            "A builder agent has probed a compiled binary, implemented source "
+            "code, and recorded its discoveries. Your job is to validate each "
+            "discovery against the ground truth binary and catch "
+            "overconfidence and missed exploration.\n\n"
+            "## Your Task\n\n"
+            "1. **Read the discoveries** — Read /workspace/discoveries.md "
+            "to see what the builder found and claims to have implemented.\n\n"
+            "2. **Validate each discovery** — For EACH discovery entry:\n"
+            "   a. Independently run the relevant command against "
+            "/workspace/executable.bak (the ground truth binary)\n"
+            "   b. Run the same command against /workspace/executable "
+            "(the builder's version)\n"
+            "   c. Compare the outputs character-by-character, including "
+            "whitespace, newlines, and exit codes\n"
+            "   d. Classify the discovery:\n"
+            "      - **verified**: the builder's implementation matches the "
+            "original binary for this behavior\n"
+            "      - **incorrect**: the builder thinks it works but the "
+            "outputs differ\n"
+            "      - **unexplored**: the builder noted this but didn't fully "
+            "implement or test it\n\n"
+            "3. **Write the review** — Save your review to "
+            "/workspace/review.md with classifications for each discovery. "
+            "Include the exact commands you ran and the outputs you "
+            "observed.\n\n"
+            "4. **Write TODOs if needed** — If ANY discoveries are "
+            "'incorrect' or 'unexplored', write /workspace/todos.md with "
+            "specific tasks:\n\n"
+            "   ```markdown\n"
+            "   ## TODO: <title>\n"
+            "   - **Discovery:** <reference to the discovery>\n"
+            "   - **Problem:** <what's wrong or what needs exploration>\n"
+            "   - **Expected:** <what executable.bak actually outputs>\n"
+            "   - **Actual:** <what the builder's version outputs>\n"
+            "   - **Action:** <specific thing the builder needs to fix>\n"
+            "   ```\n\n"
+            "   If ALL discoveries are 'verified', write an empty "
+            "/workspace/todos.md (or don't create it).\n\n"
+            "5. **Probe for unknown unknowns** — Run a few ADDITIONAL test "
+            "cases against executable.bak that the builder didn't think of. "
+            "Try:\n"
+            "   - Edge cases: empty input, very long input, binary input, "
+            "special characters\n"
+            "   - Flag combinations the builder didn't try\n"
+            "   - Uncommon but valid invocations\n"
+            "   - Boundary values for numeric arguments\n"
+            "   If any reveal NEW behaviors not in discoveries.md, add them "
+            "as 'unexplored' TODOs in /workspace/todos.md.\n\n"
+            "## Rules\n\n"
+            "- Act AUTONOMOUSLY — do NOT ask for confirmation or input\n"
+            "- Be ADVERSARIAL — assume the builder is overconfident\n"
+            "- Compare outputs EXACTLY — even minor whitespace differences "
+            "matter\n"
+            "- Always compare exit codes, not just stdout\n"
+            "- Do NOT fix the code yourself — only document issues for the "
+            "builder\n"
+            "- Do NOT create branches or PRs\n"
+            "- Do NOT run factory commands\n"
+        ),
+        reads={"/workspace/discoveries.md"},
+        writes={"/workspace/review.md", "/workspace/todos.md"},
+    )
+
+    # ── Node 3: Gate Verify ──────────────────────────────────────
     nodes["gate_verify"] = GateNode(
         id="gate_verify",
         evaluator_type="fn",
         evaluator_command=(
             "cd {project_path} && "
-            "if ! test -f compile.sh; then "
-            "echo 'reloop: compile.sh missing'; "
-            "exit 0; fi && "
-            "if ! bash compile.sh 2>&1; then "
-            "echo 'reloop: compile.sh failed'; "
-            "exit 0; fi && "
-            "if ! test -f /workspace/executable; then "
-            "echo 'reloop: /workspace/executable not found after compilation'; "
-            "exit 0; fi && "
-            "if [ -f /workspace/tests/test_behavior.sh ]; then "
-            "cd /workspace && "
-            "RESULT=$(bash tests/test_behavior.sh 2>&1 | tail -1) && "
-            "echo \"$RESULT\" && "
-            "if echo \"$RESULT\" | grep -q '0 failed'; then "
-            "echo 'pass: all behavioral tests pass'; "
+            "if [ ! -f /workspace/todos.md ]; then "
+            "echo 'pass: no todos file, all discoveries verified'; "
+            "elif [ ! -s /workspace/todos.md ]; then "
+            "echo 'pass: todos file is empty, all discoveries verified'; "
+            "elif grep -q '## TODO' /workspace/todos.md; then "
+            "echo 'reloop: todos remain to be addressed'; "
             "else "
-            "echo \"reloop: $RESULT\"; "
-            "fi; "
-            "else "
-            "echo 'pass: compile.sh succeeded, no test scaffold found'; "
+            "echo 'pass: no todo items found'; "
             "fi"
         ),
-        reads={".factory/reviews/builder-latest.md"},
+        reads={"/workspace/todos.md"},
     )
 
-    # ── Node 4: Auto Merge ────────────────────────────────────────
+    # ── Node 4: Auto Merge ───────────────────────────────────────
     nodes["auto_merge"] = FnNode(
         id="auto_merge",
         command=(
@@ -303,19 +238,19 @@ def workflow() -> Workflow:
             "fi; done && "
             "echo \"Updated $BASE to $(git rev-parse --short HEAD)\""
         ),
-        reads={".factory/reviews/builder-latest.md"},
+        reads={"/workspace/review.md"},
     )
 
-    # ── Edges ─────────────────────────────────────────────────────
+    # ── Edges ────────────────────────────────────────────────────
 
     edges = [
-        Edge(source="discover", target="builder"),
-        Edge(source="builder", target="gate_verify"),
+        Edge(source="builder", target="reviewer"),
+        Edge(source="reviewer", target="gate_verify"),
         Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
         Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),
     ]
 
-    # ── Trigger ───────────────────────────────────────────────────
+    # ── Trigger ──────────────────────────────────────────────────
 
     def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
         return ctx.get("mode") == "programbench"
@@ -324,7 +259,7 @@ def workflow() -> Workflow:
         name="programbench",
         nodes=nodes,
         edges=edges,
-        start_node="discover",
+        start_node="builder",
         terminal=True,
         trigger=trigger,
     )


### PR DESCRIPTION
Closes #954

## Changes

- Replaced the 4-node `discover → builder → gate_verify → auto_merge` pipeline with a new adversarial verification loop: `builder → reviewer → gate_verify → auto_merge`
- **Builder** now does its own discovery AND implementation in a single node, maintaining a structured `/workspace/discoveries.md` file with evidence for each behavioral finding
- **Reviewer** (new node, researcher role) adversarially validates each discovery by independently running commands against the ground truth binary (`executable.bak`) and the builder's version, writing `/workspace/todos.md` with specific fix items when mismatches are found
- **Gate** now checks `todos.md` for remaining items instead of running `test_behavior.sh` and `compile.sh`
- On RELOOP, the builder reads `todos.md` and addresses each specific issue before continuing
- Reviewer also probes for "unknown unknowns" — edge cases the builder didn't think to test
- Updated all tests to match the new node structure (32 tests, all passing)