### PR TITLE
fix: remove --max-turns from analyze_failure.py diagnosis

### DIFF
--- a/scripts/langfuse/analyze_failure.py
+++ b/scripts/langfuse/analyze_failure.py
@@ -86,7 +86,7 @@ def run_llm_summary(trace_dump: str, benchmark: str, instance_id: str) -> str | 
 
     try:
         result = subprocess.run(
-            ["claude", "-p", prompt, "--max-turns", "1"],
+            ["claude", "-p", prompt],
             capture_output=True,
             text=True,
             timeout=120,
@@ -111,7 +111,7 @@ def run_llm_analysis(trace_dump: str, benchmark: str, instance_id: str) -> str |
 
     try:
         result = subprocess.run(
-            ["claude", "-p", prompt, "--max-turns", "3"],
+            ["claude", "-p", prompt],
             capture_output=True,
             text=True,
             timeout=180,


### PR DESCRIPTION
Closes the --max-turns timeout issue in the failure analysis script.

## Changes

- Removed `--max-turns 1` from `run_llm_summary()` — was causing `Error: Reached max turns` instead of producing a useful summary when trace dumps are large
- Removed `--max-turns 3` from `run_llm_analysis()` — same problem for full diagnosis

PR #1000 removed `--max-turns` from the benchmark executor but missed this script. The existing subprocess `timeout` values (120s and 180s) are the appropriate safety nets.