### PR TITLE
fix: design mode routing preserves ceo_mode='design' for ALL design invocations

### DIFF
--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -577,7 +577,14 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     interactive = (
         design_existing or bool(design_idea) or bool(research_ideation) or mode == "create"
     )
-    ceo_mode = "create" if mode == "create" else ("build" if interactive else mode)
+    if mode == "create":
+        ceo_mode = "create"
+    elif design_existing:
+        ceo_mode = "design"
+    elif interactive:
+        ceo_mode = "build"
+    else:
+        ceo_mode = mode
     if clean_pr_flag is not None:
         clean_pr_resolved = clean_pr_flag
     else:

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -579,7 +579,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     )
     if mode == "create":
         ceo_mode = "create"
-    elif design_existing:
+    elif mode == "design":
         ceo_mode = "design"
     elif interactive:
         ceo_mode = "build"
@@ -1697,8 +1697,9 @@ def _build_ceo_task(
             f"Run the Plan Loop (P0-P3) with interactive approval. "
             f"Research the space, synthesize a build plan, and refine it "
             f"through user feedback before building.\n\n"
-            f"After the user approves the final plan, persist it to "
-            f".factory/strategy/current.md and proceed to Build mode.\n"
+            f"After you approve the plan at the strategy gate, persist it to "
+            f".factory/strategy/current.md — the workflow continues to "
+            f"implementation automatically.\n"
         )
 
     if research_ideation:

--- a/factory/state.py
+++ b/factory/state.py
@@ -80,9 +80,17 @@ def detect_state(project_path: Path) -> ProjectState:
         log.info("detect_state_result", state=ProjectState.EVALS_PENDING_REVIEW.value)
         return ProjectState.EVALS_PENDING_REVIEW
 
-    if (project_path / ".factory" / "config.json").exists():
+    factory_dir = project_path / ".factory"
+    if (factory_dir / "config.json").exists():
         log.info("detect_state_result", state=ProjectState.HAS_FACTORY.value)
         return ProjectState.HAS_FACTORY
