### PR TITLE
fix: increase benchmark timeouts to 2h and forward node timeout in executor

### DIFF
--- a/factory/runners/_subprocess.py
+++ b/factory/runners/_subprocess.py
@@ -38,7 +38,7 @@ async def run_subprocess(
     runner_name: str,
     role: str,
     sanitize: bool = False,
-    max_timeout: float = 3600.0,
+    max_timeout: float = 14400.0,
     on_line: Callable[[bytes], None] | None = None,
 ) -> AgentRunResult:
     """Run a subprocess with streaming, timeout, and error handling.

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -105,7 +105,6 @@ class ClaudeRunner:
             "-p", request.task,
             "--output-format", "stream-json",
             "--verbose",
-            "--max-turns", "1000",
             "--disallowedTools", "Agent",
         ]
         if request.skip_permissions:

--- a/factory/workflow/contributed/featurebench/test_workflow.py
+++ b/factory/workflow/contributed/featurebench/test_workflow.py
@@ -56,7 +56,7 @@ class TestFeaturebenchWorkflow:
         assert isinstance(node, AgentNode)
         assert node.role == AgentRole.BUILDER
         assert node.max_iterations == 3
-        assert node.timeout == 1200
+        assert node.timeout == 7200
         assert "interface" in node.prompt_template.lower()
         assert "nameerror" in node.prompt_template.lower()
         assert "cross-file" in node.prompt_template.lower()

--- a/factory/workflow/contributed/featurebench/workflow.py
+++ b/factory/workflow/contributed/featurebench/workflow.py
@@ -71,7 +71,7 @@ def workflow() -> Workflow:
         id="builder",
         role=AgentRole.BUILDER,
         model="opus",
-        timeout=1200,
+        timeout=7200,
         max_iterations=3,
         prompt_template=(
             "You are implementing a new feature in a Python codebase for "

--- a/factory/workflow/contributed/legacybench/test_workflow.py
+++ b/factory/workflow/contributed/legacybench/test_workflow.py
@@ -54,7 +54,7 @@ class TestLegacybenchWorkflow:
         assert isinstance(node, AgentNode)
         assert node.role == AgentRole.BUILDER
         assert node.max_iterations == 3
-        assert node.timeout == 1200
+        assert node.timeout == 7200
 
     def test_gate_verify_is_fn_evaluator(self) -> None:
         """Gate uses fn evaluator (not agent) for speed and determinism."""

--- a/factory/workflow/contributed/legacybench/workflow.py
+++ b/factory/workflow/contributed/legacybench/workflow.py
@@ -81,7 +81,7 @@ def workflow() -> Workflow:
         id="builder",
         role=AgentRole.BUILDER,
         model="opus",
-        timeout=1200,
+        timeout=7200,
         max_iterations=3,
         prompt_template=(
             "You are fixing a bug in legacy code for the Legacy-Bench benchmark.\n\n"

--- a/factory/workflow/contributed/programbench/test_workflow.py
+++ b/factory/workflow/contributed/programbench/test_workflow.py
@@ -48,7 +48,7 @@ class TestProgrambenchWorkflow:
         assert isinstance(node, AgentNode)
         assert node.role == AgentRole.BUILDER
         assert node.max_iterations == 3
-        assert node.timeout == 1200
+        assert node.timeout == 7200
         assert "discoveries.md" in node.prompt_template
         assert "autonomous" in node.prompt_template.lower()
         assert "__DATE__" in node.prompt_template

--- a/factory/workflow/contributed/programbench/workflow.py
+++ b/factory/workflow/contributed/programbench/workflow.py
@@ -46,7 +46,7 @@ def workflow() -> Workflow:
         id="builder",
         role=AgentRole.BUILDER,
         model="opus",
-        timeout=1200,
+        timeout=7200,
         max_iterations=3,
         prompt_template=(
             "You are reverse-engineering a compiled binary and producing "
@@ -131,7 +131,7 @@ def workflow() -> Workflow:
         id="reviewer",
         role=AgentRole.RESEARCHER,
         model="opus",
-        timeout=900,
+        timeout=7200,
         max_iterations=1,
         prompt_template=(
             "You are an adversarial reviewer for the ProgramBench benchmark. "

--- a/factory/workflow/contributed/swebench/test_workflow.py
+++ b/factory/workflow/contributed/swebench/test_workflow.py
@@ -55,7 +55,7 @@ class TestSwebenchWorkflow:
         assert isinstance(node, AgentNode)
         assert node.role == AgentRole.BUILDER
         assert node.max_iterations == 3
-        assert node.timeout == 1200
+        assert node.timeout == 7200
         assert "MINIMAL" in node.prompt_template
         assert "run" in node.prompt_template.lower()
         assert "test" in node.prompt_template.lower()

--- a/factory/workflow/contributed/swebench/workflow.py
+++ b/factory/workflow/contributed/swebench/workflow.py
@@ -64,7 +64,7 @@ def workflow() -> Workflow:
         id="builder",
         role=AgentRole.BUILDER,
         model="opus",
-        timeout=1200,
+        timeout=7200,
         max_iterations=3,
         prompt_template=(
             "You are fixing a bug in an open-source project for the SWE-bench benchmark.\n\n"

--- a/factory/workflow/contributed/terminalbench/test_workflow.py
+++ b/factory/workflow/contributed/terminalbench/test_workflow.py
@@ -57,7 +57,7 @@ class TestTerminalbenchWorkflow:
         assert isinstance(node, AgentNode)
         assert node.role == AgentRole.BUILDER
         assert node.max_iterations == 3
-        assert node.timeout == 1200
+        assert node.timeout == 7200
         assert "terminal" in node.prompt_template.lower()
         assert "autonomous" in node.prompt_template.lower()
         assert "verify" in node.prompt_template.lower()

--- a/factory/workflow/contributed/terminalbench/workflow.py
+++ b/factory/workflow/contributed/terminalbench/workflow.py
@@ -83,7 +83,7 @@ def workflow() -> Workflow:
         id="builder",
         role=AgentRole.BUILDER,
         model="opus",
-        timeout=1200,
+        timeout=7200,
         max_iterations=3,
         prompt_template=(
             "You are solving a real-world engineering task in a terminal environment.\n\n"

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -495,11 +495,18 @@ class WorkflowExecutor:
             if pool_entry:
                 model = pool_entry.model
 
+        timeout = node.timeout
+        if timeout is None:
+            pool_entry = self.agent_pool.get(node.role.value)
+            if pool_entry:
+                timeout = pool_entry.timeout
+
         stdout, code = await invoke_agent(
             node.role.value,  # type: ignore[arg-type]
             task,
             self.project_path,
             model=model or None,
+            timeout=float(timeout) if timeout is not None else 600.0,
         )
 
         if code != 0:


### PR DESCRIPTION
## Summary

- Increase `AgentNode.timeout` from 1200s to 7200s (2 hours) in all 5 benchmark workflows (featurebench, swebench, terminalbench, legacybench, programbench)
- Forward `node.timeout` from workflow definitions to `invoke_agent` in the executor — previously the node timeout was silently dropped and the hardcoded default of 600s always won
- Bump `max_timeout` wall-clock backstop from 3600s to 14400s (4 hours) so it doesn't kill agents before their configured timeout expires
- Remove `--max-turns 1000` from Claude Code CLI invocation, letting Claude Code use its own default

## Test plan

- [x] All 134 workflow definition tests pass
- [x] All 139 benchmark-specific tests pass (timeout assertions updated)
- [x] Runner tests unaffected (3 pre-existing failures unrelated to these changes)
- [ ] Run featurebench CI to verify agents no longer hit premature timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)