### PR TITLE
feat: make ToM-SWE benchmark CI-interoperable

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,7 @@ on:
           - programbench
           - legacybench
           - harborindex
+          - tomswe
           - all
       instance_id:
         description: 'Instance ID (leave default for smoke test)'
@@ -86,6 +87,10 @@ jobs:
             solver: factory
             default_instance: 'bix-filter-chip-variants'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'harborindex' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
+          - benchmark: tomswe
+            solver: factory
+            default_instance: 'sympy__sympy-20590'
+            enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'tomswe' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           # Claude Code solver entries — enabled on schedule, release, or workflow_dispatch with matching benchmark+solver
           - benchmark: swebench
             solver: claude-code
@@ -111,6 +116,10 @@ jobs:
             solver: claude-code
             default_instance: 'bix-filter-chip-variants'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'harborindex' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+          - benchmark: tomswe
+            solver: claude-code
+            default_instance: 'sympy__sympy-20590'
+            enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'tomswe' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
 
     steps:
       - name: Skip if not enabled

--- a/SPEC.md
+++ b/SPEC.md
@@ -20,7 +20,7 @@ The Remote Factory solves this by providing an **autonomous software improvement
 2. Enforce non-overridable quality gates (precheck) that prevent regressions
 3. Support multiple CLI backends (Claude Code, Bob Shell, Codex, OpenCode) via a runner abstraction
 4. Evolve agent behavior over time through cross-project playbook learning (ACE)
-5. Provide 20 workflow modes as composable, validated DAGs with formal execution semantics
+5. Provide 22 workflow modes as composable, validated DAGs with formal execution semantics
 6. Maintain full experiment history with append-only TSV and per-experiment artifact directories
 
 ### §2.2 Non-Goals
@@ -85,7 +85,7 @@ Pure tools that do not make decisions. Entry point `factory/cli.py` dispatches v
 
 ### Layer 2: Workflow Graph Engine (`factory/workflow/`)
 
-All 20 factory modes are defined as directed graphs of typed nodes in `factory/workflow/definitions.py`. Each graph is a `Workflow` Pydantic model with `AgentNode`, `FnNode`, `GateNode`, `ForkNode`, `JoinNode`, and `Study` primitives connected by `Edge` objects.
+All 22 factory modes are defined as directed graphs of typed nodes in `factory/workflow/definitions.py`. Each graph is a `Workflow` Pydantic model with `AgentNode`, `FnNode`, `GateNode`, `ForkNode`, `JoinNode`, and `Study` primitives connected by `Edge` objects.
 
 The same graph definition produces two execution formats:
 - **Headless**: `WorkflowExecutor` (`factory/workflow/executor.py`) walks the DAG deterministically
@@ -116,7 +116,7 @@ factory/models.py                    ← Foundation: all Pydantic types
     ├── factory/strategy.py          ← FEEC heuristic, plateau/stuck detection
     ├── factory/workflow/
     │   ├── primitives.py            ← 6 node types, Edge, Verdict, Workflow
-    │   ├── definitions.py           ← 20 workflow DAGs
+    │   ├── definitions.py           ← 22 workflow DAGs
     │   ├── executor.py              ← Async DAG walker
     │   ├── validation.py            ← Graph validation (networkx)
     │   ├── skill_export.py          ← DAG → SKILL.md conversion
@@ -560,7 +560,7 @@ check_ceilings(project_path, cycle_start):
 
 | Contract | Normative |
 |---|---|
-| `register_all()` returns exactly 20 workflows | MUST |
+| `register_all()` returns exactly 22 workflows | MUST |
 | All workflows MUST pass `validate_graph()` | MUST |
 | W₁ Build: trigger on `NO_REPO` or `REPO_INCOMPLETE` | MUST |
 | W₂ Design: W₁ with user gate at strategy approval; trigger requires `interactive=True` | MUST |
@@ -842,7 +842,7 @@ ANTHROPIC_API_KEY = "sk-ant-..."
 | 12 | Clean PR safety: stages only specific files, never untracked | `strip_pr_artifacts` |
 | 13 | Annotation-source fidelity: exported skills match source workflow graph | `validate_skill` |
 | 14 | Broken symlink handling in `ensure_factory_dir` | store initialization |
-| 15 | `register_all()` returns exactly 20 workflows; all pass `validate_graph()` | test_annotations.py |
+| 15 | `register_all()` returns exactly 22 workflows; all pass `validate_graph()` | test_annotations.py |
 | 16 | Tiered history: MAX_INLINE_HISTORY = 10 | `format_tiered_history` |
 | 17 | Bob ceiling accumulates across invocations using `cycle.json` `started_at` | `check_ceilings` |
 | 18 | ANSI sanitization: genuine blank lines preserved; redraw-only lines dropped | `_stream.py` |
@@ -882,7 +882,7 @@ ANTHROPIC_API_KEY = "sk-ant-..."
 - [ ] All Pydantic models use `ConfigDict(strict=True, extra="forbid")`
 - [ ] `ExperimentStore` uses `FileLock` for `begin()` and `finalize()`
 - [ ] Precheck gate is non-overridable by the CEO agent (implemented as `GateNode(evaluator_type="fn")`)
-- [ ] All 20 workflows validate cleanly via `validate_graph()`
+- [ ] All 22 workflows validate cleanly via `validate_graph()`
 - [ ] Weight sums: default hygiene 50% + growth 50% = 100%
 - [ ] FEEC priority order: FIX(0) < EXPLOIT(1) < EXPLORE(2) < COMBINE(3)
 - [ ] Consecutive agent failure threshold = 2

--- a/benchmarks/config.sh
+++ b/benchmarks/config.sh
@@ -4,7 +4,7 @@
 # benchmark_all_names, and benchmark_instance_id.
 
 benchmark_all_names() {
-    echo "swebench featurebench terminalbench programbench harborindex"
+    echo "swebench featurebench terminalbench programbench harborindex tomswe"
 }
 
 benchmark_config() {
@@ -60,9 +60,15 @@ benchmark_config() {
             BENCH_AGENT_IMPORT_FLAG="--agent-import-path"
             BENCH_FILTER_STYLE="exact"
             ;;
+        tomswe)
+            BENCH_DATASET="tomswe"
+            BENCH_AGENT_CLASS="factory_harbor_agent:TomsweFactoryCeo"
+            BENCH_AGENT_IMPORT_FLAG="--agent-import-path"
+            BENCH_FILTER_STYLE="glob"
+            ;;
         *)
             echo "ERROR: Unknown benchmark '${name}'"
-            echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex"
+            echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe"
             return 1
             ;;
     esac

--- a/benchmarks/config.sh
+++ b/benchmarks/config.sh
@@ -61,10 +61,10 @@ benchmark_config() {
             BENCH_FILTER_STYLE="exact"
             ;;
         tomswe)
-            BENCH_LOCAL_PATH="${HARNESS_DIR}/benchmarks/tomswe-harbor"
+            BENCH_DATASET='swe-bench/swe-bench-verified'
             BENCH_AGENT_CLASS="factory_harbor_agent:TomsweFactoryCeo"
             BENCH_AGENT_IMPORT_FLAG="--agent-import-path"
-            BENCH_FILTER_STYLE="exact"
+            BENCH_FILTER_STYLE="glob"
             ;;
         *)
             echo "ERROR: Unknown benchmark '${name}'"

--- a/benchmarks/config.sh
+++ b/benchmarks/config.sh
@@ -61,10 +61,10 @@ benchmark_config() {
             BENCH_FILTER_STYLE="exact"
             ;;
         tomswe)
-            BENCH_DATASET="tomswe"
+            BENCH_LOCAL_PATH="${HARNESS_DIR}/benchmarks/tomswe-harbor"
             BENCH_AGENT_CLASS="factory_harbor_agent:TomsweFactoryCeo"
             BENCH_AGENT_IMPORT_FLAG="--agent-import-path"
-            BENCH_FILTER_STYLE="glob"
+            BENCH_FILTER_STYLE="exact"
             ;;
         *)
             echo "ERROR: Unknown benchmark '${name}'"

--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -1,5 +1,6 @@
 """Harbor agent that runs ``factory ceo`` as a benchmark solver."""
 
+import hashlib
 import os
 import re
 from typing import override
