### PR TITLE
feat(knowledge): add OLS troubleshooting eval benchmark adapter

### DIFF
--- a/factory/agents/prompts/knowledge_analyst.md
+++ b/factory/agents/prompts/knowledge_analyst.md
@@ -1,0 +1,199 @@
+# Knowledge Analyst Agent
+
+## Identity
+
+You are the Knowledge Analyst agent for the Software Factory — an expert at exploring knowledge graphs built from agent execution traces. You discover failure patterns, trace causal chains, detect contradictions, and surface actionable improvement opportunities.
+
+## Context
+
+You operate on a knowledge graph stored at `.factory/knowledge/{task_id}.json`. The graph contains triplets `(subject, predicate, object)` extracted from observing an external agent's behavior. Your job is to interactively query the graph, follow leads, and produce structured insights.
+
+Read `.factory/knowledge/task_config.json` first to get the `task_id` and task context.
+
+## Available Operations
+
+Query the knowledge graph using `python3 -c` commands. All operations load the graph from disk first.
+
+### Boilerplate (use at the top of every command)
+
+```python
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph, PredicateType
+cfg = json.loads(pathlib.Path(".factory/knowledge/task_config.json").read_text())
+task_id = cfg["task_id"]
+data = json.loads(pathlib.Path(f".factory/knowledge/{task_id}.json").read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+```
+
+### Get graph statistics
+
+```bash
+python3 -c "
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph
+cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text())
+task_id = cfg['task_id']
+data = json.loads(pathlib.Path(f'.factory/knowledge/{task_id}.json').read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+stats = graph.stats()
+print(json.dumps(stats, indent=2, default=str))
+"
+```
+
+### Query by predicate
+
+```bash
+python3 -c "
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph, PredicateType
+cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text())
+task_id = cfg['task_id']
+data = json.loads(pathlib.Path(f'.factory/knowledge/{task_id}.json').read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+for t in graph.query_by_predicate(PredicateType.FAILS_WITH):
+    print(f'{t.subject.name} --{t.predicate.value}--> {t.object.name} (conf={t.confidence})')
+"
+```
+
+### Query with filters
+
+```bash
+python3 -c "
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph, PredicateType
+cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text())
+task_id = cfg['task_id']
+data = json.loads(pathlib.Path(f'.factory/knowledge/{task_id}.json').read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+# Filter by subject, predicate, and/or object (use None to skip a filter)
+for t in graph.query(subject_id='agent:main', predicate=PredicateType.CALLS):
+    print(f'{t.subject.name} --{t.predicate.value}--> {t.object.name}')
+"
+```
+
+### Traverse from an entity (BFS, multi-hop)
+
+```bash
+python3 -c "
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph
+cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text())
+task_id = cfg['task_id']
+data = json.loads(pathlib.Path(f'.factory/knowledge/{task_id}.json').read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+paths = graph.traverse('ENTITY_ID_HERE', max_hops=3)
+for path in paths[:20]:
+    chain = ' -> '.join(f'{t.subject.name}--{t.predicate.value}-->{t.object.name}' for t in path)
+    print(chain)
+"
+```
+
+### Follow causal chains
+
+```bash
+python3 -c "
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph
+cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text())
+task_id = cfg['task_id']
+data = json.loads(pathlib.Path(f'.factory/knowledge/{task_id}.json').read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+chains = graph.causal_chain('ENTITY_ID_HERE', max_depth=5)
+for i, chain in enumerate(chains):
+    steps = ' -> '.join(f'{t.subject.name}--{t.predicate.value}-->{t.object.name}' for t in chain)
+    print(f'Chain {i}: {steps}')
+"
+```
+
+### Find paths between two entities
+
+```bash
+python3 -c "
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph
+cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text())
+task_id = cfg['task_id']
+data = json.loads(pathlib.Path(f'.factory/knowledge/{task_id}.json').read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+paths = graph.find_paths('FROM_ENTITY_ID', 'TO_ENTITY_ID', max_hops=5)
+for path in paths:
+    chain = ' -> '.join(f'{t.subject.name}--{t.predicate.value}-->{t.object.name}' for t in path)
+    print(chain)
+"
+```
+
+### Match structural patterns
+
+```bash
+python3 -c "
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph, PredicateType
+cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text())
+task_id = cfg['task_id']
+data = json.loads(pathlib.Path(f'.factory/knowledge/{task_id}.json').read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+# Find all: ?agent fails_at ?task, ?task requires ?tool
+matches = graph.match_pattern([
+    (None, PredicateType.FAILS_AT, None),
+    (None, PredicateType.REQUIRES, None),
+])
+for match in matches:
+    chain = ' -> '.join(f'{t.subject.name}--{t.predicate.value}-->{t.object.name}' for t in match)
+    print(chain)
+"
+```
+
+### Get related entities
+
+```bash
+python3 -c "
+import json, pathlib
+from factory.knowledge.models import KnowledgeGraph
+cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text())
+task_id = cfg['task_id']
+data = json.loads(pathlib.Path(f'.factory/knowledge/{task_id}.json').read_text())
+graph = KnowledgeGraph.model_validate(data, strict=False)
+for e in graph.related_entities('ENTITY_ID_HERE'):
+    print(f'{e.id} ({e.type.value}): {e.name}')
+"
+```
+
+## Task
+
+1. **Load and survey** — Get stats to understand graph size, predicate distribution, and failure hotspots.
+2. **Explore failures** — Query for `FAILS_WITH`, `FAILS_AT` predicates. Follow causal chains from failure entities to find root causes.
+3. **Detect contradictions** — Look for entities that have both `SUCCEEDS_AT` and `FAILS_AT` relationships (flaky behavior signal).
+4. **Find improvement opportunities** — Use `match_pattern` to find tasks that require tools the agent never calls. Check high-degree entities that are bottlenecks.
+5. **Build causal explanations** — For each significant finding, trace the causal chain to construct a full explanation.
+6. **Produce structured insights** — Write to `.factory/knowledge/{task_id}_insights.json`.
+
+## Output
+
+Write insights as a JSON array to `.factory/knowledge/{task_id}_insights.json`:
+
+```json
+[
+  {
+    "type": "failure_pattern",
+    "title": "Short descriptive title",
+    "description": "Detailed explanation of the insight",
+    "confidence": 0.85,
+    "evidence_triplet_ids": ["triplet_id_1", "triplet_id_2"],
+    "causal_path": ["entity_id_1", "entity_id_2"],
+    "suggested_action": "Concrete actionable suggestion"
+  }
+]
+```
+
+Valid types: `failure_pattern`, `missing_knowledge`, `contradiction`, `improvement_opportunity`, `causal_chain`.
+
+Also print a human-readable summary to stdout.
+
+## Rules
+
+- Act AUTONOMOUSLY — do not ask for confirmation
+- Start with `stats()` before diving into specifics
+- Produce at least 3 insights if the graph has sufficient data (10+ triplets)
+- Each insight MUST reference specific triplet IDs as evidence
+- If the graph has fewer than 5 triplets, report what you can and note the data is thin
+- Replace `ENTITY_ID_HERE` placeholders with actual entity IDs from the graph

--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -14,10 +14,20 @@ from factory.runners import get_runner
 logger = logging.getLogger(__name__)
 
 AgentRole = Literal[
-    "researcher", "strategist", "builder", "qa",
-    "health_checker", "code_reviewer", "adversarial_tester",
-    "archivist", "ceo", "failure_analyst", "refiner", "profiler",
+    "researcher",
+    "strategist",
+    "builder",
+    "qa",
+    "health_checker",
+    "code_reviewer",
+    "adversarial_tester",
+    "archivist",
+    "ceo",
+    "failure_analyst",
+    "refiner",
+    "profiler",
     "refactory",
+    "knowledge_analyst",
 ]
 
 # Consecutive failure tracking
@@ -47,6 +57,7 @@ def reset_failure_counter() -> None:
     """Reset the consecutive failure counter. Call at start of a cycle."""
     global _consecutive_failures
     _consecutive_failures = 0
+
 
 IDENTITY_REANCHOR = """\
 
@@ -97,10 +108,11 @@ def resolve_prompt(
     # Fall back to factory default
     default_path = _PROMPTS_DIR / f"{role}.md"
     if not default_path.exists():
-        override_hint = f" or {project_path / '.factory' / 'agents' / f'{role}.md'}" if project_path else ""
+        override_hint = (
+            f" or {project_path / '.factory' / 'agents' / f'{role}.md'}" if project_path else ""
+        )
         raise FileNotFoundError(
-            f"No prompt found for agent role '{role}'. "
-            f"Expected at {default_path}{override_hint}"
+            f"No prompt found for agent role '{role}'. Expected at {default_path}{override_hint}"
         )
 
     prompt = default_path.read_text()
@@ -215,12 +227,18 @@ async def invoke_agent(
         if return_code != 0:
             logger.warning("%s agent exited with code %d", role, return_code)
             _emit_safe(
-                project_path, "agent.failed", agent=role,
+                project_path,
+                "agent.failed",
+                agent=role,
                 data={"return_code": return_code, "stderr": stdout[:200] if stdout else ""},
             )
             _complete_span_safe(
-                project_path, sid, status="failed",
-                usage=usage, metadata=result.metadata, output=stdout,
+                project_path,
+                sid,
+                status="failed",
+                usage=usage,
+                metadata=result.metadata,
+                output=stdout,
             )
             if _track_failures:
                 _consecutive_failures += 1
@@ -230,25 +248,33 @@ async def invoke_agent(
             if review_tag:
                 completed_data["review_tag"] = review_tag
             if usage is not None:
-                completed_data.update({
-                    "input_tokens": usage.input_tokens,
-                    "output_tokens": usage.output_tokens,
-                    "cache_read_tokens": usage.cache_read_tokens,
-                    "total_cost_usd": usage.total_cost_usd,
-                    "duration_ms": usage.duration_ms,
-                    "num_turns": usage.num_turns,
-                    "model": usage.model,
-                })
+                completed_data.update(
+                    {
+                        "input_tokens": usage.input_tokens,
+                        "output_tokens": usage.output_tokens,
+                        "cache_read_tokens": usage.cache_read_tokens,
+                        "total_cost_usd": usage.total_cost_usd,
+                        "duration_ms": usage.duration_ms,
+                        "num_turns": usage.num_turns,
+                        "model": usage.model,
+                    }
+                )
             for meta_key in ("session_id", "stop_reason", "terminal_reason"):
                 if result.metadata.get(meta_key) is not None:
                     completed_data[meta_key] = result.metadata[meta_key]
             _emit_safe(
-                project_path, "agent.completed", agent=role,
+                project_path,
+                "agent.completed",
+                agent=role,
                 data=completed_data,
             )
             _complete_span_safe(
-                project_path, sid, status="completed",
-                usage=usage, metadata=result.metadata, output=stdout,
+                project_path,
+                sid,
+                status="completed",
+                usage=usage,
+                metadata=result.metadata,
+                output=stdout,
             )
             if _track_failures:
                 _consecutive_failures = 0
@@ -308,7 +334,8 @@ def _begin_span_safe(
         parent_span_id = os.environ.get("FACTORY_PARENT_SPAN_ID")
         logger.debug(
             "Langfuse env: FACTORY_TRACE_ID=%s FACTORY_PARENT_SPAN_ID=%s",
-            trace_id, parent_span_id,
+            trace_id,
+            parent_span_id,
         )
         if not trace_id:
             result = begin_trace(project_path.name, cycle_id=f"standalone-{role}")
@@ -348,8 +375,15 @@ def _complete_span_safe(
         usage_dict: dict | None = None
         if usage is not None:
             usage_dict = {}
-            for key in ("input_tokens", "output_tokens", "cache_read_tokens",
-                        "total_cost_usd", "duration_ms", "num_turns", "model"):
+            for key in (
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "total_cost_usd",
+                "duration_ms",
+                "num_turns",
+                "model",
+            ):
                 val = getattr(usage, key, None)
                 if val is not None:
                     usage_dict[key] = val
@@ -360,18 +394,25 @@ def _complete_span_safe(
             ingest_transcript_to_span(trace_id, span_id, claude_session_id, project_path)
 
         end_span(
-            trace_id, span_id,
-            status=status, usage=usage_dict, metadata=meta or None,
+            trace_id,
+            span_id,
+            status=status,
+            usage=usage_dict,
+            metadata=meta or None,
             output=output[:4000] if output else None,
         )
         from factory.telemetry import flush as _flush
+
         _flush()
     except Exception:
         logger.debug("Failed to complete span %s", span_id, exc_info=True)
 
 
 def _save_review(
-    project_path: Path, role: str, output: str, return_code: int,
+    project_path: Path,
+    role: str,
+    output: str,
+    return_code: int,
     review_tag: str | None = None,
 ) -> None:
     """Save agent output to .factory/reviews/<role>-latest.md for CEO review.

--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -1,4 +1,5 @@
 """CLI _helpers commands."""
+
 from __future__ import annotations
 
 import argparse
@@ -16,7 +17,23 @@ log = structlog.get_logger()
 _WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
 
 
-CEO_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "research", "review", "qa", "deep-qa", "create", "swebench"]
+CEO_MODES = [
+    "auto",
+    "auto-fresh",
+    "build",
+    "discover",
+    "improve",
+    "meta",
+    "design",
+    "interactive",
+    "research",
+    "review",
+    "qa",
+    "deep-qa",
+    "create",
+    "swebench",
+    "knowledge",
+]
 
 
 RUN_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "research", "swebench"]
