### PR TITLE
feat: add optimize workflow mode for factory mode effectiveness tuning

### DIFF
--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -16,7 +16,7 @@ log = structlog.get_logger()
 _WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
 
 
-CEO_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "parallel-improve", "research", "review", "qa", "deep-qa", "create", "swebench"]
+CEO_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "optimize", "parallel-improve", "research", "review", "qa", "deep-qa", "create", "swebench"]
 
 
 RUN_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "parallel-improve", "research", "swebench"]

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -704,6 +704,7 @@ def build_parser() -> argparse.ArgumentParser:
         "build, discover, improve, meta, design (research + brainstorm → spec → build), "
         "research (autonomous research optimization), review (on-demand PR review), "
         "qa (QA verification pipeline for PRs), "
+        "optimize (analyze and tune factory mode effectiveness — requires --focus <mode_name>), "
         "or create (meta-mode for creating or updating factory modes — "
         "use --focus \"mode_name: change\" to update an existing mode)",
     )

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -390,6 +390,34 @@ def cmd_ceo(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
+    if mode == "optimize":
+        for flag in ("headless", "bg"):
+            if getattr(args, flag, False):
+                print(
+                    f"Error: --mode optimize requires foreground mode (incompatible with {flag})",
+                    file=sys.stderr,
+                )
+                return 1
+        if prompt_file:
+            print(
+                "Error: --mode optimize and --prompt are mutually exclusive.",
+                file=sys.stderr,
+            )
+            return 1
+        if not focus:
+            print(
+                "Error: --mode optimize requires --focus <target_mode_name>. "
+                "Example: factory ceo /path --mode optimize --focus improve",
+                file=sys.stderr,
+            )
+            return 1
+        if not Path(raw_path).expanduser().resolve().is_dir():
+            print(
+                "Error: --mode optimize requires an existing project directory.",
+                file=sys.stderr,
+            )
+            return 1
+
     if mode == "research":
         if prompt_file:
             print(
@@ -540,7 +568,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    if focus and mode not in ("improve", "research", "create") and not design_existing:
+    if focus and mode not in ("improve", "research", "create", "optimize") and not design_existing:
         print(
             f"Error: --focus (targeted mode) only works in improve, research, or create mode, got '{mode}'. "
             "The project must already be built before targeting specific items.",
@@ -587,10 +615,13 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     ensure_skills(wt_path)
 
     interactive = (
-        design_existing or bool(design_idea) or bool(research_ideation) or mode == "create"
+        design_existing or bool(design_idea) or bool(research_ideation)
+        or mode == "create" or mode == "optimize"
     )
     if mode == "create":
         ceo_mode = "create"
+    elif mode == "optimize":
+        ceo_mode = "optimize"
     elif mode == "design":
         ceo_mode = "design"
     elif interactive:
@@ -1889,6 +1920,32 @@ def _build_ceo_task(
             "\n\nRun Create mode: this mode creates a new factory mode (workflow + skill + "
             "CLI wiring + tests) from the user's description above. "
             "The full step-by-step playbook is in your system prompt above."
+        )
+    elif mode == "optimize":
+        task += (
+            f"\n\n## Optimize Mode\n\n"
+            f"**Target mode:** {focus}\n\n"
+            f"You are analyzing the `{focus}` workflow mode to identify performance "
+            f"weaknesses and generate targeted improvements.\n\n"
+            f"**Workflow:**\n"
+            f"1. Study the project to gather baseline context\n"
+            f"2. Spawn the Researcher to analyze `{focus}` mode performance:\n"
+            f"   - Keep/revert rates from .factory/results.tsv\n"
+            f"   - Agent redirect/timeout patterns from .factory/events.jsonl\n"
+            f"   - CEO verdict patterns from .factory/reviews/\n"
+            f"   - Workflow definition via `factory workflow show {focus}`\n"
+            f"   - SKILL.md at skills/workflow-{focus}/SKILL.md\n"
+            f"3. Review the analysis (CEO gate)\n"
+            f"4. Spawn the Strategist to generate a change specification\n"
+            f"5. Present changes to user for approval\n"
+            f"6. Delegate to create mode: "
+            f"`factory ceo {{project_path}} --mode create --focus \"{focus}: <changes>\"`\n\n"
+            f"**Constraints:**\n"
+            f"- Max 1 optimization per invocation\n"
+            f"- Do NOT propose removing safety gates or QA verification steps\n"
+            f"- Prefer prompt/gate/timeout changes over structural graph rewiring\n"
+            f"- The change spec must be implementable in a single PR\n"
+            f"- Create mode handles all QA — do NOT run your own deep-QA pipeline\n"
         )
     else:
         task += (

--- a/factory/models.py
+++ b/factory/models.py
@@ -519,7 +519,7 @@ class CycleState(BaseModel):
     started_at: datetime
     mode: Literal[
         "build", "create", "deep-qa", "design", "discover",
-        "improve", "meta", "parallel-improve", "qa", "refine",
+        "improve", "meta", "optimize", "parallel-improve", "qa", "refine",
         "research", "review", "swebench",
     ]
     initial_prompt: str = ""

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -11,6 +11,7 @@ W₈: Refine Mode
 W₉: Create Mode (meta-mode for creating new factory modes)
 W₁₀: Spec Generate Mode
 W₁₁: Spec Update Mode
+W₁₂: Optimize Mode (meta-mode: analyze mode performance → change spec → delegate to create)
 
 All 5 core workflows (build, improve, research, refine, create) use the deep-QA
 verification pipeline: 3 specialist agents (health_checker, code_reviewer,
@@ -51,6 +52,7 @@ __all__ = [
     "review_workflow",
     "refine_workflow",
     "create_workflow",
+    "optimize_workflow",
     "skill_refine_workflow",
     "doc_generate_workflow",
     "doc_update_workflow",
@@ -1757,6 +1759,203 @@ def create_workflow() -> Workflow:
     )
 
 
+# ── W₁₂: Optimize Mode ────────────────────────────────────────────
+
+
+def optimize_workflow() -> Workflow:
+    """W₁₂: Optimize Mode — analyze mode performance → change spec → delegate to create mode.
+
+    Study → Researcher(mode analysis) → CEO gate → Strategist(change spec) →
+    User approval gate → Archivist(async) → FnNode(delegate to create mode) →
+    Archivist(async)
+    """
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # ── Phase 1: Study ────────────────────────────────────────────
+    nodes["study"] = Study(
+        id="study",
+        command="factory study {project_path}",
+        writes={".factory/strategy/observations.md"},
+    )
+
+    # ── Phase 2: Researcher — analyze target mode performance ─────
+    nodes["researcher"] = AgentNode(
+        id="researcher",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Mode performance analysis. "
+            "Read the target mode name from the CEO task (--focus argument). "
+            "Analyze the target mode's effectiveness by reading:\n"
+            "1. Workflow definition: run `factory workflow show <target_mode>`\n"
+            "2. SKILL.md: read `skills/workflow-<target_mode>/SKILL.md`\n"
+            "3. Experiment history: read `.factory/results.tsv` — compute keep rate, "
+            "avg score delta per keep, revert rate, error rate for experiments "
+            "that ran under this mode\n"
+            "4. CEO verdicts: read `.factory/reviews/ceo-verdict-*.md` — count "
+            "REDIRECT and ABORT frequencies per agent role\n"
+            "5. Events: read `.factory/events.jsonl` — identify agent timeouts, "
+            "failures, and avg invocations per cycle\n"
+            "6. Archive: read `.factory/archive/` — extract qualitative patterns, "
+            "recurring failures, anti-patterns\n\n"
+            "Produce a structured performance report:\n"
+            "- Mode effectiveness metrics (keep rate, avg delta, cycle count)\n"
+            "- Agent-level metrics (redirect rate, timeout rate per role)\n"
+            "- Bottleneck identification (which nodes/gates cause most failures)\n"
+            "- Weakness classification (prompt quality, gate criteria, node ordering, "
+            "missing steps, timeout values)\n"
+            "- Specific recommendations with evidence\n\n"
+            "Write findings to .factory/strategy/research-mode-analysis.md."
+        ),
+        reads={".factory/strategy/observations.md"},
+        writes={".factory/strategy/research-mode-analysis.md"},
+        timeout=600,
+    )
+
+    # ── Phase 2b: CEO gate on research ────────────────────────────
+    nodes["gate_research"] = GateNode(
+        id="gate_research",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Review the mode performance analysis. "
+            "Is the analysis grounded in actual data (metrics, counts, evidence)? "
+            "Are the identified weaknesses specific and actionable? "
+            "Does the analysis cover all relevant data sources "
+            "(results.tsv, events.jsonl, CEO verdicts, archive)? "
+            "REDIRECT if the analysis is vague or missing key data sources."
+        ),
+        reads={".factory/strategy/research-mode-analysis.md"},
+    )
+
+    # ── Phase 3: Strategist — generate change specification ───────
+    nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Generate a workflow change specification for the target mode. "
+            "Read the mode performance analysis at "
+            ".factory/strategy/research-mode-analysis.md. "
+            "Read the CEO research review at "
+            ".factory/reviews/ceo-verdict-researcher.md.\n\n"
+            "Produce a change specification that includes:\n"
+            "1. Target mode name and current workflow summary\n"
+            "2. Identified weaknesses (with metrics from the analysis)\n"
+            "3. Proposed changes — for each change:\n"
+            "   - Which node/edge/gate/prompt to modify, add, or remove\n"
+            "   - What the current behavior is\n"
+            "   - What the new behavior should be\n"
+            "   - Expected impact on the identified weakness\n"
+            "4. Changes NOT proposed (and why — risk assessment)\n"
+            "5. A one-line summary suitable for --focus argument to create mode\n\n"
+            "Scope: The change spec must be implementable in a single PR. "
+            "Prefer targeted prompt/gate/timeout changes over structural graph rewiring. "
+            "Do NOT propose removing safety gates or QA steps.\n\n"
+            "Write the specification to .factory/strategy/current.md."
+        ),
+        reads={".factory/strategy/research-mode-analysis.md"},
+        writes={".factory/strategy/current.md"},
+        timeout=600,
+    )
+
+    # ── Phase 3b: User approval gate ──────────────────────────────
+    nodes["gate_strategy"] = GateNode(
+        id="gate_strategy",
+        evaluator_type="user",
+        gate_prompt=(
+            "Review the proposed workflow changes for the target mode. "
+            "The change specification describes what will be modified and why. "
+            "Approve to proceed with delegating to create mode, or provide feedback."
+        ),
+        reads={".factory/strategy/current.md"},
+    )
+
+    # ── Phase 4: Archivist (async) — archive the approved spec ────
+    nodes["archivist_plan"] = AgentNode(
+        id="archivist_plan",
+        role=AgentRole.ARCHIVIST,
+        prompt_template=(
+            "Archive the approved workflow optimization specification. "
+            "Record: target mode, identified weaknesses, proposed changes, "
+            "and the user's approval decision. "
+            "Write to .factory/archive/optimizer-plan.md."
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/archive/optimizer-plan.md"},
+        timeout=300,
+        blocking=False,
+    )
+
+    # ── Phase 5: Delegate to create mode ──────────────────────────
+    nodes["delegate_create"] = FnNode(
+        id="delegate_create",
+        command=(
+            'factory ceo {project_path} --mode create '
+            '--focus "$OPTIMIZE_TARGET: $OPTIMIZE_CHANGES"'
+        ),
+        notes=(
+            "Delegate the actual workflow modification to create mode. "
+            "The CEO must substitute $OPTIMIZE_TARGET with the target mode name "
+            "and $OPTIMIZE_CHANGES with the one-line change summary from the "
+            "Strategist's specification. Create mode handles the full pipeline: "
+            "research existing workflow → strategist spec → builder implementation → "
+            "health check → code review → adversarial QA → precheck → archival."
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Phase 6: Archivist (async) — record outcome ──────────────
+    nodes["archivist_outcome"] = AgentNode(
+        id="archivist_outcome",
+        role=AgentRole.ARCHIVIST,
+        prompt_template=(
+            "Archive the optimization outcome. "
+            "Record: what create mode produced, whether the PR was opened, "
+            "and the final state of the workflow change. "
+            "Write to .factory/archive/optimizer-outcome.md."
+        ),
+        reads={
+            ".factory/strategy/current.md",
+            ".factory/reviews/builder-latest.md",
+        },
+        writes={".factory/archive/optimizer-outcome.md"},
+        timeout=300,
+        blocking=False,
+    )
+
+    # ── Edges ─────────────────────────────────────────────────────
+    edges = [
+        # Study → Researcher
+        Edge(source="study", target="researcher"),
+        # Researcher → CEO gate
+        Edge(source="researcher", target="gate_research"),
+        # CEO gate: proceed → Strategist, reloop → Researcher
+        Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+        Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
+        # Strategist → User approval gate
+        Edge(source="strategist", target="gate_strategy"),
+        # User gate: proceed → Archivist(async) + Delegate, reloop → Strategist
+        Edge(source="gate_strategy", target="archivist_plan", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="delegate_create", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # Delegate → Archivist outcome
+        Edge(source="delegate_create", target="archivist_outcome"),
+    ]
+
+    # ── Trigger ───────────────────────────────────────────────────
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "optimize" and state == ProjectState.HAS_FACTORY
+
+    return Workflow(
+        name="optimize",
+        nodes=nodes,
+        edges=edges,
+        start_node="study",
+        trigger=trigger,
+    )
+
+
 # ── W₁₀: Skill Refine ────────────────────────────────────────────
 
 
@@ -2581,6 +2780,7 @@ def register_all() -> dict[str, Workflow]:
         "meta": meta_workflow(),
         "refine": refine_workflow(),
         "create": create_workflow(),
+        "optimize": optimize_workflow(),
         "skill-refine": skill_refine_workflow(),
         "doc-generate": doc_generate_workflow(),
         "doc-update": doc_update_workflow(),

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -142,6 +142,19 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
         ),
         "argument_hint": '"mode description" or "existing_mode: change description"',
     },
+    "optimize": {
+        "description": (
+            "Optimize an existing factory mode by analyzing its performance across "
+            "recent cycles, identifying weaknesses (high redirect rates, agent timeouts, "
+            "low keep rates), and generating targeted workflow changes. Delegates "
+            "implementation to create mode (update-existing-mode path) which runs "
+            "its own full QA pipeline. "
+            "Use when the user says 'optimize the improve mode', 'tune the build workflow', "
+            "or wants to improve factory mode effectiveness based on historical data. "
+            "Requires --focus <target_mode_name>."
+        ),
+        "argument_hint": '"<project_path> --focus <target_mode>"',
+    },
     "swebench": {
         "description": (
             "SWE-bench benchmark mode — minimal 4-node pipeline for solving "

--- a/tests/test_optimize_workflow.py
+++ b/tests/test_optimize_workflow.py
@@ -1,0 +1,124 @@
+from factory.models import ProjectState
+from factory.workflow.definitions import optimize_workflow, register_all
+from factory.workflow.primitives import AgentNode, AgentRole, FnNode, GateNode, Study
+from factory.workflow.validation import validate_workflow
+
+
+def test_optimize_workflow_validates():
+    """optimize workflow graph passes structural validation."""
+    wf = optimize_workflow()
+    errors = validate_workflow(wf)
+    assert errors == [], f"Validation errors: {errors}"
+
+
+def test_optimize_trigger_correct_conditions():
+    """optimize triggers only for mode=optimize + HAS_FACTORY."""
+    wf = optimize_workflow()
+
+    # Should trigger
+    assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "optimize"}) is True
+
+    # Should NOT trigger — wrong mode
+    assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"}) is False
+    assert wf.trigger(ProjectState.HAS_FACTORY, {}) is False
+
+    # Should NOT trigger — wrong state
+    assert wf.trigger(ProjectState.NO_FACTORY, {"mode": "optimize"}) is False
+    assert wf.trigger(ProjectState.NO_REPO, {"mode": "optimize"}) is False
+    assert wf.trigger(ProjectState.REPO_INCOMPLETE, {"mode": "optimize"}) is False
+    assert wf.trigger(ProjectState.EVALS_PENDING_REVIEW, {"mode": "optimize"}) is False
+
+
+def test_optimize_registered():
+    """optimize workflow is registered in register_all."""
+    workflows = register_all()
+    assert "optimize" in workflows
+    assert workflows["optimize"].name == "optimize"
+
+
+def test_optimize_node_structure():
+    """optimize workflow has exactly the expected 8 nodes."""
+    wf = optimize_workflow()
+    expected = {
+        "study", "researcher", "gate_research",
+        "strategist", "gate_strategy",
+        "archivist_plan", "delegate_create", "archivist_outcome",
+    }
+    assert set(wf.nodes.keys()) == expected
+
+
+def test_optimize_node_types():
+    """Each node has the correct type and role."""
+    wf = optimize_workflow()
+
+    assert isinstance(wf.nodes["study"], Study)
+    assert isinstance(wf.nodes["researcher"], AgentNode)
+    assert wf.nodes["researcher"].role == AgentRole.RESEARCHER
+    assert isinstance(wf.nodes["gate_research"], GateNode)
+    assert wf.nodes["gate_research"].evaluator_role == AgentRole.CEO
+    assert isinstance(wf.nodes["strategist"], AgentNode)
+    assert wf.nodes["strategist"].role == AgentRole.STRATEGIST
+    assert isinstance(wf.nodes["gate_strategy"], GateNode)
+    assert wf.nodes["gate_strategy"].evaluator_type == "user"
+    assert isinstance(wf.nodes["archivist_plan"], AgentNode)
+    assert wf.nodes["archivist_plan"].role == AgentRole.ARCHIVIST
+    assert isinstance(wf.nodes["delegate_create"], FnNode)
+    assert isinstance(wf.nodes["archivist_outcome"], AgentNode)
+    assert wf.nodes["archivist_outcome"].role == AgentRole.ARCHIVIST
+
+
+def test_optimize_archivist_non_blocking():
+    """Archivist nodes are non-blocking (fire-and-forget)."""
+    wf = optimize_workflow()
+    assert wf.nodes["archivist_plan"].blocking is False
+    assert wf.nodes["archivist_outcome"].blocking is False
+
+
+def test_optimize_start_node():
+    """optimize workflow starts at study."""
+    wf = optimize_workflow()
+    assert wf.start_node == "study"
+
+
+def test_optimize_edge_count():
+    """optimize workflow has exactly 9 edges."""
+    wf = optimize_workflow()
+    assert len(wf.edges) == 9
+
+
+def test_optimize_user_gate_present():
+    """optimize workflow has a user approval gate (not just CEO/fn)."""
+    wf = optimize_workflow()
+    user_gates = [
+        n for n in wf.nodes.values()
+        if isinstance(n, GateNode) and n.evaluator_type == "user"
+    ]
+    assert len(user_gates) == 1
+    assert user_gates[0].id == "gate_strategy"
+
+
+def test_optimize_delegate_command():
+    """delegate_create FnNode invokes create mode with --focus."""
+    wf = optimize_workflow()
+    node = wf.nodes["delegate_create"]
+    assert isinstance(node, FnNode)
+    assert "--mode create" in node.command
+    assert "--focus" in node.command
+
+
+def test_optimize_in_ceo_modes():
+    """optimize is listed in CEO_MODES."""
+    from factory.cli._helpers import CEO_MODES
+    assert "optimize" in CEO_MODES
+
+
+def test_optimize_skill_export():
+    """optimize workflow produces a SKILL.md via skill export."""
+    from factory.workflow.skill_export import workflow_to_skill_md
+
+    wf = optimize_workflow()
+    skill_md = workflow_to_skill_md(wf)
+    assert len(skill_md) > 100
+    assert "study" in skill_md.lower()
+    assert "researcher" in skill_md.lower()
+    assert "strategist" in skill_md.lower()


### PR DESCRIPTION
Closes #N/A (factory create mode task)

## Changes
- Added `optimize_workflow()` function to `factory/workflow/definitions.py` — 8-node DAG: Study → Researcher (mode analysis) → CEO gate → Strategist (change spec) → User approval gate → Archivist (async) → Delegate to create mode → Archivist (async)
- Registered in `register_all()` and `__all__`
- Added `WORKFLOW_META` entry in `factory/workflow/skill_export.py` with description and argument hint
- CLI wiring: added `optimize` to `CEO_MODES`, updated `--mode` help text, added validation block (requires `--focus`, foreground-only, existing project), updated focus allowlist, added mode routing and task construction in `_build_ceo_task()`
- Updated `CycleState.mode` Literal in `factory/models.py` to include `optimize`
- Generated `skills/workflow-optimize/SKILL.md` via `factory workflow export-skills`
- Added 12 tests in `tests/test_optimize_workflow.py` — graph validation, trigger conditions, node structure/types, edge count, user gate, delegate command, CEO_MODES listing, skill export

## Design
The optimize mode is intentionally simple (8 nodes vs 14+ for improve) because it's an analysis + delegation mode, not a full build pipeline. It analyzes a target mode's performance data (results.tsv, events.jsonl, CEO verdicts, archive), generates a change specification, and delegates implementation to create mode's update-existing-mode path which runs its own full QA pipeline.

Interactive-only (headless blocked) because auto-approving workflow modifications is unsafe.

## Validation
- `factory workflow validate optimize` → VALID (8 nodes, 9 edges)
- `factory workflow export-skills` → generates workflow-optimize/SKILL.md (114 lines)
- `pytest tests/test_optimize_workflow.py -v` → 12/12 passed
- `pytest tests/test_models.py tests/test_skill_export.py -v` → 103/103 passed (no regressions)
- `ruff check` → all checks passed