@@ -30,6 +31,215 @@ COMMON_ENV_VARS = (
     "FACTORY_BENCHMARK",
     "FACTORY_INSTANCE_ID",
 )
+
+
+TOMSWE_PROFILES: list[dict[str, object]] = [
+    {
+        "profile_id": "P01",
+        "verbosity": "concise",
+        "question_timing": "upfront",
+        "response_style": "short",
+        "coding_preferences": [
+            "pytest over unittest",
+            "type hints required",
+            "f-strings over format()",
+            "single-responsibility functions",
+            "descriptive variable names",
+        ],
+    },
+    {
+        "profile_id": "P02",
+        "verbosity": "verbose",
+        "question_timing": "ongoing",
+        "response_style": "verbose",
+        "coding_preferences": [
+            "unittest with setUp/tearDown",
+            "docstrings on all public methods",
+            "defensive error handling",
+            "logging over print statements",
+            "class-based design patterns",
+            "comprehensive inline comments",
+        ],
+    },
+    {
+        "profile_id": "P03",
+        "verbosity": "concise",
+        "question_timing": "upfront",
+        "response_style": "verbose",
+        "coding_preferences": [
+            "functional programming style",
+            "list comprehensions over loops",
+            "dataclasses over plain dicts",
+            "minimal dependencies",
+            "pathlib over os.path",
+        ],
+    },
+    {
+        "profile_id": "P04",
+        "verbosity": "verbose",
+        "question_timing": "upfront",
+        "response_style": "short",
+        "coding_preferences": [
+            "pytest fixtures over setup methods",
+            "abstract base classes for interfaces",
+            "enum over string constants",
+            "context managers for resource handling",
+            "snake_case naming strictly enforced",
+            "no wildcard imports",
+        ],
+    },
+    {
+        "profile_id": "P05",
+        "verbosity": "concise",
+        "question_timing": "ongoing",
+        "response_style": "short",
+        "coding_preferences": [
+            "minimal comments — code should be self-documenting",
+            "early returns over nested if/else",
+            "prefer composition over inheritance",
+            "use walrus operator where it simplifies",
+            "keep functions under 20 lines",
+        ],
+    },
+    {
+        "profile_id": "P06",
+        "verbosity": "verbose",
+        "question_timing": "ongoing",
+        "response_style": "verbose",
+        "coding_preferences": [
+            "type hints with Optional and Union",
+            "property decorators over getters/setters",
+            "named tuples for lightweight data",
+            "explicit exception types over bare except",
+            "reStructuredText docstring format",
+            "separate test file per module",
+            "integration tests alongside unit tests",
+        ],
+    },
+    {
+        "profile_id": "P07",
+        "verbosity": "concise",
+        "question_timing": "upfront",
+        "response_style": "short",
+        "coding_preferences": [
+            "Google-style docstrings",
+            "absolute imports only",
+            "collections.abc over typing for containers",
+            "prefer standard library over third-party",
+            "guard clauses at function start",
+        ],
+    },
+    {
+        "profile_id": "P08",
+        "verbosity": "verbose",
+        "question_timing": "upfront",
+        "response_style": "verbose",
+        "coding_preferences": [
+            "Pydantic models for validation",
+            "structured logging with structlog",
+            "async/await for I/O operations",
+            "dependency injection pattern",
+            "conventional commits for git messages",
+            "100 char line length maximum",
+        ],
+    },
+    {
+        "profile_id": "P09",
+        "verbosity": "concise",
+        "question_timing": "ongoing",
+        "response_style": "verbose",
+        "coding_preferences": [
+            "pytest parametrize for test variants",
+            "builder pattern for complex objects",
+            "protocol classes over ABCs",
+            "match/case for dispatch logic",
+            "X | Y union syntax over Union",
+        ],
+    },
+    {
+        "profile_id": "P10",
+        "verbosity": "verbose",
+        "question_timing": "ongoing",
+        "response_style": "short",
+        "coding_preferences": [
+            "TDD approach — write tests first",
+            "black formatter compliance",
+            "isort for import ordering",
+            "no mutable default arguments",
+            "explicit __all__ exports",
+            "slots=True on dataclasses",
+        ],
+    },
+    {
+        "profile_id": "P11",
+        "verbosity": "concise",
+        "question_timing": "upfront",
+        "response_style": "short",
+        "coding_preferences": [
+            "LBYL over EAFP where possible",
+            "itertools for complex iterations",
+            "functools.lru_cache for memoization",
+            "private methods with underscore prefix",
+            "constants in UPPER_SNAKE_CASE",
+        ],
+    },
+    {
+        "profile_id": "P12",
+        "verbosity": "verbose",
+        "question_timing": "upfront",
+        "response_style": "verbose",
+        "coding_preferences": [
+            "EAFP over LBYL — ask forgiveness",
+            "contextlib utilities for context managers",
+            "textwrap.dedent for multiline strings",
+            "attrs over dataclasses",
+            "Numpy-style docstrings",
+            "hypothesis for property-based testing",
+            "separate constants module",
+        ],
+    },
+    {
+        "profile_id": "P13",
+        "verbosity": "concise",
+        "question_timing": "ongoing",
+        "response_style": "short",
+        "coding_preferences": [
+            "simple flat module structure",
+            "dict.get() over KeyError handling",
+            "one assert per test method",
+            "no global state",
+            "pure functions where possible",
+        ],
+    },
+    {
+        "profile_id": "P14",
+        "verbosity": "verbose",
+        "question_timing": "ongoing",
+        "response_style": "verbose",
+        "coding_preferences": [
+            "layered architecture (services/repos/models)",
+            "factory methods for object creation",
+            "immutable data structures preferred",
+            "typing.TypeAlias for complex types",
+            "rich library for CLI output",
+            "click over argparse for CLI",
+        ],
+    },
+    {
+        "profile_id": "P15",
+        "verbosity": "concise",
+        "question_timing": "upfront",
+        "response_style": "verbose",
+        "coding_preferences": [
+            "argparse for CLI — standard library only",
+            "os.environ.get with defaults",
+            "json over yaml for configuration",
+            "subprocess.run over os.system",
+            "tempfile module for temp resources",
+            "atexit for cleanup handlers",
+        ],
+    },
+]
 
 
 class FactoryCeo(BaseInstalledAgent):
@@ -389,7 +599,11 @@ class HarborIndexFactoryCeo(FactoryCeo):
 
 
 class TomsweFactoryCeo(FactoryCeo):
-    """Runs the deterministic tomswe workflow."""
+    """Runs the deterministic tomswe workflow with user-profile injection.
+
+    Reuses the swe-bench dataset but appends a deterministically-selected
+    ToM-SWE user profile to the task instruction before solving.
+    """
 
     @staticmethod
     @override
@@ -403,4 +617,176 @@ class TomsweFactoryCeo(FactoryCeo):
             'factory workflow run tomswe . '
             '2>&1 </dev/null | tee /logs/agent/factory-ceo.txt'
             '; exit 0'
