### PR TITLE
update README installation instructions to be global

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -57,7 +57,9 @@ jobs:
 
       - name: Install factory
         working-directory: factory-trusted
-        run: uv sync --extra telemetry
+        run: |
+          uv sync --extra telemetry
+          uv tool install -e .
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -85,7 +87,7 @@ jobs:
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
         run: |
-          uv run factory ceo ${{ github.workspace }}/pr-code --mode deep-qa --pr ${{ steps.pr.outputs.number }} --headless
+          factory ceo ${{ github.workspace }}/pr-code --mode deep-qa --pr ${{ steps.pr.outputs.number }} --headless
 
       - name: Approve PR if verdict is KEEP
         if: success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,15 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: |
+          uv sync --all-groups
+          uv tool install -e .
       - name: Ruff check
         run: uv run ruff check .
       - name: Mypy
         run: uv run mypy factory/
       - name: Lint contributed workflows
-        run: uv run factory workflow lint-contributed
+        run: factory workflow lint-contributed
       - name: Check plugin agents in sync
         if: hashFiles('agents/') != ''
         run: uv run python scripts/sync_agents.py --check

--- a/.github/workflows/eval-baseline.yml
+++ b/.github/workflows/eval-baseline.yml
@@ -26,10 +26,12 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --all-groups --extra telemetry
+        run: |
+          uv sync --all-groups --extra telemetry
+          uv tool install -e .
 
       - name: Initialize factory config
-        run: uv run factory init .
+        run: factory init .
 
       - name: Run eval
         id: eval
@@ -38,7 +40,7 @@ jobs:
           LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
           LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
         run: |
-          uv run factory eval . > eval_output.json || true
+          factory eval . > eval_output.json || true
           cat eval_output.json
           python3 -c "import json; json.load(open('eval_output.json'))" || { echo 'ERROR: eval_output.json is missing or invalid JSON'; exit 1; }
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -22,13 +22,15 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: |
+          uv sync --all-groups
+          uv tool install -e .
 
       - name: Generate plugin agent files
         run: uv run python scripts/sync_agents.py
 
       - name: Generate workflow skills
-        run: uv run factory workflow export-skills --output-dir skills
+        run: factory workflow export-skills --output-dir skills
 
       - name: Copy skills to .agents/skills
         run: cp -r skills/ .agents/skills/

--- a/README.md
+++ b/README.md
@@ -19,25 +19,26 @@ All state is local — per-project in `.factory/` (add to `.gitignore`), global 
 
 ## Quick Start
 
-**Prerequisites:** Python 3.11+, [uv](https://docs.astral.sh/uv/), and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated).
+**Prerequisites:** Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated).
 
 ```bash
-git clone https://github.com/akashgit/remote-factory.git
-cd remote-factory
-uv sync
+# Install globally (pick one)
+pipx install git+https://github.com/akashgit/remote-factory.git      # via pipx
+uv tool install git+https://github.com/akashgit/remote-factory.git   # via uv
+pip install git+https://github.com/akashgit/remote-factory.git       # via pip
 ```
 
 Then start with one of the two main workflows:
 
 ```bash
 # Design — brainstorm an idea, refine it, then build
-uv run factory ceo "my idea" --mode design
+factory ceo "my idea" --mode design
 
 # Improve — point at an existing project for continuous improvement
-uv run factory ceo /path/to/project --mode improve --focus "issue # or whatever you want to improve or fix"
+factory ceo /path/to/project --mode improve --focus "issue # or whatever you want to improve or fix"
 
 # Co-improve — if you want to iterate on the implementation plan before implementation starts for an improvement
-uv run factory ceo /path/to/project --mode design --focus "issue # or whatever you want to improve or fix"
+factory ceo /path/to/project --mode design --focus "issue # or whatever you want to improve or fix"
 ```
 
 See the [full setup guide](docs/setup.md) for authentication and environment variables.
@@ -48,10 +49,10 @@ See the [full setup guide](docs/setup.md) for authentication and environment var
 
 | I want to… | Command |
 |---|---|
