### PR TITLE
fix: use Harbor artifacts in analyze_failure.py when no Langfuse trace exists

### DIFF
--- a/benchmarks/lib.sh
+++ b/benchmarks/lib.sh
@@ -143,6 +143,122 @@ extract_langfuse_hostname() {
     echo "${hostname}"
 }
 
+# create_langfuse_trace — Create a wrapper Langfuse trace via the REST API.
+# Uses Python3 urllib (stdlib) so no pip install is needed.
+# Echoes the 32-char hex trace ID on success, empty string on failure.
+# Env: LANGFUSE_HOST (or LANGFUSE_BASE_URL), LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY
+create_langfuse_trace() {
+    local benchmark="${1:-}"
+    local instance_id="${2:-}"
+    local solver="${3:-}"
+    local git_ref="${4:-}"
+
+    python3 -c "
+import json, os, sys, uuid, urllib.request, urllib.error, base64, time
+
+host = os.environ.get('LANGFUSE_HOST') or os.environ.get('LANGFUSE_BASE_URL', '')
+pub_key = os.environ.get('LANGFUSE_PUBLIC_KEY', '')
+sec_key = os.environ.get('LANGFUSE_SECRET_KEY', '')
+
+if not host or not pub_key or not sec_key:
+    sys.exit(0)
+
+host = host.rstrip('/')
+trace_id = uuid.uuid4().hex
+auth = base64.b64encode(f'{pub_key}:{sec_key}'.encode()).decode()
+
+payload = {
+    'batch': [{
+        'id': uuid.uuid4().hex,
+        'type': 'trace-create',
+        'timestamp': time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime()),
+        'body': {
+            'id': trace_id,
+            'name': 'benchmark:${benchmark}/${instance_id}',
+            'metadata': {
+                'benchmark': '${benchmark}',
+                'instance_id': '${instance_id}',
+                'solver': '${solver}',
+                'git_ref': '${git_ref}',
+                'source': 'run-harbor.sh',
+            },
+        },
+    }],
+    'metadata': {},
+}
+
+req = urllib.request.Request(
+    f'{host}/api/public/ingestion',
+    data=json.dumps(payload).encode(),
+    headers={'Content-Type': 'application/json', 'Authorization': f'Basic {auth}'},
+    method='POST',
+)
+try:
+    urllib.request.urlopen(req, timeout=10)
+except Exception:
+    sys.exit(0)
+
+print(trace_id)
+" 2>/dev/null || true
+}
+
+# close_langfuse_trace — Mark a wrapper Langfuse trace as completed.
+# Posts a span-end event with duration and status info.
+close_langfuse_trace() {
+    local trace_id="${1:-}"
+    local status="${2:-unknown}"
+    local duration="${3:-0}"
+
+    if [ -z "${trace_id}" ]; then
+        return 0
+    fi
+
+    python3 -c "
+import json, os, sys, uuid, urllib.request, urllib.error, base64, time
+
+host = os.environ.get('LANGFUSE_HOST') or os.environ.get('LANGFUSE_BASE_URL', '')
+pub_key = os.environ.get('LANGFUSE_PUBLIC_KEY', '')
+sec_key = os.environ.get('LANGFUSE_SECRET_KEY', '')
+
+if not host or not pub_key or not sec_key:
+    sys.exit(0)
+
+host = host.rstrip('/')
+auth = base64.b64encode(f'{pub_key}:{sec_key}'.encode()).decode()
+
+payload = {
+    'batch': [{
+        'id': uuid.uuid4().hex,
+        'type': 'span-create',
+        'timestamp': time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime()),
+        'body': {
+            'id': uuid.uuid4().hex,
+            'traceId': '${trace_id}',
+            'name': 'harbor-execution',
+            'startTime': time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime(time.time() - ${duration})),
+            'endTime': time.strftime('%Y-%m-%dT%H:%M:%S.000Z', time.gmtime()),
+            'metadata': {
+                'status': '${status}',
+                'duration_seconds': ${duration},
+            },
+        },
+    }],
+    'metadata': {},
+}
+
+req = urllib.request.Request(
+    f'{host}/api/public/ingestion',
+    data=json.dumps(payload).encode(),
+    headers={'Content-Type': 'application/json', 'Authorization': f'Basic {auth}'},
+    method='POST',
+)
+try:
+    urllib.request.urlopen(req, timeout=10)
+except Exception:
+    pass
+" 2>/dev/null || true
+}
+
 extract_trace_id() {
     local jobs_dir="$1"
     local trace_id=""

--- a/benchmarks/run-harbor.sh
+++ b/benchmarks/run-harbor.sh
@@ -123,12 +123,31 @@ cleanup() {
         if [ -n "${log_file}" ] && [ -f "${log_file}" ]; then
             mkdir -p "${CI_RESULTS_DIR}"
             cp "${log_file}" "${CI_RESULTS_DIR}/${TIMESTAMP}-${BENCHMARK}-trial.log"
+        elif [ -f "${HARBOR_LOG:-}" ]; then
+            mkdir -p "${CI_RESULTS_DIR}"
+            cp "${HARBOR_LOG}" "${CI_RESULTS_DIR}/${TIMESTAMP}-${BENCHMARK}-trial.log"
         fi
+    elif [ -f "${HARBOR_LOG:-}" ]; then
+        mkdir -p "${CI_RESULTS_DIR}"
+        cp "${HARBOR_LOG}" "${CI_RESULTS_DIR}/${TIMESTAMP}-${BENCHMARK}-trial.log"
     fi
 
     LANGFUSE_TRACE_ID=""
     if [ "${MODE}" = "task" ] && [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
         LANGFUSE_TRACE_ID=$(extract_trace_id "${JOBS_DIR}")
+    fi
+
+    # Fall back to the pre-created wrapper trace if the container didn't produce one
+    if [ -z "${LANGFUSE_TRACE_ID}" ] && [ -n "${PRE_TRACE_ID:-}" ]; then
+        LANGFUSE_TRACE_ID="${PRE_TRACE_ID}"
+    fi
+
+    # Close the wrapper trace with duration and status
+    if [ -n "${LANGFUSE_TRACE_ID}" ] && [ -n "${PRE_TRACE_ID:-}" ]; then
+        local end_ts duration_s
+        end_ts="$(date +%s)"
+        duration_s=$(( end_ts - START_TIME ))
+        close_langfuse_trace "${LANGFUSE_TRACE_ID}" "${STATUS}" "${duration_s}"
     fi
 
     if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
@@ -405,9 +424,25 @@ if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
     HARBOR_CMD+=(--mounts '[{"type": "bind", "source": "'"${GCLOUD_ADC}"'", "target": "/tmp/gcloud-adc.json", "read_only": true}]')
 fi
 
-# Execute Harbor
+# Create a wrapper Langfuse trace before Harbor starts (factory solver only).
+# If the factory CLI crashes before creating its own trace, this ensures
+# a trace_id always exists for analyze_failure.py.
+PRE_TRACE_ID=""
+if [ "${MODE}" = "task" ] && [ "${BENCHMARK_SOLVER}" = "factory" ]; then
+    PRE_TRACE_ID=$(create_langfuse_trace "${BENCHMARK}" "${INSTANCE_ID}" "${BENCHMARK_SOLVER}" "${FACTORY_GIT_REF:-}")
+    if [ -n "${PRE_TRACE_ID}" ]; then
+        echo "    Pre-trace ID:    ${PRE_TRACE_ID}"
+        mkdir -p "${JOBS_DIR}"
+        echo "${PRE_TRACE_ID}" > "${JOBS_DIR}/trace_id.txt"
+    fi
+fi
+
+# Execute Harbor — capture output to a log file for failure analysis
+HARBOR_LOG="${CI_RESULTS_DIR}/${TIMESTAMP}-${BENCHMARK}-${BENCHMARK_SOLVER}-harbor.log"
+mkdir -p "${CI_RESULTS_DIR}"
+
 HARBOR_EXIT=0
-"${HARBOR_CMD[@]}" 2>&1 || HARBOR_EXIT=$?
+"${HARBOR_CMD[@]}" 2>&1 | tee "${HARBOR_LOG}"; HARBOR_EXIT=${PIPESTATUS[0]}
 
 if [ "${HARBOR_EXIT}" -ne 0 ]; then
     echo "    Harbor exited with code ${HARBOR_EXIT}"

--- a/scripts/langfuse/analyze_failure.py
+++ b/scripts/langfuse/analyze_failure.py
@@ -134,6 +134,22 @@ def run_llm_analysis(trace_dump: str, benchmark: str, instance_id: str) -> str |
     return None
 
 
+def _find_trial_log(result_dir: Path | None, result_data: dict) -> str:
+    if result_dir is None:
+        return ""
+    timestamp = result_data.get("timestamp", "")
+    benchmark = result_data.get("benchmark", "")
+    if timestamp and benchmark:
+        trial_log_path = result_dir / f"{timestamp}-{benchmark}-trial.log"
+        if trial_log_path.exists():
+            content = trial_log_path.read_text(errors="replace")
+            max_size = 50 * 1024
+            if len(content) > max_size:
+                content = content[-max_size:]
+            return content
+    return ""
+
+
 def generate_report(
     result_data: dict,
     trace: dict | None,
@@ -142,6 +158,7 @@ def generate_report(
     use_llm: bool = True,
     verbose: bool = False,
     summary: bool = False,
+    result_dir: Path | None = None,
 ) -> str:
     benchmark = result_data["benchmark"]
     instance_id = result_data["instance_id"]
@@ -149,14 +166,27 @@ def generate_report(
     duration = result_data.get("duration_seconds", 0)
 
     if summary:
-        if trace is None or not use_llm:
+        if trace is not None:
+            if not use_llm:
+                return "No trace available for summary."
+            trace_dump = format_trace_dump(trace)
+            if verbose:
+                print(f"[verbose] Summary trace dump: {len(trace_dump)} chars", file=sys.stderr)
+            text = run_llm_summary(trace_dump, benchmark, instance_id)
+            if text:
+                return text
             return "No trace available for summary."
-        trace_dump = format_trace_dump(trace)
-        if verbose:
-            print(f"[verbose] Summary trace dump: {len(trace_dump)} chars", file=sys.stderr)
-        text = run_llm_summary(trace_dump, benchmark, instance_id)
-        if text:
-            return text
+        exception_text = (result_data.get("details") or {}).get("exception", "")
+        trial_log = _find_trial_log(result_dir, result_data)
+        combined = ""
+        if trial_log:
+            combined += f"=== trial.log ===\n{trial_log}\n"
+        if exception_text:
+            combined += f"=== exception ===\n{exception_text}\n"
+        if combined and use_llm:
+            text = run_llm_summary(combined, benchmark, instance_id)
+            if text:
+                return text
         return "No trace available for summary."
 
     header = (
@@ -169,8 +199,23 @@ def generate_report(
 
     if trace is None:
         exception_text = (result_data.get("details") or {}).get("exception", "")
+        trial_log = _find_trial_log(result_dir, result_data)
+        combined = ""
+        if trial_log:
+            combined += f"=== trial.log ===\n{trial_log}\n"
         if exception_text:
-            return header + "\n#### Exception from Harbor\n\n" + exception_text + "\n"
+            combined += f"=== exception ===\n{exception_text}\n"
+        if combined:
+            if use_llm:
+                diagnosis = run_llm_analysis(combined, benchmark, instance_id)
+                if diagnosis:
+                    return header + "\n#### Diagnosis\n\n" + diagnosis + "\n"
+            parts = header + "\n#### Harbor Artifacts\n\n"
+            if exception_text:
+                parts += "**Exception:**\n\n" + exception_text + "\n\n"
+            if trial_log:
+                parts += "**Trial Log (last 50KB):**\n\n```\n" + trial_log + "\n```\n"
+            return parts
         return header + "\nNo matching Langfuse trace found.\n"
 
     trace_dump = format_trace_dump(trace)
@@ -213,20 +258,14 @@ def main() -> int:
         return 0
 
     solver = result_data.get("solver", "")
+    result_dir = result_path.parent
+
     if solver == "claude-code":
-        if args.summary:
-            report = "Trace analysis not available for claude-code solver."
-        else:
-            benchmark = result_data.get("benchmark", "unknown")
-            instance_id = result_data.get("instance_id", "unknown")
-            duration = result_data.get("duration_seconds", 0)
-            report = (
-                f"### Failure Analysis: {benchmark} / {instance_id}\n\n"
-                f"**Solver:** {solver}\n"
-                f"**Duration:** {duration}s\n\n"
-                "Trace analysis not available — claude-code solver does not create "
-                "factory-managed Langfuse traces.\n"
-            )
+        report = generate_report(
+            result_data, trace=None, trace_id=None, host=None,
+            use_llm=not args.no_llm, verbose=args.verbose,
+            summary=args.summary, result_dir=result_dir,
+        )
         _write_output(report, args.output)
         return 0
 
@@ -234,7 +273,10 @@ def main() -> int:
         host, _, _ = load_creds()
     except (KeyError, Exception) as e:
         print(f"WARNING: Langfuse credentials not available ({e}), skipping.", file=sys.stderr)
-        report = generate_report(result_data, trace=None, trace_id=None, host=None, use_llm=False)
+        report = generate_report(
+            result_data, trace=None, trace_id=None, host=None,
+            use_llm=False, result_dir=result_dir,
+        )
         _write_output(report, args.output)
         return 0
 
@@ -274,7 +316,7 @@ def main() -> int:
     report = generate_report(
         result_data, trace=trace, trace_id=trace_id, host=host,
         use_llm=not args.no_llm, verbose=args.verbose,
-        summary=args.summary,
+        summary=args.summary, result_dir=result_dir,
     )
     _write_output(report, args.output)
     return 0

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -13,7 +13,7 @@ import pytest
 import factory.telemetry as telemetry_mod
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "langfuse"))
-from analyze_failure import find_matching_trace
+from analyze_failure import _find_trial_log, find_matching_trace, generate_report, main
 
 
 @pytest.fixture(autouse=True)
@@ -448,3 +448,109 @@ class TestFindMatchingTrace:
                 datetime(2026, 1, 1), 3600,
             )
         assert result is None
+
+
+class TestGenerateReportFallback:
+    @staticmethod
+    def _result_data(
+        solver: str = "factory",
+        exception: str = "",
+        benchmark: str = "swebench",
+        instance_id: str = "django-123",
+        timestamp: str = "20260101T000000Z",
+    ) -> dict:
+        data: dict = {
+            "benchmark": benchmark,
+            "instance_id": instance_id,
+            "solver": solver,
+            "duration_seconds": 120,
+            "resolved": False,
+            "timestamp": timestamp,
+        }
+        if exception:
+            data["details"] = {"exception": exception}
+        return data
+
+    def test_claude_code_solver_not_short_circuited(self, tmp_path: Path) -> None:
+        data = self._result_data(solver="claude-code", exception="RuntimeError: timeout after 300s")
+        result_json = tmp_path / "result.json"
+        result_json.write_text(json.dumps(data))
+
+        with patch("analyze_failure.run_llm_analysis"), patch("analyze_failure.run_llm_summary"):
+            with patch("sys.argv", ["analyze_failure", str(result_json), "--no-llm"]):
+                with patch("analyze_failure._write_output") as mock_write:
+                    main()
+        report = mock_write.call_args[0][0]
+        assert "RuntimeError: timeout after 300s" in report
+
+    def test_trial_log_fallback_no_trace(self, tmp_path: Path) -> None:
+        data = self._result_data(timestamp="20260101T000000Z", benchmark="swebench")
+        trial_log = tmp_path / "20260101T000000Z-swebench-trial.log"
+        trial_log.write_text("ERROR: solver crashed at step 3\nTraceback: ...")
+
+        report = generate_report(
+            data, trace=None, trace_id=None, host=None,
+            use_llm=False, result_dir=tmp_path,
+        )
+        assert "Harbor Artifacts" in report
+        assert "solver crashed at step 3" in report
+
+    def test_trial_log_with_llm_analysis(self, tmp_path: Path) -> None:
+        data = self._result_data(timestamp="20260101T000000Z", benchmark="swebench")
+        trial_log = tmp_path / "20260101T000000Z-swebench-trial.log"
+        trial_log.write_text("ERROR: solver crashed at step 3")
+
+        with patch("analyze_failure.run_llm_analysis", return_value="The solver crashed due to OOM") as mock_llm:
+            report = generate_report(
+                data, trace=None, trace_id=None, host=None,
+                use_llm=True, result_dir=tmp_path,
+            )
+        assert "The solver crashed due to OOM" in report
+        assert "Diagnosis" in report
+        mock_llm.assert_called_once()
+        assert "solver crashed at step 3" in mock_llm.call_args[0][0]
+
+    def test_no_trace_no_artifacts(self) -> None:
+        data = self._result_data()
+        report = generate_report(
+            data, trace=None, trace_id=None, host=None,
+            use_llm=False, result_dir=None,
+        )
+        assert "No matching Langfuse trace found" in report
+
+    def test_summary_mode_uses_trial_log(self, tmp_path: Path) -> None:
+        data = self._result_data(timestamp="20260101T000000Z", benchmark="swebench")
+        trial_log = tmp_path / "20260101T000000Z-swebench-trial.log"
+        trial_log.write_text("ERROR: solver timeout")
+
+        with patch("analyze_failure.run_llm_summary", return_value="Solver timed out") as mock_summary:
+            report = generate_report(
+                data, trace=None, trace_id=None, host=None,
+                use_llm=True, summary=True, result_dir=tmp_path,
+            )
+        assert report == "Solver timed out"
+        mock_summary.assert_called_once()
+        assert "solver timeout" in mock_summary.call_args[0][0]
+
+
+class TestFindTrialLog:
+    def test_finds_matching_trial_log(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "20260101T000000Z-swebench-trial.log"
+        log_file.write_text("log content here")
+        result = _find_trial_log(tmp_path, {"timestamp": "20260101T000000Z", "benchmark": "swebench"})
+        assert result == "log content here"
+
+    def test_truncates_large_log(self, tmp_path: Path) -> None:
+        log_file = tmp_path / "20260101T000000Z-swebench-trial.log"
+        content = "x" * (60 * 1024)
+        log_file.write_text(content)
+        result = _find_trial_log(tmp_path, {"timestamp": "20260101T000000Z", "benchmark": "swebench"})
+        assert len(result) == 50 * 1024
+
+    def test_returns_empty_when_no_dir(self) -> None:
+        result = _find_trial_log(None, {"timestamp": "20260101T000000Z", "benchmark": "swebench"})
+        assert result == ""
+
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        result = _find_trial_log(tmp_path, {"timestamp": "20260101T000000Z", "benchmark": "swebench"})
+        assert result == ""


### PR DESCRIPTION
Closes #1004, #965

## Changes

- **Removed claude-code solver short-circuit** in `main()` — claude-code results now flow through `generate_report()` instead of returning a static dead-end message. Langfuse credential loading and trace search are still skipped for claude-code (since it genuinely has no traces).
- **Added `_find_trial_log()` helper** — discovers `${TIMESTAMP}-${BENCHMARK}-trial.log` files adjacent to the result JSON, reading up to 50KB (tail-truncated for large logs).
- **Enhanced `generate_report()` no-trace path** — when `trace is None`, builds combined text from trial.log + `details.exception`. If LLM is enabled, passes combined text to `run_llm_analysis()` for diagnosis. If LLM is disabled (or fails), renders artifacts under `#### Harbor Artifacts`. Only falls through to "No matching Langfuse trace found" when genuinely nothing is available.
- **Fixed summary mode** — when no trace exists but trial.log/exception are available, passes them to `run_llm_summary()` instead of returning the static "No trace available" message.
- **Added `result_dir` parameter** to `generate_report()` — passed from `main()` as the result JSON's parent directory so the function knows where to look for sibling artifacts.
- **Added 9 tests** covering: claude-code solver no longer short-circuited, trial.log fallback, LLM analysis with trial.log, no-artifacts preserved behavior, summary mode with trial.log, and `_find_trial_log` edge cases (truncation, missing dir, missing file).
- **Captured Harbor output to log file** (`run-harbor.sh`) — Harbor's stdout/stderr is now tee'd to `${TIMESTAMP}-${BENCHMARK}-${BENCHMARK_SOLVER}-harbor.log`. When trial.log isn't found in the Harbor jobs directory, the harbor log is copied to the trial.log artifact path so `analyze_failure.py` picks it up automatically.
- **Fixed tee exit code swallowing** — uses `PIPESTATUS[0]` to preserve Harbor's actual exit code through the tee pipe.
- **Added pre-execution Langfuse wrapper trace** (`lib.sh` + `run-harbor.sh`) — creates a trace before Harbor starts so a trace_id always exists even when the factory CLI crashes before creating its own. The trace is closed with duration/status in the cleanup trap.