+        )
+
+    @staticmethod
+    def _select_profile(instruction: str) -> dict[str, object]:
+        idx = int(hashlib.sha256(instruction.encode()).hexdigest(), 16) % len(TOMSWE_PROFILES)
+        return TOMSWE_PROFILES[idx]
+
+    @staticmethod
+    def _format_profile(profile: dict[str, object]) -> str:
+        prefs = profile["coding_preferences"]
+        assert isinstance(prefs, list)
+        prefs_str = "\n".join(f"- {p}" for p in prefs)
+        return (
+            f"## User Profile\n\n"
+            f"**Profile ID:** {profile['profile_id']}\n"
+            f"**Verbosity:** {profile['verbosity']}\n"
+            f"**Question Timing:** {profile['question_timing']}\n"
+            f"**Response Style:** {profile['response_style']}\n\n"
+            f"**Coding Preferences:**\n{prefs_str}\n"
+        )
+
+    @override
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        """Run factory tomswe workflow with an injected user profile."""
+        api_key = (
+            self._get_env("ANTHROPIC_API_KEY")
+            or self._get_env("ANTHROPIC_AUTH_TOKEN")
+            or ""
+        )
+
+        env: dict[str, str] = {
+            "ANTHROPIC_API_KEY": api_key,
+            "IS_SANDBOX": "1",
+            "CLAUDE_CONFIG_DIR": "/logs/agent/sessions",
+        }
+
+        if self.model_name:
+            env["ANTHROPIC_MODEL"] = self.model_name.split("/")[-1]
+
+        for var in COMMON_ENV_VARS:
+            val = self._get_env(var) or os.environ.get(var)
+            if val and var not in env:
+                env[var] = val
+
+        env = {k: v for k, v in env.items() if v}
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "mkdir -p $CLAUDE_CONFIG_DIR/debug "
+                "$CLAUDE_CONFIG_DIR/projects "
+                "$CLAUDE_CONFIG_DIR/shell-snapshots "
+                "$CLAUDE_CONFIG_DIR/statsig "
+                "$CLAUDE_CONFIG_DIR/todos "
+                "$CLAUDE_CONFIG_DIR/skills"
+            ),
+            env=env,
+        )
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "cat > ./factory.md << 'FACTORYEOF'\n"
+                "---\n"
+                "goal: Solve the given coding task\n"
+                "---\n"
+                "FACTORYEOF"
+            ),
+            env=env,
+        )
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                'set -e; '
+                'if [ ! -d .git ]; then git init -b main; fi && '
+                'git config user.name "Factory Agent" && '
+                'git config user.email "factory@agent.local" && '
+                'printf "/proc\\n/sys\\n/dev\\n/run\\n/tmp\\n/var\\n/root\\n'
+                '/home\\n/usr\\n/bin\\n/sbin\\n/lib\\n/lib64\\n/etc\\n'
+                '/boot\\n/mnt\\n/opt\\n/srv\\n/media\\n/logs\\n" > .gitignore && '
+                'git add -A && '
+                'git commit -m "initial state" --allow-empty'
+            ),
+            env=env,
+        )
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                'mkdir -p .factory && '
+                'printf \'{}\\n\' > .factory/config.json && '
+                'printf \'{"human_reviewed": true, "dimensions": []}\\n\' > .factory/eval_profile.json'
+            ),
+            env=env,
+        )
+
+        # Inject a deterministically-selected user profile into the instruction
+        profile = self._select_profile(instruction)
+        augmented = instruction + "\n\n" + self._format_profile(profile)
+
+        await self.exec_as_agent(
+            environment,
+            command=f"cat > /tmp/task-instruction.md << 'INSTREOF'\n{augmented}\nINSTREOF",
+            env=env,
+        )
+
+        await self.exec_as_agent(
+            environment,
+            command=self._get_factory_command(),
+            env=env,
+        )
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "cp /testbed/.factory/trace_id.txt /logs/agent/trace_id.txt 2>/dev/null || "
+                "cp .factory/trace_id.txt /logs/agent/trace_id.txt 2>/dev/null; "
+                "exit 0"
+            ),
+            env=env,
+        )
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set +e; "
+                'FACTORY_BRANCH=$(git branch --list "factory/*" | head -1 | tr -d " *"); '
+                'if [ -n "$FACTORY_BRANCH" ]; then '
+                '  echo "Merging factory branch: $FACTORY_BRANCH"; '
+                '  git merge "$FACTORY_BRANCH" --no-edit 2>/dev/null '
+                '    || git cherry-pick "$FACTORY_BRANCH" --no-edit 2>/dev/null '
+                "    || true; "
+                "fi; "
+                'if [ -z "$FACTORY_BRANCH" ]; then '
+                '  echo "No factory branch, finding orphaned commits..."; '
+                "  ORPHAN_COMMITS=$(git fsck --unreachable --no-reflogs 2>/dev/null "
+                "    | grep 'unreachable commit' | awk '{print \\$3}'); "
+                '  if [ -n "$ORPHAN_COMMITS" ]; then '
+                '    BEST_COMMIT=""; '
+                "    BEST_TIME=0; "
+                "    for SHA in $ORPHAN_COMMITS; do "
+                '      COMMIT_TIME=$(git show -s --format=\'%ct\' "$SHA" 2>/dev/null || echo 0); '
+                '      if [ "$COMMIT_TIME" -gt "$BEST_TIME" ]; then '
+                "        BEST_TIME=$COMMIT_TIME; "
+                "        BEST_COMMIT=$SHA; "
+                "      fi; "
+                "    done; "
+                '    if [ -n "$BEST_COMMIT" ]; then '
+                '      echo "Recovering from orphan tip: $BEST_COMMIT"; '
+                '      echo "  Message: $(git log -1 --format=\'%s\' $BEST_COMMIT 2>/dev/null)"; '
+                '      git checkout "$BEST_COMMIT" -- . 2>/dev/null || true; '
+                "      git checkout HEAD -- .factory/ eval/ factory.md 2>/dev/null || true; "
+                "      rm -rf .factory/ eval/ factory.md 2>/dev/null || true; "
+                "    fi; "
+                "  fi; "
+                "fi; "
+                'for wt in .factory-worktrees/*/; do '
+                '  if [ -d "$wt" ]; then '
+                '    echo "Recovering files from worktree: $wt"; '
+                "    rsync -a --exclude='.git' --exclude='.factory' "
+                '      "$wt" ./ 2>/dev/null || true; '
+                "  fi; "
+                "done; "
+                "exit 0"
+            ),
+            env=env,
         )

--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -386,3 +386,21 @@ class HarborIndexFactoryCeo(FactoryCeo):
     @override
     def name() -> str:
         return "harbor-index-factory-ceo"
+
+
+class TomsweFactoryCeo(FactoryCeo):
+    """Runs the deterministic tomswe workflow."""
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "tomswe-factory-ceo"
+
+    @override
+    def _get_factory_command(self) -> str:
+        return (
+            'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; '
+            'factory workflow run tomswe . '
+            '2>&1 </dev/null | tee /logs/agent/factory-ceo.txt'
+            '; exit 0'
+        )

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -7,7 +7,11 @@ set -euo pipefail
 # Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]
 #
 # Arguments:
+<<<<<<< HEAD
 #   benchmark      Required. One of: swebench, featurebench, terminalbench, programbench, legacybench, harborindex
+=======
+#   benchmark      Required. One of: swebench, featurebench, terminalbench, programbench, legacybench, tomswe
+>>>>>>> b91b1e4 (feat: add ToM-SWE local Harbor task and update runner config)
 #   instance_id    Required. Benchmark-specific instance identifier
 #
 # Options:
@@ -23,7 +27,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ $# -lt 2 ]; then
     echo "Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]"
     echo ""
+<<<<<<< HEAD
     echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex"
+=======
+    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, tomswe"
+>>>>>>> b91b1e4 (feat: add ToM-SWE local Harbor task and update runner config)
     exit 1
 fi
 
@@ -58,10 +66,10 @@ esac
 
 # Validate benchmark
 case "${BENCHMARK}" in
-    swebench|featurebench|terminalbench|programbench|legacybench|harborindex) ;;
+    swebench|featurebench|terminalbench|programbench|legacybench|harborindex|tomswe) ;;
     *)
         echo "ERROR: Unknown benchmark '${BENCHMARK}'"
-        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex"
+        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe"
         exit 1
         ;;
 esac

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -7,11 +7,7 @@ set -euo pipefail
 # Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]
 #
 # Arguments:
-<<<<<<< HEAD
-#   benchmark      Required. One of: swebench, featurebench, terminalbench, programbench, legacybench, harborindex
-=======
-#   benchmark      Required. One of: swebench, featurebench, terminalbench, programbench, legacybench, tomswe
->>>>>>> b91b1e4 (feat: add ToM-SWE local Harbor task and update runner config)
+#   benchmark      Required. One of: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe
 #   instance_id    Required. Benchmark-specific instance identifier
 #
 # Options:
@@ -27,11 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ $# -lt 2 ]; then
     echo "Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]"
     echo ""
-<<<<<<< HEAD
-    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex"
-=======
-    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, tomswe"
->>>>>>> b91b1e4 (feat: add ToM-SWE local Harbor task and update runner config)
+    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe"
     exit 1
 fi
 

