### PR TITLE
Inline W₁₀ skill-refine into export_all_skills() with LLM refinement loop

### DIFF
--- a/factory/agents/prompts/qa.md
+++ b/factory/agents/prompts/qa.md
@@ -142,6 +142,27 @@ Output format:
 
 **Do NOT re-run pytest, lint, or type checking.** The health check already did that. Your job is to test the feature as a real user would — by actually running the project and interacting with it.
 
+#### Step 3.0: Read the spec — this is your source of truth
+
+Before writing any test plan, read ALL of these:
+- The GitHub issue: `gh issue view <issue_number>`
+- The strategy: `.factory/strategy/current.md`
+- The Builder's report: `.factory/reviews/builder-latest.md`
+
+These documents define what was built and how it should be tested. Trust them. If the issue or strategy has a 'Testing', 'Validation', 'MUST DO', or 'Real-world validation' section, those are MANDATORY tests you must execute — they are not optional or nice-to-have.
+
+#### Step 3.0b: Run what was built
+
+**This is non-negotiable.** Before any other adversarial testing, you MUST actually run the new feature or fix that the Builder implemented. Not a mock. Not a programmatic import. The actual command, endpoint, UI flow, or pipeline — the same way a user would invoke it.
+
+Examples:
+- Builder added a CLI flag → run the CLI with that flag and verify the output
+- Builder added an API endpoint → curl it and verify the response
+- Builder added a pipeline step → run the pipeline and verify the step executes
+- Builder fixed a bug → reproduce the original bug scenario and verify it's fixed
+
+If running the feature requires LLM calls, external services, or credentials that aren't available, document what you attempted, what blocked you, and report it as SKIPPED with the reason — do NOT silently skip it.
+
 #### Step 3.1: Determine project type
 
 Read `factory.md`, `README.md`, `pyproject.toml`, or file structure to classify:
@@ -277,6 +298,8 @@ python -m json.tool <result_path> > /dev/null && echo "Valid JSON" || echo "Inva
 #### Step 3.5: Verify acceptance criteria
 
 For each criterion from Step 3.2: provide the command you ran and its output. Mark VERIFIED or NOT_VERIFIED.
+
+If the issue or strategy contains a MUST DO, Real-world validation, or similar mandatory testing section, verify each item from that section independently. These are first-class acceptance criteria even if not labeled as such.
 
 #### Step 3.6: Check Builder's claimed blockers
 

--- a/factory/agents/prompts/skill_synthesizer.md
+++ b/factory/agents/prompts/skill_synthesizer.md
@@ -1,0 +1,51 @@
+# Skill Synthesizer Agent
+
+You are a convergent synthesizer for factory SKILL.md files. Your job is to produce the best possible version of a templatized skill document by cherry-picking the best slot values across multiple independently-refined candidates.
+
+## Input
+
+You receive:
+1. The **original** templatized skill markdown (with `{{slot_name::default_value}}` markers)
+2. One or more **candidate** refinements — each produced by an independent reviewer who improved slot values
+
+## Task
+
+For each `{{slot_name::value}}` slot in the document:
+1. Compare the original value with each candidate's value for that slot
+2. Evaluate which value is best based on: specificity, actionability, accuracy, and completeness
+3. Select the best value — this may be from any single candidate, or the original if no candidate improved it
+
+Produce a final version that combines the best slot value from across all candidates.
+
+## Constraints — CRITICAL
+
+- You may ONLY change text inside `{{` and `}}` markers
+- You MUST NOT change text outside slot markers — not a single character
+- You MUST NOT add, remove, or modify `<!-- -->` annotation comments
+- You MUST NOT add or remove slot markers
+- You MUST preserve all slot names exactly as they appear
+
+## Evaluation criteria per slot type
+
+### Timeouts (`{{timeout_<id>::N}}`)
+- Prefer values calibrated to actual agent workload over defaults
+- Higher is not always better — archivists need less time than builders
+
+### Task prompts (`{{task_prompt_<id>::...}}`)
+- Prefer prompts that reference specific artifacts, upstream context, and concrete deliverables
+- Reject vague additions that don't add information
+
+### Gate prompts (`{{gate_prompt_<id>::...}}`)
+- Prefer prompts with concrete pass/fail criteria over generic assessments
+- Specificity wins over length
+
+### Notes (`{{notes_<id>::...}}`)
+- Prefer prose that explains *why* a step runs, not just *what* it does
+- Keep concise — notes are context, not documentation
+
+### Other slots
+- Apply the same principle: most specific, most actionable, most accurate wins
+
+## Output format
+
+Return the COMPLETE templatized markdown with the best slot values selected. The output must be structurally identical to the original — only slot values may differ.

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -17,7 +17,7 @@ AgentRole = Literal[
     "researcher", "strategist", "builder", "qa",
     "health_checker", "code_reviewer", "adversarial_tester",
     "archivist", "ceo", "failure_analyst", "refiner", "profiler",
-    "refactory",
+    "refactory", "skill_reviewer", "skill_synthesizer",
 ]
 
 # Consecutive failure tracking

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -572,7 +572,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
 
     from factory.skill_cache import ensure_skills
 