+
+    if factory_dir.exists():
+        log.warning(
+            "factory_dir_without_config",
+            factory_dir=str(factory_dir),
+            hint="Run 'factory init' to generate config.json from factory.md",
+        )
 
     if _has_open_plan_issues(project_path):
         log.info("detect_state_result", state=ProjectState.REPO_INCOMPLETE.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1939,14 +1939,14 @@ class TestBuildCeoTaskDesign:
         assert "No specific topic was provided" in task
 
     def test_new_idea_emits_plan_loop_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
+        task = _build_ceo_task(tmp_path, "design", design_idea="weather CLI")
         assert "## Plan Loop (Interactive)" in task
         assert "weather CLI" in task
 
     def test_existing_uses_same_header_as_new_idea(self, tmp_path):
         """Both new ideas and existing projects use the same Plan Loop header."""
         existing_task = _build_ceo_task(tmp_path, "design", design_existing=True)
-        new_task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
+        new_task = _build_ceo_task(tmp_path, "design", design_idea="weather CLI")
         assert "## Plan Loop (Interactive)" in existing_task
         assert "## Plan Loop (Interactive)" in new_task
 
@@ -1974,14 +1974,16 @@ class TestCeoModeRouting:
         assert "Run design mode: read `skills/workflow-design/SKILL.md`" in task
         assert "Run Build mode" not in task
 
-    def test_design_idea_routes_to_build(self):
-        """New idea in design mode routes to ceo_mode='build' for Plan Loop."""
+    def test_design_idea_routes_to_design(self):
+        """New idea in design mode routes to ceo_mode='design'."""
         with _mock_foreground() as mock_run:
             main(["ceo", "weather CLI", "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
         assert "## Plan Loop (Interactive)" in task
+        assert "Run design mode" in task
+        assert "Run Build mode" not in task
 
     def test_create_mode_routes_to_create(self, tmp_path):
         """mode='create' always sets ceo_mode='create'."""
@@ -2012,6 +2014,17 @@ class TestCeoModeRouting:
         task = _build_ceo_task(tmp_path, "design", design_existing=True)
         assert "Run design mode: read `skills/workflow-design/SKILL.md`" in task
         assert "Run Build mode" not in task
+
+    def test_research_ideation_routes_to_build(self):
+        """research_ideation (--mode research) routes to ceo_mode='build', not 'design'."""
+        with _mock_foreground() as mock_run:
+            main(["ceo", "SWE-bench solver", "--mode", "research"])
+        cmd = mock_run.call_args[0][0]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "## Plan Loop (Interactive)" in task
+        assert "Run Build mode" in task
+        assert "Run design mode" not in task
 
 
 class TestCreateModeFocus:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1923,19 +1923,19 @@ class TestBuildCeoTaskDesign:
     """Unit tests for _build_ceo_task design_existing parameter."""
 
     def test_existing_project_emits_plan_loop_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        task = _build_ceo_task(tmp_path, "design", design_existing=True)
         assert "## Plan Loop (Interactive)" in task
         assert "existing_project: true" in task
         assert "existing project" in task
 
     def test_existing_project_with_focus(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", design_existing=True, focus="auth layer")
+        task = _build_ceo_task(tmp_path, "design", design_existing=True, focus="auth layer")
         assert "## Plan Loop (Interactive)" in task
         assert "auth layer" in task
         assert "Focus topic" in task
 
     def test_existing_project_without_focus(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        task = _build_ceo_task(tmp_path, "design", design_existing=True)
         assert "No specific topic was provided" in task
 
     def test_new_idea_emits_plan_loop_section(self, tmp_path):
@@ -1945,20 +1945,73 @@ class TestBuildCeoTaskDesign:
 
     def test_existing_uses_same_header_as_new_idea(self, tmp_path):
         """Both new ideas and existing projects use the same Plan Loop header."""
-        existing_task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        existing_task = _build_ceo_task(tmp_path, "design", design_existing=True)
         new_task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
         assert "## Plan Loop (Interactive)" in existing_task
         assert "## Plan Loop (Interactive)" in new_task
 
     def test_existing_project_has_existing_flag(self, tmp_path):
         """Existing project task includes the existing_project flag for CEO conditionals."""
-        task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        task = _build_ceo_task(tmp_path, "design", design_existing=True)
         assert "existing_project: true" in task
 
     def test_existing_mode_shows_display_mode(self, tmp_path):
         """When display_mode is provided, task shows it instead of internal mode."""
-        task = _build_ceo_task(tmp_path, "build", design_existing=True, display_mode="design")
+        task = _build_ceo_task(tmp_path, "design", design_existing=True, display_mode="design")
         assert "Mode: design" in task
+
+
+class TestCeoModeRouting:
+    """Tests for ceo_mode routing logic at ceo.py:580 (issue #999)."""
+
+    def test_design_existing_routes_to_design(self, tmp_path):
+        """design_existing=True preserves ceo_mode='design'."""
+        with _mock_foreground() as mock_run:
+            main(["ceo", str(tmp_path), "--mode", "design"])
+        cmd = mock_run.call_args[0][0]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "Run design mode: read `skills/workflow-design/SKILL.md`" in task
+        assert "Run Build mode" not in task
+
+    def test_design_idea_routes_to_build(self):
+        """New idea in design mode routes to ceo_mode='build' for Plan Loop."""
+        with _mock_foreground() as mock_run:
+            main(["ceo", "weather CLI", "--mode", "design"])
+        cmd = mock_run.call_args[0][0]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "## Plan Loop (Interactive)" in task
+
+    def test_create_mode_routes_to_create(self, tmp_path):
+        """mode='create' always sets ceo_mode='create'."""
+        (tmp_path / ".git").mkdir()
+        with _mock_foreground() as mock_run:
+            main(["ceo", str(tmp_path), "--mode", "create", "--focus", "a new mode"])
+        cmd = mock_run.call_args[0][0]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "Run Create mode" in task
+
+    def test_improve_mode_routes_to_improve(self, tmp_path):
+        """mode='improve' (no interactive flags) preserves ceo_mode='improve'."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".factory").mkdir()
+        (tmp_path / ".factory" / "config.json").write_text(
+            '{"goal":"x","scope":[],"guards":[],"eval_command":"x","eval_threshold":0.8,"constraints":[]}'
+        )
+        with _mock_foreground() as mock_run:
+            main(["ceo", str(tmp_path)])
+        cmd = mock_run.call_args[0][0]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "Run improve mode: read `skills/workflow-improve/SKILL.md`" in task
+
+    def test_design_existing_task_string(self, tmp_path):
+        """design_existing=True task contains design SKILL.md reference, not Build."""
+        task = _build_ceo_task(tmp_path, "design", design_existing=True)
+        assert "Run design mode: read `skills/workflow-design/SKILL.md`" in task
+        assert "Run Build mode" not in task
 
 
 class TestCreateModeFocus:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1898,28 +1898,26 @@ class TestDisallowedAgentTool:
                 dt_idx = all_args.index("--disallowedTools")
                 assert all_args[dt_idx + 1] == "Agent"
 
-    def test_background_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
-        with patch("factory.runners._background.subprocess.run") as mock_run:
+    async def test_background_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
+        from factory.runners._background import run_in_background
+
+        with (
+            patch("factory.runners._background.subprocess.run") as mock_run,
+            patch("factory.runners._background.asyncio.sleep", new_callable=AsyncMock),
+        ):
             mock_run.return_value = type("R", (), {"stdout": "backgrounded · abc123", "stderr": "", "returncode": 0})()
 
-            from factory.runners._background import run_in_background
-
-            try:
-                asyncio.get_event_loop().run_until_complete(
-                    run_in_background(
-                        prompt="Test", task="Test", cwd=tmp_path, role="test",
-                        timeout=0.1,
-                    )
-                )
-            except Exception:
-                pass
+            await run_in_background(
+                prompt="Test", task="Test", cwd=tmp_path, role="test",
+                timeout=0.1,
+            )
 
             cmd = mock_run.call_args_list[0][0][0]
             assert "--disallowedTools" in cmd
             dt_idx = cmd.index("--disallowedTools")
             assert cmd[dt_idx + 1] == "Agent"
 
-    def test_tmux_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
+    async def test_tmux_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
         from factory.runners._tmux_persist import run_in_tmux
 
         with (
@@ -1933,15 +1931,10 @@ class TestDisallowedAgentTool:
             (tmp_path / "settings.json").write_text("{}")
             mock_run.return_value = type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
 
-            try:
-                asyncio.get_event_loop().run_until_complete(
-                    run_in_tmux(
-                        prompt="Test", task="Test", cwd=tmp_path, role="test",
-                        project_path=tmp_path, timeout=0.1,
-                    )
-                )
-            except Exception:
-                pass
+            await run_in_tmux(
+                prompt="Test", task="Test", cwd=tmp_path, role="test",
+                project_path=tmp_path, timeout=0.1,
+            )
 
             first_call_args = mock_run.call_args_list[0][0][0]
             wrapper_script_path = first_call_args[-1]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -89,6 +89,33 @@ class TestDetectState:
         assert detect_state(tmp_project) == ProjectState.EVALS_PENDING_REVIEW
 
 
+class TestFactoryDirWithoutConfig:
+    def test_warns_when_factory_dir_exists_without_config(self, tmp_project):
+        """detect_state warns when .factory/ exists but config.json is missing."""
+        (tmp_project / ".factory").mkdir()
+        with (
+            patch("factory.state.subprocess.run", return_value=type("R", (), {"returncode": 0, "stdout": "[]"})()),
+            patch("factory.state.log") as mock_log,
+        ):
+            state = detect_state(tmp_project)
+        assert state == ProjectState.NO_FACTORY
+        mock_log.warning.assert_called_once_with(
+            "factory_dir_without_config",
+            factory_dir=str(tmp_project / ".factory"),
+            hint="Run 'factory init' to generate config.json from factory.md",
+        )
+
+    def test_no_warning_without_factory_dir(self, tmp_project):
+        """detect_state does not warn when .factory/ doesn't exist."""
+        with (
+            patch("factory.state.subprocess.run", return_value=type("R", (), {"returncode": 0, "stdout": "[]"})()),
+            patch("factory.state.log") as mock_log,
+        ):
+            state = detect_state(tmp_project)
+        assert state == ProjectState.NO_FACTORY
+        mock_log.warning.assert_not_called()
+
+
 class TestHasOpenPlanIssues:
     def test_returns_false_when_gh_not_found(self, tmp_project):
         """_has_open_plan_issues returns False when gh CLI is not available."""


### PR DESCRIPTION
Closes #999, addresses #908

## Changes

- **Fix design mode routing (ceo.py:580):** Replace `elif design_existing:` with `elif mode == "design":` so that ALL `--mode design` invocations (both new ideas and existing projects) route to `ceo_mode="design"`. Previously, new ideas via `--mode design` fell through to `ceo_mode="build"`, bypassing the design workflow and its user approval gate.

- **Update design_idea task string:** Remove incorrect "proceed to Build mode" language. The design workflow handles everything end-to-end — after user approval at the strategy gate, the workflow continues to implementation automatically.

- **Update and expand test coverage:** Rename `test_design_idea_routes_to_build` → `test_design_idea_routes_to_design` with assertions that `design_idea` gets "Run design mode" (not "Run Build mode"). Add `test_research_ideation_routes_to_build` verifying that `--mode research` still correctly routes to `ceo_mode="build"`. Fix `TestBuildCeoTaskDesign` tests to pass `mode="design"` instead of `"build"` for design_idea cases.

- **Diagnostic warning in state.py** (from prior commit): When `.factory/` exists but `config.json` is missing, `detect_state()` logs a warning with a hint to run `factory init`.

## Test plan

- [x] All 13 targeted tests pass (`pytest -k 'CeoMode or BuildCeoTaskDesign'`)
- [x] `test_design_idea_routes_to_design` verifies new idea gets design workflow
- [x] `test_research_ideation_routes_to_build` verifies research still gets build mode
- [x] `test_design_existing_routes_to_design` unchanged, still passes