--- a/benchmarks/tomswe-harbor/csv-export/environment/Dockerfile
+++ b/benchmarks/tomswe-harbor/csv-export/environment/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y --no-install-recommends git curl procps ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+
+RUN printf 'def to_csv(rows, headers):\n    lines = [",".join(headers)]\n    for row in rows:\n        lines.append(",".join(str(v) for v in row.values()))\n    return "\\n".join(lines) + "\\n"\n' > /workspace/exporter.py
+
+RUN printf 'import csv\nimport io\nimport pytest\nfrom exporter import to_csv\n\ndef test_basic():\n    rows = [{"name": "Alice", "age": "30"}]\n    result = to_csv(rows, ["name", "age"])\n    reader = csv.reader(io.StringIO(result))\n    data = list(reader)\n    assert data == [["name", "age"], ["Alice", "30"]]\n\ndef test_comma_in_field():\n    rows = [{"name": "Smith, John", "age": "25"}]\n    result = to_csv(rows, ["name", "age"])\n    reader = csv.reader(io.StringIO(result))\n    data = list(reader)\n    assert data == [["name", "age"], ["Smith, John", "25"]]\n\ndef test_quote_in_field():\n    rows = [{"name": '"The Boss"', "age": "40"}]\n    result = to_csv(rows, ["name", "age"])\n    reader = csv.reader(io.StringIO(result))\n    data = list(reader)\n    assert data[1][0] == '"'"'"The Boss"'"'"'\n\ndef test_multiple_rows():\n    rows = [\n        {"name": "Alice", "age": "30"},\n        {"name": "Bob, Jr.", "age": "25"},\n    ]\n    result = to_csv(rows, ["name", "age"])\n    reader = csv.reader(io.StringIO(result))\n    data = list(reader)\n    assert len(data) == 3\n    assert data[2] == ["Bob, Jr.", "25"]\n' > /workspace/test_exporter.py
+
+RUN pip install pytest
+RUN useradd -m -s /bin/bash agent 2>/dev/null || true && chown -R agent:agent /workspace
+RUN git config --system safe.directory /workspace && git config --system safe.directory '*'
+USER agent
+WORKDIR /workspace
+RUN git config --global user.name "Factory Agent" && \
+    git config --global user.email "factory@agent.local" && \
+    git config --global init.defaultBranch main && \
+    git init && \
+    printf "/proc\n/sys\n/dev\n/run\n/tmp\n/var\n/root\n/home\n/usr\n/bin\n/sbin\n/lib\n/lib64\n/etc\n/boot\n/mnt\n/opt\n/srv\n/media\n/logs\n" > .gitignore && \
+    git add -A && git commit -m "initial state"
+USER root

--- a/benchmarks/tomswe-harbor/csv-export/instruction.md
+++ b/benchmarks/tomswe-harbor/csv-export/instruction.md
@@ -1,0 +1,9 @@
+The export feature is broken for some records. When users download their data, certain rows come out garbled. It works fine most of the time though.
+
+## User Profile
+You are working with a data engineer who has these preferences:
+- **Verbosity:** verbose — likes to understand the full picture before changes
+- **Testing:** pytest, always test edge cases with special characters
+- **Code style:** use the csv module from stdlib (no pandas for simple CSV ops), type hints
+- **Git:** descriptive commit messages explaining the why, not just the what
+- **Data handling:** never silently drop or modify data, raise on corruption

--- a/benchmarks/tomswe-harbor/csv-export/task.toml
+++ b/benchmarks/tomswe-harbor/csv-export/task.toml
@@ -1,0 +1,26 @@
+schema_version = "1.3"
+
+[task]
+name = "tomswe/csv-export"
+description = "Fix CSV export to handle fields with commas and quotes"
+authors = []
+keywords = ["tomswe", "csv", "quoting"]
+
+[metadata]
+difficulty = "medium"
+category = "programming"
+
+[environment]
+network_mode = "public"
+build_timeout_sec = 900.0
+cpus = 2
+memory_mb = 4096
+storage_mb = 10240
+gpus = 0
+mcp_servers = []
+
+[agent]
+timeout_sec = 3600.0
+
+[verifier]
+timeout_sec = 300.0

--- a/benchmarks/tomswe-harbor/csv-export/tests/test.sh
+++ b/benchmarks/tomswe-harbor/csv-export/tests/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace
+pip install pytest -q 2>/dev/null
+RESULT=$(python -m pytest test_exporter.py -v 2>&1) || true
+if echo "$RESULT" | grep -q 'passed' && ! echo "$RESULT" | grep -q 'failed'; then
+    echo '{"reward": 1.0}' > /logs/verifier/reward.json
+else
+    echo '{"reward": 0.0}' > /logs/verifier/reward.json
+fi
+echo "$RESULT"

--- a/benchmarks/tomswe-harbor/date-parse/environment/Dockerfile
+++ b/benchmarks/tomswe-harbor/date-parse/environment/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y --no-install-recommends git curl procps ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+
+RUN printf 'from datetime import datetime\n\ndef parse_date(date_str):\n    return datetime.strptime(date_str, "%%Y-%%m-%%d")\n' > /workspace/dateutil.py
+
+RUN printf 'import pytest\nfrom datetime import datetime\nfrom dateutil import parse_date\n\ndef test_iso_format():\n    result = parse_date("2024-01-15")\n    assert result == datetime(2024, 1, 15)\n\ndef test_us_format():\n    result = parse_date("01/15/2024")\n    assert result == datetime(2024, 1, 15)\n\ndef test_eu_format():\n    result = parse_date("15-01-2024")\n    assert result == datetime(2024, 1, 15)\n\ndef test_invalid_raises():\n    with pytest.raises(ValueError):\n        parse_date("not-a-date")\n\ndef test_iso_with_time():\n    result = parse_date("2024-01-15T10:30:00")\n    assert result == datetime(2024, 1, 15, 10, 30, 0)\n' > /workspace/test_dateutil.py
+
+RUN pip install pytest
+RUN useradd -m -s /bin/bash agent 2>/dev/null || true && chown -R agent:agent /workspace
+RUN git config --system safe.directory /workspace && git config --system safe.directory '*'
+USER agent
+WORKDIR /workspace
+RUN git config --global user.name "Factory Agent" && \
+    git config --global user.email "factory@agent.local" && \
+    git config --global init.defaultBranch main && \
+    git init && \
+    printf "/proc\n/sys\n/dev\n/run\n/tmp\n/var\n/root\n/home\n/usr\n/bin\n/sbin\n/lib\n/lib64\n/etc\n/boot\n/mnt\n/opt\n/srv\n/media\n/logs\n" > .gitignore && \
+    git add -A && git commit -m "initial state"
+USER root

--- a/benchmarks/tomswe-harbor/date-parse/instruction.md
+++ b/benchmarks/tomswe-harbor/date-parse/instruction.md
@@ -1,0 +1,9 @@
+The date handling is causing issues for some of our international users. Not sure exactly what's going wrong but timestamps seem weird.
+
+## User Profile
+You are working with a developer who has these preferences:
+- **Verbosity:** concise — gets straight to the point
+- **Testing:** pytest with parametrize for edge cases
+- **Code style:** type hints required, imports sorted with isort conventions, single-responsibility functions
+- **Git:** conventional commits (fix:, feat:, refactor:)
+- **Error handling:** explicit exceptions over silent failures, never use bare except

--- a/benchmarks/tomswe-harbor/date-parse/task.toml
+++ b/benchmarks/tomswe-harbor/date-parse/task.toml
@@ -1,0 +1,26 @@
+schema_version = "1.3"
+
+[task]
+name = "tomswe/date-parse"
+description = "Fix date parsing to handle multiple date formats"
+authors = []
+keywords = ["tomswe", "date", "parsing"]
+
+[metadata]
+difficulty = "medium"
+category = "programming"
+
+[environment]
+network_mode = "public"
+build_timeout_sec = 900.0
+cpus = 2
+memory_mb = 4096
+storage_mb = 10240
+gpus = 0
+mcp_servers = []
+
+[agent]
+timeout_sec = 3600.0
+
+[verifier]
+timeout_sec = 300.0

--- a/benchmarks/tomswe-harbor/date-parse/tests/test.sh
+++ b/benchmarks/tomswe-harbor/date-parse/tests/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace
+pip install pytest -q 2>/dev/null
+RESULT=$(python -m pytest test_dateutil.py -v 2>&1) || true
+if echo "$RESULT" | grep -q 'passed' && ! echo "$RESULT" | grep -q 'failed'; then
+    echo '{"reward": 1.0}' > /logs/verifier/reward.json
+else
+    echo '{"reward": 0.0}' > /logs/verifier/reward.json
+fi
+echo "$RESULT"

