### PR TITLE
fix: handle unborn repos in worktree creation

### DIFF
--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -49,8 +49,22 @@ def create_worktree(
         cwd=project_path,
         capture_output=True,
         text=True,
-        check=True,
     )
+    if result.returncode != 0:
+        if _is_unborn_repo(project_path):
+            _bootstrap_unborn_repo(project_path)
+            result = subprocess.run(
+                ["git", "rev-parse", base_branch],
+                cwd=project_path,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        else:
+            raise RuntimeError(
+                f"Branch '{base_branch}' does not exist in {project_path}. "
+                "Set `target_branch` in .factory/config.json or check your git state."
+            )
     base_commit = result.stdout.strip()
 
     if run_id is not None:
@@ -310,6 +324,28 @@ def prune_stale(project_path: Path) -> list[str]:
     return pruned
 
 
+def _is_unborn_repo(project_path: Path) -> bool:
+    """Return True if the repo exists but has no commits (unborn HEAD)."""
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode != 0
+
+
+def _bootstrap_unborn_repo(project_path: Path) -> None:
+    """Create an initial empty commit so worktrees can branch from it."""
+    log.info("bootstrap_unborn_repo", path=str(project_path))
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init (factory bootstrap)"],
+        cwd=project_path,
+        capture_output=True,
+        check=True,
+    )
+
+
 def detect_default_branch(project_path: Path) -> str:
     """Detect the default branch for a git repository.
 
@@ -343,7 +379,7 @@ def detect_default_branch(project_path: Path) -> str:
             log.debug("detect_default_branch", source="probe", branch=candidate)
             return candidate
 
-    # Current branch
+    # Current branch (works on repos with commits)
     result = subprocess.run(
         ["git", "rev-parse", "--abbrev-ref", "HEAD"],
         cwd=project_path,
@@ -355,6 +391,18 @@ def detect_default_branch(project_path: Path) -> str:
         if branch != "HEAD":
             log.debug("detect_default_branch", source="current_head", branch=branch)
             return branch
+
+    # Unborn repo: rev-parse fails but symbolic-ref still resolves HEAD
+    result = subprocess.run(
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        cwd=project_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        branch = result.stdout.strip()
+        log.debug("detect_default_branch", source="symbolic_ref", branch=branch)
+        return branch
 
     log.debug("detect_default_branch", source="fallback", branch="main")
     return "main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,19 @@ markers = [
     "slow: tests that make real API calls (deselect with -m 'not slow')",
 ]
 
+[tool.coverage.run]
+branch = true
+source = ["factory"]
+omit = [
+    "tests/*",
+    "eval/*",
+    "factory/dashboard/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+
 [tool.ruff]
 line-length = 100
 extend-exclude = ["mkdocs.yml"]

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -1,0 +1,483 @@
+"""Tests for factory/runners/opencode.py — OpenCodeRunner implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import factory.runners.opencode as oc_module
+from factory.models import AgentRunRequest, AgentRunResult
+from factory.runners.opencode import (
+    OpenCodeAuthError,
+    OpenCodeRunner,
+    _can_source_key_from_shell,
+    _check_auth,
+    _check_binary_compat,
+    _find_opencode_bin_dir,
+    _prepend_opencode_path,
+    _source_openai_key_from_shell,
+    is_opencode_dry_run,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_opencode_globals() -> None:
+    """Reset module-level auth/compat guards before each test."""
+    oc_module._auth_checked = False
+    oc_module._compat_checked = False
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeAuthError
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeAuthError:
+    def test_error_message(self) -> None:
+        err = OpenCodeAuthError()
+        assert "OPENAI_API_KEY" in str(err)
+        assert "config.toml" in str(err)
+        assert "[credentials.opencode]" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# _can_source_key_from_shell
+# ---------------------------------------------------------------------------
+
+
+class TestCanSourceKeyFromShell:
+    def test_returns_true_when_key_found(self) -> None:
+        mock_result = MagicMock(stdout="sk-fake-key-123\n")
+        with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
+            assert _can_source_key_from_shell() is True
+
+    def test_returns_false_when_empty(self) -> None:
+        mock_result = MagicMock(stdout="\n")
+        with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
+            assert _can_source_key_from_shell() is False
+
+    def test_returns_false_on_file_not_found(self) -> None:
+        with patch(
+            "factory.runners.opencode.subprocess.run", side_effect=FileNotFoundError
+        ):
+            assert _can_source_key_from_shell() is False
+
+    def test_returns_false_on_timeout(self) -> None:
+        import subprocess
+
+        with patch(
+            "factory.runners.opencode.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="zsh", timeout=5),
+        ):
+            assert _can_source_key_from_shell() is False
+
+
+# ---------------------------------------------------------------------------
+# _check_auth
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAuth:
+    def test_skips_when_already_checked(self) -> None:
+        oc_module._auth_checked = True
+        # Should return immediately without raising
+        _check_auth()
+
+    def test_passes_with_env_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        with patch("factory.runners.opencode._check_binary_compat"):
+            _check_auth()
+        assert oc_module._auth_checked is True
+
+    def test_passes_with_shell_sourced_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("factory.runners.opencode._check_binary_compat"):
+            with patch("factory.runners.opencode._can_source_key_from_shell", return_value=True):
+                _check_auth()
+        assert oc_module._auth_checked is True
+
+    def test_raises_without_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("factory.runners.opencode._check_binary_compat"):
+            with patch("factory.runners.opencode._can_source_key_from_shell", return_value=False):
+                with pytest.raises(OpenCodeAuthError, match="OPENAI_API_KEY"):
+                    _check_auth()
+
+
+# ---------------------------------------------------------------------------
+# _check_binary_compat
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBinaryCompat:
+    def test_skips_when_already_checked(self) -> None:
+        oc_module._compat_checked = True
+        # Should return immediately
+        _check_binary_compat()
+
+    def test_returns_early_when_no_binary(self) -> None:
+        with patch("shutil.which", return_value=None):
+            _check_binary_compat()
+        assert oc_module._compat_checked is True
+
+    def test_go_binary_detected(self) -> None:
+        mock_result = MagicMock(stdout="opencode version v0.0.55", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
+            with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
+                _check_binary_compat()
+        assert oc_module._compat_checked is True
+
+    def test_npm_binary_warns(self) -> None:
+        mock_result = MagicMock(stdout="some npm output", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
+            with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
+                _check_binary_compat()
+        assert oc_module._compat_checked is True
+
+    def test_version_in_stderr(self) -> None:
+        mock_result = MagicMock(stdout="", stderr="opencode version v0.1.0")
+        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
+            with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
+                _check_binary_compat()
+        assert oc_module._compat_checked is True
+
+    def test_file_not_found_handled(self) -> None:
+        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
+            with patch(
+                "factory.runners.opencode.subprocess.run",
+                side_effect=FileNotFoundError,
+            ):
+                _check_binary_compat()
+        assert oc_module._compat_checked is True
+
+    def test_timeout_handled(self) -> None:
+        import subprocess
+
+        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
+            with patch(
+                "factory.runners.opencode.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="opencode", timeout=10),
+            ):
+                _check_binary_compat()
+        assert oc_module._compat_checked is True
+
+
+# ---------------------------------------------------------------------------
+# _find_opencode_bin_dir
+# ---------------------------------------------------------------------------
+
+
+class TestFindOpencodeBinDir:
+    def test_found_on_path(self) -> None:
+        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
+            assert _find_opencode_bin_dir() == "/usr/local/bin"
+
+    def test_found_in_gopath(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GOPATH", "/custom/go")
+        with patch("shutil.which", return_value=None):
+            with patch.object(Path, "is_file", return_value=True):
+                result = _find_opencode_bin_dir()
+        assert result is not None
+
+    def test_found_in_home_go_bin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GOPATH", raising=False)
+        with patch("shutil.which", return_value=None):
+            with patch.object(Path, "is_file", side_effect=lambda: True):
+                # The first candidate is Path.home() / "go" / "bin"
+                result = _find_opencode_bin_dir()
+        # Should find it or not depending on mocking; just verify no crash
+        assert result is None or isinstance(result, str)
+
+    def test_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GOPATH", raising=False)
+        with patch("shutil.which", return_value=None):
+            with patch.object(Path, "is_file", return_value=False):
+                assert _find_opencode_bin_dir() is None
+
+
+# ---------------------------------------------------------------------------
+# _prepend_opencode_path
+# ---------------------------------------------------------------------------
+
+
+class TestPrependOpencodePath:
+    def test_prepends_when_found(self) -> None:
+        env: dict[str, str] = {"PATH": "/usr/bin:/bin"}
+        with patch(
+            "factory.runners.opencode._find_opencode_bin_dir",
+            return_value="/home/user/go/bin",
+        ):
+            _prepend_opencode_path(env)
+        assert env["PATH"].startswith("/home/user/go/bin:")
+
+    def test_no_op_when_already_first(self) -> None:
+        env: dict[str, str] = {"PATH": "/home/user/go/bin:/usr/bin"}
+        with patch(
+            "factory.runners.opencode._find_opencode_bin_dir",
+            return_value="/home/user/go/bin",
+        ):
+            _prepend_opencode_path(env)
+        assert env["PATH"] == "/home/user/go/bin:/usr/bin"
+
+    def test_no_op_when_not_found(self) -> None:
+        env: dict[str, str] = {"PATH": "/usr/bin"}
+        with patch(
+            "factory.runners.opencode._find_opencode_bin_dir", return_value=None
+        ):
+            _prepend_opencode_path(env)
+        assert env["PATH"] == "/usr/bin"
+
+
+# ---------------------------------------------------------------------------
+# _source_openai_key_from_shell
+# ---------------------------------------------------------------------------
+
+
+class TestSourceOpenaiKeyFromShell:
+    def test_no_op_when_key_exists(self) -> None:
+        env: dict[str, str] = {"OPENAI_API_KEY": "already-set"}
+        # Should not call subprocess at all
+        _source_openai_key_from_shell(env)
+        assert env["OPENAI_API_KEY"] == "already-set"
+
+    def test_sources_key_from_zshrc(self) -> None:
+        env: dict[str, str] = {}
+        mock_result = MagicMock(stdout="sk-sourced-key\n")
+        with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
+            _source_openai_key_from_shell(env)
+        assert env["OPENAI_API_KEY"] == "sk-sourced-key"
+
+    def test_no_key_from_zshrc(self) -> None:
+        env: dict[str, str] = {}
+        mock_result = MagicMock(stdout="\n")
+        with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
+            _source_openai_key_from_shell(env)
+        assert "OPENAI_API_KEY" not in env
+
+    def test_handles_file_not_found(self) -> None:
+        env: dict[str, str] = {}
+        with patch(
+            "factory.runners.opencode.subprocess.run", side_effect=FileNotFoundError
+        ):
+            _source_openai_key_from_shell(env)
+        assert "OPENAI_API_KEY" not in env
+
+    def test_handles_timeout(self) -> None:
+        import subprocess
+
+        env: dict[str, str] = {}
+        with patch(
+            "factory.runners.opencode.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="zsh", timeout=5),
+        ):
+            _source_openai_key_from_shell(env)
+        assert "OPENAI_API_KEY" not in env
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeRunner.build_command
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommand:
+    def test_command_structure(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        with patch("factory.runners.opencode._prepend_opencode_path"):
+            with patch("factory.runners.opencode._source_openai_key_from_shell"):
+                cmd, env, temp_files = runner.build_command(
+                    AgentRunRequest(
+                        prompt="You are the CEO.",
+                        task="Run experiment",
+                        cwd=tmp_path,
+                        role="ceo",
+                    )
+                )
+
+        assert cmd[0] == "opencode"
+        assert "-p" in cmd
+        assert "-c" in cmd
+        assert str(tmp_path) in cmd
+        assert "-q" in cmd
+        full_prompt = cmd[cmd.index("-p") + 1]
+        assert "You are the CEO." in full_prompt
+        assert "Run experiment" in full_prompt
+        assert "## Current Task" in full_prompt
+        assert temp_files == []
+        assert "VIRTUAL_ENV" not in env
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeRunner.headless
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeHeadless:
+    async def test_dry_run_returns_stub(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
+        runner = OpenCodeRunner()
+        result = await runner.headless(
+            AgentRunRequest(
+                prompt="Test prompt",
+                task="Test task",
+                cwd=tmp_path,
+                role="researcher",
+            )
+        )
+        assert result.return_code == 0
+        assert "[DRY-RUN]" in result.stdout
+        assert "researcher" in result.stdout
+
+    async def test_background_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
+        runner = OpenCodeRunner()
+        result = await runner.headless(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                role="builder",
+                extras={"background": True},
+            )
+        )
+        assert result.return_code == 0
+
+    async def test_headless_calls_run_subprocess(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
+
+        runner = OpenCodeRunner()
+        with patch("factory.runners.opencode._check_auth"):
+            with patch("factory.runners.opencode._prepend_opencode_path"):
+                with patch("factory.runners.opencode._source_openai_key_from_shell"):
+                    with patch(
+                        "factory.runners.opencode.run_subprocess",
+                        new_callable=AsyncMock,
+                    ) as mock_run:
+                        mock_run.return_value = AgentRunResult(
+                            stdout="output", return_code=0
+                        )
+                        result = await runner.headless(
+                            AgentRunRequest(
+                                prompt="You are a test agent.",
+                                task="Say hello",
+                                cwd=tmp_path,
+                                role="researcher",
+                                timeout=60.0,
+                            )
+                        )
+
+                        assert result.return_code == 0
+                        assert result.stdout == "output"
+
+                        call_kwargs = mock_run.call_args.kwargs
+                        assert call_kwargs["runner_name"] == "opencode"
+                        assert call_kwargs["role"] == "researcher"
+                        assert call_kwargs["timeout"] == 60.0
+                        cmd = mock_run.call_args[0][0]
+                        assert cmd[0] == "opencode"
+                        assert "-q" in cmd
+
+    async def test_headless_raises_without_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
+
+        runner = OpenCodeRunner()
+        with patch("factory.runners.opencode._check_binary_compat"):
+            with patch(
+                "factory.runners.opencode._can_source_key_from_shell",
+                return_value=False,
+            ):
+                with pytest.raises(OpenCodeAuthError):
+                    await runner.headless(
+                        AgentRunRequest(
+                            prompt="Test",
+                            task="Test",
+                            cwd=tmp_path,
+                            role="researcher",
+                        )
+                    )
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeRunner.interactive_run
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeInteractive:
+    def test_dry_run(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
+        runner = OpenCodeRunner()
+        code = runner.interactive_run(
+            AgentRunRequest(
+                prompt="Test prompt",
+                task="Test task",
+                cwd=tmp_path,
+                role="ceo",
+            )
+        )
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "[DRY-RUN]" in captured.out
+
+    def test_interactive_run_calls_subprocess(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
+        runner = OpenCodeRunner()
+
+        with patch("factory.runners.opencode._prepend_opencode_path"):
+            with patch("factory.runners.opencode._source_openai_key_from_shell"):
+                with patch("factory.runners.opencode.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    code = runner.interactive_run(
+                        AgentRunRequest(
+                            prompt="You are the CEO.",
+                            task="Start session",
+                            cwd=tmp_path,
+                            role="ceo",
+                        )
+                    )
+                    assert code == 0
+                    cmd = mock_run.call_args[0][0]
+                    assert cmd[0] == "opencode"
+                    assert "-p" in cmd
+                    assert "-c" in cmd
+                    assert "-q" not in cmd  # interactive does not use -q
+
+
+# ---------------------------------------------------------------------------
+# is_opencode_dry_run
+# ---------------------------------------------------------------------------
+
+
+class TestIsOpencodeDryRun:
+    def test_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
+        assert is_opencode_dry_run() is True
+
+    def test_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
+        assert is_opencode_dry_run() is False
+
+    def test_true_word(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "true")
+        assert is_opencode_dry_run() is True
+
+    def test_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "yes")
+        assert is_opencode_dry_run() is True

--- a/tests/test_parallel_improve.py
+++ b/tests/test_parallel_improve.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1024,3 +1025,483 @@ class TestParseHypothesesEdgeCases:
         result = _parse_hypotheses(f)
         assert len(result) == 1
         assert "caching" in result[0].lower()
+
+
+# ── Integration tests for live execution paths ─────────────────
+
+
+def _git_project(tmp_path: Path) -> Path:
+    """Create a git-initialised project with .factory/ scaffolding for live tests."""
+    import subprocess as sp
+
+    project = tmp_path / "live-project"
+    project.mkdir()
+    sp.run(["git", "init"], cwd=project, capture_output=True, check=True)
+    sp.run(
+        ["git", "commit", "--allow-empty", "-m", "initial"],
+        cwd=project, capture_output=True, check=True,
+        env={
+            "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+            "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com",
+            "HOME": str(tmp_path), "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        },
+    )
+    factory_dir = project / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "strategy").mkdir()
+    (factory_dir / "reviews").mkdir()
+    (factory_dir / "experiments").mkdir()
+    (factory_dir / "archive").mkdir()
+    (factory_dir / "config.json").write_text("{}")
+    (factory_dir / "results.tsv").write_text(
+        "id\ttimestamp\thypothesis\tchange_summary\tissue_number\tpr_number\t"
+        "score_before\tscore_after\tdelta\tverdict\tcost_usd\tnotes\tresearch_citations\n"
+    )
+    return project
+
+
+@pytest.mark.real_worktree
+class TestSubgraphForkLiveExecution:
+    """Integration tests for _execute_subgraph_fork with real git worktrees."""
+
+    async def test_live_worktree_creation_and_cleanup(self, tmp_path: Path) -> None:
+        """Verify worktrees are actually created on disk and subgraph runs in them."""
+        project = _git_project(tmp_path)
+
+        (project / ".factory" / "strategy" / "current.md").write_text(
+            "## Hypothesis 1\nAdd logging\n\n## Hypothesis 2\nAdd metrics\n"
+        )
+
+        wf = Workflow(
+            name="test-live-fork",
+            nodes={
+                "fork": SubgraphForkNode(
+                    id="fork", subgraph_entry="step_a", subgraph_exit="step_b",
+                    parallelism=2, writes={"fork.json"},
+                ),
+                "step_a": FnNode(id="step_a", command="echo start", writes={"a.txt"}),
+                "step_b": FnNode(id="step_b", command="echo done", reads={"a.txt"}, writes={"b.txt"}),
+            },
+            edges=[Edge(source="step_a", target="step_b")],
+            start_node="fork",
+        )
+
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+        result = await executor.execute()
+
+        results = json.loads(result.node_outputs["fork"])
+        assert len(results) == 2
+        for r in results:
+            assert r["success"] is True
+            assert r["branch"].startswith("factory/exp-")
+            wt = Path(r["worktree_path"])
+            assert wt.name.startswith("exp-")
+
+    async def test_live_fork_respects_parallelism_cap(self, tmp_path: Path) -> None:
+        """When hypotheses > parallelism, branch_count is capped at parallelism."""
+        project = _git_project(tmp_path)
+
+        (project / ".factory" / "strategy" / "current.md").write_text(
+            "## Hypothesis 1\nH1\n\n## Hypothesis 2\nH2\n\n## Hypothesis 3\nH3\n"
+        )
+
+        wf = Workflow(
+            name="test-cap",
+            nodes={
+                "fork": SubgraphForkNode(
+                    id="fork", subgraph_entry="step_a", subgraph_exit="step_b",
+                    parallelism=2, writes={"fork.json"},
+                ),
+                "step_a": FnNode(id="step_a", command="echo ok", writes={"a.txt"}),
+                "step_b": FnNode(id="step_b", command="echo done", reads={"a.txt"}, writes={"b.txt"}),
+            },
+            edges=[Edge(source="step_a", target="step_b")],
+            start_node="fork",
+        )
+
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+        result = await executor.execute()
+
+        results = json.loads(result.node_outputs["fork"])
+        assert len(results) == 2, "Should cap at parallelism=2 despite 3 hypotheses"
+
+    async def test_live_fork_uses_real_head_commit(self, tmp_path: Path) -> None:
+        """Verify the live path resolves HEAD via git rev-parse (not a dummy hash)."""
+        import subprocess as sp
+
+        project = _git_project(tmp_path)
+
+        head = sp.run(
+            ["git", "rev-parse", "HEAD"], cwd=project,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        (project / ".factory" / "strategy" / "current.md").write_text(
+            "## Hypothesis 1\nTest commit resolution\n"
+        )
+
+        wf = Workflow(
+            name="test-head",
+            nodes={
+                "fork": SubgraphForkNode(
+                    id="fork", subgraph_entry="step_a", subgraph_exit="step_b",
+                    parallelism=1, writes={"fork.json"},
+                ),
+                "step_a": FnNode(id="step_a", command="echo ok", writes={"a.txt"}),
+                "step_b": FnNode(id="step_b", command="echo done", reads={"a.txt"}, writes={"b.txt"}),
+            },
+            edges=[Edge(source="step_a", target="step_b")],
+            start_node="fork",
+        )
+
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+        result = await executor.execute()
+
+        results = json.loads(result.node_outputs["fork"])
+        assert results[0]["success"] is True
+        branch = results[0]["branch"]
+        branch_commit = sp.run(
+            ["git", "rev-parse", branch], cwd=project,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        assert branch_commit == head
+
+    async def test_live_fork_no_strategy_file_defaults_to_parallelism(
+        self, tmp_path: Path,
+    ) -> None:
+        """When no strategy file exists, branch_count falls back to parallelism."""
+        project = _git_project(tmp_path)
+
+        wf = Workflow(
+            name="test-no-strat",
+            nodes={
+                "fork": SubgraphForkNode(
+                    id="fork", subgraph_entry="step_a", subgraph_exit="step_b",
+                    parallelism=2, writes={"fork.json"},
+                ),
+                "step_a": FnNode(id="step_a", command="echo ok", writes={"a.txt"}),
+                "step_b": FnNode(id="step_b", command="echo done", reads={"a.txt"}, writes={"b.txt"}),
+            },
+            edges=[Edge(source="step_a", target="step_b")],
+            start_node="fork",
+        )
+
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+        result = await executor.execute()
+
+        results = json.loads(result.node_outputs["fork"])
+        assert len(results) == 2
+
+
+@pytest.mark.real_worktree
+class TestSelectionLiveExecution:
+    """Integration tests for _execute_selection with real git repos."""
+
+    async def test_live_merge_winner_into_baseline(self, tmp_path: Path) -> None:
+        """Verify the winning branch is actually merged into the project."""
+        import subprocess as sp
+
+        project = _git_project(tmp_path)
+
+        head = sp.run(
+            ["git", "rev-parse", "HEAD"], cwd=project,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        from factory.worktree import create_experiment_worktree
+
+        wt_path, branch = create_experiment_worktree(project, 1, head)
+
+        (wt_path / "new_file.txt").write_text("winner content")
+        sp.run(["git", "add", "new_file.txt"], cwd=wt_path, capture_output=True, check=True)
+        sp.run(
+            ["git", "commit", "-m", "winner commit"],
+            cwd=wt_path, capture_output=True, check=True,
+            env={
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com",
+                "HOME": str(tmp_path), "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            },
+        )
+
+        (wt_path / ".factory").mkdir(exist_ok=True)
+        (wt_path / ".factory" / "last_eval.json").write_text(json.dumps({"total": 0.95}))
+
+        wf = Workflow(
+            name="test-merge",
+            nodes={
+                "pre": FnNode(id="pre", command="echo pre", writes={"pre.txt"}),
+                "select": SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+            },
+            edges=[Edge(source="pre", target="select")],
+            start_node="pre",
+        )
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+        executor.result.node_outputs["fork"] = json.dumps([{
+            "exp_id": 1, "success": True, "halted": False, "halt_reason": "",
+            "worktree_path": str(wt_path), "branch": branch, "hypothesis": "winner",
+        }])
+        executor.completed_files = {"pre.txt"}
+
+        await executor._execute_selection(
+            SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+        )
+
+        assert not executor.result.halted
+        merged_file = project / "new_file.txt"
+        assert merged_file.exists(), "Winner's file should be merged into project"
+        assert merged_file.read_text() == "winner content"
+
+    async def test_live_loser_worktree_removed(self, tmp_path: Path) -> None:
+        """Verify losing worktrees are cleaned up after selection."""
+        import subprocess as sp
+
+        project = _git_project(tmp_path)
+
+        head = sp.run(
+            ["git", "rev-parse", "HEAD"], cwd=project,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        from factory.worktree import create_experiment_worktree
+
+        wt1, br1 = create_experiment_worktree(project, 1, head)
+        wt2, br2 = create_experiment_worktree(project, 2, head)
+
+        for wt in (wt1, wt2):
+            (wt / ".factory").mkdir(exist_ok=True)
+
+        (wt1 / ".factory" / "last_eval.json").write_text(json.dumps({"total": 0.6}))
+        (wt2 / ".factory" / "last_eval.json").write_text(json.dumps({"total": 0.9}))
+
+        for wt, name in ((wt1, "file1.txt"), (wt2, "file2.txt")):
+            (wt / name).write_text("content")
+            sp.run(["git", "add", name], cwd=wt, capture_output=True, check=True)
+            sp.run(
+                ["git", "commit", "-m", f"add {name}"],
+                cwd=wt, capture_output=True, check=True,
+                env={
+                    "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+                    "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com",
+                    "HOME": str(tmp_path), "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                },
+            )
+
+        wf = Workflow(
+            name="test-cleanup",
+            nodes={
+                "pre": FnNode(id="pre", command="echo pre", writes={"pre.txt"}),
+                "select": SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+            },
+            edges=[Edge(source="pre", target="select")],
+            start_node="pre",
+        )
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+        executor.result.node_outputs["fork"] = json.dumps([
+            {"exp_id": 1, "success": True, "halted": False, "halt_reason": "",
+             "worktree_path": str(wt1), "branch": br1, "hypothesis": "h1"},
+            {"exp_id": 2, "success": True, "halted": False, "halt_reason": "",
+             "worktree_path": str(wt2), "branch": br2, "hypothesis": "h2"},
+        ])
+        executor.completed_files = {"pre.txt"}
+
+        await executor._execute_selection(
+            SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+        )
+
+        assert not executor.result.halted
+        selection = json.loads(executor.result.node_outputs["select"])
+        assert selection["winner_exp_id"] == 2
+        assert not wt1.exists(), "Loser worktree should be removed"
+
+
+@pytest.mark.real_worktree
+class TestErrorRecoveryPaths:
+    """Integration tests for error handling and recovery in live execution."""
+
+    async def test_fork_worktree_creation_failure_captured(self, tmp_path: Path) -> None:
+        """When create_experiment_worktree raises, the branch result is marked failed."""
+        project = _git_project(tmp_path)
+
+        (project / ".factory" / "strategy" / "current.md").write_text(
+            "## Hypothesis 1\nH1\n"
+        )
+
+        wf = Workflow(
+            name="test-wt-fail",
+            nodes={
+                "fork": SubgraphForkNode(
+                    id="fork", subgraph_entry="step_a", subgraph_exit="step_b",
+                    parallelism=1, writes={"fork.json"},
+                ),
+                "step_a": FnNode(id="step_a", command="echo ok", writes={"a.txt"}),
+                "step_b": FnNode(id="step_b", command="echo done", reads={"a.txt"}, writes={"b.txt"}),
+            },
+            edges=[Edge(source="step_a", target="step_b")],
+            start_node="fork",
+        )
+
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+
+        with patch(
+            "factory.worktree.create_experiment_worktree",
+            side_effect=RuntimeError("disk full"),
+        ):
+            result = await executor.execute()
+
+        results = json.loads(result.node_outputs["fork"])
+        assert len(results) == 1
+        assert results[0]["success"] is False
+        assert results[0]["halted"] is True
+
+    async def test_fork_subprocess_timeout_captured(self, tmp_path: Path) -> None:
+        """When git rev-parse times out, the fork halts gracefully."""
+        import subprocess as sp
+
+        project = _git_project(tmp_path)
+
+        (project / ".factory" / "strategy" / "current.md").write_text(
+            "## Hypothesis 1\nH1\n"
+        )
+
+        wf = Workflow(
+            name="test-timeout",
+            nodes={
+                "fork": SubgraphForkNode(
+                    id="fork", subgraph_entry="step_a", subgraph_exit="step_b",
+                    parallelism=1, writes={"fork.json"},
+                ),
+                "step_a": FnNode(id="step_a", command="echo ok", writes={"a.txt"}),
+                "step_b": FnNode(id="step_b", command="echo done", reads={"a.txt"}, writes={"b.txt"}),
+            },
+            edges=[Edge(source="step_a", target="step_b")],
+            start_node="fork",
+        )
+
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+
+        with patch(
+            "subprocess.run",
+            side_effect=sp.CalledProcessError(128, "git rev-parse"),
+        ):
+            result = await executor.execute()
+
+        assert result.halted is True
+
+    async def test_selection_merge_conflict_halts(self, tmp_path: Path) -> None:
+        """When merging the winner causes a conflict, selection halts."""
+        import subprocess as sp
+
+        project = _git_project(tmp_path)
+
+        head = sp.run(
+            ["git", "rev-parse", "HEAD"], cwd=project,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        from factory.worktree import create_experiment_worktree
+
+        wt, branch = create_experiment_worktree(project, 1, head)
+
+        (project / "conflict.txt").write_text("base content")
+        sp.run(["git", "add", "conflict.txt"], cwd=project, capture_output=True, check=True)
+        sp.run(
+            ["git", "commit", "-m", "base change"],
+            cwd=project, capture_output=True, check=True,
+            env={
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com",
+                "HOME": str(tmp_path), "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            },
+        )
+
+        (wt / "conflict.txt").write_text("branch content")
+        sp.run(["git", "add", "conflict.txt"], cwd=wt, capture_output=True, check=True)
+        sp.run(
+            ["git", "commit", "-m", "branch change"],
+            cwd=wt, capture_output=True, check=True,
+            env={
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com",
+                "HOME": str(tmp_path), "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            },
+        )
+
+        wf = Workflow(
+            name="test-conflict",
+            nodes={
+                "pre": FnNode(id="pre", command="echo pre", writes={"pre.txt"}),
+                "select": SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+            },
+            edges=[Edge(source="pre", target="select")],
+            start_node="pre",
+        )
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+        executor.result.node_outputs["fork"] = json.dumps([{
+            "exp_id": 1, "success": True, "halted": False, "halt_reason": "",
+            "worktree_path": str(wt), "branch": branch, "hypothesis": "h1",
+        }])
+        executor.completed_files = {"pre.txt"}
+
+        await executor._execute_selection(
+            SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+        )
+
+        assert executor.result.halted is True
+        assert "failed to merge winner branch" in executor.result.halt_reason
+
+    async def test_selection_worktree_cleanup_failure_non_fatal(
+        self, tmp_path: Path,
+    ) -> None:
+        """When worktree removal fails, selection still succeeds."""
+        import subprocess as sp
+
+        project = _git_project(tmp_path)
+
+        head = sp.run(
+            ["git", "rev-parse", "HEAD"], cwd=project,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        from factory.worktree import create_experiment_worktree
+
+        wt, branch = create_experiment_worktree(project, 1, head)
+
+        (wt / "ok.txt").write_text("ok")
+        sp.run(["git", "add", "ok.txt"], cwd=wt, capture_output=True, check=True)
+        sp.run(
+            ["git", "commit", "-m", "ok"],
+            cwd=wt, capture_output=True, check=True,
+            env={
+                "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@t.com",
+                "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@t.com",
+                "HOME": str(tmp_path), "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            },
+        )
+        (wt / ".factory").mkdir(exist_ok=True)
+        (wt / ".factory" / "last_eval.json").write_text(json.dumps({"total": 0.8}))
+
+        wf = Workflow(
+            name="test-cleanup-fail",
+            nodes={
+                "pre": FnNode(id="pre", command="echo pre", writes={"pre.txt"}),
+                "select": SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+            },
+            edges=[Edge(source="pre", target="select")],
+            start_node="pre",
+        )
+        executor = WorkflowExecutor(wf, project, dry_run=False)
+        executor.result.node_outputs["fork"] = json.dumps([{
+            "exp_id": 1, "success": True, "halted": False, "halt_reason": "",
+            "worktree_path": str(wt), "branch": branch, "hypothesis": "h1",
+        }])
+        executor.completed_files = {"pre.txt"}
+
+        with patch("factory.worktree.remove_worktree", side_effect=OSError("perm denied")):
+            await executor._execute_selection(
+                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+            )
+
+        assert not executor.result.halted
+        selection = json.loads(executor.result.node_outputs["select"])
+        assert selection["winner_exp_id"] == 1

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -176,3 +176,290 @@ def test_verdict_patterns_in_report(tmp_path: Path) -> None:
     report = build_performance_report(project)
     assert "researcher:PROCEED" in report.verdict_patterns
     assert "builder:REDIRECT" in report.verdict_patterns
+
+
+# ── _extract_exp_number ──────────────────────────────────────────
+
+
+def test_extract_exp_number_with_prefix() -> None:
+    from factory.report import _extract_exp_number
+
+    assert _extract_exp_number("myproject-042") == "042"
+
+
+def test_extract_exp_number_digits_only() -> None:
+    from factory.report import _extract_exp_number
+
+    assert _extract_exp_number("042") == "042"
+
+
+def test_extract_exp_number_no_digits() -> None:
+    from factory.report import _extract_exp_number
+
+    assert _extract_exp_number("no-number-here") == "no-number-here"
+
+
+# ── parse_ceo_verdicts — experiment ID and no-verdict skip ───────
+
+
+def test_parse_ceo_verdicts_with_experiment_id(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    (factory_dir / "reviews" / "ceo-verdict-qa.md").write_text(
+        "## CEO Review: QA Agent\n"
+        "Results from experiment 3\n"
+        "- **Verdict:** ABORT\n"
+        "- **Rationale:** Critical failure\n"
+    )
+
+    verdicts = parse_ceo_verdicts(project)
+    assert len(verdicts) == 1
+    assert verdicts[0].experiment_id == 3
+    assert verdicts[0].verdict == "ABORT"
+
+
+def test_parse_ceo_verdicts_no_verdict_match(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    (factory_dir / "reviews" / "ceo-verdict-builder.md").write_text(
+        "## CEO Review: Builder Agent\n"
+        "No structured verdict here, just free text.\n"
+    )
+
+    verdicts = parse_ceo_verdicts(project)
+    assert verdicts == []
+
+
+# ── parse_observations — archive JSON files ─────────────────────
+
+
+def test_parse_observations_archive_json_valid(tmp_path: Path) -> None:
+    """Valid JSON dict with 'learned' key in archive/experiments/."""
+    import json
+
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    archive_exp = factory_dir / "archive" / "experiments"
+    archive_exp.mkdir(parents=True)
+
+    (archive_exp / "proj-001.json").write_text(
+        json.dumps({"learned": "We discovered that caching improves throughput significantly."})
+    )
+
+    observations = parse_observations(project)
+    assert any("caching" in o.content for o in observations)
+    assert any("archive" in o.tags for o in observations)
+
+
+def test_parse_observations_archive_json_invalid(tmp_path: Path) -> None:
+    """Invalid JSON in archive/experiments/ should be skipped."""
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    archive_exp = factory_dir / "archive" / "experiments"
+    archive_exp.mkdir(parents=True)
+
+    (archive_exp / "bad.json").write_text("not valid json {{{")
+
+    observations = parse_observations(project)
+    json_obs = [o for o in observations if "bad.json" in o.source]
+    assert json_obs == []
+
+
+def test_parse_observations_archive_json_non_dict(tmp_path: Path) -> None:
+    """JSON that parses to a non-dict (e.g. a list) should be skipped."""
+    import json
+
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    archive_exp = factory_dir / "archive" / "experiments"
+    archive_exp.mkdir(parents=True)
+
+    (archive_exp / "list.json").write_text(json.dumps([1, 2, 3]))
+
+    observations = parse_observations(project)
+    json_obs = [o for o in observations if "list.json" in o.source]
+    assert json_obs == []
+
+
+def test_parse_observations_archive_md_skipped_by_exp_number(tmp_path: Path) -> None:
+    """An .md file whose exp number overlaps with a seen JSON exp number should be skipped."""
+    import json
+
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    archive_exp = factory_dir / "archive" / "experiments"
+    archive_exp.mkdir(parents=True)
+
+    # JSON for experiment 007 — will be seen first
+    (archive_exp / "proj-007.json").write_text(
+        json.dumps({"learned": "JSON observation that is long enough to pass the 10-char threshold."})
+    )
+    # MD for same experiment number — should be skipped
+    (archive_exp / "proj-007.md").write_text(
+        "This is a markdown note for the same experiment that should be skipped because JSON was already seen."
+    )
+
+    observations = parse_observations(project)
+    md_obs = [o for o in observations if o.source.endswith("proj-007.md")]
+    assert md_obs == []
+    json_obs = [o for o in observations if o.source.endswith("proj-007.json")]
+    assert len(json_obs) == 1
+
+
+def test_parse_observations_archive_md_short_content(tmp_path: Path) -> None:
+    """An .md file with content shorter than 50 chars should be skipped."""
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    archive_exp = factory_dir / "archive" / "experiments"
+    archive_exp.mkdir(parents=True)
+
+    (archive_exp / "short.md").write_text("Too short.")
+
+    observations = parse_observations(project)
+    short_obs = [o for o in observations if "short.md" in o.source]
+    assert short_obs == []
+
+
+def test_parse_observations_non_experiment_archive_skip_experiment_subdir(tmp_path: Path) -> None:
+    """Non-experiment archive .md files that ARE under archive/experiments/ should be skipped
+    in the final loop (line 134)."""
+
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    archive_dir = factory_dir / "archive"
+    archive_exp = archive_dir / "experiments"
+    archive_exp.mkdir(parents=True)
+
+    # A patterns dir outside experiments — should be picked up
+    patterns_dir = archive_dir / "patterns"
+    patterns_dir.mkdir()
+    (patterns_dir / "pattern1.md").write_text(
+        "This is a pattern note that is long enough to exceed the 50-char threshold for inclusion."
+    )
+
+    observations = parse_observations(project)
+    pattern_obs = [o for o in observations if "pattern1.md" in o.source]
+    assert len(pattern_obs) == 1
+
+
+def test_parse_observations_non_experiment_archive_short_md(tmp_path: Path) -> None:
+    """Non-experiment archive .md files shorter than 50 chars should be skipped (line 139)."""
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    archive_dir = factory_dir / "archive"
+    archive_dir.mkdir(parents=True)
+
+    patterns_dir = archive_dir / "patterns"
+    patterns_dir.mkdir()
+    (patterns_dir / "tiny.md").write_text("Short.")
+
+    observations = parse_observations(project)
+    tiny_obs = [o for o in observations if "tiny.md" in o.source]
+    assert tiny_obs == []
+
+
+# ── _parse_datetimes ─────────────────────────────────────────────
+
+
+def test_parse_datetimes_converts_iso_strings() -> None:
+    from datetime import datetime
+
+    from factory.report import _parse_datetimes
+
+    data: dict = {
+        "generated_at": "2026-01-15T10:30:00",
+        "observations": [
+            {"timestamp": "2026-01-14T08:00:00", "other": "value"},
+            {"timestamp": "2026-01-13T09:00:00"},
+        ],
+    }
+    _parse_datetimes(data)
+
+    assert isinstance(data["generated_at"], datetime)
+    assert data["generated_at"].year == 2026
+    assert data["generated_at"].month == 1
+    assert data["generated_at"].day == 15
+
+    for obs in data["observations"]:
+        assert isinstance(obs["timestamp"], datetime)
+
+
+def test_parse_datetimes_skips_non_string_values() -> None:
+    from datetime import datetime
+
+    from factory.report import _parse_datetimes
+
+    now = datetime.now()
+    data: dict = {
+        "generated_at": now,
+        "observations": [{"timestamp": now}],
+    }
+    _parse_datetimes(data)
+
+    # Should remain unchanged
+    assert data["generated_at"] is now
+    assert data["observations"][0]["timestamp"] is now
+
+
+# ── build_performance_report — store.load_history() exception ────
+
+
+def test_build_performance_report_history_exception(tmp_path: Path) -> None:
+    """When store.load_history() raises, records should default to []."""
+    from unittest.mock import AsyncMock, patch
+
+    project = tmp_path / "proj"
+    _make_factory_dir(project)
+
+    mock_store = AsyncMock()
+    mock_store.load_history.side_effect = RuntimeError("DB gone")
+
+    with patch("factory.store.ExperimentStore", return_value=mock_store):
+        report = build_performance_report(project)
+
+    assert report.total_experiments == 0
+    assert report.keep_count == 0
+    assert report.revert_count == 0
+    assert report.error_count == 0
+    assert report.latest_score is None
+
+
+def test_parse_observations_section_no_content(tmp_path: Path) -> None:
+    """Observation sections with title only (no content) should be skipped (line 83)."""
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    (factory_dir / "strategy" / "observations.md").write_text(
+        "## Empty Section\n\n## Also Empty\n"
+    )
+
+    observations = parse_observations(project)
+    assert observations == []
+
+
+def test_parse_ceo_verdicts_issues_with_empty_line(tmp_path: Path) -> None:
+    """Issues block with a blank line between items — blank line should be skipped (line 50)."""
+    project = tmp_path / "proj"
+    factory_dir = _make_factory_dir(project)
+
+    (factory_dir / "reviews" / "ceo-verdict-qa.md").write_text(
+        "- **Verdict:** REDIRECT\n"
+        "- **Rationale:** Needs work\n"
+        "- **Issues found:**\n"
+        "- First issue\n"
+        "\n"
+        "- Second issue\n"
+    )
+
+    verdicts = parse_ceo_verdicts(project)
+    assert len(verdicts) == 1
+    assert len(verdicts[0].issues) == 2

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -2139,3 +2139,249 @@ class TestOpenCodeBuildInteractiveCommand:
         ))
 
         assert temp_files == []
+
+
+class TestGetRunnerChoices:
+    """Tests for get_runner_choices() — returns sorted list of runner names."""
+
+    def test_returns_sorted_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import get_runner_choices
+
+        # Reset entrypoints loaded flag to ensure clean state
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        choices = get_runner_choices()
+        assert isinstance(choices, list)
+        assert choices == sorted(choices)
+        # All built-in runners should be present
+        assert "claude" in choices
+        assert "bob" in choices
+        assert "codex" in choices
+        assert "opencode" in choices
+
+    def test_returns_strings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import get_runner_choices
+
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        choices = get_runner_choices()
+        assert all(isinstance(c, str) for c in choices)
+
+
+class TestGetAllRunnerMeta:
+    """Tests for get_all_runner_meta() — returns metadata for all runners."""
+
+    def test_returns_list_of_runner_meta(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import get_all_runner_meta
+        from factory.runners.protocol import RunnerMeta
+
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        metas = get_all_runner_meta()
+        assert isinstance(metas, list)
+        assert len(metas) > 0
+        assert all(isinstance(m, RunnerMeta) for m in metas)
+
+    def test_includes_all_builtin_runners(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import get_all_runner_meta
+
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        metas = get_all_runner_meta()
+        names = {m.name for m in metas}
+        assert "claude" in names
+        assert "bob" in names
+
+    def test_handles_runner_without_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import get_all_runner_meta, register_runner
+
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        # Register a fake runner class that has no metadata() method
+        class FakeRunner:
+            name = "fake"
+
+        original_runners = dict(runners_mod._RUNNERS)
+        try:
+            register_runner("fake", FakeRunner)  # type: ignore[arg-type]
+            metas = get_all_runner_meta()
+            # Should not raise — FakeRunner is silently skipped
+            fake_names = [m.name for m in metas if m.name == "fake"]
+            assert len(fake_names) == 0
+        finally:
+            runners_mod._RUNNERS.clear()
+            runners_mod._RUNNERS.update(original_runners)
+
+
+class TestRegisterRunner:
+    """Tests for register_runner() — adds new runner to the registry."""
+
+    def test_register_new_runner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import register_runner, get_available_runners
+
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        class MockRunner:
+            name = "mock"
+
+        original_runners = dict(runners_mod._RUNNERS)
+        try:
+            register_runner("mock", MockRunner)  # type: ignore[arg-type]
+            available = get_available_runners()
+            assert "mock" in available
+            assert available["mock"] is MockRunner
+        finally:
+            runners_mod._RUNNERS.clear()
+            runners_mod._RUNNERS.update(original_runners)
+
+    def test_register_overwrites_existing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import register_runner, get_available_runners
+
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        class NewClaude:
+            name = "claude"
+
+        original_runners = dict(runners_mod._RUNNERS)
+        try:
+            register_runner("claude", NewClaude)  # type: ignore[arg-type]
+            available = get_available_runners()
+            assert available["claude"] is NewClaude
+        finally:
+            runners_mod._RUNNERS.clear()
+            runners_mod._RUNNERS.update(original_runners)
+
+
+class TestGetAvailableRunners:
+    """Tests for get_available_runners() — returns all registered runners."""
+
+    def test_returns_dict_copy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import get_available_runners
+
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        runners = get_available_runners()
+        assert isinstance(runners, dict)
+        # Should be a copy, not the internal dict
+        runners["new_key"] = "test"  # type: ignore[assignment]
+        runners2 = get_available_runners()
+        assert "new_key" not in runners2
+
+    def test_includes_builtin_runners(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from factory.runners import get_available_runners
+
+        import factory.runners as runners_mod
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", True)
+
+        runners = get_available_runners()
+        assert "claude" in runners
+        assert "bob" in runners
+        assert "codex" in runners
+        assert "opencode" in runners
+
+
+class TestLoadEntrypointRunners:
+    """Tests for _load_entrypoint_runners() — entry_points discovery."""
+
+    def test_loads_only_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import factory.runners as runners_mod
+
+        # Reset the flag
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)
+
+        with patch("factory.runners.entry_points", create=True):
+            runners_mod._load_entrypoint_runners()
+            # Second call should be a no-op
+            runners_mod._load_entrypoint_runners()
+
+        # entry_points should have been imported and called inside the function
+        # but since we patched at module level (not importlib.metadata), let's verify
+        # the flag is now True
+        assert runners_mod._entrypoints_loaded is True
+
+    def test_loads_plugin_runner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import factory.runners as runners_mod
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)
+        original_runners = dict(runners_mod._RUNNERS)
+
+        class PluginRunner:
+            name = "plugin"
+
+        mock_ep = MagicMock()
+        mock_ep.name = "plugin"
+        mock_ep.load.return_value = PluginRunner
+
+        try:
+            with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+                runners_mod._load_entrypoint_runners()
+
+            assert "plugin" in runners_mod._RUNNERS
+            assert runners_mod._RUNNERS["plugin"] is PluginRunner
+        finally:
+            runners_mod._RUNNERS.clear()
+            runners_mod._RUNNERS.update(original_runners)
+            monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)
+
+    def test_skips_existing_runner_names(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import factory.runners as runners_mod
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)
+        original_claude = runners_mod._RUNNERS["claude"]
+
+        mock_ep = MagicMock()
+        mock_ep.name = "claude"  # Same as built-in
+        mock_ep.load.return_value = MagicMock()
+
+        try:
+            with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+                runners_mod._load_entrypoint_runners()
+
+            # Should NOT have replaced the built-in claude runner
+            assert runners_mod._RUNNERS["claude"] is original_claude
+            mock_ep.load.assert_not_called()
+        finally:
+            monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)
+
+    def test_handles_plugin_load_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import factory.runners as runners_mod
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)
+        original_runners = dict(runners_mod._RUNNERS)
+
+        mock_ep = MagicMock()
+        mock_ep.name = "broken_plugin"
+        mock_ep.load.side_effect = RuntimeError("plugin load failed")
+
+        try:
+            with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+                runners_mod._load_entrypoint_runners()  # Should not raise
+
+            # Broken plugin should not be registered
+            assert "broken_plugin" not in runners_mod._RUNNERS
+        finally:
+            runners_mod._RUNNERS.clear()
+            runners_mod._RUNNERS.update(original_runners)
+            monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)
+
+    def test_handles_entry_points_import_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import factory.runners as runners_mod
+
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)
+
+        with patch("importlib.metadata.entry_points", side_effect=Exception("no entry_points")):
+            runners_mod._load_entrypoint_runners()  # Should not raise
+
+        assert runners_mod._entrypoints_loaded is True
+        monkeypatch.setattr(runners_mod, "_entrypoints_loaded", False)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import sys
+import time as _time
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -554,3 +556,763 @@ class TestFindTrialLog:
     def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
         result = _find_trial_log(tmp_path, {"timestamp": "20260101T000000Z", "benchmark": "swebench"})
         assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage tests for telemetry module
+# ---------------------------------------------------------------------------
+
+class TestIsEnabledInitFails:
+    """Cover lines 43-45: Langfuse IS available but constructor raises."""
+
+    def test_returns_false_when_langfuse_init_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANGFUSE_HOST", "http://localhost:3000")
+        monkeypatch.setattr(telemetry_mod, "_HAS_LANGFUSE", True)
+        monkeypatch.setattr(
+            telemetry_mod, "Langfuse",
+            MagicMock(side_effect=RuntimeError("connection refused")),
+            raising=False,
+        )
+        assert telemetry_mod.is_enabled() is False
+        assert telemetry_mod._client is None
+
+
+class TestGetClient:
+    """Cover line 50: _get_client raises when not initialised."""
+
+    def test_raises_when_not_initialised(self) -> None:
+        telemetry_mod._client = None
+        with pytest.raises(RuntimeError, match="Langfuse not initialised"):
+            telemetry_mod._get_client()
+
+
+class TestSetTraceNameOnSpan:
+    """Cover lines 60-70: OTel span attribute setting."""
+
+    def test_sets_trace_name_and_input(self) -> None:
+        mock_otel_span = MagicMock()
+        mock_otel_span.is_recording.return_value = True
+        mock_obs = MagicMock()
+        mock_obs._otel_span = mock_otel_span
+
+        mock_attrs = MagicMock()
+        mock_attrs.TRACE_NAME = "langfuse.trace.name"
+        mock_attrs.TRACE_INPUT = "langfuse.trace.input"
+
+        with patch(
+            "factory.telemetry.LangfuseOtelSpanAttributes",
+            mock_attrs,
+            create=True,
+        ):
+            # Patch the import inside the function
+            with patch.dict("sys.modules", {
+                "langfuse._client.attributes": MagicMock(
+                    LangfuseOtelSpanAttributes=mock_attrs,
+                ),
+            }):
+                telemetry_mod._set_trace_name_on_span(mock_obs, "my-trace", {"key": "val"})
+
+        mock_otel_span.set_attribute.assert_any_call("langfuse.trace.name", "my-trace")
+        mock_otel_span.set_attribute.assert_any_call(
+            "langfuse.trace.input", '{"key": "val"}',
+        )
+
+    def test_sets_string_input_directly(self) -> None:
+        mock_otel_span = MagicMock()
+        mock_otel_span.is_recording.return_value = True
+        mock_obs = MagicMock()
+        mock_obs._otel_span = mock_otel_span
+
+        mock_attrs = MagicMock()
+        mock_attrs.TRACE_NAME = "langfuse.trace.name"
+        mock_attrs.TRACE_INPUT = "langfuse.trace.input"
+
+        with patch.dict("sys.modules", {
+            "langfuse._client.attributes": MagicMock(
+                LangfuseOtelSpanAttributes=mock_attrs,
+            ),
+        }):
+            telemetry_mod._set_trace_name_on_span(mock_obs, "my-trace", "raw string input")
+
+        mock_otel_span.set_attribute.assert_any_call("langfuse.trace.input", "raw string input")
+
+    def test_skips_when_no_otel_span(self) -> None:
+        mock_obs = MagicMock(spec=[])  # no _otel_span attribute
+        with patch.dict("sys.modules", {
+            "langfuse._client.attributes": MagicMock(),
+        }):
+            # Should not raise
+            telemetry_mod._set_trace_name_on_span(mock_obs, "name")
+
+    def test_skips_when_not_recording(self) -> None:
+        mock_otel_span = MagicMock()
+        mock_otel_span.is_recording.return_value = False
+        mock_obs = MagicMock()
+        mock_obs._otel_span = mock_otel_span
+
+        with patch.dict("sys.modules", {
+            "langfuse._client.attributes": MagicMock(),
+        }):
+            telemetry_mod._set_trace_name_on_span(mock_obs, "name")
+
+        mock_otel_span.set_attribute.assert_not_called()
+
+    def test_handles_import_error_gracefully(self) -> None:
+        mock_obs = MagicMock()
+        # Remove the module so import fails inside the function
+        with patch.dict("sys.modules", {"langfuse._client.attributes": None}):
+            # Should not raise
+            telemetry_mod._set_trace_name_on_span(mock_obs, "name")
+
+
+class TestBeginTraceDisabled:
+    """Cover line 80: begin_trace returns None when disabled."""
+
+    def test_returns_none_when_disabled(self) -> None:
+        telemetry_mod._client = None
+        with patch.object(telemetry_mod, "_HAS_LANGFUSE", False):
+            assert telemetry_mod.begin_trace("proj", "c1") is None
+
+
+class TestBeginSpanBranches:
+    """Cover lines 112, 127, 136: begin_span edge cases."""
+
+    def test_returns_none_when_disabled(self) -> None:
+        telemetry_mod._client = None
+        with patch.object(telemetry_mod, "_HAS_LANGFUSE", False):
+            assert telemetry_mod.begin_span("t1", "p1", "builder") is None
+
+    def test_with_trace_context_and_parent_span_id(self) -> None:
+        """Line 127: parent_span_id provided but not in _observations."""
+        mock_client = MagicMock()
+        mock_obs = MagicMock()
+        mock_obs.id = "span-tc"
+        mock_obs.trace_id = "trace-tc"
+        mock_client.start_observation.return_value = mock_obs
+        telemetry_mod._client = mock_client
+        # parent_span_id given but NOT in _observations => falls to elif trace_id
+        result = telemetry_mod.begin_span("trace-tc", "missing-parent", "qa")
+        assert result == "span-tc"
+        call_kwargs = mock_client.start_observation.call_args[1]
+        assert call_kwargs["trace_context"] == {
+            "trace_id": "trace-tc",
+            "parent_span_id": "missing-parent",
+        }
+
+    def test_with_no_trace_id_and_no_parent(self) -> None:
+        """Line 136: no parent obs, empty trace_id."""
+        mock_client = MagicMock()
+        mock_obs = MagicMock()
+        mock_obs.id = "span-bare"
+        mock_obs.trace_id = "trace-bare"
+        mock_client.start_observation.return_value = mock_obs
+        telemetry_mod._client = mock_client
+
+        result = telemetry_mod.begin_span("", None, "researcher", task="do stuff")
+        assert result == "span-bare"
+        mock_client.start_observation.assert_called_once_with(
+            name="agent:researcher",
+            as_type="span",
+            input="do stuff",
+            metadata={"role": "researcher", "model": None},
+        )
+
+
+class TestEndSpanBranches:
+    """Cover lines 159, 162: end_span edge cases."""
+
+    def test_noop_when_disabled(self) -> None:
+        telemetry_mod._client = None
+        with patch.object(telemetry_mod, "_HAS_LANGFUSE", False):
+            telemetry_mod.end_span("t1", "s1")  # should not raise
+
+    def test_noop_when_empty_span_id(self) -> None:
+        telemetry_mod._client = MagicMock()
+        telemetry_mod.end_span("t1", "")  # should not raise
+
+    def test_noop_when_span_not_found(self) -> None:
+        telemetry_mod._client = MagicMock()
+        telemetry_mod.end_span("t1", "nonexistent")  # should not raise
+
+    def test_usage_from_object_attrs(self) -> None:
+        """Usage as an object with attributes instead of dict."""
+        mock_obs = MagicMock()
+        telemetry_mod._client = MagicMock()
+        telemetry_mod._observations["s1"] = mock_obs
+
+        class UsageObj:
+            input_tokens = 200
+            output_tokens = 100
+            cache_read_tokens = 50
+            total_cost_usd = 0.1
+            duration_ms = 500.0
+            num_turns = 3
+            model = "opus"
+
+        telemetry_mod.end_span("t1", "s1", usage=UsageObj())
+        meta = mock_obs.update.call_args[1]["metadata"]
+        assert meta["input_tokens"] == 200
+        assert meta["model"] == "opus"
+
+
+class TestEndTraceBranches:
+    """Cover lines 186, 189->193: end_trace edge cases."""
+
+    def test_noop_when_disabled(self) -> None:
+        telemetry_mod._client = None
+        with patch.object(telemetry_mod, "_HAS_LANGFUSE", False):
+            telemetry_mod.end_trace("t1")  # should not raise
+
+    def test_obs_not_found(self) -> None:
+        """Line 189->193: obs is None, should just log."""
+        telemetry_mod._client = MagicMock()
+        telemetry_mod.end_trace("t1", span_id="nonexistent")  # should not raise
+
+    def test_with_custom_output(self) -> None:
+        mock_obs = MagicMock()
+        telemetry_mod._client = MagicMock()
+        telemetry_mod._observations["s1"] = mock_obs
+        telemetry_mod.end_trace("t1", span_id="s1", output="done!")
+        mock_obs.update.assert_called_once_with(output="done!")
+
+
+class TestFindTranscriptFallback:
+    """Cover lines 223->229, 225->224, 228: fallback directory search."""
+
+    def test_finds_transcript_via_fallback_search(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        claude_dir = tmp_path / "claude-config" / "projects"
+        # Put the transcript in a differently-named dir
+        other_dir = claude_dir / "some-other-project-dir"
+        other_dir.mkdir(parents=True)
+        transcript_file = other_dir / "sess-fallback.jsonl"
+        transcript_file.write_text('{"type":"user"}\n')
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+        project_path = tmp_path / "my-project"
+
+        result = telemetry_mod._find_transcript("sess-fallback", project_path)
+        assert result == transcript_file
+
+    def test_returns_none_when_not_found_anywhere(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        claude_dir = tmp_path / "claude-config" / "projects"
+        claude_dir.mkdir(parents=True)
+
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+        project_path = tmp_path / "my-project"
+
+        result = telemetry_mod._find_transcript("nonexistent-session", project_path)
+        assert result is None
+
+
+class TestProcessTranscriptItem:
+    """Cover _process_transcript_item for various item types."""
+
+    def _make_parent(self) -> MagicMock:
+        parent = MagicMock()
+        tool_obs = MagicMock()
+        parent.start_observation.return_value = tool_obs
+        return parent
+
+    def test_user_string_content(self) -> None:
+        """Line 254: content part is a raw string."""
+        parent = self._make_parent()
+        item = {"type": "user", "message": {"content": ["hello world"]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        parent.create_event.assert_called_once_with(name="user_message", input="hello world")
+
+    def test_user_text_type_part(self) -> None:
+        """Line 269->252: text type dict in user content."""
+        parent = self._make_parent()
+        item = {"type": "user", "message": {"content": [
+            {"type": "text", "text": "some text"},
+        ]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        parent.create_event.assert_called_once_with(name="user_message", input="some text")
+
+    def test_user_tool_result_not_in_pending(self) -> None:
+        """Lines 280-285: tool_result with tool_use_id not in pending_tools."""
+        parent = self._make_parent()
+        item = {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "orphan-id", "content": ["result data"]},
+        ]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        parent.create_event.assert_called_once_with(
+            name="tool_output",
+            output="result data",
+            metadata={"tool_use_id": "orphan-id"},
+        )
+
+    def test_user_tool_result_with_list_content(self) -> None:
+        """Tool result content is a list."""
+        parent = self._make_parent()
+        tool_obs = MagicMock()
+        pending = {"tu-1": tool_obs}
+        item = {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "tu-1", "content": ["part1", "part2"]},
+        ]}}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        tool_obs.update.assert_called_once_with(output="part1part2")
+        tool_obs.end.assert_called_once()
+        assert "tu-1" not in pending
+
+    def test_user_empty_text_ignored(self) -> None:
+        """Lines 289->355: text parts present but empty => no event."""
+        parent = self._make_parent()
+        item = {"type": "user", "message": {"content": [
+            {"type": "text", "text": "   "},
+        ]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 0
+        parent.create_event.assert_not_called()
+
+    def test_assistant_non_dict_content_skipped(self) -> None:
+        """Line 301: non-dict content parts are skipped."""
+        parent = self._make_parent()
+        item = {"type": "assistant", "message": {"content": [
+            "raw string part",
+            {"type": "text", "text": "real text"},
+        ]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        parent.create_event.assert_called_once_with(name="assistant_message", output="real text")
+
+    def test_assistant_empty_text_skipped(self) -> None:
+        """Lines 305->299: empty text in assistant content."""
+        parent = self._make_parent()
+        item = {"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "  "},
+        ]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 0
+
+    def test_assistant_tool_use_no_id(self) -> None:
+        """Line 323: tool_use with empty id => ends immediately."""
+        parent = self._make_parent()
+        tool_obs = MagicMock()
+        parent.start_observation.return_value = tool_obs
+        item = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Bash", "input": {"cmd": "ls"}, "id": ""},
+        ]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        tool_obs.end.assert_called_once()
+        assert len(pending) == 0
+
+    def test_assistant_thinking_type(self) -> None:
+        """Lines 325-332: thinking content type."""
+        parent = self._make_parent()
+        item = {"type": "assistant", "message": {"content": [
+            {"type": "thinking", "thinking": "Let me think about this..."},
+        ]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        parent.create_event.assert_called_once_with(
+            name="thinking", output="Let me think about this...",
+        )
+
+    def test_assistant_thinking_empty_skipped(self) -> None:
+        parent = self._make_parent()
+        item = {"type": "assistant", "message": {"content": [
+            {"type": "thinking", "thinking": "   "},
+        ]}}
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 0
+
+    def test_tool_result_type_with_pending(self) -> None:
+        """Lines 334-353: top-level tool_result item type with matching pending."""
+        parent = self._make_parent()
+        tool_obs = MagicMock()
+        pending = {"tu-2": tool_obs}
+        item = {
+            "type": "tool_result",
+            "tool_use_id": "tu-2",
+            "content": [{"type": "text", "text": "output here"}],
+        }
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        tool_obs.update.assert_called_once_with(output="output here")
+        tool_obs.end.assert_called_once()
+
+    def test_tool_result_type_without_pending(self) -> None:
+        """Lines 348-352: top-level tool_result with no matching pending."""
+        parent = self._make_parent()
+        pending: dict[str, Any] = {}
+        item = {
+            "type": "tool_result",
+            "tool_use_id": "tu-orphan",
+            "content": ["string content"],
+        }
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 1
+        parent.create_event.assert_called_once_with(name="tool_output", output="string content")
+
+    def test_tool_result_type_empty_text_ignored(self) -> None:
+        """tool_result with empty text."""
+        parent = self._make_parent()
+        pending: dict[str, Any] = {}
+        item = {
+            "type": "tool_result",
+            "tool_use_id": "tu-x",
+            "content": [{"type": "text", "text": "   "}],
+        }
+        count = telemetry_mod._process_transcript_item(item, parent, pending)
+        assert count == 0
+
+    def test_unknown_type_returns_zero(self) -> None:
+        parent = self._make_parent()
+        pending: dict[str, Any] = {}
+        count = telemetry_mod._process_transcript_item(
+            {"type": "system"}, parent, pending,
+        )
+        assert count == 0
+
+
+class TestIngestTranscriptEdgeCases:
+    """Cover lines 370, 379-380, 389, 392-393, 397-398."""
+
+    def test_returns_false_when_disabled(self, tmp_path: Path) -> None:
+        """Line 370."""
+        telemetry_mod._client = None
+        with patch.object(telemetry_mod, "_HAS_LANGFUSE", False):
+            assert telemetry_mod.ingest_transcript_to_span(
+                "t1", "s1", "sess", tmp_path,
+            ) is False
+
+    def test_returns_false_when_parent_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 379-380."""
+        telemetry_mod._client = MagicMock()
+        # Create a transcript file so _find_transcript succeeds
+        claude_dir = tmp_path / "claude-config" / "projects"
+        dir_name = str(tmp_path.resolve()).replace("/", "-").replace(".", "-")
+        transcript_dir = claude_dir / dir_name
+        transcript_dir.mkdir(parents=True)
+        (transcript_dir / "sess-1.jsonl").write_text('{"type":"user"}\n')
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+
+        # _observations does NOT have span-1
+        assert telemetry_mod.ingest_transcript_to_span(
+            "t1", "span-1", "sess-1", tmp_path,
+        ) is False
+
+    def test_handles_empty_lines_and_bad_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 389, 392-393: empty lines and JSON decode errors."""
+        telemetry_mod._client = MagicMock()
+        mock_parent = MagicMock()
+        telemetry_mod._observations["s1"] = mock_parent
+
+        claude_dir = tmp_path / "claude-config" / "projects"
+        dir_name = str(tmp_path.resolve()).replace("/", "-").replace(".", "-")
+        transcript_dir = claude_dir / dir_name
+        transcript_dir.mkdir(parents=True)
+        transcript_file = transcript_dir / "sess-bad.jsonl"
+        transcript_file.write_text("\n\n{not valid json}\n\n")
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+
+        result = telemetry_mod.ingest_transcript_to_span(
+            "t1", "s1", "sess-bad", tmp_path,
+        )
+        assert result is False  # no observations created
+
+    def test_cleans_up_pending_tools(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 397-398: leftover pending tools get ended."""
+        telemetry_mod._client = MagicMock()
+        mock_parent = MagicMock()
+        mock_tool_obs = MagicMock()
+        mock_parent.start_observation.return_value = mock_tool_obs
+        telemetry_mod._observations["s1"] = mock_parent
+
+        claude_dir = tmp_path / "claude-config" / "projects"
+        dir_name = str(tmp_path.resolve()).replace("/", "-").replace(".", "-")
+        transcript_dir = claude_dir / dir_name
+        transcript_dir.mkdir(parents=True)
+        transcript_file = transcript_dir / "sess-pending.jsonl"
+        # Tool use with no matching result
+        items = [
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Read", "input": {}, "id": "tu-999"},
+            ]}},
+        ]
+        transcript_file.write_text(
+            "\n".join(json.dumps(i) for i in items) + "\n",
+        )
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+
+        result = telemetry_mod.ingest_transcript_to_span(
+            "t1", "s1", "sess-pending", tmp_path,
+        )
+        assert result is True
+        mock_tool_obs.update.assert_called_with(metadata={"status": "no_result"})
+        mock_tool_obs.end.assert_called_once()
+
+
+class TestFindRecentTranscript:
+    """Cover line 421: no candidates after session_start."""
+
+    def test_returns_none_when_no_recent_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+        claude_dir = tmp_path / "claude-config" / "projects"
+        dir_name = str(tmp_path.resolve()).replace("/", "-").replace(".", "-")
+        proj_dir = claude_dir / dir_name
+        proj_dir.mkdir(parents=True)
+        # Create a file but set session_start far in the future
+        old_file = proj_dir / "old-session.jsonl"
+        old_file.write_text("{}\n")
+        result = telemetry_mod._find_recent_transcript(tmp_path, _time.time() + 9999)
+        assert result is None
+
+    def test_returns_most_recent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+        claude_dir = tmp_path / "claude-config" / "projects"
+        dir_name = str(tmp_path.resolve()).replace("/", "-").replace(".", "-")
+        proj_dir = claude_dir / dir_name
+        proj_dir.mkdir(parents=True)
+
+        session_start = _time.time() - 10
+        f1 = proj_dir / "sess-a.jsonl"
+        f2 = proj_dir / "sess-b.jsonl"
+        f1.write_text("{}\n")
+        _time.sleep(0.05)
+        f2.write_text("{}\n")
+
+        result = telemetry_mod._find_recent_transcript(tmp_path, session_start)
+        assert result == f2
+
+    def test_returns_none_when_dir_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+        result = telemetry_mod._find_recent_transcript(tmp_path, 0.0)
+        assert result is None
+
+
+class TestTranscriptTailer:
+    """Cover TranscriptTailer: start, stop_and_drain, _run, _ingest_new_lines."""
+
+    def _make_tailer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        *, on_line: Any = None,
+    ) -> telemetry_mod.TranscriptTailer:
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude-config"))
+        telemetry_mod._client = MagicMock()
+        mock_parent = MagicMock()
+        telemetry_mod._observations["span-tailer"] = mock_parent
+
+        tailer = telemetry_mod.TranscriptTailer(
+            trace_id="trace-tailer",
+            span_id="span-tailer",
+            project_path=tmp_path,
+            session_start=_time.time() - 10,
+            on_line=on_line,
+        )
+        # Use very short intervals for tests
+        tailer.POLL_INTERVAL = 0.05
+        tailer.FIND_TIMEOUT = 0.5
+        tailer.FIND_INTERVAL = 0.05
+        return tailer
+
+    def _create_transcript(self, tmp_path: Path, lines: list[str]) -> Path:
+        claude_dir = tmp_path / "claude-config" / "projects"
+        dir_name = str(tmp_path.resolve()).replace("/", "-").replace(".", "-")
+        proj_dir = claude_dir / dir_name
+        proj_dir.mkdir(parents=True, exist_ok=True)
+        transcript_file = proj_dir / "tailer-sess.jsonl"
+        transcript_file.write_text("\n".join(lines) + "\n")
+        return transcript_file
+
+    def test_start_and_stop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Lines 476-477, 483-484: basic start/stop lifecycle."""
+        items = [
+            json.dumps({"type": "user", "message": {"content": ["hello"]}}),
+        ]
+        self._create_transcript(tmp_path, items)
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+        tailer.start()
+        _time.sleep(0.3)
+        count = tailer.stop_and_drain()
+        assert count >= 1
+
+    def test_stop_without_start(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """stop_and_drain when thread was never started."""
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+        count = tailer.stop_and_drain()
+        assert count == 0
+
+    def test_stop_drains_pending_tools(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 483-484: pending tools cleaned up on stop."""
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+        mock_tool = MagicMock()
+        tailer._pending_tools["tu-left"] = mock_tool
+        tailer.stop_and_drain()
+        mock_tool.update.assert_called_with(metadata={"status": "no_result"})
+        mock_tool.end.assert_called_once()
+
+    def test_stop_handles_pending_tool_exception(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 483-484: exception during pending tool cleanup."""
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+        mock_tool = MagicMock()
+        mock_tool.update.side_effect = RuntimeError("boom")
+        tailer._pending_tools["tu-err"] = mock_tool
+        # Should not raise
+        tailer.stop_and_drain()
+
+    def test_stop_handles_final_drain_exception(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 476-477: exception during final drain."""
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+        transcript_path = self._create_transcript(tmp_path, ['{"type":"user"}'])
+        tailer._transcript_path = transcript_path
+
+        with patch.object(tailer, "_ingest_new_lines", side_effect=RuntimeError("drain fail")):
+            count = tailer.stop_and_drain()
+        assert count == 0
+
+    def test_run_transcript_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 500-501: transcript never appears within timeout."""
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+        tailer.FIND_TIMEOUT = 0.1
+        tailer.start()
+        _time.sleep(0.3)
+        count = tailer.stop_and_drain()
+        assert count == 0
+
+    def test_ingest_with_on_line_callback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 530, 535-536: on_line callback and empty lines."""
+        collected: list[bytes] = []
+        items = [
+            json.dumps({"type": "user", "message": {"content": ["hi"]}}),
+            "",  # empty line
+            json.dumps({"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "hello"},
+            ]}}),
+        ]
+        self._create_transcript(tmp_path, items)
+        tailer = self._make_tailer(tmp_path, monkeypatch, on_line=collected.append)
+        tailer.start()
+        _time.sleep(0.3)
+        count = tailer.stop_and_drain()
+        assert count >= 2
+        assert len(collected) >= 2
+        assert all(isinstance(b, bytes) for b in collected)
+
+    def test_on_line_exception_handled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 535-536: on_line raises."""
+
+        def bad_callback(data: bytes) -> None:
+            raise ValueError("callback error")
+
+        items = [json.dumps({"type": "user", "message": {"content": ["hi"]}})]
+        self._create_transcript(tmp_path, items)
+        tailer = self._make_tailer(tmp_path, monkeypatch, on_line=bad_callback)
+        tailer.start()
+        _time.sleep(0.3)
+        count = tailer.stop_and_drain()
+        # Should still ingest despite callback error
+        assert count >= 1
+
+    def test_ingest_json_decode_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 543-544: bad JSON in transcript."""
+        items = [
+            "{invalid json!!!",
+            json.dumps({"type": "user", "message": {"content": ["valid"]}}),
+        ]
+        self._create_transcript(tmp_path, items)
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+        tailer.start()
+        _time.sleep(0.3)
+        count = tailer.stop_and_drain()
+        assert count >= 1  # the valid line
+
+    def test_ingest_item_processing_exception(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 549-550: _process_transcript_item raises."""
+        items = [json.dumps({"type": "user", "message": {"content": ["hi"]}})]
+        self._create_transcript(tmp_path, items)
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+
+        with patch.object(
+            telemetry_mod, "_process_transcript_item",
+            side_effect=RuntimeError("process error"),
+        ):
+            tailer.start()
+            _time.sleep(0.3)
+            count = tailer.stop_and_drain()
+        assert count == 0
+
+    def test_ingest_no_parent_span(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Line 538: parent is None => skip processing."""
+        items = [json.dumps({"type": "user", "message": {"content": ["hi"]}})]
+        self._create_transcript(tmp_path, items)
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+        # Remove the parent span from observations
+        telemetry_mod._observations.pop("span-tailer", None)
+        tailer.start()
+        _time.sleep(0.3)
+        count = tailer.stop_and_drain()
+        assert count == 0
+
+    def test_run_ingest_exception_in_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Lines 507-508: exception during _ingest_new_lines in run loop."""
+        items = [json.dumps({"type": "user", "message": {"content": ["hi"]}})]
+        self._create_transcript(tmp_path, items)
+        tailer = self._make_tailer(tmp_path, monkeypatch)
+
+        call_count = 0
+        original_ingest = tailer._ingest_new_lines
+
+        def failing_ingest() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise RuntimeError("ingest error")
+            original_ingest()
+
+        tailer._ingest_new_lines = failing_ingest  # type: ignore[assignment]
+        tailer.start()
+        _time.sleep(0.5)
+        tailer.stop_and_drain()
+        assert call_count >= 2  # confirms it retried after error

--- a/tests/test_template_score.py
+++ b/tests/test_template_score.py
@@ -1,0 +1,213 @@
+"""Tests for factory/templates/score.py — template eval script."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from factory.templates.score import eval_lint, eval_tests, main
+
+
+# ---------------------------------------------------------------------------
+# eval_tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvalTests:
+    """Tests for eval_tests()."""
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_passing_tests(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="5 passed in 0.3s",
+            stderr="",
+        )
+        result = eval_tests()
+        assert result["name"] == "tests"
+        assert result["score"] == 1.0
+        assert result["weight"] == 0.5
+        assert result["passed"] is True
+        assert "5 passed" in result["details"]
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_failing_tests(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="2 failed, 3 passed",
+            stderr="",
+        )
+        result = eval_tests()
+        assert result["name"] == "tests"
+        assert result["score"] == 0.0
+        assert result["weight"] == 0.5
+        assert result["passed"] is False
+        assert "2 failed" in result["details"]
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_timeout(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="pytest", timeout=300)
+        result = eval_tests()
+        assert result["name"] == "tests"
+        assert result["score"] == 0.0
+        assert result["passed"] is False
+        assert "timed out" in result["details"]
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_empty_stdout_falls_back_to_stderr(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="FATAL: collection error",
+        )
+        result = eval_tests()
+        assert result["passed"] is False
+        assert "FATAL" in result["details"]
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_details_truncated_to_500_chars(self, mock_run: MagicMock) -> None:
+        long_output = "x" * 1000
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=long_output,
+            stderr="",
+        )
+        result = eval_tests()
+        assert len(result["details"]) == 500
+
+
+# ---------------------------------------------------------------------------
+# eval_lint
+# ---------------------------------------------------------------------------
+
+
+class TestEvalLint:
+    """Tests for eval_lint()."""
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_clean_lint(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="All checks passed!",
+            stderr="",
+        )
+        result = eval_lint()
+        assert result["name"] == "lint"
+        assert result["score"] == 1.0
+        assert result["weight"] == 0.3
+        assert result["passed"] is True
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_lint_violations_partial_score(self, mock_run: MagicMock) -> None:
+        # 3 violation lines + 1 summary line = 4 lines total
+        # violation_count = max(0, 4 - 1) = 3
+        # score = max(0.0, 1.0 - 3 * 0.1) = 0.7
+        stdout = (
+            "file1.py:1:1: E501 line too long\n"
+            "file2.py:2:1: E302 expected 2 blank lines\n"
+            "file3.py:3:1: W291 trailing whitespace\n"
+            "Found 3 errors."
+        )
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout=stdout,
+            stderr="",
+        )
+        result = eval_lint()
+        assert result["name"] == "lint"
+        assert result["passed"] is False
+        assert result["score"] == 0.7
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_lint_many_violations_score_floors_at_zero(self, mock_run: MagicMock) -> None:
+        # 20 violation lines + 1 summary = 21 lines, violation_count = 20
+        # score = max(0.0, 1.0 - 20 * 0.1) = max(0.0, -1.0) = 0.0
+        lines = [f"file.py:{i}:1: E501 line too long" for i in range(20)]
+        lines.append("Found 20 errors.")
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="\n".join(lines),
+            stderr="",
+        )
+        result = eval_lint()
+        assert result["score"] == 0.0
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_lint_timeout(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="ruff", timeout=60)
+        result = eval_lint()
+        assert result["name"] == "lint"
+        assert result["score"] == 0.0
+        assert result["weight"] == 0.3
+        assert result["passed"] is False
+        assert "timed out" in result["details"]
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_lint_empty_stdout(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        result = eval_lint()
+        assert result["details"] == "No output"
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_lint_details_truncated(self, mock_run: MagicMock) -> None:
+        long_output = "v" * 1000
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=long_output,
+            stderr="",
+        )
+        result = eval_lint()
+        assert len(result["details"]) == 500
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """Tests for main() — JSON output to stdout."""
+
+    @patch("factory.templates.score.EVALS", [])
+    def test_main_empty_evals(self, capsys) -> None:
+        main()
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data == {"results": []}
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_main_outputs_valid_json(self, mock_run: MagicMock, capsys) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        main()
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "results" in data
+        assert len(data["results"]) == 2
+        names = {r["name"] for r in data["results"]}
+        assert names == {"tests", "lint"}
+
+    @patch("factory.templates.score.EVALS")
+    def test_main_calls_all_evals(self, mock_evals: MagicMock, capsys) -> None:
+        fn1 = MagicMock(return_value={"name": "a", "score": 1.0, "weight": 0.5, "passed": True, "details": ""})
+        fn2 = MagicMock(return_value={"name": "b", "score": 0.5, "weight": 0.5, "passed": False, "details": "err"})
+        mock_evals.__iter__ = MagicMock(return_value=iter([fn1, fn2]))
+        main()
+        fn1.assert_called_once()
+        fn2.assert_called_once()
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data["results"]) == 2
+        assert data["results"][0]["name"] == "a"
+        assert data["results"][1]["name"] == "b"
+
+    @patch("factory.templates.score.subprocess.run")
+    def test_main_trailing_newline(self, mock_run: MagicMock, capsys) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        main()
+        captured = capsys.readouterr()
+        assert captured.out.endswith("\n")

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -313,3 +313,240 @@ class TestProfilePrecedence:
         load_config(profile="vertex")
         result = resolve("runner", cli_value=None, env_var="FACTORY_RUNNER", default="fallback")
         assert result == "claude"
+
+
+class TestResolveEmptyTomlValue:
+    """Cover the branch where toml_val is not None but strips to empty string."""
+
+    def test_empty_toml_value_falls_through_to_default(self) -> None:
+        from factory.user_config import resolve
+
+        # toml_val is "" -> strip -> empty -> skip -> use default
+        result = resolve("runner", config={"defaults": {"runner": ""}}, default="fallback")
+        assert result == "fallback"
+
+    def test_whitespace_toml_value_falls_through_to_default(self) -> None:
+        from factory.user_config import resolve
+
+        result = resolve("runner", config={"defaults": {"runner": "   "}}, default="fallback")
+        assert result == "fallback"
+
+    def test_none_default_when_toml_value_empty(self) -> None:
+        from factory.user_config import resolve
+
+        result = resolve("runner", config={"defaults": {"runner": ""}})
+        assert result is None
+
+
+class TestShowConfigCredentialsAndOtherSections:
+    """Cover show_config paths: credentials sections and 'other sections'."""
+
+    def test_show_config_masks_sensitive_in_defaults(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        config_dir.write_text(
+            '[defaults]\nrunner = "claude"\napi_key = "sk-secret-value-1234"'
+        )
+        output = show_config()
+        assert "claude" in output
+        # The api_key should be masked in defaults
+        assert "sk-secret-value-1234" not in output
+        assert "1234" in output
+        assert "****" in output
+
+    def test_show_config_reveal_shows_sensitive_in_defaults(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        config_dir.write_text(
+            '[defaults]\napi_key = "sk-secret-value-1234"'
+        )
+        output = show_config(reveal=True)
+        assert "sk-secret-value-1234" in output
+
+    def test_show_config_other_sections(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        config_dir.write_text(
+            '[defaults]\nrunner = "claude"\n\n'
+            '[custom_section]\nfoo = "bar"\nmy_secret_key = "hidden-9999"'
+        )
+        output = show_config()
+        # Other section should appear
+        assert "[custom_section]" in output
+        assert "foo = bar" in output
+        # Sensitive key in other section should be masked
+        assert "hidden-9999" not in output
+        assert "9999" in output
+
+    def test_show_config_other_section_reveal(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        config_dir.write_text(
+            '[custom_section]\nmy_secret_key = "hidden-9999"'
+        )
+        output = show_config(reveal=True)
+        assert "hidden-9999" in output
+
+    def test_show_config_non_dict_section_rendered(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        # A top-level section that is not defaults or credentials should be rendered
+        config_dir.write_text(
+            '[defaults]\nrunner = "claude"\n\n'
+            '[other]\nfoo = "val"'
+        )
+        output = show_config()
+        assert "[other]" in output
+        assert "foo = val" in output
+
+    def test_show_config_multiple_credential_profiles(self, config_dir: Path) -> None:
+        from factory.user_config import show_config
+
+        config_dir.write_text(
+            '[credentials.vertex]\nANTHROPIC_API_KEY = "sk-vert-1234"\n\n'
+            '[credentials.codex]\nCODEX_API_KEY = "sk-codex-5678"'
+        )
+        output = show_config()
+        assert "[credentials.vertex]" in output
+        assert "[credentials.codex]" in output
+        # Both keys should be masked
+        assert "sk-vert-1234" not in output
+        assert "sk-codex-5678" not in output
+        assert "1234" in output
+        assert "5678" in output
+
+
+class TestMigrateEnvToConfigMocked:
+    """Cover migrate_env_to_config with mocked tomli_w (since it's not installed)."""
+
+    def test_migrate_with_mocked_tomli_w(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+        from unittest.mock import MagicMock
+
+        # Mock tomli_w module
+        mock_tomli_w = MagicMock()
+        mock_tomli_w.dumps.return_value = '[defaults]\nrunner = "bob"\n'
+        monkeypatch.setitem(sys.modules, "tomli_w", mock_tomli_w)
+
+        # Clear all FACTORY_* env vars that migrate_env_to_config looks for
+        for key in (
+            "FACTORY_RUNNER", "FACTORY_MODEL", "FACTORY_PROJECTS_DIR",
+            "FACTORY_VAULT_PATH", "FACTORY_PLAYBOOKS_DIR", "FACTORY_REGISTRY_DIR",
+            "FACTORY_MANAGED_DIRS", "FACTORY_RUNNER_QUIET", "FACTORY_BOB_DRY_RUN",
+            "FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", "FACTORY_CEO_RESPAWN_DISABLED",
+            "FACTORY_CEO_MAX_RESPAWNS",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("FACTORY_RUNNER", "bob")
+        monkeypatch.setenv("FACTORY_MODEL", "opus")
+
+        from factory.user_config import migrate_env_to_config
+
+        msg = migrate_env_to_config()
+        assert "Migrated 2 env var(s)" in msg
+        assert config_dir.exists()
+
+        # Verify tomli_w.dumps was called with the right structure
+        call_args = mock_tomli_w.dumps.call_args[0][0]
+        assert "defaults" in call_args
+        assert call_args["defaults"]["runner"] == "bob"
+        assert call_args["defaults"]["model"] == "opus"
+
+    def test_migrate_no_env_vars_set(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_tomli_w = MagicMock()
+        mock_tomli_w.dumps.return_value = ""
+        monkeypatch.setitem(sys.modules, "tomli_w", mock_tomli_w)
+
+        # Clear all FACTORY_ env vars
+        for key in [
+            "FACTORY_RUNNER", "FACTORY_MODEL", "FACTORY_PROJECTS_DIR",
+            "FACTORY_VAULT_PATH", "FACTORY_PLAYBOOKS_DIR", "FACTORY_REGISTRY_DIR",
+            "FACTORY_MANAGED_DIRS", "FACTORY_RUNNER_QUIET", "FACTORY_BOB_DRY_RUN",
+            "FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", "FACTORY_CEO_RESPAWN_DISABLED",
+            "FACTORY_CEO_MAX_RESPAWNS",
+        ]:
+            monkeypatch.delenv(key, raising=False)
+
+        from factory.user_config import migrate_env_to_config
+
+        msg = migrate_env_to_config()
+        assert "0" in msg
+
+        # Should have been called with empty data (no defaults section)
+        call_args = mock_tomli_w.dumps.call_args[0][0]
+        assert call_args == {}
+
+    def test_migrate_refuses_existing_file(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_tomli_w = MagicMock()
+        monkeypatch.setitem(sys.modules, "tomli_w", mock_tomli_w)
+
+        config_dir.parent.mkdir(parents=True, exist_ok=True)
+        config_dir.write_text("existing")
+
+        from factory.user_config import migrate_env_to_config
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            migrate_env_to_config()
+
+    def test_migrate_import_error_without_tomli_w(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        # Ensure tomli_w is NOT importable
+        monkeypatch.delitem(sys.modules, "tomli_w", raising=False)
+
+        # Mock the import to raise ImportError
+        import builtins
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "tomli_w":
+                raise ImportError("No module named 'tomli_w'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+
+        from factory.user_config import migrate_env_to_config
+
+        with pytest.raises(ImportError, match="tomli_w is required"):
+            migrate_env_to_config()
+
+    def test_migrate_secure_permissions(
+        self, config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+        import stat
+        from unittest.mock import MagicMock
+
+        mock_tomli_w = MagicMock()
+        mock_tomli_w.dumps.return_value = '[defaults]\nrunner = "claude"\n'
+        monkeypatch.setitem(sys.modules, "tomli_w", mock_tomli_w)
+
+        for key in (
+            "FACTORY_RUNNER", "FACTORY_MODEL", "FACTORY_PROJECTS_DIR",
+            "FACTORY_VAULT_PATH", "FACTORY_PLAYBOOKS_DIR", "FACTORY_REGISTRY_DIR",
+            "FACTORY_MANAGED_DIRS", "FACTORY_RUNNER_QUIET", "FACTORY_BOB_DRY_RUN",
+            "FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", "FACTORY_CEO_RESPAWN_DISABLED",
+            "FACTORY_CEO_MAX_RESPAWNS",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("FACTORY_RUNNER", "claude")
+
+        from factory.user_config import migrate_env_to_config
+
+        migrate_env_to_config()
+        mode = stat.S_IMODE(config_dir.stat().st_mode)
+        assert mode == 0o600

--- a/tests/test_workflow_cli.py
+++ b/tests/test_workflow_cli.py
@@ -1,16 +1,37 @@
-"""Tests for factory/workflow/cli.py — _cmd_run() coverage."""
+"""Tests for factory/workflow/cli.py — full coverage."""
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from factory.workflow.cli import _cmd_run
+from factory.workflow.cli import (
+    _cmd_export_skills,
+    _cmd_lint_contributed,
+    _cmd_list,
+    _cmd_run,
+    _cmd_show,
+    _cmd_validate,
+    cmd_workflow,
+)
 from factory.workflow.executor import ExecutionResult
-from factory.workflow.primitives import DEFAULT_AGENT_POOL
+from factory.workflow.primitives import (
+    DEFAULT_AGENT_POOL,
+    AgentNode,
+    AgentRole,
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    Study,
+    VerdictType,
+    Workflow,
+)
 from factory.workflow.registry import WorkflowRegistry
 
 
@@ -120,3 +141,354 @@ class TestCmdRun:
             agent_pool=DEFAULT_AGENT_POOL,
             dry_run=True,
         )
+
+
+# ── helpers for new tests ──────────────────────────────────────
+
+
+def _build_simple_workflow() -> Workflow:
+    """Build a small workflow with various node types for testing."""
+    nodes: dict[str, AgentNode | FnNode | GateNode | ForkNode | JoinNode | Study] = {
+        "study": Study(id="study", reads=set(), writes={"observations"}, focus="code"),
+        "research": AgentNode(
+            id="research", role=AgentRole.RESEARCHER, reads={"observations"}, writes={"findings"}
+        ),
+        "gate": GateNode(
+            id="gate", evaluator_type="agent", reads={"findings"}, writes=set()
+        ),
+        "fork": ForkNode(id="fork", targets=["build_a", "build_b"], reads=set(), writes=set()),
+        "join": JoinNode(id="join", sources=["build_a", "build_b"], reads=set(), writes=set()),
+        "build_fn": FnNode(id="build_fn", reads=set(), writes={"artifact"}),
+    }
+    edges = [
+        Edge(source="study", target="research"),
+        Edge(source="research", target="gate"),
+        Edge(source="gate", target="fork", condition=VerdictType.PROCEED),
+        Edge(source="gate", target="study", condition=VerdictType.HALT),
+        Edge(source="fork", target="join"),
+    ]
+    return Workflow(name="test_wf", nodes=nodes, edges=edges, start_node="study")
+
+
+# ── cmd_workflow dispatch ──────────────────────────────────────
+
+
+class TestCmdWorkflow:
+    def test_no_subcommand_returns_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = argparse.Namespace()  # no workflow_command attr
+        assert cmd_workflow(args) == 1
+        assert "Usage:" in capsys.readouterr().out
+
+    def test_none_subcommand_returns_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = argparse.Namespace(workflow_command=None)
+        assert cmd_workflow(args) == 1
+        assert "Usage:" in capsys.readouterr().out
+
+    def test_unknown_subcommand_returns_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = argparse.Namespace(workflow_command="bogus")
+        assert cmd_workflow(args) == 1
+        assert "Unknown workflow subcommand: bogus" in capsys.readouterr().out
+
+    def test_dispatches_to_list(self) -> None:
+        args = argparse.Namespace(workflow_command="list", project_path=None)
+        with patch("factory.workflow.cli._cmd_list", return_value=0) as m:
+            assert cmd_workflow(args) == 0
+            m.assert_called_once_with(args)
+
+    def test_dispatches_to_show(self) -> None:
+        args = argparse.Namespace(workflow_command="show", name="build", project_path=None)
+        with patch("factory.workflow.cli._cmd_show", return_value=0) as m:
+            assert cmd_workflow(args) == 0
+            m.assert_called_once_with(args)
+
+    def test_dispatches_to_validate(self) -> None:
+        args = argparse.Namespace(workflow_command="validate", name="build", project_path=None)
+        with patch("factory.workflow.cli._cmd_validate", return_value=0) as m:
+            assert cmd_workflow(args) == 0
+            m.assert_called_once_with(args)
+
+    def test_dispatches_to_export_skills(self) -> None:
+        args = argparse.Namespace(workflow_command="export-skills")
+        with patch("factory.workflow.cli._cmd_export_skills", return_value=0) as m:
+            assert cmd_workflow(args) == 0
+            m.assert_called_once_with(args)
+
+    def test_dispatches_to_lint_contributed(self) -> None:
+        args = argparse.Namespace(workflow_command="lint-contributed")
+        with patch("factory.workflow.cli._cmd_lint_contributed", return_value=0) as m:
+            assert cmd_workflow(args) == 0
+            m.assert_called_once_with(args)
+
+
+# ── _cmd_list ──────────────────────────────────────────────────
+
+
+class TestCmdList:
+    def test_lists_workflows(self, capsys: pytest.CaptureFixture[str]) -> None:
+        wf = _build_simple_workflow()
+
+        @dataclass
+        class FakeEntry:
+            name: str
+            description: str = ""
+            path: str = ""
+            source: str = "builtin"
+
+        entries = [FakeEntry(name="test_wf")]
+
+        with (
+            patch.object(WorkflowRegistry, "list_workflows", return_value=entries),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=wf),
+        ):
+            args = argparse.Namespace(project_path=None)
+            result = _cmd_list(args)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "test_wf" in out
+        assert "study" in out  # start_node
+
+    def test_list_with_project_path(self, tmp_path: Path) -> None:
+        with (
+            patch.object(WorkflowRegistry, "list_workflows", return_value=[]),
+        ):
+            args = argparse.Namespace(project_path=str(tmp_path))
+            result = _cmd_list(args)
+        assert result == 0
+
+    def test_list_skips_none_workflows(self, capsys: pytest.CaptureFixture[str]) -> None:
+        @dataclass
+        class FakeEntry:
+            name: str
+            description: str = ""
+            path: str = ""
+            source: str = "builtin"
+
+        entries = [FakeEntry(name="missing")]
+
+        with (
+            patch.object(WorkflowRegistry, "list_workflows", return_value=entries),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=None),
+        ):
+            args = argparse.Namespace(project_path=None)
+            result = _cmd_list(args)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "missing" not in out.split("\n")[-1]  # not printed as a row
+
+
+# ── _cmd_show ──────────────────────────────────────────────────
+
+
+class TestCmdShow:
+    def test_unknown_workflow_returns_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=None):
+            args = argparse.Namespace(name="nope", project_path=None)
+            assert _cmd_show(args) == 1
+        assert "Unknown workflow: nope" in capsys.readouterr().out
+
+    def test_show_prints_graph(self, capsys: pytest.CaptureFixture[str]) -> None:
+        wf = _build_simple_workflow()
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=wf):
+            args = argparse.Namespace(name="test_wf", project_path=None)
+            assert _cmd_show(args) == 0
+
+        out = capsys.readouterr().out
+        assert "Workflow: test_wf" in out
+        assert "Start:    study" in out
+        assert "Nodes:" in out
+        assert "Edges:" in out
+        # Check node types are rendered
+        assert "Agent(researcher)" in out
+        assert "Gate(agent)" in out
+        assert "Fork(2)" in out
+        assert "Join(2)" in out
+        assert "Study" in out
+        assert "Fn" in out
+        # Check edge conditions
+        assert "proceed" in out
+        assert "halt" in out
+
+    def test_show_truncates_long_reads_writes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify reads/writes longer than 28 chars are truncated."""
+        long_reads = {f"very_long_read_name_{i}" for i in range(5)}
+        nodes: dict[str, FnNode] = {
+            "fn": FnNode(id="fn", reads=long_reads, writes=long_reads),
+        }
+        wf = Workflow(
+            name="long_wf",
+            nodes=nodes,
+            edges=[],
+            start_node="fn",
+        )
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=wf):
+            args = argparse.Namespace(name="long_wf", project_path=None)
+            assert _cmd_show(args) == 0
+
+        out = capsys.readouterr().out
+        assert "..." in out
+
+
+# ── _cmd_validate ──────────────────────────────────────────────
+
+
+class TestCmdValidate:
+    def test_unknown_workflow_returns_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=None):
+            args = argparse.Namespace(name="nope", project_path=None)
+            assert _cmd_validate(args) == 1
+        assert "Unknown workflow: nope" in capsys.readouterr().out
+
+    def test_valid_workflow_returns_0(self, capsys: pytest.CaptureFixture[str]) -> None:
+        wf = MagicMock()
+        wf.validate_graph.return_value = []
+        wf.nodes = {"a": MagicMock(), "b": MagicMock()}
+        wf.edges = [MagicMock()]
+
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=wf):
+            args = argparse.Namespace(name="ok_wf", project_path=None)
+            assert _cmd_validate(args) == 0
+
+        out = capsys.readouterr().out
+        assert "VALID" in out
+        assert "2 nodes" in out
+
+    def test_invalid_workflow_returns_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        wf = MagicMock()
+        wf.validate_graph.return_value = ["orphan node X", "missing edge Y"]
+
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=wf):
+            args = argparse.Namespace(name="bad_wf", project_path=None)
+            assert _cmd_validate(args) == 1
+
+        out = capsys.readouterr().out
+        assert "2 issue(s)" in out
+        assert "orphan node X" in out
+        assert "missing edge Y" in out
+
+
+# ── _cmd_export_skills ─────────────────────────────────────────
+
+
+class TestCmdExportSkills:
+    def test_export_no_verify(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        fake_paths = [tmp_path / "skill-a" / "SKILL.md", tmp_path / "skill-b" / "SKILL.md"]
+        for p in fake_paths:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("# skill content")
+
+        with (
+            patch.object(WorkflowRegistry, "discover", return_value={"wf1": MagicMock()}),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=MagicMock()),
+            patch(
+                "factory.workflow.skill_export.export_all_skills",
+                return_value=fake_paths,
+            ),
+        ):
+            args = argparse.Namespace(
+                output_dir=str(tmp_path), verify=False, project_path=None
+            )
+            assert _cmd_export_skills(args) == 0
+
+        out = capsys.readouterr().out
+        assert "Exported 2 skills" in out
+
+    def test_export_verify_pass(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        fake_path = tmp_path / "skill-a" / "SKILL.md"
+        fake_path.parent.mkdir(parents=True, exist_ok=True)
+        fake_path.write_text("# valid skill")
+
+        with (
+            patch.object(WorkflowRegistry, "discover", return_value={"wf1": MagicMock()}),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=MagicMock()),
+            patch("factory.workflow.skill_export.export_all_skills", return_value=[fake_path]),
+            patch("factory.workflow.skill_export.validate_skill", return_value=[]),
+        ):
+            args = argparse.Namespace(
+                output_dir=str(tmp_path), verify=True, project_path=None
+            )
+            assert _cmd_export_skills(args) == 0
+
+        out = capsys.readouterr().out
+        assert "All skills valid" in out
+
+    def test_export_verify_fail(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        fake_path = tmp_path / "skill-bad" / "SKILL.md"
+        fake_path.parent.mkdir(parents=True, exist_ok=True)
+        fake_path.write_text("# broken")
+
+        with (
+            patch.object(WorkflowRegistry, "discover", return_value={"wf1": MagicMock()}),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=MagicMock()),
+            patch("factory.workflow.skill_export.export_all_skills", return_value=[fake_path]),
+            patch("factory.workflow.skill_export.validate_skill", return_value=["missing section X"]),
+        ):
+            args = argparse.Namespace(
+                output_dir=str(tmp_path), verify=True, project_path=None
+            )
+            assert _cmd_export_skills(args) == 1
+
+        out = capsys.readouterr().out
+        assert "INVALID" in out
+        assert "missing section X" in out
+        assert "1 validation issue(s)" in out
+
+    def test_export_skips_none_workflows(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with (
+            patch.object(
+                WorkflowRegistry, "discover", return_value={"wf1": MagicMock(), "wf2": MagicMock()}
+            ),
+            patch.object(WorkflowRegistry, "get_workflow", side_effect=[MagicMock(), None]),
+            patch("factory.workflow.skill_export.export_all_skills", return_value=[]) as mock_export,
+        ):
+            args = argparse.Namespace(
+                output_dir=str(tmp_path), verify=False, project_path=None
+            )
+            _cmd_export_skills(args)
+
+        # Only 1 workflow should be passed (the non-None one)
+        workflows_arg = mock_export.call_args[0][1]
+        assert len(workflows_arg) == 1
+
+
+# ── _cmd_lint_contributed ──────────────────────────────────────
+
+
+class TestCmdLintContributed:
+    def test_clean_returns_0(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("factory.workflow.lint.lint_contributed", return_value=[]):
+            args = argparse.Namespace(path=str(tmp_path))
+            assert _cmd_lint_contributed(args) == 0
+        assert "clean" in capsys.readouterr().out
+
+    def test_issues_returns_1(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        @dataclass
+        class FakeLintIssue:
+            directory: str
+            check: str
+            message: str
+
+        issues = [
+            FakeLintIssue(directory="foo", check="missing_file", message="no README.md"),
+            FakeLintIssue(directory="bar", check="bad_meta", message="invalid meta dict"),
+        ]
+        with patch("factory.workflow.lint.lint_contributed", return_value=issues):
+            args = argparse.Namespace(path=str(tmp_path))
+            assert _cmd_lint_contributed(args) == 1
+
+        out = capsys.readouterr().out
+        assert "2 issue(s)" in out
+        assert "foo" in out
+        assert "no README.md" in out
+
+    def test_default_path_used(self) -> None:
+        """When path is None, uses the default contributed directory."""
+        with patch("factory.workflow.lint.lint_contributed", return_value=[]) as m:
+            args = argparse.Namespace(path=None)
+            _cmd_lint_contributed(args)
+
+        called_path = m.call_args[0][0]
+        assert "contributed" in str(called_path)

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,7 +1,6 @@
 """Tests for factory/worktree.py — git worktree lifecycle management."""
 
 import json
-import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,6 +1,7 @@
 """Tests for factory/worktree.py — git worktree lifecycle management."""
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -8,7 +9,9 @@ from unittest.mock import patch
 import pytest
 
 from factory.worktree import (
+    _bootstrap_unborn_repo,
     _has_active_sessions,
+    _is_unborn_repo,
     _seed_experiment_factory,
     create_experiment_worktree,
     create_worktree,
@@ -719,3 +722,103 @@ class TestSeedExperimentFactory:
 
         assert dest.is_dir()
         assert list(dest.iterdir()) == []
+
+
+@pytest.fixture
+def unborn_repo(tmp_path: Path) -> Path:
+    """Create a git repo with no commits (unborn HEAD)."""
+    project = tmp_path / "unborn"
+    project.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=project, capture_output=True, check=True)
+    factory_dir = project / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "config.json").write_text("{}")
+    return project
+
+
+class TestIsUnbornRepo:
+    def test_unborn_repo_detected(self, unborn_repo: Path) -> None:
+        assert _is_unborn_repo(unborn_repo) is True
+
+    def test_repo_with_commits_not_unborn(self, git_project: Path) -> None:
+        assert _is_unborn_repo(git_project) is False
+
+
+class TestBootstrapUnbornRepo:
+    def test_creates_initial_commit(self, unborn_repo: Path) -> None:
+        env = {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@test.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@test.com",
+            "HOME": str(unborn_repo.parent),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+        with patch.dict("os.environ", env):
+            _bootstrap_unborn_repo(unborn_repo)
+
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=unborn_repo, capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+
+    def test_commit_message_is_factory_bootstrap(self, unborn_repo: Path) -> None:
+        env = {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@test.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@test.com",
+            "HOME": str(unborn_repo.parent),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+        with patch.dict("os.environ", env):
+            _bootstrap_unborn_repo(unborn_repo)
+
+        result = subprocess.run(
+            ["git", "log", "--oneline", "-1"],
+            cwd=unborn_repo, capture_output=True, text=True,
+        )
+        assert "init (factory bootstrap)" in result.stdout
+
+
+class TestCreateWorktreeUnbornRepo:
+    def test_worktree_created_on_unborn_repo(self, unborn_repo: Path) -> None:
+        """create_worktree bootstraps an unborn repo and creates the worktree."""
+        env = {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@test.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@test.com",
+            "HOME": str(unborn_repo.parent),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+        with patch.dict("os.environ", env):
+            wt_path, branch = create_worktree(unborn_repo)
+
+        assert wt_path.exists()
+        assert branch.startswith("factory/run-")
+
+    def test_error_when_branch_missing_on_non_unborn_repo(self, git_project: Path) -> None:
+        """Raises RuntimeError if the base branch doesn't exist and repo is not unborn."""
+        with pytest.raises(RuntimeError, match="does not exist"):
+            create_worktree(git_project, base_branch="nonexistent-branch")
+
+
+class TestDetectDefaultBranchUnborn:
+    def test_unborn_repo_returns_branch_via_symbolic_ref(self, unborn_repo: Path) -> None:
+        """Unborn repo (no commits) still detects the branch name from symbolic HEAD."""
+        result = detect_default_branch(unborn_repo)
+        assert result == "main"
+
+    def test_unborn_repo_with_custom_branch(self, tmp_path: Path) -> None:
+        """Unborn repo initialized with a non-standard branch name."""
+        project = tmp_path / "custom-branch"
+        project.mkdir()
+        subprocess.run(
+            ["git", "init", "-b", "trunk"],
+            cwd=project, capture_output=True, check=True,
+        )
+
+        result = detect_default_branch(project)
+        assert result == "trunk"

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -804,6 +804,133 @@ class TestCreateWorktreeUnbornRepo:
             create_worktree(git_project, base_branch="nonexistent-branch")
 
 
+class TestDetectDefaultBranchRemoteHead:
+    def test_uses_remote_head_when_available(self, git_project: Path) -> None:
+        """detect_default_branch returns the remote HEAD ref when origin is configured."""
+        subprocess.run(
+            ["git", "remote", "add", "origin", str(git_project)],
+            cwd=git_project, capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
+            cwd=git_project, capture_output=True, check=True,
+        )
+
+        assert detect_default_branch(git_project) == "main"
+
+
+class TestPruneStaleNonexistentPath:
+    def test_returns_empty_for_nonexistent_path(self, tmp_path: Path) -> None:
+        gone = tmp_path / "does-not-exist"
+        assert prune_stale(gone) == []
+
+
+class TestSeedExperimentFactoryExistingDir:
+    def test_replaces_existing_directory(self, tmp_path: Path) -> None:
+        """When dest is an existing directory (not a symlink), it is replaced."""
+        source = tmp_path / ".factory"
+        source.mkdir()
+        (source / "config.json").write_text('{"new": true}')
+
+        dest = tmp_path / "worktree" / ".factory"
+        dest.mkdir(parents=True)
+        (dest / "stale.txt").write_text("old data")
+
+        _seed_experiment_factory(source, dest)
+
+        assert dest.is_dir()
+        assert not dest.is_symlink()
+        assert (dest / "config.json").read_text() == '{"new": true}'
+        assert not (dest / "stale.txt").exists()
+
+
+class TestEventEmissionFailure:
+    def test_event_error_does_not_propagate(self, git_project: Path) -> None:
+        """create_experiment_worktree swallows event emission errors."""
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=git_project, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        with patch("factory.events.emit_event", side_effect=RuntimeError("event bus down")):
+            wt_path, branch = create_experiment_worktree(git_project, 99, head_sha)
+
+        assert wt_path.exists()
+        assert branch == "factory/exp-99"
+
+
+class TestCreateWorktreeEventFailure:
+    def test_create_worktree_swallows_event_error(self, git_project: Path) -> None:
+        with patch("factory.events.emit_event", side_effect=RuntimeError("boom")):
+            wt_path, branch = create_worktree(git_project)
+
+        assert wt_path.exists()
+        assert branch.startswith("factory/run-")
+
+    def test_remove_worktree_swallows_event_error(self, git_project: Path) -> None:
+        wt_path, branch = create_worktree(git_project)
+
+        with patch("factory.events.emit_event", side_effect=RuntimeError("boom")):
+            remove_worktree(git_project, wt_path, branch)
+
+        assert not wt_path.exists()
+
+
+class TestCreateWorktreeExistingFactory:
+    def test_replaces_existing_factory_dir_with_symlink(self, tmp_path: Path) -> None:
+        """When .factory/ is tracked in git, the worktree gets a real dir that must be replaced."""
+        project = tmp_path / "project"
+        project.mkdir()
+
+        env = {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@test.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@test.com",
+            "HOME": str(tmp_path),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+
+        subprocess.run(["git", "init", "-b", "main"], cwd=project, capture_output=True, check=True)
+        factory_dir = project / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "config.json").write_text("{}")
+        subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial with .factory"],
+            cwd=project, capture_output=True, check=True, env=env,
+        )
+
+        wt_path, _ = create_worktree(project)
+
+        assert (wt_path / ".factory").is_symlink()
+        assert (wt_path / ".factory").resolve() == factory_dir.resolve()
+
+
+class TestPreserveTelemetryNoFactory:
+    def test_no_factory_dir_is_noop(self, git_project: Path) -> None:
+        """_preserve_telemetry returns early when worktree has no .factory/."""
+        from factory.worktree import _preserve_telemetry
+
+        fake_wt = git_project / "no-factory-here"
+        fake_wt.mkdir()
+
+        _preserve_telemetry(fake_wt, git_project)
+
+
+class TestDetectDefaultBranchFallback:
+    def test_fallback_when_all_detection_fails(self, tmp_path: Path) -> None:
+        """When every detection method fails, returns 'main'."""
+        project = tmp_path / "bare"
+        project.mkdir()
+        subprocess.run(["git", "init"], cwd=project, capture_output=True, check=True)
+
+        with patch("factory.worktree.subprocess.run", return_value=subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="",
+        )):
+            assert detect_default_branch(project) == "main"
+
+
 class TestDetectDefaultBranchUnborn:
     def test_unborn_repo_returns_branch_via_symbolic_ref(self, unborn_repo: Path) -> None:
         """Unborn repo (no commits) still detects the branch name from symbolic HEAD."""


### PR DESCRIPTION
When a git repo has no commits (unborn HEAD), `create_worktree` crashed with an unhandled CalledProcessError from `git rev-parse`. Now it detects unborn repos and auto-creates an initial empty commit before branching.

Also fixes `detect_default_branch` to correctly identify the branch name on unborn repos (e.g. `master` vs `main`) via `git symbolic-ref`.