@@ -89,10 +106,16 @@ def _ensure_dashboard(project_path: Path, port: int = _DASHBOARD_PORT) -> None:
 
     # Start dashboard as a detached background process
     cmd = [
-        sys.executable, "-m", "factory", "dashboard",
-        "--projects-dir", str(projects_dir),
-        "--port", str(port),
-        "--host", "0.0.0.0",
+        sys.executable,
+        "-m",
+        "factory",
+        "dashboard",
+        "--projects-dir",
+        str(projects_dir),
+        "--port",
+        str(port),
+        "--host",
+        "0.0.0.0",
     ]
     subprocess.Popen(
         cmd,
@@ -113,8 +136,8 @@ def _print_banner(mode: str = "improve") -> None:
         return
 
     c = "\033[1;36m"  # bold cyan
-    d = "\033[2m"      # dim
-    r = "\033[0m"      # reset
+    d = "\033[2m"  # dim
+    r = "\033[0m"  # reset
 
     mode_line = "" if mode == "welcome" else f"{d}  Mode: {mode}{r}\n"
     banner = (
@@ -208,4 +231,3 @@ def _load_env_local() -> None:
                     key, _, value = line.partition("=")
                     os.environ.setdefault(key.strip(), value.strip())
             break
-

--- a/factory/knowledge/__init__.py
+++ b/factory/knowledge/__init__.py
@@ -25,6 +25,7 @@ from factory.knowledge.tau_adapter import (
     compute_aggregate_score as compute_aggregate_score,
     extract_scores as extract_scores,
     parse_simulation as parse_simulation,
+    run_tau_eval as run_tau_eval,
 )
 
 __all__ = [

--- a/factory/knowledge/__init__.py
+++ b/factory/knowledge/__init__.py
@@ -11,6 +11,10 @@ from factory.knowledge.insight import (
     InsightType as InsightType,
     format_insights as format_insights,
 )
+from factory.knowledge.gates import (
+    evaluate_insights_gate as evaluate_insights_gate,
+    generate_report as generate_report,
+)
 from factory.knowledge.models import (
     Entity as Entity,
     EntityType as EntityType,
@@ -18,14 +22,18 @@ from factory.knowledge.models import (
     KnowledgeTaskConfig as KnowledgeTaskConfig,
     PredicateType as PredicateType,
     TauBenchTaskConfig as TauBenchTaskConfig,
+    TauRunState as TauRunState,
     Triplet as Triplet,
 )
 from factory.knowledge.store import KnowledgeStore as KnowledgeStore
 from factory.knowledge.tau_adapter import (
     compute_aggregate_score as compute_aggregate_score,
+    evaluate_compare_gate as evaluate_compare_gate,
+    evaluate_score_gate as evaluate_score_gate,
     extract_scores as extract_scores,
     parse_simulation as parse_simulation,
     run_tau_eval as run_tau_eval,
+    write_failing_tasks as write_failing_tasks,
 )
 
 __all__ = [

--- a/factory/knowledge/__init__.py
+++ b/factory/knowledge/__init__.py
@@ -15,6 +15,7 @@ from factory.knowledge.models import (
     Entity as Entity,
     EntityType as EntityType,
     KnowledgeGraph as KnowledgeGraph,
+    KnowledgeTaskConfig as KnowledgeTaskConfig,
     PredicateType as PredicateType,
     Triplet as Triplet,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "InsightType",
     "KnowledgeGraph",
     "KnowledgeStore",
+    "KnowledgeTaskConfig",
     "PredicateType",
     "Triplet",
     "extract_from_diff",

--- a/factory/knowledge/__init__.py
+++ b/factory/knowledge/__init__.py
@@ -17,9 +17,15 @@ from factory.knowledge.models import (
     KnowledgeGraph as KnowledgeGraph,
     KnowledgeTaskConfig as KnowledgeTaskConfig,
     PredicateType as PredicateType,
+    TauBenchTaskConfig as TauBenchTaskConfig,
     Triplet as Triplet,
 )
 from factory.knowledge.store import KnowledgeStore as KnowledgeStore
+from factory.knowledge.tau_adapter import (
+    compute_aggregate_score as compute_aggregate_score,
+    extract_scores as extract_scores,
+    parse_simulation as parse_simulation,
+)
 
 __all__ = [
     "Entity",
@@ -31,10 +37,14 @@ __all__ = [
     "KnowledgeStore",
     "KnowledgeTaskConfig",
     "PredicateType",
+    "TauBenchTaskConfig",
     "Triplet",
+    "compute_aggregate_score",
     "extract_from_diff",
     "extract_from_tool_calls",
+    "extract_scores",
     "extract_triplets_from_log",
     "format_insights",
     "parse_extraction_response",
+    "parse_simulation",
 ]

--- a/factory/knowledge/__init__.py
+++ b/factory/knowledge/__init__.py
@@ -1,0 +1,38 @@
+"""Knowledge graph module — triplet-based representation of learned facts."""
+
+from factory.knowledge.extractor import (
+    extract_from_diff as extract_from_diff,
+    extract_from_tool_calls as extract_from_tool_calls,
+    extract_triplets_from_log as extract_triplets_from_log,
+    parse_extraction_response as parse_extraction_response,
+)
+from factory.knowledge.insight import (
+    Insight as Insight,
+    InsightType as InsightType,
+    format_insights as format_insights,
+)
+from factory.knowledge.models import (
+    Entity as Entity,
+    EntityType as EntityType,
+    KnowledgeGraph as KnowledgeGraph,
+    PredicateType as PredicateType,
+    Triplet as Triplet,
+)
+from factory.knowledge.store import KnowledgeStore as KnowledgeStore
+
+__all__ = [
+    "Entity",
+    "EntityType",
+    "ExtractionResult",
+    "Insight",
+    "InsightType",
+    "KnowledgeGraph",
+    "KnowledgeStore",
+    "PredicateType",
+    "Triplet",
+    "extract_from_diff",
+    "extract_from_tool_calls",
+    "extract_triplets_from_log",
+    "format_insights",
+    "parse_extraction_response",
+]

--- a/factory/knowledge/extractor.py
+++ b/factory/knowledge/extractor.py
@@ -1,0 +1,388 @@
+"""Knowledge extraction — convert agent logs and tool traces into triplets."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+
+from factory.knowledge.models import (
+    Entity,
+    EntityType,
+    PredicateType,
+    Triplet,
+    _short_uuid,
+)
+
+log = structlog.get_logger()
+
+
+# ── extraction result ────────────────────────────────────────────
+
+
+class _ExtractionResult:
+    """Container for extraction output (not persisted, used in-process)."""
+
+    __slots__ = ("triplets", "raw_response", "source_label")
+
+    def __init__(
+        self,
+        triplets: list[Triplet],
+        raw_response: str = "",
+        source_label: str = "",
+    ) -> None:
+        self.triplets = triplets
+        self.raw_response = raw_response
+        self.source_label = source_label
+
+
+# ── deterministic extraction ─────────────────────────────────────
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9_]", "_", name.lower()).strip("_")
+
+
+def _make_entity(entity_type: EntityType, name: str, **attrs: str | float | bool) -> Entity:
+    slug = _slugify(name)
+    return Entity(
+        id=f"{entity_type.value}:{slug}",
+        type=entity_type,
+        name=name,
+        attributes=dict(attrs) if attrs else {},
+    )
+
+
+def extract_from_tool_calls(
+    tool_calls: list[dict[str, object]],
+    task_context: str,
+    *,
+    agent_name: str = "agent",
+    source_label: str = "tool_trace",
+) -> _ExtractionResult:
+    """Extract triplets from a structured list of tool calls.
+
+    Each tool_call dict should have: name, arguments (optional), result (optional),
+    error (optional), success (optional bool).
+    """
+    agent = _make_entity(EntityType.AGENT, agent_name)
+    task = _make_entity(EntityType.TASK, task_context)
+    now = datetime.now()
+    triplets: list[Triplet] = []
+    prev_action: Entity | None = None
+    has_failure = False
+
+    for i, call in enumerate(tool_calls):
+        tool_name = str(call.get("name", f"unknown_tool_{i}"))
+        tool = _make_entity(EntityType.TOOL, tool_name)
+        action = _make_entity(
+            EntityType.ACTION,
+            f"{tool_name}_call_{i}",
+            index=float(i),
+        )
+
+        triplets.append(
+            Triplet(
+                subject=agent,
+                predicate=PredicateType.CALLS,
+                object=tool,
+                source=source_label,
+                timestamp=now,
+                evidence=f"Tool call #{i}: {tool_name}",
+            )
+        )
+
+        if prev_action is not None:
+            triplets.append(
+                Triplet(
+                    subject=prev_action,
+                    predicate=PredicateType.PRECEDES,
+                    object=action,
+                    source=source_label,
+                    timestamp=now,
+                )
+            )
+
+        error = call.get("error")
+        success = call.get("success", error is None)
+
+        if error:
+            has_failure = True
+            error_entity = _make_entity(
+                EntityType.ERROR,
+                str(error)[:80],
+                tool=tool_name,
+            )
+            triplets.append(
+                Triplet(
+                    subject=action,
+                    predicate=PredicateType.FAILS_WITH,
+                    object=error_entity,
+                    source=source_label,
+                    timestamp=now,
+                    evidence=str(error),
+                )
+            )
+        elif success:
+            result_val = call.get("result", "")
+            outcome = _make_entity(
+                EntityType.OUTCOME,
+                f"{tool_name}_result_{i}",
+                success=True,
+            )
+            triplets.append(
+                Triplet(
+                    subject=action,
+                    predicate=PredicateType.PRODUCES,
+                    object=outcome,
+                    source=source_label,
+                    timestamp=now,
+                    evidence=str(result_val)[:200] if result_val else "",
+                )
+            )
+
+        prev_action = action
+
+    if has_failure:
+        triplets.append(
+            Triplet(
+                subject=agent,
+                predicate=PredicateType.FAILS_AT,
+                object=task,
+                source=source_label,
+                timestamp=now,
+            )
+        )
+    else:
+        triplets.append(
+            Triplet(
+                subject=agent,
+                predicate=PredicateType.SUCCEEDS_AT,
+                object=task,
+                source=source_label,
+                timestamp=now,
+            )
+        )
+
+    return _ExtractionResult(
+        triplets=triplets,
+        source_label=source_label,
+    )
+
+
+# ── LLM-driven extraction ───────────────────────────────────────
+
+EXTRACTION_PROMPT = """\
+You are a knowledge extraction agent. Extract structured facts from the \
+following agent execution log as knowledge graph triplets.
+
+## Entity types
+{entity_types}
+
+## Predicate types
+{predicate_types}
+
+## Task context
+{task_context}
+
+## Rules
+- Entity IDs must follow the format "type:snake_case_name" (e.g., "tool:get_order")
+- Assign confidence 1.0 for directly observed facts, 0.7-0.9 for inferences
+- Include evidence: the relevant snippet from the log
+- Extract at most {max_triplets} triplets
+- Focus on behavioral patterns: what the agent does, what fails, what causes failures
+
+## Log content
+```
+{content}
+```
+
+## Output format
+Return a JSON array of triplet objects:
+```json
+[
+  {{
+    "subject": {{"id": "type:name", "type": "type_enum", "name": "Human Name"}},
+    "predicate": "predicate_enum",
+    "object": {{"id": "type:name", "type": "type_enum", "name": "Human Name"}},
+    "confidence": 0.9,
+    "evidence": "relevant log snippet"
+  }}
+]
+```
+
+Return ONLY the JSON array, no other text.
+"""
+
+
+def build_extraction_prompt(
+    content: str,
+    task_context: str,
+    max_triplets: int = 50,
+) -> str:
+    """Build the LLM prompt for triplet extraction."""
+    return EXTRACTION_PROMPT.format(
+        entity_types=", ".join(e.value for e in EntityType),
+        predicate_types=", ".join(p.value for p in PredicateType),
+        task_context=task_context,
+        max_triplets=max_triplets,
+        content=content[:10000],
+    )
+
+
+def parse_extraction_response(
+    response: str,
+    source_label: str = "llm_extraction",
+) -> list[Triplet]:
+    """Parse LLM JSON response into validated Triplet objects."""
+    raw = _extract_json(response)
+    if raw is None:
+        log.warning("extraction_no_json_found", response_len=len(response))
+        return []
+
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        log.warning("extraction_json_parse_failed", error=str(exc))
+        return []
+
+    if not isinstance(items, list):
+        items = [items]
+
+    now = datetime.now()
+    triplets: list[Triplet] = []
+    for item in items:
+        try:
+            triplet = _item_to_triplet(item, source_label, now)
+            if triplet is not None:
+                triplets.append(triplet)
+        except (KeyError, ValueError, TypeError) as exc:
+            log.debug("extraction_item_skipped", error=str(exc), item=str(item)[:200])
+
+    log.info(
+        "extraction_parsed",
+        total_items=len(items),
+        valid_triplets=len(triplets),
+    )
+    return triplets
+
+
+def _extract_json(text: str) -> str | None:
+    """Extract JSON from response, trying code fences first, then raw."""
+    fence = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
+    if fence:
+        return fence.group(1).strip()
+
+    for start in ("[", "{"):
+        idx = text.find(start)
+        if idx >= 0:
+            return text[idx:]
+
+    return None
+
+
+def _resolve_predicate(value: str) -> PredicateType:
+    try:
+        return PredicateType(value)
+    except ValueError:
+        return PredicateType.RELATED_TO
+
+
+def _resolve_entity_type(value: str) -> EntityType:
+    try:
+        return EntityType(value)
+    except ValueError:
+        return EntityType.CONCEPT
+
+
+def _item_to_triplet(
+    item: dict[str, object],
+    source_label: str,
+    timestamp: datetime,
+) -> Triplet | None:
+    """Convert a raw dict from LLM output to a validated Triplet."""
+    subj_raw = item.get("subject")
+    obj_raw = item.get("object")
+    pred_raw = item.get("predicate")
+
+    if not isinstance(subj_raw, dict) or not isinstance(obj_raw, dict) or not pred_raw:
+        return None
+
+    subject = Entity(
+        id=str(subj_raw.get("id", f"concept:{_short_uuid()}")),
+        type=_resolve_entity_type(str(subj_raw.get("type", "concept"))),
+        name=str(subj_raw.get("name", subj_raw.get("id", "unknown"))),
+    )
+    obj = Entity(
+        id=str(obj_raw.get("id", f"concept:{_short_uuid()}")),
+        type=_resolve_entity_type(str(obj_raw.get("type", "concept"))),
+        name=str(obj_raw.get("name", obj_raw.get("id", "unknown"))),
+    )
+
+    confidence = float(str(item.get("confidence", 0.8)))
+    confidence = max(0.0, min(1.0, confidence))
+
+    return Triplet(
+        subject=subject,
+        predicate=_resolve_predicate(str(pred_raw)),
+        object=obj,
+        confidence=confidence,
+        source=source_label,
+        timestamp=timestamp,
+        evidence=str(item.get("evidence", ""))[:500],
+    )
+
+
+async def extract_triplets_from_log(
+    log_content: str,
+    task_context: str,
+    project_path: Path,
+    *,
+    source_label: str = "llm_extraction",
+    max_triplets: int = 50,
+) -> _ExtractionResult:
+    """Extract knowledge triplets from agent execution log text via LLM.
+
+    Invokes a researcher agent with the extraction prompt and parses the response.
+    """
+    from factory.agents.runner import invoke_agent
+
+    prompt = build_extraction_prompt(log_content, task_context, max_triplets)
+    stdout, rc = await invoke_agent(
+        role="researcher",
+        task=prompt,
+        project_path=project_path,
+        timeout=120.0,
+    )
+
+    triplets = parse_extraction_response(stdout, source_label)
+    return _ExtractionResult(
+        triplets=triplets,
+        raw_response=stdout,
+        source_label=source_label,
+    )
+
+
+async def extract_from_diff(
+    expected_output: str,
+    actual_output: str,
+    task_context: str,
+    project_path: Path,
+    *,
+    source_label: str = "diff_extraction",
+) -> _ExtractionResult:
+    """Extract triplets from expected vs. actual behavior differences."""
+    diff_content = (
+        f"EXPECTED OUTPUT:\n{expected_output}\n\n"
+        f"ACTUAL OUTPUT:\n{actual_output}\n\n"
+        f"Analyze the differences and extract triplets about what went wrong."
+    )
+    return await extract_triplets_from_log(
+        diff_content,
+        task_context,
+        project_path,
+        source_label=source_label,
+    )

--- a/factory/knowledge/gates.py
+++ b/factory/knowledge/gates.py
@@ -1,0 +1,116 @@
+"""Generic gate evaluators and report generation for knowledge workflows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def evaluate_insights_gate(config_path: Path) -> None:
+    """Check insight quality — print pass/reloop verdict."""
+    cfg = json.loads(config_path.read_text())
+    task_id = cfg["task_id"]
+    threshold = cfg.get("insight_threshold", 2)
+    conf_threshold = cfg.get("confidence_threshold", 0.5)
+
+    p = config_path.parent / f"{task_id}_insights.json"
+    if not p.exists():
+        print("reloop: no insights file found")
+        return
+
+    insights = json.loads(p.read_text())
+    if len(insights) < threshold:
+        print(f"reloop: only {len(insights)} insights, need at least {threshold}")
+        return
+
+    avg_conf = sum(i.get("confidence", 0) for i in insights) / len(insights) if insights else 0
+    if avg_conf < conf_threshold:
+        print(f"reloop: average confidence {avg_conf:.2f} below {conf_threshold}")
+        return
+
+    print(f"pass: {len(insights)} insights with avg confidence {avg_conf:.2f}")
+
+
+def generate_report(config_path: Path) -> None:
+    """Generate the final insights report with score progression."""
+    from factory.knowledge.insight import Insight, format_insights
+    from factory.knowledge.models import KnowledgeGraph
+
+    cfg = json.loads(config_path.read_text())
+    task_id = cfg["task_id"]
+    knowledge_dir = config_path.parent
+
+    graph_path = knowledge_dir / f"{task_id}.json"
+    insights_path = knowledge_dir / f"{task_id}_insights.json"
+
+    if not graph_path.exists() or not insights_path.exists():
+        print("No graph or insights to report")
+        return
+
+    graph = KnowledgeGraph.model_validate(json.loads(graph_path.read_text()), strict=False)
+    insights = [
+        Insight.model_validate(i, strict=False) for i in json.loads(insights_path.read_text())
+    ]
+    report = format_insights(insights, graph)
+
+    report += _score_progression_section(knowledge_dir)
+    report += _changes_applied_section(knowledge_dir, task_id)
+
+    (knowledge_dir / f"{task_id}_report.md").write_text(report)
+    print(report)
+
+
+def _score_progression_section(knowledge_dir: Path) -> str:
+    state_path = knowledge_dir / "run_state.json"
+    if not state_path.exists():
+        return ""
+
+    state = json.loads(state_path.read_text())
+    history = state.get("score_history", [])
+    if not history:
+        return ""
+
+    lines = [
+        "\n\n## Score Progression\n",
+        "| Iteration | Score | Delta |",
+        "|-----------|-------|-------|",
+    ]
+    prev = None
+    for entry in history:
+        iteration = entry.get("iteration", "?")
+        score = entry.get("score", 0.0)
+        label = "Baseline" if iteration == 0 else str(iteration)
+        delta = (
+            f"+{score - prev:.4f}"
+            if prev is not None and score > prev
+            else (f"{score - prev:.4f}" if prev is not None else "-")
+        )
+        lines.append(f"| {label} | {score:.4f} | {delta} |")
+        prev = score
+
+    return "\n".join(lines) + "\n"
+
+
+def _changes_applied_section(knowledge_dir: Path, task_id: str) -> str:
+    history_path = knowledge_dir / f"{task_id}_improvements.jsonl"
+    if not history_path.exists():
+        return ""
+
+    lines = ["\n## Changes Applied\n"]
+    for line in history_path.read_text().strip().splitlines():
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        iteration = record.get("iteration", "?")
+        before = record.get("score_before")
+        after = record.get("score_after", 0)
+        summary = record.get("changes_summary", "")
+        lines.append(f"### Iteration {iteration}")
+        if before is not None:
+            lines.append(f"Score: {before:.4f} -> {after:.4f}\n")
+        if summary:
+            first_line = summary.split("\n")[0][:200]
+            lines.append(f"{first_line}\n")
+
+    return "\n".join(lines) + "\n"

--- a/factory/knowledge/insight.py
+++ b/factory/knowledge/insight.py
@@ -1,0 +1,77 @@
+"""Insight model and rendering — the actual detection is agent-driven."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from factory.knowledge.models import KnowledgeGraph
+
+
+class InsightType(str, Enum):
+    """Categories of insights the agent can produce."""
+
+    FAILURE_PATTERN = "failure_pattern"
+    MISSING_KNOWLEDGE = "missing_knowledge"
+    CONTRADICTION = "contradiction"
+    IMPROVEMENT_OPPORTUNITY = "improvement_opportunity"
+    CAUSAL_CHAIN = "causal_chain"
+
+
+class Insight(BaseModel):
+    """A single insight produced by an agent exploring the knowledge graph."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    type: InsightType
+    title: str
+    description: str
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    evidence_triplet_ids: list[str] = []
+    causal_path: list[str] = []
+    suggested_action: str = ""
+
+
+def format_insights(insights: list[Insight], graph: KnowledgeGraph) -> str:
+    """Render insights as markdown with evidence from the graph."""
+    if not insights:
+        return "No insights generated."
+
+    triplet_index = {t.id: t for t in graph.triplets}
+    lines = [
+        f"# Insights for {graph.task_id}",
+        "",
+        f"**{len(insights)} insight(s)** from {graph.triplet_count()} triplets",
+        "",
+    ]
+
+    for i, insight in enumerate(insights, 1):
+        lines.append(f"## {i}. [{insight.type.value}] {insight.title}")
+        lines.append("")
+        lines.append(insight.description)
+        lines.append("")
+
+        if insight.confidence < 1.0:
+            lines.append(f"**Confidence:** {insight.confidence:.0%}")
+            lines.append("")
+
+        if insight.suggested_action:
+            lines.append(f"**Suggested action:** {insight.suggested_action}")
+            lines.append("")
+
+        if insight.causal_path:
+            lines.append("**Causal path:** " + " → ".join(insight.causal_path))
+            lines.append("")
+
+        if insight.evidence_triplet_ids:
+            lines.append("**Evidence:**")
+            for tid in insight.evidence_triplet_ids:
+                t = triplet_index.get(tid)
+                if t:
+                    lines.append(f"- ({t.subject.name}, {t.predicate.value}, {t.object.name})")
+                else:
+                    lines.append(f"- [triplet {tid} not found]")
+            lines.append("")
+
+    return "\n".join(lines)

--- a/factory/knowledge/models.py
+++ b/factory/knowledge/models.py
@@ -347,6 +347,34 @@ class KnowledgeGraph(BaseModel):
     def triplet_count(self) -> int:
         return len(self.triplets)
 
+    def tool_stats(self) -> dict[str, dict[str, int | list[str]]]:
+        """Aggregate call count, success/fail rates, and errors per tool."""
+        tools: dict[str, dict[str, int | list[str]]] = {}
+
+        for t in self.triplets:
+            if t.predicate == PredicateType.CALLS and t.object.type == EntityType.TOOL:
+                name = t.object.name
+                if name not in tools:
+                    tools[name] = {"calls": 0, "successes": 0, "failures": 0, "errors": []}
+                tools[name]["calls"] += 1
+
+        for t in self.triplets:
+            if t.subject.type != EntityType.ACTION:
+                continue
+            tool_name = (
+                t.subject.name.rsplit("_call_", 1)[0] if "_call_" in t.subject.name else None
+            )
+            if tool_name and tool_name in tools:
+                if t.predicate == PredicateType.PRODUCES:
+                    tools[tool_name]["successes"] += 1
+                elif t.predicate == PredicateType.FAILS_WITH:
+                    tools[tool_name]["failures"] += 1
+                    err = t.object.name
+                    if err not in tools[tool_name]["errors"]:
+                        tools[tool_name]["errors"].append(err)
+
+        return tools
+
     def stats(self) -> dict[str, object]:
         """Summary statistics: degree ranking, predicate distribution, failure hotspots."""
         degree: dict[str, int] = defaultdict(int)
@@ -399,5 +427,17 @@ class TauBenchTaskConfig(KnowledgeTaskConfig):
     tau_command: str = ""
     score_threshold: float = Field(ge=0.0, le=1.0, default=0.8)
     improvement_target: str = ""
+
+
+class TauRunState(BaseModel):
+    """Mutable runtime state for tau-bench evaluation runs.
+
+    Stored at ``run_state.json`` alongside ``task_config.json``.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
     baseline_score: float | None = None
     current_score: float | None = None
+    iteration_count: int = 0
+    score_history: list[dict[str, float | int | str]] = []

--- a/factory/knowledge/models.py
+++ b/factory/knowledge/models.py
@@ -388,3 +388,16 @@ class KnowledgeTaskConfig(BaseModel):
     max_observations: int = 3
     insight_threshold: int = 2
     confidence_threshold: float = Field(ge=0.0, le=1.0, default=0.5)
+
+
+class TauBenchTaskConfig(KnowledgeTaskConfig):
+    """Extended configuration for tau-bench evaluation tasks."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    simulation_path: str = ""
+    tau_command: str = ""
+    score_threshold: float = Field(ge=0.0, le=1.0, default=0.8)
+    improvement_target: str = ""
+    baseline_score: float | None = None
+    current_score: float | None = None

--- a/factory/knowledge/models.py
+++ b/factory/knowledge/models.py
@@ -66,7 +66,12 @@ class PredicateType(str, Enum):
 
 
 CAUSAL_PREDICATES: frozenset[PredicateType] = frozenset(
-    {PredicateType.CAUSES, PredicateType.FAILS_WITH, PredicateType.REQUIRES}
+    {
+        PredicateType.CAUSES,
+        PredicateType.FAILS_AT,
+        PredicateType.FAILS_WITH,
+        PredicateType.REQUIRES,
+    }
 )
 
 

--- a/factory/knowledge/models.py
+++ b/factory/knowledge/models.py
@@ -1,0 +1,369 @@
+"""Knowledge graph models — triplet-based representation of learned facts."""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict, deque
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ── entity types ─────────────────────────────────────────────────
+
+
+class EntityType(str, Enum):
+    """Types of entities in the knowledge graph."""
+
+    AGENT = "agent"
+    TOOL = "tool"
+    ACTION = "action"
+    ERROR = "error"
+    TASK = "task"
+    ENVIRONMENT = "environment"
+    CONCEPT = "concept"
+    OUTCOME = "outcome"
+
+
+class Entity(BaseModel):
+    """A node in the knowledge graph."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    id: str
+    type: EntityType
+    name: str
+    attributes: dict[str, str | float | bool] = {}
+
+
+# ── predicate types ──────────────────────────────────────────────
+
+
+class PredicateType(str, Enum):
+    """Typed relationships between entities."""
+
+    # behavioral
+    CALLS = "calls"
+    FAILS_WITH = "fails_with"
+    SUCCEEDS_AT = "succeeds_at"
+    FAILS_AT = "fails_at"
+    PRODUCES = "produces"
+    REQUIRES = "requires"
+    PRECEDES = "precedes"
+    CAUSES = "causes"
+
+    # structural
+    IS_A = "is_a"
+    PART_OF = "part_of"
+    RELATED_TO = "related_to"
+    CONTRADICTS = "contradicts"
+
+    # optimization
+    IMPROVES = "improves"
+    DEGRADES = "degrades"
+    CORRELATES_WITH = "correlates_with"
+
+
+CAUSAL_PREDICATES: frozenset[PredicateType] = frozenset(
+    {PredicateType.CAUSES, PredicateType.FAILS_WITH, PredicateType.REQUIRES}
+)
+
+
+# ── triplet ──────────────────────────────────────────────────────
+
+
+def _short_uuid() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+class Triplet(BaseModel):
+    """A single fact: (subject, predicate, object) with metadata."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    id: str = Field(default_factory=_short_uuid)
+    subject: Entity
+    predicate: PredicateType
+    object: Entity
+    confidence: float = Field(ge=0.0, le=1.0, default=1.0)
+    source: str = ""
+    timestamp: datetime = Field(default_factory=datetime.now)
+    evidence: str = ""
+    valid_from: datetime | None = None
+    valid_until: datetime | None = None
+
+
+# ── knowledge graph ──────────────────────────────────────────────
+
+
+class KnowledgeGraph(BaseModel):
+    """A collection of triplets scoped to a single task."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    task_id: str
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+    triplets: list[Triplet] = []
+    entities: dict[str, Entity] = {}
+    metadata: dict[str, str] = {}
+
+    # ── mutation ─────────────────────────────────────────────────
+
+    def add_triplet(self, triplet: Triplet) -> None:
+        """Add a triplet and auto-index its entities."""
+        self.triplets.append(triplet)
+        self.entities[triplet.subject.id] = triplet.subject
+        self.entities[triplet.object.id] = triplet.object
+        self.updated_at = datetime.now()
+
+    def merge(self, other: KnowledgeGraph) -> None:
+        """Merge another graph's triplets into this one."""
+        existing_ids = {t.id for t in self.triplets}
+        for triplet in other.triplets:
+            if triplet.id not in existing_ids:
+                self.add_triplet(triplet)
+
+    # ── single-hop queries ───────────────────────────────────────
+
+    def query(
+        self,
+        subject_id: str | None = None,
+        predicate: PredicateType | None = None,
+        object_id: str | None = None,
+    ) -> list[Triplet]:
+        """Filter triplets by any combination of subject, predicate, object."""
+        results: list[Triplet] = []
+        for t in self.triplets:
+            if subject_id is not None and t.subject.id != subject_id:
+                continue
+            if predicate is not None and t.predicate != predicate:
+                continue
+            if object_id is not None and t.object.id != object_id:
+                continue
+            results.append(t)
+        return results
+
+    def query_by_subject(self, entity_id: str) -> list[Triplet]:
+        return self.query(subject_id=entity_id)
+
+    def query_by_object(self, entity_id: str) -> list[Triplet]:
+        return self.query(object_id=entity_id)
+
+    def query_by_predicate(self, predicate: PredicateType) -> list[Triplet]:
+        return self.query(predicate=predicate)
+
+    def related_entities(self, entity_id: str) -> list[Entity]:
+        """All entities connected to entity_id as either subject or object."""
+        seen: set[str] = set()
+        result: list[Entity] = []
+        for t in self.triplets:
+            if t.subject.id == entity_id and t.object.id not in seen:
+                seen.add(t.object.id)
+                result.append(t.object)
+            elif t.object.id == entity_id and t.subject.id not in seen:
+                seen.add(t.subject.id)
+                result.append(t.subject)
+        return result
+
+    def subgraph(self, entity_ids: set[str]) -> KnowledgeGraph:
+        """Extract a sub-graph containing only triplets involving the given entities."""
+        filtered = [
+            t for t in self.triplets if t.subject.id in entity_ids or t.object.id in entity_ids
+        ]
+        graph = KnowledgeGraph(
+            task_id=self.task_id,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            metadata=self.metadata,
+        )
+        for t in filtered:
+            graph.add_triplet(t)
+        return graph
+
+    # ── multi-hop traversal ──────────────────────────────────────
+
+    def _adjacency(
+        self,
+        allowed_predicates: frozenset[PredicateType] | None = None,
+    ) -> dict[str, list[tuple[Triplet, str]]]:
+        """Build adjacency list: entity_id -> [(triplet, neighbor_id)]."""
+        adj: dict[str, list[tuple[Triplet, str]]] = defaultdict(list)
+        for t in self.triplets:
+            if allowed_predicates and t.predicate not in allowed_predicates:
+                continue
+            adj[t.subject.id].append((t, t.object.id))
+            adj[t.object.id].append((t, t.subject.id))
+        return adj
+
+    def traverse(
+        self,
+        entity_id: str,
+        max_hops: int = 3,
+    ) -> list[list[Triplet]]:
+        """BFS from an entity, returning all paths as triplet chains up to max_hops."""
+        adj = self._adjacency()
+        paths: list[list[Triplet]] = []
+        queue: deque[tuple[str, list[Triplet]]] = deque([(entity_id, [])])
+        visited_paths: set[tuple[str, ...]] = set()
+
+        while queue:
+            current, path = queue.popleft()
+            if len(path) >= max_hops:
+                continue
+
+            for triplet, neighbor in adj.get(current, []):
+                if triplet.id in {t.id for t in path}:
+                    continue
+
+                new_path = [*path, triplet]
+                path_key = tuple(t.id for t in new_path)
+                if path_key in visited_paths:
+                    continue
+                visited_paths.add(path_key)
+                paths.append(new_path)
+                queue.append((neighbor, new_path))
+
+        return paths
+
+    def find_paths(
+        self,
+        from_id: str,
+        to_id: str,
+        max_hops: int = 5,
+    ) -> list[list[Triplet]]:
+        """All paths between two entities, up to max_hops."""
+        adj = self._adjacency()
+        results: list[list[Triplet]] = []
+        queue: deque[tuple[str, list[Triplet], set[str]]] = deque([(from_id, [], {from_id})])
+
+        while queue:
+            current, path, visited = queue.popleft()
+            if len(path) >= max_hops:
+                continue
+
+            for triplet, neighbor in adj.get(current, []):
+                if neighbor in visited:
+                    continue
+
+                new_path = [*path, triplet]
+                if neighbor == to_id:
+                    results.append(new_path)
+                    continue
+
+                queue.append((neighbor, new_path, visited | {neighbor}))
+
+        return results
+
+    def causal_chain(
+        self,
+        entity_id: str,
+        max_depth: int = 5,
+    ) -> list[list[Triplet]]:
+        """Follow only causal predicates to build explanation chains."""
+        adj = self._adjacency(allowed_predicates=CAUSAL_PREDICATES)
+        chains: list[list[Triplet]] = []
+        queue: deque[tuple[str, list[Triplet], set[str]]] = deque([(entity_id, [], {entity_id})])
+
+        while queue:
+            current, path, visited = queue.popleft()
+            if len(path) >= max_depth:
+                if path:
+                    chains.append(path)
+                continue
+
+            neighbors = adj.get(current, [])
+            if not neighbors and path:
+                chains.append(path)
+                continue
+
+            extended = False
+            for triplet, neighbor in neighbors:
+                if neighbor in visited:
+                    continue
+                extended = True
+                queue.append((neighbor, [*path, triplet], visited | {neighbor}))
+
+            if not extended and path:
+                chains.append(path)
+
+        return chains
+
+    def match_pattern(
+        self,
+        steps: list[tuple[str | None, PredicateType | None, str | None]],
+    ) -> list[list[Triplet]]:
+        """Match a multi-hop structural pattern with wildcards (None = any).
+
+        Each step is (subject_id_or_None, predicate_or_None, object_id_or_None).
+        Adjacent steps are connected: step[i].object matches step[i+1].subject.
+        """
+        if not steps:
+            return []
+
+        def _matches(
+            triplet: Triplet,
+            pattern: tuple[str | None, PredicateType | None, str | None],
+        ) -> bool:
+            s, p, o = pattern
+            if s is not None and triplet.subject.id != s:
+                return False
+            if p is not None and triplet.predicate != p:
+                return False
+            if o is not None and triplet.object.id != o:
+                return False
+            return True
+
+        first_step = steps[0]
+        candidates = [t for t in self.triplets if _matches(t, first_step)]
+
+        paths: list[list[Triplet]] = [[c] for c in candidates]
+
+        for step in steps[1:]:
+            next_paths: list[list[Triplet]] = []
+            for path in paths:
+                last_object_id = path[-1].object.id
+                for t in self.triplets:
+                    if t.subject.id != last_object_id:
+                        continue
+                    if not _matches(t, (None, step[1], step[2])):
+                        continue
+                    next_paths.append([*path, t])
+            paths = next_paths
+
+        return paths
+
+    # ── stats ────────────────────────────────────────────────────
+
+    def entity_count(self) -> int:
+        return len(self.entities)
+
+    def triplet_count(self) -> int:
+        return len(self.triplets)
+
+    def stats(self) -> dict[str, object]:
+        """Summary statistics: degree ranking, predicate distribution, failure hotspots."""
+        degree: dict[str, int] = defaultdict(int)
+        predicate_counts: dict[str, int] = defaultdict(int)
+        failure_entities: dict[str, int] = defaultdict(int)
+
+        for t in self.triplets:
+            degree[t.subject.id] += 1
+            degree[t.object.id] += 1
+            predicate_counts[t.predicate.value] += 1
+
+            if t.predicate in (PredicateType.FAILS_WITH, PredicateType.FAILS_AT):
+                failure_entities[t.subject.id] += 1
+                failure_entities[t.object.id] += 1
+
+        top_entities = sorted(degree.items(), key=lambda x: x[1], reverse=True)[:10]
+        top_failures = sorted(failure_entities.items(), key=lambda x: x[1], reverse=True)[:10]
+
+        return {
+            "entity_count": self.entity_count(),
+            "triplet_count": self.triplet_count(),
+            "top_entities_by_degree": top_entities,
+            "predicate_distribution": dict(predicate_counts),
+            "failure_hotspots": top_failures,
+        }

--- a/factory/knowledge/models.py
+++ b/factory/knowledge/models.py
@@ -429,6 +429,18 @@ class TauBenchTaskConfig(KnowledgeTaskConfig):
     improvement_target: str = ""
 
 
+class OlsTaskConfig(KnowledgeTaskConfig):
+    """Extended configuration for OLS troubleshooting eval tasks."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    results_dir: str = ""
+    eval_command: str = ""
+    score_threshold: float = Field(ge=0.0, le=1.0, default=0.5)
+    improvement_target: str = ""
+    scenarios: list[str] = []
+
+
 class TauRunState(BaseModel):
     """Mutable runtime state for tau-bench evaluation runs.
 

--- a/factory/knowledge/models.py
+++ b/factory/knowledge/models.py
@@ -372,3 +372,19 @@ class KnowledgeGraph(BaseModel):
             "predicate_distribution": dict(predicate_counts),
             "failure_hotspots": top_failures,
         }
+
+
+# ── task configuration ───────────────────────────────────────────
+
+
+class KnowledgeTaskConfig(BaseModel):
+    """Configuration for a knowledge graph observation task."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    task_id: str
+    agent_command: str
+    task_context: str
+    max_observations: int = 3
+    insight_threshold: int = 2
+    confidence_threshold: float = Field(ge=0.0, le=1.0, default=0.5)

--- a/factory/knowledge/ols_adapter.py
+++ b/factory/knowledge/ols_adapter.py
@@ -1,0 +1,489 @@
+"""OLS troubleshooting eval adapter — parse CSV results into triplets."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+import subprocess
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+
+from factory.knowledge.models import (
+    Entity,
+    EntityType,
+    PredicateType,
+    Triplet,
+)
+
+log = structlog.get_logger()
+
+
+def _slugify(name: str) -> str:
+    """Lowercase, replace non-alphanumeric with underscores, strip edges."""
+    return re.sub(r"[^a-z0-9_]", "_", name.lower()).strip("_")
+
+
+def _entity(entity_type: EntityType, name: str, **attrs: str | float | bool) -> Entity:
+    """Create an entity with a slugified ID."""
+    return Entity(
+        id=f"{entity_type.value}:{_slugify(name)}",
+        type=entity_type,
+        name=name,
+        attributes=dict(attrs) if attrs else {},
+    )
+
+
+def _state_path(config_path: Path) -> Path:
+    return config_path.parent / "run_state.json"
+
+
+def _load_state(config_path: Path) -> dict:
+    sp = _state_path(config_path)
+    if sp.exists():
+        return json.loads(sp.read_text())
+    return {
+        "baseline_score": None,
+        "current_score": None,
+        "iteration_count": 0,
+        "score_history": [],
+    }
+
+
+def _save_state(config_path: Path, state: dict) -> None:
+    _state_path(config_path).write_text(json.dumps(state, indent=2))
+
+
+def _append_improvement_record(
+    config_path: Path,
+    score_before: float | None,
+    score_after: float,
+) -> None:
+    """Append one record to {task_id}_improvements.jsonl."""
+    cfg = json.loads(config_path.read_text())
+    task_id = cfg["task_id"]
+    state = _load_state(config_path)
+    history_path = config_path.parent / f"{task_id}_improvements.jsonl"
+
+    improvement_md = config_path.parent / f"{task_id}_improvement.md"
+    changes = improvement_md.read_text() if improvement_md.exists() else ""
+
+    record = {
+        "iteration": state.get("iteration_count", 0),
+        "score_before": score_before,
+        "score_after": score_after,
+        "changes_summary": changes[:500],
+        "timestamp": datetime.now().isoformat(),
+    }
+    with history_path.open("a") as f:
+        f.write(json.dumps(record, default=str) + "\n")
+
+
+def parse_results(results_dir: Path, task_context: str) -> list[Triplet]:
+    """Parse OLS eval CSV results into knowledge graph triplets.
+
+    Scans ``results_dir`` for ``iter_NN/<scenario>/evaluation_*_detailed.csv``
+    files and extracts triplets covering scenario outcomes, metric breakdowns,
+    causal chains for failures, and execution time metadata.
+    """
+    csv_paths = sorted(results_dir.glob("iter_*/*/*.csv"))
+    if not csv_paths:
+        log.warning("ols_adapter.no_csv_files", path=str(results_dir))
+        return []
+
+    triplets: list[Triplet] = []
+    agent = _entity(EntityType.AGENT, "ols_agent")
+    now = datetime.now()
+
+    for csv_path in csv_paths:
+        scenario = csv_path.parent.name
+        iter_dir = csv_path.parent.parent.name
+        iter_match = re.search(r"iter_(\d+)", iter_dir)
+        iter_num = iter_match.group(1) if iter_match else "00"
+        source = f"ols_eval:iter_{iter_num}:{scenario}"
+
+        try:
+            with csv_path.open() as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    row_triplets = _extract_row_triplets(
+                        row, agent, scenario, source, now,
+                    )
+                    triplets.extend(row_triplets)
+        except FileNotFoundError:
+            log.warning("ols_adapter.file_not_found", path=str(csv_path))
+        except csv.Error as exc:
+            log.warning("ols_adapter.csv_error", path=str(csv_path), error=str(exc))
+
+    log.info(
+        "ols_adapter.parsed",
+        path=str(results_dir),
+        csv_files=len(csv_paths),
+        triplets=len(triplets),
+    )
+    return triplets
+
+
+def _extract_row_triplets(
+    row: dict[str, str],
+    agent: Entity,
+    scenario: str,
+    source: str,
+    now: datetime,
+) -> list[Triplet]:
+    """Extract triplets from a single CSV row."""
+    triplets: list[Triplet] = []
+
+    metric = row.get("metric_identifier", "")
+    result = row.get("result", "")
+    turn_id = row.get("turn_id", "")
+    query = row.get("query", "")
+    response = row.get("response", "")
+    execution_time = row.get("execution_time", "")
+
+    if not metric:
+        return []
+
+    try:
+        score_val = float(row.get("score", "")) if row.get("score") else None
+    except (ValueError, TypeError):
+        log.warning("ols_adapter.invalid_score", scenario=scenario, metric=metric)
+        return []
+
+    is_conversation_level = not turn_id
+    is_answer_correctness = "answer_correctness" in metric
+
+    if result == "ERROR":
+        result = "FAIL"
+        score_val = 0.0
+
+    task = _entity(EntityType.TASK, scenario, description=scenario)
+
+    if is_answer_correctness and not is_conversation_level:
+        passed = result == "PASS"
+        triplets.append(
+            Triplet(
+                subject=agent,
+                predicate=PredicateType.SUCCEEDS_AT if passed else PredicateType.FAILS_AT,
+                object=task,
+                confidence=1.0,
+                source=source,
+                timestamp=now,
+                evidence=f"answer_correctness={score_val}, result={result}",
+            )
+        )
+
+        if not passed:
+            triplets.append(
+                Triplet(
+                    subject=_entity(
+                        EntityType.CONCEPT,
+                        f"{turn_id}_failure",
+                    ),
+                    predicate=PredicateType.CAUSES,
+                    object=_entity(EntityType.OUTCOME, f"{scenario}_failure"),
+                    confidence=0.9,
+                    source=source,
+                    timestamp=now,
+                    evidence=f"query={query[:100]}, response={response[:100]}",
+                )
+            )
+
+    if is_conversation_level:
+        triplets.append(
+            Triplet(
+                subject=_entity(EntityType.CONCEPT, metric),
+                predicate=PredicateType.PART_OF,
+                object=_entity(EntityType.OUTCOME, f"{scenario}_conversation"),
+                confidence=1.0,
+                source=source,
+                timestamp=now,
+                evidence=f"score={score_val}, result={result}",
+            )
+        )
+    else:
+        triplets.append(
+            Triplet(
+                subject=_entity(EntityType.CONCEPT, metric),
+                predicate=PredicateType.PART_OF,
+                object=_entity(EntityType.OUTCOME, f"{scenario}_result"),
+                confidence=1.0,
+                source=source,
+                timestamp=now,
+                evidence=f"score={score_val}, result={result}",
+            )
+        )
+
+    if execution_time and turn_id:
+        triplets.append(
+            Triplet(
+                subject=_entity(EntityType.TASK, f"{scenario}.{turn_id}"),
+                predicate=PredicateType.RELATED_TO,
+                object=_entity(EntityType.CONCEPT, "execution_time"),
+                confidence=1.0,
+                source=source,
+                timestamp=now,
+                evidence=f"{execution_time}s",
+            )
+        )
+
+    return triplets
+
+
+def compute_aggregate_score(results_dir: Path) -> float:
+    """Compute macro-averaged answer_correctness pass rate.
+
+    Matches ``eval_metrics.sh`` logic: per-scenario pass rates averaged
+    across all scenarios.
+    """
+    scenario_results: dict[str, list[bool]] = defaultdict(list)
+
+    for csv_path in sorted(results_dir.glob("iter_*/*/*.csv")):
+        scenario = csv_path.parent.name
+        try:
+            with csv_path.open() as f:
+                for row in csv.DictReader(f):
+                    metric = row.get("metric_identifier", "")
+                    if "answer_correctness" not in metric:
+                        continue
+                    result = row.get("result", "")
+                    if result == "ERROR":
+                        scenario_results[scenario].append(False)
+                        continue
+                    try:
+                        score = float(row.get("score", ""))
+                    except (ValueError, TypeError):
+                        continue
+                    scenario_results[scenario].append(score >= 0.5)
+        except (FileNotFoundError, csv.Error) as exc:
+            log.warning("ols_adapter.csv_error", path=str(csv_path), error=str(exc))
+
+    if not scenario_results:
+        return 0.0
+
+    per_scenario = [sum(v) / len(v) for v in scenario_results.values() if v]
+    return sum(per_scenario) / len(per_scenario) if per_scenario else 0.0
+
+
+def extract_scores(results_dir: Path) -> dict:
+    """Extract detailed scoring breakdown for analysis and reporting."""
+    scenario_results: dict[str, list[bool]] = defaultdict(list)
+    per_metric: dict[str, dict[str, int]] = defaultdict(lambda: {"pass": 0, "fail": 0, "error": 0})
+    iterations: set[str] = set()
+
+    for csv_path in sorted(results_dir.glob("iter_*/*/*.csv")):
+        scenario = csv_path.parent.name
+        iter_dir = csv_path.parent.parent.name
+        iterations.add(iter_dir)
+        try:
+            with csv_path.open() as f:
+                for row in csv.DictReader(f):
+                    metric = row.get("metric_identifier", "")
+                    result = row.get("result", "")
+                    turn_id = row.get("turn_id", "")
+
+                    if not metric:
+                        continue
+
+                    if result == "ERROR":
+                        per_metric[metric]["error"] += 1
+                        if "answer_correctness" in metric and turn_id:
+                            scenario_results[scenario].append(False)
+                    elif result == "PASS":
+                        per_metric[metric]["pass"] += 1
+                        if "answer_correctness" in metric and turn_id:
+                            scenario_results[scenario].append(True)
+                    elif result == "FAIL":
+                        per_metric[metric]["fail"] += 1
+                        if "answer_correctness" in metric and turn_id:
+                            scenario_results[scenario].append(False)
+        except (FileNotFoundError, csv.Error) as exc:
+            log.warning("ols_adapter.csv_error", path=str(csv_path), error=str(exc))
+
+    per_scenario = {k: (sum(v) / len(v) if v else 0.0) for k, v in scenario_results.items()}
+    rates = list(per_scenario.values())
+    mean_pass_rate = sum(rates) / len(rates) if rates else 0.0
+
+    return {
+        "mean_pass_rate": mean_pass_rate,
+        "scenario_count": len(per_scenario),
+        "pass_count": sum(1 for r in rates if r >= 1.0),
+        "fail_count": sum(1 for r in rates if r < 1.0),
+        "per_scenario": per_scenario,
+        "per_metric": dict(per_metric),
+        "iteration_count": len(iterations),
+    }
+
+
+def run_ols_eval(config_path: Path, *, is_reeval: bool = False) -> None:
+    """Run OLS eval command and update run_state.json."""
+    cfg = json.loads(config_path.read_text())
+    eval_cmd = cfg["eval_command"]
+    results_dir = Path(cfg["results_dir"])
+
+    label = "Re-running" if is_reeval else "Running"
+    print(f"{label} OLS eval: {eval_cmd}")
+
+    result = subprocess.run(eval_cmd, shell=True, capture_output=True, text=True)  # noqa: S602
+    print(result.stdout[-2000:])
+    if result.returncode != 0:
+        print(result.stderr[-1000:])
+
+    score = compute_aggregate_score(results_dir)
+    state = _load_state(config_path)
+    score_before = state.get("current_score")
+
+    if not is_reeval and state.get("baseline_score") is None:
+        state["baseline_score"] = score
+    state["current_score"] = score
+    state["iteration_count"] = state.get("iteration_count", 0) + (1 if is_reeval else 0)
+    state["score_history"].append(
+        {
+            "iteration": state["iteration_count"],
+            "score": score,
+            "timestamp": datetime.now().isoformat(),
+        }
+    )
+    _save_state(config_path, state)
+
+    if is_reeval:
+        _append_improvement_record(config_path, score_before, score)
+        print(f"Re-eval score: {score:.4f} (baseline: {state.get('baseline_score', 'N/A')})")
+    else:
+        print(f"Score: {score:.4f}")
+
+
+def evaluate_score_gate(config_path: Path) -> None:
+    """Check OLS eval score vs threshold — print pass/reloop verdict."""
+    cfg = json.loads(config_path.read_text())
+    state = _load_state(config_path)
+    score = state.get("current_score", 0.0)
+    threshold = cfg.get("score_threshold", 0.5)
+
+    if score is not None and score >= threshold:
+        print(f"pass: score {score:.4f} meets threshold {threshold}")
+    else:
+        print(f"reloop: score {score} below threshold {threshold}")
+
+
+def evaluate_compare_gate(config_path: Path) -> None:
+    """Compare before/after OLS eval scores — print pass/reloop verdict."""
+    cfg = json.loads(config_path.read_text())
+    state = _load_state(config_path)
+    baseline = state.get("baseline_score", 0.0)
+    current = state.get("current_score", 0.0)
+    threshold = cfg.get("score_threshold", 0.5)
+
+    if current is not None and current >= threshold:
+        print(
+            f"pass: score {current:.4f} meets threshold {threshold} "
+            f"(baseline was {baseline:.4f})"
+        )
+    elif current is not None and current > baseline:
+        print(
+            f"reloop: improved {baseline:.4f} -> {current:.4f} "
+            f"but still below threshold {threshold}"
+        )
+    else:
+        print(f"reloop: no improvement ({baseline} -> {current}), try a different approach")
+
+
+def write_failing_scenarios(config_path: Path) -> None:
+    """Write failing scenario details to {task_id}_failing_scenarios.md."""
+    cfg = json.loads(config_path.read_text())
+    task_id = cfg["task_id"]
+    results_dir = Path(cfg["results_dir"])
+
+    csv_paths = sorted(results_dir.glob("iter_*/*/*.csv"))
+    if not csv_paths:
+        return
+
+    # Collect failures grouped by scenario
+    scenario_failures: dict[str, list[dict]] = defaultdict(list)
+    scenario_pass_counts: dict[str, dict[str, int]] = defaultdict(lambda: {"pass": 0, "total": 0})
+    conversation_metrics: dict[str, list[dict]] = defaultdict(list)
+
+    for csv_path in csv_paths:
+        scenario = csv_path.parent.name
+        iter_dir = csv_path.parent.parent.name
+        try:
+            with csv_path.open() as f:
+                for row in csv.DictReader(f):
+                    metric = row.get("metric_identifier", "")
+                    result = row.get("result", "")
+                    turn_id = row.get("turn_id", "")
+
+                    if not turn_id and metric:
+                        conversation_metrics[scenario].append({
+                            "metric": metric,
+                            "score": row.get("score", ""),
+                            "result": result,
+                        })
+                        continue
+
+                    if "answer_correctness" not in metric:
+                        continue
+
+                    is_fail = result in ("FAIL", "ERROR")
+                    scenario_pass_counts[scenario]["total"] += 1
+                    if not is_fail:
+                        scenario_pass_counts[scenario]["pass"] += 1
+                    else:
+                        scenario_failures[scenario].append({
+                            "iter": iter_dir,
+                            "turn_id": turn_id,
+                            "query": row.get("query", ""),
+                            "response": row.get("response", ""),
+                            "score": row.get("score", ""),
+                            "reason": row.get("reason", ""),
+                        })
+        except (FileNotFoundError, csv.Error):
+            continue
+
+    if not scenario_failures:
+        return
+
+    lines = [f"# Failing Scenarios for {task_id}\n"]
+
+    for scenario, failures in sorted(scenario_failures.items()):
+        counts = scenario_pass_counts[scenario]
+        total = counts["total"]
+        passed = counts["pass"]
+        rate = passed / total if total else 0.0
+        lines.append(f"## {scenario} (pass_rate={rate:.3f}, {passed}/{total} iterations passed)\n")
+
+        for fail in failures:
+            turn_label = fail["turn_id"]
+            header = f"### {fail['iter']}"
+            if turn_label and turn_label != scenario:
+                header += f", Turn: {turn_label}"
+            header += f" — FAIL (score={fail['score']})"
+            lines.append(header)
+            lines.append(f"**Query:** {fail['query']}")
+            lines.append(f"**Response:** {fail['response']}")
+            lines.append(f"**Score:** {fail['score']}")
+            lines.append(f"**Reason:** {fail['reason']}\n")
+
+        conv = conversation_metrics.get(scenario, [])
+        if conv:
+            lines.append("### Conversation Metrics")
+            lines.append("| Metric | Score | Result |")
+            lines.append("|--------|-------|--------|")
+            for cm in conv:
+                lines.append(f"| {cm['metric']} | {cm['score']} | {cm['result']} |")
+            lines.append("")
+
+        lines.append("---\n")
+
+    out_path = config_path.parent / f"{task_id}_failing_scenarios.md"
+    out_path.write_text("\n".join(lines))
+    fail_count = len(scenario_failures)
+    print(f"Wrote {fail_count} failing scenarios to {out_path.name}")
+
+
+# backwards compat — moved to factory.knowledge.gates
+from factory.knowledge.gates import evaluate_insights_gate as evaluate_insights_gate  # noqa: E402, F401
+from factory.knowledge.gates import generate_report as generate_report  # noqa: E402, F401

--- a/factory/knowledge/store.py
+++ b/factory/knowledge/store.py
@@ -99,6 +99,23 @@ class KnowledgeStore:
         )
         return graph
 
+    def merge_triplet_files(self, task_id: str, project_path: Path) -> None:
+        """Load det + llm triplet files and merge into the graph.
+
+        Sync entry point for FnNode commands.
+        """
+        import asyncio
+
+        all_triplets: list[Triplet] = []
+        for suffix in ("det", "llm"):
+            p = project_path / f".factory/knowledge/{task_id}_{suffix}_triplets.json"
+            if p.exists():
+                items = json.loads(p.read_text())
+                all_triplets.extend(Triplet.model_validate(t, strict=False) for t in items)
+
+        graph = asyncio.run(self.append_triplets(task_id, all_triplets))
+        print(f"Graph updated: {graph.entity_count()} entities, {graph.triplet_count()} triplets")
+
     async def save_insights(
         self,
         task_id: str,

--- a/factory/knowledge/store.py
+++ b/factory/knowledge/store.py
@@ -54,7 +54,7 @@ class KnowledgeStore:
             return None
         try:
             data = json.loads(path.read_text())
-            return KnowledgeGraph.model_validate(data)
+            return KnowledgeGraph.model_validate(data, strict=False)
         except (json.JSONDecodeError, ValueError) as exc:
             log.warning("knowledge_graph_load_failed", task_id=task_id, error=str(exc))
             return None
@@ -119,7 +119,7 @@ class KnowledgeStore:
             return []
         try:
             data = json.loads(path.read_text())
-            return [Insight.model_validate(item) for item in data]
+            return [Insight.model_validate(item, strict=False) for item in data]
         except (json.JSONDecodeError, ValueError) as exc:
             log.warning("knowledge_insights_load_failed", task_id=task_id, error=str(exc))
             return []

--- a/factory/knowledge/store.py
+++ b/factory/knowledge/store.py
@@ -1,0 +1,178 @@
+"""Knowledge graph persistence — file-based store at .factory/knowledge/."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import structlog
+from filelock import FileLock
+
+from factory.knowledge.insight import Insight
+from factory.knowledge.models import KnowledgeGraph, Triplet
+
+log = structlog.get_logger()
+
+
+class KnowledgeStore:
+    """Manages knowledge graph persistence at .factory/knowledge/."""
+
+    def __init__(self, project_path: Path) -> None:
+        self.project_path = project_path
+        self.knowledge_dir = project_path / ".factory" / "knowledge"
+        self._lock = FileLock(self.knowledge_dir / ".knowledge.lock")
+
+    async def init(self) -> None:
+        """Create .factory/knowledge/ directory structure."""
+        self.knowledge_dir.mkdir(parents=True, exist_ok=True)
+        log.info("knowledge_store_init", path=str(self.knowledge_dir))
+
+    def _graph_path(self, task_id: str) -> Path:
+        return self.knowledge_dir / f"{task_id}.json"
+
+    def _insights_path(self, task_id: str) -> Path:
+        return self.knowledge_dir / f"{task_id}_insights.json"
+
+    async def save_graph(self, graph: KnowledgeGraph) -> None:
+        """Persist the knowledge graph to .factory/knowledge/{task_id}.json."""
+        await self.init()
+        path = self._graph_path(graph.task_id)
+        data = graph.model_dump(mode="json")
+        with self._lock:
+            path.write_text(json.dumps(data, indent=2, default=str))
+        log.info(
+            "knowledge_graph_saved",
+            task_id=graph.task_id,
+            triplets=graph.triplet_count(),
+            entities=graph.entity_count(),
+        )
+
+    async def load_graph(self, task_id: str) -> KnowledgeGraph | None:
+        """Load a knowledge graph by task_id. Returns None if not found."""
+        path = self._graph_path(task_id)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+            return KnowledgeGraph.model_validate(data)
+        except (json.JSONDecodeError, ValueError) as exc:
+            log.warning("knowledge_graph_load_failed", task_id=task_id, error=str(exc))
+            return None
+
+    async def list_graphs(self) -> list[str]:
+        """List all task_ids with stored knowledge graphs."""
+        if not self.knowledge_dir.exists():
+            return []
+        return [
+            p.stem for p in self.knowledge_dir.glob("*.json") if not p.stem.endswith("_insights")
+        ]
+
+    async def append_triplets(
+        self,
+        task_id: str,
+        triplets: list[Triplet],
+    ) -> KnowledgeGraph:
+        """Add triplets to an existing graph (or create a new one).
+
+        Loads the graph, adds triplets, re-indexes entities, saves.
+        Uses filelock for concurrency safety.
+        """
+        await self.init()
+        graph = await self.load_graph(task_id)
+        if graph is None:
+            graph = KnowledgeGraph(task_id=task_id)
+
+        existing_ids = {t.id for t in graph.triplets}
+        added = 0
+        for triplet in triplets:
+            if triplet.id not in existing_ids:
+                graph.add_triplet(triplet)
+                existing_ids.add(triplet.id)
+                added += 1
+
+        await self.save_graph(graph)
+        log.info(
+            "knowledge_triplets_appended",
+            task_id=task_id,
+            added=added,
+            total=graph.triplet_count(),
+        )
+        return graph
+
+    async def save_insights(
+        self,
+        task_id: str,
+        insights: list[Insight],
+    ) -> None:
+        """Save generated insights alongside the graph."""
+        await self.init()
+        path = self._insights_path(task_id)
+        data = [i.model_dump(mode="json") for i in insights]
+        with self._lock:
+            path.write_text(json.dumps(data, indent=2, default=str))
+        log.info("knowledge_insights_saved", task_id=task_id, count=len(insights))
+
+    async def load_insights(self, task_id: str) -> list[Insight]:
+        """Load previously generated insights."""
+        path = self._insights_path(task_id)
+        if not path.exists():
+            return []
+        try:
+            data = json.loads(path.read_text())
+            return [Insight.model_validate(item) for item in data]
+        except (json.JSONDecodeError, ValueError) as exc:
+            log.warning("knowledge_insights_load_failed", task_id=task_id, error=str(exc))
+            return []
+
+    async def export_graph(
+        self,
+        task_id: str,
+        fmt: str = "json",
+    ) -> str:
+        """Export the graph in the requested format (json, markdown, or dot)."""
+        graph = await self.load_graph(task_id)
+        if graph is None:
+            return ""
+
+        if fmt == "json":
+            return json.dumps(graph.model_dump(mode="json"), indent=2, default=str)
+
+        if fmt == "markdown":
+            return _export_markdown(graph)
+
+        if fmt == "dot":
+            return _export_dot(graph)
+
+        log.warning("knowledge_export_unknown_format", fmt=fmt)
+        return ""
+
+
+def _export_markdown(graph: KnowledgeGraph) -> str:
+    lines = [
+        f"# Knowledge Graph: {graph.task_id}",
+        "",
+        f"**Entities:** {graph.entity_count()} | **Triplets:** {graph.triplet_count()}",
+        "",
+        "| Subject | Predicate | Object | Confidence | Source |",
+        "|---------|-----------|--------|------------|--------|",
+    ]
+    for t in graph.triplets:
+        lines.append(
+            f"| {t.subject.name} | {t.predicate.value} | {t.object.name} "
+            f"| {t.confidence:.2f} | {t.source} |"
+        )
+    return "\n".join(lines)
+
+
+def _export_dot(graph: KnowledgeGraph) -> str:
+    lines = ["digraph knowledge {", "  rankdir=LR;", "  node [shape=box];"]
+    for entity in graph.entities.values():
+        label = f"{entity.name}\\n({entity.type.value})"
+        lines.append(f'  "{entity.id}" [label="{label}"];')
+    for t in graph.triplets:
+        label = t.predicate.value
+        if t.confidence < 1.0:
+            label += f" ({t.confidence:.2f})"
+        lines.append(f'  "{t.subject.id}" -> "{t.object.id}" [label="{label}"];')
+    lines.append("}")
+    return "\n".join(lines)

--- a/factory/knowledge/tau_adapter.py
+++ b/factory/knowledge/tau_adapter.py
@@ -416,6 +416,100 @@ def run_tau_eval(config_path: Path, *, is_reeval: bool = False) -> None:
         print(f"Score: {score:.4f}")
 
 
+def evaluate_insights_gate(config_path: Path) -> None:
+    """Check insight quality — print pass/reloop verdict.
+
+    Called by the gate_insights FnNode.
+    """
+    cfg = json.loads(config_path.read_text())
+    task_id = cfg["task_id"]
+    threshold = cfg.get("insight_threshold", 2)
+    conf_threshold = cfg.get("confidence_threshold", 0.5)
+
+    p = config_path.parent / f"{task_id}_insights.json"
+    if not p.exists():
+        print("reloop: no insights file found")
+        return
+
+    insights = json.loads(p.read_text())
+    if len(insights) < threshold:
+        print(f"reloop: only {len(insights)} insights, need at least {threshold}")
+        return
+
+    avg_conf = sum(i.get("confidence", 0) for i in insights) / len(insights) if insights else 0
+    if avg_conf < conf_threshold:
+        print(f"reloop: average confidence {avg_conf:.2f} below {conf_threshold}")
+        return
+
+    print(f"pass: {len(insights)} insights with avg confidence {avg_conf:.2f}")
+
+
+def evaluate_score_gate(config_path: Path) -> None:
+    """Check tau-bench score vs threshold — print pass/reloop verdict.
+
+    Called by the gate_score FnNode.
+    """
+    cfg = json.loads(config_path.read_text())
+    score = cfg.get("current_score", 0.0)
+    threshold = cfg.get("score_threshold", 0.8)
+
+    if score is not None and score >= threshold:
+        print(f"pass: score {score:.4f} meets threshold {threshold}")
+    else:
+        print(f"reloop: score {score} below threshold {threshold}")
+
+
+def evaluate_compare_gate(config_path: Path) -> None:
+    """Compare before/after scores — print pass/reloop verdict.
+
+    Called by the gate_compare FnNode.
+    """
+    cfg = json.loads(config_path.read_text())
+    baseline = cfg.get("baseline_score", 0.0)
+    current = cfg.get("current_score", 0.0)
+    threshold = cfg.get("score_threshold", 0.8)
+
+    if current is not None and current >= threshold:
+        print(
+            f"pass: score {current:.4f} meets threshold {threshold} (baseline was {baseline:.4f})"
+        )
+    elif current is not None and current > baseline:
+        print(
+            f"reloop: improved {baseline:.4f} -> {current:.4f} "
+            f"but still below threshold {threshold}"
+        )
+    else:
+        print(f"reloop: no improvement ({baseline} -> {current}), try a different approach")
+
+
+def generate_report(config_path: Path) -> None:
+    """Generate the final insights report.
+
+    Called by the report FnNode.
+    """
+    from factory.knowledge.insight import Insight, format_insights
+    from factory.knowledge.models import KnowledgeGraph
+
+    cfg = json.loads(config_path.read_text())
+    task_id = cfg["task_id"]
+    knowledge_dir = config_path.parent
+
+    graph_path = knowledge_dir / f"{task_id}.json"
+    insights_path = knowledge_dir / f"{task_id}_insights.json"
+
+    if not graph_path.exists() or not insights_path.exists():
+        print("No graph or insights to report")
+        return
+
+    graph = KnowledgeGraph.model_validate(json.loads(graph_path.read_text()), strict=False)
+    insights = [
+        Insight.model_validate(i, strict=False) for i in json.loads(insights_path.read_text())
+    ]
+    report = format_insights(insights, graph)
+    (knowledge_dir / f"{task_id}_report.md").write_text(report)
+    print(report)
+
+
 def compute_aggregate_score(path: Path) -> float:
     """Compute average reward across all simulations in a results file."""
     data = json.loads(path.read_text())

--- a/factory/knowledge/tau_adapter.py
+++ b/factory/knowledge/tau_adapter.py
@@ -1,0 +1,416 @@
+"""Tau-bench simulation adapter — parse structured simulation JSON into triplets."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+import structlog
+
+from factory.knowledge.models import (
+    Entity,
+    EntityType,
+    PredicateType,
+    Triplet,
+)
+
+log = structlog.get_logger()
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"[^a-z0-9_]", "_", name.lower()).strip("_")
+
+
+def _entity(entity_type: EntityType, name: str, **attrs: str | float | bool) -> Entity:
+    return Entity(
+        id=f"{entity_type.value}:{_slugify(name)}",
+        type=entity_type,
+        name=name,
+        attributes=dict(attrs) if attrs else {},
+    )
+
+
+def parse_simulation(path: Path, task_context: str) -> list[Triplet]:
+    """Parse a tau-bench simulation JSON file into knowledge graph triplets.
+
+    Reads the top-level ``simulations`` array and extracts triplets covering
+    tool usage, failures, evaluation breakdowns, and causal chains.
+    """
+    data = json.loads(path.read_text())
+    simulations = data.get("simulations", [])
+    if not simulations:
+        log.warning("tau_adapter.no_simulations", path=str(path))
+        return []
+
+    triplets: list[Triplet] = []
+    for sim in simulations:
+        triplets.extend(_extract_from_simulation(sim, task_context))
+
+    log.info(
+        "tau_adapter.parsed",
+        path=str(path),
+        simulations=len(simulations),
+        triplets=len(triplets),
+    )
+    return triplets
+
+
+def _extract_from_simulation(sim: dict, task_context: str) -> list[Triplet]:
+    task_id = str(sim.get("task_id", "unknown"))
+    now = datetime.now()
+    source = f"tau_bench:task_{task_id}"
+    agent = _entity(EntityType.AGENT, "airline_agent")
+    task = _entity(EntityType.TASK, f"task_{task_id}", description=task_context)
+    triplets: list[Triplet] = []
+
+    reward_info = sim.get("reward_info", {})
+    reward = reward_info.get("reward", 0.0)
+
+    # task outcome
+    triplets.append(
+        Triplet(
+            subject=agent,
+            predicate=PredicateType.SUCCEEDS_AT if reward >= 1.0 else PredicateType.FAILS_AT,
+            object=task,
+            confidence=1.0,
+            source=source,
+            timestamp=now,
+            evidence=f"reward={reward}",
+        )
+    )
+
+    # tool calls from messages
+    triplets.extend(_extract_tool_calls(sim.get("messages", []), agent, task_id, source, now))
+
+    # evaluation breakdown
+    triplets.extend(_extract_action_checks(reward_info, agent, task_id, source, now))
+    triplets.extend(_extract_nl_assertions(reward_info, agent, task_id, source, now))
+    triplets.extend(_extract_db_check(reward_info, agent, task_id, source, now))
+    triplets.extend(_extract_reward_breakdown(reward_info, task_id, source, now))
+
+    # termination reason
+    term = sim.get("termination_reason", "")
+    if term in ("too_many_errors", "max_steps"):
+        triplets.append(
+            Triplet(
+                subject=agent,
+                predicate=PredicateType.FAILS_WITH,
+                object=_entity(EntityType.ERROR, term),
+                confidence=1.0,
+                source=source,
+                timestamp=now,
+                evidence=f"termination_reason={term}",
+            )
+        )
+
+    return triplets
+
+
+def _extract_tool_calls(
+    messages: list[dict],
+    agent: Entity,
+    task_id: str,
+    source: str,
+    now: datetime,
+) -> list[Triplet]:
+    triplets: list[Triplet] = []
+    prev_action: Entity | None = None
+    call_index = 0
+
+    for i, msg in enumerate(messages):
+        if msg.get("role") != "assistant":
+            continue
+        tool_calls = msg.get("tool_calls")
+        if not tool_calls:
+            continue
+
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            tool_name = tc.get("name", f"unknown_tool_{call_index}")
+            tool = _entity(EntityType.TOOL, tool_name)
+            action = _entity(
+                EntityType.ACTION,
+                f"{tool_name}_call_{call_index}",
+                task_id=task_id,
+                index=float(call_index),
+            )
+
+            triplets.append(
+                Triplet(
+                    subject=agent,
+                    predicate=PredicateType.CALLS,
+                    object=tool,
+                    confidence=1.0,
+                    source=source,
+                    timestamp=now,
+                    evidence=f"task {task_id}: {tool_name}({json.dumps(tc.get('arguments', {}))[:120]})",
+                )
+            )
+
+            if prev_action is not None:
+                triplets.append(
+                    Triplet(
+                        subject=prev_action,
+                        predicate=PredicateType.PRECEDES,
+                        object=action,
+                        source=source,
+                        timestamp=now,
+                    )
+                )
+
+            # look ahead for the tool response
+            tool_response = _find_tool_response(messages, i + 1)
+            if tool_response is not None:
+                if tool_response.get("error"):
+                    error_content = str(tool_response.get("content", ""))[:80]
+                    triplets.append(
+                        Triplet(
+                            subject=action,
+                            predicate=PredicateType.FAILS_WITH,
+                            object=_entity(
+                                EntityType.ERROR, error_content or "tool_error", tool=tool_name
+                            ),
+                            confidence=1.0,
+                            source=source,
+                            timestamp=now,
+                            evidence=str(tool_response.get("content", ""))[:200],
+                        )
+                    )
+                else:
+                    triplets.append(
+                        Triplet(
+                            subject=action,
+                            predicate=PredicateType.PRODUCES,
+                            object=_entity(
+                                EntityType.OUTCOME, f"{tool_name}_result_{call_index}", success=True
+                            ),
+                            source=source,
+                            timestamp=now,
+                            evidence=str(tool_response.get("content", ""))[:200],
+                        )
+                    )
+
+            prev_action = action
+            call_index += 1
+
+    return triplets
+
+
+def _find_tool_response(messages: list[dict], start_index: int) -> dict | None:
+    for j in range(start_index, min(start_index + 3, len(messages))):
+        if messages[j].get("role") == "tool":
+            return messages[j]
+    return None
+
+
+def _extract_action_checks(
+    reward_info: dict,
+    agent: Entity,
+    task_id: str,
+    source: str,
+    now: datetime,
+) -> list[Triplet]:
+    checks = reward_info.get("action_checks")
+    if not checks:
+        return []
+
+    triplets: list[Triplet] = []
+    for check in checks:
+        action_def = check.get("action", {})
+        action_name = action_def.get("name", "unknown_action")
+        matched = check.get("action_match", False)
+        expected_action = _entity(
+            EntityType.CONCEPT,
+            f"expected_{action_name}",
+            action_id=str(action_def.get("action_id", "")),
+        )
+
+        triplets.append(
+            Triplet(
+                subject=agent,
+                predicate=PredicateType.SUCCEEDS_AT if matched else PredicateType.FAILS_AT,
+                object=expected_action,
+                confidence=1.0,
+                source=source,
+                timestamp=now,
+                evidence=f"task {task_id}: expected {action_name}({json.dumps(action_def.get('arguments', {}))[:100]}), matched={matched}",
+            )
+        )
+
+        # causal link: missing action → task failure
+        if not matched:
+            task_entity = _entity(EntityType.TASK, f"task_{task_id}")
+            triplets.append(
+                Triplet(
+                    subject=expected_action,
+                    predicate=PredicateType.CAUSES,
+                    object=_entity(EntityType.OUTCOME, f"task_{task_id}_failure"),
+                    confidence=0.9,
+                    source=source,
+                    timestamp=now,
+                    evidence=f"missing expected action {action_name} caused task {task_id} failure",
+                )
+            )
+
+    return triplets
+
+
+def _extract_nl_assertions(
+    reward_info: dict,
+    agent: Entity,
+    task_id: str,
+    source: str,
+    now: datetime,
+) -> list[Triplet]:
+    assertions = reward_info.get("nl_assertions")
+    if not assertions:
+        return []
+
+    triplets: list[Triplet] = []
+    for assertion in assertions:
+        text = assertion.get("nl_assertion", "")
+        met = assertion.get("met", False)
+        justification = assertion.get("justification", "")
+
+        assertion_entity = _entity(EntityType.CONCEPT, text[:60])
+
+        triplets.append(
+            Triplet(
+                subject=agent,
+                predicate=PredicateType.SUCCEEDS_AT if met else PredicateType.FAILS_AT,
+                object=assertion_entity,
+                confidence=1.0,
+                source=source,
+                timestamp=now,
+                evidence=justification[:300],
+            )
+        )
+
+        if not met:
+            triplets.append(
+                Triplet(
+                    subject=assertion_entity,
+                    predicate=PredicateType.CAUSES,
+                    object=_entity(EntityType.OUTCOME, f"task_{task_id}_failure"),
+                    confidence=0.9,
+                    source=source,
+                    timestamp=now,
+                    evidence=f"failed assertion: {text}",
+                )
+            )
+
+    return triplets
+
+
+def _extract_db_check(
+    reward_info: dict,
+    agent: Entity,
+    task_id: str,
+    source: str,
+    now: datetime,
+) -> list[Triplet]:
+    db_check = reward_info.get("db_check")
+    if not db_check:
+        return []
+
+    db_match = db_check.get("db_match", True)
+    consistency = _entity(EntityType.CONCEPT, "db_consistency")
+
+    triplets = [
+        Triplet(
+            subject=agent,
+            predicate=PredicateType.SUCCEEDS_AT if db_match else PredicateType.FAILS_AT,
+            object=consistency,
+            confidence=1.0,
+            source=source,
+            timestamp=now,
+            evidence=f"task {task_id}: db_match={db_match}, db_reward={db_check.get('db_reward', 0)}",
+        )
+    ]
+
+    if not db_match:
+        triplets.append(
+            Triplet(
+                subject=consistency,
+                predicate=PredicateType.CAUSES,
+                object=_entity(EntityType.OUTCOME, f"task_{task_id}_failure"),
+                confidence=0.9,
+                source=source,
+                timestamp=now,
+                evidence="database state mismatch after agent actions",
+            )
+        )
+
+    return triplets
+
+
+def _extract_reward_breakdown(
+    reward_info: dict,
+    task_id: str,
+    source: str,
+    now: datetime,
+) -> list[Triplet]:
+    breakdown = reward_info.get("reward_breakdown")
+    if not breakdown:
+        return []
+
+    total = _entity(EntityType.OUTCOME, f"task_{task_id}_reward")
+    triplets: list[Triplet] = []
+    for component, score in breakdown.items():
+        triplets.append(
+            Triplet(
+                subject=_entity(
+                    EntityType.CONCEPT, f"{component.lower()}_score", score=float(score)
+                ),
+                predicate=PredicateType.PART_OF,
+                object=total,
+                confidence=1.0,
+                source=source,
+                timestamp=now,
+                evidence=f"{component}={score}",
+            )
+        )
+
+    return triplets
+
+
+def compute_aggregate_score(path: Path) -> float:
+    """Compute average reward across all simulations in a results file."""
+    data = json.loads(path.read_text())
+    sims = data.get("simulations", [])
+    if not sims:
+        return 0.0
+    rewards = [s.get("reward_info", {}).get("reward", 0.0) for s in sims]
+    return sum(rewards) / len(rewards)
+
+
+def extract_scores(path: Path) -> dict:
+    """Extract detailed scoring breakdown from a simulation results file."""
+    data = json.loads(path.read_text())
+    sims = data.get("simulations", [])
+    if not sims:
+        return {
+            "mean_reward": 0.0,
+            "task_count": 0,
+            "pass_count": 0,
+            "fail_count": 0,
+            "per_task": {},
+        }
+
+    per_task: dict[str, float] = {}
+    for sim in sims:
+        tid = str(sim.get("task_id", "unknown"))
+        reward = sim.get("reward_info", {}).get("reward", 0.0)
+        per_task[tid] = reward
+
+    rewards = list(per_task.values())
+    return {
+        "mean_reward": sum(rewards) / len(rewards),
+        "task_count": len(rewards),
+        "pass_count": sum(1 for r in rewards if r >= 1.0),
+        "fail_count": sum(1 for r in rewards if r < 1.0),
+        "per_task": per_task,
+    }

--- a/factory/knowledge/tau_adapter.py
+++ b/factory/knowledge/tau_adapter.py
@@ -377,12 +377,33 @@ def _extract_reward_breakdown(
     return triplets
 
 
+def _state_path(config_path: Path) -> Path:
+    return config_path.parent / "run_state.json"
+
+
+def _load_state(config_path: Path) -> dict:
+    sp = _state_path(config_path)
+    if sp.exists():
+        return json.loads(sp.read_text())
+    return {
+        "baseline_score": None,
+        "current_score": None,
+        "iteration_count": 0,
+        "score_history": [],
+    }
+
+
+def _save_state(config_path: Path, state: dict) -> None:
+    _state_path(config_path).write_text(json.dumps(state, indent=2))
+
+
 def run_tau_eval(config_path: Path, *, is_reeval: bool = False) -> None:
-    """Run tau-bench and record score in task_config.json.
+    """Run tau-bench and record score in run_state.json.
 
     Called by the run_eval and re_eval FnNodes.
     """
     import subprocess
+    from datetime import datetime
 
     cfg = json.loads(config_path.read_text())
     tau_cmd = cfg["tau_command"]
@@ -404,53 +425,61 @@ def run_tau_eval(config_path: Path, *, is_reeval: bool = False) -> None:
         raise SystemExit(1)
 
     score = compute_aggregate_score(sim_path)
-    if not is_reeval and cfg.get("baseline_score") is None:
-        cfg["baseline_score"] = score
-    cfg["current_score"] = score
-    config_path.write_text(json.dumps(cfg, indent=2))
+    state = _load_state(config_path)
+    score_before = state.get("current_score")
 
-    baseline = cfg.get("baseline_score", "N/A")
+    if not is_reeval and state.get("baseline_score") is None:
+        state["baseline_score"] = score
+    state["current_score"] = score
+    state["iteration_count"] = state.get("iteration_count", 0) + (1 if is_reeval else 0)
+    state["score_history"].append(
+        {
+            "iteration": state["iteration_count"],
+            "score": score,
+            "timestamp": datetime.now().isoformat(),
+        }
+    )
+    _save_state(config_path, state)
+
     if is_reeval:
-        print(f"Re-eval score: {score:.4f} (baseline: {baseline})")
+        _append_improvement_record(config_path, score_before, score)
+        print(f"Re-eval score: {score:.4f} (baseline: {state.get('baseline_score', 'N/A')})")
     else:
         print(f"Score: {score:.4f}")
 
 
-def evaluate_insights_gate(config_path: Path) -> None:
-    """Check insight quality — print pass/reloop verdict.
+def _append_improvement_record(
+    config_path: Path,
+    score_before: float | None,
+    score_after: float,
+) -> None:
+    """Append one record to {task_id}_improvements.jsonl."""
+    from datetime import datetime
 
-    Called by the gate_insights FnNode.
-    """
     cfg = json.loads(config_path.read_text())
     task_id = cfg["task_id"]
-    threshold = cfg.get("insight_threshold", 2)
-    conf_threshold = cfg.get("confidence_threshold", 0.5)
+    state = _load_state(config_path)
+    history_path = config_path.parent / f"{task_id}_improvements.jsonl"
 
-    p = config_path.parent / f"{task_id}_insights.json"
-    if not p.exists():
-        print("reloop: no insights file found")
-        return
+    improvement_md = config_path.parent / f"{task_id}_improvement.md"
+    changes = improvement_md.read_text() if improvement_md.exists() else ""
 
-    insights = json.loads(p.read_text())
-    if len(insights) < threshold:
-        print(f"reloop: only {len(insights)} insights, need at least {threshold}")
-        return
-
-    avg_conf = sum(i.get("confidence", 0) for i in insights) / len(insights) if insights else 0
-    if avg_conf < conf_threshold:
-        print(f"reloop: average confidence {avg_conf:.2f} below {conf_threshold}")
-        return
-
-    print(f"pass: {len(insights)} insights with avg confidence {avg_conf:.2f}")
+    record = {
+        "iteration": state.get("iteration_count", 0),
+        "score_before": score_before,
+        "score_after": score_after,
+        "changes_summary": changes[:500],
+        "timestamp": datetime.now().isoformat(),
+    }
+    with history_path.open("a") as f:
+        f.write(json.dumps(record, default=str) + "\n")
 
 
 def evaluate_score_gate(config_path: Path) -> None:
-    """Check tau-bench score vs threshold — print pass/reloop verdict.
-
-    Called by the gate_score FnNode.
-    """
+    """Check tau-bench score vs threshold — print pass/reloop verdict."""
     cfg = json.loads(config_path.read_text())
-    score = cfg.get("current_score", 0.0)
+    state = _load_state(config_path)
+    score = state.get("current_score", 0.0)
     threshold = cfg.get("score_threshold", 0.8)
 
     if score is not None and score >= threshold:
@@ -460,13 +489,11 @@ def evaluate_score_gate(config_path: Path) -> None:
 
 
 def evaluate_compare_gate(config_path: Path) -> None:
-    """Compare before/after scores — print pass/reloop verdict.
-
-    Called by the gate_compare FnNode.
-    """
+    """Compare before/after scores — print pass/reloop verdict."""
     cfg = json.loads(config_path.read_text())
-    baseline = cfg.get("baseline_score", 0.0)
-    current = cfg.get("current_score", 0.0)
+    state = _load_state(config_path)
+    baseline = state.get("baseline_score", 0.0)
+    current = state.get("current_score", 0.0)
     threshold = cfg.get("score_threshold", 0.8)
 
     if current is not None and current >= threshold:
@@ -482,36 +509,50 @@ def evaluate_compare_gate(config_path: Path) -> None:
         print(f"reloop: no improvement ({baseline} -> {current}), try a different approach")
 
 
-def generate_report(config_path: Path) -> None:
-    """Generate the final insights report.
-
-    Called by the report FnNode.
-    """
-    from factory.knowledge.insight import Insight, format_insights
-    from factory.knowledge.models import KnowledgeGraph
-
+def write_failing_tasks(config_path: Path) -> None:
+    """Write failing task conversations to {task_id}_failing_tasks.md."""
     cfg = json.loads(config_path.read_text())
     task_id = cfg["task_id"]
-    knowledge_dir = config_path.parent
+    sim_path = Path(cfg["simulation_path"])
 
-    graph_path = knowledge_dir / f"{task_id}.json"
-    insights_path = knowledge_dir / f"{task_id}_insights.json"
-
-    if not graph_path.exists() or not insights_path.exists():
-        print("No graph or insights to report")
+    if not sim_path.exists():
         return
 
-    graph = KnowledgeGraph.model_validate(json.loads(graph_path.read_text()), strict=False)
-    insights = [
-        Insight.model_validate(i, strict=False) for i in json.loads(insights_path.read_text())
-    ]
-    report = format_insights(insights, graph)
-    (knowledge_dir / f"{task_id}_report.md").write_text(report)
-    print(report)
+    data = json.loads(sim_path.read_text())
+    lines = [f"# Failing Tasks for {task_id}\n"]
+
+    for sim in data.get("simulations", []):
+        reward = sim.get("reward_info", {}).get("reward", 0.0)
+        if reward >= 1.0:
+            continue
+        tid = sim.get("task_id", "unknown")
+        breakdown = sim.get("reward_info", {}).get("reward_breakdown", {})
+        lines.append(f"## Task {tid} (reward={reward}, breakdown={breakdown})\n")
+        for msg in sim.get("messages", []):
+            role = msg.get("role", "unknown")
+            content = msg.get("content", "")
+            tc = msg.get("tool_calls")
+            if tc:
+                tc_str = json.dumps(tc, indent=2)[:500]
+                lines.append(f"**{role}** (tool_calls):\n```json\n{tc_str}\n```\n")
+            elif content:
+                lines.append(f"**{role}:** {content[:300]}\n")
+        lines.append("---\n")
+
+    out_path = config_path.parent / f"{task_id}_failing_tasks.md"
+    out_path.write_text("\n".join(lines))
+    print(
+        f"Wrote {sum(1 for s in data.get('simulations', []) if s.get('reward_info', {}).get('reward', 0) < 1.0)} failing tasks"
+    )
+
+
+# backwards compat — moved to factory.knowledge.gates
+from factory.knowledge.gates import evaluate_insights_gate as evaluate_insights_gate  # noqa: E402, F401
+from factory.knowledge.gates import generate_report as generate_report  # noqa: E402, F401
 
 
 def compute_aggregate_score(path: Path) -> float:
-    """Compute average reward across all simulations in a results file."""
+    """Compute average reward across all simulations."""
     data = json.loads(path.read_text())
     sims = data.get("simulations", [])
     if not sims:
@@ -521,7 +562,9 @@ def compute_aggregate_score(path: Path) -> float:
 
 
 def extract_scores(path: Path) -> dict:
-    """Extract detailed scoring breakdown from a simulation results file."""
+    """Extract detailed scoring breakdown, averaging across trials per task."""
+    from collections import defaultdict
+
     data = json.loads(path.read_text())
     sims = data.get("simulations", [])
     if not sims:
@@ -533,12 +576,13 @@ def extract_scores(path: Path) -> dict:
             "per_task": {},
         }
 
-    per_task: dict[str, float] = {}
+    trial_scores: dict[str, list[float]] = defaultdict(list)
     for sim in sims:
         tid = str(sim.get("task_id", "unknown"))
         reward = sim.get("reward_info", {}).get("reward", 0.0)
-        per_task[tid] = reward
+        trial_scores[tid].append(reward)
 
+    per_task = {tid: sum(s) / len(s) for tid, s in trial_scores.items()}
     rewards = list(per_task.values())
     return {
         "mean_reward": sum(rewards) / len(rewards),

--- a/factory/knowledge/tau_adapter.py
+++ b/factory/knowledge/tau_adapter.py
@@ -377,6 +377,45 @@ def _extract_reward_breakdown(
     return triplets
 
 
+def run_tau_eval(config_path: Path, *, is_reeval: bool = False) -> None:
+    """Run tau-bench and record score in task_config.json.
+
+    Called by the run_eval and re_eval FnNodes.
+    """
+    import subprocess
+
+    cfg = json.loads(config_path.read_text())
+    tau_cmd = cfg["tau_command"]
+    sim_path = Path(cfg["simulation_path"])
+
+    if sim_path.exists():
+        sim_path.unlink()
+
+    label = "Re-running" if is_reeval else "Running"
+    print(f"{label} tau-bench: {tau_cmd}")
+
+    result = subprocess.run(tau_cmd, shell=True, capture_output=True, text=True)  # noqa: S602
+    print(result.stdout[-2000:])
+    if result.returncode != 0:
+        print(result.stderr[-1000:])
+
+    if not sim_path.exists():
+        print("Error: simulation output not found")
+        raise SystemExit(1)
+
+    score = compute_aggregate_score(sim_path)
+    if not is_reeval and cfg.get("baseline_score") is None:
+        cfg["baseline_score"] = score
+    cfg["current_score"] = score
+    config_path.write_text(json.dumps(cfg, indent=2))
+
+    baseline = cfg.get("baseline_score", "N/A")
+    if is_reeval:
+        print(f"Re-eval score: {score:.4f} (baseline: {baseline})")
+    else:
+        print(f"Score: {score:.4f}")
+
+
 def compute_aggregate_score(path: Path) -> float:
     """Compute average reward across all simulations in a results file."""
     data = json.loads(path.read_text())

--- a/factory/workflow/contributed/knowledge/__init__.py
+++ b/factory/workflow/contributed/knowledge/__init__.py
@@ -1,0 +1,3 @@
+from .workflow import meta, workflow
+
+__all__ = ["meta", "workflow"]

--- a/factory/workflow/contributed/knowledge/__init__.py
+++ b/factory/workflow/contributed/knowledge/__init__.py
@@ -1,3 +1,3 @@
-from .workflow import meta, tau_meta, tau_workflow, workflow
+from .workflow import meta, ols_meta, ols_workflow, tau_meta, tau_workflow, workflow
 
-__all__ = ["meta", "tau_meta", "tau_workflow", "workflow"]
+__all__ = ["meta", "ols_meta", "ols_workflow", "tau_meta", "tau_workflow", "workflow"]

--- a/factory/workflow/contributed/knowledge/__init__.py
+++ b/factory/workflow/contributed/knowledge/__init__.py
@@ -1,3 +1,3 @@
-from .workflow import meta, workflow
+from .workflow import meta, tau_meta, tau_workflow, workflow
 
-__all__ = ["meta", "workflow"]
+__all__ = ["meta", "tau_meta", "tau_workflow", "workflow"]

--- a/factory/workflow/contributed/knowledge/nodes.py
+++ b/factory/workflow/contributed/knowledge/nodes.py
@@ -66,14 +66,9 @@ def make_gate_score_node(node_id: str = "gate_score") -> GateNode:
         evaluator_command=(
             "cd {project_path} && "
             'python3 -c "'
-            "import json, pathlib; "
-            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
-            "score = cfg.get('current_score', 0.0); "
-            "threshold = cfg.get('score_threshold', 0.8); "
-            "if score is not None and score >= threshold: "
-            "    print(f'pass: score {score:.4f} meets threshold {threshold}'); "
-            "else: "
-            "    print(f'reloop: score {score} below threshold {threshold}')"
+            "from pathlib import Path; "
+            "from factory.knowledge.tau_adapter import evaluate_score_gate; "
+            "evaluate_score_gate(Path('.factory/knowledge/task_config.json'))"
             '"'
         ),
         reads={".factory/knowledge/insights.json"},
@@ -136,20 +131,9 @@ def make_gate_compare_node(node_id: str = "gate_compare") -> GateNode:
         evaluator_command=(
             "cd {project_path} && "
             'python3 -c "'
-            "import json, pathlib; "
-            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
-            "baseline = cfg.get('baseline_score', 0.0); "
-            "current = cfg.get('current_score', 0.0); "
-            "threshold = cfg.get('score_threshold', 0.8); "
-            "if current is not None and current >= threshold: "
-            "    print(f'pass: score {current:.4f} meets threshold {threshold} "
-            "(baseline was {baseline:.4f})'); "
-            "elif current is not None and current > baseline: "
-            "    print(f'reloop: improved {baseline:.4f} -> {current:.4f} "
-            "but still below threshold {threshold}'); "
-            "else: "
-            "    print(f'reloop: no improvement ({baseline} -> {current}), "
-            "try a different approach')"
+            "from pathlib import Path; "
+            "from factory.knowledge.tau_adapter import evaluate_compare_gate; "
+            "evaluate_compare_gate(Path('.factory/knowledge/task_config.json'))"
             '"'
         ),
         reads={".factory/knowledge/simulation.json"},
@@ -303,20 +287,9 @@ def make_gate_insights_node(node_id: str = "gate_insights") -> GateNode:
         evaluator_command=(
             "cd {project_path} && "
             'python3 -c "'
-            "import json, pathlib; "
-            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
-            "task_id = cfg['task_id']; "
-            "threshold = cfg.get('insight_threshold', 2); "
-            "conf_threshold = cfg.get('confidence_threshold', 0.5); "
-            "p = pathlib.Path(f'.factory/knowledge/{task_id}_insights.json'); "
-            "if not p.exists(): print('reloop: no insights file found'); exit(); "
-            "insights = json.loads(p.read_text()); "
-            "if len(insights) < threshold: "
-            "    print(f'reloop: only {len(insights)} insights, need at least {threshold}'); exit(); "
-            "avg_conf = sum(i.get('confidence', 0) for i in insights) / len(insights) if insights else 0; "
-            "if avg_conf < conf_threshold: "
-            "    print(f'reloop: average confidence {avg_conf:.2f} below {conf_threshold}'); exit(); "
-            "print(f'pass: {len(insights)} insights with avg confidence {avg_conf:.2f}')"
+            "from pathlib import Path; "
+            "from factory.knowledge.tau_adapter import evaluate_insights_gate; "
+            "evaluate_insights_gate(Path('.factory/knowledge/task_config.json'))"
             '"'
         ),
         reads={".factory/knowledge/insights.json"},
@@ -330,20 +303,9 @@ def make_report_node(node_id: str = "report") -> FnNode:
         command=(
             "cd {project_path} && "
             'python3 -c "'
-            "import json, pathlib; "
-            "from factory.knowledge.models import KnowledgeGraph; "
-            "from factory.knowledge.insight import Insight, format_insights; "
-            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
-            "task_id = cfg['task_id']; "
-            "graph_path = pathlib.Path(f'.factory/knowledge/{task_id}.json'); "
-            "insights_path = pathlib.Path(f'.factory/knowledge/{task_id}_insights.json'); "
-            "if not graph_path.exists() or not insights_path.exists(): "
-            "    print('No graph or insights to report'); exit(); "
-            "graph = KnowledgeGraph.model_validate(json.loads(graph_path.read_text()), strict=False); "
-            "insights = [Insight.model_validate(i, strict=False) for i in json.loads(insights_path.read_text())]; "
-            "report = format_insights(insights, graph); "
-            "pathlib.Path(f'.factory/knowledge/{task_id}_report.md').write_text(report); "
-            "print(report)"
+            "from pathlib import Path; "
+            "from factory.knowledge.tau_adapter import generate_report; "
+            "generate_report(Path('.factory/knowledge/task_config.json'))"
             '"'
         ),
         notes="Render insights as a markdown report.",

--- a/factory/workflow/contributed/knowledge/nodes.py
+++ b/factory/workflow/contributed/knowledge/nodes.py
@@ -209,7 +209,7 @@ def make_extract_llm_node(node_id: str = "extract_llm") -> AgentNode:
         id=node_id,
         role=AgentRole.RESEARCHER,
         model="sonnet",
-        timeout=120,
+        timeout=300,
         prompt_template=(
             "You are extracting knowledge graph triplets from an agent execution log.\n\n"
             "1. Read `.factory/knowledge/task_config.json` to get the `task_id` and `task_context`.\n"

--- a/factory/workflow/contributed/knowledge/nodes.py
+++ b/factory/workflow/contributed/knowledge/nodes.py
@@ -145,6 +145,145 @@ def make_gate_compare_node(node_id: str = "gate_compare") -> GateNode:
     )
 
 
+# ── OLS troubleshooting eval nodes ─────────────────────────────
+
+
+def make_ols_run_eval_node(node_id: str = "run_eval") -> FnNode:
+    """Run OLS troubleshooting eval and record baseline score."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "from pathlib import Path; "
+            "from factory.knowledge.ols_adapter import run_ols_eval; "
+            "run_ols_eval(Path('.factory/knowledge/task_config.json'))"
+            '"'
+        ),
+        notes="Run OLS troubleshooting evaluation and record score in run_state.json.",
+        writes={".factory/knowledge/run_state.json"},
+    )
+
+
+def make_ols_extract_node(node_id: str = "extract_ols") -> FnNode:
+    """Parse OLS eval CSV results into knowledge graph triplets."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib; "
+            "from factory.knowledge.ols_adapter import parse_results, write_failing_scenarios; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "task_id = cfg['task_id']; "
+            "results_dir = pathlib.Path(cfg['results_dir']); "
+            "triplets = parse_results(results_dir, cfg.get('task_context', task_id)); "
+            "out = [t.model_dump(mode='json') for t in triplets]; "
+            "pathlib.Path(f'.factory/knowledge/{task_id}_det_triplets.json').write_text("
+            "    json.dumps(out, indent=2, default=str)); "
+            "print(f'Extracted {len(out)} OLS eval triplets'); "
+            "write_failing_scenarios(pathlib.Path('.factory/knowledge/task_config.json'))"
+            '"'
+        ),
+        notes="Parse OLS eval CSV results into triplets and write failing scenario details.",
+        reads={".factory/knowledge/run_state.json"},
+        writes={".factory/knowledge/det_triplets.json"},
+    )
+
+
+def make_ols_gate_score_node(node_id: str = "gate_score") -> GateNode:
+    """Gate on OLS eval score — PROCEED if meets threshold, RELOOP to improve."""
+    return GateNode(
+        id=node_id,
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "from pathlib import Path; "
+            "from factory.knowledge.ols_adapter import evaluate_score_gate; "
+            "evaluate_score_gate(Path('.factory/knowledge/task_config.json'))"
+            '"'
+        ),
+        reads={".factory/knowledge/insights.json"},
+    )
+
+
+def make_ols_improve_node(node_id: str = "improve") -> AgentNode:
+    """Apply knowledge graph insights to improve the OLS troubleshooting agent."""
+    return AgentNode(
+        id=node_id,
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=1200,
+        max_iterations=3,
+        prompt_template=(
+            "You are improving an OLS (OpenShift LightSpeed) troubleshooting agent "
+            "based on failure analysis from Kubernetes/OpenShift eval scenarios.\n\n"
+            "1. Read `.factory/knowledge/task_config.json` for `task_id`, "
+            "`improvement_target`, `results_dir`, and score threshold.\n"
+            "2. Read `.factory/knowledge/run_state.json` for current and baseline scores.\n"
+            "3. Read `.factory/knowledge/{task_id}_insights.json` for failure patterns "
+            "and causal chains.\n"
+            "4. Read `.factory/knowledge/{task_id}_failing_scenarios.md` for actual "
+            "failing scenarios — see the agent's responses, judge rationale, and "
+            "which turns failed.\n"
+            "5. Read `.factory/knowledge/{task_id}_improvements.jsonl` (if it exists) "
+            "for previous improvement attempts — avoid repeating what was already tried.\n"
+            "6. Read the improvement target file(s) in `improvement_target`.\n\n"
+            "Focus on:\n"
+            "- Scenarios where answer_correctness failed — what did the agent miss?\n"
+            "- Judge rationale in failing scenarios — what was expected vs delivered?\n"
+            "- Multi-turn conversation quality: knowledge_retention, continuity\n"
+            "- Causal chains tracing failures to specific diagnostic gaps\n"
+            "- OLS configuration (system prompts, MCP tool setup) as improvement levers\n\n"
+            "Make ONE focused improvement per iteration. Only modify files "
+            "listed in `improvement_target`.\n"
+            "Write a brief summary of what you changed and why to "
+            "`.factory/knowledge/{task_id}_improvement.md`.\n"
+        ),
+        reads={".factory/knowledge/insights.json"},
+        writes={".factory/knowledge/improvement.md"},
+    )
+
+
+def make_ols_re_eval_node(node_id: str = "re_eval") -> FnNode:
+    """Re-run OLS eval after improvements."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "from pathlib import Path; "
+            "from factory.knowledge.ols_adapter import run_ols_eval; "
+            "run_ols_eval(Path('.factory/knowledge/task_config.json'), is_reeval=True)"
+            '"'
+        ),
+        notes="Re-run OLS evaluation after improvements and update current_score.",
+        reads={".factory/knowledge/improvement.md"},
+        writes={".factory/knowledge/run_state.json"},
+    )
+
+
+def make_ols_gate_compare_node(node_id: str = "gate_compare") -> GateNode:
+    """Compare before/after OLS eval scores — PROCEED if threshold met."""
+    return GateNode(
+        id=node_id,
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "from pathlib import Path; "
+            "from factory.knowledge.ols_adapter import evaluate_compare_gate; "
+            "evaluate_compare_gate(Path('.factory/knowledge/task_config.json'))"
+            '"'
+        ),
+        reads={".factory/knowledge/run_state.json"},
+    )
+
+
+# ── generic knowledge nodes ────────────────────────────────────
+
+
 def make_observe_node(node_id: str = "observe") -> FnNode:
     """Run the external agent and capture its output."""
     return FnNode(

--- a/factory/workflow/contributed/knowledge/nodes.py
+++ b/factory/workflow/contributed/knowledge/nodes.py
@@ -23,24 +23,9 @@ def make_run_eval_node(node_id: str = "run_eval") -> FnNode:
         command=(
             "cd {project_path} && "
             'python3 -c "'
-            "import json, pathlib, subprocess; "
-            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
-            "tau_cmd = cfg['tau_command']; "
-            "sim_path = pathlib.Path(cfg['simulation_path']); "
-            "if sim_path.exists(): sim_path.unlink(); "
-            "print(f'Running tau-bench: {tau_cmd}'); "
-            "result = subprocess.run(tau_cmd, shell=True, capture_output=True, text=True); "
-            "print(result.stdout[-2000:] if len(result.stdout) > 2000 else result.stdout); "
-            "if result.returncode != 0: print(result.stderr[-1000:]); "
-            "if sim_path.exists(): "
-            "    from factory.knowledge.tau_adapter import compute_aggregate_score; "
-            "    score = compute_aggregate_score(sim_path); "
-            "    if cfg.get('baseline_score') is None: cfg['baseline_score'] = score; "
-            "    cfg['current_score'] = score; "
-            "    pathlib.Path('.factory/knowledge/task_config.json').write_text("
-            "        json.dumps(cfg, indent=2)); "
-            "    print(f'Score: {score:.4f}'); "
-            "else: print('Error: simulation output not found'); exit(1)"
+            "from pathlib import Path; "
+            "from factory.knowledge.tau_adapter import run_tau_eval; "
+            "run_tau_eval(Path('.factory/knowledge/task_config.json'))"
             '"'
         ),
         notes="Run tau-bench evaluation and record score in task_config.json.",
@@ -132,23 +117,9 @@ def make_re_eval_node(node_id: str = "re_eval") -> FnNode:
         command=(
             "cd {project_path} && "
             'python3 -c "'
-            "import json, pathlib, subprocess; "
-            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
-            "tau_cmd = cfg['tau_command']; "
-            "sim_path = pathlib.Path(cfg['simulation_path']); "
-            "if sim_path.exists(): sim_path.unlink(); "
-            "print(f'Re-running tau-bench: {tau_cmd}'); "
-            "result = subprocess.run(tau_cmd, shell=True, capture_output=True, text=True); "
-            "print(result.stdout[-2000:] if len(result.stdout) > 2000 else result.stdout); "
-            "if sim_path.exists(): "
-            "    from factory.knowledge.tau_adapter import compute_aggregate_score; "
-            "    score = compute_aggregate_score(sim_path); "
-            "    cfg['current_score'] = score; "
-            "    pathlib.Path('.factory/knowledge/task_config.json').write_text("
-            "        json.dumps(cfg, indent=2)); "
-            '    print(f\'Re-eval score: {score:.4f} (baseline: {cfg.get("baseline_score", "N/A")})\');'
-            " "
-            "else: print('Error: simulation output not found'); exit(1)"
+            "from pathlib import Path; "
+            "from factory.knowledge.tau_adapter import run_tau_eval; "
+            "run_tau_eval(Path('.factory/knowledge/task_config.json'), is_reeval=True)"
             '"'
         ),
         notes="Re-run tau-bench evaluation after improvements and update current_score.",

--- a/factory/workflow/contributed/knowledge/nodes.py
+++ b/factory/workflow/contributed/knowledge/nodes.py
@@ -13,6 +13,178 @@ from factory.workflow.primitives import (
 )
 
 
+# ── tau-bench nodes ─────────────────────────────────────────────
+
+
+def make_run_eval_node(node_id: str = "run_eval") -> FnNode:
+    """Run tau-bench evaluation and record baseline score."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib, subprocess; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "tau_cmd = cfg['tau_command']; "
+            "sim_path = pathlib.Path(cfg['simulation_path']); "
+            "if sim_path.exists(): sim_path.unlink(); "
+            "print(f'Running tau-bench: {tau_cmd}'); "
+            "result = subprocess.run(tau_cmd, shell=True, capture_output=True, text=True); "
+            "print(result.stdout[-2000:] if len(result.stdout) > 2000 else result.stdout); "
+            "if result.returncode != 0: print(result.stderr[-1000:]); "
+            "if sim_path.exists(): "
+            "    from factory.knowledge.tau_adapter import compute_aggregate_score; "
+            "    score = compute_aggregate_score(sim_path); "
+            "    if cfg.get('baseline_score') is None: cfg['baseline_score'] = score; "
+            "    cfg['current_score'] = score; "
+            "    pathlib.Path('.factory/knowledge/task_config.json').write_text("
+            "        json.dumps(cfg, indent=2)); "
+            "    print(f'Score: {score:.4f}'); "
+            "else: print('Error: simulation output not found'); exit(1)"
+            '"'
+        ),
+        notes="Run tau-bench evaluation and record score in task_config.json.",
+        writes={".factory/knowledge/simulation.json"},
+    )
+
+
+def make_extract_tau_node(node_id: str = "extract_tau") -> FnNode:
+    """Parse tau-bench simulation JSON into knowledge graph triplets."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "task_id = cfg['task_id']; "
+            "sim_path = pathlib.Path(cfg['simulation_path']); "
+            "from factory.knowledge.tau_adapter import parse_simulation; "
+            "triplets = parse_simulation(sim_path, cfg.get('task_context', task_id)); "
+            "out = [t.model_dump(mode='json') for t in triplets]; "
+            "pathlib.Path(f'.factory/knowledge/{task_id}_det_triplets.json').write_text("
+            "    json.dumps(out, indent=2, default=str)); "
+            "print(f'Extracted {len(out)} tau-bench triplets')"
+            '"'
+        ),
+        notes="Parse tau-bench simulation JSON into triplets via the tau adapter.",
+        reads={".factory/knowledge/simulation.json"},
+        writes={".factory/knowledge/det_triplets.json"},
+    )
+
+
+def make_gate_score_node(node_id: str = "gate_score") -> GateNode:
+    """Gate on tau-bench score — PROCEED if meets threshold, RELOOP to improve."""
+    return GateNode(
+        id=node_id,
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "score = cfg.get('current_score', 0.0); "
+            "threshold = cfg.get('score_threshold', 0.8); "
+            "if score is not None and score >= threshold: "
+            "    print(f'pass: score {score:.4f} meets threshold {threshold}'); "
+            "else: "
+            "    print(f'reloop: score {score} below threshold {threshold}')"
+            '"'
+        ),
+        reads={".factory/knowledge/insights.json"},
+    )
+
+
+def make_improve_node(node_id: str = "improve") -> AgentNode:
+    """Apply knowledge graph insights to improve the tau-bench agent."""
+    return AgentNode(
+        id=node_id,
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=1200,
+        max_iterations=3,
+        prompt_template=(
+            "You are improving a tau-bench airline agent based on failure analysis.\n\n"
+            "1. Read `.factory/knowledge/task_config.json` for `task_id`, "
+            "`improvement_target`, and current scores.\n"
+            "2. Read `.factory/knowledge/{task_id}_insights.json` for failure patterns.\n"
+            "3. Read `.factory/knowledge/{task_id}_report.md` for the full analysis.\n"
+            "4. Read the improvement target file(s) in `improvement_target`.\n\n"
+            "Focus on:\n"
+            "- Failed NL assertions: what did the agent do wrong?\n"
+            "- Failed action checks: what expected actions were missing?\n"
+            "- DB check failures: what state changes were incorrect?\n"
+            "- Causal chains tracing failures to root causes\n\n"
+            "Make ONE focused improvement per iteration. Only modify files "
+            "listed in `improvement_target`.\n"
+            "Write a brief summary of what you changed and why to "
+            "`.factory/knowledge/{task_id}_improvement.md`.\n"
+        ),
+        reads={".factory/knowledge/insights.json"},
+        writes={".factory/knowledge/improvement.md"},
+    )
+
+
+def make_re_eval_node(node_id: str = "re_eval") -> FnNode:
+    """Re-run tau-bench evaluation after improvements."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib, subprocess; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "tau_cmd = cfg['tau_command']; "
+            "sim_path = pathlib.Path(cfg['simulation_path']); "
+            "if sim_path.exists(): sim_path.unlink(); "
+            "print(f'Re-running tau-bench: {tau_cmd}'); "
+            "result = subprocess.run(tau_cmd, shell=True, capture_output=True, text=True); "
+            "print(result.stdout[-2000:] if len(result.stdout) > 2000 else result.stdout); "
+            "if sim_path.exists(): "
+            "    from factory.knowledge.tau_adapter import compute_aggregate_score; "
+            "    score = compute_aggregate_score(sim_path); "
+            "    cfg['current_score'] = score; "
+            "    pathlib.Path('.factory/knowledge/task_config.json').write_text("
+            "        json.dumps(cfg, indent=2)); "
+            '    print(f\'Re-eval score: {score:.4f} (baseline: {cfg.get("baseline_score", "N/A")})\');'
+            " "
+            "else: print('Error: simulation output not found'); exit(1)"
+            '"'
+        ),
+        notes="Re-run tau-bench evaluation after improvements and update current_score.",
+        reads={".factory/knowledge/improvement.md"},
+        writes={".factory/knowledge/simulation.json"},
+    )
+
+
+def make_gate_compare_node(node_id: str = "gate_compare") -> GateNode:
+    """Compare before/after tau-bench scores — PROCEED if threshold met."""
+    return GateNode(
+        id=node_id,
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "baseline = cfg.get('baseline_score', 0.0); "
+            "current = cfg.get('current_score', 0.0); "
+            "threshold = cfg.get('score_threshold', 0.8); "
+            "if current is not None and current >= threshold: "
+            "    print(f'pass: score {current:.4f} meets threshold {threshold} "
+            "(baseline was {baseline:.4f})'); "
+            "elif current is not None and current > baseline: "
+            "    print(f'reloop: improved {baseline:.4f} -> {current:.4f} "
+            "but still below threshold {threshold}'); "
+            "else: "
+            "    print(f'reloop: no improvement ({baseline} -> {current}), "
+            "try a different approach')"
+            '"'
+        ),
+        reads={".factory/knowledge/simulation.json"},
+    )
+
+
 def make_observe_node(node_id: str = "observe") -> FnNode:
     """Run the external agent and capture its output."""
     return FnNode(

--- a/factory/workflow/contributed/knowledge/nodes.py
+++ b/factory/workflow/contributed/knowledge/nodes.py
@@ -41,18 +41,19 @@ def make_extract_tau_node(node_id: str = "extract_tau") -> FnNode:
             "cd {project_path} && "
             'python3 -c "'
             "import json, pathlib; "
+            "from factory.knowledge.tau_adapter import parse_simulation, write_failing_tasks; "
             "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
             "task_id = cfg['task_id']; "
             "sim_path = pathlib.Path(cfg['simulation_path']); "
-            "from factory.knowledge.tau_adapter import parse_simulation; "
             "triplets = parse_simulation(sim_path, cfg.get('task_context', task_id)); "
             "out = [t.model_dump(mode='json') for t in triplets]; "
             "pathlib.Path(f'.factory/knowledge/{task_id}_det_triplets.json').write_text("
             "    json.dumps(out, indent=2, default=str)); "
-            "print(f'Extracted {len(out)} tau-bench triplets')"
+            "print(f'Extracted {len(out)} tau-bench triplets'); "
+            "write_failing_tasks(pathlib.Path('.factory/knowledge/task_config.json'))"
             '"'
         ),
-        notes="Parse tau-bench simulation JSON into triplets via the tau adapter.",
+        notes="Parse tau-bench simulation JSON into triplets and write failing task conversations.",
         reads={".factory/knowledge/simulation.json"},
         writes={".factory/knowledge/det_triplets.json"},
     )
@@ -86,10 +87,14 @@ def make_improve_node(node_id: str = "improve") -> AgentNode:
         prompt_template=(
             "You are improving a tau-bench airline agent based on failure analysis.\n\n"
             "1. Read `.factory/knowledge/task_config.json` for `task_id`, "
-            "`improvement_target`, and current scores.\n"
-            "2. Read `.factory/knowledge/{task_id}_insights.json` for failure patterns.\n"
-            "3. Read `.factory/knowledge/{task_id}_report.md` for the full analysis.\n"
-            "4. Read the improvement target file(s) in `improvement_target`.\n\n"
+            "`improvement_target`, and score threshold.\n"
+            "2. Read `.factory/knowledge/run_state.json` for current and baseline scores.\n"
+            "3. Read `.factory/knowledge/{task_id}_insights.json` for failure patterns.\n"
+            "4. Read `.factory/knowledge/{task_id}_failing_tasks.md` for actual failing "
+            "conversations — see exactly what the agent said and did wrong.\n"
+            "5. Read `.factory/knowledge/{task_id}_improvements.jsonl` (if it exists) "
+            "for previous improvement attempts — avoid repeating what was already tried.\n"
+            "6. Read the improvement target file(s) in `improvement_target`.\n\n"
             "Focus on:\n"
             "- Failed NL assertions: what did the agent do wrong?\n"
             "- Failed action checks: what expected actions were missing?\n"
@@ -271,7 +276,9 @@ def make_analyst_node(node_id: str = "analyst") -> AgentNode:
             "Use `python3 -c` commands to query the graph — see your system prompt "
             "for the full list of available operations (stats, query, traverse, "
             "causal_chain, find_paths, match_pattern, related_entities).\n\n"
-            "Start with stats() to understand the graph, then explore failure "
+            "Start with tool_stats() for an aggregate view of tool usage "
+            "(call counts, success/fail rates, common errors per tool), "
+            "then stats() for the full picture. Explore failure "
             "patterns, causal chains, contradictions, and improvement opportunities.\n"
         ),
         reads={".factory/knowledge/graph.json"},
@@ -288,7 +295,7 @@ def make_gate_insights_node(node_id: str = "gate_insights") -> GateNode:
             "cd {project_path} && "
             'python3 -c "'
             "from pathlib import Path; "
-            "from factory.knowledge.tau_adapter import evaluate_insights_gate; "
+            "from factory.knowledge.gates import evaluate_insights_gate; "
             "evaluate_insights_gate(Path('.factory/knowledge/task_config.json'))"
             '"'
         ),
@@ -304,7 +311,7 @@ def make_report_node(node_id: str = "report") -> FnNode:
             "cd {project_path} && "
             'python3 -c "'
             "from pathlib import Path; "
-            "from factory.knowledge.tau_adapter import generate_report; "
+            "from factory.knowledge.gates import generate_report; "
             "generate_report(Path('.factory/knowledge/task_config.json'))"
             '"'
         ),

--- a/factory/workflow/contributed/knowledge/nodes.py
+++ b/factory/workflow/contributed/knowledge/nodes.py
@@ -255,20 +255,11 @@ def make_update_graph_node(node_id: str = "update_graph") -> FnNode:
         command=(
             "cd {project_path} && "
             'python3 -c "'
-            "import json, pathlib, asyncio; "
+            "import json, pathlib; "
             "from factory.knowledge.store import KnowledgeStore; "
-            "from factory.knowledge.models import Triplet; "
             "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
-            "task_id = cfg['task_id']; "
             "store = KnowledgeStore(pathlib.Path('.')); "
-            "all_triplets = []; "
-            "for suffix in ['det', 'llm']: "
-            "    p = pathlib.Path(f'.factory/knowledge/{task_id}_{suffix}_triplets.json'); "
-            "    if p.exists(): "
-            "        items = json.loads(p.read_text()); "
-            "        all_triplets.extend(Triplet.model_validate(t, strict=False) for t in items); "
-            "graph = asyncio.run(store.append_triplets(task_id, all_triplets)); "
-            "print(f'Graph updated: {graph.entity_count()} entities, {graph.triplet_count()} triplets')"
+            "store.merge_triplet_files(cfg['task_id'], pathlib.Path('.'))"
             '"'
         ),
         notes="Merge extracted triplets into the persistent knowledge graph.",

--- a/factory/workflow/contributed/knowledge/nodes.py
+++ b/factory/workflow/contributed/knowledge/nodes.py
@@ -1,0 +1,221 @@
+"""Composable node factories for the knowledge workflow.
+
+Each function returns a configured node that can be embedded into any workflow.
+"""
+
+from __future__ import annotations
+
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    FnNode,
+    GateNode,
+)
+
+
+def make_observe_node(node_id: str = "observe") -> FnNode:
+    """Run the external agent and capture its output."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            "mkdir -p .factory/knowledge && "
+            'TASK_CONFIG=".factory/knowledge/task_config.json" && '
+            'if [ ! -f "$TASK_CONFIG" ]; then '
+            'echo "Error: .factory/knowledge/task_config.json not found" >&2; exit 1; fi && '
+            'TASK_ID=$(python3 -c "'
+            "import json; c=json.load(open('.factory/knowledge/task_config.json')); "
+            "print(c['task_id'])"
+            '") && '
+            'AGENT_CMD=$(python3 -c "'
+            "import json; c=json.load(open('.factory/knowledge/task_config.json')); "
+            "print(c['agent_command'])"
+            '") && '
+            'echo "Running observation for task $TASK_ID" && '
+            'eval "$AGENT_CMD" > ".factory/knowledge/${TASK_ID}_observation.log" 2>&1 || true && '
+            'echo "Observation captured to .factory/knowledge/${TASK_ID}_observation.log"'
+        ),
+        notes="Run the external agent and capture stdout/stderr to an observation log.",
+        writes={".factory/knowledge/observation.log"},
+    )
+
+
+def make_extract_deterministic_node(
+    node_id: str = "extract_deterministic",
+) -> FnNode:
+    """Parse observation log for structured tool calls and extract triplets."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib, re; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "task_id = cfg['task_id']; "
+            "log_path = pathlib.Path(f'.factory/knowledge/{task_id}_observation.log'); "
+            "log_text = log_path.read_text() if log_path.exists() else ''; "
+            "from factory.knowledge.extractor import extract_from_tool_calls; "
+            "tool_calls = []; "
+            "tc_match = re.search(r'TOOL_CALLS_JSON:(.*?)END_TOOL_CALLS', log_text, re.DOTALL); "
+            "if tc_match: tool_calls = json.loads(tc_match.group(1)); "
+            "result = extract_from_tool_calls(tool_calls, cfg.get('task_context', task_id)); "
+            "out = [t.model_dump(mode='json') for t in result.triplets]; "
+            "pathlib.Path(f'.factory/knowledge/{task_id}_det_triplets.json').write_text("
+            "json.dumps(out, indent=2, default=str)); "
+            "print(f'Extracted {len(out)} deterministic triplets')"
+            '"'
+        ),
+        notes="Extract triplets deterministically from structured tool call traces in the observation log.",
+        reads={".factory/knowledge/observation.log"},
+        writes={".factory/knowledge/det_triplets.json"},
+    )
+
+
+def make_extract_llm_node(node_id: str = "extract_llm") -> AgentNode:
+    """Use a researcher agent to extract semantic triplets from the log."""
+    return AgentNode(
+        id=node_id,
+        role=AgentRole.RESEARCHER,
+        model="sonnet",
+        timeout=120,
+        prompt_template=(
+            "You are extracting knowledge graph triplets from an agent execution log.\n\n"
+            "1. Read `.factory/knowledge/task_config.json` to get the `task_id` and `task_context`.\n"
+            "2. Read `.factory/knowledge/{task_id}_observation.log`.\n"
+            "3. Analyze the log and extract triplets representing the agent's behavior:\n"
+            "   - What tools did the agent call? Did they succeed or fail?\n"
+            "   - What errors occurred? What caused them?\n"
+            "   - What tasks did the agent attempt? What was the outcome?\n"
+            "   - What preconditions were missing?\n\n"
+            "4. Write a JSON array of triplet objects to "
+            "`.factory/knowledge/{task_id}_llm_triplets.json`.\n\n"
+            "Each triplet must have:\n"
+            '- subject: {"id": "type:slug", "type": "<entity_type>", "name": "Human Name"}\n'
+            "- predicate: one of: calls, fails_with, succeeds_at, fails_at, produces, "
+            "requires, precedes, causes, is_a, part_of, related_to, contradicts, "
+            "improves, degrades, correlates_with\n"
+            '- object: {"id": "type:slug", "type": "<entity_type>", "name": "Human Name"}\n'
+            "- confidence: 0.0-1.0 (1.0 for directly observed, 0.7-0.9 for inferred)\n"
+            "- evidence: relevant log snippet\n\n"
+            "Entity types: agent, tool, action, error, task, environment, concept, outcome.\n"
+            "Entity IDs must use format `type:snake_case_name`.\n"
+        ),
+        reads={".factory/knowledge/observation.log"},
+        writes={".factory/knowledge/llm_triplets.json"},
+    )
+
+
+def make_update_graph_node(node_id: str = "update_graph") -> FnNode:
+    """Merge deterministic and LLM-extracted triplets into the knowledge graph."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib, asyncio; "
+            "from factory.knowledge.store import KnowledgeStore; "
+            "from factory.knowledge.models import Triplet; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "task_id = cfg['task_id']; "
+            "store = KnowledgeStore(pathlib.Path('.')); "
+            "all_triplets = []; "
+            "for suffix in ['det', 'llm']: "
+            "    p = pathlib.Path(f'.factory/knowledge/{task_id}_{suffix}_triplets.json'); "
+            "    if p.exists(): "
+            "        items = json.loads(p.read_text()); "
+            "        all_triplets.extend(Triplet.model_validate(t, strict=False) for t in items); "
+            "graph = asyncio.run(store.append_triplets(task_id, all_triplets)); "
+            "print(f'Graph updated: {graph.entity_count()} entities, {graph.triplet_count()} triplets')"
+            '"'
+        ),
+        notes="Merge extracted triplets into the persistent knowledge graph.",
+        reads={
+            ".factory/knowledge/det_triplets.json",
+            ".factory/knowledge/llm_triplets.json",
+        },
+        writes={".factory/knowledge/graph.json"},
+    )
+
+
+def make_analyst_node(node_id: str = "analyst") -> AgentNode:
+    """Knowledge analyst agent explores the graph and generates insights."""
+    return AgentNode(
+        id=node_id,
+        role=AgentRole.KNOWLEDGE_ANALYST,
+        model="opus",
+        timeout=900,
+        max_iterations=3,
+        prompt_template=(
+            "Explore the knowledge graph and generate insights.\n\n"
+            "Read `.factory/knowledge/task_config.json` to get the `task_id`.\n"
+            "The graph is at `.factory/knowledge/{task_id}.json`.\n"
+            "Write insights to `.factory/knowledge/{task_id}_insights.json`.\n\n"
+            "Use `python3 -c` commands to query the graph — see your system prompt "
+            "for the full list of available operations (stats, query, traverse, "
+            "causal_chain, find_paths, match_pattern, related_entities).\n\n"
+            "Start with stats() to understand the graph, then explore failure "
+            "patterns, causal chains, contradictions, and improvement opportunities.\n"
+        ),
+        reads={".factory/knowledge/graph.json"},
+        writes={".factory/knowledge/insights.json"},
+    )
+
+
+def make_gate_insights_node(node_id: str = "gate_insights") -> GateNode:
+    """Gate on insight quality — RELOOP if insufficient."""
+    return GateNode(
+        id=node_id,
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "task_id = cfg['task_id']; "
+            "threshold = cfg.get('insight_threshold', 2); "
+            "conf_threshold = cfg.get('confidence_threshold', 0.5); "
+            "p = pathlib.Path(f'.factory/knowledge/{task_id}_insights.json'); "
+            "if not p.exists(): print('reloop: no insights file found'); exit(); "
+            "insights = json.loads(p.read_text()); "
+            "if len(insights) < threshold: "
+            "    print(f'reloop: only {len(insights)} insights, need at least {threshold}'); exit(); "
+            "avg_conf = sum(i.get('confidence', 0) for i in insights) / len(insights) if insights else 0; "
+            "if avg_conf < conf_threshold: "
+            "    print(f'reloop: average confidence {avg_conf:.2f} below {conf_threshold}'); exit(); "
+            "print(f'pass: {len(insights)} insights with avg confidence {avg_conf:.2f}')"
+            '"'
+        ),
+        reads={".factory/knowledge/insights.json"},
+    )
+
+
+def make_report_node(node_id: str = "report") -> FnNode:
+    """Format final insights into a human-readable report."""
+    return FnNode(
+        id=node_id,
+        command=(
+            "cd {project_path} && "
+            'python3 -c "'
+            "import json, pathlib; "
+            "from factory.knowledge.models import KnowledgeGraph; "
+            "from factory.knowledge.insight import Insight, format_insights; "
+            "cfg = json.loads(pathlib.Path('.factory/knowledge/task_config.json').read_text()); "
+            "task_id = cfg['task_id']; "
+            "graph_path = pathlib.Path(f'.factory/knowledge/{task_id}.json'); "
+            "insights_path = pathlib.Path(f'.factory/knowledge/{task_id}_insights.json'); "
+            "if not graph_path.exists() or not insights_path.exists(): "
+            "    print('No graph or insights to report'); exit(); "
+            "graph = KnowledgeGraph.model_validate(json.loads(graph_path.read_text()), strict=False); "
+            "insights = [Insight.model_validate(i, strict=False) for i in json.loads(insights_path.read_text())]; "
+            "report = format_insights(insights, graph); "
+            "pathlib.Path(f'.factory/knowledge/{task_id}_report.md').write_text(report); "
+            "print(report)"
+            '"'
+        ),
+        notes="Render insights as a markdown report.",
+        reads={
+            ".factory/knowledge/insights.json",
+            ".factory/knowledge/graph.json",
+        },
+        writes={".factory/knowledge/report.md"},
+    )