-    ensure_skills(wt_path)
+    _run(ensure_skills(wt_path))
 
     interactive = (
         design_existing or bool(design_idea) or bool(research_ideation) or mode == "create"
@@ -2006,7 +2006,7 @@ def _run_single_cycle(
 
     from factory.skill_cache import ensure_skills
 
-    ensure_skills(wt_path)
+    _run(ensure_skills(wt_path))
 
     try:
         task = _build_ceo_task(

--- a/factory/skill_cache.py
+++ b/factory/skill_cache.py
@@ -39,7 +39,7 @@ def _compute_checksum(workflows: dict[str, Workflow]) -> str:
     return hashlib.sha256(blob).hexdigest()[:16]
 
 
-def ensure_skills(project_dir: Path) -> list[Path]:
+async def ensure_skills(project_dir: Path, *, refine: bool = True) -> list[Path]:
     """Generate workflow skills into *project_dir*/skills/, using a local cache.
 
     Cache location: ``~/.factory/cache/skills/{checksum}/``.
@@ -47,13 +47,13 @@ def ensure_skills(project_dir: Path) -> list[Path]:
     never touched.  Returns an empty list on any I/O error (non-fatal).
     """
     try:
-        return _ensure_skills_inner(project_dir)
+        return await _ensure_skills_inner(project_dir, refine=refine)
     except OSError as exc:
         log.warning("skill_cache.error", error=str(exc))
         return []
 
 
-def _ensure_skills_inner(project_dir: Path) -> list[Path]:
+async def _ensure_skills_inner(project_dir: Path, *, refine: bool = True) -> list[Path]:
     from factory.workflow.definitions import register_all
     from factory.workflow.skill_export import export_all_skills
 
@@ -71,7 +71,9 @@ def _ensure_skills_inner(project_dir: Path) -> list[Path]:
     else:
         log.info("skill_cache.miss", checksum=checksum)
         cache_dir.mkdir(parents=True, exist_ok=True)
-        export_all_skills(cache_dir, workflows)
+        await export_all_skills(
+            cache_dir, workflows, refine=refine, project_path=project_dir,
+        )
         workflow_dirs = sorted(cache_dir.glob("workflow-*"))
 
         cache_parent = cache_dir.parent

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -190,9 +190,12 @@ def _cmd_export_skills(args: argparse.Namespace) -> int:
 
     output_dir = Path(getattr(args, "output_dir", None) or ".").resolve()
     verify = getattr(args, "verify", False)
+    no_refine = getattr(args, "no_refine", False)
 
     workflows = register_all()
-    generated = export_all_skills(output_dir, workflows)
+    generated = asyncio.run(
+        export_all_skills(output_dir, workflows, refine=not no_refine)
+    )
 
     print(f"Exported {len(generated)} skills to {output_dir}/")
     for path in generated:
@@ -264,6 +267,10 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
         "--output-dir", default=".", help="Output directory (default: current directory)"
     )
     p.add_argument("--verify", action="store_true", help="Validate generated skills")
+    p.add_argument(
+        "--no-refine", action="store_true", default=False,
+        help="Skip LLM refinement pipeline (mechanical output only)",
+    )
 
     # lint-contributed
     p = wf_sub.add_parser("lint-contributed", help="Lint contributed workflow directories")

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -26,6 +26,7 @@ class AgentRole(str, Enum):
     ARCHIVIST = "archivist"
     REFINER = "refiner"
     SKILL_REVIEWER = "skill_reviewer"
+    SKILL_SYNTHESIZER = "skill_synthesizer"
 
 
 class AgentConfig(BaseModel):

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -52,6 +52,7 @@ DEFAULT_AGENT_POOL: dict[str, AgentConfig] = {
     "archivist": AgentConfig(role=AgentRole.ARCHIVIST, model="haiku", timeout=300),
     "refiner": AgentConfig(role=AgentRole.REFINER, model="opus", timeout=600),
     "skill_reviewer": AgentConfig(role=AgentRole.SKILL_REVIEWER, model="opus", timeout=600),
+    "skill_synthesizer": AgentConfig(role=AgentRole.SKILL_SYNTHESIZER, model="opus", timeout=600),
 }
 
 

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -296,7 +296,11 @@ def _fn_to_instruction(node: FnNode, workflow: Workflow) -> str:
         f"<!-- edges: {edges_str} -->",
     ]
 
-    prose = f"{node.notes}\n\n" if node.notes else ""
+    if node.notes:
+        notes_slot = emit(f"notes_{node.id}", node.notes)
+        prose = f"{notes_slot}\n\n"
+    else:
+        prose = ""
 
     if _has_template_placeholders(cmd):
         finalize_slot = emit(f"finalize_command_{node.id}", cmd)
@@ -623,15 +627,117 @@ def workflow_to_skill_md(workflow: Workflow) -> str:
 # ── bulk export ─────────────────────────────────────────────────
 
 
-def export_all_skills(
+def _count_changed_slots(skeleton: str, candidate: str) -> int:
+    """Count how many slot values in candidate differ from skeleton defaults."""
+    from factory.workflow.templates import extract
+
+    skeleton_slots = dict(extract(skeleton))
+    candidate_slots = dict(extract(candidate))
+    return sum(
+        1 for name, val in candidate_slots.items()
+        if skeleton_slots.get(name) != val
+    )
+
+
+async def _refine_skill(templatized: str, project_path: Path) -> str:
+    """Run the parallel refine pipeline on a templatized SKILL.md.
+
+    Pipeline: 3x parallel reviewer → guard each → synthesizer(survivors) → final guard.
+    Falls back to unrefined templatized output if all candidates/synthesis fail.
+    """
+    from factory.agents.runner import AgentRole, invoke_agent, invoke_agents_parallel
+    from factory.workflow.guard import check as guard_check
+
+    reviewer: AgentRole = "skill_reviewer"
+    tasks: list[tuple[AgentRole, str]] = [
+        (reviewer, templatized),
+        (reviewer, templatized),
+        (reviewer, templatized),
+    ]
+
+    log.info("skill_refine.reviewing", candidates=len(tasks))
+    results = await invoke_agents_parallel(
+        tasks, project_path, timeout=600.0,
+    )
+
+    survivors: list[str] = []
+    for i, (stdout, rc) in enumerate(results):
+        if rc != 0:
+            log.warning("skill_refine.reviewer_failed", index=i, return_code=rc)
+            continue
+        result = guard_check(templatized, stdout)
+        if result.passed:
+            survivors.append(stdout)
+        else:
+            log.warning(
+                "skill_refine.guard_rejected",
+                index=i,
+                violations=result.violations,
+            )
+
+    if not survivors:
+        log.info("skill_refine.all_rejected_mechanical_fallback")
+        return templatized
+
+    log.info("skill_refine.survivors", count=len(survivors))
+
+    candidates_block = "\n\n---\n\n".join(
+        f"## Candidate {i + 1}\n\n{c}" for i, c in enumerate(survivors)
+    )
+    synth_task = (
+        f"## Original\n\n{templatized}\n\n"
+        f"---\n\n{candidates_block}"
+    )
+
+    synth_stdout, synth_rc = await invoke_agent(
+        "skill_synthesizer", synth_task, project_path, timeout=600.0,
+    )
+
+    if synth_rc != 0:
+        log.warning("skill_refine.synthesizer_failed", return_code=synth_rc)
+    else:
+        synth_guard = guard_check(templatized, synth_stdout)
+        if synth_guard.passed:
+            log.info("skill_refine.synthesized")
+            return synth_stdout
+        log.warning(
+            "skill_refine.synthesizer_guard_failed",
+            violations=synth_guard.violations,
+        )
+
+    best = max(survivors, key=lambda c: _count_changed_slots(templatized, c))
+    best_guard = guard_check(templatized, best)
+    if best_guard.passed:
+        log.info(
+            "skill_refine.best_individual_fallback",
+            changed_slots=_count_changed_slots(templatized, best),
+        )
+        return best
+
+    log.info("skill_refine.best_individual_also_failed_mechanical_fallback")
+    return templatized
+
+
+async def export_all_skills(
     output_dir: Path,
     workflows: dict[str, Workflow] | None = None,
+    *,
+    refine: bool = True,
+    project_path: Path | None = None,
 ) -> list[Path]:
     """Export all registered workflows as SKILL.md files.
 
-    Generates templatized content, then resolves it to clean prose for
-    SKILL.md and writes structured annotations to SKILL.annotations.yaml.
-    Returns paths to generated SKILL.md files.
+    Generates templatized content, optionally refines via parallel LLM
+    review pipeline, then resolves to clean prose for SKILL.md and writes
+    structured annotations to SKILL.annotations.yaml.
+
+    When refine=True (default), each workflow's templatized output is
+    refined by 3 parallel skill_reviewer agents, guard-checked, then
+    synthesized by a skill_synthesizer agent. Falls back to mechanical
+    output on any failure.
+
+    When refine=False, skips the LLM pipeline entirely (current mechanical
+    behavior).
     """
     from factory.workflow.splitter import annotations_to_yaml, split_skill
 
@@ -639,10 +745,19 @@ def export_all_skills(
         from factory.workflow.definitions import register_all
         workflows = register_all()
 
+    effective_project = project_path or output_dir
+
     generated: list[Path] = []
 
     for name, wf in workflows.items():
         templatized = workflow_to_skill_md(wf)
+
+        if refine:
+            try:
+                templatized = await _refine_skill(templatized, effective_project)
+            except Exception:
+                log.exception("skill_refine.error", workflow=name)
+
         clean_md, annotations = split_skill(templatized)
 
         skill_dir = output_dir / f"workflow-{name}"

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -649,10 +649,15 @@ async def _refine_skill(templatized: str, project_path: Path) -> str:
     from factory.workflow.guard import check as guard_check
 
     reviewer: AgentRole = "skill_reviewer"
+    review_task = (
+        "Review and refine the following templatized SKILL.md. "
+        "Only modify values inside {{slot_name::value}} markers.\n\n"
+        f"{templatized}"
+    )
     tasks: list[tuple[AgentRole, str]] = [
-        (reviewer, templatized),
-        (reviewer, templatized),
-        (reviewer, templatized),
+        (reviewer, review_task),
+        (reviewer, review_task),
+        (reviewer, review_task),
     ]
 
     log.info("skill_refine.reviewing", candidates=len(tasks))
@@ -685,6 +690,9 @@ async def _refine_skill(templatized: str, project_path: Path) -> str:
         f"## Candidate {i + 1}\n\n{c}" for i, c in enumerate(survivors)
     )
     synth_task = (
+        "Synthesize the best slot values from the following candidates "
+        "into a single refined SKILL.md. Only modify values inside "
+        "{{slot_name::value}} markers.\n\n"
         f"## Original\n\n{templatized}\n\n"
         f"---\n\n{candidates_block}"
     )

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -706,16 +706,11 @@ async def _refine_skill(templatized: str, project_path: Path) -> str:
         )
 
     best = max(survivors, key=lambda c: _count_changed_slots(templatized, c))
-    best_guard = guard_check(templatized, best)
-    if best_guard.passed:
-        log.info(
-            "skill_refine.best_individual_fallback",
-            changed_slots=_count_changed_slots(templatized, best),
-        )
-        return best
-
-    log.info("skill_refine.best_individual_also_failed_mechanical_fallback")
-    return templatized
+    log.info(
+        "skill_refine.best_individual_fallback",
+        changed_slots=_count_changed_slots(templatized, best),
+    )
+    return best
 
 
 async def export_all_skills(

--- a/factory/workflow/splitter.py
+++ b/factory/workflow/splitter.py
@@ -25,6 +25,7 @@ _SLOT_PREFIXES = (
     "max_iterations_",
     "failure_action_",
     "finalize_command_",
+    "notes_",
 )
 
 

--- a/tests/test_skill_cache.py
+++ b/tests/test_skill_cache.py
@@ -58,44 +58,46 @@ class TestComputeChecksum:
 
 
 class TestEnsureSkills:
-    def test_cache_miss(self, tmp_path: Path, monkeypatch: object) -> None:
+    async def test_cache_miss(self, tmp_path: Path, monkeypatch: object) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))  # type: ignore[arg-type]
 
         project = tmp_path / "proj"
         project.mkdir()
 