-| **Start from a raw idea** | `uv run factory ceo "my idea" --mode design` |
-| **Improve an existing project** | `uv run factory ceo /path/to/project --mode improve --focus "issue number or whatever you want to improve or fix ` |
-| **Co-improve an existing project** | `uv run factory ceo /path/to/project --mode design --focus "description of whatever you want to improve or fix ` |
-| **Create a new factory mode** | `uv run factory ceo /path/to/factory --mode create --focus "mode description"` |
+| **Start from a raw idea** | `factory ceo "my idea" --mode design` |
+| **Improve an existing project** | `factory ceo /path/to/project --mode improve --focus "issue number or whatever you want to improve or fix ` |
+| **Co-improve an existing project** | `factory ceo /path/to/project --mode design --focus "description of whatever you want to improve or fix ` |
+| **Create a new factory mode** | `factory ceo /path/to/factory --mode create --focus "mode description"` |
 
 ---
 
@@ -61,22 +62,22 @@ Use design mode when you want to brainstorm before building. Start a conversatio
 
 ```bash
 # From a raw idea — discuss and refine into a buildable spec
-uv run factory ceo "distributed task runner" --mode design
+factory ceo "distributed task runner" --mode design
 
 # From a spec file — read and discuss before building
-uv run factory ceo ~/ideas/my-app-spec.md --mode design
+factory ceo ~/ideas/my-app-spec.md --mode design
 ```
 
 Design mode also works on existing projects. The CEO studies the backlog, eval scores, open issues, and experiment history, then discusses what to work on before executing:
 
 ```bash
-uv run factory ceo ~/factory-projects/my-app --mode design
+factory ceo ~/factory-projects/my-app --mode design
 
 # Seed the conversation with a topic
-uv run factory ceo ~/factory-projects/my-app --mode design --focus "auth layer"
+factory ceo ~/factory-projects/my-app --mode design --focus "auth layer"
 ```
 
-You can also pass a spec file or URL directly — `uv run factory ceo spec.md` — and re:factory builds without the design conversation.
+You can also pass a spec file or URL directly — `factory ceo spec.md` — and re:factory builds without the design conversation.
 
 ---
 
@@ -85,7 +86,7 @@ You can also pass a spec file or URL directly — `uv run factory ceo spec.md` �
 Improve mode is re:factory's continuous improvement loop for existing projects. Point it at a codebase and it autonomously observes the project state, generates hypotheses for improvements, builds and tests changes, and keeps or reverts each experiment based on eval scores.
 
 ```bash
-uv run factory ceo ~/factory-projects/my-app --mode improve
+factory ceo ~/factory-projects/my-app --mode improve
 ```
 
 Each cycle: **observe** → **hypothesize** → **build** → **review** → **measure** → **decide** (keep or revert) → **archive**. The Strategist picks work from the backlog using FEEC priority (Fix > Exploit > Explore > Combine).
@@ -93,9 +94,9 @@ Each cycle: **observe** → **hypothesize** → **build** → **review** → **m
 When you know exactly what you want, `--focus` pins a single target — one hypothesis, one experiment, done:
 
 ```bash
-uv run factory ceo ~/my-app --mode improve --focus "add dark mode toggle"
-uv run factory ceo ~/my-app --mode improve --focus 42                       # GitHub issue
-uv run factory ceo ~/my-app --mode improve --focus "owner/repo#42"          # Issue shorthand
+factory ceo ~/my-app --mode improve --focus "add dark mode toggle"
+factory ceo ~/my-app --mode improve --focus 42                       # GitHub issue
+factory ceo ~/my-app --mode improve --focus "owner/repo#42"          # Issue shorthand
 ```
 
 ---
@@ -113,7 +114,7 @@ Each request runs through the full experiment pipeline: the **Refiner** scopes i
 You can also invoke refinements directly with `--refine`:
 
 ```bash
-uv run factory ceo ~/my-app --refine "add rate limiting to the API"
+factory ceo ~/my-app --refine "add rate limiting to the API"
 ```
 
 There's no cap on refinements. Advisory warnings appear at 5 and 10 to flag context growth, but the user decides when to stop.