--- a/benchmarks/tomswe-harbor/dedup-list/environment/Dockerfile
+++ b/benchmarks/tomswe-harbor/dedup-list/environment/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y --no-install-recommends git curl procps ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+
+RUN printf 'def deduplicate(items):\n    return list(set(items))\n' > /workspace/dedup.py
+
+RUN printf 'import pytest\nfrom dedup import deduplicate\n\ndef test_basic_dedup():\n    assert deduplicate([1, 2, 2, 3]) == [1, 2, 3]\n\ndef test_preserves_order():\n    assert deduplicate([3, 1, 2, 1, 3]) == [3, 1, 2]\n\ndef test_strings():\n    assert deduplicate(["b", "a", "b", "c", "a"]) == ["b", "a", "c"]\n\ndef test_empty():\n    assert deduplicate([]) == []\n\ndef test_no_duplicates():\n    assert deduplicate([1, 2, 3]) == [1, 2, 3]\n' > /workspace/test_dedup.py
+
+RUN pip install pytest
+RUN useradd -m -s /bin/bash agent 2>/dev/null || true && chown -R agent:agent /workspace
+RUN git config --system safe.directory /workspace && git config --system safe.directory '*'
+USER agent
+WORKDIR /workspace
+RUN git config --global user.name "Factory Agent" && \
+    git config --global user.email "factory@agent.local" && \
+    git config --global init.defaultBranch main && \
+    git init && \
+    printf "/proc\n/sys\n/dev\n/run\n/tmp\n/var\n/root\n/home\n/usr\n/bin\n/sbin\n/lib\n/lib64\n/etc\n/boot\n/mnt\n/opt\n/srv\n/media\n/logs\n" > .gitignore && \
+    git add -A && git commit -m "initial state"
+USER root

--- a/benchmarks/tomswe-harbor/dedup-list/instruction.md
+++ b/benchmarks/tomswe-harbor/dedup-list/instruction.md
@@ -1,0 +1,9 @@
+We're getting duplicate entries in the output. The data cleanup step doesn't seem to be working properly — users want unique results but the order matters to them.
+
+## User Profile
+You are working with a developer who has these preferences:
+- **Verbosity:** concise
+- **Testing:** pytest, fixtures for test data
+- **Code style:** functional style preferred (no mutation, use map/filter/reduce), type hints, f-strings over .format()
+- **Git:** conventional commits
+- **Performance:** avoid O(n²) solutions, document time complexity

--- a/benchmarks/tomswe-harbor/dedup-list/task.toml
+++ b/benchmarks/tomswe-harbor/dedup-list/task.toml
@@ -1,0 +1,26 @@
+schema_version = "1.3"
+
+[task]
+name = "tomswe/dedup-list"
+description = "Fix deduplication to preserve insertion order"
+authors = []
+keywords = ["tomswe", "dedup", "ordering"]
+
+[metadata]
+difficulty = "easy"
+category = "programming"
+
+[environment]
+network_mode = "public"
+build_timeout_sec = 900.0
+cpus = 2
+memory_mb = 4096
+storage_mb = 10240
+gpus = 0
+mcp_servers = []
+
+[agent]
+timeout_sec = 3600.0
+
+[verifier]
+timeout_sec = 300.0

--- a/benchmarks/tomswe-harbor/dedup-list/tests/test.sh
+++ b/benchmarks/tomswe-harbor/dedup-list/tests/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace
+pip install pytest -q 2>/dev/null
+RESULT=$(python -m pytest test_dedup.py -v 2>&1) || true
+if echo "$RESULT" | grep -q 'passed' && ! echo "$RESULT" | grep -q 'failed'; then
+    echo '{"reward": 1.0}' > /logs/verifier/reward.json
+else
+    echo '{"reward": 0.0}' > /logs/verifier/reward.json
+fi
+echo "$RESULT"

--- a/benchmarks/tomswe-harbor/discount-calc/environment/Dockerfile
+++ b/benchmarks/tomswe-harbor/discount-calc/environment/Dockerfile
@@ -11,5 +11,21 @@ RUN printf 'import pytest\nfrom pricing import calculate_total\n\ndef test_basic
 
 RUN pip install pytest
 
-# Do NOT git init here — FactoryCeo.run() handles git initialization
 RUN useradd -m -s /bin/bash agent 2>/dev/null || true && chown -R agent:agent /workspace
+
+# Mark /workspace as safe for ALL users (root writes during Harbor install
+# phase cause git safe.directory ownership mismatches for the agent user).
+RUN git config --system safe.directory /workspace && \
+    git config --system safe.directory '*'
+
+# Pre-initialize git as agent with full repo + initial commit.
+USER agent
+WORKDIR /workspace
+RUN git config --global user.name "Factory Agent" && \
+    git config --global user.email "factory@agent.local" && \
+    git config --global init.defaultBranch main && \
+    git init && \
+    printf "/proc\n/sys\n/dev\n/run\n/tmp\n/var\n/root\n/home\n/usr\n/bin\n/sbin\n/lib\n/lib64\n/etc\n/boot\n/mnt\n/opt\n/srv\n/media\n/logs\n" > .gitignore && \
+    git add -A && \
+    git commit -m "initial state"
+USER root

--- a/benchmarks/tomswe-harbor/discount-calc/environment/Dockerfile
+++ b/benchmarks/tomswe-harbor/discount-calc/environment/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git curl procps ca-certificates && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Create the sample project with a discount calculation bug
+RUN mkdir -p /workspace && printf 'def calculate_total(items):\n    total = 0\n    for item in items:\n        total += item["price"]\n    return total\n' > /workspace/pricing.py
+
+RUN printf 'import pytest\nfrom pricing import calculate_total\n\ndef test_basic_total():\n    items = [{"price": 10.0}, {"price": 20.0}]\n    assert calculate_total(items) == 30.0\n\ndef test_with_discount():\n    items = [{"price": 100.0, "discount": 0.1}, {"price": 50.0, "discount": 0.2}]\n    assert calculate_total(items) == 130.0  # 90 + 40\n\ndef test_no_discount():\n    items = [{"price": 25.0}, {"price": 75.0}]\n    assert calculate_total(items) == 100.0\n\ndef test_zero_discount():\n    items = [{"price": 50.0, "discount": 0.0}]\n    assert calculate_total(items) == 50.0\n' > /workspace/test_pricing.py
+
+RUN pip install pytest
+
+RUN git init -b main /workspace && cd /workspace && git add -A && git config user.email 'test@test.com' && git config user.name 'Test' && git commit -m 'initial'
+
+RUN useradd -m -s /bin/bash agent 2>/dev/null || true && chown -R agent:agent /workspace

--- a/benchmarks/tomswe-harbor/discount-calc/environment/Dockerfile
+++ b/benchmarks/tomswe-harbor/discount-calc/environment/Dockerfile
@@ -5,12 +5,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends git curl procps
 WORKDIR /workspace
 
 # Create the sample project with a discount calculation bug
-RUN mkdir -p /workspace && printf 'def calculate_total(items):\n    total = 0\n    for item in items:\n        total += item["price"]\n    return total\n' > /workspace/pricing.py
+RUN printf 'def calculate_total(items):\n    total = 0\n    for item in items:\n        total += item["price"]\n    return total\n' > /workspace/pricing.py
 
 RUN printf 'import pytest\nfrom pricing import calculate_total\n\ndef test_basic_total():\n    items = [{"price": 10.0}, {"price": 20.0}]\n    assert calculate_total(items) == 30.0\n\ndef test_with_discount():\n    items = [{"price": 100.0, "discount": 0.1}, {"price": 50.0, "discount": 0.2}]\n    assert calculate_total(items) == 130.0  # 90 + 40\n\ndef test_no_discount():\n    items = [{"price": 25.0}, {"price": 75.0}]\n    assert calculate_total(items) == 100.0\n\ndef test_zero_discount():\n    items = [{"price": 50.0, "discount": 0.0}]\n    assert calculate_total(items) == 50.0\n' > /workspace/test_pricing.py
 
 RUN pip install pytest
 
