### PR TITLE
feat: add Harbor-Index benchmark integration

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,7 @@ on:
           - terminalbench
           - programbench
           - legacybench
+          - harborindex
           - all
       instance_id:
         description: 'Instance ID (leave default for smoke test)'
@@ -81,6 +82,10 @@ jobs:
             solver: factory
             default_instance: '1907c2-c-debug-legacy-buddy-fix'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'legacybench' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
+          - benchmark: harborindex
+            solver: factory
+            default_instance: 'bix-filter-chip-variants'
+            enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'harborindex' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           # Claude Code solver entries — enabled on schedule, release, or workflow_dispatch with matching benchmark+solver
           - benchmark: swebench
             solver: claude-code
@@ -102,6 +107,10 @@ jobs:
             solver: claude-code
             default_instance: '1907c2-c-debug-legacy-buddy-fix'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'legacybench' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+          - benchmark: harborindex
+            solver: claude-code
+            default_instance: 'bix-filter-chip-variants'
+            enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'harborindex' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
 
     steps:
       - name: Skip if not enabled

--- a/benchmarks/config.sh
+++ b/benchmarks/config.sh
@@ -4,7 +4,7 @@
 # benchmark_all_names, and benchmark_instance_id.
 
 benchmark_all_names() {
-    echo "swebench featurebench terminalbench programbench"
+    echo "swebench featurebench terminalbench programbench harborindex"
 }
 
 benchmark_config() {
@@ -54,9 +54,15 @@ benchmark_config() {
             BENCH_AGENT_IMPORT_FLAG="--agent-import-path"
             BENCH_FILTER_STYLE="glob"
             ;;
+        harborindex)
+            BENCH_DATASET="harbor-index/harbor-index-1.0"
+            BENCH_AGENT_CLASS="factory_harbor_agent:HarborIndexFactoryCeo"
+            BENCH_AGENT_IMPORT_FLAG="--agent-import-path"
+            BENCH_FILTER_STYLE="exact"
+            ;;
         *)
             echo "ERROR: Unknown benchmark '${name}'"
-            echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench"
+            echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex"
             return 1
             ;;
     esac

--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -377,3 +377,12 @@ class FeaturebenchFactoryCeo(FactoryCeo):
             '2>&1 </dev/null | tee /logs/agent/factory-ceo.txt'
             '; exit 0'
         )
+
+
+class HarborIndexFactoryCeo(FactoryCeo):
+    """Runs the generic factory ceo approach for the Harbor-Index meta-benchmark."""
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "harbor-index-factory-ceo"

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]
 #
 # Arguments:
-#   benchmark      Required. One of: swebench, featurebench, terminalbench, programbench, legacybench
+#   benchmark      Required. One of: swebench, featurebench, terminalbench, programbench, legacybench, harborindex
 #   instance_id    Required. Benchmark-specific instance identifier
 #
 # Options:
@@ -23,7 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ $# -lt 2 ]; then
     echo "Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]"
     echo ""
-    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench"
+    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex"
     exit 1
 fi
 
@@ -58,10 +58,10 @@ esac
 
 # Validate benchmark
 case "${BENCHMARK}" in
-    swebench|featurebench|terminalbench|programbench|legacybench) ;;
+    swebench|featurebench|terminalbench|programbench|legacybench|harborindex) ;;
     *)
         echo "ERROR: Unknown benchmark '${BENCHMARK}'"
-        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench"
+        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Closes #1017

## Changes

- **benchmarks/config.sh**: Add `harborindex` to `benchmark_all_names()` and `benchmark_config()` with dataset `harbor-index/harbor-index-1.0`, exact filter style, and `HarborIndexFactoryCeo` agent class
- **benchmarks/factory_harbor_agent.py**: Add `HarborIndexFactoryCeo` class that inherits from `FactoryCeo` without overriding `_get_factory_command()` — the generic CEO approach handles Harbor-Index's diverse meta-benchmark tasks
- **benchmarks/run.sh**: Add `harborindex` to validation case statement and update usage/error messages
- **.github/workflows/benchmark.yml**: Add `harborindex` to workflow_dispatch choices and add factory + claude-code matrix entries with default instance `bix-filter-chip-variants`