### PR TITLE
fix: disallow Claude Code native Agent tool in factory subprocesses

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -31,6 +31,7 @@ You communicate directly with the user when running in foreground mode. You expl
 - Write verdict files to `.factory/reviews/`
 
 **Forbidden Actions (Sacred Rule 8 violation):**
+- Using Claude Code's native `Agent` tool to spawn subagents — always use `factory agent <role>` via Bash instead. The native Agent tool bypasses prompt resolution, playbook injection, review file capture, event emission, and telemetry. It is disabled at the CLI level via `--disallowedTools`.
 - Writing or editing source code files (*.py, *.js, *.ts, *.go, etc.)
 - Running `python eval/score.py`, `pytest`, `ruff`, `mypy` directly
 - Running `WebSearch`/`WebFetch` for research

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -1548,6 +1548,7 @@ def cmd_refactory(args: argparse.Namespace) -> int:
             session_id,
             "--append-system-prompt-file",
             prompt_file.name,
+            "--disallowedTools", "Agent",
             "--dangerously-skip-permissions",
         ]
     else:
@@ -1557,6 +1558,7 @@ def cmd_refactory(args: argparse.Namespace) -> int:
             session_id,
             "--append-system-prompt-file",
             prompt_file.name,
+            "--disallowedTools", "Agent",
             "--dangerously-skip-permissions",
         ]
 

--- a/factory/runners/_background.py
+++ b/factory/runners/_background.py
@@ -76,6 +76,7 @@ async def run_in_background(
     cmd = [
         "claude", "--bg", "--name", session_name,
         "--append-system-prompt-file", prompt_path, "-p", task,
+        "--disallowedTools", "Agent",
     ]
     if dangerously_skip_permissions:
         cmd.append("--dangerously-skip-permissions")

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -169,7 +169,8 @@ async def run_in_tmux(
 
     settings_file = _generate_settings(sentinel_file, tmpdir, project_path)
 
-    cmd = ["claude", "--settings", str(settings_file), "--append-system-prompt-file", str(prompt_file)]
+    cmd = ["claude", "--settings", str(settings_file), "--append-system-prompt-file", str(prompt_file),
+           "--disallowedTools", "Agent"]
     if dangerously_skip_permissions:
         cmd.append("--dangerously-skip-permissions")
     if model:

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -106,6 +106,7 @@ class ClaudeRunner:
             "--output-format", "stream-json",
             "--verbose",
             "--max-turns", "1000",
+            "--disallowedTools", "Agent",
         ]
         if request.skip_permissions:
             cmd.append("--dangerously-skip-permissions")
@@ -214,6 +215,7 @@ class ClaudeRunner:
         cmd = [
             "claude",
             "--append-system-prompt-file", prompt_file.name,
+            "--disallowedTools", "Agent",
         ]
         if request.skip_permissions:
             cmd.append("--dangerously-skip-permissions")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -353,6 +353,18 @@ class TestCeoPrompt:
         )
         assert has_archivist
 
+    def test_forbids_native_agent_tool(self, ceo_prompt: str) -> None:
+        """CEO prompt explicitly forbids using Claude Code's native Agent tool."""
+        assert "native" in ceo_prompt.lower() or "Agent" in ceo_prompt
+        assert "disallowedTools" in ceo_prompt or "--disallowedTools" in ceo_prompt
+
+    def test_forbidden_actions_list_agent_tool(self, ceo_prompt: str) -> None:
+        """The Forbidden Actions list includes native Agent tool prohibition."""
+        forbidden_section_start = ceo_prompt.index("**Forbidden Actions")
+        forbidden_section = ceo_prompt[forbidden_section_start:forbidden_section_start + 800]
+        assert "Agent" in forbidden_section
+        assert "factory agent" in forbidden_section
+
 
 # ── Strategist Ideation Mode ─────────────────────────────────────
 

--- a/tests/test_refactory.py
+++ b/tests/test_refactory.py
@@ -257,6 +257,36 @@ class TestCmdRefactory:
         model_idx = cmd.index("--model")
         assert cmd[model_idx + 1] == "sonnet"
 
+    def test_new_session_includes_disallowed_tools(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_refactory, build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["refactory", str(tmp_path)])
+        with patch("shutil.which", return_value="/usr/bin/claude"), \
+             patch("os.execvp") as mock_exec:
+            cmd_refactory(args)
+
+        cmd = mock_exec.call_args[0][1]
+        assert "--disallowedTools" in cmd
+        dt_idx = cmd.index("--disallowedTools")
+        assert cmd[dt_idx + 1] == "Agent"
+
+    def test_resume_session_includes_disallowed_tools(self, tmp_path: Path) -> None:
+        from factory.cli import cmd_refactory, build_parser
+
+        save_session_id(tmp_path, "existing-uuid")
+        parser = build_parser()
+        args = parser.parse_args(["refactory", str(tmp_path)])
+        with patch("shutil.which", return_value="/usr/bin/claude"), \
+             patch("os.execvp") as mock_exec:
+            cmd_refactory(args)
+
+        cmd = mock_exec.call_args[0][1]
+        assert "--resume" in cmd
+        assert "--disallowedTools" in cmd
+        dt_idx = cmd.index("--disallowedTools")
+        assert cmd[dt_idx + 1] == "Agent"
+
     def test_default_path_uses_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from factory.cli import cmd_refactory, build_parser
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1898,6 +1898,57 @@ class TestDisallowedAgentTool:
                 dt_idx = all_args.index("--disallowedTools")
                 assert all_args[dt_idx + 1] == "Agent"
 