-RUN git init -b main /workspace && cd /workspace && git add -A && git config user.email 'test@test.com' && git config user.name 'Test' && git commit -m 'initial'
-
+# Do NOT git init here — FactoryCeo.run() handles git initialization
 RUN useradd -m -s /bin/bash agent 2>/dev/null || true && chown -R agent:agent /workspace

--- a/benchmarks/tomswe-harbor/discount-calc/instruction.md
+++ b/benchmarks/tomswe-harbor/discount-calc/instruction.md
@@ -1,0 +1,9 @@
+The pricing module isn't quite right. Some customers are complaining about their totals. Can you take a look?
+
+## User Profile
+You are working with a developer who has these preferences:
+- **Verbosity:** concise — prefers short responses, gets impatient with long explanations
+- **Testing:** always uses pytest, expects comprehensive test coverage
+- **Code style:** type hints on all function signatures, descriptive variable names
+- **Git:** conventional commit messages (feat:, fix:, etc.)
+- **Documentation:** minimal inline comments, prefers self-documenting code

--- a/benchmarks/tomswe-harbor/discount-calc/task.toml
+++ b/benchmarks/tomswe-harbor/discount-calc/task.toml
@@ -1,0 +1,33 @@
+schema_version = "1.3"
+
+[task]
+name = "tomswe/discount-calc"
+description = "Fix pricing module to handle discount calculations correctly"
+authors = []
+keywords = ["tomswe", "pricing", "discount"]
+
+[metadata]
+difficulty = "easy"
+category = "programming"
+tags = ["pricing", "bug-fix"]
+
+[environment]
+network_mode = "public"
+build_timeout_sec = 900.0
+cpus = 2
+memory_mb = 4096
+storage_mb = 10240
+gpus = 0
+mcp_servers = []
+
+[environment.env]
+
+[agent]
+timeout_sec = 3600.0
+
+[verifier]
+timeout_sec = 300.0
+
+[verifier.env]
+
+[solution.env]

--- a/benchmarks/tomswe-harbor/discount-calc/tests/test.sh
+++ b/benchmarks/tomswe-harbor/discount-calc/tests/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace
+pip install pytest -q 2>/dev/null
+RESULT=$(pytest test_pricing.py -v 2>&1) || true
+if echo "$RESULT" | grep -q 'passed' && ! echo "$RESULT" | grep -q 'failed'; then
+    echo '{"reward": 1.0}' > /logs/verifier/reward.json
+else
+    echo '{"reward": 0.0}' > /logs/verifier/reward.json
+fi
+echo "$RESULT"

--- a/benchmarks/tomswe-harbor/sort-order/environment/Dockerfile
+++ b/benchmarks/tomswe-harbor/sort-order/environment/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y --no-install-recommends git curl procps ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /workspace
+
+RUN printf 'def sort_names(names):\n    return sorted(names)\n' > /workspace/sorter.py
+
+RUN printf 'from sorter import sort_names\nimport unittest\n\nclass TestSorter(unittest.TestCase):\n    def test_basic(self):\n        self.assertEqual(sort_names(["banana", "apple"]), ["apple", "banana"])\n\n    def test_case_insensitive(self):\n        result = sort_names(["banana", "Apple", "cherry"])\n        self.assertEqual(result, ["Apple", "banana", "cherry"])\n\n    def test_empty(self):\n        self.assertEqual(sort_names([]), [])\n\n    def test_single(self):\n        self.assertEqual(sort_names(["only"]), ["only"])\n\nif __name__ == "__main__":\n    unittest.main()\n' > /workspace/test_sorter.py
+
+RUN pip install pytest
+RUN useradd -m -s /bin/bash agent 2>/dev/null || true && chown -R agent:agent /workspace
+RUN git config --system safe.directory /workspace && git config --system safe.directory '*'
+USER agent
+WORKDIR /workspace
+RUN git config --global user.name "Factory Agent" && \
+    git config --global user.email "factory@agent.local" && \
+    git config --global init.defaultBranch main && \
+    git init && \
+    printf "/proc\n/sys\n/dev\n/run\n/tmp\n/var\n/root\n/home\n/usr\n/bin\n/sbin\n/lib\n/lib64\n/etc\n/boot\n/mnt\n/opt\n/srv\n/media\n/logs\n" > .gitignore && \
+    git add -A && git commit -m "initial state"
+USER root

--- a/benchmarks/tomswe-harbor/sort-order/instruction.md
+++ b/benchmarks/tomswe-harbor/sort-order/instruction.md
@@ -1,0 +1,9 @@
+Something's off with how items are being ordered in the results. Users keep saying the output doesn't look right.
+
+## User Profile
+You are working with a developer who has these preferences:
+- **Verbosity:** verbose — appreciates detailed explanations and thorough breakdowns
+- **Testing:** prefers unittest over pytest, likes setUp/tearDown patterns
+- **Code style:** no type hints, prefers shorter variable names, heavy use of list comprehensions
+- **Git:** simple commit messages, no conventional commits
+- **Documentation:** extensive docstrings on all public functions

--- a/benchmarks/tomswe-harbor/sort-order/task.toml
+++ b/benchmarks/tomswe-harbor/sort-order/task.toml
@@ -1,0 +1,26 @@
+schema_version = "1.3"
+
+[task]
+name = "tomswe/sort-order"
+description = "Fix sorting to handle case-insensitive alphabetical ordering"
+authors = []
+keywords = ["tomswe", "sorting", "case-sensitivity"]
+
+[metadata]
+difficulty = "easy"
+category = "programming"
+
+[environment]
+network_mode = "public"
+build_timeout_sec = 900.0
+cpus = 2
+memory_mb = 4096
+storage_mb = 10240
+gpus = 0
+mcp_servers = []
+
+[agent]
+timeout_sec = 3600.0
+
+[verifier]
+timeout_sec = 300.0

--- a/benchmarks/tomswe-harbor/sort-order/tests/test.sh
+++ b/benchmarks/tomswe-harbor/sort-order/tests/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace
+pip install pytest -q 2>/dev/null
+RESULT=$(python -m pytest test_sorter.py -v 2>&1) || true
+if echo "$RESULT" | grep -q 'passed' && ! echo "$RESULT" | grep -q 'failed'; then
+    echo '{"reward": 1.0}' > /logs/verifier/reward.json
+else
+    echo '{"reward": 0.0}' > /logs/verifier/reward.json
+fi
+echo "$RESULT"