-        paths = ensure_skills(project)
+        paths = await ensure_skills(project, refine=False)
         assert len(paths) > 0
         assert all(p.name == "SKILL.md" for p in paths)
 
         cache_root = tmp_path / ".factory" / "cache" / "skills"
         assert cache_root.exists()
 
-    def test_cache_hit(self, tmp_path: Path, monkeypatch: object) -> None:
+    async def test_cache_hit(self, tmp_path: Path, monkeypatch: object) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))  # type: ignore[arg-type]
 
         project = tmp_path / "proj"
         project.mkdir()
 
-        ensure_skills(project)
+        await ensure_skills(project, refine=False)
 
         with patch(
             "factory.workflow.skill_export.export_all_skills",
             wraps=None,
         ) as mock_export:
             mock_export.return_value = []
-            paths = ensure_skills(project)
+            paths = await ensure_skills(project, refine=False)
             mock_export.assert_not_called()
 
         assert len(paths) > 0
 
-    def test_cache_miss_evicts_stale_checksums(self, tmp_path: Path, monkeypatch: object) -> None:
+    async def test_cache_miss_evicts_stale_checksums(
+        self, tmp_path: Path, monkeypatch: object,
+    ) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))  # type: ignore[arg-type]
 
         project = tmp_path / "proj"
         project.mkdir()
 