@@ -125,7 +126,7 @@ There's no cap on refinements. Advisory warnings appear at 5 and 10 to flag cont
 Create mode lets you build new factory modes — new workflows, new pipelines, new factories. Pass a description via `--focus` to tell the CEO what mode to create. It's fully interactive — the CEO researches existing patterns, synthesizes a workflow spec, gets your approval, then implements everything: workflow definition, SKILL.md, CLI wiring, and tests.
 
 ```bash
-uv run factory ceo /path/to/factory --mode create --focus "a mode that validates PRs with multi-stage checks"
+factory ceo /path/to/factory --mode create --focus "a mode that validates PRs with multi-stage checks"
 ```
 
 The pipeline: **3 parallel researchers** (existing patterns, intent analysis, best practices) → **Strategist** synthesizes a workflow spec → **you approve** (like design mode) → **Builder** implements → **QA** verifies end-to-end → **PR**.
@@ -136,7 +137,7 @@ Point it at the factory repo itself to extend re:factory with custom pipelines.
 
 ## Eval System
 
-Every change is measured by an 11-dimension composite score across three tiers: **Hygiene** (tests, lint, types, coverage), **Growth** (API surface, experiment diversity, observability), and **Project** (user-defined domain metrics). On first run, `uv run factory discover` auto-detects your project's language and framework to generate the eval profile. See [Eval System](docs/eval.md) for scoring details, weights, and guards.
+Every change is measured by an 11-dimension composite score across three tiers: **Hygiene** (tests, lint, types, coverage), **Growth** (API surface, experiment diversity, observability), and **Project** (user-defined domain metrics). On first run, `factory discover` auto-detects your project's language and framework to generate the eval profile. See [Eval System](docs/eval.md) for scoring details, weights, and guards.
 
 ---
 
@@ -158,7 +159,7 @@ The pipeline produces two artifacts per workflow:
 Regenerate all skills after changing workflow definitions:
 
 ```bash
-uv run factory workflow export-skills
+factory workflow export-skills
 ```
 
 A regression test (`test_annotations_match_source`) runs in CI to catch drift between workflow definitions and exported skills.
@@ -186,15 +187,15 @@ Built something with re:factory? Open a PR to add it here.
 
 ```bash
 # Core workflow
-uv run factory ceo "idea" --mode design         # Design from a raw idea
-uv run factory ceo <path> --mode improve        # Improve an existing project
-uv run factory ceo <path> --refine "..."        # Single targeted refinement
-uv run factory ceo <path> --mode create --focus "description"  # Create a new factory mode
-uv run factory ceo <path> --loop                # Continuous improvement loop
-uv run factory tmux <path> --loop               # Loop in detached tmux session
+factory ceo "idea" --mode design         # Design from a raw idea
+factory ceo <path> --mode improve        # Improve an existing project
+factory ceo <path> --refine "..."        # Single targeted refinement
+factory ceo <path> --mode create --focus "description"  # Create a new factory mode
+factory ceo <path> --loop                # Continuous improvement loop
+factory tmux <path> --loop               # Loop in detached tmux session
 ```
 
-See `uv run factory --help` for the complete list.
+See `factory --help` for the complete list.
 
 ---
 
@@ -204,11 +205,11 @@ re:factory supports multiple CLI backends. Default is Claude Code — switch wit
 
 ```bash
 # Direct
-CODEX_API_KEY="..." uv run factory ceo /path --runner codex
-BOBSHELL_API_KEY="..." uv run factory ceo /path --runner bob
+CODEX_API_KEY="..." factory ceo /path --runner codex
+BOBSHELL_API_KEY="..." factory ceo /path --runner bob
 
 # Via config.toml profile (persistent)
-uv run factory ceo /path --profile codex
+factory ceo /path --profile codex
 ```
 
 Configure profiles in `~/.factory/config.toml`:
@@ -223,7 +224,7 @@ FACTORY_RUNNER = "bob"
 BOBSHELL_API_KEY = "..."
 ```
 
-Run `uv run factory config show` to see resolved config, or `uv run factory config edit` to open the file. See [Setup Guide](docs/setup.md) for full details.
+Run `factory config show` to see resolved config, or `factory config edit` to open the file. See [Setup Guide](docs/setup.md) for full details.
 
 ---
 
@@ -250,7 +251,7 @@ The dev credentials above match the docker-compose setup. Add them to your `~/.b
 ### Viewing Traces
 
 1. Start LangFuse: `scripts/langfuse-setup start`
-2. Run the factory: `uv run factory ceo /path/to/project`
+2. Run the factory: `factory ceo /path/to/project`
 3. Open `http://localhost:3000` in your browser
 4. Login: `dev@localhost.local` / `devpassword123`
 