--- a/factory/workflow/contributed/tomswe/README.md
+++ b/factory/workflow/contributed/tomswe/README.md
@@ -1,0 +1,43 @@
+# ToM-SWE Benchmark Workflow
+
+Preference-aware task solving under deliberately vague instructions.
+
+[ToM-SWE](https://github.com/All-Hands-AI/ToM-SWE) (ICML 2026, OpenHands) evaluates
+stateful SWE agents via 15 developer profiles. Tasks are deliberately vague — the agent
+must infer user intent from context clues and follow the user's coding preferences
+(naming conventions, testing approach, git workflow, documentation habits) as described
+in an embedded user profile.
+
+## Pipeline
+
+```
+study ──► builder ──► gate_verify ──► auto_merge
+              ▲            │
+              └── RELOOP ──┘
+```
+
+- **study**: Discover repo structure, read task instruction with embedded user profile
+- **builder**: Opus agent (7200s, 3 iterations) — infer intent, apply preferences, implement, test, commit
+- **gate_verify**: fn evaluator — check commits exist + test pass/fail signals
+- **auto_merge**: Fast-forward main to the working branch
+
+## Usage
+
+```bash
+factory workflow run tomswe .
+```
+
+## What Makes ToM-SWE Different
+
+| Aspect | SWE-bench | ToM-SWE |
+|--------|-----------|---------|
+| Instructions | Explicit bug description | Deliberately vague |
+| User context | None | Embedded developer profile |
+| Agent behavior | Fix the described bug | Infer intent + follow preferences |
+| Evaluation | Patch correctness | Task resolution + preference alignment |
+
+## MVP Approach
+
+The user profile is embedded directly in `/tmp/task-instruction.md` as a `## User Profile`
+section. The builder reads both the vague task description and the profile as static context.
+No sidecar services, no LLM-powered simulator, no session management.

--- a/factory/workflow/contributed/tomswe/__init__.py
+++ b/factory/workflow/contributed/tomswe/__init__.py
@@ -1,0 +1,3 @@
+from .workflow import meta, workflow
+
+__all__ = ["meta", "workflow"]

--- a/factory/workflow/contributed/tomswe/test_workflow.py
+++ b/factory/workflow/contributed/tomswe/test_workflow.py
@@ -1,0 +1,196 @@
+"""Tests for the ToM-SWE contributed workflow."""
+
+from __future__ import annotations
+
+from factory.models import ProjectState
+from factory.workflow.contributed.tomswe import meta, workflow
+from factory.workflow.definitions import register_all
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    FnNode,
+    GateNode,
+    VerdictType,
+)
+
+
+class TestTomsweWorkflow:
+    """Tests for tomswe workflow graph structure."""
+
+    def test_workflow_name(self) -> None:
+        wf = workflow()
+        assert wf.name == "tomswe"
+
+    def test_node_count(self) -> None:
+        """Workflow has exactly 4 nodes: study, builder, gate_verify, auto_merge."""
+        wf = workflow()
+        assert len(wf.nodes) == 4
+        assert set(wf.nodes.keys()) == {"study", "builder", "gate_verify", "auto_merge"}
+
+    def test_start_node(self) -> None:
+        wf = workflow()
+        assert wf.start_node == "study"
+
+    def test_graph_validates(self) -> None:
+        """Graph passes structural validation (DAG check, edge consistency)."""
+        wf = workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Workflow has validation issues: {issues}"
+
+    def test_edge_count(self) -> None:
+        """4 edges: study->builder, builder->gate, gate->merge, gate->builder RELOOP."""
+        wf = workflow()
+        assert len(wf.edges) == 4
+
+    def test_study_node_is_fn(self) -> None:
+        wf = workflow()
+        node = wf.nodes["study"]
+        assert isinstance(node, FnNode)
+        assert "find" in node.command
+        assert "task-instruction" in node.command
+
+    def test_builder_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.BUILDER
+        assert node.max_iterations == 3
+        assert node.timeout == 7200
+        assert "preference" in node.prompt_template.lower()
+        assert "vague" in node.prompt_template.lower()
+        assert "infer" in node.prompt_template.lower()
+
+    def test_gate_verify_is_fn_evaluator(self) -> None:
+        """Gate uses fn evaluator (not agent) for speed and determinism."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert node.evaluator_command is not None
+        assert "pass:" in node.evaluator_command
+        assert "reloop:" in node.evaluator_command
+        assert "fail:" in node.evaluator_command
+
+    def test_auto_merge_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["auto_merge"]
+        assert isinstance(node, FnNode)
+        assert "git update-ref" in node.command
+
+    def test_proceed_edge_to_merge(self) -> None:
+        """gate_verify has a PROCEED edge to auto_merge."""
+        wf = workflow()
+        proceed_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "auto_merge"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(proceed_edges) == 1
+
+    def test_reloop_edge_exists(self) -> None:
+        """gate_verify has a RELOOP edge back to builder."""
+        wf = workflow()
+        reloop_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "builder"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(reloop_edges) == 1
+
+    def test_no_eval_infrastructure(self) -> None:
+        """No factory eval nodes (begin, finalize, precheck, study)."""
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "begin" not in node_ids
+        assert "finalize" not in node_ids
+        assert "gate_precheck" not in node_ids
+        for node in wf.nodes.values():
+            if isinstance(node, FnNode):
+                assert "factory eval" not in node.command
+                assert "factory finalize" not in node.command
+                assert "factory precheck" not in node.command
+                assert "factory begin" not in node.command
+
+    def test_no_deep_qa_nodes(self) -> None:
+        """No deep-QA pipeline nodes."""
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "health_checker" not in node_ids
+        assert "code_reviewer" not in node_ids
+        assert "adversarial_tester" not in node_ids
+        assert "gate_review" not in node_ids
+
+    def test_no_research_strategy_nodes(self) -> None:
+        """No researcher or strategist nodes."""
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "researcher" not in node_ids
+        assert "strategist" not in node_ids
+        assert "gate_research" not in node_ids
+        assert "gate_strategy" not in node_ids
+
+
+class TestTomsweTerminal:
+    """Tests for the terminal flag on tomswe workflow."""
+
+    def test_workflow_is_terminal(self) -> None:
+        wf = workflow()
+        assert wf.terminal is True
+
+    def test_registered_workflow_is_terminal(self) -> None:
+        workflows = register_all()
+        assert workflows["tomswe"].terminal is True
+
+
+class TestTomsweTrigger:
+    """Tests for the trigger function."""
+
+    def test_trigger_matches_tomswe_mode(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "tomswe"})
+
+    def test_trigger_matches_without_factory(self) -> None:
+        """Trigger fires on mode alone, regardless of project state."""
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.NO_REPO, {"mode": "tomswe"})
+        assert wf.trigger(ProjectState.NO_FACTORY, {"mode": "tomswe"})
+
+    def test_trigger_rejects_other_modes(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "swebench"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+class TestTomsweRegistration:
+    """Tests for registration in the global workflow registry."""
+
+    def test_registered_in_register_all(self) -> None:
+        workflows = register_all()
+        assert "tomswe" in workflows
+
+    def test_registered_workflow_valid(self) -> None:
+        workflows = register_all()
+        wf = workflows["tomswe"]
+        issues = wf.validate_graph()
+        assert issues == [], f"Registered tomswe workflow has issues: {issues}"
+
+    def test_registered_workflow_has_trigger(self) -> None:
+        workflows = register_all()
+        wf = workflows["tomswe"]
+        assert wf.trigger is not None
+
+
+class TestTomsweMeta:
+    """Tests for the module-level meta dict."""
+
+    def test_meta_has_name(self) -> None:
+        assert meta["name"] == "tomswe"
+
+    def test_meta_has_description(self) -> None:
+        assert "tomswe" in meta["description"].lower() or "ToM-SWE" in meta["description"]

--- a/factory/workflow/contributed/tomswe/workflow.py
+++ b/factory/workflow/contributed/tomswe/workflow.py
@@ -1,0 +1,175 @@
+"""ToM-SWE benchmark workflow — preference-aware task solving under vague instructions.
+
+4-node pipeline: study → builder → gate_verify → auto_merge
+RELOOP from gate_verify back to builder (max 3 iterations) on test failure.
+
+Designed for Harbor containers where:
+- Task instruction is at /tmp/task-instruction.md (passed via --prompt)
+- Task instruction contains DELIBERATELY VAGUE requirements and a user profile
+- The agent must infer intent and follow user coding preferences
+- Harbor's verifier is the FINAL authority on pass/fail
+- Harbor checks the MAIN branch for changes
+- No .factory/ infrastructure (no eval, no experiments, no deep-QA)
+"""
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Edge,
+    FnNode,
+    GateNode,
+    VerdictType,
+    Workflow,
+)
+
+meta = {
+    "name": "tomswe",
+    "description": (
+        "ToM-SWE benchmark mode — preference-aware 4-node pipeline for solving "
+        "deliberately vague coding tasks with embedded user profiles. "
+        "study → builder → gate_verify → auto_merge with RELOOP on test failure."
+    ),
+}
+
+
+def workflow() -> Workflow:
+    """Build the ToM-SWE workflow from scratch (not composed from improve)."""
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # ── Node 1: Study ──────────────────────────────────────────────
+    nodes["study"] = FnNode(
+        id="study",
+        command=(
+            "mkdir -p {project_path}/.factory/reviews && "
+            "cd {project_path} && "
+            "("
+            "echo '=== Repository Structure ===' && "
+            "find . -type f -name '*.py' | head -200 && "
+            "echo '\\n=== Test Files ===' && "
+            "find . -type f -name 'test_*.py' -o -name '*_test.py' | head -50 && "
+            "echo '\\n=== Configuration Files ===' && "
+            "ls -la setup.py setup.cfg pyproject.toml tox.ini conftest.py 2>/dev/null || true && "
+            "echo '\\n=== Task Instruction ===' && "
+            "cat /tmp/task-instruction.md 2>/dev/null || "
+            "echo 'No task instruction file found at /tmp/task-instruction.md'"
+            ") > .factory/reviews/study-output.md 2>&1"
+        ),
+        writes={".factory/reviews/study-output.md"},
+    )
+
+    # ── Node 2: Builder ────────────────────────────────────────────
+    nodes["builder"] = AgentNode(
+        id="builder",
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=7200,
+        max_iterations=3,
+        prompt_template=(
+            "You are solving a task for the ToM-SWE benchmark. The task instruction "
+            "contains DELIBERATELY VAGUE requirements and a user profile describing "
+            "the user's coding preferences and interaction style.\n\n"
+            "## Your Task\n\n"
+            "1. **Read the task instruction** — Read /tmp/task-instruction.md. Extract "
+            "BOTH the vague task description AND the user profile section.\n\n"
+            "2. **Infer user intent** — Determine what the user actually wants from "
+            "the vague description by analyzing context clues, surrounding code "
+            "patterns, and the user profile.\n\n"
+            "3. **Apply user preferences** — Follow the user's coding style (naming "
+            "conventions, testing approach, git workflow, documentation habits) as "
+            "described in the profile.\n\n"
+            "4. **Explore the codebase** — Read relevant source files, test files, "
+            "and configuration to understand the project structure.\n\n"
+            "5. **Implement the solution** — Make changes that align with BOTH the "
+            "inferred task requirements AND the user's preferred coding style.\n\n"
+            "6. **Run tests** — Verify the fix works and existing tests still pass. "
+            "Use pytest, tox, or whatever test runner the project uses.\n\n"
+            "7. **Commit your changes** — Commit directly on the current branch "
+            "with a message following the user's commit convention preferences "
+            "(if specified in the profile).\n\n"
+            "## Rules\n\n"
+            "- When instructions are vague, infer the most likely intent from context "
+            "— do NOT ask for clarification\n"
+            "- Follow the user's coding preferences from the profile section\n"
+            "- Prefer the user's preferred tools/libraries when multiple options exist\n"
+            "- MUST run tests before committing — never commit untested code\n"
+            "- Do NOT create branches or PRs — commit on current branch\n"
+            "- Do NOT run factory commands (factory eval, factory study, etc.)\n"
+            "- Do NOT modify test files unless the task requires it\n"
+            "- If tests fail after your fix, investigate and fix the issue\n"
+        ),
+        reads={".factory/reviews/study-output.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Node 3: Gate Verify ────────────────────────────────────────
+    nodes["gate_verify"] = GateNode(
+        id="gate_verify",
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            "CHANGES=$(git diff HEAD~1 --stat 2>/dev/null || echo 'NO_COMMITS') && "
+            "if [ \"$CHANGES\" = 'NO_COMMITS' ] || [ -z \"$CHANGES\" ]; then "
+            "echo 'fail: builder did not commit any changes'; "
+            "exit 0; fi && "
+            "BUILDER_OUTPUT=$(cat .factory/reviews/builder-latest.md 2>/dev/null || echo '') && "
+            "if echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(pass|succeed|ok|PASSED)'; then "
+            "echo 'pass: builder reports tests passing'; "
+            "elif echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(fail|error|FAILED)'; then "
+            "echo 'reloop: builder needs to retry — tests did not pass'; "
+            "else "
+            "echo 'pass: changes committed, no issues detected'; "
+            "fi"
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Node 4: Auto Merge ─────────────────────────────────────────
+    nodes["auto_merge"] = FnNode(
+        id="auto_merge",
+        command=(
+            "cd {project_path} && "
+            "CURRENT=$(git rev-parse --abbrev-ref HEAD) && "
+            "COMMON=$(git rev-parse --git-common-dir) && "
+            "BASE=$(git --git-dir=\"$COMMON\" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main) && "
+            "if [ \"$CURRENT\" = \"$BASE\" ]; then "
+            "echo \"Already on $BASE — no merge needed\"; "
+            "exit 0; fi && "
+            "git update-ref refs/heads/\"$BASE\" HEAD && "
+            "PARENT_WT=$(cd \"$COMMON/..\" && pwd) && "
+            "git diff-tree --no-commit-id --name-only -r HEAD HEAD~1 | "
+            "while read file; do "
+            "if [ -f \"$file\" ]; then "
+            "mkdir -p \"$PARENT_WT/$(dirname $file)\" && "
+            "cp \"$file\" \"$PARENT_WT/$file\"; "
+            "fi; done && "
+            "echo \"Updated $BASE to $(git rev-parse --short HEAD)\""
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Edges ──────────────────────────────────────────────────────
+
+    edges = [
+        Edge(source="study", target="builder"),
+        Edge(source="builder", target="gate_verify"),
+        Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
+        Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),
+    ]
+
+    # ── Trigger ────────────────────────────────────────────────────
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "tomswe"
+
+    return Workflow(
+        name="tomswe",
+        nodes=nodes,
+        edges=edges,
+        start_node="study",
+        terminal=True,
+        trigger=trigger,
+    )

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2284,6 +2284,7 @@ def register_all() -> dict[str, Workflow]:
     from factory.workflow.contributed.featurebench import workflow as featurebench_workflow
     from factory.workflow.contributed.programbench import workflow as programbench_workflow
     from factory.workflow.contributed.terminalbench import workflow as terminalbench_workflow
+    from factory.workflow.contributed.tomswe import workflow as tomswe_workflow
 
     return {
         "build": build_workflow(),
@@ -2298,6 +2299,7 @@ def register_all() -> dict[str, Workflow]:
         "programbench": programbench_workflow(),
         "swebench": swebench_workflow(),
         "terminalbench": terminalbench_workflow(),
+        "tomswe": tomswe_workflow(),
         "research": research_workflow(),
         "meta": meta_workflow(),
         "refine": refine_workflow(),

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -520,16 +520,13 @@ class TestRealWorkflowSkills:
 # ── QA phase enforcement ──────────────────────────────────────────
 
 
-QA_EXEMPT_WORKFLOWS = {"featurebench", "legacybench", "programbench", "swebench", "terminalbench"}
-
-
 def _workflows_with_builder() -> list[str]:
     """Return names of workflows containing a Builder AgentNode."""
     from factory.workflow.definitions import register_all
 
     names = []
     for name, wf in register_all().items():
-        if name in QA_EXEMPT_WORKFLOWS:
+        if wf.terminal:
             continue
         has_builder = any(
             isinstance(n, AgentNode) and n.role == AgentRole.BUILDER

--- a/tests/test_spec_generate.py
+++ b/tests/test_spec_generate.py
@@ -237,7 +237,7 @@ class TestRegistryIncludesSpec:
 
     def test_register_all_count(self) -> None:
         all_wf = register_all()
-        assert len(all_wf) == 21
+        assert len(all_wf) == 22
 
     def test_all_workflows_validate(self) -> None:
         all_wf = register_all()

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -401,14 +401,11 @@ class TestDocFreshnessGate:
 # ── Builder → QA reachability audit ────────────────────────────
 
 
-QA_EXEMPT_WORKFLOWS = {"featurebench", "legacybench", "programbench", "swebench", "terminalbench"}  # Benchmark workflows use external verifiers
-
-
 def _workflows_with_builder() -> list[str]:
     """Return names of workflows containing a Builder AgentNode."""
     names = []
     for name, wf in register_all().items():
-        if name in QA_EXEMPT_WORKFLOWS:
+        if wf.terminal:
             continue
         has_builder = any(
             isinstance(n, AgentNode) and n.role == AgentRole.BUILDER for n in wf.nodes.values()


### PR DESCRIPTION
Closes #1019

## Changes

- **benchmarks/factory_harbor_agent.py**: Added 15 user profiles (`TOMSWE_PROFILES`) matching the ToM-SWE paper's profile structure (verbosity, question timing, response style, coding preferences). Overrode `run()` in `TomsweFactoryCeo` to inject a deterministically-selected profile (SHA-256 hash of instruction content) into the task instruction before writing to `/tmp/task-instruction.md`.
- **benchmarks/config.sh**: Switched tomswe from `BENCH_LOCAL_PATH` (local sample tasks) to `BENCH_DATASET='swe-bench/swe-bench-verified'` with `BENCH_FILTER_STYLE='glob'` for CI interoperability.
- **.github/workflows/benchmark.yml**: Added `tomswe` to the `workflow_dispatch` benchmark options and added factory + claude-code solver matrix entries with `default_instance: 'sympy__sympy-20590'`.

Local sample tasks in `benchmarks/tomswe-harbor/` are preserved for quick local testing.