### PR TITLE
fix: preserve Harbor exception details in benchmark CI artifacts

### DIFF
--- a/benchmarks/lib.sh
+++ b/benchmarks/lib.sh
@@ -35,8 +35,8 @@ write_result() {
     duration=$(( end_time - START_TIME ))
     mkdir -p "${CI_RESULTS_DIR}"
     python3 -c "
-import json, sys
-_dj = '${DETAILS_JSON:-}'
+import json, os, sys
+_dj = os.environ.get('DETAILS_JSON', '')
 details = json.loads(_dj) if _dj else {}
 result = {
     'benchmark': '${BENCHMARK}',

--- a/benchmarks/run-harbor.sh
+++ b/benchmarks/run-harbor.sh
@@ -168,6 +168,7 @@ cleanup() {
                 DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER}"'", "cost_usd": '"${COST_USD}"', "input_tokens": '"${INPUT_TOKENS}"', "output_tokens": '"${OUTPUT_TOKENS}"', "cache_read_tokens": '"${CACHE_READ_TOKENS}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
             fi
         fi
+        export DETAILS_JSON
         write_result
     else
         local end_time duration

--- a/benchmarks/run-harbor.sh
+++ b/benchmarks/run-harbor.sh
@@ -105,6 +105,27 @@ TASKS_JSON="[]"
 cleanup() {
     local exit_code=$?
 
+    HARBOR_EXCEPTION=""
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        local exc_file
+        exc_file=$(find "${JOBS_DIR}" -maxdepth 4 -name 'exception.txt' -type f 2>/dev/null | head -1)
+        if [ -n "${exc_file}" ] && [ -f "${exc_file}" ]; then
+            mkdir -p "${CI_RESULTS_DIR}"
+            cp "${exc_file}" "${CI_RESULTS_DIR}/${TIMESTAMP}-${BENCHMARK}-exception.txt"
+            HARBOR_EXCEPTION=$(cat "${exc_file}")
+            echo "--- Harbor exception ---" >&2
+            echo "${HARBOR_EXCEPTION}" >&2
+            echo "--- end exception ---" >&2
+        fi
+
+        local log_file
+        log_file=$(find "${JOBS_DIR}" -maxdepth 4 -name 'trial.log' -type f 2>/dev/null | head -1)
+        if [ -n "${log_file}" ] && [ -f "${log_file}" ]; then
+            mkdir -p "${CI_RESULTS_DIR}"
+            cp "${log_file}" "${CI_RESULTS_DIR}/${TIMESTAMP}-${BENCHMARK}-trial.log"
+        fi
+    fi
+
     LANGFUSE_TRACE_ID=""
     if [ "${MODE}" = "task" ] && [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
         LANGFUSE_TRACE_ID=$(extract_trace_id "${JOBS_DIR}")
@@ -130,10 +151,22 @@ cleanup() {
 
     if [ "${MODE}" = "task" ]; then
         PASSED="${RESOLVED}"
+        ESCAPED_EXCEPTION=""
+        if [ -n "${HARBOR_EXCEPTION}" ]; then
+            ESCAPED_EXCEPTION=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read().strip()))" <<< "${HARBOR_EXCEPTION}")
+        fi
         if [ "${BENCHMARK}" = "featurebench" ]; then
-            DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"', "solver": "'"${BENCHMARK_SOLVER}"'", "cost_usd": '"${COST_USD}"', "input_tokens": '"${INPUT_TOKENS}"', "output_tokens": '"${OUTPUT_TOKENS}"', "cache_read_tokens": '"${CACHE_READ_TOKENS}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
+            if [ -n "${ESCAPED_EXCEPTION}" ]; then
+                DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"', "solver": "'"${BENCHMARK_SOLVER}"'", "cost_usd": '"${COST_USD}"', "input_tokens": '"${INPUT_TOKENS}"', "output_tokens": '"${OUTPUT_TOKENS}"', "cache_read_tokens": '"${CACHE_READ_TOKENS}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'", "exception": '"${ESCAPED_EXCEPTION}"'}'
+            else
+                DETAILS_JSON='{"pass_rate": '"${PASS_RATE}"', "solver": "'"${BENCHMARK_SOLVER}"'", "cost_usd": '"${COST_USD}"', "input_tokens": '"${INPUT_TOKENS}"', "output_tokens": '"${OUTPUT_TOKENS}"', "cache_read_tokens": '"${CACHE_READ_TOKENS}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
+            fi
         else
-            DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER}"'", "cost_usd": '"${COST_USD}"', "input_tokens": '"${INPUT_TOKENS}"', "output_tokens": '"${OUTPUT_TOKENS}"', "cache_read_tokens": '"${CACHE_READ_TOKENS}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
+            if [ -n "${ESCAPED_EXCEPTION}" ]; then
+                DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER}"'", "cost_usd": '"${COST_USD}"', "input_tokens": '"${INPUT_TOKENS}"', "output_tokens": '"${OUTPUT_TOKENS}"', "cache_read_tokens": '"${CACHE_READ_TOKENS}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'", "exception": '"${ESCAPED_EXCEPTION}"'}'
+            else
+                DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER}"'", "cost_usd": '"${COST_USD}"', "input_tokens": '"${INPUT_TOKENS}"', "output_tokens": '"${OUTPUT_TOKENS}"', "cache_read_tokens": '"${CACHE_READ_TOKENS}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS}"', "trace_id": "'"${LANGFUSE_TRACE_ID}"'"}'
+            fi
         fi
         write_result
     else

--- a/scripts/langfuse/analyze_failure.py
+++ b/scripts/langfuse/analyze_failure.py
@@ -157,6 +157,9 @@ def generate_report(
         header += f"**Trace:** [{trace_id}]({host}/trace/{trace_id})\n"
 
     if trace is None:
+        exception_text = (result_data.get("details") or {}).get("exception", "")
+        if exception_text:
+            return header + "\n#### Exception from Harbor\n\n" + exception_text + "\n"
         return header + "\nNo matching Langfuse trace found.\n"
 
     trace_dump = format_trace_dump(trace)


### PR DESCRIPTION
Closes #1011

## Changes

- **`benchmarks/run-harbor.sh` — `cleanup()`**: Extract `exception.txt` and `trial.log` from Harbor's jobs directory before `rm -rf`, copying them to `CI_RESULTS_DIR` with the standard timestamp prefix. Exception text is printed to stderr so it appears in CI logs without downloading artifacts.
- **`benchmarks/run-harbor.sh` — `DETAILS_JSON`**: Include the exception text as a JSON-escaped `"exception"` field in the result details, so it flows through `write_result()` into the result JSON file for `analyze_failure.py` consumption.
- **`scripts/langfuse/analyze_failure.py`**: Display exception text in the failure report when no Langfuse trace is available, providing immediate diagnostic context.
- **`benchmarks/lib.sh` — `write_result()`**: Fix multi-line exception escaping bug found by adversarial QA. Changed DETAILS_JSON passing from shell string interpolation (`_dj = '${DETAILS_JSON}'`) to environment variable (`os.environ.get('DETAILS_JSON', '')`), preventing Python's string parser from reinterpreting `\n` escapes as actual newlines.
- **`benchmarks/run-harbor.sh`**: Export DETAILS_JSON before calling `write_result` so it's available via `os.environ`.