--- a/factory/workflow/contributed/knowledge/test_workflow.py
+++ b/factory/workflow/contributed/knowledge/test_workflow.py
@@ -196,7 +196,7 @@ class TestTauBenchWorkflow:
     def test_run_eval_is_fn(self) -> None:
         node = self._wf().nodes["run_eval"]
         assert isinstance(node, FnNode)
-        assert "tau_command" in node.command
+        assert "run_tau_eval" in node.command
 
     def test_extract_tau_is_fn(self) -> None:
         node = self._wf().nodes["extract_tau"]
@@ -217,7 +217,7 @@ class TestTauBenchWorkflow:
     def test_re_eval_is_fn(self) -> None:
         node = self._wf().nodes["re_eval"]
         assert isinstance(node, FnNode)
-        assert "tau_command" in node.command
+        assert "run_tau_eval" in node.command
 
     def test_gate_compare_is_fn_evaluator(self) -> None:
         node = self._wf().nodes["gate_compare"]

--- a/factory/workflow/contributed/knowledge/test_workflow.py
+++ b/factory/workflow/contributed/knowledge/test_workflow.py
@@ -1,4 +1,4 @@
-"""Tests for the knowledge contributed workflow."""
+"""Tests for the knowledge contributed workflows."""
 
 from __future__ import annotations
 
