### PR TITLE
fix: convert disallowed-tools tests to async to fix IndexError

### DIFF
--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1898,28 +1898,26 @@ class TestDisallowedAgentTool:
                 dt_idx = all_args.index("--disallowedTools")
                 assert all_args[dt_idx + 1] == "Agent"
 
-    def test_background_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
-        with patch("factory.runners._background.subprocess.run") as mock_run:
+    async def test_background_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
+        from factory.runners._background import run_in_background
+
+        with (
+            patch("factory.runners._background.subprocess.run") as mock_run,
+            patch("factory.runners._background.asyncio.sleep", new_callable=AsyncMock),
+        ):
             mock_run.return_value = type("R", (), {"stdout": "backgrounded · abc123", "stderr": "", "returncode": 0})()
 
-            from factory.runners._background import run_in_background
-
-            try:
-                asyncio.get_event_loop().run_until_complete(
-                    run_in_background(
-                        prompt="Test", task="Test", cwd=tmp_path, role="test",
-                        timeout=0.1,
-                    )
-                )
-            except Exception:
-                pass
+            await run_in_background(
+                prompt="Test", task="Test", cwd=tmp_path, role="test",
+                timeout=0.1,
+            )
 
             cmd = mock_run.call_args_list[0][0][0]
             assert "--disallowedTools" in cmd
             dt_idx = cmd.index("--disallowedTools")
             assert cmd[dt_idx + 1] == "Agent"
 
-    def test_tmux_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
+    async def test_tmux_command_includes_disallowed_tools(self, tmp_path: Path) -> None:
         from factory.runners._tmux_persist import run_in_tmux
 
         with (
@@ -1933,15 +1931,10 @@ class TestDisallowedAgentTool:
             (tmp_path / "settings.json").write_text("{}")
             mock_run.return_value = type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
 
-            try:
-                asyncio.get_event_loop().run_until_complete(
-                    run_in_tmux(
-                        prompt="Test", task="Test", cwd=tmp_path, role="test",
-                        project_path=tmp_path, timeout=0.1,
-                    )
-                )
-            except Exception:
-                pass
+            await run_in_tmux(
+                prompt="Test", task="Test", cwd=tmp_path, role="test",
+                project_path=tmp_path, timeout=0.1,
+            )
 
             first_call_args = mock_run.call_args_list[0][0][0]
             wrapper_script_path = first_call_args[-1]


### PR DESCRIPTION
## Changes
- Converted `test_background_command_includes_disallowed_tools` and `test_tmux_command_includes_disallowed_tools` from sync to async test functions
- Removed `try/except Exception: pass` wrappers that silently swallowed failures
- Replaced `asyncio.get_event_loop().run_until_complete()` with direct `await` calls (pytest-asyncio auto mode handles async tests)
- Added `asyncio.sleep` mock in the background test to avoid the 5-second polling delay

Both tests were failing with `IndexError: list index out of range` because the sync `run_until_complete()` call fails under pytest-asyncio's already-running event loop, the exception is caught and ignored, and the subprocess mocks are never called — leaving `call_args_list` empty.