### PR TITLE
fix: wire WorkflowRegistry into workflow CLI for user/project discovery

### DIFF
--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import structlog
 
-from factory.workflow.definitions import register_all
+from factory.workflow.registry import WorkflowRegistry
 from factory.workflow.executor import WorkflowExecutor
 from factory.workflow.primitives import (
     DEFAULT_AGENT_POOL,
@@ -54,11 +54,10 @@ def _cmd_run(args: argparse.Namespace) -> int:
     project_path = Path(args.project_path).resolve()
     dry_run = getattr(args, "dry_run", False)
 
-    workflows = register_all()
-    wf = workflows.get(name)
+    wf = WorkflowRegistry.get_workflow(name, project_path)
     if not wf:
         print(f"Unknown workflow: {name}")
-        print(f"Available: {', '.join(workflows)}")
+        print(f"Available: {', '.join(WorkflowRegistry._entries)}")
         return 1
 
     executor = WorkflowExecutor(
@@ -91,14 +90,17 @@ def _cmd_run(args: argparse.Namespace) -> int:
 
 def _cmd_list(args: argparse.Namespace) -> int:
     """List all registered workflows."""
-    workflows = register_all()
+    project_path = Path(getattr(args, "project_path", None) or ".").resolve()
+    entries = WorkflowRegistry.list_workflows(project_path)
 
     header = f"{'Name':<12} {'Nodes':>6} {'Edges':>6} {'Start Node':<20}"
     print(header)
     print("-" * len(header))
 
-    for name, wf in workflows.items():
-        print(f"{name:<12} {len(wf.nodes):>6} {len(wf.edges):>6} {wf.start_node:<20}")
+    for entry in entries:
+        wf = WorkflowRegistry.get_workflow(entry.name)
+        if wf:
+            print(f"{entry.name:<12} {len(wf.nodes):>6} {len(wf.edges):>6} {wf.start_node:<20}")
 
     return 0
 
@@ -106,8 +108,8 @@ def _cmd_list(args: argparse.Namespace) -> int:
 def _cmd_show(args: argparse.Namespace) -> int:
     """Show a workflow's graph as a node/edge table."""
     name = args.name
-    workflows = register_all()
-    wf = workflows.get(name)
+    project_path = Path(getattr(args, "project_path", None) or ".").resolve()
+    wf = WorkflowRegistry.get_workflow(name, project_path)
     if not wf:
         print(f"Unknown workflow: {name}")
         return 1
@@ -166,8 +168,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
 def _cmd_validate(args: argparse.Namespace) -> int:
     """Validate a workflow using NetworkX."""
     name = args.name
-    workflows = register_all()
-    wf = workflows.get(name)
+    project_path = Path(getattr(args, "project_path", None) or ".").resolve()
+    wf = WorkflowRegistry.get_workflow(name, project_path)
     if not wf:
         print(f"Unknown workflow: {name}")
         return 1
@@ -191,7 +193,13 @@ def _cmd_export_skills(args: argparse.Namespace) -> int:
     output_dir = Path(getattr(args, "output_dir", None) or ".").resolve()
     verify = getattr(args, "verify", False)
 
-    workflows = register_all()
+    project_path = Path(getattr(args, "project_path", None) or ".").resolve()
+    entries = WorkflowRegistry.discover(project_path)
+    workflows = {}
+    for name, entry in entries.items():
+        wf = WorkflowRegistry.get_workflow(name)
+        if wf:
+            workflows[name] = wf
     generated = export_all_skills(output_dir, workflows)
 
     print(f"Exported {len(generated)} skills to {output_dir}/")
@@ -248,15 +256,18 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     p.add_argument("--dry-run", action="store_true", help="Execute without real agent calls")
 
     # list
-    wf_sub.add_parser("list", help="List all registered workflows")
+    p = wf_sub.add_parser("list", help="List all registered workflows")
+    p.add_argument("--project-path", default=None, help="Project path for local workflow discovery")
 
     # show
     p = wf_sub.add_parser("show", help="Show workflow graph details")
     p.add_argument("name", help="Workflow name")
+    p.add_argument("--project-path", default=None, help="Project path for local workflow discovery")
 
     # validate
     p = wf_sub.add_parser("validate", help="Validate workflow graph structure")
     p.add_argument("name", help="Workflow name")
+    p.add_argument("--project-path", default=None, help="Project path for local workflow discovery")
 
     # export-skills
     p = wf_sub.add_parser("export-skills", help="Export workflows as SKILL.md files")
@@ -264,6 +275,7 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
         "--output-dir", default=".", help="Output directory (default: current directory)"
     )
     p.add_argument("--verify", action="store_true", help="Validate generated skills")
+    p.add_argument("--project-path", default=None, help="Project path for local workflow discovery")
 
     # lint-contributed
     p = wf_sub.add_parser("lint-contributed", help="Lint contributed workflow directories")

--- a/tests/test_workflow_cli.py
+++ b/tests/test_workflow_cli.py
@@ -11,6 +11,15 @@ import pytest
 from factory.workflow.cli import _cmd_run
 from factory.workflow.executor import ExecutionResult
 from factory.workflow.primitives import DEFAULT_AGENT_POOL
+from factory.workflow.registry import WorkflowRegistry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Reset registry state before each test."""
+    WorkflowRegistry.reset()
+    yield
+    WorkflowRegistry.reset()
 
 
 def _make_args(name: str, project_path: str, dry_run: bool = False) -> argparse.Namespace:
@@ -40,7 +49,7 @@ def _failure_result() -> ExecutionResult:
 class TestCmdRun:
     def test_unknown_workflow_returns_1(self, tmp_path: Path) -> None:
         args = _make_args("nonexistent", str(tmp_path))
-        with patch("factory.workflow.cli.register_all", return_value={}):
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=None):
             assert _cmd_run(args) == 1
 
     def test_success_returns_0(self, tmp_path: Path) -> None:
@@ -49,7 +58,7 @@ class TestCmdRun:
         mock_executor.execute = AsyncMock(return_value=_success_result())
 
         with (
-            patch("factory.workflow.cli.register_all", return_value={"build": mock_wf}),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=mock_wf),
             patch("factory.workflow.cli.WorkflowExecutor", return_value=mock_executor),
             patch("factory.agents.runner.begin_cycle_session", return_value="span-123") as mock_begin,
             patch("factory.agents.runner.complete_cycle_session") as mock_complete,
@@ -66,7 +75,7 @@ class TestCmdRun:
         mock_executor.execute = AsyncMock(return_value=_failure_result())
 
         with (
-            patch("factory.workflow.cli.register_all", return_value={"build": mock_wf}),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=mock_wf),
             patch("factory.workflow.cli.WorkflowExecutor", return_value=mock_executor),
             patch("factory.agents.runner.begin_cycle_session", return_value=None),
             patch("factory.agents.runner.complete_cycle_session"),
@@ -81,7 +90,7 @@ class TestCmdRun:
         mock_executor.execute = AsyncMock(side_effect=RuntimeError("boom"))
 
         with (
-            patch("factory.workflow.cli.register_all", return_value={"build": mock_wf}),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=mock_wf),
             patch("factory.workflow.cli.WorkflowExecutor", return_value=mock_executor),
             patch("factory.agents.runner.begin_cycle_session", return_value="span-456") as mock_begin,
             patch("factory.agents.runner.complete_cycle_session") as mock_complete,
@@ -98,7 +107,7 @@ class TestCmdRun:
         mock_executor.execute = AsyncMock(return_value=_success_result())
 
         with (
-            patch("factory.workflow.cli.register_all", return_value={"improve": mock_wf}),
+            patch.object(WorkflowRegistry, "get_workflow", return_value=mock_wf),
             patch("factory.workflow.cli.WorkflowExecutor", return_value=mock_executor) as mock_cls,
             patch("factory.agents.runner.begin_cycle_session", return_value=None),
             patch("factory.agents.runner.complete_cycle_session"),


### PR DESCRIPTION
## Summary
- Wire `WorkflowRegistry` into all workflow CLI commands so user/project workflows are discovered
- Replace direct `register_all()` calls (builtins-only) with `WorkflowRegistry` methods at all 5 call sites in `factory/workflow/cli.py`
- Add `--project-path` arg to `list`, `show`, `validate`, `export-skills` subcommands for project-local discovery

Fixes #1037

## Test plan
- [x] Existing tests updated and passing (22/22)
- [x] Reproduced bug before fix: `factory workflow list` and `factory workflow run my_swebench` fail to find project-local workflow
- [x] Verified fix: both commands discover and execute project-local workflow from `.factory/workflows/`
- [x] ruff clean, mypy clean

## Smoke test plan
- [x] Happy path: `factory workflow run my_swebench <project> --dry-run` discovers and executes project-local workflow
- [x] Regression: `factory workflow list` still shows all 23 builtins
- [x] Edge case: unknown workflow still prints "Unknown workflow" with available names

## Reproduction (before/after)

Setup — place a workflow file at `<project>/.factory/workflows/my_swebench.py` with `meta` dict and `workflow()` function per the `WorkflowRegistry` contract.

```
=== BEFORE (bug) ===
$ factory workflow list | grep my_swebench
(empty — not discovered)

$ factory workflow run my_swebench <project>
Unknown workflow: my_swebench
Available: build, design, discover, review, improve, parallel-improve, qa, deep-qa, legacybench, featurebench, programbench, swebench, terminalbench, tomswe, research, meta, refine, create, skill-refine, doc-generate, doc-update, spec-generate, spec-update

=== AFTER (fix) ===
$ factory workflow list --project-path <project>
my_swebench       4      4 study               

$ factory workflow run my_swebench <project> --dry-run
{
  "workflow": "my_swebench",
  "success": true,
  "halted": false,
  "halt_reason": "",
  "nodes_executed": 4,
  "duration_ms": 10.3,
  "files_produced": [
    ".factory/reviews/builder-latest.md",
    ".factory/reviews/study-output.md"
  ]
}
```

## Unit tests

```
$ pytest tests/test_workflow_cli.py tests/test_workflow_registry.py -v
22 passed in 0.10s
```