@@ -295,7 +296,7 @@ Once installed, the plugin exposes:
 - Namespaced subagents — invoke with `factory:ceo`, `factory:researcher`, `factory:builder`, etc.
 - The bundled skills under `.agents/skills/` (e.g. `pipeline-subagents`, `implement`).
 
-The plugin still shells out to the `factory` CLI for the heavy lifting, so you'll need `uv` and the `factory` package installed locally as described in [Quick Start](#quick-start).
+The plugin still shells out to the `factory` CLI for the heavy lifting, so you'll need the `factory` package installed globally as described in [Quick Start](#quick-start).
 
 To update later: `/plugin marketplace update remote-factory`. To remove: `/plugin uninstall factory@remote-factory`.
 
@@ -306,8 +307,8 @@ To update later: `/plugin marketplace update remote-factory`. To remove: `/plugi
 If you'd rather skip the marketplace and just register the specialist agents as standalone Claude Code (or Codex) subagents, use the built-in installer:
 
 ```bash
-uv run factory install                   # Install all 9 agents to ~/.claude/agents/
-uv run factory install --runner codex    # Or install Codex TOML agents to ~/.codex/agents/
+factory install                   # Install all 9 agents to ~/.claude/agents/
+factory install --runner codex    # Or install Codex TOML agents to ~/.codex/agents/
 claude --agent factory-ceo "improve this project"
 claude --agent factory-researcher "study the auth system"
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All state is local — per-project in `.factory/` (add to `.gitignore`), global 
 
 ## Quick Start
 