+    def test_background_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
+        with patch("factory.runners._background.subprocess.run") as mock_run:
+            mock_run.return_value = type("R", (), {"stdout": "backgrounded · abc123", "stderr": "", "returncode": 0})()
+
+            from factory.runners._background import run_in_background
+
+            try:
+                asyncio.get_event_loop().run_until_complete(
+                    run_in_background(
+                        prompt="Test", task="Test", cwd=tmp_path, role="test",
+                        timeout=0.1,
+                    )
+                )
+            except Exception:
+                pass
+
+            cmd = mock_run.call_args_list[0][0][0]
+            assert "--disallowedTools" in cmd
+            dt_idx = cmd.index("--disallowedTools")
+            assert cmd[dt_idx + 1] == "Agent"
+
+    def test_tmux_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
+        from factory.runners._tmux_persist import run_in_tmux
+
+        with (
+            patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
+            patch("factory.runners._tmux_persist._session_exists", return_value=True),
+            patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._generate_settings") as mock_settings,
+            patch("factory.runners._tmux_persist._cleanup"),
+        ):
+            mock_settings.return_value = tmp_path / "settings.json"
+            (tmp_path / "settings.json").write_text("{}")
+            mock_run.return_value = type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+            try:
+                asyncio.get_event_loop().run_until_complete(
+                    run_in_tmux(
+                        prompt="Test", task="Test", cwd=tmp_path, role="test",
+                        project_path=tmp_path, timeout=0.1,
+                    )
+                )
+            except Exception:
+                pass
+
+            first_call_args = mock_run.call_args_list[0][0][0]
+            wrapper_script_path = first_call_args[-1]
+            wrapper_content = Path(wrapper_script_path).read_text()
+            assert "--disallowedTools" in wrapper_content
+            assert "Agent" in wrapper_content
+
 
 class TestBobBuildInteractiveCommand:
     """Tests for BobRunner.build_interactive_command()."""

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1845,6 +1845,60 @@ class TestClaudeBuildInteractiveCommand:
             f.unlink(missing_ok=True)
 
 
+class TestDisallowedAgentTool:
+    """Tests for --disallowedTools Agent across all Claude Code execution paths."""
+
+    def test_build_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
+        runner = ClaudeRunner()
+        cmd, _, temp_files = runner.build_command(AgentRunRequest(
+            prompt="Test", task="Test", cwd=tmp_path,
+        ))
+
+        assert "--disallowedTools" in cmd
+        dt_idx = cmd.index("--disallowedTools")
+        assert cmd[dt_idx + 1] == "Agent"
+
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_build_interactive_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
+        runner = ClaudeRunner()
+        cmd, _, temp_files = runner.build_interactive_command(AgentRunRequest(
+            prompt="Test", task="Test", cwd=tmp_path,
+        ))
+
+        assert "--disallowedTools" in cmd
+        dt_idx = cmd.index("--disallowedTools")
+        assert cmd[dt_idx + 1] == "Agent"
+
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    async def test_headless_subprocess_receives_disallowed_tools(self, tmp_path: Path) -> None:
+        runner = ClaudeRunner()
+
+        with patch(
+            "factory.runners._subprocess.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (b'{"result":"ok"}', b"")
+
+            with patch(
+                "factory.runners._subprocess.asyncio.create_subprocess_exec", new_callable=AsyncMock
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(AgentRunRequest(
+                    prompt="Test", task="Test", cwd=tmp_path,
+                ))
+
+                all_args = list(mock_exec.call_args[0])
+                assert "--disallowedTools" in all_args
+                dt_idx = all_args.index("--disallowedTools")
+                assert all_args[dt_idx + 1] == "Agent"
+
+
 class TestBobBuildInteractiveCommand:
     """Tests for BobRunner.build_interactive_command()."""
 


### PR DESCRIPTION
## Summary

- Add `--disallowedTools Agent` to all Claude Code invocation paths (headless, interactive, background, tmux) so spawned agents cannot use Claude Code's native `Agent` tool
- Add explicit prohibition of the native Agent tool to the CEO prompt's Forbidden Actions list with rationale (bypasses prompt resolution, playbook injection, review file capture, event emission, and telemetry)
- Add tests verifying the `--disallowedTools` flag is present in built commands and that the CEO prompt references the prohibition

## Problem

The CEO and specialist agents run as Claude Code subprocesses, which gives them access to Claude Code's native `Agent` tool alongside `factory agent <role>`. Claude Code's system prompt actively encourages using its native Agent tool for delegation, causing the CEO to sometimes prefer it over the intended `factory agent` CLI path. When this happens:

- No prompt resolution — specialists don't get their role-specific prompts
- No ACE playbook injection — evolved playbooks are skipped  
- No review file saved — nothing at `.factory/reviews/<role>-latest.md`
- No event emission — no `agent.started`/`agent.completed` events
- No telemetry — no Langfuse spans or token tracking
- No failure tracking — consecutive failure counter isn't touched
- No identity re-anchor — `IDENTITY_REANCHOR` footer isn't appended

## Test plan

- [x] All 100 existing runner tests pass
- [x] All 76 existing prompt tests pass
- [x] 3 new tests verify `--disallowedTools Agent` in `build_command`, `build_interactive_command`, and actual subprocess args
- [x] 2 new tests verify CEO prompt forbids native Agent tool in Forbidden Actions section
- [x] `ruff check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)