### PR TITLE
feat: inject workflow SKILL.md into CEO system prompt to survive compaction

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -67,6 +67,7 @@ def resolve_prompt(
     project_path: Path | None = None,
     *,
     use_profile: bool = False,
+    workflow_mode: str | None = None,
 ) -> str:
     """Resolve the prompt for an agent role.
 
@@ -76,6 +77,10 @@ def resolve_prompt(
 
     When *use_profile* is True, loads ~/.factory/profile.md and appends it
     after the ACE playbook injection.
+
+    When *workflow_mode* is set and *role* is ``"ceo"``, the corresponding
+    ``skills/workflow-{workflow_mode}/SKILL.md`` is appended to the prompt
+    so it survives context compaction.
 
     Returns the prompt content as a string.
     """
@@ -92,6 +97,8 @@ def resolve_prompt(
                 logger.info("Injected playbook for %s (project override)", role)
             if use_profile:
                 prompt = _maybe_inject_profile(prompt, role)
+            if role == "ceo" and workflow_mode and project_path is not None:
+                prompt = _maybe_inject_skill(prompt, project_path, workflow_mode)
             return prompt
 
     # Fall back to factory default
@@ -114,6 +121,9 @@ def resolve_prompt(
     if use_profile:
         prompt = _maybe_inject_profile(prompt, role)
 
+    if role == "ceo" and workflow_mode and project_path is not None:
+        prompt = _maybe_inject_skill(prompt, project_path, workflow_mode)
+
     return prompt
 
 
@@ -126,6 +136,17 @@ def _maybe_inject_profile(prompt: str, role: str) -> str:
         prompt = inject_profile(prompt, profile)
         logger.info("Injected user profile for %s", role)
     return prompt
+
+
+def _maybe_inject_skill(prompt: str, project_path: Path, workflow_mode: str) -> str:
+    """Append the workflow SKILL.md to the CEO prompt so it survives compaction."""
+    skill_path = project_path / "skills" / f"workflow-{workflow_mode}" / "SKILL.md"
+    if not skill_path.exists():
+        logger.warning("SKILL.md not found for mode %s at %s", workflow_mode, skill_path)
+        return prompt
+    skill_content = skill_path.read_text()
+    logger.info("Injected SKILL.md for workflow-%s into CEO prompt", workflow_mode)
+    return prompt + f"\n\n# Workflow Playbook ({workflow_mode})\n\n{skill_content}"
 
 
 async def invoke_agent(
@@ -143,6 +164,7 @@ async def invoke_agent(
     tmux_persist: bool = False,
     background: bool = False,
     review_tag: str | None = None,
+    workflow_mode: str | None = None,
 ) -> tuple[str, int]:
     """Invoke a Claude Code agent with the resolved prompt + task.
 
@@ -154,7 +176,7 @@ async def invoke_agent(
     """
     global _consecutive_failures
 
-    prompt = resolve_prompt(role, project_path, use_profile=use_profile)
+    prompt = resolve_prompt(role, project_path, use_profile=use_profile, workflow_mode=workflow_mode)
 
     if os.environ.get("FACTORY_NO_GITHUB") == "1":
         prompt += (

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -389,6 +389,7 @@ async def run_ceo_with_completion_guard(
     use_profile: bool = False,
     tmux_persist: bool = False,
     background: bool = False,
+    workflow_mode: str | None = None,
 ) -> tuple[str, int]:
     """Spawn CEO; if it exits with planned work undone, re-spawn until done or cap hit.
 
@@ -407,6 +408,7 @@ async def run_ceo_with_completion_guard(
         use_profile: If True, inject user profile into the CEO prompt.
         tmux_persist: If True, run agents in tmux windows.
         background: If True, dispatch via claude --bg (single dispatch, no respawn).
+        workflow_mode: If set, inject the SKILL.md for this mode into the CEO prompt.
 
     Returns:
         (final_output, exit_code)
@@ -419,6 +421,7 @@ async def run_ceo_with_completion_guard(
             "ceo", initial_task, project_path,
             timeout=timeout, model=model, runner_name=runner_name,
             background=True, session_name=session_name, use_profile=use_profile,
+            workflow_mode=workflow_mode,
         )
 
     # Check escape hatch
@@ -432,6 +435,7 @@ async def run_ceo_with_completion_guard(
             session_name=session_name,
             use_profile=use_profile,
             tmux_persist=tmux_persist,
+            workflow_mode=workflow_mode,
         )
 
     if max_respawns is None:
@@ -473,6 +477,7 @@ async def run_ceo_with_completion_guard(
             session_name=session_name,
             use_profile=use_profile,
             tmux_persist=tmux_persist,
+            workflow_mode=workflow_mode,
         )
         final_output = result
 

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -148,7 +148,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         if not headless:
             from factory.models import AgentRunRequest
 
-            prompt = resolve_prompt("ceo", project_path)
+            prompt = resolve_prompt("ceo", project_path, workflow_mode="review")
             runner = get_runner(runner_name)
             return runner.interactive_run(
                 AgentRunRequest(
@@ -172,6 +172,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 model=model,
                 timeout=7200.0,
                 max_respawns=1,
+                workflow_mode="review",
             )
         )
         print(result)
@@ -204,8 +205,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             f"Project: {project_path}\nMode: qa\n\n"
             f"## QA Verification Directive\n\n"
             f"Run the QA verification pipeline for PR #{pr_number}{repo_clause}.\n\n"
-            f"Read and follow the workflow-qa SKILL.md playbook at "
-            f"skills/workflow-qa/SKILL.md.\n\n"
+            f"Follow the workflow-qa playbook in your system prompt above.\n\n"
             f"Key parameters:\n"
             f"- PR_NUMBER={pr_number}\n"
             f"- PROJECT_PATH={project_path}\n"
@@ -228,7 +228,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         if not headless:
             from factory.models import AgentRunRequest
 
-            prompt = resolve_prompt("ceo", project_path)
+            prompt = resolve_prompt("ceo", project_path, workflow_mode="qa")
             runner = get_runner(runner_name)
             rc = runner.interactive_run(
                 AgentRunRequest(
@@ -254,6 +254,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 model=model,
                 timeout=7200.0,
                 max_respawns=1,
+                workflow_mode="qa",
             )
         )
         complete_cycle_session(project_path, cycle_span_id)
@@ -313,7 +314,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         if not headless:
             from factory.models import AgentRunRequest
 
-            prompt = resolve_prompt("ceo", project_path)
+            prompt = resolve_prompt("ceo", project_path, workflow_mode="deep-qa")
             runner = get_runner(runner_name)
             rc = runner.interactive_run(
                 AgentRunRequest(
@@ -339,6 +340,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 model=model,
                 timeout=7200.0,
                 max_respawns=1,
+                workflow_mode="deep-qa",
             )
         )
         complete_cycle_session(project_path, cycle_span_id)
@@ -669,6 +671,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                     use_profile=use_profile,
                     tmux_persist=tmux_persist,
                     background=background,
+                    workflow_mode=ceo_mode,
                 )
             )
             print(result)
@@ -713,7 +716,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             mark_read(project_path, pending_ids)
         from factory.models import AgentRunRequest as _RunReq
 
-        prompt = resolve_prompt("ceo", wt_path, use_profile=use_profile)
+        prompt = resolve_prompt("ceo", wt_path, use_profile=use_profile, workflow_mode=ceo_mode)
         runner = get_runner(runner_name)
         return runner.interactive_run(
             _RunReq(
@@ -1725,7 +1728,7 @@ def _build_ceo_task(
             f"\n\n## Create Mode (New Factory Mode)\n\n"
             f"**Mode description from user:**\n{create_description}\n\n"
             f"You are in Create mode — a meta-mode for creating new factory modes.\n\n"
-            f"Follow the Create workflow (skills/workflow-create/SKILL.md):\n"
+            f"Follow the Create workflow playbook in your system prompt:\n"
             f"1. Research existing workflow patterns and the user's intent\n"
             f"2. Synthesize a complete workflow specification\n"
             f"3. Present the spec to the user for interactive approval\n"
@@ -1802,7 +1805,8 @@ def _build_ceo_task(
             "\n\nRun Build mode: the project is new or incomplete. Run the Plan Loop "
             "(P0-P3) to produce an approved build plan, then follow the Build pipeline "
             "(B3-B6): Build phases → E2E verification. "
-            "Do NOT skip to Improve mode — the project needs to be built first."
+            "Do NOT skip to Improve mode — the project needs to be built first. "
+            "The full step-by-step playbook is in your system prompt above."
         )
     elif mode == "discover":
         if discover_only:
@@ -1822,7 +1826,8 @@ def _build_ceo_task(
         task += (
             "\n\nRun Meta mode: full self-improvement. First, run the complete Improve loop "
             "on this project (experiments, keep/revert decisions). Then run ACE playbook "
-            "evolution for all agent roles using cross-project experiment data."
+            "evolution for all agent roles using cross-project experiment data. "
+            "The full step-by-step playbook is in your system prompt above."
         )
     elif mode == "research":
         task += (
@@ -1831,19 +1836,20 @@ def _build_ceo_task(
             "target value, and run command. Each cycle: form a hypothesis to improve the "
             "metric, implement the change within mutable_surfaces only (leave fixed_surfaces "
             "untouched), run the research command, compare results against the target, and "
-            "make a keep/revert decision. Respect research_constraints and cost_budget."
+            "make a keep/revert decision. Respect research_constraints and cost_budget. "
+            "The full step-by-step playbook is in your system prompt above."
         )
     elif mode == "create":
         task += (
-            "\n\nRun Create mode: read `skills/workflow-create/SKILL.md` for the full "
-            "step-by-step playbook. This mode creates a new factory mode (workflow + skill + "
-            "CLI wiring + tests) from the user's description above."
+            "\n\nRun Create mode: this mode creates a new factory mode (workflow + skill + "
+            "CLI wiring + tests) from the user's description above. "
+            "The full step-by-step playbook is in your system prompt above."
         )
     else:
         task += (
-            f"\n\nRun {mode} mode: read `skills/workflow-{mode}/SKILL.md` for the full "
-            f"step-by-step playbook. Follow the instructions exactly as written — "
-            f"do not add additional steps, research, or ceremony beyond what the SKILL.md describes."
+            f"\n\nRun {mode} mode. Follow the step-by-step playbook in your system prompt "
+            f"exactly as written — do not add additional steps, research, or ceremony "
+            f"beyond what the playbook describes."
         )
 
     if no_github:
@@ -2037,6 +2043,7 @@ def _run_single_cycle(
                 use_profile=use_profile,
                 tmux_persist=tmux_persist,
                 background=background,
+                workflow_mode=mode,
             )
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1405,7 +1405,7 @@ class TestCmdCeoQa:
         assert "Mode: qa" in task
         assert "PR #42" in task
         assert "factory review --verdict" in task
-        assert "workflow-qa SKILL.md" in task
+        assert "workflow-qa playbook" in task
         assert "qa-latest.md" in task
         assert "Do NOT post any PR comments" in task
         assert "health_checker" not in task
@@ -1971,7 +1971,8 @@ class TestCeoModeRouting:
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "Run design mode: read `skills/workflow-design/SKILL.md`" in task
+        assert "Run design mode" in task
+        assert "playbook" in task.lower()
         assert "Run Build mode" not in task
 
     def test_design_idea_routes_to_design(self):
@@ -2007,12 +2008,14 @@ class TestCeoModeRouting:
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
-        assert "Run improve mode: read `skills/workflow-improve/SKILL.md`" in task
+        assert "Run improve mode" in task
+        assert "playbook" in task.lower()
 
     def test_design_existing_task_string(self, tmp_path):
-        """design_existing=True task contains design SKILL.md reference, not Build."""
+        """design_existing=True task contains design mode reference, not Build."""
         task = _build_ceo_task(tmp_path, "design", design_existing=True)
-        assert "Run design mode: read `skills/workflow-design/SKILL.md`" in task
+        assert "Run design mode" in task
+        assert "playbook" in task.lower()
         assert "Run Build mode" not in task
 
     def test_research_ideation_routes_to_build(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -42,6 +42,60 @@ class TestResolvePromptWithProfile:
         assert profile_idx > playbook_idx
 
 
+class TestResolvePromptWithWorkflowMode:
+    def test_ceo_with_workflow_mode_injects_skill(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "skills" / "workflow-improve"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Improve Workflow\n\nStep 1: study")
+        prompt = resolve_prompt("ceo", tmp_path, workflow_mode="improve")
+        assert "# Workflow Playbook (improve)" in prompt
+        assert "# Improve Workflow" in prompt
+        assert "Step 1: study" in prompt
+
+    def test_ceo_without_workflow_mode_no_skill(self, tmp_path: Path) -> None:
+        prompt = resolve_prompt("ceo", tmp_path)
+        assert "# Workflow Playbook" not in prompt
+
+    def test_non_ceo_role_ignores_workflow_mode(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "skills" / "workflow-improve"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Improve Workflow\n\nStep 1: study")
+        prompt = resolve_prompt("researcher", tmp_path, workflow_mode="improve")
+        assert "# Workflow Playbook" not in prompt
+
+    def test_missing_skill_file_no_error(self, tmp_path: Path) -> None:
+        prompt = resolve_prompt("ceo", tmp_path, workflow_mode="nonexistent")
+        assert "# Workflow Playbook" not in prompt
+
+
+class TestBuildCeoTaskNoSkillRead:
+    def test_improve_mode_no_skill_read_instruction(self, tmp_path: Path) -> None:
+        from factory.cli.ceo import _build_ceo_task
+
+        task = _build_ceo_task(tmp_path, "improve")
+        assert "read `skills/workflow-" not in task
+        assert "playbook" in task.lower()
+
+    def test_build_mode_no_skill_read_instruction(self, tmp_path: Path) -> None:
+        from factory.cli.ceo import _build_ceo_task
+
+        task = _build_ceo_task(tmp_path, "build")
+        assert "read `skills/workflow-" not in task
+
+    def test_create_mode_no_skill_read_instruction(self, tmp_path: Path) -> None:
+        from factory.cli.ceo import _build_ceo_task
+
+        task = _build_ceo_task(tmp_path, "create")
+        assert "read `skills/workflow-" not in task
+        assert "skills/workflow-create/SKILL.md" not in task
+
+    def test_research_mode_no_skill_read_instruction(self, tmp_path: Path) -> None:
+        from factory.cli.ceo import _build_ceo_task
+
+        task = _build_ceo_task(tmp_path, "research")
+        assert "read `skills/workflow-" not in task
+
+
 class TestSaveReview:
     def test_creates_reviews_dir(self, tmp_path: Path) -> None:
         project = tmp_path / "myproject"


### PR DESCRIPTION
Closes #1022

## Changes

- **`factory/agents/runner.py`**: Added `workflow_mode` parameter to `resolve_prompt()` and `invoke_agent()`. New `_maybe_inject_skill()` helper appends `skills/workflow-{mode}/SKILL.md` content to the CEO prompt with a `# Workflow Playbook ({mode})` heading.
- **`factory/ceo_completion.py`**: Added `workflow_mode` parameter to `run_ceo_with_completion_guard()`, passed through to all three `invoke_agent()` call sites (background, respawn-disabled, main loop).
- **`factory/cli/ceo.py`**: All CEO launch paths now pass `workflow_mode`:
  - Interactive foreground (`resolve_prompt(..., workflow_mode=ceo_mode)`)
  - Headless via completion guard (`workflow_mode=ceo_mode`)
  - Review, QA, deep-QA early exits (`workflow_mode="review"/"qa"/"deep-qa"`)
  - `_run_single_cycle()` loop path (`workflow_mode=mode`)
- **`factory/cli/ceo.py` — `_build_ceo_task()`**: Removed all `read skills/workflow-{mode}/SKILL.md` instructions. Replaced with "The full step-by-step playbook is in your system prompt above."
- **Tests**: 8 new tests covering SKILL.md injection (present when expected, absent for non-CEO roles, graceful on missing file) and task string cleanup (no `read skills/workflow-` in any mode).

## Why

During long CEO sessions (especially design mode with multiple user feedback rounds), context compaction lossy-summarizes the SKILL.md content the CEO read as a conversation message. This causes the CEO to lose precise workflow step sequencing in later phases. Moving SKILL.md into the system prompt ensures it survives compaction — the system prompt is re-injected on every turn.

Token cost is marginal (~800-1200 tokens per SKILL.md, fully cached after the first turn).