-        ensure_skills(project)
+        await ensure_skills(project, refine=False)
 
         cache_root = tmp_path / ".factory" / "cache" / "skills"
         first_dirs = list(cache_root.iterdir())
@@ -110,13 +112,15 @@ class TestEnsureSkills:
             lambda: different_workflow,
         )
 
-        ensure_skills(project)
+        await ensure_skills(project, refine=False)
 
         remaining = [d for d in cache_root.iterdir() if d.is_dir()]
         assert len(remaining) == 1
         assert remaining[0] != old_checksum_dir
 
-    def test_only_workflow_dirs_copied(self, tmp_path: Path, monkeypatch: object) -> None:
+    async def test_only_workflow_dirs_copied(
+        self, tmp_path: Path, monkeypatch: object,
+    ) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))  # type: ignore[arg-type]
 
         project = tmp_path / "proj"
@@ -127,6 +131,6 @@ class TestEnsureSkills:
         marker = hand_written / "SKILL.md"
         marker.write_text("hand-written")
 
-        ensure_skills(project)
+        await ensure_skills(project, refine=False)
 
         assert marker.read_text() == "hand-written"

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -397,27 +397,29 @@ class TestWorkflowToSkillMd:
 
 
 class TestExportAllSkills:
-    def test_creates_skill_files(self, tmp_path: Path) -> None:
+    async def test_creates_skill_files(self, tmp_path: Path) -> None:
         builder = _make_agent("builder", AgentRole.BUILDER)
         wf = _minimal_workflow(name="test_wf", nodes={"builder": builder})