-**Prerequisites:** Python 3.11+, [uv](https://docs.astral.sh/uv/#installation) (installed) and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated).
+**Prerequisites:** Python 3.11+, [uv](https://docs.astral.sh/uv/#installation), and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated).
 
 ### Quick Install
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,21 @@ All state is local — per-project in `.factory/` (add to `.gitignore`), global 
 
 ## Quick Start
 
-**Prerequisites:** Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated).
+**Prerequisites:** Python 3.11+, [uv](https://docs.astral.sh/uv/#installation) (installed) and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated).
+
+### Quick Install
 
 ```bash
-# Install globally (pick one)
-pipx install git+https://github.com/akashgit/remote-factory.git      # via pipx
-uv tool install git+https://github.com/akashgit/remote-factory.git   # via uv
-pip install git+https://github.com/akashgit/remote-factory.git       # via pip
+uv tool install git+https://github.com/akashgit/remote-factory.git
+```
+
+### Development Install
+
+```bash
+git clone https://github.com/akashgit/remote-factory.git
+cd remote-factory
+uv sync
+uv tool install -e .
 ```
 
 Then start with one of the two main workflows:
@@ -41,7 +49,7 @@ factory ceo /path/to/project --mode improve --focus "issue # or whatever you wan
 factory ceo /path/to/project --mode design --focus "issue # or whatever you want to improve or fix"
 ```
 
-See the [full setup guide](docs/setup.md) for authentication and environment variables.
+See the [full setup guide](docs/setup.md) for authentication, environment variables, and justification for why we install globally.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,9 +113,10 @@ factory tmux ~/my-project --loop
 ## Quick Start
 
 ```bash
-# Install from source (recommended — re:factory evolves fast)
-git clone https://github.com/akashgit/remote-factory.git
-cd remote-factory && uv sync && uv tool install -e .
+# Install globally (pick one)
+pipx install git+https://github.com/akashgit/remote-factory.git      # via pipx
+uv tool install git+https://github.com/akashgit/remote-factory.git   # via uv
+pip install git+https://github.com/akashgit/remote-factory.git       # via pip
 
 # Register the CEO as a Claude Code agent
 factory install

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,11 +114,6 @@ factory tmux ~/my-project --loop
 
 See [setup.md](setup.md) for installation instructions.
 
-
-# Register the CEO as a Claude Code agent
-factory install
-```
-
 **Prerequisites:** Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated). No external services, databases, or Obsidian required — re:factory stores all state locally.
 
 Per-project state lives in `.factory/` (experiment history, strategy, archive notes). Global state lives in `~/.factory/` (project registry, evolved playbooks). Projects are auto-registered when experiments begin — no manual setup needed. See [Setup Guide](setup.md) for environment variables and authentication options.

--- a/docs/index.md
+++ b/docs/index.md
@@ -112,11 +112,8 @@ factory tmux ~/my-project --loop
 
 ## Quick Start
 
-```bash
-# Install globally (pick one)
-pipx install git+https://github.com/akashgit/remote-factory.git      # via pipx
-uv tool install git+https://github.com/akashgit/remote-factory.git   # via uv
-pip install git+https://github.com/akashgit/remote-factory.git       # via pip
+See [setup.md](setup.md) for installation instructions.
+
 
 # Register the CEO as a Claude Code agent
 factory install

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,33 +14,21 @@
 
 ## Installation
 
-Install re:factory globally so `factory` is available everywhere on your machine.
+Install re:factory globally so the `factory` command is available everywhere on your machine. This is important because factory uses worktrees that are not guaranteed to inherit the local environment.
 
-### Option A: One-liner (recommended)
+### Option A: One-liner (recommended; installs `uv` if necessary)
 
 ```bash
 curl -sSf https://raw.githubusercontent.com/akashgit/remote-factory/main/install.sh | bash
 ```
 
-### Option B: pipx
-
-```bash
-pipx install git+https://github.com/akashgit/remote-factory.git
-```
-
-### Option C: uv tool
+### Option B: `uv`
 
 ```bash
 uv tool install git+https://github.com/akashgit/remote-factory.git
 ```
 
-### Option D: pip
-
-```bash
-pip install git+https://github.com/akashgit/remote-factory.git
-```
-
-### Option E: From source (for development)
+### Option C: From source (for development)
 
 re:factory evolves fast — installing from source lets you `git pull` to stay current.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,14 +7,40 @@
 | Python | 3.11+ | System or [pyenv](https://github.com/pyenv/pyenv) |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Latest | `npm install -g @anthropic-ai/claude-code` |
 | Node.js | 18+ | Required for Claude Code and MCP servers |
-| [uv](https://docs.astral.sh/uv/) | Latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` (for dev install) |
+| [uv](https://docs.astral.sh/uv/) | Latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` (optional) |
 | tmux | Any | `brew install tmux` (optional, for long-running sessions) |
 
 **Claude Code must be installed and authenticated.** re:factory spawns `claude` as subprocesses — it does not call the Claude API directly. However you've authenticated Claude Code (API key, Vertex AI, etc.) is how re:factory will access Claude.
 
 ## Installation
 
-### Option A: From source (recommended)
+Install re:factory globally so `factory` is available everywhere on your machine.
+
+### Option A: One-liner (recommended)
+
+```bash
+curl -sSf https://raw.githubusercontent.com/akashgit/remote-factory/main/install.sh | bash
+```
+
+### Option B: pipx
+
+```bash
+pipx install git+https://github.com/akashgit/remote-factory.git
+```
+
+### Option C: uv tool
+
+```bash
+uv tool install git+https://github.com/akashgit/remote-factory.git
+```
+
+### Option D: pip
+
+```bash
+pip install git+https://github.com/akashgit/remote-factory.git
+```
+
+### Option E: From source (for development)
 
 re:factory evolves fast — installing from source lets you `git pull` to stay current.
 
@@ -25,25 +51,11 @@ uv sync
 uv tool install -e .
 ```
 
-### Option B: From pip
-
-```bash
-pip install git+https://github.com/akashgit/remote-factory.git
-```
-
-### Option C: One-liner
-
-```bash
-curl -sSf https://raw.githubusercontent.com/akashgit/remote-factory/main/install.sh | bash
-```
-
 ### Verify
 
 ```bash
 factory --help
 ```
-
-If running from source without `uv tool install`, prefix commands with `uv run` (e.g., `uv run factory ceo "..."`). If you've installed the CLI, bare `factory` works directly.
 
 ## CEO Agent Registration
 
@@ -146,14 +158,14 @@ re:factory inherits Claude Code's authentication. Configure whichever method you
 ```bash
 # 1. Install tooling
 npm install -g @anthropic-ai/claude-code     # Claude Code
-curl -LsSf https://astral.sh/uv/install.sh | sh  # uv (optional, for dev install)
 
 # 2. Authenticate Claude Code (if not already done)
 claude  # follow the prompts
 
-# 3. Install re:factory
-git clone https://github.com/akashgit/remote-factory.git
-cd remote-factory && uv sync && uv tool install -e .
+# 3. Install re:factory globally (pick one)
+pipx install git+https://github.com/akashgit/remote-factory.git      # via pipx
+uv tool install git+https://github.com/akashgit/remote-factory.git   # via uv
+pip install git+https://github.com/akashgit/remote-factory.git       # via pip
 
 # 4. Register CEO agent
 factory install

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,7 +14,7 @@
 
 ## Installation
 
-Install re:factory globally so the `factory` command is available everywhere on your machine. This is important because factory uses worktrees that are not guaranteed to inherit the local environment.
+Install re:factory globally so the `factory` command is available everywhere on your machine. This is important because factory creates worktrees that are not guaranteed to inherit the local environment, but we need factory agents to be able to correctly call factory commands via CLI regardless of the location of the git worktree.
 
 ### Option A: One-liner (recommended; installs `uv` if necessary)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,7 +7,7 @@
 | Python | 3.11+ | System or [pyenv](https://github.com/pyenv/pyenv) |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Latest | `npm install -g @anthropic-ai/claude-code` |
 | Node.js | 18+ | Required for Claude Code and MCP servers |
-| [uv](https://docs.astral.sh/uv/) | Latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` (optional) |
+| [uv](https://docs.astral.sh/uv/) | Latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` (auto-installed by Option A) |
 | tmux | Any | `brew install tmux` (optional, for long-running sessions) |
 
 **Claude Code must be installed and authenticated.** re:factory spawns `claude` as subprocesses — it does not call the Claude API directly. However you've authenticated Claude Code (API key, Vertex AI, etc.) is how re:factory will access Claude.
@@ -150,10 +150,8 @@ npm install -g @anthropic-ai/claude-code     # Claude Code
 # 2. Authenticate Claude Code (if not already done)
 claude  # follow the prompts
 
-# 3. Install re:factory globally (pick one)
-pipx install git+https://github.com/akashgit/remote-factory.git      # via pipx
-uv tool install git+https://github.com/akashgit/remote-factory.git   # via uv
-pip install git+https://github.com/akashgit/remote-factory.git       # via pip
+# 3. Install re:factory globally
+uv tool install git+https://github.com/akashgit/remote-factory.git
 
 # 4. Register CEO agent
 factory install

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,78 @@
+"""E2E tests for the two install paths documented in README.md.
+
+Each test installs into an isolated UV_TOOL_DIR / UV_TOOL_BIN_DIR so
+nothing touches the real system.  No Docker, no network — installs
+from the local checkout.
+
+Requires `uv` on PATH.  Skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_uv_available = shutil.which("uv") is not None
+
+pytestmark = [
+    pytest.mark.skipif(not _uv_available, reason="uv not available"),
+]
+
+
+@pytest.fixture()
+def isolated_tool_env(tmp_path: Path):
+    """Yield env dict that redirects uv tool install to a temp directory."""
+    tool_dir = tmp_path / "tools"
+    bin_dir = tmp_path / "bin"
+    env = os.environ.copy()
+    env["UV_TOOL_DIR"] = str(tool_dir)
+    env["UV_TOOL_BIN_DIR"] = str(bin_dir)
+    yield env, bin_dir
+
+
+class TestQuickInstall:
+    """README 'Quick Install': uv tool install git+https://..."""
+
+    def test_non_editable_install(self, isolated_tool_env):
+        env, bin_dir = isolated_tool_env
+        subprocess.run(
+            ["uv", "tool", "install", str(REPO_ROOT)],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        result = subprocess.run(
+            [str(bin_dir / "factory"), "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "factory" in result.stdout
+
+
+class TestDevInstall:
+    """README 'Development Install': git clone && uv sync && uv tool install -e ."""
+
+    def test_editable_install(self, isolated_tool_env):
+        env, bin_dir = isolated_tool_env
+        subprocess.run(
+            ["uv", "tool", "install", "-e", str(REPO_ROOT)],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        result = subprocess.run(
+            [str(bin_dir / "factory"), "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "factory" in result.stdout


### PR DESCRIPTION
So that `factory` can be called from anywhere, we now instruct users to install factory globally.