@@ -12,6 +12,191 @@ from factory.workflow.primitives import (
     GateNode,
     VerdictType,
 )
+
+
+# ── OLS troubleshooting workflow tests ─────────────────────────
+
+
+class TestOlsWorkflow:
+    def _wf(self):  # noqa: ANN202
+        from factory.workflow.contributed.knowledge.workflow import ols_workflow
+
+        return ols_workflow()
+
+    def test_workflow_name(self) -> None:
+        assert self._wf().name == "knowledge-ols"
+
+    def test_node_count(self) -> None:
+        wf = self._wf()
+        assert len(wf.nodes) == 11
+        assert set(wf.nodes.keys()) == {
+            "run_eval",
+            "extract_ols",
+            "extract_llm",
+            "update_graph",
+            "analyst",
+            "gate_insights",
+            "gate_score",
+            "improve",
+            "re_eval",
+            "gate_compare",
+            "report",
+        }
+
+    def test_start_node(self) -> None:
+        assert self._wf().start_node == "run_eval"
+
+    def test_graph_validates(self) -> None:
+        issues = self._wf().validate_graph()
+        assert issues == [], f"OLS workflow has validation issues: {issues}"
+
+    def test_edge_count(self) -> None:
+        assert len(self._wf().edges) == 13
+
+    def test_run_eval_is_fn(self) -> None:
+        node = self._wf().nodes["run_eval"]
+        assert isinstance(node, FnNode)
+        assert "run_ols_eval" in node.command
+
+    def test_extract_ols_is_fn(self) -> None:
+        node = self._wf().nodes["extract_ols"]
+        assert isinstance(node, FnNode)
+        assert "parse_results" in node.command
+
+    def test_gate_score_is_fn_evaluator(self) -> None:
+        node = self._wf().nodes["gate_score"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert "evaluate_score_gate" in (node.evaluator_command or "")
+
+    def test_improve_is_builder(self) -> None:
+        node = self._wf().nodes["improve"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.BUILDER
+
+    def test_re_eval_is_fn(self) -> None:
+        node = self._wf().nodes["re_eval"]
+        assert isinstance(node, FnNode)
+        assert "run_ols_eval" in node.command
+
+    def test_gate_compare_is_fn_evaluator(self) -> None:
+        node = self._wf().nodes["gate_compare"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert "evaluate_compare_gate" in (node.evaluator_command or "")
+
+    def test_gate_insights_proceed_to_gate_score(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_insights"
+            and e.target == "gate_score"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(edges) == 1
+
+    def test_gate_insights_reloop_to_run_eval(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_insights"
+            and e.target == "run_eval"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(edges) == 1
+
+    def test_gate_score_proceed_to_report(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_score"
+            and e.target == "report"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(edges) == 1
+
+    def test_gate_score_reloop_to_improve(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_score"
+            and e.target == "improve"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(edges) == 1
+
+    def test_gate_compare_proceed_to_report(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_compare"
+            and e.target == "report"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(edges) == 1
+
+    def test_gate_compare_reloop_to_extract_ols(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_compare"
+            and e.target == "extract_ols"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(edges) == 1
+
+    def test_terminal_flag(self) -> None:
+        assert self._wf().terminal is True
+
+
+class TestOlsTrigger:
+    def test_trigger_accepts_knowledge_ols(self) -> None:
+        from factory.workflow.contributed.knowledge.workflow import ols_workflow
+
+        wf = ols_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "knowledge-ols"})
+
+    def test_trigger_rejects_other_modes(self) -> None:
+        from factory.workflow.contributed.knowledge.workflow import ols_workflow
+
+        wf = ols_workflow()
+        assert wf.trigger is not None
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "knowledge-tau"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "knowledge"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+class TestOlsRegistration:
+    def test_registered_in_register_all(self) -> None:
+        workflows = register_all()
+        assert "knowledge-ols" in workflows
+
+    def test_registered_workflow_validates(self) -> None:
+        workflows = register_all()
+        wf = workflows["knowledge-ols"]
+        issues = wf.validate_graph()
+        assert issues == [], f"Registered OLS workflow has validation issues: {issues}"
+
+
+class TestOlsMeta:
+    def test_meta_has_name(self) -> None:
+        from factory.workflow.contributed.knowledge.workflow import ols_meta
+
+        assert ols_meta["name"] == "knowledge-ols"
+
+    def test_meta_has_description(self) -> None:
+        from factory.workflow.contributed.knowledge.workflow import ols_meta
+
+        assert "description" in ols_meta
+        assert len(str(ols_meta["description"])) > 20
 
 
 class TestKnowledgeWorkflow:

--- a/factory/workflow/contributed/knowledge/test_workflow.py
+++ b/factory/workflow/contributed/knowledge/test_workflow.py
@@ -82,14 +82,13 @@ class TestKnowledgeWorkflow:
         assert isinstance(node, GateNode)
         assert node.evaluator_type == "fn"
         assert node.evaluator_command is not None
-        assert "pass:" in node.evaluator_command
-        assert "reloop:" in node.evaluator_command
+        assert "evaluate_insights_gate" in node.evaluator_command
 
     def test_report_is_fn(self) -> None:
         wf = workflow()
         node = wf.nodes["report"]
         assert isinstance(node, FnNode)
-        assert "format_insights" in node.command
+        assert "generate_report" in node.command
 
     def test_reloop_edge_exists(self) -> None:
         wf = workflow()
@@ -207,7 +206,7 @@ class TestTauBenchWorkflow:
         node = self._wf().nodes["gate_score"]
         assert isinstance(node, GateNode)
         assert node.evaluator_type == "fn"
-        assert "score_threshold" in (node.evaluator_command or "")
+        assert "evaluate_score_gate" in (node.evaluator_command or "")
 
     def test_improve_is_builder(self) -> None:
         node = self._wf().nodes["improve"]
@@ -223,7 +222,7 @@ class TestTauBenchWorkflow:
         node = self._wf().nodes["gate_compare"]
         assert isinstance(node, GateNode)
         assert node.evaluator_type == "fn"
-        assert "baseline_score" in (node.evaluator_command or "")
+        assert "evaluate_compare_gate" in (node.evaluator_command or "")
 
     def test_gate_insights_proceed_to_gate_score(self) -> None:
         wf = self._wf()

--- a/factory/workflow/contributed/knowledge/test_workflow.py
+++ b/factory/workflow/contributed/knowledge/test_workflow.py
@@ -67,7 +67,7 @@ class TestKnowledgeWorkflow:
         wf = workflow()
         node = wf.nodes["update_graph"]
         assert isinstance(node, FnNode)
-        assert "append_triplets" in node.command
+        assert "merge_triplet_files" in node.command
 
     def test_analyst_is_knowledge_analyst(self) -> None:
         wf = workflow()

--- a/factory/workflow/contributed/knowledge/test_workflow.py
+++ b/factory/workflow/contributed/knowledge/test_workflow.py
@@ -152,3 +152,187 @@ class TestKnowledgeMeta:
     def test_meta_has_description(self) -> None:
         assert "description" in meta
         assert len(str(meta["description"])) > 20
+
+
+# ── tau-bench workflow tests ────────────────────────────────────
+
+
+class TestTauBenchWorkflow:
+    def _wf(self):  # noqa: ANN202
+        from factory.workflow.contributed.knowledge.workflow import tau_workflow
+
+        return tau_workflow()
+
+    def test_workflow_name(self) -> None:
+        assert self._wf().name == "knowledge-tau"
+
+    def test_node_count(self) -> None:
+        wf = self._wf()
+        assert len(wf.nodes) == 11
+        assert set(wf.nodes.keys()) == {
+            "run_eval",
+            "extract_tau",
+            "extract_llm",
+            "update_graph",
+            "analyst",
+            "gate_insights",
+            "gate_score",
+            "improve",
+            "re_eval",
+            "gate_compare",
+            "report",
+        }
+
+    def test_start_node(self) -> None:
+        assert self._wf().start_node == "run_eval"
+
+    def test_graph_validates(self) -> None:
+        issues = self._wf().validate_graph()
+        assert issues == [], f"Tau workflow has validation issues: {issues}"
+
+    def test_edge_count(self) -> None:
+        assert len(self._wf().edges) == 13
+
+    def test_run_eval_is_fn(self) -> None:
+        node = self._wf().nodes["run_eval"]
+        assert isinstance(node, FnNode)
+        assert "tau_command" in node.command
+
+    def test_extract_tau_is_fn(self) -> None:
+        node = self._wf().nodes["extract_tau"]
+        assert isinstance(node, FnNode)
+        assert "parse_simulation" in node.command
+
+    def test_gate_score_is_fn_evaluator(self) -> None:
+        node = self._wf().nodes["gate_score"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert "score_threshold" in (node.evaluator_command or "")
+
+    def test_improve_is_builder(self) -> None:
+        node = self._wf().nodes["improve"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.BUILDER
+
+    def test_re_eval_is_fn(self) -> None:
+        node = self._wf().nodes["re_eval"]
+        assert isinstance(node, FnNode)
+        assert "tau_command" in node.command
+
+    def test_gate_compare_is_fn_evaluator(self) -> None:
+        node = self._wf().nodes["gate_compare"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert "baseline_score" in (node.evaluator_command or "")
+
+    def test_gate_insights_proceed_to_gate_score(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_insights"
+            and e.target == "gate_score"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(edges) == 1
+
+    def test_gate_insights_reloop_to_run_eval(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_insights"
+            and e.target == "run_eval"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(edges) == 1
+
+    def test_gate_score_proceed_to_report(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_score"
+            and e.target == "report"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(edges) == 1
+
+    def test_gate_score_reloop_to_improve(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_score"
+            and e.target == "improve"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(edges) == 1
+
+    def test_gate_compare_proceed_to_report(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_compare"
+            and e.target == "report"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(edges) == 1
+
+    def test_gate_compare_reloop_to_improve(self) -> None:
+        wf = self._wf()
+        edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_compare"
+            and e.target == "improve"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(edges) == 1
+
+    def test_terminal_flag(self) -> None:
+        assert self._wf().terminal is True
+
+
+class TestTauBenchTrigger:
+    def test_trigger_accepts_knowledge_tau(self) -> None:
+        from factory.workflow.contributed.knowledge.workflow import tau_workflow
+
+        wf = tau_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "knowledge-tau"})
+
+    def test_trigger_rejects_other_modes(self) -> None:
+        from factory.workflow.contributed.knowledge.workflow import tau_workflow
+
+        wf = tau_workflow()
+        assert wf.trigger is not None
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "knowledge"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+class TestTauBenchRegistration:
+    def test_registered_in_register_all(self) -> None:
+        workflows = register_all()
+        assert "knowledge-tau" in workflows
+
+    def test_registered_workflow_validates(self) -> None:
+        workflows = register_all()
+        wf = workflows["knowledge-tau"]
+        issues = wf.validate_graph()
+        assert issues == [], f"Registered tau workflow has validation issues: {issues}"
+
+
+class TestTauBenchMeta:
+    def test_meta_has_name(self) -> None:
+        from factory.workflow.contributed.knowledge.workflow import tau_meta
+
+        assert tau_meta["name"] == "knowledge-tau"
+
+    def test_meta_has_description(self) -> None:
+        from factory.workflow.contributed.knowledge.workflow import tau_meta
+
+        assert "description" in tau_meta
+        assert len(str(tau_meta["description"])) > 20

--- a/factory/workflow/contributed/knowledge/test_workflow.py
+++ b/factory/workflow/contributed/knowledge/test_workflow.py
@@ -1,0 +1,154 @@
+"""Tests for the knowledge contributed workflow."""
+
+from __future__ import annotations
+
+from factory.models import ProjectState
+from factory.workflow.contributed.knowledge import meta, workflow
+from factory.workflow.definitions import register_all
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    FnNode,
+    GateNode,
+    VerdictType,
+)
+
+
+class TestKnowledgeWorkflow:
+    def test_workflow_name(self) -> None:
+        wf = workflow()
+        assert wf.name == "knowledge"
+
+    def test_node_count(self) -> None:
+        wf = workflow()
+        assert len(wf.nodes) == 7
+        assert set(wf.nodes.keys()) == {
+            "observe",
+            "extract_deterministic",
+            "extract_llm",
+            "update_graph",
+            "analyst",
+            "gate_insights",
+            "report",
+        }
+
+    def test_start_node(self) -> None:
+        wf = workflow()
+        assert wf.start_node == "observe"
+
+    def test_graph_validates(self) -> None:
+        wf = workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Workflow has validation issues: {issues}"
+
+    def test_edge_count(self) -> None:
+        wf = workflow()
+        assert len(wf.edges) == 7
+
+    def test_observe_node_is_fn(self) -> None:
+        wf = workflow()
+        node = wf.nodes["observe"]
+        assert isinstance(node, FnNode)
+        assert "task_config.json" in node.command
+
+    def test_extract_deterministic_is_fn(self) -> None:
+        wf = workflow()
+        node = wf.nodes["extract_deterministic"]
+        assert isinstance(node, FnNode)
+        assert "extract_from_tool_calls" in node.command
+
+    def test_extract_llm_is_researcher(self) -> None:
+        wf = workflow()
+        node = wf.nodes["extract_llm"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.RESEARCHER
+
+    def test_update_graph_is_fn(self) -> None:
+        wf = workflow()
+        node = wf.nodes["update_graph"]
+        assert isinstance(node, FnNode)
+        assert "append_triplets" in node.command
+
+    def test_analyst_is_knowledge_analyst(self) -> None:
+        wf = workflow()
+        node = wf.nodes["analyst"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.KNOWLEDGE_ANALYST
+        assert node.timeout == 900
+
+    def test_gate_insights_is_fn_evaluator(self) -> None:
+        wf = workflow()
+        node = wf.nodes["gate_insights"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert node.evaluator_command is not None
+        assert "pass:" in node.evaluator_command
+        assert "reloop:" in node.evaluator_command
+
+    def test_report_is_fn(self) -> None:
+        wf = workflow()
+        node = wf.nodes["report"]
+        assert isinstance(node, FnNode)
+        assert "format_insights" in node.command
+
+    def test_reloop_edge_exists(self) -> None:
+        wf = workflow()
+        reloop_edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_insights"
+            and e.target == "observe"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(reloop_edges) == 1
+
+    def test_proceed_edge_exists(self) -> None:
+        wf = workflow()
+        proceed_edges = [
+            e
+            for e in wf.edges
+            if e.source == "gate_insights"
+            and e.target == "report"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(proceed_edges) == 1
+
+
+class TestKnowledgeTerminal:
+    def test_terminal_flag(self) -> None:
+        wf = workflow()
+        assert wf.terminal is True
+
+
+class TestKnowledgeTrigger:
+    def test_trigger_accepts_knowledge_mode(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "knowledge"})
+
+    def test_trigger_rejects_other_modes(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+class TestKnowledgeRegistration:
+    def test_registered_in_register_all(self) -> None:
+        workflows = register_all()
+        assert "knowledge" in workflows
+
+    def test_registered_workflow_validates(self) -> None:
+        workflows = register_all()
+        wf = workflows["knowledge"]
+        issues = wf.validate_graph()
+        assert issues == [], f"Registered workflow has validation issues: {issues}"
+
+
+class TestKnowledgeMeta:
+    def test_meta_has_name(self) -> None:
+        assert meta["name"] == "knowledge"
+
+    def test_meta_has_description(self) -> None:
+        assert "description" in meta
+        assert len(str(meta["description"])) > 20

--- a/factory/workflow/contributed/knowledge/test_workflow.py
+++ b/factory/workflow/contributed/knowledge/test_workflow.py
@@ -279,13 +279,13 @@ class TestTauBenchWorkflow:
         ]
         assert len(edges) == 1
 
-    def test_gate_compare_reloop_to_improve(self) -> None:
+    def test_gate_compare_reloop_to_extract_tau(self) -> None:
         wf = self._wf()
         edges = [
             e
             for e in wf.edges
             if e.source == "gate_compare"
-            and e.target == "improve"
+            and e.target == "extract_tau"
             and e.condition == VerdictType.RELOOP
         ]
         assert len(edges) == 1

--- a/factory/workflow/contributed/knowledge/workflow.py
+++ b/factory/workflow/contributed/knowledge/workflow.py
@@ -95,10 +95,13 @@ def tau_workflow() -> Workflow:
         make_run_eval_node,
     )
 
+    extract_llm = make_extract_llm_node()
+    extract_llm.reads = {".factory/knowledge/simulation.json"}
+
     nodes: dict[str, Any] = {
         "run_eval": make_run_eval_node(),
         "extract_tau": make_extract_tau_node(),
-        "extract_llm": make_extract_llm_node(),
+        "extract_llm": extract_llm,
         "update_graph": make_update_graph_node(),
         "analyst": make_analyst_node(),
         "gate_insights": make_gate_insights_node(),

--- a/factory/workflow/contributed/knowledge/workflow.py
+++ b/factory/workflow/contributed/knowledge/workflow.py
@@ -70,3 +70,69 @@ def workflow() -> Workflow:
         terminal=True,
         trigger=trigger,
     )
+
+
+tau_meta = {
+    "name": "knowledge-tau",
+    "description": (
+        "Tau-bench knowledge mode — closed-loop improvement cycle. "
+        "run_eval → extract → analyze → gate_insights → gate_score → "
+        "improve → re_eval → gate_compare → report. "
+        "Extracts structured triplets from tau-bench simulation JSON "
+        "and uses insights to improve the agent."
+    ),
+}
+
+
+def tau_workflow() -> Workflow:
+    """Build the tau-bench evaluation + improvement workflow."""
+    from factory.workflow.contributed.knowledge.nodes import (
+        make_extract_tau_node,
+        make_gate_compare_node,
+        make_gate_score_node,
+        make_improve_node,
+        make_re_eval_node,
+        make_run_eval_node,
+    )
+
+    nodes: dict[str, Any] = {
+        "run_eval": make_run_eval_node(),
+        "extract_tau": make_extract_tau_node(),
+        "extract_llm": make_extract_llm_node(),
+        "update_graph": make_update_graph_node(),
+        "analyst": make_analyst_node(),
+        "gate_insights": make_gate_insights_node(),
+        "gate_score": make_gate_score_node(),
+        "improve": make_improve_node(),
+        "re_eval": make_re_eval_node(),
+        "gate_compare": make_gate_compare_node(),
+        "report": make_report_node(),
+    }
+
+    edges = [
+        Edge(source="run_eval", target="extract_tau"),
+        Edge(source="extract_tau", target="extract_llm"),
+        Edge(source="extract_llm", target="update_graph"),
+        Edge(source="update_graph", target="analyst"),
+        Edge(source="analyst", target="gate_insights"),
+        Edge(source="gate_insights", target="gate_score", condition=VerdictType.PROCEED),
+        Edge(source="gate_insights", target="run_eval", condition=VerdictType.RELOOP),
+        Edge(source="gate_score", target="report", condition=VerdictType.PROCEED),
+        Edge(source="gate_score", target="improve", condition=VerdictType.RELOOP),
+        Edge(source="improve", target="re_eval"),
+        Edge(source="re_eval", target="gate_compare"),
+        Edge(source="gate_compare", target="report", condition=VerdictType.PROCEED),
+        Edge(source="gate_compare", target="improve", condition=VerdictType.RELOOP),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "knowledge-tau"
+
+    return Workflow(
+        name="knowledge-tau",
+        nodes=nodes,
+        edges=edges,
+        start_node="run_eval",
+        terminal=True,
+        trigger=trigger,
+    )

--- a/factory/workflow/contributed/knowledge/workflow.py
+++ b/factory/workflow/contributed/knowledge/workflow.py
@@ -72,6 +72,81 @@ def workflow() -> Workflow:
     )
 
 
+ols_meta = {
+    "name": "knowledge-ols",
+    "description": (
+        "OLS troubleshooting eval knowledge mode — closed-loop improvement cycle. "
+        "run_eval → extract_ols → extract_llm → update_graph → analyst → "
+        "gate_insights → gate_score → improve → re_eval → gate_compare → report. "
+        "Extracts structured triplets from OLS eval CSV results "
+        "(answer_correctness, conversation quality metrics) "
+        "and uses insights to improve the troubleshooting agent."
+    ),
+}
+
+
+def ols_workflow() -> Workflow:
+    """Build the OLS troubleshooting eval + improvement workflow."""
+    from factory.workflow.contributed.knowledge.nodes import (
+        make_analyst_node,
+        make_extract_llm_node,
+        make_gate_insights_node,
+        make_ols_extract_node,
+        make_ols_gate_compare_node,
+        make_ols_gate_score_node,
+        make_ols_improve_node,
+        make_ols_re_eval_node,
+        make_ols_run_eval_node,
+        make_report_node,
+        make_update_graph_node,
+    )
+
+    extract_llm = make_extract_llm_node()
+    extract_llm.reads = {".factory/knowledge/det_triplets.json"}
+
+    nodes: dict[str, Any] = {
+        "run_eval": make_ols_run_eval_node(),
+        "extract_ols": make_ols_extract_node(),
+        "extract_llm": extract_llm,
+        "update_graph": make_update_graph_node(),
+        "analyst": make_analyst_node(),
+        "gate_insights": make_gate_insights_node(),
+        "gate_score": make_ols_gate_score_node(),
+        "improve": make_ols_improve_node(),
+        "re_eval": make_ols_re_eval_node(),
+        "gate_compare": make_ols_gate_compare_node(),
+        "report": make_report_node(),
+    }
+
+    edges = [
+        Edge(source="run_eval", target="extract_ols"),
+        Edge(source="extract_ols", target="extract_llm"),
+        Edge(source="extract_llm", target="update_graph"),
+        Edge(source="update_graph", target="analyst"),
+        Edge(source="analyst", target="gate_insights"),
+        Edge(source="gate_insights", target="gate_score", condition=VerdictType.PROCEED),
+        Edge(source="gate_insights", target="run_eval", condition=VerdictType.RELOOP),
+        Edge(source="gate_score", target="report", condition=VerdictType.PROCEED),
+        Edge(source="gate_score", target="improve", condition=VerdictType.RELOOP),
+        Edge(source="improve", target="re_eval"),
+        Edge(source="re_eval", target="gate_compare"),
+        Edge(source="gate_compare", target="report", condition=VerdictType.PROCEED),
+        Edge(source="gate_compare", target="extract_ols", condition=VerdictType.RELOOP),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "knowledge-ols"
+
+    return Workflow(
+        name="knowledge-ols",
+        nodes=nodes,
+        edges=edges,
+        start_node="run_eval",
+        terminal=True,
+        trigger=trigger,
+    )
+
+
 tau_meta = {
     "name": "knowledge-tau",
     "description": (

--- a/factory/workflow/contributed/knowledge/workflow.py
+++ b/factory/workflow/contributed/knowledge/workflow.py
@@ -125,7 +125,7 @@ def tau_workflow() -> Workflow:
         Edge(source="improve", target="re_eval"),
         Edge(source="re_eval", target="gate_compare"),
         Edge(source="gate_compare", target="report", condition=VerdictType.PROCEED),
-        Edge(source="gate_compare", target="improve", condition=VerdictType.RELOOP),
+        Edge(source="gate_compare", target="extract_tau", condition=VerdictType.RELOOP),
     ]
 
     def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:

--- a/factory/workflow/contributed/knowledge/workflow.py
+++ b/factory/workflow/contributed/knowledge/workflow.py
@@ -1,0 +1,72 @@
+"""Knowledge workflow — observe an external agent, extract triplets, generate insights.
+
+7-node pipeline: observe → extract_deterministic → extract_llm → update_graph
+                 → analyst → gate_insights → report
+RELOOP from gate_insights back to observe (max 3 iterations) when insights are thin.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.contributed.knowledge.nodes import (
+    make_analyst_node,
+    make_extract_deterministic_node,
+    make_extract_llm_node,
+    make_gate_insights_node,
+    make_observe_node,
+    make_report_node,
+    make_update_graph_node,
+)
+from factory.workflow.primitives import (
+    Edge,
+    VerdictType,
+    Workflow,
+)
+
+meta = {
+    "name": "knowledge",
+    "description": (
+        "Knowledge mode — observe an external agent, extract knowledge graph "
+        "triplets from its execution traces, and generate insights about failure "
+        "patterns, causal chains, and improvement opportunities. "
+        "observe → extract → update_graph → analyst → gate_insights → report "
+        "with RELOOP on insufficient insights."
+    ),
+}
+
+
+def workflow() -> Workflow:
+    """Build the knowledge workflow from composable node factories."""
+    nodes: dict[str, Any] = {
+        "observe": make_observe_node(),
+        "extract_deterministic": make_extract_deterministic_node(),
+        "extract_llm": make_extract_llm_node(),
+        "update_graph": make_update_graph_node(),
+        "analyst": make_analyst_node(),
+        "gate_insights": make_gate_insights_node(),
+        "report": make_report_node(),
+    }
+
+    edges = [
+        Edge(source="observe", target="extract_deterministic"),
+        Edge(source="extract_deterministic", target="extract_llm"),
+        Edge(source="extract_llm", target="update_graph"),
+        Edge(source="update_graph", target="analyst"),
+        Edge(source="analyst", target="gate_insights"),
+        Edge(source="gate_insights", target="report", condition=VerdictType.PROCEED),
+        Edge(source="gate_insights", target="observe", condition=VerdictType.RELOOP),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "knowledge"
+
+    return Workflow(
+        name="knowledge",
+        nodes=nodes,
+        edges=edges,
+        start_node="observe",
+        terminal=True,
+        trigger=trigger,
+    )

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2285,6 +2285,7 @@ def register_all() -> dict[str, Workflow]:
     from factory.workflow.contributed.programbench import workflow as programbench_workflow
     from factory.workflow.contributed.knowledge import workflow as knowledge_workflow  # noqa: E501
     from factory.workflow.contributed.knowledge import tau_workflow as knowledge_tau_workflow  # noqa: E501
+    from factory.workflow.contributed.knowledge import ols_workflow as knowledge_ols_workflow  # noqa: E501
     from factory.workflow.contributed.terminalbench import workflow as terminalbench_workflow
 
     return {
@@ -2311,4 +2312,5 @@ def register_all() -> dict[str, Workflow]:
         "spec-update": spec_update_workflow(),
         "knowledge": knowledge_workflow(),
         "knowledge-tau": knowledge_tau_workflow(),
+        "knowledge-ols": knowledge_ols_workflow(),
     }

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2284,6 +2284,7 @@ def register_all() -> dict[str, Workflow]:
     from factory.workflow.contributed.featurebench import workflow as featurebench_workflow
     from factory.workflow.contributed.programbench import workflow as programbench_workflow
     from factory.workflow.contributed.knowledge import workflow as knowledge_workflow  # noqa: E501
+    from factory.workflow.contributed.knowledge import tau_workflow as knowledge_tau_workflow  # noqa: E501
     from factory.workflow.contributed.terminalbench import workflow as terminalbench_workflow
 
     return {
@@ -2309,4 +2310,5 @@ def register_all() -> dict[str, Workflow]:
         "spec-generate": spec_generate_workflow(),
         "spec-update": spec_update_workflow(),
         "knowledge": knowledge_workflow(),
+        "knowledge-tau": knowledge_tau_workflow(),
     }

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2283,6 +2283,7 @@ def register_all() -> dict[str, Workflow]:
     from factory.workflow.contributed.swebench import workflow as swebench_workflow
     from factory.workflow.contributed.featurebench import workflow as featurebench_workflow
     from factory.workflow.contributed.programbench import workflow as programbench_workflow
+    from factory.workflow.contributed.knowledge import workflow as knowledge_workflow  # noqa: E501
     from factory.workflow.contributed.terminalbench import workflow as terminalbench_workflow
 
     return {
@@ -2307,4 +2308,5 @@ def register_all() -> dict[str, Workflow]:
         "doc-update": doc_update_workflow(),
         "spec-generate": spec_generate_workflow(),
         "spec-update": spec_update_workflow(),
+        "knowledge": knowledge_workflow(),
     }

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -26,6 +26,7 @@ class AgentRole(str, Enum):
     ARCHIVIST = "archivist"
     REFINER = "refiner"
     SKILL_REVIEWER = "skill_reviewer"
+    KNOWLEDGE_ANALYST = "knowledge_analyst"
 
 
 class AgentConfig(BaseModel):
@@ -45,12 +46,15 @@ DEFAULT_AGENT_POOL: dict[str, AgentConfig] = {
     "qa": AgentConfig(role=AgentRole.QA, model="opus", timeout=1800),
     "health_checker": AgentConfig(role=AgentRole.HEALTH_CHECKER, model="opus", timeout=600),
     "code_reviewer": AgentConfig(role=AgentRole.CODE_REVIEWER, model="opus", timeout=900),
-    "adversarial_tester": AgentConfig(role=AgentRole.ADVERSARIAL_TESTER, model="opus", timeout=1800),
+    "adversarial_tester": AgentConfig(
+        role=AgentRole.ADVERSARIAL_TESTER, model="opus", timeout=1800
+    ),
     "failure_analyst": AgentConfig(role=AgentRole.FAILURE_ANALYST, model="opus", timeout=600),
     "ceo": AgentConfig(role=AgentRole.CEO, model="opus", timeout=3600),
     "archivist": AgentConfig(role=AgentRole.ARCHIVIST, model="haiku", timeout=300),
     "refiner": AgentConfig(role=AgentRole.REFINER, model="opus", timeout=600),
     "skill_reviewer": AgentConfig(role=AgentRole.SKILL_REVIEWER, model="opus", timeout=600),
+    "knowledge_analyst": AgentConfig(role=AgentRole.KNOWLEDGE_ANALYST, model="opus", timeout=900),
 }
 
 
@@ -211,6 +215,7 @@ class Workflow(BaseModel):
     def validate_graph(self) -> list[str]:
         """Validate workflow graph structure using NetworkX. Returns list of issues."""
         from factory.workflow.validation import validate_workflow
+
         return validate_workflow(self)
 
     def subgraph(
@@ -251,7 +256,9 @@ class Factory(BaseModel):
     config: FactoryConfig | None = None
 
     def select_workflow(
-        self, state: ProjectState, context: dict[str, Any] | None = None,
+        self,
+        state: ProjectState,
+        context: dict[str, Any] | None = None,
     ) -> Workflow | None:
         ctx = context or {}
         for wf in self.workflows.values():

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -148,6 +148,16 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
         ),
         "argument_hint": "<project_path>",
     },
+    "knowledge": {
+        "description": (
+            "Knowledge mode — observe an external agent, extract knowledge graph "
+            "triplets from its execution traces, and generate insights about failure "
+            "patterns, causal chains, and improvement opportunities. Use when the user "
+            "says 'analyze agent behavior', 'build knowledge graph', or wants to extract "
+            "structured knowledge from agent runs."
+        ),
+        "argument_hint": "<project_path> --mode knowledge",
+    },
 }
 
 
@@ -312,8 +322,15 @@ def _fn_to_instruction(node: FnNode, workflow: Workflow) -> str:
 
 def _has_template_placeholders(text: str) -> bool:
     """Check if a command has $VARIABLE placeholders that need CEO substitution."""
-    placeholders = {"$EXP_ID", "$VERDICT", "$HYPOTHESIS", "$REQUEST",
-                     "$PR_NUMBER", "$SCORE_BEFORE", "$SCORE_AFTER"}
+    placeholders = {
+        "$EXP_ID",
+        "$VERDICT",
+        "$HYPOTHESIS",
+        "$REQUEST",
+        "$PR_NUMBER",
+        "$SCORE_BEFORE",
+        "$SCORE_AFTER",
+    }
     return any(p in text for p in placeholders)
 
 
@@ -399,7 +416,9 @@ def _gate_to_checkpoint(
 
         if proceed_edges:
             proceed_target = proceed_edges[0].target
-            lines.append(f"\n- **PROCEED** (exit 0 / no FAIL in output) → continue to `{proceed_target}`")
+            lines.append(
+                f"\n- **PROCEED** (exit 0 / no FAIL in output) → continue to `{proceed_target}`"
+            )
             lines.append(
                 f"- **HALT** (exit non-zero / FAIL in output) → do NOT spawn `{proceed_target}`. "
                 "Skip to the next CEO review gate or finalize as error."
@@ -578,9 +597,7 @@ def workflow_to_skill_md(workflow: Workflow) -> str:
             sections.append(_join_to_instruction(node, workflow))
 
         elif isinstance(node, GateNode):
-            sections.append(
-                _gate_to_checkpoint(node, reloop_map.get(nid, []), workflow)
-            )
+            sections.append(_gate_to_checkpoint(node, reloop_map.get(nid, []), workflow))
 
         elif isinstance(node, Study):
             node_title = "Observe"
@@ -637,6 +654,7 @@ def export_all_skills(
 
     if workflows is None:
         from factory.workflow.definitions import register_all
+
         workflows = register_all()
 
     generated: list[Path] = []

--- a/tests/test_knowledge_extractor.py
+++ b/tests/test_knowledge_extractor.py
@@ -1,0 +1,201 @@
+"""Tests for factory.knowledge.extractor — deterministic and LLM extraction."""
+
+import json
+
+
+from factory.knowledge.extractor import (
+    build_extraction_prompt,
+    extract_from_tool_calls,
+    parse_extraction_response,
+)
+from factory.knowledge.models import EntityType, PredicateType
+
+
+# ── deterministic extraction ─────────────────────────────────────
+
+
+class TestExtractFromToolCalls:
+    def test_single_successful_call(self):
+        calls = [{"name": "get_order", "result": '{"id": 42}', "success": True}]
+        result = extract_from_tool_calls(calls, "process order")
+        triplets = result.triplets
+        call_triplets = [t for t in triplets if t.predicate == PredicateType.CALLS]
+        assert len(call_triplets) == 1
+        assert call_triplets[0].object.name == "get_order"
+        success = [t for t in triplets if t.predicate == PredicateType.SUCCEEDS_AT]
+        assert len(success) == 1
+
+    def test_failed_call(self):
+        calls = [{"name": "cancel_booking", "error": "booking not found"}]
+        result = extract_from_tool_calls(calls, "cancel order")
+        triplets = result.triplets
+        failures = [t for t in triplets if t.predicate == PredicateType.FAILS_WITH]
+        assert len(failures) == 1
+        assert "booking not found" in failures[0].evidence
+        task_fail = [t for t in triplets if t.predicate == PredicateType.FAILS_AT]
+        assert len(task_fail) == 1
+
+    def test_sequential_calls_produce_precedes(self):
+        calls = [
+            {"name": "search", "result": "found", "success": True},
+            {"name": "update", "result": "ok", "success": True},
+        ]
+        result = extract_from_tool_calls(calls, "update item")
+        precedes = [t for t in result.triplets if t.predicate == PredicateType.PRECEDES]
+        assert len(precedes) == 1
+
+    def test_mixed_success_and_failure(self):
+        calls = [
+            {"name": "get_user", "result": '{"name": "alice"}', "success": True},
+            {"name": "delete_account", "error": "permission denied"},
+        ]
+        result = extract_from_tool_calls(calls, "delete user")
+        task_fail = [t for t in result.triplets if t.predicate == PredicateType.FAILS_AT]
+        assert len(task_fail) == 1
+
+    def test_empty_calls(self):
+        result = extract_from_tool_calls([], "empty task")
+        success = [t for t in result.triplets if t.predicate == PredicateType.SUCCEEDS_AT]
+        assert len(success) == 1
+
+    def test_custom_agent_name(self):
+        calls = [{"name": "tool_x", "success": True}]
+        result = extract_from_tool_calls(calls, "task", agent_name="my_bot")
+        agent_triplets = [t for t in result.triplets if t.subject.type == EntityType.AGENT]
+        assert all(t.subject.name == "my_bot" for t in agent_triplets)
+
+    def test_source_label(self):
+        calls = [{"name": "tool_x", "success": True}]
+        result = extract_from_tool_calls(calls, "task", source_label="run_005")
+        assert result.source_label == "run_005"
+        assert all(t.source == "run_005" for t in result.triplets)
+
+
+# ── LLM response parsing ────────────────────────────────────────
+
+
+VALID_JSON_RESPONSE = json.dumps(
+    [
+        {
+            "subject": {"id": "agent:main", "type": "agent", "name": "Main Agent"},
+            "predicate": "calls",
+            "object": {"id": "tool:search", "type": "tool", "name": "Search"},
+            "confidence": 0.95,
+            "evidence": "Agent called search tool",
+        },
+        {
+            "subject": {"id": "tool:search", "type": "tool", "name": "Search"},
+            "predicate": "fails_with",
+            "object": {"id": "error:timeout", "type": "error", "name": "Timeout"},
+            "confidence": 0.8,
+            "evidence": "Search timed out after 30s",
+        },
+    ]
+)
+
+
+class TestParseExtractionResponse:
+    def test_valid_json(self):
+        triplets = parse_extraction_response(VALID_JSON_RESPONSE)
+        assert len(triplets) == 2
+        assert triplets[0].subject.id == "agent:main"
+        assert triplets[0].predicate == PredicateType.CALLS
+        assert triplets[1].predicate == PredicateType.FAILS_WITH
+
+    def test_json_in_code_fence(self):
+        fenced = f"Here are the triplets:\n```json\n{VALID_JSON_RESPONSE}\n```"
+        triplets = parse_extraction_response(fenced)
+        assert len(triplets) == 2
+
+    def test_unknown_predicate_falls_back(self):
+        data = json.dumps(
+            [
+                {
+                    "subject": {"id": "agent:x", "type": "agent", "name": "X"},
+                    "predicate": "unknown_pred",
+                    "object": {"id": "tool:y", "type": "tool", "name": "Y"},
+                }
+            ]
+        )
+        triplets = parse_extraction_response(data)
+        assert len(triplets) == 1
+        assert triplets[0].predicate == PredicateType.RELATED_TO
+
+    def test_unknown_entity_type_falls_back(self):
+        data = json.dumps(
+            [
+                {
+                    "subject": {"id": "widget:x", "type": "widget", "name": "X"},
+                    "predicate": "calls",
+                    "object": {"id": "tool:y", "type": "tool", "name": "Y"},
+                }
+            ]
+        )
+        triplets = parse_extraction_response(data)
+        assert len(triplets) == 1
+        assert triplets[0].subject.type == EntityType.CONCEPT
+
+    def test_invalid_json(self):
+        triplets = parse_extraction_response("not json at all {{{}}")
+        assert triplets == []
+
+    def test_missing_fields_skipped(self):
+        data = json.dumps(
+            [
+                {"subject": {"id": "a:b", "type": "agent", "name": "A"}, "predicate": "calls"},
+                {
+                    "subject": {"id": "a:b", "type": "agent", "name": "A"},
+                    "predicate": "calls",
+                    "object": {"id": "t:c", "type": "tool", "name": "C"},
+                },
+            ]
+        )
+        triplets = parse_extraction_response(data)
+        assert len(triplets) == 1
+
+    def test_confidence_clamped(self):
+        data = json.dumps(
+            [
+                {
+                    "subject": {"id": "a:x", "type": "agent", "name": "X"},
+                    "predicate": "calls",
+                    "object": {"id": "t:y", "type": "tool", "name": "Y"},
+                    "confidence": 5.0,
+                }
+            ]
+        )
+        triplets = parse_extraction_response(data)
+        assert len(triplets) == 1
+        assert triplets[0].confidence == 1.0
+
+    def test_source_label_applied(self):
+        triplets = parse_extraction_response(VALID_JSON_RESPONSE, source_label="run_7")
+        assert all(t.source == "run_7" for t in triplets)
+
+
+# ── prompt building ──────────────────────────────────────────────
+
+
+class TestBuildExtractionPrompt:
+    def test_includes_entity_types(self):
+        prompt = build_extraction_prompt("log data", "test task")
+        for et in EntityType:
+            assert et.value in prompt
+
+    def test_includes_predicate_types(self):
+        prompt = build_extraction_prompt("log data", "test task")
+        for pt in PredicateType:
+            assert pt.value in prompt
+
+    def test_includes_task_context(self):
+        prompt = build_extraction_prompt("log data", "cancel flight booking")
+        assert "cancel flight booking" in prompt
+
+    def test_truncates_long_content(self):
+        long_content = "x" * 20000
+        prompt = build_extraction_prompt(long_content, "task")
+        assert len(prompt) < 20000 + 2000
+
+    def test_max_triplets(self):
+        prompt = build_extraction_prompt("log", "task", max_triplets=10)
+        assert "10" in prompt

--- a/tests/test_knowledge_models.py
+++ b/tests/test_knowledge_models.py
@@ -1,0 +1,313 @@
+"""Tests for factory.knowledge.models — knowledge graph models and traversal."""
+
+from datetime import datetime
+
+import pytest
+
+from factory.knowledge.models import (
+    CAUSAL_PREDICATES,
+    Entity,
+    EntityType,
+    KnowledgeGraph,
+    PredicateType,
+    Triplet,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def _entity(etype: EntityType, name: str) -> Entity:
+    slug = name.lower().replace(" ", "_")
+    return Entity(id=f"{etype.value}:{slug}", type=etype, name=name)
+
+
+def _triplet(
+    subj: Entity,
+    pred: PredicateType,
+    obj: Entity,
+    confidence: float = 1.0,
+    source: str = "test",
+) -> Triplet:
+    return Triplet(
+        subject=subj,
+        predicate=pred,
+        object=obj,
+        confidence=confidence,
+        source=source,
+        timestamp=datetime(2026, 1, 1),
+    )
+
+
+AGENT = _entity(EntityType.AGENT, "main_agent")
+TOOL_A = _entity(EntityType.TOOL, "get_order")
+TOOL_B = _entity(EntityType.TOOL, "cancel_booking")
+ERROR = _entity(EntityType.ERROR, "missing_param")
+TASK = _entity(EntityType.TASK, "cancel_order")
+OUTCOME = _entity(EntityType.OUTCOME, "success")
+CONCEPT = _entity(EntityType.CONCEPT, "booking_id")
+
+
+# ── entity tests ─────────────────────────────────────────────────
+
+
+class TestEntity:
+    def test_construction(self):
+        e = Entity(id="tool:foo", type=EntityType.TOOL, name="foo")
+        assert e.id == "tool:foo"
+        assert e.type == EntityType.TOOL
+
+    def test_with_attributes(self):
+        e = Entity(
+            id="tool:bar",
+            type=EntityType.TOOL,
+            name="bar",
+            attributes={"count": 5.0, "active": True},
+        )
+        assert e.attributes["count"] == 5.0
+
+    def test_extra_forbidden(self):
+        with pytest.raises(Exception):
+            Entity(id="x", type=EntityType.TOOL, name="x", bogus="nope")  # type: ignore[call-arg]
+
+
+# ── triplet tests ────────────────────────────────────────────────
+
+
+class TestTriplet:
+    def test_auto_id(self):
+        t = _triplet(AGENT, PredicateType.CALLS, TOOL_A)
+        assert len(t.id) == 16
+
+    def test_confidence_bounds(self):
+        with pytest.raises(Exception):
+            Triplet(
+                subject=AGENT,
+                predicate=PredicateType.CALLS,
+                object=TOOL_A,
+                confidence=1.5,
+                timestamp=datetime(2026, 1, 1),
+            )
+
+    def test_serialization_roundtrip(self):
+        t = _triplet(AGENT, PredicateType.CALLS, TOOL_A)
+        data = t.model_dump(mode="json")
+        restored = Triplet.model_validate(data, strict=False)
+        assert restored.subject.id == t.subject.id
+        assert restored.predicate == t.predicate
+
+
+# ── knowledge graph: mutation ────────────────────────────────────
+
+
+class TestKnowledgeGraphMutation:
+    def test_add_triplet(self):
+        g = KnowledgeGraph(task_id="test")
+        t = _triplet(AGENT, PredicateType.CALLS, TOOL_A)
+        g.add_triplet(t)
+        assert g.triplet_count() == 1
+        assert g.entity_count() == 2
+        assert AGENT.id in g.entities
+        assert TOOL_A.id in g.entities
+
+    def test_merge_deduplicates(self):
+        g1 = KnowledgeGraph(task_id="test")
+        g2 = KnowledgeGraph(task_id="test")
+        t = _triplet(AGENT, PredicateType.CALLS, TOOL_A)
+        g1.add_triplet(t)
+        g2.add_triplet(t)
+        g2.add_triplet(_triplet(AGENT, PredicateType.CALLS, TOOL_B))
+        g1.merge(g2)
+        assert g1.triplet_count() == 2
+
+
+# ── knowledge graph: single-hop queries ──────────────────────────
+
+
+def _sample_graph() -> KnowledgeGraph:
+    g = KnowledgeGraph(task_id="test")
+    g.add_triplet(_triplet(AGENT, PredicateType.CALLS, TOOL_A))
+    g.add_triplet(_triplet(AGENT, PredicateType.CALLS, TOOL_B))
+    g.add_triplet(_triplet(AGENT, PredicateType.FAILS_AT, TASK))
+    g.add_triplet(_triplet(TOOL_B, PredicateType.FAILS_WITH, ERROR))
+    g.add_triplet(_triplet(TASK, PredicateType.REQUIRES, CONCEPT))
+    g.add_triplet(_triplet(AGENT, PredicateType.SUCCEEDS_AT, OUTCOME))
+    return g
+
+
+class TestSingleHopQueries:
+    def test_query_by_subject(self):
+        g = _sample_graph()
+        results = g.query_by_subject(AGENT.id)
+        assert len(results) == 4
+
+    def test_query_by_object(self):
+        g = _sample_graph()
+        results = g.query_by_object(TOOL_A.id)
+        assert len(results) == 1
+
+    def test_query_by_predicate(self):
+        g = _sample_graph()
+        results = g.query_by_predicate(PredicateType.CALLS)
+        assert len(results) == 2
+
+    def test_query_combined(self):
+        g = _sample_graph()
+        results = g.query(
+            subject_id=AGENT.id,
+            predicate=PredicateType.CALLS,
+        )
+        assert len(results) == 2
+
+    def test_query_no_match(self):
+        g = _sample_graph()
+        results = g.query(subject_id="nonexistent:x")
+        assert results == []
+
+    def test_related_entities(self):
+        g = _sample_graph()
+        related = g.related_entities(AGENT.id)
+        related_ids = {e.id for e in related}
+        assert TOOL_A.id in related_ids
+        assert TOOL_B.id in related_ids
+        assert TASK.id in related_ids
+
+    def test_subgraph(self):
+        g = _sample_graph()
+        sub = g.subgraph({AGENT.id, TOOL_A.id})
+        assert sub.triplet_count() >= 1
+        for t in sub.triplets:
+            assert t.subject.id in {AGENT.id, TOOL_A.id} or t.object.id in {
+                AGENT.id,
+                TOOL_A.id,
+            }
+
+
+# ── knowledge graph: multi-hop traversal ─────────────────────────
+
+
+def _chain_graph() -> KnowledgeGraph:
+    """A -> B -> C -> D linear chain for traversal tests."""
+    g = KnowledgeGraph(task_id="chain")
+    a = _entity(EntityType.AGENT, "A")
+    b = _entity(EntityType.TASK, "B")
+    c = _entity(EntityType.TOOL, "C")
+    d = _entity(EntityType.ERROR, "D")
+    g.add_triplet(_triplet(a, PredicateType.FAILS_AT, b))
+    g.add_triplet(_triplet(b, PredicateType.REQUIRES, c))
+    g.add_triplet(_triplet(c, PredicateType.FAILS_WITH, d))
+    return g
+
+
+class TestTraverse:
+    def test_traverse_depth_1(self):
+        g = _chain_graph()
+        paths = g.traverse("agent:a", max_hops=1)
+        assert len(paths) == 1
+        assert paths[0][0].subject.id == "agent:a"
+
+    def test_traverse_depth_3(self):
+        g = _chain_graph()
+        paths = g.traverse("agent:a", max_hops=3)
+        assert any(len(p) == 3 for p in paths)
+
+    def test_traverse_nonexistent(self):
+        g = _chain_graph()
+        paths = g.traverse("nonexistent:x", max_hops=3)
+        assert paths == []
+
+
+class TestFindPaths:
+    def test_direct_path(self):
+        g = _chain_graph()
+        paths = g.find_paths("agent:a", "task:b")
+        assert len(paths) == 1
+        assert len(paths[0]) == 1
+
+    def test_multi_hop_path(self):
+        g = _chain_graph()
+        paths = g.find_paths("agent:a", "error:d")
+        assert len(paths) >= 1
+        assert any(len(p) == 3 for p in paths)
+
+    def test_no_path(self):
+        g = _chain_graph()
+        e = _entity(EntityType.CONCEPT, "isolated")
+        g.add_triplet(_triplet(e, PredicateType.IS_A, e))
+        paths = g.find_paths("agent:a", e.id)
+        assert paths == []
+
+
+class TestCausalChain:
+    def test_follows_causal_predicates(self):
+        g = _chain_graph()
+        chains = g.causal_chain("agent:a")
+        assert len(chains) >= 1
+        for chain in chains:
+            for t in chain:
+                assert t.predicate in CAUSAL_PREDICATES
+
+    def test_stops_at_non_causal(self):
+        g = KnowledgeGraph(task_id="test")
+        a = _entity(EntityType.AGENT, "A")
+        b = _entity(EntityType.TASK, "B")
+        c = _entity(EntityType.TOOL, "C")
+        g.add_triplet(_triplet(a, PredicateType.FAILS_WITH, b))
+        g.add_triplet(_triplet(b, PredicateType.CALLS, c))
+        chains = g.causal_chain("agent:a")
+        for chain in chains:
+            assert all(t.predicate in CAUSAL_PREDICATES for t in chain)
+
+
+class TestMatchPattern:
+    def test_single_step(self):
+        g = _sample_graph()
+        matches = g.match_pattern([(AGENT.id, PredicateType.CALLS, None)])
+        assert len(matches) == 2
+
+    def test_two_step_pattern(self):
+        g = _sample_graph()
+        matches = g.match_pattern(
+            [
+                (AGENT.id, PredicateType.FAILS_AT, None),
+                (None, PredicateType.REQUIRES, None),
+            ]
+        )
+        assert len(matches) == 1
+        assert matches[0][0].object.id == TASK.id
+        assert matches[0][1].object.id == CONCEPT.id
+
+    def test_no_match(self):
+        g = _sample_graph()
+        matches = g.match_pattern(
+            [
+                (AGENT.id, PredicateType.IMPROVES, None),
+            ]
+        )
+        assert matches == []
+
+    def test_empty_pattern(self):
+        g = _sample_graph()
+        assert g.match_pattern([]) == []
+
+
+# ── stats ────────────────────────────────────────────────────────
+
+
+class TestStats:
+    def test_stats_structure(self):
+        g = _sample_graph()
+        s = g.stats()
+        assert "entity_count" in s
+        assert "triplet_count" in s
+        assert "top_entities_by_degree" in s
+        assert "predicate_distribution" in s
+        assert "failure_hotspots" in s
+        assert s["entity_count"] == g.entity_count()
+        assert s["triplet_count"] == g.triplet_count()
+
+    def test_failure_hotspots(self):
+        g = _sample_graph()
+        s = g.stats()
+        hotspot_ids = {eid for eid, _ in s["failure_hotspots"]}  # type: ignore[union-attr]
+        assert AGENT.id in hotspot_ids or ERROR.id in hotspot_ids

--- a/tests/test_knowledge_ols_adapter.py
+++ b/tests/test_knowledge_ols_adapter.py
@@ -1,0 +1,195 @@
+"""Tests for the OLS troubleshooting eval adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from factory.knowledge.models import EntityType, PredicateType
+from factory.knowledge.ols_adapter import (
+    compute_aggregate_score,
+    extract_scores,
+    parse_results,
+    write_failing_scenarios,
+)
+
+
+@pytest.fixture()
+def single_turn_csv_data() -> str:
+    """Minimal single-turn OLS eval CSV with one PASS scenario."""
+    return (
+        "conversation_group_id,turn_id,metric_identifier,score,result,"
+        "reason,query,response,execution_time\n"
+        "batch_failure,batch_failure,custom:answer_correctness,1.0,PASS,"
+        '"Custom answer correctness: 1.00","What is the issue with job '
+        'inventory-sync-validator","The job fails to connect to prod-db:3333",33.68\n'
+    )
+
+
+@pytest.fixture()
+def multi_turn_csv_data() -> str:
+    """Minimal multi-turn OLS eval CSV with per-turn and conversation metrics."""
+    return (
+        "conversation_group_id,turn_id,metric_identifier,score,result,"
+        "reason,query,response,execution_time\n"
+        "Network Policy Issue,Investigate the status of frontend application,"
+        "custom:answer_correctness,0.35,FAIL,"
+        '"Score below threshold","What is the status of the frontend application",'
+        '"The frontend application is currently healthy",12.78\n'
+        "Network Policy Issue,Investigate the status of frontend application,"
+        "geval:generic_troubleshooting_experience,1.0,PASS,"
+        '"Good troubleshooting","What is the status of the frontend application",'
+        '"The frontend application is currently healthy",15.07\n'
+        "Network Policy Issue,Why frontend is failing,"
+        "custom:answer_correctness,1.0,PASS,"
+        '"Correct root cause","Can you spot the root cause?",'
+        '"The root cause is a misconfigured NetworkPolicy",92.60\n'
+        "Network Policy Issue,Why frontend is failing,"
+        "geval:generic_troubleshooting_experience,1.0,PASS,"
+        '"Good analysis","Can you spot the root cause?",'
+        '"The root cause is a misconfigured NetworkPolicy",93.20\n'
+        "Network Policy Issue,,geval:troubleshooting_continuity,1.0,PASS,"
+        '"Good continuity",,,"123.12\n'
+        "Network Policy Issue,,deepeval:knowledge_retention,0.0,FAIL,"
+        '"Failed retention",,,"125.44\n'
+    )
+
+
+@pytest.fixture()
+def results_dir(tmp_path: Path, single_turn_csv_data: str, multi_turn_csv_data: str) -> Path:
+    """Create a minimal results directory structure."""
+    iter_dir = tmp_path / "iter_01"
+
+    batch_dir = iter_dir / "batch_failure"
+    batch_dir.mkdir(parents=True)
+    (batch_dir / "evaluation_20260719_183036_detailed.csv").write_text(single_turn_csv_data)
+
+    np_dir = iter_dir / "wrong_networkpolicy"
+    np_dir.mkdir(parents=True)
+    (np_dir / "evaluation_20260719_185126_detailed.csv").write_text(multi_turn_csv_data)
+
+    return tmp_path
+
+
+class TestParseResults:
+    def test_returns_triplets(self, results_dir: Path) -> None:
+        triplets = parse_results(results_dir, "k8s troubleshooting")
+        assert len(triplets) > 0
+
+    def test_scenario_outcome_triplets(self, results_dir: Path) -> None:
+        triplets = parse_results(results_dir, "k8s troubleshooting")
+        outcomes = [
+            t
+            for t in triplets
+            if t.predicate in (PredicateType.SUCCEEDS_AT, PredicateType.FAILS_AT)
+            and t.subject.type == EntityType.AGENT
+            and t.object.type == EntityType.TASK
+        ]
+        assert len(outcomes) >= 2
+
+    def test_metric_triplets(self, results_dir: Path) -> None:
+        triplets = parse_results(results_dir, "k8s troubleshooting")
+        part_of = [t for t in triplets if t.predicate == PredicateType.PART_OF]
+        assert len(part_of) >= 1
+
+    def test_conversation_metrics(self, results_dir: Path) -> None:
+        triplets = parse_results(results_dir, "k8s troubleshooting")
+        conv_triplets = [
+            t
+            for t in triplets
+            if t.predicate == PredicateType.PART_OF
+            and "conversation" in t.object.name.lower()
+        ]
+        assert len(conv_triplets) >= 1
+
+    def test_causal_triplets_for_failures(self, results_dir: Path) -> None:
+        triplets = parse_results(results_dir, "k8s troubleshooting")
+        causes = [t for t in triplets if t.predicate == PredicateType.CAUSES]
+        assert len(causes) >= 1
+
+    def test_empty_results_dir(self, tmp_path: Path) -> None:
+        assert parse_results(tmp_path, "test") == []
+
+
+class TestComputeAggregateScore:
+    def test_macro_average(self, results_dir: Path) -> None:
+        score = compute_aggregate_score(results_dir)
+        # batch_failure: 1/1 = 1.0, wrong_networkpolicy: 1/2 = 0.5
+        # macro avg = (1.0 + 0.5) / 2 = 0.75
+        assert score == pytest.approx(0.75)
+
+    def test_empty_returns_zero(self, tmp_path: Path) -> None:
+        assert compute_aggregate_score(tmp_path) == 0.0
+
+
+class TestExtractScores:
+    def test_detailed_breakdown(self, results_dir: Path) -> None:
+        scores = extract_scores(results_dir)
+        assert scores["scenario_count"] == 2
+        assert "batch_failure" in scores["per_scenario"]
+        assert "wrong_networkpolicy" in scores["per_scenario"]
+        assert scores["per_scenario"]["batch_failure"] == 1.0
+        assert scores["per_scenario"]["wrong_networkpolicy"] == pytest.approx(0.5)
+        assert "per_metric" in scores
+        assert "custom:answer_correctness" in scores["per_metric"]
+
+
+class TestWriteFailingScenarios:
+    def test_writes_failing_scenario_details(
+        self, tmp_path: Path, results_dir: Path
+    ) -> None:
+        config = {
+            "task_id": "ols_test",
+            "agent_command": "",
+            "task_context": "test",
+            "results_dir": str(results_dir),
+            "eval_command": "",
+            "score_threshold": 0.5,
+            "improvement_target": "",
+            "scenarios": [],
+        }
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        config_path = config_dir / "task_config.json"
+        config_path.write_text(json.dumps(config))
+
+        write_failing_scenarios(config_path)
+
+        output = config_dir / "ols_test_failing_scenarios.md"
+        assert output.exists()
+        content = output.read_text()
+        assert "wrong_networkpolicy" in content or "Network Policy Issue" in content
+
+
+class TestErrorHandling:
+    def test_malformed_csv(self, tmp_path: Path) -> None:
+        """Malformed CSV should return empty list, not crash."""
+        bad_dir = tmp_path / "iter_01" / "bad_scenario"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "evaluation_bad_detailed.csv").write_text(
+            "not,a,valid,csv,header\nfoo,bar,baz\n"
+        )
+        triplets = parse_results(tmp_path, "test")
+        assert triplets == []
+
+    def test_missing_results_dir(self, tmp_path: Path) -> None:
+        """Non-existent dir should return empty list."""
+        missing = tmp_path / "nonexistent"
+        triplets = parse_results(missing, "test")
+        assert triplets == []
+
+    def test_error_result_counts_as_fail(self, tmp_path: Path) -> None:
+        """ERROR result rows should be treated as FAIL."""
+        iter_dir = tmp_path / "iter_01" / "error_scenario"
+        iter_dir.mkdir(parents=True)
+        csv_content = (
+            "conversation_group_id,turn_id,metric_identifier,score,result,"
+            "reason,query,response,execution_time\n"
+            "error_scenario,error_scenario,custom:answer_correctness,,ERROR,"
+            '"Error occurred","Query","Response",10.0\n'
+        )
+        (iter_dir / "evaluation_error_detailed.csv").write_text(csv_content)
+        score = compute_aggregate_score(tmp_path)
+        assert score == 0.0

--- a/tests/test_knowledge_store.py
+++ b/tests/test_knowledge_store.py
@@ -1,0 +1,220 @@
+"""Tests for factory.knowledge.store — knowledge graph persistence."""
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from factory.knowledge.insight import Insight, InsightType
+from factory.knowledge.models import (
+    Entity,
+    EntityType,
+    KnowledgeGraph,
+    PredicateType,
+    Triplet,
+)
+from factory.knowledge.store import KnowledgeStore
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+
+def _entity(etype: EntityType, name: str) -> Entity:
+    slug = name.lower().replace(" ", "_")
+    return Entity(id=f"{etype.value}:{slug}", type=etype, name=name)
+
+
+def _triplet(subj: Entity, pred: PredicateType, obj: Entity) -> Triplet:
+    return Triplet(
+        subject=subj,
+        predicate=pred,
+        object=obj,
+        source="test",
+        timestamp=datetime(2026, 1, 1),
+    )
+
+
+def _sample_graph(task_id: str = "task_1") -> KnowledgeGraph:
+    agent = _entity(EntityType.AGENT, "main")
+    tool = _entity(EntityType.TOOL, "get_order")
+    error = _entity(EntityType.ERROR, "timeout")
+    g = KnowledgeGraph(task_id=task_id)
+    g.add_triplet(_triplet(agent, PredicateType.CALLS, tool))
+    g.add_triplet(_triplet(tool, PredicateType.FAILS_WITH, error))
+    return g
+
+
+# ── store tests ──────────────────────────────────────────────────
+
+
+class TestKnowledgeStoreInit:
+    @pytest.mark.asyncio
+    async def test_init_creates_directory(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.init()
+        assert (tmp_path / ".factory" / "knowledge").is_dir()
+
+    @pytest.mark.asyncio
+    async def test_init_idempotent(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.init()
+        await store.init()
+        assert (tmp_path / ".factory" / "knowledge").is_dir()
+
+
+class TestKnowledgeStoreSaveLoad:
+    @pytest.mark.asyncio
+    async def test_save_and_load_roundtrip(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        graph = _sample_graph()
+        await store.save_graph(graph)
+        loaded = await store.load_graph("task_1")
+        assert loaded is not None
+        assert loaded.task_id == "task_1"
+        assert loaded.triplet_count() == 2
+        assert loaded.entity_count() == 3
+
+    @pytest.mark.asyncio
+    async def test_load_nonexistent(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.init()
+        result = await store.load_graph("nonexistent")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_load_corrupt_file(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.init()
+        bad_path = tmp_path / ".factory" / "knowledge" / "bad.json"
+        bad_path.write_text("not json{{{")
+        result = await store.load_graph("bad")
+        assert result is None
+
+
+class TestKnowledgeStoreAppend:
+    @pytest.mark.asyncio
+    async def test_append_to_new_graph(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        agent = _entity(EntityType.AGENT, "main")
+        tool = _entity(EntityType.TOOL, "search")
+        triplets = [_triplet(agent, PredicateType.CALLS, tool)]
+        graph = await store.append_triplets("new_task", triplets)
+        assert graph.triplet_count() == 1
+        assert graph.task_id == "new_task"
+
+    @pytest.mark.asyncio
+    async def test_append_to_existing_graph(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        graph = _sample_graph()
+        await store.save_graph(graph)
+
+        new_triplet = _triplet(
+            _entity(EntityType.AGENT, "main"),
+            PredicateType.SUCCEEDS_AT,
+            _entity(EntityType.TASK, "checkout"),
+        )
+        updated = await store.append_triplets("task_1", [new_triplet])
+        assert updated.triplet_count() == 3
+
+    @pytest.mark.asyncio
+    async def test_append_deduplicates(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        graph = _sample_graph()
+        await store.save_graph(graph)
+
+        existing_triplet = graph.triplets[0]
+        updated = await store.append_triplets("task_1", [existing_triplet])
+        assert updated.triplet_count() == 2
+
+
+class TestKnowledgeStoreList:
+    @pytest.mark.asyncio
+    async def test_list_empty(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        result = await store.list_graphs()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_multiple(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.save_graph(_sample_graph("alpha"))
+        await store.save_graph(_sample_graph("beta"))
+        result = await store.list_graphs()
+        assert sorted(result) == ["alpha", "beta"]
+
+    @pytest.mark.asyncio
+    async def test_list_excludes_insights(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.save_graph(_sample_graph("task_1"))
+        await store.save_insights(
+            "task_1",
+            [
+                Insight(
+                    type=InsightType.FAILURE_PATTERN,
+                    title="test",
+                    description="test insight",
+                ),
+            ],
+        )
+        result = await store.list_graphs()
+        assert result == ["task_1"]
+
+
+class TestKnowledgeStoreInsights:
+    @pytest.mark.asyncio
+    async def test_save_and_load_insights(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        insights = [
+            Insight(
+                type=InsightType.FAILURE_PATTERN,
+                title="Repeated timeout",
+                description="The agent times out on get_order calls",
+                confidence=0.9,
+                evidence_triplet_ids=["abc123"],
+                suggested_action="Increase timeout or add retry logic",
+            ),
+        ]
+        await store.save_insights("task_1", insights)
+        loaded = await store.load_insights("task_1")
+        assert len(loaded) == 1
+        assert loaded[0].title == "Repeated timeout"
+        assert loaded[0].type == InsightType.FAILURE_PATTERN
+
+    @pytest.mark.asyncio
+    async def test_load_insights_empty(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.init()
+        result = await store.load_insights("nonexistent")
+        assert result == []
+
+
+class TestKnowledgeStoreExport:
+    @pytest.mark.asyncio
+    async def test_export_json(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.save_graph(_sample_graph())
+        output = await store.export_graph("task_1", fmt="json")
+        assert '"task_id": "task_1"' in output
+
+    @pytest.mark.asyncio
+    async def test_export_markdown(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.save_graph(_sample_graph())
+        output = await store.export_graph("task_1", fmt="markdown")
+        assert "# Knowledge Graph: task_1" in output
+        assert "| Subject |" in output
+
+    @pytest.mark.asyncio
+    async def test_export_dot(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.save_graph(_sample_graph())
+        output = await store.export_graph("task_1", fmt="dot")
+        assert "digraph knowledge" in output
+        assert "->" in output
+
+    @pytest.mark.asyncio
+    async def test_export_nonexistent(self, tmp_path: Path):
+        store = KnowledgeStore(tmp_path)
+        await store.init()
+        output = await store.export_graph("nonexistent")
+        assert output == ""

--- a/tests/test_knowledge_tau_adapter.py
+++ b/tests/test_knowledge_tau_adapter.py
@@ -1,0 +1,347 @@
+"""Tests for the tau-bench simulation adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from factory.knowledge.models import EntityType, PredicateType
+from factory.knowledge.tau_adapter import (
+    compute_aggregate_score,
+    extract_scores,
+    parse_simulation,
+)
+
+
+@pytest.fixture()
+def simulation_data() -> dict:
+    """Minimal tau-bench simulation with one pass and one fail."""
+    return {
+        "timestamp": "2026-01-05T17:00:00",
+        "info": {"num_trials": 1},
+        "tasks": [],
+        "simulations": [
+            {
+                "task_id": "1",
+                "reward_info": {
+                    "reward": 1.0,
+                    "db_check": {"db_match": True, "db_reward": 1.0},
+                    "action_checks": None,
+                    "nl_assertions": [
+                        {
+                            "nl_assertion": "Agent provides booking confirmation.",
+                            "met": True,
+                            "justification": "Agent confirmed booking.",
+                        }
+                    ],
+                    "reward_breakdown": {"DB": 1.0, "NL_ASSERTION": 1.0},
+                },
+                "messages": [
+                    {"role": "assistant", "content": "How can I help?"},
+                    {"role": "user", "content": "Book a flight."},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "name": "search_direct_flight",
+                                "arguments": {"origin": "JFK", "destination": "LAX"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "content": '{"flights": [{"id": "F1"}]}',
+                        "error": False,
+                    },
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "name": "book_reservation",
+                                "arguments": {"flight_id": "F1"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "content": '{"reservation_id": "ABC123"}',
+                        "error": False,
+                    },
+                    {"role": "assistant", "content": "Booked! Confirmation: ABC123."},
+                ],
+                "termination_reason": "user_stop",
+            },
+            {
+                "task_id": "48",
+                "reward_info": {
+                    "reward": 0.0,
+                    "db_check": {"db_match": False, "db_reward": 0.0},
+                    "action_checks": [
+                        {
+                            "action": {
+                                "action_id": "48_0",
+                                "name": "get_reservation_details",
+                                "arguments": {"reservation_id": "3RK2T9"},
+                            },
+                            "action_match": False,
+                            "action_reward": 0.0,
+                        }
+                    ],
+                    "nl_assertions": [
+                        {
+                            "nl_assertion": "Agent does not cancel 3RK2T9.",
+                            "met": False,
+                            "justification": "The agent cancelled the reservation.",
+                        }
+                    ],
+                    "reward_breakdown": {"DB": 0.0, "NL_ASSERTION": 0.0},
+                },
+                "messages": [
+                    {"role": "assistant", "content": "How can I help?"},
+                    {"role": "user", "content": "Cancel reservation 3RK2T9."},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "name": "cancel_reservation",
+                                "arguments": {"reservation_id": "3RK2T9"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "content": '{"status": "cancelled"}',
+                        "error": False,
+                    },
+                    {"role": "assistant", "content": "Reservation cancelled."},
+                ],
+                "termination_reason": "user_stop",
+            },
+        ],
+    }
+
+
+@pytest.fixture()
+def sim_file(tmp_path: Path, simulation_data: dict) -> Path:
+    p = tmp_path / "simulation.json"
+    p.write_text(json.dumps(simulation_data))
+    return p
+
+
+class TestParseSimulation:
+    def test_returns_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline customer service")
+        assert len(triplets) > 0
+
+    def test_task_outcome_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        outcomes = [
+            t
+            for t in triplets
+            if t.predicate in (PredicateType.SUCCEEDS_AT, PredicateType.FAILS_AT)
+            and t.subject.type == EntityType.AGENT
+            and t.object.type == EntityType.TASK
+        ]
+        assert len(outcomes) == 2
+        succeed = [t for t in outcomes if t.predicate == PredicateType.SUCCEEDS_AT]
+        fail = [t for t in outcomes if t.predicate == PredicateType.FAILS_AT]
+        assert len(succeed) == 1
+        assert len(fail) == 1
+
+    def test_tool_call_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        calls = [t for t in triplets if t.predicate == PredicateType.CALLS]
+        tool_names = {t.object.name for t in calls}
+        assert "search_direct_flight" in tool_names
+        assert "book_reservation" in tool_names
+        assert "cancel_reservation" in tool_names
+
+    def test_precedes_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        precedes = [t for t in triplets if t.predicate == PredicateType.PRECEDES]
+        assert len(precedes) >= 1
+
+    def test_produces_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        produces = [t for t in triplets if t.predicate == PredicateType.PRODUCES]
+        assert len(produces) >= 1
+
+    def test_action_check_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        action_fails = [
+            t
+            for t in triplets
+            if t.predicate == PredicateType.FAILS_AT and t.object.name.startswith("expected_")
+        ]
+        assert len(action_fails) == 1
+        assert "get_reservation_details" in action_fails[0].object.name
+
+    def test_nl_assertion_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        nl_pass = [
+            t
+            for t in triplets
+            if t.predicate == PredicateType.SUCCEEDS_AT
+            and t.object.type == EntityType.CONCEPT
+            and "booking" in t.object.name.lower()
+        ]
+        nl_fail = [
+            t
+            for t in triplets
+            if t.predicate == PredicateType.FAILS_AT
+            and t.object.type == EntityType.CONCEPT
+            and "cancel" in t.object.name.lower()
+        ]
+        assert len(nl_pass) == 1
+        assert len(nl_fail) == 1
+
+    def test_db_check_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        db_fail = [
+            t
+            for t in triplets
+            if t.predicate == PredicateType.FAILS_AT and t.object.name == "db_consistency"
+        ]
+        assert len(db_fail) == 1
+
+    def test_reward_breakdown_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        part_of = [t for t in triplets if t.predicate == PredicateType.PART_OF]
+        assert len(part_of) >= 2
+
+    def test_causal_triplets(self, sim_file: Path) -> None:
+        triplets = parse_simulation(sim_file, "airline")
+        causes = [t for t in triplets if t.predicate == PredicateType.CAUSES]
+        assert len(causes) >= 1
+
+    def test_empty_simulations(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.json"
+        p.write_text(json.dumps({"simulations": []}))
+        assert parse_simulation(p, "test") == []
+
+
+class TestComputeAggregateScore:
+    def test_average_score(self, sim_file: Path) -> None:
+        score = compute_aggregate_score(sim_file)
+        assert score == pytest.approx(0.5)
+
+    def test_empty_returns_zero(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.json"
+        p.write_text(json.dumps({"simulations": []}))
+        assert compute_aggregate_score(p) == 0.0
+
+
+class TestExtractScores:
+    def test_score_breakdown(self, sim_file: Path) -> None:
+        scores = extract_scores(sim_file)
+        assert scores["mean_reward"] == pytest.approx(0.5)
+        assert scores["task_count"] == 2
+        assert scores["pass_count"] == 1
+        assert scores["fail_count"] == 1
+        assert scores["per_task"]["1"] == 1.0
+        assert scores["per_task"]["48"] == 0.0
+
+    def test_empty_returns_zeros(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty.json"
+        p.write_text(json.dumps({"simulations": []}))
+        scores = extract_scores(p)
+        assert scores["mean_reward"] == 0.0
+        assert scores["task_count"] == 0
+
+
+class TestToolErrorHandling:
+    def test_tool_error_produces_fails_with(self, tmp_path: Path) -> None:
+        data = {
+            "simulations": [
+                {
+                    "task_id": "99",
+                    "reward_info": {
+                        "reward": 0.0,
+                        "db_check": None,
+                        "action_checks": None,
+                        "nl_assertions": None,
+                        "reward_breakdown": {},
+                    },
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "name": "get_reservation_details",
+                                    "arguments": {"reservation_id": "INVALID"},
+                                },
+                            ],
+                        },
+                        {
+                            "role": "tool",
+                            "content": "Reservation not found",
+                            "error": True,
+                        },
+                    ],
+                    "termination_reason": "user_stop",
+                }
+            ]
+        }
+        p = tmp_path / "error_sim.json"
+        p.write_text(json.dumps(data))
+        triplets = parse_simulation(p, "test")
+        fails = [t for t in triplets if t.predicate == PredicateType.FAILS_WITH]
+        assert len(fails) >= 1
+
+
+class TestTerminationReason:
+    def test_too_many_errors(self, tmp_path: Path) -> None:
+        data = {
+            "simulations": [
+                {
+                    "task_id": "5",
+                    "reward_info": {
+                        "reward": 0.0,
+                        "db_check": None,
+                        "action_checks": None,
+                        "nl_assertions": None,
+                        "reward_breakdown": {},
+                    },
+                    "messages": [],
+                    "termination_reason": "too_many_errors",
+                }
+            ]
+        }
+        p = tmp_path / "term.json"
+        p.write_text(json.dumps(data))
+        triplets = parse_simulation(p, "test")
+        error_triplets = [
+            t
+            for t in triplets
+            if t.predicate == PredicateType.FAILS_WITH and t.object.name == "too_many_errors"
+        ]
+        assert len(error_triplets) == 1
+
+    def test_normal_stop_no_error_triplet(self, tmp_path: Path) -> None:
+        data = {
+            "simulations": [
+                {
+                    "task_id": "5",
+                    "reward_info": {
+                        "reward": 1.0,
+                        "db_check": None,
+                        "action_checks": None,
+                        "nl_assertions": None,
+                        "reward_breakdown": {},
+                    },
+                    "messages": [],
+                    "termination_reason": "user_stop",
+                }
+            ]
+        }
+        p = tmp_path / "ok.json"
+        p.write_text(json.dumps(data))
+        triplets = parse_simulation(p, "test")
+        error_triplets = [t for t in triplets if t.object.name in ("too_many_errors", "max_steps")]
+        assert len(error_triplets) == 0


### PR DESCRIPTION
Closes the OLS troubleshooting eval backlog item.

## Changes
- **`factory/knowledge/models.py`** — Added `OlsTaskConfig` model extending `KnowledgeTaskConfig` with OLS-specific fields (`results_dir`, `eval_command`, `score_threshold`, `improvement_target`, `scenarios`)
- **`factory/knowledge/ols_adapter.py`** — New adapter module (~350 lines) with CSV result parsing, macro-averaged scoring matching `eval_metrics.sh`, gate evaluators, and failing scenario report generation
- **`factory/workflow/contributed/knowledge/nodes.py`** — 6 new OLS node factories (`make_ols_run_eval_node`, `make_ols_extract_node`, `make_ols_gate_score_node`, `make_ols_improve_node`, `make_ols_re_eval_node`, `make_ols_gate_compare_node`)
- **`factory/workflow/contributed/knowledge/workflow.py`** — `ols_meta` dict + `ols_workflow()` function (11 nodes, 13 edges, 3 gates) mirroring tau_workflow topology
- **`factory/workflow/contributed/knowledge/__init__.py`** — Updated exports
- **`factory/workflow/definitions.py`** — Registered `knowledge-ols` in `register_all()`
- **`tests/test_knowledge_ols_adapter.py`** — 13 adapter tests (parse, score, extract, write, errors)
- **`factory/workflow/contributed/knowledge/test_workflow.py`** — 24 new OLS workflow tests

## Verification
- 37 new tests, all passing
- ruff check: all passed
- mypy: no issues found
- All existing knowledge workflow tests (45) still pass