-        paths = export_all_skills(tmp_path, workflows={"test_wf": wf})
+        paths = await export_all_skills(tmp_path, workflows={"test_wf": wf}, refine=False)
         assert len(paths) == 1
         assert paths[0].exists()
         assert paths[0].name == "SKILL.md"
         assert "workflow-test_wf" in str(paths[0].parent)
 
-    def test_creates_directory_structure(self, tmp_path: Path) -> None:
+    async def test_creates_directory_structure(self, tmp_path: Path) -> None:
         wf1 = _minimal_workflow(name="build")
         wf2 = _minimal_workflow(name="improve")
-        paths = export_all_skills(tmp_path, workflows={"build": wf1, "improve": wf2})
+        paths = await export_all_skills(
+            tmp_path, workflows={"build": wf1, "improve": wf2}, refine=False,
+        )
         assert len(paths) == 2
         dirs = {p.parent.name for p in paths}
         assert "workflow-build" in dirs
         assert "workflow-improve" in dirs
 
-    def test_written_content_passes_validation(self, tmp_path: Path) -> None:
+    async def test_written_content_passes_validation(self, tmp_path: Path) -> None:
         wf = _minimal_workflow(name="build")
-        paths = export_all_skills(tmp_path, workflows={"build": wf})
+        paths = await export_all_skills(tmp_path, workflows={"build": wf}, refine=False)
         content = paths[0].read_text()
         issues = validate_skill(content)
         assert issues == [], f"Validation issues: {issues}"
@@ -502,11 +504,11 @@ class TestRealWorkflowSkills:
         assert "workflow-refine" in content
         assert "refiner" in content.lower()
 
-    def test_all_registered_skills_exported(self, tmp_path: Path) -> None:
+    async def test_all_registered_skills_exported(self, tmp_path: Path) -> None:
         from factory.workflow.definitions import register_all
 
         workflows = register_all()
-        paths = export_all_skills(tmp_path, workflows=workflows)
+        paths = await export_all_skills(tmp_path, workflows=workflows, refine=False)
         assert len(paths) == len(workflows), f"Expected {len(workflows)} skills, got {len(paths)}"
         dirs = {p.parent.name for p in paths}
         expected = {f"workflow-{name}" for name in workflows}

--- a/tests/test_skill_refine.py
+++ b/tests/test_skill_refine.py
@@ -1,0 +1,319 @@
+"""Tests for the LLM refinement pipeline in export_all_skills()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from factory.workflow.primitives import AgentNode, AgentRole, Edge, FnNode, Workflow
+from factory.workflow.skill_export import (
+    _count_changed_slots,
+    export_all_skills,
+    workflow_to_skill_md,
+)
+from factory.workflow.splitter import _SLOT_PREFIXES, _slot_belongs_to_node
+from factory.workflow.templates import extract
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def _make_agent(
+    id: str,
+    role: AgentRole = AgentRole.BUILDER,
+    *,
+    prompt: str = "Do the build.",
+) -> AgentNode:
+    return AgentNode(
+        id=id,
+        role=role,
+        blocking=True,
+        prompt_template=prompt,
+        reads=set(),
+        writes=set(),
+    )
+
+
+def _minimal_workflow(name: str = "test_wf") -> Workflow:
+    builder = _make_agent("builder")
+    return Workflow(
+        name=name,
+        nodes={"builder": builder},
+        edges=[],
+        start_node="builder",
+    )
+
+
+def _workflow_with_fn_notes() -> Workflow:
+    fn = FnNode(
+        id="fn_begin",
+        command="factory begin {project_path}",
+        notes="Open a new experiment for the current hypothesis.",
+    )
+    builder = _make_agent("builder")
+    return Workflow(
+        name="test_notes",
+        nodes={"fn_begin": fn, "builder": builder},
+        edges=[Edge(source="fn_begin", target="builder")],
+        start_node="fn_begin",
+    )
+
+
+# ── FnNode notes slots ──────────────────────────────────────────
+
+
+class TestFnNodeNotesSlots:
+    def test_notes_emit_template_slot(self) -> None:
+        wf = _workflow_with_fn_notes()
+        result = workflow_to_skill_md(wf)
+        assert "{{notes_fn_begin::" in result
+        assert "Open a new experiment" in result
+
+    def test_notes_slot_before_bash_block(self) -> None:
+        wf = _workflow_with_fn_notes()
+        result = workflow_to_skill_md(wf)
+        idx_slot = result.index("{{notes_fn_begin::")
+        idx_bash = result.index("```bash", idx_slot)
+        assert idx_slot < idx_bash
+
+    def test_empty_notes_no_slot(self) -> None:
+        fn = FnNode(id="fn_eval", command="factory eval {project_path}")
+        wf = Workflow(
+            name="test_empty",
+            nodes={"fn_eval": fn},
+            edges=[],
+            start_node="fn_eval",
+        )
+        result = workflow_to_skill_md(wf)
+        assert "{{notes_" not in result
+
+    def test_notes_extractable_as_slot(self) -> None:
+        wf = _workflow_with_fn_notes()
+        result = workflow_to_skill_md(wf)
+        slots = dict(extract(result))
+        assert "notes_fn_begin" in slots
+        assert slots["notes_fn_begin"] == "Open a new experiment for the current hypothesis."
+
+
+# ── _SLOT_PREFIXES ───────────────────────────────────────────────
+
+
+class TestSlotPrefixes:
+    def test_notes_in_prefixes(self) -> None:
+        assert "notes_" in _SLOT_PREFIXES
+
+    def test_slot_belongs_to_node_notes(self) -> None:
+        assert _slot_belongs_to_node("notes_fn_begin", "fn_begin")
+
+    def test_slot_belongs_to_node_notes_negative(self) -> None:
+        assert not _slot_belongs_to_node("notes_fn_begin", "fn_eval")
+
+
+# ── _count_changed_slots ─────────────────────────────────────────
+
+
+class TestCountChangedSlots:
+    def test_no_changes(self) -> None:
+        skeleton = "text {{a::1}} more {{b::2}}"
+        assert _count_changed_slots(skeleton, skeleton) == 0
+
+    def test_one_change(self) -> None:
+        skeleton = "text {{a::1}} more {{b::2}}"
+        candidate = "text {{a::changed}} more {{b::2}}"
+        assert _count_changed_slots(skeleton, candidate) == 1
+
+    def test_all_changed(self) -> None:
+        skeleton = "text {{a::1}} more {{b::2}}"
+        candidate = "text {{a::x}} more {{b::y}}"
+        assert _count_changed_slots(skeleton, candidate) == 2
+
+
+# ── export_all_skills refine=False ────────────────────────────────
+
+
+class TestExportNoRefine:
+    async def test_no_refine_produces_output(self, tmp_path: Path) -> None:
+        wf = _minimal_workflow()
+        paths = await export_all_skills(
+            tmp_path, {"test_wf": wf}, refine=False,
+        )
+        assert len(paths) == 1
+        assert paths[0].exists()
+        content = paths[0].read_text()
+        assert "workflow-test_wf" in content
+
+    async def test_no_refine_no_agent_calls(self, tmp_path: Path) -> None:
+        wf = _minimal_workflow()
+        with patch(
+            "factory.agents.runner.invoke_agents_parallel"
+        ) as mock_par, patch(
+            "factory.agents.runner.invoke_agent"
+        ) as mock_single:
+            await export_all_skills(
+                tmp_path, {"test_wf": wf}, refine=False,
+            )
+            mock_par.assert_not_called()
+            mock_single.assert_not_called()
+
+
+# ── export_all_skills refine=True ─────────────────────────────────
+
+
+class TestExportWithRefine:
+    async def test_spawns_3_reviewers(self, tmp_path: Path) -> None:
+        wf = _minimal_workflow()
+        templatized = workflow_to_skill_md(wf)
+
+        mock_parallel = AsyncMock(return_value=[
+            (templatized, 0),
+            (templatized, 0),
+            (templatized, 0),
+        ])
+        mock_synth = AsyncMock(return_value=(templatized, 0))
+
+        with patch(
+            "factory.agents.runner.invoke_agents_parallel",
+            mock_parallel,
+        ), patch(
+            "factory.agents.runner.invoke_agent",
+            mock_synth,
+        ):
+            await export_all_skills(
+                tmp_path, {"test_wf": wf}, refine=True,
+            )
+
+            mock_parallel.assert_called_once()
+            call_args = mock_parallel.call_args
+            tasks = call_args[0][0]
+            assert len(tasks) == 3
+            assert all(role == "skill_reviewer" for role, _ in tasks)
+
+    async def test_synthesizer_receives_survivors(self, tmp_path: Path) -> None:
+        wf = _minimal_workflow()
+        templatized = workflow_to_skill_md(wf)
+
+        mock_parallel = AsyncMock(return_value=[
+            (templatized, 0),
+            (templatized, 0),
+            ("bad output", 1),
+        ])
+        mock_synth = AsyncMock(return_value=(templatized, 0))
+
+        with patch(
+            "factory.agents.runner.invoke_agents_parallel",
+            mock_parallel,
+        ), patch(
+            "factory.agents.runner.invoke_agent",
+            mock_synth,
+        ):
+            await export_all_skills(
+                tmp_path, {"test_wf": wf}, refine=True,
+            )
+
+            mock_synth.assert_called_once()
+            call_args = mock_synth.call_args
+            assert call_args[0][0] == "skill_synthesizer"
+            synth_task = call_args[0][1]
+            assert "## Original" in synth_task
+            assert "## Candidate 1" in synth_task
+            assert "## Candidate 2" in synth_task
+
+
+# ── fallback chain ────────────────────────────────────────────────
+
+
+class TestFallbackChain:
+    async def test_all_candidates_fail_guard_mechanical_fallback(
+        self, tmp_path: Path,
+    ) -> None:
+        wf = _minimal_workflow()
+        templatized = workflow_to_skill_md(wf)
+
+        bad_output = templatized + "\n<!-- injected annotation -->"
+
+        mock_parallel = AsyncMock(return_value=[
+            (bad_output, 0),
+            (bad_output, 0),
+            (bad_output, 0),
+        ])
+
+        with patch(
+            "factory.agents.runner.invoke_agents_parallel",
+            mock_parallel,
+        ), patch(
+            "factory.agents.runner.invoke_agent",
+        ) as mock_synth:
+            paths = await export_all_skills(
+                tmp_path, {"test_wf": wf}, refine=True,
+            )
+            mock_synth.assert_not_called()
+            content = paths[0].read_text()
+            assert "workflow-test_wf" in content
+
+    async def test_synthesizer_fails_guard_best_individual(
+        self, tmp_path: Path,
+    ) -> None:
+        wf = _minimal_workflow()
+        templatized = workflow_to_skill_md(wf)
+
+        mock_parallel = AsyncMock(return_value=[
+            (templatized, 0),
+            (templatized, 0),
+            (templatized, 0),
+        ])
+        bad_synth = templatized + "\n<!-- injected -->"
+        mock_synth = AsyncMock(return_value=(bad_synth, 0))
+
+        with patch(
+            "factory.agents.runner.invoke_agents_parallel",
+            mock_parallel,
+        ), patch(
+            "factory.agents.runner.invoke_agent",
+            mock_synth,
+        ):
+            paths = await export_all_skills(
+                tmp_path, {"test_wf": wf}, refine=True,
+            )
+            assert paths[0].exists()
+
+    async def test_all_reviewers_return_nonzero_mechanical_fallback(
+        self, tmp_path: Path,
+    ) -> None:
+        wf = _minimal_workflow()
+
+        mock_parallel = AsyncMock(return_value=[
+            ("", 1),
+            ("", 1),
+            ("", 1),
+        ])
+
+        with patch(
+            "factory.agents.runner.invoke_agents_parallel",
+            mock_parallel,
+        ), patch(
+            "factory.agents.runner.invoke_agent",
+        ) as mock_synth:
+            paths = await export_all_skills(
+                tmp_path, {"test_wf": wf}, refine=True,
+            )
+            mock_synth.assert_not_called()
+            assert paths[0].exists()
+
+
+# ── synthesizer prompt exists ──────────────────────────────────────
+
+
+class TestSynthesizerPrompt:
+    def test_prompt_file_exists(self) -> None:
+        prompt_path = (
+            Path(__file__).resolve().parent.parent
+            / "factory" / "agents" / "prompts" / "skill_synthesizer.md"
+        )
+        assert prompt_path.exists(), f"Missing prompt: {prompt_path}"
+
+    def test_prompt_loadable(self) -> None:
+        from factory.agents.runner import resolve_prompt
+
+        prompt = resolve_prompt("skill_synthesizer")
+        assert "synthesizer" in prompt.lower()
+        assert "slot" in prompt.lower()


### PR DESCRIPTION
Closes #1024

## Changes

- **FnNode notes slots**: `_fn_to_instruction()` now emits `{{notes_{id}::...}}` template slots for FnNode notes, making them refinable by the Opus reviewer. Added `"notes_"` to `_SLOT_PREFIXES` in splitter.
- **SKILL_SYNTHESIZER role**: Added to `AgentRole` enum in primitives and runner's `AgentRole` Literal type.
- **Synthesizer prompt**: Created `factory/agents/prompts/skill_synthesizer.md` — a convergent agent that cherry-picks best slot values across independently-refined candidates.
- **Parallel refine pipeline**: `export_all_skills()` is now async with a `refine: bool = True` parameter. When enabled, runs 3x parallel skill_reviewer agents, guard-checks each, synthesizes survivors, with a full fallback chain (all fail → mechanical, synthesizer fails → best individual, best fails → mechanical).
- **Async call sites**: `ensure_skills()` is now async. CLI call sites in `ceo.py` use `_run()`, `workflow/cli.py` uses `asyncio.run()`.
- **`--no-refine` flag**: Added to `factory workflow export-skills` subparser for fast mechanical-only output.
- **Tests**: 19 new tests in `test_skill_refine.py` covering refine pipeline, fallback chain, notes slots, synthesizer prompt loading. Updated existing tests in `test_skill_export.py` and `test_skill_cache.py` for async compatibility.