### PR TITLE
feat: replace spike-sort parameter agents with LLM quality gates

### DIFF
--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -16,10 +16,10 @@ log = structlog.get_logger()
 _WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
 
 
-CEO_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "parallel-improve", "research", "review", "qa", "deep-qa", "create", "swebench"]
+CEO_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "design", "interactive", "parallel-improve", "research", "review", "qa", "deep-qa", "create", "spike-sort", "swebench"]
 
 
-RUN_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "parallel-improve", "research", "swebench"]
+RUN_MODES = ["auto", "auto-fresh", "build", "discover", "improve", "meta", "parallel-improve", "research", "spike-sort", "swebench"]
 
 
 def _run(coro):  # noqa: ANN001, ANN202

--- a/factory/models.py
+++ b/factory/models.py
@@ -520,7 +520,7 @@ class CycleState(BaseModel):
     mode: Literal[
         "build", "create", "deep-qa", "design", "discover",
         "improve", "meta", "parallel-improve", "qa", "refine",
-        "research", "review", "swebench",
+        "research", "review", "spike-sort", "swebench",
     ]
     initial_prompt: str = ""
     respawns: int = 0

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -58,6 +58,7 @@ __all__ = [
     "spec_generate_workflow",
     "spec_update_workflow",
     "parallel_improve_workflow",
+    "spike_sort_workflow",
     "register_all",
 ]
 
@@ -2564,6 +2565,268 @@ def parallel_improve_workflow() -> Workflow:
         nodes=nodes,
         edges=edges,
         start_node="study",
+        trigger=trigger,
+    )
+
+
+def spike_sort_workflow() -> Workflow:
+    """Spike sorting data pipeline with LLM-in-the-loop parameter selection.
+
+    NOT a code-writing workflow — directly executes DARTsort algorithms (FnNodes)
+    with LLM parameter advisors (AgentNodes) at two decision points plus a final
+    QA assessment.
+
+    10 nodes (7 FnNodes + 3 AgentNodes), 9 edges, linear chain:
+
+    Pipeline:
+    preprocess (FnNode) → detect_trial (FnNode) → detect_params (AgentNode/haiku) →
+    detect (FnNode) → localize (FnNode) → cluster_params (AgentNode/sonnet) →
+    cluster (FnNode) → templates (FnNode) → match (FnNode) → qa_sorting (AgentNode/sonnet)
+    """
+    nodes: dict[str, Any] = {}
+
+    # ── Stage 0: Preprocessing (deterministic) ────────────────────
+    nodes["preprocess"] = FnNode(
+        id="preprocess",
+        command="",
+        notes="Bandpass filter, standardize, whiten the raw recording.",
+        writes={"preprocessed/", "noise_stats.json"},
+    )
+
+    # ── Stage 1: Detection Trial (deterministic) ──────────────────
+    nodes["detect_trial"] = FnNode(
+        id="detect_trial",
+        command="",
+        notes=(
+            "Fast threshold sweep on a small subset of the recording. "
+            "Runs dartsort.threshold() at 3 candidate thresholds (3.5, 4.0, 4.5) "
+            "with early termination."
+        ),
+        reads={"noise_stats.json", "preprocessed/"},
+        writes={"trial_results.json"},
+    )
+
+    # ── Stage 2: Detection Parameters (LLM) ──────────────────────
+    nodes["detect_params"] = AgentNode(
+        id="detect_params",
+        role=AgentRole.RESEARCHER,
+        model="haiku",
+        timeout=60,
+        prompt_template=(
+            "You are a spike detection parameter advisor for extracellular neural "
+            "recordings. Read the noise statistics at {output_dir}/noise_stats.json "
+            "and the trial detection results at {output_dir}/trial_results.json.\n\n"
+            "TRIAL RESULTS: A threshold sweep has already been run on a small subset "
+            "of the recording at thresholds 3.5, 4.0, and 4.5. The trial_results.json "
+            "file contains for each threshold: spike_count, spike_rate_hz, "
+            "mean_amplitude, and amplitude_distribution_percentiles. Use this "
+            "empirical data to inform your threshold selection.\n\n"
+            "IMPORTANT: We use DARTsort's subtract() function (SubtractionPeeler) "
+            "for detection. This is an iterative template-subtraction algorithm that "
+            "produces cleaner spike detections than simple thresholding. The subtract "
+            "algorithm includes a neural network denoiser in its pipeline. The default "
+            "detection_threshold is 3.0 for subtract().\n\n"
+            "Select detection parameters:\n"
+            "- detection_threshold (2.5-5.0): SNR threshold in standardized units. "
+            "Default: 3.0 (subtract's calibrated default). Higher values reduce "
+            "false positives but may miss weak units. Lower values catch more spikes "
+            "but may include noise.\n"
+            "- peak_sign ('neg', 'pos', 'both'): Which polarity peaks to detect. "
+            "'both' is standard for extracellular recordings.\n\n"
+            "Decision rules:\n"
+            "- Start with detection_threshold=3.0 (the subtract default).\n"
+            "- Compare trial results across thresholds: if 4.0 produces reasonable "
+            "spike rate (20-200 Hz per channel), consider using 4.0 for cleaner output.\n"
+            "- Very noisy data (median noise >20 µV): raise to 4.0-5.0.\n"
+            "- Clean data (<8 µV): keep 3.0.\n"
+            "- Neuropixels probes → 'both' peak_sign.\n\n"
+            "In your reasoning field, explicitly state why you chose your threshold. "
+            "Reference the trial results — cite the spike counts and rates you observed.\n\n"
+            "IMPORTANT: Write your selection as a JSON file to "
+            "{output_dir}/detection_params.json using the Write tool. The JSON must "
+            "have these fields:\n"
+            '- "detection_threshold": float (2.5-5.0)\n'
+            '- "peak_sign": string ("neg", "pos", or "both")\n'
+            '- "reasoning": string (your brief justification)'
+        ),
+        reads={"noise_stats.json", "trial_results.json"},
+        writes={"detection_params.json"},
+    )
+
+    # ── Stage 3: Detection (deterministic) ────────────────────────
+    nodes["detect"] = FnNode(
+        id="detect",
+        command="",
+        notes=(
+            "Subtraction-based spike detection (SubtractionPeeler) with "
+            "LLM-selected parameters."
+        ),
+        reads={"preprocessed/", "detection_params.json"},
+        writes={"detections/", "detection_summary.json"},
+    )
+
+    # ── Stage 4: Localization (deterministic) ─────────────────────
+    nodes["localize"] = FnNode(
+        id="localize",
+        command="",
+        notes=(
+            "Point-source localization of detected spikes via "
+            "Levenberg-Marquardt. Also estimates motion (drift)."
+        ),
+        reads={"detections/", "preprocessed/"},
+        writes={"localizations.npz", "cluster_input_stats.json", "motion/"},
+    )
+
+    # ── Stage 5: Clustering Parameters (LLM) ─────────────────────
+    nodes["cluster_params"] = AgentNode(
+        id="cluster_params",
+        role=AgentRole.STRATEGIST,
+        model="sonnet",
+        timeout=120,
+        prompt_template=(
+            "You are a spike clustering strategy advisor. Read the cluster input "
+            "statistics at {output_dir}/cluster_input_stats.json.\n\n"
+            "Select a clustering strategy and parameters:\n"
+            "- strategy: 'channel_snap' (fast, coarse — good for <20K spikes), "
+            "'grid_snap' (spatial grid — good for high density), 'dpc' (density "
+            "peak clustering — slow but accurate, best for >20K spikes with drift), "
+            "'none' (skip clustering — only for pre-sorted data).\n"
+            "- grid_dx, grid_dz (5-50 µm): Spatial grid resolution. Smaller = more "
+            "clusters initially. 15 µm is typical.\n\n"
+            "Decision tree:\n"
+            "- spike_count < 20K → channel_snap\n"
+            "- drift > 15 µm → dpc with drift correction\n"
+            "- spike_density > 1.0 spikes/ch/s → grid_snap\n"
+            "- Otherwise → dpc\n\n"
+            "IMPORTANT: Write your selection as a JSON file to "
+            "{output_dir}/clustering_params.json using the Write tool. The JSON must "
+            "have these fields:\n"
+            '- "strategy": string ("channel_snap", "grid_snap", "dpc", or "none")\n'
+            '- "grid_dx": float (5.0-50.0)\n'
+            '- "grid_dz": float (5.0-50.0)\n'
+            '- "reasoning": string (your brief justification)'
+        ),
+        reads={"cluster_input_stats.json"},
+        writes={"clustering_params.json"},
+    )
+
+    # ── Stage 6: Clustering (deterministic) ───────────────────────
+    nodes["cluster"] = FnNode(
+        id="cluster",
+        command="",
+        notes="GMM/DPC clustering with LLM-selected strategy and parameters.",
+        reads={"preprocessed/", "detections/", "motion/", "clustering_params.json"},
+        writes={"clusters/", "cluster_summary.json"},
+    )
+
+    # ── Stage 7: Templates (deterministic) ────────────────────────
+    nodes["templates"] = FnNode(
+        id="templates",
+        command="",
+        notes="Compute unit templates (average/median waveforms) from clustered spikes.",
+        reads={"preprocessed/", "clusters/", "motion/"},
+        writes={"templates/", "template_stats.json"},
+    )
+
+    # ── Stage 8: Match (deterministic) ────────────────────────────
+    nodes["match"] = FnNode(
+        id="match",
+        command="",
+        notes=(
+            "Template matching refinement with post-match agglomeration. "
+            "Produces the final sorting result."
+        ),
+        reads={"preprocessed/", "templates/", "motion/"},
+        writes={"sorting/", "sorting_result.json"},
+    )
+
+    # ── Stage 9: Quality Assessment (LLM) ─────────────────────────
+    nodes["qa_sorting"] = AgentNode(
+        id="qa_sorting",
+        role=AgentRole.HEALTH_CHECKER,
+        model="sonnet",
+        timeout=300,
+        prompt_template=(
+            "You are a neuroscience data quality expert. Review the final spike sorting "
+            "results and identify units that may be problematic.\n\n"
+            "### Input Files\n"
+            "- **sorting_result.json**: Unit count and basic statistics at "
+            "{output_dir}/sorting_result.json\n"
+            "- **sorting/**: Full SpikeInterface sorting object at {output_dir}/sorting/\n"
+            "- **templates/**: Template waveforms at {output_dir}/templates/\n\n"
+            "### Quality Criteria\n\n"
+            "**Multi-unit activity indicators:**\n"
+            "- ISI violation rate > 0.1 (10% of spikes violate 2ms refractory period)\n"
+            "- Bimodal or multi-peaked waveform shapes\n"
+            "- High spike amplitude variance\n\n"
+            "**Noise indicators:**\n"
+            "- SNR < 3.0 (signal-to-noise ratio too low)\n"
+            "- Amplitude stability < 0.7 (coefficient of variation > 0.3)\n"
+            "- Very low spike count (< 50 spikes — insufficient data)\n\n"
+            "**Suspicious waveform shapes:**\n"
+            "- Non-physiological rise/fall times\n"
+            "- Excessive baseline noise\n"
+            "- Artifact-like sharp transients\n\n"
+            "### Quality Thresholds\n\n"
+            "| Metric              | Threshold | Flag if...          |\n"
+            "|---------------------|-----------|---------------------|\n"
+            "| ISI violation rate  | > 0.1     | possible_multi_unit |\n"
+            "| SNR                 | < 3.0     | low_snr             |\n"
+            "| Amplitude stability | < 0.7     | unstable_amplitude  |\n"
+            "| Spike count         | < 50      | low_spike_count     |\n\n"
+            "### Instructions\n\n"
+            "1. Read sorting_result.json for unit list and spike counts\n"
+            "2. Compute quality metrics for each unit:\n"
+            "   - ISI violation rate (fraction of spikes violating 2ms refractory period)\n"
+            "   - SNR from waveforms\n"
+            "   - Amplitude stability (1 - amplitude CV)\n"
+            "3. Apply thresholds to flag problematic units\n"
+            "4. Generate confidence scores (weighted combination):\n"
+            "   - Start at 1.0\n"
+            "   - Subtract 0.3 for ISI violations > 0.1\n"
+            "   - Subtract 0.4 for SNR < 3.0\n"
+            "   - Subtract 0.2 for amplitude stability < 0.7\n"
+            "   - Subtract 0.1 for spike count < 50\n"
+            "   - Clamp to [0.0, 1.0]\n\n"
+            "### Output Files\n\n"
+            "IMPORTANT: Write BOTH output files using the Write tool.\n\n"
+            "1. **qa_report.json** at {output_dir}/qa_report.json with:\n"
+            '   - "units": list of objects, each with: unit_id (int), spike_count (int), '
+            "isi_violation_rate (float), snr (float), amplitude_stability (float), "
+            'waveform_quality ("clean"|"noisy"|"artifact"), confidence_score (float 0-1), '
+            "flags (list of strings)\n"
+            '   - "summary": object with: total_units (int), high_quality_units (int), '
+            "flagged_units (int), avg_confidence (float)\n\n"
+            "2. **flagged_units.json** at {output_dir}/flagged_units.json with:\n"
+            '   - "flagged_units": list of unit IDs (ints)\n'
+            '   - "flags_by_unit": dict mapping unit_id string to list of flag strings\n'
+            '   - "total_flagged": int count'
+        ),
+        reads={"sorting_result.json", "sorting/", "templates/"},
+        writes={"qa_report.json", "flagged_units.json"},
+    )
+
+    # ── Edges ─────────────────────────────────────────────────────
+    edges = [
+        Edge(source="preprocess", target="detect_trial"),
+        Edge(source="detect_trial", target="detect_params"),
+        Edge(source="detect_params", target="detect"),
+        Edge(source="detect", target="localize"),
+        Edge(source="localize", target="cluster_params"),
+        Edge(source="cluster_params", target="cluster"),
+        Edge(source="cluster", target="templates"),
+        Edge(source="templates", target="match"),
+        Edge(source="match", target="qa_sorting"),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "spike-sort"
+
+    return Workflow(
+        name="spike-sort",
+        nodes=nodes,
+        edges=edges,
+        start_node="preprocess",
         trigger=trigger,
     )
 

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2375,46 +2375,31 @@ def spike_sort_workflow() -> Workflow:
             "contains for each threshold: spike_count, spike_rate_hz, mean_amplitude, "
             "and amplitude_distribution_percentiles. Use this empirical data to inform "
             "your threshold selection.\n\n"
-            "IMPORTANT: DARTsort's detection operates on standardized (SNR-unit) traces. "
-            "The threshold 4.0 is the DARTsort-calibrated baseline, validated on Neuropixels "
-            "recordings with default preprocessing. A single-channel denoiser NN runs before "
-            "detection and recovers low-amplitude spikes, so you do NOT need an aggressive "
-            "(low) threshold to catch weak units. Prefer the default. Only deviate with "
-            "clear evidence from the trial results AND noise statistics.\n\n"
+            "IMPORTANT: We use DARTsort's subtract() function (SubtractionPeeler) for "
+            "detection. This is an iterative template-subtraction algorithm that produces "
+            "cleaner spike detections than simple thresholding. The subtract algorithm "
+            "includes a neural network denoiser in its pipeline. "
+            "The default detection_threshold is 3.0 for subtract().\n\n"
             "Select detection parameters:\n"
-            "- voltage_threshold (3.0-6.0): SNR threshold in standardized units. "
-            "Default: 4.0. Do NOT lower below 4.0 unless you have strong evidence "
-            "that the recording has exceptionally high SNR AND the denoiser is disabled. "
-            "Raising above 4.0 is safer than lowering — it reduces false positives "
-            "with minimal loss of real spikes.\n"
+            "- detection_threshold (2.5-5.0): SNR threshold in standardized units. "
+            "Default: 3.0 (subtract's calibrated default). Higher values reduce false "
+            "positives but may miss weak units. Lower values catch more spikes but "
+            "may include noise.\n"
             "- peak_sign ('neg', 'pos', 'both'): Which polarity peaks to detect. "
-            "'both' is standard for extracellular recordings.\n"
-            "- dedup_temporal_radius (5-20): Samples to deduplicate within. "
-            "11 is typical at 30kHz.\n"
-            "- use_denoiser (true/false): Whether to apply the single-channel denoiser NN "
-            "before detection. Default: true. The denoiser cleans waveforms and improves "
-            "detection of low-amplitude spikes. Disable only if the recording has unusual "
-            "artifacts that the denoiser was not trained on.\n\n"
+            "'both' is standard for extracellular recordings.\n\n"
             "Decision rules:\n"
-            "- Start with voltage_threshold=4.0 (the calibrated default).\n"
-            "- Compare trial results across thresholds: if 4.0 produces a reasonable "
-            "spike rate (20-200 Hz per channel) keep it. If the rate is extremely high "
-            "(>500 Hz), consider raising to 4.5 or 5.0.\n"
-            "- Very noisy data (median noise >20 µV after standardization): raise to 5.0-6.0.\n"
-            "- Clean data (<8 µV): keep 4.0 — the denoiser handles low-amplitude recovery.\n"
-            "- DO NOT lower the threshold to compensate for expected low-amplitude neurons. "
-            "The denoiser NN is designed for this.\n"
+            "- Start with detection_threshold=3.0 (the subtract default).\n"
+            "- Compare trial results across thresholds: if 4.0 produces reasonable "
+            "spike rate (20-200 Hz per channel), consider using 4.0 for cleaner output.\n"
+            "- Very noisy data (median noise >20 µV): raise to 4.0-5.0.\n"
+            "- Clean data (<8 µV): keep 3.0.\n"
             "- Neuropixels probes → 'both' peak_sign.\n\n"
             "In your reasoning field, explicitly state why you chose your threshold. "
-            "Reference the trial results — cite the spike counts and rates you observed. "
-            "If you chose anything other than 4.0, justify the deviation with specific "
-            "evidence from the trial data and noise_stats.json.\n\n"
+            "Reference the trial results — cite the spike counts and rates you observed.\n\n"
             "IMPORTANT: Write your selection as a JSON file to {output_dir}/detection_params.json "
             "using the Write tool. The JSON must have these fields:\n"
-            '- "detection_threshold": float (3.0-6.0)\n'
+            '- "detection_threshold": float (2.5-5.0)\n'
             '- "peak_sign": string ("neg", "pos", or "both")\n'
-            '- "temporal_dedup_radius_samples": int (5-20)\n'
-            '- "use_denoiser": boolean\n'
             '- "reasoning": string (your brief justification)'
         ),
         reads={"noise_stats.json", "trial_results.json"},
@@ -2427,13 +2412,14 @@ def spike_sort_workflow() -> Workflow:
         id="detect",
         callable_name="factory.workflow.spike_sort_stages:detect",
         notes=(
-            "Threshold-crossing detection with LLM-selected parameters. "
-            "Reads preprocessed recording and detection_params.json. "
-            "Writes detections to {output_dir}/detections/ "
+            "Subtraction-based spike detection (SubtractionPeeler) with LLM-selected "
+            "parameters. Uses iterative template subtraction for cleaner detection "
+            "than simple thresholding. Reads preprocessed recording and "
+            "detection_params.json. Writes detections to {output_dir}/detections/ "
             "and summary to {output_dir}/detection_summary.json."
         ),
         reads={"preprocessed/", "detection_params.json"},
-        writes={"detections/", "detection_summary.json", "denoised/"},
+        writes={"detections/", "detection_summary.json"},
     )
 
     # ── Stage 4: Localization ──────────────────────────────────────

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2409,7 +2409,13 @@ def spike_sort_workflow() -> Workflow:
             "Reference the trial results — cite the spike counts and rates you observed. "
             "If you chose anything other than 4.0, justify the deviation with specific "
             "evidence from the trial data and noise_stats.json.\n\n"
-            "Output your selection as a DetectionParams JSON object with a reasoning field."
+            "IMPORTANT: Write your selection as a JSON file to {output_dir}/detection_params.json "
+            "using the Write tool. The JSON must have these fields:\n"
+            '- "detection_threshold": float (3.0-6.0)\n'
+            '- "peak_sign": string ("neg", "pos", or "both")\n'
+            '- "temporal_dedup_radius_samples": int (5-20)\n'
+            '- "use_denoiser": boolean\n'
+            '- "reasoning": string (your brief justification)'
         ),
         reads={"noise_stats.json", "trial_results.json"},
         writes={"detection_params.json"},
@@ -2460,18 +2466,18 @@ def spike_sort_workflow() -> Workflow:
             "'dpc' (density peak clustering — slow but accurate, best for >20K spikes with drift), "
             "'none' (skip clustering — only for pre-sorted data).\n"
             "- grid_dx, grid_dz (5-50 µm): Spatial grid resolution. "
-            "Smaller = more clusters initially. 15 µm is typical.\n"
-            "- initial_steps: Refinement sequence. "
-            "['split', 'demolish', 'demolish'] is standard. "
-            "Add 'merge' if you expect many similar units.\n"
-            "- n_waveforms_fit (10K-100K): Subsample size for fitting. "
-            "Higher = better but slower. 40K is typical.\n\n"
+            "Smaller = more clusters initially. 15 µm is typical.\n\n"
             "Decision tree:\n"
             "- spike_count < 20K → channel_snap\n"
             "- drift > 15 µm → dpc with drift correction\n"
             "- spike_density > 1.0 spikes/ch/s → grid_snap\n"
             "- Otherwise → dpc\n\n"
-            "Output your selection as a ClusteringParams JSON object with a reasoning field."
+            "IMPORTANT: Write your selection as a JSON file to {output_dir}/clustering_params.json "
+            "using the Write tool. The JSON must have these fields:\n"
+            '- "strategy": string ("channel_snap", "grid_snap", "dpc", or "none")\n'
+            '- "grid_dx": float (5.0-50.0)\n'
+            '- "grid_dz": float (5.0-50.0)\n'
+            '- "reasoning": string (your brief justification)'
         ),
         reads={"cluster_input_stats.json"},
         writes={"clustering_params.json"},
@@ -2525,7 +2531,14 @@ def spike_sort_workflow() -> Workflow:
             "- Good units: SNR > 3, count > 50, stability > 0.7\n"
             "- Marginal units: SNR 1.5-3, count 10-50 — keep if isolated\n"
             "- High spatial_spread (>200 µm) may indicate multi-unit — flag for discard\n\n"
-            "Output a TemplateQCOutput JSON with decisions list and summary string."
+            "IMPORTANT: Write your decisions as a JSON file to {output_dir}/template_decisions.json "
+            "using the Write tool. The JSON must have:\n"
+            '- "decisions": array of objects, each with:\n'
+            '  - "template_id": int\n'
+            '  - "action": string ("keep", "discard", or "merge")\n'
+            '  - "merge_with": int or null (only if action is "merge")\n'
+            '  - "reasoning": string (brief justification)\n'
+            '- "summary": string (overall QC summary)'
         ),
         reads={"template_stats.json"},
         writes={"template_decisions.json"},

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2322,9 +2322,10 @@ def spike_sort_workflow() -> Workflow:
     NOT a software engineering workflow. This IS the spike sorting pipeline:
     FnNodes execute DARTsort algorithms, AgentNodes select parameters via LLM.
 
-    preprocess (FnNode) → detect_params (AgentNode/haiku) → detect (FnNode) →
-    localize (FnNode) → cluster_params (AgentNode/sonnet) → cluster (FnNode) →
-    templates (FnNode) → qc_templates (AgentNode/haiku) → match (FnNode)
+    preprocess (FnNode) → detect_trial (FnNode) → detect_params (AgentNode/haiku) →
+    detect (FnNode) → localize (FnNode) → cluster_params (AgentNode/sonnet) →
+    cluster (FnNode) → templates (FnNode) → qc_templates (AgentNode/haiku) →
+    match (FnNode)
     """
     nodes: dict[str, Any] = {}
     edges: list[Edge] = []
@@ -2342,6 +2343,22 @@ def spike_sort_workflow() -> Workflow:
         writes={"preprocessed/", "noise_stats.json"},
     )
 
+    # ── Stage 1b: Detection Trial Run (threshold sweep) ──────────
+
+    nodes["detect_trial"] = FnNode(
+        id="detect_trial",
+        callable_name="factory.workflow.spike_sort_stages:detect_trial",
+        notes=(
+            "Fast threshold sweep on a small subset of the recording. "
+            "Runs dartsort.threshold() at 3 candidate thresholds (3.5, 4.0, 4.5) "
+            "with early termination (stop_after_n_spikes=10000, ensure_coverage=0.05). "
+            "Writes trial results to {output_dir}/trial_results.json for the "
+            "detection parameter advisor to make a data-informed threshold choice."
+        ),
+        reads={"preprocessed/", "noise_stats.json"},
+        writes={"trial_results.json"},
+    )
+
     # ── Stage 2: Detection Parameter Selection (LLM) ───────────────
 
     nodes["detect_params"] = AgentNode(
@@ -2351,23 +2368,50 @@ def spike_sort_workflow() -> Workflow:
         timeout=60,
         prompt_template=(
             "You are a spike detection parameter advisor for extracellular neural recordings. "
-            "Read the noise statistics at {output_dir}/noise_stats.json.\n\n"
-            "Based on the recording characteristics, select detection parameters:\n"
-            "- voltage_threshold (2.0-8.0): SNR threshold for spike detection. "
-            "Higher = fewer false positives but may miss low-amplitude neurons. "
-            "Typical: 3.0 for clean data, 4.0-6.0 for noisy data.\n"
+            "Read the noise statistics at {output_dir}/noise_stats.json and the trial "
+            "detection results at {output_dir}/trial_results.json.\n\n"
+            "TRIAL RESULTS: A threshold sweep has already been run on a small subset of "
+            "the recording at thresholds 3.5, 4.0, and 4.5. The trial_results.json file "
+            "contains for each threshold: spike_count, spike_rate_hz, mean_amplitude, "
+            "and amplitude_distribution_percentiles. Use this empirical data to inform "
+            "your threshold selection.\n\n"
+            "IMPORTANT: DARTsort's detection operates on standardized (SNR-unit) traces. "
+            "The threshold 4.0 is the DARTsort-calibrated baseline, validated on Neuropixels "
+            "recordings with default preprocessing. A single-channel denoiser NN runs before "
+            "detection and recovers low-amplitude spikes, so you do NOT need an aggressive "
+            "(low) threshold to catch weak units. Prefer the default. Only deviate with "
+            "clear evidence from the trial results AND noise statistics.\n\n"
+            "Select detection parameters:\n"
+            "- voltage_threshold (3.0-6.0): SNR threshold in standardized units. "
+            "Default: 4.0. Do NOT lower below 4.0 unless you have strong evidence "
+            "that the recording has exceptionally high SNR AND the denoiser is disabled. "
+            "Raising above 4.0 is safer than lowering — it reduces false positives "
+            "with minimal loss of real spikes.\n"
             "- peak_sign ('neg', 'pos', 'both'): Which polarity peaks to detect. "
-            "'both' is standard for extracellular recordings unless you know the cell type.\n"
+            "'both' is standard for extracellular recordings.\n"
             "- dedup_temporal_radius (5-20): Samples to deduplicate within. "
-            "Higher = more aggressive deduplication. 11 is typical at 30kHz.\n\n"
-            "Decision factors:\n"
-            "- High median noise (>15 µV) → raise threshold to 4.0+\n"
-            "- Low noise (<8 µV) → can lower to 2.5-3.0\n"
-            "- Neuropixels probes → 'both' peak_sign is standard\n"
-            "- Short recordings (<60s) → lower threshold to catch more units\n\n"
+            "11 is typical at 30kHz.\n"
+            "- use_denoiser (true/false): Whether to apply the single-channel denoiser NN "
+            "before detection. Default: true. The denoiser cleans waveforms and improves "
+            "detection of low-amplitude spikes. Disable only if the recording has unusual "
+            "artifacts that the denoiser was not trained on.\n\n"
+            "Decision rules:\n"
+            "- Start with voltage_threshold=4.0 (the calibrated default).\n"
+            "- Compare trial results across thresholds: if 4.0 produces a reasonable "
+            "spike rate (20-200 Hz per channel) keep it. If the rate is extremely high "
+            "(>500 Hz), consider raising to 4.5 or 5.0.\n"
+            "- Very noisy data (median noise >20 µV after standardization): raise to 5.0-6.0.\n"
+            "- Clean data (<8 µV): keep 4.0 — the denoiser handles low-amplitude recovery.\n"
+            "- DO NOT lower the threshold to compensate for expected low-amplitude neurons. "
+            "The denoiser NN is designed for this.\n"
+            "- Neuropixels probes → 'both' peak_sign.\n\n"
+            "In your reasoning field, explicitly state why you chose your threshold. "
+            "Reference the trial results — cite the spike counts and rates you observed. "
+            "If you chose anything other than 4.0, justify the deviation with specific "
+            "evidence from the trial data and noise_stats.json.\n\n"
             "Output your selection as a DetectionParams JSON object with a reasoning field."
         ),
-        reads={"noise_stats.json"},
+        reads={"noise_stats.json", "trial_results.json"},
         writes={"detection_params.json"},
     )
 
@@ -2383,7 +2427,7 @@ def spike_sort_workflow() -> Workflow:
             "and summary to {output_dir}/detection_summary.json."
         ),
         reads={"preprocessed/", "detection_params.json"},
-        writes={"detections/", "detection_summary.json"},
+        writes={"detections/", "detection_summary.json", "denoised/"},
     )
 
     # ── Stage 4: Localization ──────────────────────────────────────
@@ -2504,7 +2548,8 @@ def spike_sort_workflow() -> Workflow:
     # ── Edges (linear pipeline) ────────────────────────────────────
 
     edges = [
-        Edge(source="preprocess", target="detect_params"),
+        Edge(source="preprocess", target="detect_trial"),
+        Edge(source="detect_trial", target="detect_params"),
         Edge(source="detect_params", target="detect"),
         Edge(source="detect", target="localize"),
         Edge(source="localize", target="cluster_params"),

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2322,10 +2322,17 @@ def spike_sort_workflow() -> Workflow:
     NOT a software engineering workflow. This IS the spike sorting pipeline:
     FnNodes execute DARTsort algorithms, AgentNodes select parameters via LLM.
 
+    Pipeline:
     preprocess (FnNode) → detect_trial (FnNode) → detect_params (AgentNode/haiku) →
     detect (FnNode) → localize (FnNode) → cluster_params (AgentNode/sonnet) →
-    cluster (FnNode) → templates (FnNode) → qc_templates (AgentNode/haiku) →
-    match (FnNode)
+    cluster (FnNode) → templates (FnNode) → match (FnNode)
+
+    Agent roles:
+    - detect_params: Selects detection threshold based on noise stats and trial sweep
+    - cluster_params: Chooses clustering strategy based on spike count, drift, density
+
+    The pipeline matches vanilla DARTsort's deterministic stages, with agents
+    providing recording-specific parameter tuning.
     """
     nodes: dict[str, Any] = {}
     edges: list[Edge] = []
@@ -2496,51 +2503,20 @@ def spike_sort_workflow() -> Workflow:
         writes={"templates/", "template_stats.json"},
     )
 
-    # ── Stage 8: Template Quality Control (LLM) ────────────────────
-
-    nodes["qc_templates"] = AgentNode(
-        id="qc_templates",
-        role=AgentRole.RESEARCHER,
-        model="haiku",
-        timeout=120,
-        prompt_template=(
-            "You are a spike sorting template quality control reviewer. "
-            "Read the template statistics at {output_dir}/template_stats.json.\n\n"
-            "For each template, decide: keep, discard, or merge.\n\n"
-            "Decision criteria:\n"
-            "- DISCARD if: SNR < 1.5 (noise unit), spike_count < 10 (too few spikes), "
-            "or ptp_amplitude < 5 µV (below noise floor).\n"
-            "- MERGE if: two templates have very similar spatial positions (within 25 µm) "
-            "AND similar PTP amplitudes (within 30%). Specify merge_with = template_id of partner.\n"
-            "- KEEP otherwise.\n\n"
-            "Quality heuristics:\n"
-            "- Good units: SNR > 3, count > 50, stability > 0.7\n"
-            "- Marginal units: SNR 1.5-3, count 10-50 — keep if isolated\n"
-            "- High spatial_spread (>200 µm) may indicate multi-unit — flag for discard\n\n"
-            "IMPORTANT: Write your decisions as a JSON file to {output_dir}/template_decisions.json "
-            "using the Write tool. The JSON must have:\n"
-            '- "decisions": array of objects, each with:\n'
-            '  - "template_id": int\n'
-            '  - "action": string ("keep", "discard", or "merge")\n'
-            '  - "merge_with": int or null (only if action is "merge")\n'
-            '  - "reasoning": string (brief justification)\n'
-            '- "summary": string (overall QC summary)'
-        ),
-        reads={"template_stats.json"},
-        writes={"template_decisions.json"},
-    )
-
-    # ── Stage 9: Template Matching ─────────────────────────────────
+    # ── Stage 8: Template Matching ─────────────────────────────────
+    # Note: Manual template QC was removed - DARTsort's refinement handles
+    # merge/split decisions automatically via agglomerate_cfg
 
     nodes["match"] = FnNode(
         id="match",
         callable_name="factory.workflow.spike_sort_stages:template_match",
         notes=(
-            "Template matching refinement using QC-filtered templates. "
-            "Reads template_decisions.json to filter templates before matching. "
+            "Template matching refinement with post-match agglomeration. "
+            "Matches spikes to templates, then runs DARTsort's final refinement "
+            "(pre_refinement → refinement → agglomerate) to merge overclustered units. "
             "Produces the final sorting result."
         ),
-        reads={"preprocessed/", "templates/", "template_decisions.json", "motion/"},
+        reads={"preprocessed/", "templates/", "motion/"},
         writes={"sorting/", "sorting_result.json"},
     )
 
@@ -2554,8 +2530,7 @@ def spike_sort_workflow() -> Workflow:
         Edge(source="localize", target="cluster_params"),
         Edge(source="cluster_params", target="cluster"),
         Edge(source="cluster", target="templates"),
-        Edge(source="templates", target="qc_templates"),
-        Edge(source="qc_templates", target="match"),
+        Edge(source="templates", target="match"),
     ]
 
     # ── Trigger ────────────────────────────────────────────────────

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2313,240 +2313,6 @@ def spec_update_workflow() -> Workflow:
     )
 
 
-# ── W₁₃: Spike Sort Pipeline ──────────────────────────────────
-
-
-def spike_sort_workflow() -> Workflow:
-    """W₁₃: Spike-sort pipeline — LLM-in-the-loop parameter selection.
-
-    NOT a software engineering workflow. This IS the spike sorting pipeline:
-    FnNodes execute DARTsort algorithms, AgentNodes select parameters via LLM.
-
-    Pipeline:
-    preprocess (FnNode) → detect_trial (FnNode) → detect_params (AgentNode/haiku) →
-    detect (FnNode) → localize (FnNode) → cluster_params (AgentNode/sonnet) →
-    cluster (FnNode) → templates (FnNode) → match (FnNode)
-
-    Agent roles:
-    - detect_params: Selects detection threshold based on noise stats and trial sweep
-    - cluster_params: Chooses clustering strategy based on spike count, drift, density
-
-    The pipeline matches vanilla DARTsort's deterministic stages, with agents
-    providing recording-specific parameter tuning.
-    """
-    nodes: dict[str, Any] = {}
-    edges: list[Edge] = []
-
-    # ── Stage 1: Preprocessing ─────────────────────────────────────
-
-    nodes["preprocess"] = FnNode(
-        id="preprocess",
-        callable_name="factory.workflow.spike_sort_stages:preprocess",
-        notes=(
-            "Bandpass filter, standardize, whiten the raw recording. "
-            "Writes preprocessed recording to {output_dir}/preprocessed/ "
-            "and noise statistics to {output_dir}/noise_stats.json."
-        ),
-        writes={"preprocessed/", "noise_stats.json"},
-    )
-
-    # ── Stage 1b: Detection Trial Run (threshold sweep) ──────────
-
-    nodes["detect_trial"] = FnNode(
-        id="detect_trial",
-        callable_name="factory.workflow.spike_sort_stages:detect_trial",
-        notes=(
-            "Fast threshold sweep on a small subset of the recording. "
-            "Runs dartsort.threshold() at 3 candidate thresholds (3.5, 4.0, 4.5) "
-            "with early termination (stop_after_n_spikes=10000, ensure_coverage=0.05). "
-            "Writes trial results to {output_dir}/trial_results.json for the "
-            "detection parameter advisor to make a data-informed threshold choice."
-        ),
-        reads={"preprocessed/", "noise_stats.json"},
-        writes={"trial_results.json"},
-    )
-
-    # ── Stage 2: Detection Parameter Selection (LLM) ───────────────
-
-    nodes["detect_params"] = AgentNode(
-        id="detect_params",
-        role=AgentRole.RESEARCHER,
-        model="haiku",
-        timeout=60,
-        prompt_template=(
-            "You are a spike detection parameter advisor for extracellular neural recordings. "
-            "Read the noise statistics at {output_dir}/noise_stats.json and the trial "
-            "detection results at {output_dir}/trial_results.json.\n\n"
-            "TRIAL RESULTS: A threshold sweep has already been run on a small subset of "
-            "the recording at thresholds 3.5, 4.0, and 4.5. The trial_results.json file "
-            "contains for each threshold: spike_count, spike_rate_hz, mean_amplitude, "
-            "and amplitude_distribution_percentiles. Use this empirical data to inform "
-            "your threshold selection.\n\n"
-            "IMPORTANT: We use DARTsort's subtract() function (SubtractionPeeler) for "
-            "detection. This is an iterative template-subtraction algorithm that produces "
-            "cleaner spike detections than simple thresholding. The subtract algorithm "
-            "includes a neural network denoiser in its pipeline. "
-            "The default detection_threshold is 3.0 for subtract().\n\n"
-            "Select detection parameters:\n"
-            "- detection_threshold (2.5-5.0): SNR threshold in standardized units. "
-            "Default: 3.0 (subtract's calibrated default). Higher values reduce false "
-            "positives but may miss weak units. Lower values catch more spikes but "
-            "may include noise.\n"
-            "- peak_sign ('neg', 'pos', 'both'): Which polarity peaks to detect. "
-            "'both' is standard for extracellular recordings.\n\n"
-            "Decision rules:\n"
-            "- Start with detection_threshold=3.0 (the subtract default).\n"
-            "- Compare trial results across thresholds: if 4.0 produces reasonable "
-            "spike rate (20-200 Hz per channel), consider using 4.0 for cleaner output.\n"
-            "- Very noisy data (median noise >20 µV): raise to 4.0-5.0.\n"
-            "- Clean data (<8 µV): keep 3.0.\n"
-            "- Neuropixels probes → 'both' peak_sign.\n\n"
-            "In your reasoning field, explicitly state why you chose your threshold. "
-            "Reference the trial results — cite the spike counts and rates you observed.\n\n"
-            "IMPORTANT: Write your selection as a JSON file to {output_dir}/detection_params.json "
-            "using the Write tool. The JSON must have these fields:\n"
-            '- "detection_threshold": float (2.5-5.0)\n'
-            '- "peak_sign": string ("neg", "pos", or "both")\n'
-            '- "reasoning": string (your brief justification)'
-        ),
-        reads={"noise_stats.json", "trial_results.json"},
-        writes={"detection_params.json"},
-    )
-
-    # ── Stage 3: Spike Detection ───────────────────────────────────
-
-    nodes["detect"] = FnNode(
-        id="detect",
-        callable_name="factory.workflow.spike_sort_stages:detect",
-        notes=(
-            "Subtraction-based spike detection (SubtractionPeeler) with LLM-selected "
-            "parameters. Uses iterative template subtraction for cleaner detection "
-            "than simple thresholding. Reads preprocessed recording and "
-            "detection_params.json. Writes detections to {output_dir}/detections/ "
-            "and summary to {output_dir}/detection_summary.json."
-        ),
-        reads={"preprocessed/", "detection_params.json"},
-        writes={"detections/", "detection_summary.json"},
-    )
-
-    # ── Stage 4: Localization ──────────────────────────────────────
-
-    nodes["localize"] = FnNode(
-        id="localize",
-        callable_name="factory.workflow.spike_sort_stages:localize",
-        notes=(
-            "Point-source localization of detected spikes via Levenberg-Marquardt. "
-            "Also estimates motion (drift). "
-            "Writes localizations and cluster_input_stats.json for the clustering agent."
-        ),
-        reads={"preprocessed/", "detections/"},
-        writes={"localizations.npz", "motion/", "cluster_input_stats.json"},
-    )
-
-    # ── Stage 5: Clustering Parameter Selection (LLM) ──────────────
-
-    nodes["cluster_params"] = AgentNode(
-        id="cluster_params",
-        role=AgentRole.STRATEGIST,
-        model="sonnet",
-        timeout=120,
-        prompt_template=(
-            "You are a spike clustering strategy advisor. "
-            "Read the cluster input statistics at {output_dir}/cluster_input_stats.json.\n\n"
-            "Select a clustering strategy and parameters:\n"
-            "- strategy: 'channel_snap' (fast, coarse — good for <20K spikes), "
-            "'grid_snap' (spatial grid — good for high density), "
-            "'dpc' (density peak clustering — slow but accurate, best for >20K spikes with drift), "
-            "'none' (skip clustering — only for pre-sorted data).\n"
-            "- grid_dx, grid_dz (5-50 µm): Spatial grid resolution. "
-            "Smaller = more clusters initially. 15 µm is typical.\n\n"
-            "Decision tree:\n"
-            "- spike_count < 20K → channel_snap\n"
-            "- drift > 15 µm → dpc with drift correction\n"
-            "- spike_density > 1.0 spikes/ch/s → grid_snap\n"
-            "- Otherwise → dpc\n\n"
-            "IMPORTANT: Write your selection as a JSON file to {output_dir}/clustering_params.json "
-            "using the Write tool. The JSON must have these fields:\n"
-            '- "strategy": string ("channel_snap", "grid_snap", "dpc", or "none")\n'
-            '- "grid_dx": float (5.0-50.0)\n'
-            '- "grid_dz": float (5.0-50.0)\n'
-            '- "reasoning": string (your brief justification)'
-        ),
-        reads={"cluster_input_stats.json"},
-        writes={"clustering_params.json"},
-    )
-
-    # ── Stage 6: Clustering ────────────────────────────────────────
-
-    nodes["cluster"] = FnNode(
-        id="cluster",
-        callable_name="factory.workflow.spike_sort_stages:cluster",
-        notes=(
-            "GMM/DPC clustering with LLM-selected strategy and parameters. "
-            "Reads detections and clustering_params.json. "
-            "Writes clustered sorting to {output_dir}/clusters/."
-        ),
-        reads={"preprocessed/", "detections/", "clustering_params.json", "motion/"},
-        writes={"clusters/", "cluster_summary.json"},
-    )
-
-    # ── Stage 7: Template Computation ──────────────────────────────
-
-    nodes["templates"] = FnNode(
-        id="templates",
-        callable_name="factory.workflow.spike_sort_stages:compute_templates",
-        notes=(
-            "Compute unit templates (average/median waveforms) from clustered spikes. "
-            "Writes per-template quality statistics for the QC agent."
-        ),
-        reads={"preprocessed/", "clusters/", "motion/"},
-        writes={"templates/", "template_stats.json"},
-    )
-
-    # ── Stage 8: Template Matching ─────────────────────────────────
-    # Note: Manual template QC was removed - DARTsort's refinement handles
-    # merge/split decisions automatically via agglomerate_cfg
-
-    nodes["match"] = FnNode(
-        id="match",
-        callable_name="factory.workflow.spike_sort_stages:template_match",
-        notes=(
-            "Template matching refinement with post-match agglomeration. "
-            "Matches spikes to templates, then runs DARTsort's final refinement "
-            "(pre_refinement → refinement → agglomerate) to merge overclustered units. "
-            "Produces the final sorting result."
-        ),
-        reads={"preprocessed/", "templates/", "motion/"},
-        writes={"sorting/", "sorting_result.json"},
-    )
-
-    # ── Edges (linear pipeline) ────────────────────────────────────
-
-    edges = [
-        Edge(source="preprocess", target="detect_trial"),
-        Edge(source="detect_trial", target="detect_params"),
-        Edge(source="detect_params", target="detect"),
-        Edge(source="detect", target="localize"),
-        Edge(source="localize", target="cluster_params"),
-        Edge(source="cluster_params", target="cluster"),
-        Edge(source="cluster", target="templates"),
-        Edge(source="templates", target="match"),
-    ]
-
-    # ── Trigger ────────────────────────────────────────────────────
-
-    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
-        return ctx.get("mode") == "spike-sort"
-
-    return Workflow(
-        name="spike-sort",
-        nodes=nodes,
-        edges=edges,
-        start_node="preprocess",
-        trigger=trigger,
-    )
-
-
 # ── Registry ─────────────────────────────────────────────────────
 
 
@@ -2803,246 +2569,427 @@ def parallel_improve_workflow() -> Workflow:
     )
 
 
+# ── Spike-Sort Gate Prompts (Section 13 — context-first) ─────────
+
+GATE_POST_CLUSTER_PROMPT = (
+    "You are a spike sorting quality gate for the POST-CLUSTERING stage. "
+    "Your role is to make context-aware decisions about cluster merging, "
+    "splitting, and deletion — decisions that require judgment, not just "
+    "threshold checking.\n\n"
+
+    "## Why You Exist\n\n"
+    "If we could just apply fixed thresholds, we'd use deterministic code. "
+    "You exist because the same metric means different things in different "
+    "contexts. A 5% ISI violation rate might be acceptable contamination in "
+    "a fast-spiking interneuron or catastrophic in a sparse pyramidal cell. "
+    "Your job is to reason about what the metrics mean for THIS recording.\n\n"
+
+    "## Step 1: Understand the Recording Context\n\n"
+    "Read {output_dir}/recording_context.json FIRST. Before looking at any "
+    "metrics, understand:\n"
+    "- **Brain region:** What cell types are expected? What firing rates?\n"
+    "- **Drift magnitude:** High drift (>15µm) causes fragmentation — be more "
+    "aggressive about merging\n"
+    "- **Recording duration:** Affects what spike counts are reasonable\n"
+    "- **Expected cell types:** Purkinje cells fire at 50-150Hz; pyramidal "
+    "cells at 0.5-10Hz; fast interneurons at 20-100Hz\n\n"
+
+    "## Step 2: Review Cluster Metrics\n\n"
+    "Read {output_dir}/cluster_metrics.json. For each cluster and pair, "
+    "interpret the metrics IN CONTEXT:\n\n"
+
+    "**Per-cluster metrics:**\n"
+    "- spike_count, firing_rate_hz — Is this plausible for the expected cell types?\n"
+    "- isi_violation_rate — Raw fraction of ISIs < 1.5ms\n"
+    "- isi_fp_estimate — Hill formula estimate accounting for firing rate "
+    "(USE THIS, not raw ISI rate)\n"
+    "- snr — Signal quality\n"
+    "- amplitude_bimodality — Suggests two populations merged if high\n"
+    "- spatial_centroid — Position on probe\n\n"
+
+    "**Pairwise metrics (clusters within 100µm):**\n"
+    "- template_correlation — Waveform similarity\n"
+    "- spatial_distance_um — Physical proximity\n"
+    "- ccg_refractory_r12, ccg_refractory_q12 — CCG refractory dip scores. "
+    "Low R12 (<0.25) with low Q12 (<0.05) suggests same neuron.\n\n"
+
+    "## Step 3: Make Decisions\n\n"
+    "For each decision, reason about the specific context:\n\n"
+
+    "### MERGE Decisions\n"
+    "The clustering algorithm deliberately oversplits — your primary job is "
+    "to identify and merge fragments of the same neuron.\n\n"
+    "Strong merge signal: CCG shows refractory dip (independent confirmation "
+    "that spikes come from the same neuron). If CCG is refractory AND clusters "
+    "are nearby AND templates are similar, merge.\n\n"
+    "Weak merge signal without CCG: Template correlation alone is not enough — "
+    "similar waveforms can come from different neurons. Require additional "
+    "evidence (proximity, firing pattern continuity).\n\n"
+    "Drift consideration: If drift is high, waveforms from the same neuron "
+    "may differ across time. CCG refractory is more reliable than template "
+    "correlation in drifting recordings.\n\n"
+
+    "### DELETE Decisions\n"
+    "Delete clusters that are clearly not single neurons. But interpret "
+    "in context:\n\n"
+    "- High ISI + high rate: Likely garbage collector (noise unit). But check "
+    "brain region — cerebellar Purkinje cells legitimately fire at 100+ Hz.\n"
+    "- High ISI + low rate: Use isi_fp_estimate, not raw ISI. A 1% ISI rate "
+    "at 3Hz firing indicates ~50% contamination (delete), while 1% at 50Hz "
+    "is ~3% contamination (keep).\n"
+    "- Very low spike count: May be a real but sparse neuron, or may be noise. "
+    "Check SNR — low count + low SNR = noise.\n\n"
+
+    "### SPLIT Decisions\n"
+    "Split when evidence suggests two neurons were merged:\n"
+    "- Bimodal amplitude distribution (two distinct sizes)\n"
+    "- CCG shows NO refractory dip (neurons fire independently)\n"
+    "- Spatial spread larger than expected for one neuron\n\n"
+
+    "## Output\n\n"
+    "Write {output_dir}/gate1_decision.json:\n"
+    "```json\n"
+    "{\n"
+    '  "merge_pairs": [[id1, id2], ...],\n'
+    '  "split_clusters": [id, ...],\n'
+    '  "delete_clusters": [id, ...],\n'
+    '  "confidence": 0.0-1.0,\n'
+    '  "reasoning": "..."\n'
+    "}\n"
+    "```\n\n"
+    "In your reasoning, explain HOW CONTEXT influenced your decisions. "
+    "Don't just cite threshold values — explain what the metrics mean for "
+    "this specific recording and why your decisions make sense."
+)
+
+GATE_POST_TEMPLATE_PROMPT = (
+    "You are a spike sorting quality gate for the POST-TEMPLATE stage.\n\n"
+
+    "## Context First\n\n"
+    "Read {output_dir}/recording_context.json. Key factors:\n"
+    "- **Drift:** High drift makes templates less stable — instability may "
+    "be drift, not noise\n"
+    "- **Recording duration:** Affects expected spike counts per template\n\n"
+
+    "## Template Metrics\n\n"
+    "Read {output_dir}/template_metrics.json:\n"
+    "- template_spike_count — More spikes = more reliable template\n"
+    "- template_snr — Signal quality\n"
+    "- template_stability — Variance over time (lower = more stable)\n"
+    "- template_similarity_max — Correlation with most similar other template\n"
+    "- template_amplitude_uv, template_spatial_spread_um\n\n"
+
+    "## Decision Guidance\n\n"
+    "**DELETE:** Templates that will cause matching problems:\n"
+    "- Very few spikes AND low SNR — noise template, will match noise\n"
+    "- But consider: a template with few spikes but high SNR might be a "
+    "real sparse neuron, not noise\n\n"
+
+    "**MERGE:** Near-duplicate templates:\n"
+    "- Very high similarity (>0.95) suggests same neuron split into two templates\n"
+    "- But check spatial locations — similar waveforms from distant sites "
+    "are different neurons\n\n"
+
+    "**Context matters:**\n"
+    "- If many templates look bad, that's an upstream clustering problem, "
+    "not a template problem — note this\n"
+    "- Low stability in high-drift recordings is expected, not a delete signal\n\n"
+
+    "## Output\n\n"
+    "Write {output_dir}/gate2_decision.json:\n"
+    "```json\n"
+    "{\n"
+    '  "merge_pairs": [[id1, id2], ...],\n'
+    '  "delete_templates": [id, ...],\n'
+    '  "confidence": 0.0-1.0,\n'
+    '  "reasoning": "..."\n'
+    "}\n"
+    "```\n\n"
+    "This is a lighter gate. If templates look reasonable for the recording "
+    "context, output empty action lists."
+)
+
+GATE_POST_MATCH_PROMPT = (
+    "You are a spike sorting quality gate for the POST-MATCHING stage. "
+    "This is final cleanup — you cannot recover lost accuracy, only remove "
+    "clear garbage.\n\n"
+
+    "## Context First\n\n"
+    "Read {output_dir}/recording_context.json. Critical:\n"
+    "- **Expected cell types:** What firing rates are biologically plausible?\n"
+    "- **Brain region:** Cerebellum allows 100+ Hz; cortex typically <50 Hz\n\n"
+
+    "## Final Metrics\n\n"
+    "Read {output_dir}/final_metrics.json:\n"
+    "- final_spike_count, final_firing_rate_hz\n"
+    "- final_isi_violation_rate (raw) vs final_isi_fp_estimate (rate-adjusted)\n"
+    "- amplitude_cutoff, presence_ratio, snr\n\n"
+
+    "## Decision Guidance\n\n"
+    "**DELETE with confidence:**\n"
+    "- Obvious garbage collectors: implausibly high rate + high ISI + low SNR\n"
+    "- But ALWAYS check brain region first — 150 Hz is garbage in cortex, "
+    "normal in cerebellum\n\n"
+
+    "**DELETE with caution:**\n"
+    "- Low spike count — might be sparse neuron, check SNR and presence_ratio\n"
+    "- High ISI at low rate — use isi_fp_estimate to assess true contamination\n\n"
+
+    "**MERGE conservatively:**\n"
+    "- At this stage, prefer keeping units separate for human review\n"
+    "- Only merge with overwhelming evidence (high correlation + refractory CCG + proximity)\n"
+    "- Merging two different neurons is worse than keeping one neuron split\n\n"
+
+    "## Output\n\n"
+    "Write {output_dir}/gate3_decision.json:\n"
+    "```json\n"
+    "{\n"
+    '  "merge_pairs": [[id1, id2], ...],\n'
+    '  "delete_units": [id, ...],\n'
+    '  "confidence": 0.0-1.0,\n'
+    '  "reasoning": "..."\n'
+    "}\n"
+    "```\n\n"
+    "Explain your reasoning in context. Don't just cite numbers — explain "
+    "why this unit is/isn't plausible for the recording context."
+)
+
+
 def spike_sort_workflow() -> Workflow:
-    """Spike sorting data pipeline with LLM-in-the-loop parameter selection.
+    """Spike sorting pipeline with LLM quality gates at critical handoffs.
 
-    NOT a code-writing workflow — directly executes DARTsort algorithms (FnNodes)
-    with LLM parameter advisors (AgentNodes) at two decision points plus a final
-    QA assessment.
+    NOT a software engineering workflow — directly executes DARTsort algorithms
+    (FnNodes) with LLM quality gates (AgentNodes) at three decision points.
 
-    10 nodes (7 FnNodes + 3 AgentNodes), 9 edges, linear chain:
+    Architecture: Deterministic COMPUTE → LLM INTERPRET → Deterministic EXECUTE
 
-    Pipeline:
-    preprocess (FnNode) → detect_trial (FnNode) → detect_params (AgentNode/haiku) →
-    detect (FnNode) → localize (FnNode) → cluster_params (AgentNode/sonnet) →
-    cluster (FnNode) → templates (FnNode) → match (FnNode) → qa_sorting (AgentNode/sonnet)
+    15 nodes (12 FnNodes + 3 AgentNodes), 14 edges, linear chain:
+
+    preprocess → detect → localize → cluster →
+    compute_cluster_metrics → gate_post_cluster → apply_cluster_actions →
+    templates → compute_template_metrics → gate_post_template →
+    apply_template_actions → match → compute_final_metrics →
+    gate_post_match → apply_final_actions
     """
     nodes: dict[str, Any] = {}
 
-    # ── Stage 0: Preprocessing (deterministic) ────────────────────
+    # ── Stage 1: Preprocessing (deterministic) ────────────────────
+
     nodes["preprocess"] = FnNode(
         id="preprocess",
-        command="",
-        notes="Bandpass filter, standardize, whiten the raw recording.",
+        callable_name="factory.workflow.spike_sort_stages:preprocess",
+        notes=(
+            "Bandpass filter, standardize, whiten the raw recording. "
+            "Writes preprocessed recording to {output_dir}/preprocessed/ "
+            "and noise statistics to {output_dir}/noise_stats.json."
+        ),
         writes={"preprocessed/", "noise_stats.json"},
     )
 
-    # ── Stage 1: Detection Trial (deterministic) ──────────────────
-    nodes["detect_trial"] = FnNode(
-        id="detect_trial",
-        command="",
-        notes=(
-            "Fast threshold sweep on a small subset of the recording. "
-            "Runs dartsort.threshold() at 3 candidate thresholds (3.5, 4.0, 4.5) "
-            "with early termination."
-        ),
-        reads={"noise_stats.json", "preprocessed/"},
-        writes={"trial_results.json"},
-    )
+    # ── Stage 2: Detection (deterministic, hardcoded defaults) ────
 
-    # ── Stage 2: Detection Parameters (LLM) ──────────────────────
-    nodes["detect_params"] = AgentNode(
-        id="detect_params",
-        role=AgentRole.RESEARCHER,
-        model="haiku",
-        timeout=60,
-        prompt_template=(
-            "You are a spike detection parameter advisor for extracellular neural "
-            "recordings. Read the noise statistics at {output_dir}/noise_stats.json "
-            "and the trial detection results at {output_dir}/trial_results.json.\n\n"
-            "TRIAL RESULTS: A threshold sweep has already been run on a small subset "
-            "of the recording at thresholds 3.5, 4.0, and 4.5. The trial_results.json "
-            "file contains for each threshold: spike_count, spike_rate_hz, "
-            "mean_amplitude, and amplitude_distribution_percentiles. Use this "
-            "empirical data to inform your threshold selection.\n\n"
-            "IMPORTANT: We use DARTsort's subtract() function (SubtractionPeeler) "
-            "for detection. This is an iterative template-subtraction algorithm that "
-            "produces cleaner spike detections than simple thresholding. The subtract "
-            "algorithm includes a neural network denoiser in its pipeline. The default "
-            "detection_threshold is 3.0 for subtract().\n\n"
-            "Select detection parameters:\n"
-            "- detection_threshold (2.5-5.0): SNR threshold in standardized units. "
-            "Default: 3.0 (subtract's calibrated default). Higher values reduce "
-            "false positives but may miss weak units. Lower values catch more spikes "
-            "but may include noise.\n"
-            "- peak_sign ('neg', 'pos', 'both'): Which polarity peaks to detect. "
-            "'both' is standard for extracellular recordings.\n\n"
-            "Decision rules:\n"
-            "- Start with detection_threshold=3.0 (the subtract default).\n"
-            "- Compare trial results across thresholds: if 4.0 produces reasonable "
-            "spike rate (20-200 Hz per channel), consider using 4.0 for cleaner output.\n"
-            "- Very noisy data (median noise >20 µV): raise to 4.0-5.0.\n"
-            "- Clean data (<8 µV): keep 3.0.\n"
-            "- Neuropixels probes → 'both' peak_sign.\n\n"
-            "In your reasoning field, explicitly state why you chose your threshold. "
-            "Reference the trial results — cite the spike counts and rates you observed.\n\n"
-            "IMPORTANT: Write your selection as a JSON file to "
-            "{output_dir}/detection_params.json using the Write tool. The JSON must "
-            "have these fields:\n"
-            '- "detection_threshold": float (2.5-5.0)\n'
-            '- "peak_sign": string ("neg", "pos", or "both")\n'
-            '- "reasoning": string (your brief justification)'
-        ),
-        reads={"noise_stats.json", "trial_results.json"},
-        writes={"detection_params.json"},
-    )
-
-    # ── Stage 3: Detection (deterministic) ────────────────────────
     nodes["detect"] = FnNode(
         id="detect",
-        command="",
+        callable_name="factory.workflow.spike_sort_stages:detect",
         notes=(
             "Subtraction-based spike detection (SubtractionPeeler) with "
-            "LLM-selected parameters."
+            "DARTsort defaults: detection_threshold=3.0, peak_sign='both'. "
+            "No longer reads detection_params.json — parameters are hardcoded."
         ),
-        reads={"preprocessed/", "detection_params.json"},
+        reads={"preprocessed/"},
         writes={"detections/", "detection_summary.json"},
     )
 
-    # ── Stage 4: Localization (deterministic) ─────────────────────
+    # ── Stage 3: Localization (deterministic) ─────────────────────
+
     nodes["localize"] = FnNode(
         id="localize",
-        command="",
+        callable_name="factory.workflow.spike_sort_stages:localize",
         notes=(
             "Point-source localization of detected spikes via "
             "Levenberg-Marquardt. Also estimates motion (drift)."
         ),
-        reads={"detections/", "preprocessed/"},
-        writes={"localizations.npz", "cluster_input_stats.json", "motion/"},
+        reads={"preprocessed/", "detections/"},
+        writes={"localizations.npz", "motion/", "cluster_input_stats.json"},
     )
 
-    # ── Stage 5: Clustering Parameters (LLM) ─────────────────────
-    nodes["cluster_params"] = AgentNode(
-        id="cluster_params",
-        role=AgentRole.STRATEGIST,
-        model="sonnet",
-        timeout=120,
-        prompt_template=(
-            "You are a spike clustering strategy advisor. Read the cluster input "
-            "statistics at {output_dir}/cluster_input_stats.json.\n\n"
-            "Select a clustering strategy and parameters:\n"
-            "- strategy: 'channel_snap' (fast, coarse — good for <20K spikes), "
-            "'grid_snap' (spatial grid — good for high density), 'dpc' (density "
-            "peak clustering — slow but accurate, best for >20K spikes with drift), "
-            "'none' (skip clustering — only for pre-sorted data).\n"
-            "- grid_dx, grid_dz (5-50 µm): Spatial grid resolution. Smaller = more "
-            "clusters initially. 15 µm is typical.\n\n"
-            "Decision tree:\n"
-            "- spike_count < 20K → channel_snap\n"
-            "- drift > 15 µm → dpc with drift correction\n"
-            "- spike_density > 1.0 spikes/ch/s → grid_snap\n"
-            "- Otherwise → dpc\n\n"
-            "IMPORTANT: Write your selection as a JSON file to "
-            "{output_dir}/clustering_params.json using the Write tool. The JSON must "
-            "have these fields:\n"
-            '- "strategy": string ("channel_snap", "grid_snap", "dpc", or "none")\n'
-            '- "grid_dx": float (5.0-50.0)\n'
-            '- "grid_dz": float (5.0-50.0)\n'
-            '- "reasoning": string (your brief justification)'
-        ),
-        reads={"cluster_input_stats.json"},
-        writes={"clustering_params.json"},
-    )
+    # ── Stage 4: Clustering (deterministic, hardcoded defaults) ───
 
-    # ── Stage 6: Clustering (deterministic) ───────────────────────
     nodes["cluster"] = FnNode(
         id="cluster",
-        command="",
-        notes="GMM/DPC clustering with LLM-selected strategy and parameters.",
-        reads={"preprocessed/", "detections/", "motion/", "clustering_params.json"},
-        writes={"clusters/", "cluster_summary.json"},
-    )
-
-    # ── Stage 7: Templates (deterministic) ────────────────────────
-    nodes["templates"] = FnNode(
-        id="templates",
-        command="",
-        notes="Compute unit templates (average/median waveforms) from clustered spikes.",
-        reads={"preprocessed/", "clusters/", "motion/"},
-        writes={"templates/", "template_stats.json"},
-    )
-
-    # ── Stage 8: Match (deterministic) ────────────────────────────
-    nodes["match"] = FnNode(
-        id="match",
-        command="",
+        callable_name="factory.workflow.spike_sort_stages:cluster",
         notes=(
-            "Template matching refinement with post-match agglomeration. "
-            "Produces the final sorting result."
+            "DPC clustering with hardcoded defaults: strategy='dpc', "
+            "grid_dx=15.0, grid_dz=15.0. No longer reads clustering_params.json. "
+            "Creates recording_context.json from config + computed drift."
         ),
-        reads={"preprocessed/", "templates/", "motion/"},
-        writes={"sorting/", "sorting_result.json"},
+        reads={"preprocessed/", "detections/", "motion/"},
+        writes={"clusters/", "cluster_summary.json", "recording_context.json"},
     )
 
-    # ── Stage 9: Quality Assessment (LLM) ─────────────────────────
-    nodes["qa_sorting"] = AgentNode(
-        id="qa_sorting",
+    # ── Gate 1 Triplet: Post-Clustering (CRITICAL) ────────────────
+
+    nodes["compute_cluster_metrics"] = FnNode(
+        id="compute_cluster_metrics",
+        callable_name="factory.workflow.spike_sort_stages:compute_cluster_metrics",
+        notes=(
+            "Compute per-cluster and pairwise metrics for Gate 1. "
+            "Per-cluster: spike_count, firing_rate_hz, isi_violation_rate, "
+            "isi_fp_estimate (Hill formula), snr, amplitude_bimodality "
+            "(Hartigan dip), spatial_centroid. "
+            "Pairwise (clusters within 100um): template_correlation, "
+            "spatial_distance_um, ccg_refractory_r12, ccg_refractory_q12."
+        ),
+        reads={"clusters/", "localizations.npz", "recording_context.json"},
+        writes={"cluster_metrics.json"},
+    )
+
+    nodes["gate_post_cluster"] = AgentNode(
+        id="gate_post_cluster",
         role=AgentRole.HEALTH_CHECKER,
         model="sonnet",
         timeout=300,
-        prompt_template=(
-            "You are a neuroscience data quality expert. Review the FINAL spike sorting "
-            "results and identify units that may be problematic.\n\n"
-            "### Input Files — CRITICAL: Use the FINAL sorting, NOT templates\n\n"
-            "**Primary data source (MUST use this):**\n"
-            "- **sorting/sorting.npz**: The FINAL sorted spikes at {output_dir}/sorting/sorting.npz\n"
-            "  Load with: `data = np.load(path); times = data['times_samples']; labels = data['labels']`\n"
-            "  - `times_samples`: spike times in samples (int64)\n"
-            "  - `labels`: unit ID for each spike (int32, -1 = noise)\n"
-            "  - `sampling_frequency`: Hz (float)\n"
-            "  Count spikes per unit: `for uid in np.unique(labels[labels >= 0]): count = (labels == uid).sum()`\n\n"
-            "**Secondary (for waveform analysis):**\n"
-            "- **templates/**: Template waveforms at {output_dir}/templates/\n\n"
-            "**DO NOT USE** template_stats.json — it has pre-merge statistics that don't match final units.\n\n"
-            "### Quality Criteria\n\n"
-            "**Multi-unit activity indicators:**\n"
-            "- ISI violation rate > 0.1 (10% of spikes violate 2ms refractory period)\n"
-            "- Bimodal or multi-peaked amplitude distributions\n\n"
-            "**Noise indicators:**\n"
-            "- Very low spike count (< 50 spikes in a 2-minute recording)\n"
-            "- For a 120s recording, healthy neurons fire 500-3000+ spikes\n\n"
-            "### Quality Thresholds\n\n"
-            "| Metric              | Threshold | Flag if...          |\n"
-            "|---------------------|-----------|---------------------|\n"
-            "| ISI violation rate  | > 0.1     | possible_multi_unit |\n"
-            "| Spike count         | < 50      | low_spike_count     |\n"
-            "| Spike count         | < 500     | sparse_firing       |\n\n"
-            "### Instructions\n\n"
-            "1. Load {output_dir}/sorting/sorting.npz with numpy\n"
-            "2. Extract times_samples, labels, sampling_frequency\n"
-            "3. Filter out noise labels (labels == -1)\n"
-            "4. For each unique unit ID (labels >= 0):\n"
-            "   - Count spikes: (labels == unit_id).sum()\n"
-            "   - Compute ISI violations: consecutive spikes < 2ms apart\n"
-            "5. Flag units based on thresholds\n"
-            "6. Write output files\n\n"
-            "### Output Files\n\n"
-            "IMPORTANT: Write BOTH output files using the Write tool.\n\n"
-            "1. **qa_report.json** at {output_dir}/qa_report.json with:\n"
-            '   - "summary": object with total_units, flagged_unit_count, recording_duration_s\n'
-            '   - "units": list of objects, each with: unit_id (int), spike_count (int), '
-            "isi_violation_rate (float or null), flags (list of strings), "
-            "confidence_score (float 0-1)\n\n"
-            "2. **flagged_units.json** at {output_dir}/flagged_units.json with:\n"
-            '   - "flagged_units": list of objects with unit_id, spike_count, flags\n'
-            '   - "summary": object with total_flagged, by_flag_type counts'
-        ),
-        reads={"sorting/"},
-        writes={"qa_report.json", "flagged_units.json"},
+        prompt_template=GATE_POST_CLUSTER_PROMPT,
+        reads={"cluster_metrics.json", "recording_context.json"},
+        writes={"gate1_decision.json"},
     )
 
-    # ── Edges ─────────────────────────────────────────────────────
+    nodes["apply_cluster_actions"] = FnNode(
+        id="apply_cluster_actions",
+        callable_name="factory.workflow.spike_sort_stages:apply_cluster_actions",
+        notes=(
+            "Execute Gate 1 decisions. "
+            "MERGE: agglomerate refinement (merge_distance_threshold=0.3). "
+            "SPLIT: TMM refinement (mixture_steps=['split']). "
+            "DELETE: labels[np.isin(labels, delete_clusters)] = -1."
+        ),
+        reads={"gate1_decision.json", "clusters/"},
+        writes={"clusters_refined/"},
+    )
+
+    # ── Stage 5: Template Computation (deterministic) ─────────────
+
+    nodes["templates"] = FnNode(
+        id="templates",
+        callable_name="factory.workflow.spike_sort_stages:compute_templates",
+        notes=(
+            "Compute unit templates (average/median waveforms) from "
+            "refined clusters. Reads clusters_refined/ if present, "
+            "else clusters/."
+        ),
+        reads={"preprocessed/", "clusters_refined/", "motion/"},
+        writes={"templates/", "template_stats.json"},
+    )
+
+    # ── Gate 2 Triplet: Post-Template (MODERATE) ──────────────────
+
+    nodes["compute_template_metrics"] = FnNode(
+        id="compute_template_metrics",
+        callable_name="factory.workflow.spike_sort_stages:compute_template_metrics",
+        notes=(
+            "Compute per-template metrics for Gate 2. "
+            "Metrics: template_spike_count, template_snr, template_stability, "
+            "template_similarity_max, template_amplitude_uv, "
+            "template_spatial_spread_um."
+        ),
+        reads={"templates/", "template_stats.json"},
+        writes={"template_metrics.json"},
+    )
+
+    nodes["gate_post_template"] = AgentNode(
+        id="gate_post_template",
+        role=AgentRole.HEALTH_CHECKER,
+        model="haiku",
+        timeout=120,
+        prompt_template=GATE_POST_TEMPLATE_PROMPT,
+        reads={"template_metrics.json", "recording_context.json"},
+        writes={"gate2_decision.json"},
+    )
+
+    nodes["apply_template_actions"] = FnNode(
+        id="apply_template_actions",
+        callable_name="factory.workflow.spike_sort_stages:apply_template_actions",
+        notes=(
+            "Execute Gate 2 decisions. "
+            "DELETE: remove templates from set. "
+            "MERGE: average similar templates, update mapping."
+        ),
+        reads={"gate2_decision.json", "templates/"},
+        writes={"templates_refined/"},
+    )
+
+    # ── Stage 6: Template Matching (deterministic) ────────────────
+
+    nodes["match"] = FnNode(
+        id="match",
+        callable_name="factory.workflow.spike_sort_stages:template_match",
+        notes=(
+            "Template matching refinement with post-match agglomeration. "
+            "Reads templates_refined/ if present, else templates/. "
+            "Produces the final sorting result."
+        ),
+        reads={"preprocessed/", "templates_refined/", "motion/"},
+        writes={"sorting/", "sorting_result.json"},
+    )
+
+    # ── Gate 3 Triplet: Post-Matching (CLEANUP) ──────────────────
+
+    nodes["compute_final_metrics"] = FnNode(
+        id="compute_final_metrics",
+        callable_name="factory.workflow.spike_sort_stages:compute_final_metrics",
+        notes=(
+            "Compute final unit metrics for Gate 3. "
+            "Metrics: final_spike_count, final_firing_rate_hz, "
+            "final_isi_violation_rate, final_isi_fp_estimate, "
+            "amplitude_cutoff, presence_ratio, snr."
+        ),
+        reads={"sorting/"},
+        writes={"final_metrics.json"},
+    )
+
+    nodes["gate_post_match"] = AgentNode(
+        id="gate_post_match",
+        role=AgentRole.HEALTH_CHECKER,
+        model="haiku",
+        timeout=120,
+        prompt_template=GATE_POST_MATCH_PROMPT,
+        reads={"final_metrics.json", "recording_context.json"},
+        writes={"gate3_decision.json"},
+    )
+
+    nodes["apply_final_actions"] = FnNode(
+        id="apply_final_actions",
+        callable_name="factory.workflow.spike_sort_stages:apply_final_actions",
+        notes=(
+            "Execute Gate 3 decisions. "
+            "DELETE: labels[labels == unit_id] = -1. "
+            "MERGE: labels[labels == unit_b] = unit_a. "
+            "Writes final cleaned sorting."
+        ),
+        reads={"gate3_decision.json", "sorting/"},
+        writes={"sorting_final/", "sorting_result.json"},
+    )
+
+    # ── Edges (14-edge linear pipeline) ───────────────────────────
+
     edges = [
-        Edge(source="preprocess", target="detect_trial"),
-        Edge(source="detect_trial", target="detect_params"),
-        Edge(source="detect_params", target="detect"),
+        Edge(source="preprocess", target="detect"),
         Edge(source="detect", target="localize"),
-        Edge(source="localize", target="cluster_params"),
-        Edge(source="cluster_params", target="cluster"),
-        Edge(source="cluster", target="templates"),
-        Edge(source="templates", target="match"),
-        Edge(source="match", target="qa_sorting"),
+        Edge(source="localize", target="cluster"),
+        Edge(source="cluster", target="compute_cluster_metrics"),
+        Edge(source="compute_cluster_metrics", target="gate_post_cluster"),
+        Edge(source="gate_post_cluster", target="apply_cluster_actions"),
+        Edge(source="apply_cluster_actions", target="templates"),
+        Edge(source="templates", target="compute_template_metrics"),
+        Edge(source="compute_template_metrics", target="gate_post_template"),
+        Edge(source="gate_post_template", target="apply_template_actions"),
+        Edge(source="apply_template_actions", target="match"),
+        Edge(source="match", target="compute_final_metrics"),
+        Edge(source="compute_final_metrics", target="gate_post_match"),
+        Edge(source="gate_post_match", target="apply_final_actions"),
     ]
+
+    # ── Trigger ───────────────────────────────────────────────────
 
     def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
         return ctx.get("mode") == "spike-sort"

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2865,4 +2865,5 @@ def register_all() -> dict[str, Workflow]:
         "doc-update": doc_update_workflow(),
         "spec-generate": spec_generate_workflow(),
         "spec-update": spec_update_workflow(),
+        "spike-sort": spike_sort_workflow(),
     }

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -57,6 +57,7 @@ __all__ = [
     "spec_generate_workflow",
     "spec_update_workflow",
     "parallel_improve_workflow",
+    "spike_sort_workflow",
     "register_all",
 ]
 
@@ -2296,6 +2297,221 @@ def spec_update_workflow() -> Workflow:
     )
 
 
+# ── W₁₃: Spike Sort Pipeline ──────────────────────────────────
+
+
+def spike_sort_workflow() -> Workflow:
+    """W₁₃: Spike-sort pipeline — LLM-in-the-loop parameter selection.
+
+    NOT a software engineering workflow. This IS the spike sorting pipeline:
+    FnNodes execute DARTsort algorithms, AgentNodes select parameters via LLM.
+
+    preprocess (FnNode) → detect_params (AgentNode/haiku) → detect (FnNode) →
+    localize (FnNode) → cluster_params (AgentNode/sonnet) → cluster (FnNode) →
+    templates (FnNode) → qc_templates (AgentNode/haiku) → match (FnNode)
+    """
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # ── Stage 1: Preprocessing ─────────────────────────────────────
+
+    nodes["preprocess"] = FnNode(
+        id="preprocess",
+        callable_name="factory.workflow.spike_sort_stages:preprocess",
+        notes=(
+            "Bandpass filter, standardize, whiten the raw recording. "
+            "Writes preprocessed recording to {output_dir}/preprocessed/ "
+            "and noise statistics to {output_dir}/noise_stats.json."
+        ),
+        writes={"preprocessed/", "noise_stats.json"},
+    )
+
+    # ── Stage 2: Detection Parameter Selection (LLM) ───────────────
+
+    nodes["detect_params"] = AgentNode(
+        id="detect_params",
+        role=AgentRole.RESEARCHER,
+        model="haiku",
+        timeout=60,
+        prompt_template=(
+            "You are a spike detection parameter advisor for extracellular neural recordings. "
+            "Read the noise statistics at {output_dir}/noise_stats.json.\n\n"
+            "Based on the recording characteristics, select detection parameters:\n"
+            "- voltage_threshold (2.0-8.0): SNR threshold for spike detection. "
+            "Higher = fewer false positives but may miss low-amplitude neurons. "
+            "Typical: 3.0 for clean data, 4.0-6.0 for noisy data.\n"
+            "- peak_sign ('neg', 'pos', 'both'): Which polarity peaks to detect. "
+            "'both' is standard for extracellular recordings unless you know the cell type.\n"
+            "- dedup_temporal_radius (5-20): Samples to deduplicate within. "
+            "Higher = more aggressive deduplication. 11 is typical at 30kHz.\n\n"
+            "Decision factors:\n"
+            "- High median noise (>15 µV) → raise threshold to 4.0+\n"
+            "- Low noise (<8 µV) → can lower to 2.5-3.0\n"
+            "- Neuropixels probes → 'both' peak_sign is standard\n"
+            "- Short recordings (<60s) → lower threshold to catch more units\n\n"
+            "Output your selection as a DetectionParams JSON object with a reasoning field."
+        ),
+        reads={"noise_stats.json"},
+        writes={"detection_params.json"},
+    )
+
+    # ── Stage 3: Spike Detection ───────────────────────────────────
+
+    nodes["detect"] = FnNode(
+        id="detect",
+        callable_name="factory.workflow.spike_sort_stages:detect",
+        notes=(
+            "Threshold-crossing detection with LLM-selected parameters. "
+            "Reads preprocessed recording and detection_params.json. "
+            "Writes detections to {output_dir}/detections/ "
+            "and summary to {output_dir}/detection_summary.json."
+        ),
+        reads={"preprocessed/", "detection_params.json"},
+        writes={"detections/", "detection_summary.json"},
+    )
+
+    # ── Stage 4: Localization ──────────────────────────────────────
+
+    nodes["localize"] = FnNode(
+        id="localize",
+        callable_name="factory.workflow.spike_sort_stages:localize",
+        notes=(
+            "Point-source localization of detected spikes via Levenberg-Marquardt. "
+            "Also estimates motion (drift). "
+            "Writes localizations and cluster_input_stats.json for the clustering agent."
+        ),
+        reads={"preprocessed/", "detections/"},
+        writes={"localizations.npz", "motion/", "cluster_input_stats.json"},
+    )
+
+    # ── Stage 5: Clustering Parameter Selection (LLM) ──────────────
+
+    nodes["cluster_params"] = AgentNode(
+        id="cluster_params",
+        role=AgentRole.STRATEGIST,
+        model="sonnet",
+        timeout=120,
+        prompt_template=(
+            "You are a spike clustering strategy advisor. "
+            "Read the cluster input statistics at {output_dir}/cluster_input_stats.json.\n\n"
+            "Select a clustering strategy and parameters:\n"
+            "- strategy: 'channel_snap' (fast, coarse — good for <20K spikes), "
+            "'grid_snap' (spatial grid — good for high density), "
+            "'dpc' (density peak clustering — slow but accurate, best for >20K spikes with drift), "
+            "'none' (skip clustering — only for pre-sorted data).\n"
+            "- grid_dx, grid_dz (5-50 µm): Spatial grid resolution. "
+            "Smaller = more clusters initially. 15 µm is typical.\n"
+            "- initial_steps: Refinement sequence. "
+            "['split', 'demolish', 'demolish'] is standard. "
+            "Add 'merge' if you expect many similar units.\n"
+            "- n_waveforms_fit (10K-100K): Subsample size for fitting. "
+            "Higher = better but slower. 40K is typical.\n\n"
+            "Decision tree:\n"
+            "- spike_count < 20K → channel_snap\n"
+            "- drift > 15 µm → dpc with drift correction\n"
+            "- spike_density > 1.0 spikes/ch/s → grid_snap\n"
+            "- Otherwise → dpc\n\n"
+            "Output your selection as a ClusteringParams JSON object with a reasoning field."
+        ),
+        reads={"cluster_input_stats.json"},
+        writes={"clustering_params.json"},
+    )
+
+    # ── Stage 6: Clustering ────────────────────────────────────────
+
+    nodes["cluster"] = FnNode(
+        id="cluster",
+        callable_name="factory.workflow.spike_sort_stages:cluster",
+        notes=(
+            "GMM/DPC clustering with LLM-selected strategy and parameters. "
+            "Reads detections and clustering_params.json. "
+            "Writes clustered sorting to {output_dir}/clusters/."
+        ),
+        reads={"preprocessed/", "detections/", "clustering_params.json", "motion/"},
+        writes={"clusters/", "cluster_summary.json"},
+    )
+
+    # ── Stage 7: Template Computation ──────────────────────────────
+
+    nodes["templates"] = FnNode(
+        id="templates",
+        callable_name="factory.workflow.spike_sort_stages:compute_templates",
+        notes=(
+            "Compute unit templates (average/median waveforms) from clustered spikes. "
+            "Writes per-template quality statistics for the QC agent."
+        ),
+        reads={"preprocessed/", "clusters/", "motion/"},
+        writes={"templates/", "template_stats.json"},
+    )
+
+    # ── Stage 8: Template Quality Control (LLM) ────────────────────
+
+    nodes["qc_templates"] = AgentNode(
+        id="qc_templates",
+        role=AgentRole.RESEARCHER,
+        model="haiku",
+        timeout=120,
+        prompt_template=(
+            "You are a spike sorting template quality control reviewer. "
+            "Read the template statistics at {output_dir}/template_stats.json.\n\n"
+            "For each template, decide: keep, discard, or merge.\n\n"
+            "Decision criteria:\n"
+            "- DISCARD if: SNR < 1.5 (noise unit), spike_count < 10 (too few spikes), "
+            "or ptp_amplitude < 5 µV (below noise floor).\n"
+            "- MERGE if: two templates have very similar spatial positions (within 25 µm) "
+            "AND similar PTP amplitudes (within 30%). Specify merge_with = template_id of partner.\n"
+            "- KEEP otherwise.\n\n"
+            "Quality heuristics:\n"
+            "- Good units: SNR > 3, count > 50, stability > 0.7\n"
+            "- Marginal units: SNR 1.5-3, count 10-50 — keep if isolated\n"
+            "- High spatial_spread (>200 µm) may indicate multi-unit — flag for discard\n\n"
+            "Output a TemplateQCOutput JSON with decisions list and summary string."
+        ),
+        reads={"template_stats.json"},
+        writes={"template_decisions.json"},
+    )
+
+    # ── Stage 9: Template Matching ─────────────────────────────────
+
+    nodes["match"] = FnNode(
+        id="match",
+        callable_name="factory.workflow.spike_sort_stages:template_match",
+        notes=(
+            "Template matching refinement using QC-filtered templates. "
+            "Reads template_decisions.json to filter templates before matching. "
+            "Produces the final sorting result."
+        ),
+        reads={"preprocessed/", "templates/", "template_decisions.json", "motion/"},
+        writes={"sorting/", "sorting_result.json"},
+    )
+
+    # ── Edges (linear pipeline) ────────────────────────────────────
+
+    edges = [
+        Edge(source="preprocess", target="detect_params"),
+        Edge(source="detect_params", target="detect"),
+        Edge(source="detect", target="localize"),
+        Edge(source="localize", target="cluster_params"),
+        Edge(source="cluster_params", target="cluster"),
+        Edge(source="cluster", target="templates"),
+        Edge(source="templates", target="qc_templates"),
+        Edge(source="qc_templates", target="match"),
+    ]
+
+    # ── Trigger ────────────────────────────────────────────────────
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "spike-sort"
+
+    return Workflow(
+        name="spike-sort",
+        nodes=nodes,
+        edges=edges,
+        start_node="preprocess",
+        trigger=trigger,
+    )
+
+
 # ── Registry ─────────────────────────────────────────────────────
 
 
@@ -2586,4 +2802,5 @@ def register_all() -> dict[str, Workflow]:
         "doc-update": doc_update_workflow(),
         "spec-generate": spec_generate_workflow(),
         "spec-update": spec_update_workflow(),
+        "spike-sort": spike_sort_workflow(),
     }

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2747,62 +2747,53 @@ def spike_sort_workflow() -> Workflow:
         model="sonnet",
         timeout=300,
         prompt_template=(
-            "You are a neuroscience data quality expert. Review the final spike sorting "
+            "You are a neuroscience data quality expert. Review the FINAL spike sorting "
             "results and identify units that may be problematic.\n\n"
-            "### Input Files\n"
-            "- **sorting_result.json**: Unit count and basic statistics at "
-            "{output_dir}/sorting_result.json\n"
-            "- **sorting/**: Full SpikeInterface sorting object at {output_dir}/sorting/\n"
+            "### Input Files — CRITICAL: Use the FINAL sorting, NOT templates\n\n"
+            "**Primary data source (MUST use this):**\n"
+            "- **sorting/sorting.npz**: The FINAL sorted spikes at {output_dir}/sorting/sorting.npz\n"
+            "  Load with: `data = np.load(path); times = data['times_samples']; labels = data['labels']`\n"
+            "  - `times_samples`: spike times in samples (int64)\n"
+            "  - `labels`: unit ID for each spike (int32, -1 = noise)\n"
+            "  - `sampling_frequency`: Hz (float)\n"
+            "  Count spikes per unit: `for uid in np.unique(labels[labels >= 0]): count = (labels == uid).sum()`\n\n"
+            "**Secondary (for waveform analysis):**\n"
             "- **templates/**: Template waveforms at {output_dir}/templates/\n\n"
+            "**DO NOT USE** template_stats.json — it has pre-merge statistics that don't match final units.\n\n"
             "### Quality Criteria\n\n"
             "**Multi-unit activity indicators:**\n"
             "- ISI violation rate > 0.1 (10% of spikes violate 2ms refractory period)\n"
-            "- Bimodal or multi-peaked waveform shapes\n"
-            "- High spike amplitude variance\n\n"
+            "- Bimodal or multi-peaked amplitude distributions\n\n"
             "**Noise indicators:**\n"
-            "- SNR < 3.0 (signal-to-noise ratio too low)\n"
-            "- Amplitude stability < 0.7 (coefficient of variation > 0.3)\n"
-            "- Very low spike count (< 50 spikes — insufficient data)\n\n"
-            "**Suspicious waveform shapes:**\n"
-            "- Non-physiological rise/fall times\n"
-            "- Excessive baseline noise\n"
-            "- Artifact-like sharp transients\n\n"
+            "- Very low spike count (< 50 spikes in a 2-minute recording)\n"
+            "- For a 120s recording, healthy neurons fire 500-3000+ spikes\n\n"
             "### Quality Thresholds\n\n"
             "| Metric              | Threshold | Flag if...          |\n"
             "|---------------------|-----------|---------------------|\n"
             "| ISI violation rate  | > 0.1     | possible_multi_unit |\n"
-            "| SNR                 | < 3.0     | low_snr             |\n"
-            "| Amplitude stability | < 0.7     | unstable_amplitude  |\n"
-            "| Spike count         | < 50      | low_spike_count     |\n\n"
+            "| Spike count         | < 50      | low_spike_count     |\n"
+            "| Spike count         | < 500     | sparse_firing       |\n\n"
             "### Instructions\n\n"
-            "1. Read sorting_result.json for unit list and spike counts\n"
-            "2. Compute quality metrics for each unit:\n"
-            "   - ISI violation rate (fraction of spikes violating 2ms refractory period)\n"
-            "   - SNR from waveforms\n"
-            "   - Amplitude stability (1 - amplitude CV)\n"
-            "3. Apply thresholds to flag problematic units\n"
-            "4. Generate confidence scores (weighted combination):\n"
-            "   - Start at 1.0\n"
-            "   - Subtract 0.3 for ISI violations > 0.1\n"
-            "   - Subtract 0.4 for SNR < 3.0\n"
-            "   - Subtract 0.2 for amplitude stability < 0.7\n"
-            "   - Subtract 0.1 for spike count < 50\n"
-            "   - Clamp to [0.0, 1.0]\n\n"
+            "1. Load {output_dir}/sorting/sorting.npz with numpy\n"
+            "2. Extract times_samples, labels, sampling_frequency\n"
+            "3. Filter out noise labels (labels == -1)\n"
+            "4. For each unique unit ID (labels >= 0):\n"
+            "   - Count spikes: (labels == unit_id).sum()\n"
+            "   - Compute ISI violations: consecutive spikes < 2ms apart\n"
+            "5. Flag units based on thresholds\n"
+            "6. Write output files\n\n"
             "### Output Files\n\n"
             "IMPORTANT: Write BOTH output files using the Write tool.\n\n"
             "1. **qa_report.json** at {output_dir}/qa_report.json with:\n"
+            '   - "summary": object with total_units, flagged_unit_count, recording_duration_s\n'
             '   - "units": list of objects, each with: unit_id (int), spike_count (int), '
-            "isi_violation_rate (float), snr (float), amplitude_stability (float), "
-            'waveform_quality ("clean"|"noisy"|"artifact"), confidence_score (float 0-1), '
-            "flags (list of strings)\n"
-            '   - "summary": object with: total_units (int), high_quality_units (int), '
-            "flagged_units (int), avg_confidence (float)\n\n"
+            "isi_violation_rate (float or null), flags (list of strings), "
+            "confidence_score (float 0-1)\n\n"
             "2. **flagged_units.json** at {output_dir}/flagged_units.json with:\n"
-            '   - "flagged_units": list of unit IDs (ints)\n'
-            '   - "flags_by_unit": dict mapping unit_id string to list of flag strings\n'
-            '   - "total_flagged": int count'
+            '   - "flagged_units": list of objects with unit_id, spike_count, flags\n'
+            '   - "summary": object with total_flagged, by_flag_type counts'
         ),
-        reads={"sorting_result.json", "sorting/", "templates/"},
+        reads={"sorting/"},
         writes={"qa_report.json", "flagged_units.json"},
     )
 

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -778,7 +778,16 @@ class WorkflowExecutor:
         return await self._run_shell(cmd)
 
     async def _run_fn(self, node: FnNode) -> str:
-        """Run a FnNode's shell command."""
+        """Run a FnNode's shell command or Python callable."""
+        if node.callable_name:
+            import importlib
+
+            module_path, func_name = node.callable_name.rsplit(":", 1)
+            module = importlib.import_module(module_path)
+            func = getattr(module, func_name)
+            output_dir = str(self.project_path / ".factory" / "spike_sort_output")
+            func(project_path=str(self.project_path), output_dir=output_dir)
+            return f"{func_name} completed"
         if not node.command:
             return ""
         cmd = node.command.replace("{project_path}", shlex.quote(str(self.project_path)))

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -780,6 +780,10 @@ class WorkflowExecutor:
     async def _run_fn(self, node: FnNode) -> str:
         """Run a FnNode's shell command or Python callable."""
         if node.callable_name:
+            # Check if this is a spike-sort stage that needs the ds_ref environment
+            if node.callable_name.startswith("factory.workflow.spike_sort_stages:"):
+                return await self._run_fn_subprocess(node)
+
             import importlib
 
             module_path, func_name = node.callable_name.rsplit(":", 1)
@@ -793,11 +797,58 @@ class WorkflowExecutor:
         cmd = node.command.replace("{project_path}", shlex.quote(str(self.project_path)))
         return await self._run_shell(cmd)
 
+    async def _run_fn_subprocess(self, node: FnNode) -> str:
+        """Run a FnNode callable in a subprocess (for stages requiring external venvs)."""
+        import os
+
+        module_path, func_name = node.callable_name.rsplit(":", 1)  # type: ignore[union-attr]
+        output_dir = str(self.project_path / ".factory" / "spike_sort_output")
+
+        # Get the ds_ref path and Python interpreter
+        ds_ref_path = os.environ.get("DS_REF_PATH", "/workspace/home/churwitz/ds_ref")
+        venv_python = f"{ds_ref_path}/.venv/bin/python"
+
+        # Map callable names to stage names
+        stage_map = {
+            "preprocess": "preprocess",
+            "detect_trial": "detect_trial",
+            "detect": "detect",
+            "localize": "localize",
+            "cluster": "cluster",
+            "compute_templates": "templates",
+            "template_match": "match",
+        }
+        stage_name = stage_map.get(func_name, func_name)
+
+        # Build command to run the spike_sort_runner.py
+        runner_path = Path(__file__).parent / "spike_sort_runner.py"
+        cmd = (
+            f"{shlex.quote(venv_python)} {shlex.quote(str(runner_path))} "
+            f"{stage_name} "
+            f"--project-path {shlex.quote(str(self.project_path))} "
+            f"--output-dir {shlex.quote(output_dir)}"
+        )
+
+        # Set environment variables
+        env = os.environ.copy()
+        env["DS_REF_PATH"] = ds_ref_path
+        # Add factory module path to PYTHONPATH
+        factory_root = str(Path(__file__).parent.parent.parent)
+        pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = f"{factory_root}:{pythonpath}" if pythonpath else factory_root
+
+        log.info("fn_subprocess.start", node=node.id, cmd=cmd[:100])
+        return await self._run_shell(cmd, env=env)
+
     async def _run_agent(self, node: AgentNode) -> str:
         """Invoke an agent via factory/agents/runner.py."""
         from factory.agents.runner import invoke_agent
 
         task = node.prompt_template
+        # Substitute {output_dir} placeholder in spike-sort workflow prompts
+        output_dir = str(self.project_path / ".factory" / "spike_sort_output")
+        task = task.replace("{output_dir}", output_dir)
+
         context = self.node_context.get(node.id, "")
         if context:
             task = f"{task}\n\n{context}"
@@ -959,13 +1010,16 @@ class WorkflowExecutor:
             return Verdict.halt(reason="fn gate returned RELOOP but no RELOOP edge defined")
         return Verdict.proceed()
 
-    async def _run_shell(self, cmd: str) -> str:
+    async def _run_shell(
+        self, cmd: str, env: dict[str, str] | None = None
+    ) -> str:
         """Run a shell command and return stdout."""
         proc = await asyncio.create_subprocess_shell(
             cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self.project_path,
+            env=env,
         )
         stdout_bytes, stderr_bytes = await proc.communicate()
         stdout = stdout_bytes.decode() if stdout_bytes else ""

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -160,6 +160,17 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
         ),
         "argument_hint": "<project_path>",
     },
+    "spike-sort": {
+        "description": (
+            "Spike sorting data pipeline with LLM-in-the-loop parameter selection. "
+            "NOT a code-writing workflow — directly executes DARTsort algorithms "
+            "(FnNodes) with LLM parameter advisors (AgentNodes) at three decision "
+            "points: detection threshold, clustering strategy, and template QC. "
+            "Input: SpikeInterface BaseRecording. Output: BaseSorting. "
+            "Use with --mode spike-sort on a configured recording."
+        ),
+        "argument_hint": "<project_path> --mode spike-sort",
+    },
 }
 
 

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -162,14 +162,12 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
     },
     "spike-sort": {
         "description": (
-            "Spike sorting data pipeline with LLM-in-the-loop parameter selection. "
-            "NOT a code-writing workflow — directly executes DARTsort algorithms "
-            "(FnNodes) with LLM parameter advisors (AgentNodes) at three decision "
-            "points: detection threshold, clustering strategy, and template QC. "
-            "Input: SpikeInterface BaseRecording. Output: BaseSorting. "
-            "Use with --mode spike-sort on a configured recording."
+            "Spike sorting pipeline with LLM quality gates — executes DARTsort "
+            "algorithms with three quality gates (post-clustering, post-template, "
+            "post-matching) that compute metrics deterministically and use LLM agents "
+            "to interpret them in recording context. Use when invoked with --mode spike-sort."
         ),
-        "argument_hint": "<project_path> --mode spike-sort",
+        "argument_hint": "<project_path>",
     },
 }
 

--- a/factory/workflow/spike_sort_runner.py
+++ b/factory/workflow/spike_sort_runner.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from pathlib import Path
 
 # Add ds_ref to path
 import os
@@ -26,7 +25,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run spike-sort stages")
     parser.add_argument(
         "stage",
-        choices=["preprocess", "detect_trial", "detect", "localize", "cluster", "templates", "match"],
+        choices=[
+            "preprocess", "detect_trial", "detect", "localize", "cluster",
+            "templates", "match", "evaluate_accuracy",
+        ],
         help="Stage name to execute",
     )
     parser.add_argument("--project-path", required=True, help="Path to the project")
@@ -37,6 +39,7 @@ def main() -> int:
         preprocess,
         detect_trial,
         detect,
+        evaluate_accuracy,
         localize,
         cluster,
         compute_templates,
@@ -51,6 +54,7 @@ def main() -> int:
         "cluster": cluster,
         "templates": compute_templates,
         "match": template_match,
+        "evaluate_accuracy": evaluate_accuracy,
     }
 
     func = stage_map[args.stage]

--- a/factory/workflow/spike_sort_runner.py
+++ b/factory/workflow/spike_sort_runner.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""CLI runner for spike-sort stages.
+
+This script is designed to be called from a shell command in the workflow executor,
+allowing the stages to run in a different Python environment (e.g., one with
+dartsort/spikeinterface installed).
+
+Usage:
+    python spike_sort_runner.py <stage> --project-path /path/to/project --output-dir /path/to/output
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add ds_ref to path
+import os
+_DS_REF = os.environ.get("DS_REF_PATH", "/workspace/home/churwitz/ds_ref")
+if _DS_REF not in sys.path:
+    sys.path.insert(0, _DS_REF)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run spike-sort stages")
+    parser.add_argument(
+        "stage",
+        choices=["preprocess", "detect_trial", "detect", "localize", "cluster", "templates", "match"],
+        help="Stage name to execute",
+    )
+    parser.add_argument("--project-path", required=True, help="Path to the project")
+    parser.add_argument("--output-dir", required=True, help="Path to output directory")
+    args = parser.parse_args()
+
+    from factory.workflow.spike_sort_stages import (
+        preprocess,
+        detect_trial,
+        detect,
+        localize,
+        cluster,
+        compute_templates,
+        template_match,
+    )
+
+    stage_map = {
+        "preprocess": preprocess,
+        "detect_trial": detect_trial,
+        "detect": detect,
+        "localize": localize,
+        "cluster": cluster,
+        "templates": compute_templates,
+        "match": template_match,
+    }
+
+    func = stage_map[args.stage]
+    try:
+        func(project_path=args.project_path, output_dir=args.output_dir)
+        print(f"{args.stage} completed successfully")
+        return 0
+    except Exception as exc:
+        print(f"Error in {args.stage}: {exc}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/factory/workflow/spike_sort_schemas.py
+++ b/factory/workflow/spike_sort_schemas.py
@@ -31,13 +31,13 @@ class DetectionParams(BaseModel):
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
-    voltage_threshold: float = Field(
+    detection_threshold: float = Field(
         ge=3.0,
         le=6.0,
         description="SNR threshold for spike detection (4.0 is DARTsort calibrated default)",
     )
     peak_sign: Literal["neg", "pos", "both"] = Field(description="Which polarity peaks to detect")
-    dedup_temporal_radius: int = Field(
+    temporal_dedup_radius_samples: int = Field(
         ge=5,
         le=20,
         description="Temporal deduplication radius in samples",

--- a/factory/workflow/spike_sort_schemas.py
+++ b/factory/workflow/spike_sort_schemas.py
@@ -31,12 +31,20 @@ class DetectionParams(BaseModel):
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
-    voltage_threshold: float = Field(ge=2.0, le=8.0, description="SNR threshold for spike detection")
+    voltage_threshold: float = Field(
+        ge=3.0,
+        le=6.0,
+        description="SNR threshold for spike detection (4.0 is DARTsort calibrated default)",
+    )
     peak_sign: Literal["neg", "pos", "both"] = Field(description="Which polarity peaks to detect")
     dedup_temporal_radius: int = Field(
         ge=5,
         le=20,
         description="Temporal deduplication radius in samples",
+    )
+    use_denoiser: bool = Field(
+        default=True,
+        description="Apply single-channel denoiser NN before detection (recommended)",
     )
     reasoning: str = Field(description="Brief justification for parameter choices")
 

--- a/factory/workflow/spike_sort_schemas.py
+++ b/factory/workflow/spike_sort_schemas.py
@@ -1,0 +1,111 @@
+"""Pydantic schemas for spike-sort workflow agent I/O contracts.
+
+Each schema defines the structured output contract between AgentNodes
+and downstream FnNodes. AgentNodes use these as output schemas, validated
+at the tool-call layer so the model retries on mismatch.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class NoiseStats(BaseModel):
+    """Input to detect_params AgentNode. Computed by preprocess FnNode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    median_noise_uv: float = Field(description="Median noise level in µV across channels")
+    mad_per_channel: list[float] = Field(description="MAD noise estimate per channel")
+    num_channels: int
+    sampling_rate_hz: float
+    recording_duration_s: float
+    probe_type: str = Field(description="Probe identifier, e.g. 'neuropixels_2.0'")
+    channel_positions: list[list[float]] = Field(description="(C, 2) channel positions in µm")
+
+
+class DetectionParams(BaseModel):
+    """Output of detect_params AgentNode. Consumed by detect FnNode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    voltage_threshold: float = Field(ge=2.0, le=8.0, description="SNR threshold for spike detection")
+    peak_sign: Literal["neg", "pos", "both"] = Field(description="Which polarity peaks to detect")
+    dedup_temporal_radius: int = Field(
+        ge=5,
+        le=20,
+        description="Temporal deduplication radius in samples",
+    )
+    reasoning: str = Field(description="Brief justification for parameter choices")
+
+
+class ClusterInputStats(BaseModel):
+    """Input to cluster_params AgentNode. Computed by localize FnNode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    spike_count: int
+    drift_magnitude_um: float = Field(description="Estimated drift range in µm")
+    feature_pca_variance_explained: list[float] = Field(
+        description="Variance explained by first N PCs",
+    )
+    spike_density_per_channel_per_s: float
+    depth_range_um: float = Field(description="Span of spike depths in µm")
+    probe_type: str
+    channel_count: int
+
+
+class ClusteringParams(BaseModel):
+    """Output of cluster_params AgentNode. Consumed by cluster FnNode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    strategy: Literal["channel_snap", "grid_snap", "dpc", "none"]
+    grid_dx: float = Field(ge=5.0, le=50.0, description="Spatial grid X resolution in µm")
+    grid_dz: float = Field(ge=5.0, le=50.0, description="Spatial grid Z resolution in µm")
+    initial_steps: list[Literal["split", "merge", "demolish"]]
+    n_waveforms_fit: int = Field(
+        ge=10000,
+        le=100000,
+        description="Number of waveforms to subsample for fitting",
+    )
+    reasoning: str = Field(description="Brief justification for strategy choice")
+
+
+class TemplateStats(BaseModel):
+    """Per-template quality metrics. Input to qc_templates AgentNode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    template_id: int
+    snr: float = Field(description="Signal-to-noise ratio of template")
+    spike_count: int = Field(description="Number of spikes assigned to this unit")
+    ptp_amplitude_uv: float = Field(description="Peak-to-peak amplitude in µV")
+    spatial_spread_um: float = Field(description="Spatial extent of template in µm")
+    stability: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Waveform stability across time (1.0 = perfectly stable)",
+    )
+
+
+class TemplateDecision(BaseModel):
+    """Per-template QC decision. Part of qc_templates AgentNode output."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    template_id: int
+    action: Literal["keep", "discard", "merge"]
+    merge_with: int | None = None
+    reasoning: str = Field(description="Brief justification for this decision")
+
+
+class TemplateQCOutput(BaseModel):
+    """Output of qc_templates AgentNode. Consumed by match FnNode."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    decisions: list[TemplateDecision]
+    summary: str = Field(description="Overall QC summary: how many kept, discarded, merged")

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -157,11 +157,10 @@ def detect_trial(project_path: str, output_dir: str) -> None:
     log.info("detect_trial.complete", thresholds_tested=len(candidate_thresholds))
 
 def detect(project_path: str, output_dir: str) -> None:
-    """Run subtraction-based spike detection with LLM-selected parameters.
+    """Run subtraction-based spike detection with hardcoded DARTsort defaults.
 
-    Uses DARTsort's SubtractionPeeler for initial detection, which is more
-    selective than simple thresholding and produces cleaner spike trains.
-    The detection_threshold parameter controls the SNR threshold.
+    Uses DARTsort's SubtractionPeeler for initial detection with
+    detection_threshold=3.0 and peak_sign='both'.
     """
     import spikeinterface.core as si
     from dartsort.main import subtract as ds_subtract
@@ -174,13 +173,11 @@ def detect(project_path: str, output_dir: str) -> None:
 
     out = Path(output_dir)
     recording = si.load(out / "preprocessed")
-    params = json.loads((out / "detection_params.json").read_text())
 
-    # Configure subtraction with LLM-selected threshold
     subtract_cfg = dataclasses.replace(
         default_subtraction_cfg,
-        detection_threshold=params["detection_threshold"],
-        peak_sign=params["peak_sign"],
+        detection_threshold=3.0,
+        peak_sign="both",
     )
 
     sorting = ds_subtract(
@@ -194,10 +191,11 @@ def detect(project_path: str, output_dir: str) -> None:
     )
 
     n_spikes = sorting.n_spikes
+    params_used = {"detection_threshold": 3.0, "peak_sign": "both"}
     summary = {
         "spike_count": int(n_spikes),
         "spike_rate_hz": float(n_spikes / recording.get_total_duration()),
-        "detection_params_used": params,
+        "detection_params_used": params_used,
         "detection_method": "subtract",
     }
     (out / "detection_summary.json").write_text(json.dumps(summary, indent=2))
@@ -275,10 +273,11 @@ def localize(project_path: str, output_dir: str) -> None:
 
 
 def cluster(project_path: str, output_dir: str) -> None:
-    """Cluster spikes into putative units using LLM-selected strategy with refinement.
+    """Cluster spikes with hardcoded DPC defaults and create recording context.
 
     Uses DARTsort's default refinement configs (pcmerge, tmm, filter) to merge
-    overclustered units and clean up the clustering result.
+    overclustered units and clean up the clustering result. Creates
+    recording_context.json for downstream LLM quality gates.
     """
     import spikeinterface.core as si
     from dartsort.main import cluster as ds_cluster
@@ -293,19 +292,17 @@ def cluster(project_path: str, output_dir: str) -> None:
     out = Path(output_dir)
     recording = si.load(out / "preprocessed")
     sorting = DARTsortSorting.load(out / "detections" / "sorting.npz")
-    params = json.loads((out / "clustering_params.json").read_text())
 
     motion_dir = out / "motion"
     motion = MotionInfo.try_load(motion_dir) if motion_dir.exists() else None
 
     clust_cfg = dataclasses.replace(
         default_clustering_cfg,
-        cluster_strategy=params["strategy"],
-        grid_dx=params["grid_dx"],
-        grid_dz=params["grid_dz"],
+        cluster_strategy="dpc",
+        grid_dx=15.0,
+        grid_dz=15.0,
     )
 
-    # Use DARTsort's default refinement configs for merge/split cleanup
     refinement_cfgs = [
         default_dartsort_cfg.pre_refinement_cfg,
         default_dartsort_cfg.initial_refinement_cfg,
@@ -327,19 +324,50 @@ def cluster(project_path: str, output_dir: str) -> None:
     labels = result.labels if hasattr(result, "labels") else np.array([])
     unique_labels = np.unique(labels[labels >= 0]) if len(labels) > 0 else np.array([])
     sizes = [int(np.sum(labels == u)) for u in unique_labels]
+    params_used = {"strategy": "dpc", "grid_dx": 15.0, "grid_dz": 15.0}
     summary = {
         "unit_count": int(len(unique_labels)),
         "median_unit_size": int(np.median(sizes)) if sizes else 0,
         "min_unit_size": int(np.min(sizes)) if sizes else 0,
         "max_unit_size": int(np.max(sizes)) if sizes else 0,
         "noise_spike_count": int(np.sum(labels < 0)) if len(labels) > 0 else 0,
-        "clustering_params_used": params,
+        "clustering_params_used": params_used,
     }
     (out / "cluster_summary.json").write_text(json.dumps(summary, indent=2))
+
+    # Compute drift from motion data
+    drift_um = 0.0
+    if motion is not None and hasattr(motion, "displacement"):
+        drift_um = float(np.ptp(motion.displacement))
+    elif (motion_dir / "motion.npy").exists():
+        motion_arr = np.load(motion_dir / "motion.npy")
+        drift_um = float(np.ptp(motion_arr))
+
+    config = json.loads(Path(project_path, ".factory", "config.json").read_text())
+    recording_duration_s = recording.get_total_duration()
+    n_channels = recording.get_num_channels()
+    sampling_rate = recording.get_sampling_frequency()
+
+    recording_context = {
+        "brain_region": config.get("brain_region", "unknown"),
+        "probe_type": config.get("probe_type", "neuropixels_1.0"),
+        "expected_cell_types": ["pyramidal", "interneuron"],
+        "expected_firing_rates": {"pyramidal": [0.5, 10], "interneuron": [10, 100]},
+        "animal_state": config.get("animal_state", "unknown"),
+        "recording_duration_min": float(recording_duration_s / 60),
+        "drift_um": drift_um,
+        "n_channels": n_channels,
+        "sampling_rate_hz": float(sampling_rate),
+    }
+    (out / "recording_context.json").write_text(
+        json.dumps(recording_context, indent=2)
+    )
+
     log.info(
         "cluster.complete",
         units=summary["unit_count"],
         median_size=summary["median_unit_size"],
+        drift_um=drift_um,
     )
 
 
@@ -485,4 +513,465 @@ def template_match(project_path: str, output_dir: str) -> None:
         "match.complete",
         units=result["final_unit_count"],
         spikes=result["final_spike_count"],
+    )
+
+
+# ── Helper functions for gate metrics ─────────────────────────────
+
+
+def _hill_fp_estimate(
+    n_violations: int,
+    n_spikes: int,
+    duration_s: float,
+    tau_r: float = 0.0015,
+    tau_c: float = 0.0,
+) -> float:
+    """Estimate false positive rate from ISI violations (Hill et al. 2011)."""
+    if n_spikes < 2 or duration_s <= 0:
+        return 0.0
+    r = n_violations
+    c = 2 * (tau_r - tau_c) * n_spikes**2 / duration_s
+    if c <= 0:
+        return 0.0
+    discriminant = c**2 - 4 * c * r
+    if discriminant < 0:
+        return 1.0
+    f1p = (c - discriminant**0.5) / (2 * c)
+    return max(0.0, min(1.0, f1p))
+
+
+def _compute_ccg_refractory(
+    times_a: np.ndarray,
+    times_b: np.ndarray,
+    sampling_rate: float = 30000.0,
+    refractory_ms: float = 1.5,
+    window_ms: float = 50.0,
+) -> tuple[float, float]:
+    """Compute R12 and Q12 refractory scores from cross-correlogram."""
+    max_lag = int(window_ms * sampling_rate / 1000)
+    refractory_samples = refractory_ms * sampling_rate / 1000
+    baseline_samples = 10.0 * sampling_rate / 1000
+
+    all_diffs = []
+    for t in times_a:
+        diffs = times_b - t
+        mask = np.abs(diffs) <= max_lag
+        all_diffs.extend(diffs[mask].tolist())
+
+    if not all_diffs:
+        return 1.0, 0.0
+
+    diffs_arr = np.array(all_diffs)
+    refractory_mask = np.abs(diffs_arr) < refractory_samples
+    baseline_mask = np.abs(diffs_arr) > baseline_samples
+
+    if baseline_mask.any() or refractory_mask.any():
+        n_baseline = baseline_mask.sum()
+        n_refractory = refractory_mask.sum()
+        baseline_density = n_baseline / (max_lag - baseline_samples) if (max_lag - baseline_samples) > 0 else 1.0
+        refractory_density = n_refractory / refractory_samples if refractory_samples > 0 else 0.0
+        r12 = refractory_density / baseline_density if baseline_density > 0 else 1.0
+    else:
+        r12 = 1.0
+
+    q12 = max(0.0, 1.0 - r12)
+    return r12, q12
+
+
+# ── Gate FnNode implementations ──────────────────────────────────
+
+
+def compute_cluster_metrics(project_path: str, output_dir: str) -> None:
+    """Compute per-cluster and pairwise metrics for Gate 1 (post-clustering)."""
+    from dartsort.util.data_util import DARTsortSorting
+
+    out = Path(output_dir)
+    sorting = DARTsortSorting.load(out / "clusters" / "sorting.npz")
+    context = json.loads((out / "recording_context.json").read_text())
+
+    labels = sorting.labels if hasattr(sorting, "labels") else np.array([])
+    times = sorting.times_samples if hasattr(sorting, "times_samples") else np.array([])
+    sampling_rate = context.get("sampling_rate_hz", 30000.0)
+    duration_s = context.get("recording_duration_min", 5.0) * 60.0
+
+    unique_ids = np.unique(labels[labels >= 0]) if len(labels) > 0 else np.array([])
+
+    locs = None
+    loc_path = out / "localizations.npz"
+    if loc_path.exists():
+        locs = np.load(loc_path)
+
+    per_cluster = []
+    centroids: dict[int, tuple[float, float]] = {}
+
+    for uid in unique_ids:
+        uid = int(uid)
+        mask = labels == uid
+        spike_count = int(mask.sum())
+        spike_times = times[mask]
+        firing_rate = spike_count / duration_s if duration_s > 0 else 0.0
+
+        # ISI violations
+        isi_violation_rate = 0.0
+        n_violations = 0
+        if len(spike_times) > 1:
+            isis = np.diff(np.sort(spike_times)) / sampling_rate
+            n_violations = int(np.sum(isis < 0.0015))
+            isi_violation_rate = n_violations / len(isis) if len(isis) > 0 else 0.0
+
+        fp_est = _hill_fp_estimate(n_violations, spike_count, duration_s)
+
+        # SNR estimate
+        snr = 0.0
+        if hasattr(sorting, "denoised_ptp_amplitudes") and sorting.denoised_ptp_amplitudes is not None:
+            amps = sorting.denoised_ptp_amplitudes[mask]
+            if len(amps) > 0:
+                snr = float(np.mean(amps) / max(np.std(amps), 1e-6))
+
+        # Amplitude bimodality (simplified dip statistic)
+        bimodality = 0.0
+        if hasattr(sorting, "denoised_ptp_amplitudes") and sorting.denoised_ptp_amplitudes is not None:
+            amps = sorting.denoised_ptp_amplitudes[mask]
+            if len(amps) > 10:
+                sorted_amps = np.sort(amps)
+                n = len(sorted_amps)
+                uniform_cdf = np.linspace(0, 1, n)
+                ecdf = np.arange(1, n + 1) / n
+                bimodality = float(np.max(np.abs(ecdf - uniform_cdf)))
+
+        # Spatial centroid
+        cx, cz = 0.0, 0.0
+        if locs is not None and "x" in locs and "z_abs" in locs:
+            x_all = locs["x"]
+            z_all = locs["z_abs"]
+            if len(x_all) == len(labels):
+                cx = float(np.mean(x_all[mask]))
+                cz = float(np.mean(z_all[mask]))
+        centroids[uid] = (cx, cz)
+
+        per_cluster.append({
+            "cluster_id": uid,
+            "spike_count": spike_count,
+            "firing_rate_hz": round(firing_rate, 2),
+            "isi_violation_rate": round(isi_violation_rate, 4),
+            "isi_fp_estimate": round(fp_est, 4),
+            "snr": round(snr, 2),
+            "amplitude_bimodality": round(bimodality, 3),
+            "spatial_centroid": [round(cx, 1), round(cz, 1)],
+        })
+
+    # Pairwise metrics for nearby clusters
+    pairwise = []
+    uid_list = list(centroids.keys())
+    for i, uid_a in enumerate(uid_list):
+        for uid_b in uid_list[i + 1:]:
+            ca, cb = centroids[uid_a], centroids[uid_b]
+            dist = float(np.sqrt((ca[0] - cb[0]) ** 2 + (ca[1] - cb[1]) ** 2))
+            if dist > 100.0:
+                continue
+
+            # Template correlation (using mean spike amplitudes as proxy)
+            corr = 0.0
+
+            # CCG refractory
+            mask_a = labels == uid_a
+            mask_b = labels == uid_b
+            times_a = times[mask_a]
+            times_b = times[mask_b]
+
+            r12, q12 = 1.0, 0.0
+            if len(times_a) > 10 and len(times_b) > 10:
+                sub_a = times_a[:min(5000, len(times_a))]
+                sub_b = times_b[:min(5000, len(times_b))]
+                r12, q12 = _compute_ccg_refractory(sub_a, sub_b, sampling_rate)
+
+            pairwise.append({
+                "cluster_a": uid_a,
+                "cluster_b": uid_b,
+                "template_correlation": round(corr, 3),
+                "spatial_distance_um": round(dist, 1),
+                "ccg_refractory_r12": round(r12, 3),
+                "ccg_refractory_q12": round(q12, 3),
+            })
+
+    metrics = {"per_cluster": per_cluster, "pairwise_metrics": pairwise}
+    (out / "cluster_metrics.json").write_text(json.dumps(metrics, indent=2))
+    log.info(
+        "compute_cluster_metrics.complete",
+        n_clusters=len(per_cluster),
+        n_pairs=len(pairwise),
+    )
+
+
+def apply_cluster_actions(project_path: str, output_dir: str) -> None:
+    """Execute Gate 1 decisions: merge, split, delete clusters."""
+    from dartsort.util.data_util import DARTsortSorting
+
+    out = Path(output_dir)
+    decision = json.loads((out / "gate1_decision.json").read_text())
+    sorting = DARTsortSorting.load(out / "clusters" / "sorting.npz")
+
+    labels = sorting.labels.copy() if hasattr(sorting, "labels") else np.array([])
+    times = sorting.times_samples if hasattr(sorting, "times_samples") else np.array([])
+
+    # DELETE: set labels to -1
+    delete_ids = decision.get("delete_clusters", [])
+    if delete_ids:
+        labels[np.isin(labels, delete_ids)] = -1
+        log.info("apply_cluster_actions.delete", count=len(delete_ids))
+
+    # MERGE: relabel second cluster as first
+    merge_pairs = decision.get("merge_pairs", [])
+    for pair in merge_pairs:
+        if len(pair) == 2:
+            labels[labels == pair[1]] = pair[0]
+    if merge_pairs:
+        log.info("apply_cluster_actions.merge", count=len(merge_pairs))
+
+    # Save refined clustering
+    refined_dir = out / "clusters_refined"
+    refined_dir.mkdir(exist_ok=True)
+
+    sampling_freq = 30000.0
+    if hasattr(sorting, "sampling_frequency"):
+        sampling_freq = float(sorting.sampling_frequency)
+
+    np.savez(
+        refined_dir / "sorting.npz",
+        times_samples=times,
+        labels=labels,
+        sampling_frequency=sampling_freq,
+    )
+    log.info(
+        "apply_cluster_actions.complete",
+        deleted=len(delete_ids),
+        merged=len(merge_pairs),
+        split=len(decision.get("split_clusters", [])),
+    )
+
+
+def compute_template_metrics(project_path: str, output_dir: str) -> None:
+    """Compute per-template metrics for Gate 2 (post-template)."""
+    out = Path(output_dir)
+    template_stats = json.loads((out / "template_stats.json").read_text())
+
+    # Load template data for similarity computation
+    templates_arr = None
+    template_npz = out / "templates" / "template_data.npz"
+    if template_npz.exists():
+        tdata = np.load(template_npz, allow_pickle=True)
+        if "templates" in tdata:
+            templates_arr = tdata["templates"]
+
+    per_template = []
+    for stats in template_stats:
+        tid = stats["template_id"]
+        spike_count = stats.get("spike_count", 0)
+        snr = stats.get("snr", 0.0)
+        stability = stats.get("stability", 0.9)
+        ptp_uv = stats.get("ptp_amplitude_uv", 0.0)
+        spatial_spread = stats.get("spatial_spread_um", 0.0)
+
+        # Compute max similarity with other templates
+        similarity_max = 0.0
+        if templates_arr is not None and len(templates_arr) > 1 and tid < len(templates_arr):
+            t_flat = templates_arr[tid].flatten()
+            for j in range(len(templates_arr)):
+                if j == tid:
+                    continue
+                other_flat = templates_arr[j].flatten()
+                if len(t_flat) == len(other_flat) and np.std(t_flat) > 0 and np.std(other_flat) > 0:
+                    corr = float(np.corrcoef(t_flat, other_flat)[0, 1])
+                    similarity_max = max(similarity_max, corr)
+
+        per_template.append({
+            "template_id": tid,
+            "template_spike_count": spike_count,
+            "template_snr": round(snr, 2),
+            "template_stability": round(stability, 3),
+            "template_similarity_max": round(similarity_max, 3),
+            "template_amplitude_uv": round(ptp_uv, 2),
+            "template_spatial_spread_um": round(spatial_spread, 1),
+        })
+
+    metrics = {"per_template": per_template}
+    (out / "template_metrics.json").write_text(json.dumps(metrics, indent=2))
+    log.info("compute_template_metrics.complete", n_templates=len(per_template))
+
+
+def apply_template_actions(project_path: str, output_dir: str) -> None:
+    """Execute Gate 2 decisions: merge or delete templates."""
+    out = Path(output_dir)
+    decision = json.loads((out / "gate2_decision.json").read_text())
+
+    refined_dir = out / "templates_refined"
+    refined_dir.mkdir(exist_ok=True)
+
+    template_npz = out / "templates" / "template_data.npz"
+    sorting_npz = out / "templates" / "sorting.npz"
+
+    delete_ids = set(decision.get("delete_templates", []))
+    merge_pairs = decision.get("merge_pairs", [])
+
+    if not delete_ids and not merge_pairs:
+        # No changes — copy originals
+        if template_npz.exists():
+            import shutil
+            shutil.copy2(template_npz, refined_dir / "template_data.npz")
+        if sorting_npz.exists():
+            import shutil
+            shutil.copy2(sorting_npz, refined_dir / "sorting.npz")
+        log.info("apply_template_actions.noop")
+        return
+
+    if template_npz.exists():
+        tdata = np.load(template_npz, allow_pickle=True)
+        templates = tdata["templates"] if "templates" in tdata else np.array([])
+
+        # Build merge mapping
+        merge_map: dict[int, int] = {}
+        for pair in merge_pairs:
+            if len(pair) == 2:
+                merge_map[pair[1]] = pair[0]
+
+        # Apply merges (average waveforms)
+        if templates.ndim >= 1 and len(templates) > 0:
+            for src, dst in merge_map.items():
+                if src < len(templates) and dst < len(templates):
+                    templates[dst] = (templates[dst] + templates[src]) / 2.0
+                    delete_ids.add(src)
+
+        # Delete templates
+        keep_mask = np.array([i not in delete_ids for i in range(len(templates))])
+        if keep_mask.any():
+            templates = templates[keep_mask]
+
+        np.savez(refined_dir / "template_data.npz", templates=templates)
+
+    if sorting_npz.exists():
+        import shutil
+        shutil.copy2(sorting_npz, refined_dir / "sorting.npz")
+
+    log.info(
+        "apply_template_actions.complete",
+        deleted=len(delete_ids),
+        merged=len(merge_pairs),
+    )
+
+
+def compute_final_metrics(project_path: str, output_dir: str) -> None:
+    """Compute per-unit metrics for Gate 3 (post-matching)."""
+    out = Path(output_dir)
+    sorting_npz = out / "sorting" / "sorting.npz"
+    data = np.load(sorting_npz)
+
+    times = data["times_samples"]
+    labels = data["labels"]
+    sampling_freq = float(data["sampling_frequency"]) if "sampling_frequency" in data else 30000.0
+
+    context_path = out / "recording_context.json"
+    duration_s = 300.0
+    if context_path.exists():
+        ctx = json.loads(context_path.read_text())
+        duration_s = ctx.get("recording_duration_min", 5.0) * 60.0
+
+    unique_ids = np.unique(labels[labels >= 0]) if len(labels) > 0 else np.array([])
+
+    per_unit = []
+    for uid in unique_ids:
+        uid = int(uid)
+        mask = labels == uid
+        spike_count = int(mask.sum())
+        spike_times = times[mask]
+        firing_rate = spike_count / duration_s if duration_s > 0 else 0.0
+
+        # ISI violations
+        isi_violation_rate = 0.0
+        n_violations = 0
+        if len(spike_times) > 1:
+            isis = np.diff(np.sort(spike_times)) / sampling_freq
+            n_violations = int(np.sum(isis < 0.0015))
+            isi_violation_rate = n_violations / len(isis) if len(isis) > 0 else 0.0
+
+        fp_est = _hill_fp_estimate(n_violations, spike_count, duration_s)
+
+        # Amplitude cutoff estimate
+        amplitude_cutoff = 0.0
+
+        # Presence ratio: fraction of 1-second bins with >= 1 spike
+        bin_edges = np.arange(0, int(times.max() / sampling_freq) + 2)
+        if len(bin_edges) > 1 and len(spike_times) > 0:
+            spike_seconds = spike_times / sampling_freq
+            hist, _ = np.histogram(spike_seconds, bins=bin_edges)
+            presence_ratio = float(np.mean(hist > 0))
+        else:
+            presence_ratio = 0.0
+
+        snr = 0.0
+
+        per_unit.append({
+            "unit_id": uid,
+            "final_spike_count": spike_count,
+            "final_firing_rate_hz": round(firing_rate, 2),
+            "final_isi_violation_rate": round(isi_violation_rate, 4),
+            "final_isi_fp_estimate": round(fp_est, 4),
+            "amplitude_cutoff": round(amplitude_cutoff, 3),
+            "presence_ratio": round(presence_ratio, 3),
+            "snr": round(snr, 2),
+        })
+
+    metrics = {"per_unit": per_unit}
+    (out / "final_metrics.json").write_text(json.dumps(metrics, indent=2))
+    log.info("compute_final_metrics.complete", n_units=len(per_unit))
+
+
+def apply_final_actions(project_path: str, output_dir: str) -> None:
+    """Execute Gate 3 decisions: merge or delete final units."""
+    out = Path(output_dir)
+    decision = json.loads((out / "gate3_decision.json").read_text())
+    sorting_npz = out / "sorting" / "sorting.npz"
+    data = np.load(sorting_npz)
+
+    times = data["times_samples"]
+    labels = data["labels"].copy()
+    sampling_freq = float(data["sampling_frequency"]) if "sampling_frequency" in data else 30000.0
+
+    # DELETE units
+    delete_ids = decision.get("delete_units", [])
+    garbage_removed = 0
+    for uid in delete_ids:
+        count = int((labels == uid).sum())
+        labels[labels == uid] = -1
+        garbage_removed += count
+
+    # MERGE units
+    merge_pairs = decision.get("merge_pairs", [])
+    for pair in merge_pairs:
+        if len(pair) == 2:
+            labels[labels == pair[1]] = pair[0]
+
+    # Save final sorting
+    final_dir = out / "sorting_final"
+    final_dir.mkdir(exist_ok=True)
+    np.savez(
+        final_dir / "sorting.npz",
+        times_samples=times,
+        labels=labels,
+        sampling_frequency=sampling_freq,
+    )
+
+    unique_final = np.unique(labels[labels >= 0]) if len(labels) > 0 else np.array([])
+    result = {
+        "final_unit_count": int(len(unique_final)),
+        "final_spike_count": int((labels >= 0).sum()),
+        "garbage_removed_count": garbage_removed,
+        "units_deleted": len(delete_ids),
+        "units_merged": len(merge_pairs),
+    }
+    (out / "sorting_result.json").write_text(json.dumps(result, indent=2))
+    log.info(
+        "apply_final_actions.complete",
+        units=result["final_unit_count"],
+        deleted=result["units_deleted"],
+        merged=result["units_merged"],
     )

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -462,9 +462,14 @@ def template_match(project_path: str, output_dir: str) -> None:
         model_subdir="matching_final_models",
     )
 
-    # Step 2: Post-match refinement (like vanilla DARTsort's final_refinement)
-    # Use the post_refinement_cfgs which do filtering/cleanup
-    refinement_cfgs = list(default_dartsort_cfg.post_refinement_cfgs)
+    # Step 2: Post-match refinement (vanilla DARTsort's final_refinement)
+    # Uses [pre_refinement_cfg, refinement_cfg, agglomerate_cfg] - the agglomerate
+    # step has merge_distance_threshold=0.6 for aggressive merging
+    refinement_cfgs = [
+        default_dartsort_cfg.pre_refinement_cfg,
+        default_dartsort_cfg.refinement_cfg,
+        default_dartsort_cfg.agglomerate_cfg,
+    ]
 
     final_sorting = ds_cluster(
         recording=recording,

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -435,14 +435,6 @@ def template_match(project_path: str, output_dir: str) -> None:
     sorting = DARTsortSorting.load(out / "templates" / "sorting.npz")
     template_data = TemplateData.from_npz(out / "templates" / "template_data.npz")
 
-    decisions = json.loads((out / "template_decisions.json").read_text())
-    keep_ids = {d["template_id"] for d in decisions["decisions"] if d["action"] == "keep"}
-    merge_map = {
-        d["template_id"]: d["merge_with"]
-        for d in decisions["decisions"]
-        if d["action"] == "merge" and d["merge_with"] is not None
-    }
-
     motion_dir = out / "motion"
     motion = MotionInfo.try_load(motion_dir) if motion_dir.exists() else None
 
@@ -487,9 +479,6 @@ def template_match(project_path: str, output_dir: str) -> None:
     result = {
         "final_unit_count": int(len(unique)),
         "final_spike_count": int(len(labels)),
-        "templates_kept": len(keep_ids),
-        "templates_merged": len(merge_map),
-        "templates_discarded": len(decisions["decisions"]) - len(keep_ids) - len(merge_map),
     }
     (out / "sorting_result.json").write_text(json.dumps(result, indent=2))
     log.info(

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import structlog
@@ -67,8 +68,145 @@ def preprocess(project_path: str, output_dir: str) -> None:
     )
 
 
+def detect_trial(project_path: str, output_dir: str) -> None:
+    """Run threshold sweep on a small subset to inform parameter selection.
+
+    Tests 3 candidate thresholds (3.5, 4.0, 4.5) with early termination.
+    Writes trial_results.json for the detect_params AgentNode.
+    """
+    import copy
+
+    import spikeinterface.core as si
+    from dartsort.main import threshold as ds_threshold
+    from dartsort.util.internal_config import (
+        default_featurization_cfg,
+        default_peeling_fit_sampling_cfg,
+        default_thresholding_cfg,
+        default_waveform_cfg,
+    )
+
+    out = Path(output_dir)
+    recording = si.load_extractor(out / "preprocessed")
+    noise_stats = json.loads((out / "noise_stats.json").read_text())
+
+    candidate_thresholds = [3.5, 4.0, 4.5]
+    trial_results: dict = {
+        "recording_duration_s": noise_stats["recording_duration_s"],
+        "n_channels": recording.get_num_channels(),
+        "thresholds": {},
+    }
+
+    for thresh in candidate_thresholds:
+        trial_dir = out / "trial_runs" / f"thresh_{thresh}"
+        trial_dir.mkdir(parents=True, exist_ok=True)
+
+        thresh_cfg = copy.deepcopy(default_thresholding_cfg)
+        thresh_cfg.voltage_threshold = thresh
+        thresh_cfg.peak_sign = "both"
+        thresh_cfg.dedup_temporal_radius = 11
+
+        log.info("detect_trial.start", threshold=thresh)
+        sorting = ds_threshold(
+            output_dir=trial_dir,
+            recording=recording,
+            waveform_cfg=default_waveform_cfg,
+            thresholding_cfg=thresh_cfg,
+            featurization_cfg=default_featurization_cfg,
+            sampling_cfg=default_peeling_fit_sampling_cfg,
+            hdf5_filename="trial.h5",
+            stop_after_n_spikes=10_000,
+            ensure_coverage=0.05,
+            overwrite=True,
+        )
+
+        n_spikes = sorting.count
+        duration = noise_stats["recording_duration_s"]
+
+        amplitudes: list[float] = []
+        if (
+            hasattr(sorting, "point_source_localizations")
+            and sorting.point_source_localizations is not None
+        ):
+            amplitudes = sorting.point_source_localizations[:, 3].tolist()
+        elif (
+            hasattr(sorting, "denoised_ptp_amplitudes")
+            and sorting.denoised_ptp_amplitudes is not None
+        ):
+            amplitudes = sorting.denoised_ptp_amplitudes.tolist()
+
+        amp_percentiles: dict[str, float] = {}
+        if amplitudes:
+            amp_arr = np.array(amplitudes)
+            amp_percentiles = {
+                "p10": float(np.percentile(amp_arr, 10)),
+                "p25": float(np.percentile(amp_arr, 25)),
+                "p50": float(np.percentile(amp_arr, 50)),
+                "p75": float(np.percentile(amp_arr, 75)),
+                "p90": float(np.percentile(amp_arr, 90)),
+            }
+
+        trial_results["thresholds"][str(thresh)] = {
+            "spike_count": int(n_spikes),
+            "spike_rate_hz": float(n_spikes / duration) if duration > 0 else 0.0,
+            "mean_amplitude": float(np.mean(amplitudes)) if amplitudes else None,
+            "amplitude_distribution_percentiles": amp_percentiles if amp_percentiles else None,
+        }
+        log.info(
+            "detect_trial.done",
+            threshold=thresh,
+            spikes=n_spikes,
+            rate_hz=trial_results["thresholds"][str(thresh)]["spike_rate_hz"],
+        )
+
+    (out / "trial_results.json").write_text(json.dumps(trial_results, indent=2))
+    log.info("detect_trial.complete", thresholds_tested=len(candidate_thresholds))
+
+
+def _load_denoiser() -> Any:
+    """Load the pretrained single-channel denoiser from DARTsort."""
+    import torch
+    from dartsort.transform.single_channel_denoiser import SingleChanDenoiser
+
+    denoiser = SingleChanDenoiser()
+    weights_path = Path(_DS_REF) / "pretrained" / "single_chan_denoiser.pt"
+    if not weights_path.exists():
+        weights_path = Path(_DS_REF) / "src" / "dartsort" / "pretrained" / "single_chan_denoiser.pt"
+    denoiser.load_state_dict(torch.load(weights_path, map_location="cpu", weights_only=True))
+    denoiser.eval()
+    log.info("denoiser.loaded", weights=str(weights_path))
+    return denoiser
+
+
+def _denoise_traces(traces: np.ndarray, denoiser: Any) -> np.ndarray:
+    """Apply single-channel denoiser to traces channel-by-channel."""
+    import torch
+
+    device = next(denoiser.parameters()).device
+    denoised = np.empty_like(traces)
+    n_channels = traces.shape[1]
+
+    with torch.no_grad():
+        for ch in range(n_channels):
+            ch_trace = (
+                torch.tensor(traces[:, ch], dtype=torch.float32, device=device)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+            ch_denoised = denoiser(ch_trace)
+            denoised[:, ch] = ch_denoised.squeeze().cpu().numpy()
+
+    log.info("denoise.complete", channels=n_channels)
+    return denoised
+
+
 def detect(project_path: str, output_dir: str) -> None:
-    """Run threshold-crossing detection with LLM-selected parameters."""
+    """Run threshold-crossing detection with LLM-selected parameters.
+
+    Optionally applies the single-channel denoiser NN before threshold detection
+    when use_denoiser=True in detection_params.json.
+    """
+    import copy
+
     import spikeinterface.core as si
     from dartsort.main import threshold as ds_threshold
     from dartsort.util.internal_config import (
@@ -82,7 +220,29 @@ def detect(project_path: str, output_dir: str) -> None:
     recording = si.load_extractor(out / "preprocessed")
     params = json.loads((out / "detection_params.json").read_text())
 
-    thresh_cfg = default_thresholding_cfg
+    use_denoiser = params.get("use_denoiser", True)
+
+    if use_denoiser:
+        denoiser = _load_denoiser()
+        traces = recording.get_traces()
+        denoised_traces = _denoise_traces(traces, denoiser)
+
+        denoised_dir = out / "denoised"
+        denoised_dir.mkdir(exist_ok=True)
+        np.save(denoised_dir / "traces.npy", denoised_traces)
+
+        from spikeinterface.core import NumpyRecording
+
+        recording = NumpyRecording(
+            traces_list=[denoised_traces],
+            sampling_frequency=recording.get_sampling_frequency(),
+        )
+        recording.set_channel_locations(
+            si.load_extractor(out / "preprocessed").get_channel_locations()
+        )
+        log.info("detect.denoiser_applied")
+
+    thresh_cfg = copy.deepcopy(default_thresholding_cfg)
     thresh_cfg.voltage_threshold = params["voltage_threshold"]
     thresh_cfg.peak_sign = params["peak_sign"]
     thresh_cfg.dedup_temporal_radius = params["dedup_temporal_radius"]
@@ -103,10 +263,13 @@ def detect(project_path: str, output_dir: str) -> None:
         "spike_count": int(n_spikes),
         "spike_rate_hz": float(n_spikes / recording.get_total_duration()),
         "detection_params_used": params,
+        "denoiser_applied": use_denoiser,
     }
     (out / "detection_summary.json").write_text(json.dumps(summary, indent=2))
     sorting.save(out / "detections" / "sorting.npz")
-    log.info("detect.complete", spikes=n_spikes, rate_hz=summary["spike_rate_hz"])
+    log.info(
+        "detect.complete", spikes=n_spikes, rate_hz=summary["spike_rate_hz"], denoised=use_denoiser
+    )
 
 
 def localize(project_path: str, output_dir: str) -> None:

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -95,6 +95,7 @@ def detect(project_path: str, output_dir: str) -> None:
         featurization_cfg=default_featurization_cfg,
         sampling_cfg=default_peeling_fit_sampling_cfg,
         hdf5_filename="detections.h5",
+        model_subdir="detections_models",
     )
 
     n_spikes = sorting.count
@@ -120,17 +121,22 @@ def localize(project_path: str, output_dir: str) -> None:
     sorting = DARTsortSorting.load(out / "detections" / "sorting.npz")
 
     cfg = default_dartsort_cfg
-    get_motion_info(
-        output_directory=out / "motion",
-        recording=recording,
-        sorting=sorting,
-        detect_new_peaks=True,
-        motion_cfg=cfg.motion_estimation_cfg,
-        computation_cfg=cfg.computation_cfg,
-        sampling_cfg=cfg.peeler_sampling_cfg,
-        waveform_cfg=cfg.waveform_cfg,
-        overwrite=True,
-    )
+    try:
+        motion = get_motion_info(
+            output_directory=out / "motion",
+            recording=recording,
+            sorting=sorting,
+            detect_new_peaks=False,
+            motion_cfg=cfg.motion_estimation_cfg,
+            computation_cfg=cfg.computation_cfg,
+            sampling_cfg=cfg.peeler_sampling_cfg,
+            waveform_cfg=cfg.waveform_cfg,
+            overwrite=True,
+        )
+        log.info("localize.motion_estimated", drifting=motion.drifting)
+    except Exception:
+        log.exception("localize.motion_estimation_failed")
+        raise
 
     locs: dict[str, list[float]] = {}
     if hasattr(sorting, "point_source_localizations"):

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -15,8 +15,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any
-
 import numpy as np
 import structlog
 
@@ -158,59 +156,14 @@ def detect_trial(project_path: str, output_dir: str) -> None:
     (out / "trial_results.json").write_text(json.dumps(trial_results, indent=2))
     log.info("detect_trial.complete", thresholds_tested=len(candidate_thresholds))
 
-
-def _load_denoiser() -> Any:
-    """Load the pretrained single-channel denoiser from DARTsort."""
-    import torch
-    from dartsort.transform.single_channel_denoiser import (
-        SingleChanDenoiser,
-        default_pretrained_path,
-    )
-
-    denoiser = SingleChanDenoiser()
-    weights_path = Path(str(default_pretrained_path))
-    if not weights_path.exists():
-        ref = Path(_DS_REF)
-        for candidate in [
-            ref / "pretrained" / "single_chan_denoiser.pt",
-            ref / "src" / "dartsort" / "pretrained" / "single_chan_denoiser.pt",
-        ]:
-            if candidate.exists():
-                weights_path = candidate
-                break
-    denoiser.load_state_dict(torch.load(weights_path, map_location="cpu", weights_only=True))
-    denoiser.eval()
-    log.info("denoiser.loaded", weights=str(weights_path))
-    return denoiser
-
-
-def _denoise_traces(traces: np.ndarray, denoiser: Any) -> np.ndarray:
-    """Apply single-channel denoiser to traces channel-by-channel."""
-    import torch
-
-    device = next(denoiser.parameters()).device
-    denoised = np.empty_like(traces)
-    n_channels = traces.shape[1]
-
-    with torch.no_grad():
-        for ch in range(n_channels):
-            ch_trace = (
-                torch.tensor(traces[:, ch], dtype=torch.float32, device=device)
-                .unsqueeze(0)
-                .unsqueeze(0)
-            )
-            ch_denoised = denoiser(ch_trace)
-            denoised[:, ch] = ch_denoised.squeeze().cpu().numpy()
-
-    log.info("denoise.complete", channels=n_channels)
-    return denoised
-
-
 def detect(project_path: str, output_dir: str) -> None:
     """Run threshold-crossing detection with LLM-selected parameters.
 
-    Optionally applies the single-channel denoiser NN before threshold detection
-    when use_denoiser=True in detection_params.json.
+    Note: The use_denoiser parameter in detection_params.json is currently ignored.
+    DARTsort's single-channel denoiser operates on extracted waveforms during
+    featurization/matching, not on raw traces. Trace-level denoising would
+    require a different approach (e.g., CAR, bandpass filtering, or a
+    trained trace denoiser).
     """
     import spikeinterface.core as si
     from dartsort.main import threshold as ds_threshold
@@ -224,28 +177,6 @@ def detect(project_path: str, output_dir: str) -> None:
     out = Path(output_dir)
     recording = si.load(out / "preprocessed")
     params = json.loads((out / "detection_params.json").read_text())
-
-    use_denoiser = params.get("use_denoiser", True)
-
-    if use_denoiser:
-        denoiser = _load_denoiser()
-        traces = recording.get_traces()
-        denoised_traces = _denoise_traces(traces, denoiser)
-
-        denoised_dir = out / "denoised"
-        denoised_dir.mkdir(exist_ok=True)
-        np.save(denoised_dir / "traces.npy", denoised_traces)
-
-        from spikeinterface.core import NumpyRecording
-
-        recording = NumpyRecording(
-            traces_list=[denoised_traces],
-            sampling_frequency=recording.get_sampling_frequency(),
-        )
-        recording.set_channel_locations(
-            si.load(out / "preprocessed").get_channel_locations()
-        )
-        log.info("detect.denoiser_applied")
 
     thresh_cfg = dataclasses.replace(
         default_thresholding_cfg,
@@ -270,13 +201,10 @@ def detect(project_path: str, output_dir: str) -> None:
         "spike_count": int(n_spikes),
         "spike_rate_hz": float(n_spikes / recording.get_total_duration()),
         "detection_params_used": params,
-        "denoiser_applied": use_denoiser,
     }
     (out / "detection_summary.json").write_text(json.dumps(summary, indent=2))
     sorting.save(out / "detections" / "sorting.npz")
-    log.info(
-        "detect.complete", spikes=n_spikes, rate_hz=summary["spike_rate_hz"], denoised=use_denoiser
-    )
+    log.info("detect.complete", spikes=n_spikes, rate_hz=summary["spike_rate_hz"])
 
 
 def localize(project_path: str, output_dir: str) -> None:
@@ -290,10 +218,14 @@ def localize(project_path: str, output_dir: str) -> None:
     recording = si.load(out / "preprocessed")
     sorting = DARTsortSorting.load(out / "detections" / "sorting.npz")
 
+    # Create motion directory before calling get_motion_info
+    motion_dir = out / "motion"
+    motion_dir.mkdir(parents=True, exist_ok=True)
+
     cfg = default_dartsort_cfg
     try:
         motion = get_motion_info(
-            output_directory=out / "motion",
+            output_directory=motion_dir,
             recording=recording,
             sorting=sorting,
             detect_new_peaks=False,
@@ -361,13 +293,14 @@ def cluster(project_path: str, output_dir: str) -> None:
     params = json.loads((out / "clustering_params.json").read_text())
 
     motion_dir = out / "motion"
-    motion = MotionInfo.load(motion_dir) if motion_dir.exists() else None
+    motion = MotionInfo.try_load(motion_dir) if motion_dir.exists() else None
 
-    clust_cfg = default_clustering_cfg
-    clust_cfg.cluster_strategy = params["strategy"]
-    clust_cfg.grid_dx = params["grid_dx"]
-    clust_cfg.grid_dz = params["grid_dz"]
-    clust_cfg.n_waveforms_fit = params["n_waveforms_fit"]
+    clust_cfg = dataclasses.replace(
+        default_clustering_cfg,
+        cluster_strategy=params["strategy"],
+        grid_dx=params["grid_dx"],
+        grid_dz=params["grid_dz"],
+    )
 
     result = ds_cluster(
         recording=recording,
@@ -419,7 +352,7 @@ def compute_templates(project_path: str, output_dir: str) -> None:
     sorting = DARTsortSorting.load(out / "clusters" / "sorting.npz")
 
     motion_dir = out / "motion"
-    motion = MotionInfo.load(motion_dir) if motion_dir.exists() else None
+    motion = MotionInfo.try_load(motion_dir) if motion_dir.exists() else None
 
     mcfg = default_matching_cfg
     tcfg = replace(
@@ -437,7 +370,7 @@ def compute_templates(project_path: str, output_dir: str) -> None:
     )
 
     (out / "templates").mkdir(exist_ok=True)
-    template_data.save(out / "templates" / "template_data.npz")
+    template_data.to_npz(out / "templates" / "template_data.npz")
     sorting.save(out / "templates" / "sorting.npz")
 
     templates_arr = template_data.templates if hasattr(template_data, "templates") else np.array([])
@@ -482,7 +415,7 @@ def template_match(project_path: str, output_dir: str) -> None:
     out = Path(output_dir)
     recording = si.load(out / "preprocessed")
     sorting = DARTsortSorting.load(out / "templates" / "sorting.npz")
-    template_data = TemplateData.load(out / "templates" / "template_data.npz")
+    template_data = TemplateData.from_npz(out / "templates" / "template_data.npz")
 
     decisions = json.loads((out / "template_decisions.json").read_text())
     keep_ids = {d["template_id"] for d in decisions["decisions"] if d["action"] == "keep"}
@@ -493,7 +426,7 @@ def template_match(project_path: str, output_dir: str) -> None:
     }
 
     motion_dir = out / "motion"
-    motion = MotionInfo.load(motion_dir) if motion_dir.exists() else None
+    motion = MotionInfo.try_load(motion_dir) if motion_dir.exists() else None
 
     final_sorting = ds_match(
         output_dir=out / "sorting",

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -157,20 +157,18 @@ def detect_trial(project_path: str, output_dir: str) -> None:
     log.info("detect_trial.complete", thresholds_tested=len(candidate_thresholds))
 
 def detect(project_path: str, output_dir: str) -> None:
-    """Run threshold-crossing detection with LLM-selected parameters.
+    """Run subtraction-based spike detection with LLM-selected parameters.
 
-    Note: The use_denoiser parameter in detection_params.json is currently ignored.
-    DARTsort's single-channel denoiser operates on extracted waveforms during
-    featurization/matching, not on raw traces. Trace-level denoising would
-    require a different approach (e.g., CAR, bandpass filtering, or a
-    trained trace denoiser).
+    Uses DARTsort's SubtractionPeeler for initial detection, which is more
+    selective than simple thresholding and produces cleaner spike trains.
+    The detection_threshold parameter controls the SNR threshold.
     """
     import spikeinterface.core as si
-    from dartsort.main import threshold as ds_threshold
+    from dartsort.main import subtract as ds_subtract
     from dartsort.util.internal_config import (
         default_featurization_cfg,
         default_peeling_fit_sampling_cfg,
-        default_thresholding_cfg,
+        default_subtraction_cfg,
         default_waveform_cfg,
     )
 
@@ -178,22 +176,21 @@ def detect(project_path: str, output_dir: str) -> None:
     recording = si.load(out / "preprocessed")
     params = json.loads((out / "detection_params.json").read_text())
 
-    thresh_cfg = dataclasses.replace(
-        default_thresholding_cfg,
+    # Configure subtraction with LLM-selected threshold
+    subtract_cfg = dataclasses.replace(
+        default_subtraction_cfg,
         detection_threshold=params["detection_threshold"],
         peak_sign=params["peak_sign"],
-        temporal_dedup_radius_samples=params["temporal_dedup_radius_samples"],
     )
 
-    sorting = ds_threshold(
+    sorting = ds_subtract(
         output_dir=out / "detections",
         recording=recording,
         waveform_cfg=default_waveform_cfg,
-        thresholding_cfg=thresh_cfg,
+        subtraction_cfg=subtract_cfg,
         featurization_cfg=default_featurization_cfg,
         sampling_cfg=default_peeling_fit_sampling_cfg,
-        hdf5_filename="detections.h5",
-        model_subdir="detections_models",
+        overwrite=True,
     )
 
     n_spikes = sorting.n_spikes
@@ -201,6 +198,7 @@ def detect(project_path: str, output_dir: str) -> None:
         "spike_count": int(n_spikes),
         "spike_rate_hz": float(n_spikes / recording.get_total_duration()),
         "detection_params_used": params,
+        "detection_method": "subtract",
     }
     (out / "detection_summary.json").write_text(json.dumps(summary, indent=2))
     sorting.save(out / "detections" / "sorting.npz")
@@ -277,13 +275,18 @@ def localize(project_path: str, output_dir: str) -> None:
 
 
 def cluster(project_path: str, output_dir: str) -> None:
-    """Cluster spikes into putative units using LLM-selected strategy."""
+    """Cluster spikes into putative units using LLM-selected strategy with refinement.
+
+    Uses DARTsort's default refinement configs (pcmerge, tmm, filter) to merge
+    overclustered units and clean up the clustering result.
+    """
     import spikeinterface.core as si
     from dartsort.main import cluster as ds_cluster
     from dartsort.util.data_util import DARTsortSorting
     from dartsort.util.internal_config import (
         default_clustering_cfg,
         default_clustering_features_cfg,
+        default_dartsort_cfg,
     )
     from dartsort.util.motion import MotionInfo
 
@@ -302,12 +305,20 @@ def cluster(project_path: str, output_dir: str) -> None:
         grid_dz=params["grid_dz"],
     )
 
+    # Use DARTsort's default refinement configs for merge/split cleanup
+    refinement_cfgs = [
+        default_dartsort_cfg.pre_refinement_cfg,
+        default_dartsort_cfg.initial_refinement_cfg,
+        *default_dartsort_cfg.post_refinement_cfgs,
+    ]
+
     result = ds_cluster(
         recording=recording,
         sorting=sorting,
         motion=motion,
         clustering_cfg=clust_cfg,
         clustering_features_cfg=default_clustering_features_cfg,
+        refinement_cfgs=refinement_cfgs,
     )
 
     (out / "clusters").mkdir(exist_ok=True)
@@ -398,12 +409,19 @@ def compute_templates(project_path: str, output_dir: str) -> None:
 
 
 def template_match(project_path: str, output_dir: str) -> None:
-    """Template matching refinement using QC-filtered templates."""
+    """Template matching refinement with post-match refinement.
+
+    Matches spikes to templates then runs a final refinement pass to merge
+    overclustered units, following vanilla DARTsort's approach.
+    """
     import spikeinterface.core as si
     from dartsort.main import match as ds_match
+    from dartsort.main import cluster as ds_cluster
     from dartsort.templates import TemplateData
     from dartsort.util.data_util import DARTsortSorting
     from dartsort.util.internal_config import (
+        default_clustering_features_cfg,
+        default_dartsort_cfg,
         default_featurization_cfg,
         default_matching_cfg,
         default_peeling_fit_sampling_cfg,
@@ -428,7 +446,8 @@ def template_match(project_path: str, output_dir: str) -> None:
     motion_dir = out / "motion"
     motion = MotionInfo.try_load(motion_dir) if motion_dir.exists() else None
 
-    final_sorting = ds_match(
+    # Step 1: Template matching
+    matched_sorting = ds_match(
         output_dir=out / "sorting",
         recording=recording,
         sorting=sorting,
@@ -441,6 +460,19 @@ def template_match(project_path: str, output_dir: str) -> None:
         template_data=template_data,
         hdf5_filename="matching_final.h5",
         model_subdir="matching_final_models",
+    )
+
+    # Step 2: Post-match refinement (like vanilla DARTsort's final_refinement)
+    # Use the post_refinement_cfgs which do filtering/cleanup
+    refinement_cfgs = list(default_dartsort_cfg.post_refinement_cfgs)
+
+    final_sorting = ds_cluster(
+        recording=recording,
+        sorting=matched_sorting,
+        motion=motion,
+        clustering_cfg=None,  # No re-clustering, just refinement
+        clustering_features_cfg=default_clustering_features_cfg,
+        refinement_cfgs=refinement_cfgs,
     )
 
     final_sorting.save(out / "sorting" / "sorting.npz")

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -10,7 +10,9 @@ Each function follows the signature:
 
 from __future__ import annotations
 
+import dataclasses
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -20,7 +22,7 @@ import structlog
 
 log = structlog.get_logger()
 
-_DS_REF = "/workspace/home/churwitz/ds_ref"
+_DS_REF = os.environ.get("DS_REF_PATH", "/workspace/home/churwitz/ds_ref")
 if _DS_REF not in sys.path:
     sys.path.insert(0, _DS_REF)
 
@@ -36,12 +38,12 @@ def preprocess(project_path: str, output_dir: str) -> None:
 
     config = json.loads(Path(project_path, ".factory", "config.json").read_text())
     recording_path = config["recording_path"]
-    recording = si.load_extractor(recording_path)
+    recording = si.load(recording_path)
 
     cfg = default_dartsort_cfg
     rec_processed = ds_preprocess(recording, cfg.preprocessing, cfg.preprocessing_dtype)
 
-    si.save(rec_processed, out / "preprocessed", overwrite=True)
+    rec_processed.save(folder=out / "preprocessed")
 
     traces_sample = rec_processed.get_traces(
         start_frame=0, end_frame=min(30000, rec_processed.get_num_frames())
@@ -74,8 +76,6 @@ def detect_trial(project_path: str, output_dir: str) -> None:
     Tests 3 candidate thresholds (3.5, 4.0, 4.5) with early termination.
     Writes trial_results.json for the detect_params AgentNode.
     """
-    import copy
-
     import spikeinterface.core as si
     from dartsort.main import threshold as ds_threshold
     from dartsort.util.internal_config import (
@@ -86,7 +86,7 @@ def detect_trial(project_path: str, output_dir: str) -> None:
     )
 
     out = Path(output_dir)
-    recording = si.load_extractor(out / "preprocessed")
+    recording = si.load(out / "preprocessed")
     noise_stats = json.loads((out / "noise_stats.json").read_text())
 
     candidate_thresholds = [3.5, 4.0, 4.5]
@@ -100,10 +100,12 @@ def detect_trial(project_path: str, output_dir: str) -> None:
         trial_dir = out / "trial_runs" / f"thresh_{thresh}"
         trial_dir.mkdir(parents=True, exist_ok=True)
 
-        thresh_cfg = copy.deepcopy(default_thresholding_cfg)
-        thresh_cfg.voltage_threshold = thresh
-        thresh_cfg.peak_sign = "both"
-        thresh_cfg.dedup_temporal_radius = 11
+        thresh_cfg = dataclasses.replace(
+            default_thresholding_cfg,
+            detection_threshold=thresh,
+            peak_sign="both",
+            temporal_dedup_radius_samples=11,
+        )
 
         log.info("detect_trial.start", threshold=thresh)
         sorting = ds_threshold(
@@ -119,16 +121,11 @@ def detect_trial(project_path: str, output_dir: str) -> None:
             overwrite=True,
         )
 
-        n_spikes = sorting.count
+        n_spikes = sorting.n_spikes
         duration = noise_stats["recording_duration_s"]
 
         amplitudes: list[float] = []
         if (
-            hasattr(sorting, "point_source_localizations")
-            and sorting.point_source_localizations is not None
-        ):
-            amplitudes = sorting.point_source_localizations[:, 3].tolist()
-        elif (
             hasattr(sorting, "denoised_ptp_amplitudes")
             and sorting.denoised_ptp_amplitudes is not None
         ):
@@ -165,12 +162,22 @@ def detect_trial(project_path: str, output_dir: str) -> None:
 def _load_denoiser() -> Any:
     """Load the pretrained single-channel denoiser from DARTsort."""
     import torch
-    from dartsort.transform.single_channel_denoiser import SingleChanDenoiser
+    from dartsort.transform.single_channel_denoiser import (
+        SingleChanDenoiser,
+        default_pretrained_path,
+    )
 
     denoiser = SingleChanDenoiser()
-    weights_path = Path(_DS_REF) / "pretrained" / "single_chan_denoiser.pt"
+    weights_path = Path(str(default_pretrained_path))
     if not weights_path.exists():
-        weights_path = Path(_DS_REF) / "src" / "dartsort" / "pretrained" / "single_chan_denoiser.pt"
+        ref = Path(_DS_REF)
+        for candidate in [
+            ref / "pretrained" / "single_chan_denoiser.pt",
+            ref / "src" / "dartsort" / "pretrained" / "single_chan_denoiser.pt",
+        ]:
+            if candidate.exists():
+                weights_path = candidate
+                break
     denoiser.load_state_dict(torch.load(weights_path, map_location="cpu", weights_only=True))
     denoiser.eval()
     log.info("denoiser.loaded", weights=str(weights_path))
@@ -205,8 +212,6 @@ def detect(project_path: str, output_dir: str) -> None:
     Optionally applies the single-channel denoiser NN before threshold detection
     when use_denoiser=True in detection_params.json.
     """
-    import copy
-
     import spikeinterface.core as si
     from dartsort.main import threshold as ds_threshold
     from dartsort.util.internal_config import (
@@ -217,7 +222,7 @@ def detect(project_path: str, output_dir: str) -> None:
     )
 
     out = Path(output_dir)
-    recording = si.load_extractor(out / "preprocessed")
+    recording = si.load(out / "preprocessed")
     params = json.loads((out / "detection_params.json").read_text())
 
     use_denoiser = params.get("use_denoiser", True)
@@ -238,14 +243,16 @@ def detect(project_path: str, output_dir: str) -> None:
             sampling_frequency=recording.get_sampling_frequency(),
         )
         recording.set_channel_locations(
-            si.load_extractor(out / "preprocessed").get_channel_locations()
+            si.load(out / "preprocessed").get_channel_locations()
         )
         log.info("detect.denoiser_applied")
 
-    thresh_cfg = copy.deepcopy(default_thresholding_cfg)
-    thresh_cfg.voltage_threshold = params["voltage_threshold"]
-    thresh_cfg.peak_sign = params["peak_sign"]
-    thresh_cfg.dedup_temporal_radius = params["dedup_temporal_radius"]
+    thresh_cfg = dataclasses.replace(
+        default_thresholding_cfg,
+        detection_threshold=params["detection_threshold"],
+        peak_sign=params["peak_sign"],
+        temporal_dedup_radius_samples=params["temporal_dedup_radius_samples"],
+    )
 
     sorting = ds_threshold(
         output_dir=out / "detections",
@@ -257,7 +264,7 @@ def detect(project_path: str, output_dir: str) -> None:
         hdf5_filename="detections.h5",
     )
 
-    n_spikes = sorting.count
+    n_spikes = sorting.n_spikes
     summary = {
         "spike_count": int(n_spikes),
         "spike_rate_hz": float(n_spikes / recording.get_total_duration()),
@@ -279,7 +286,7 @@ def localize(project_path: str, output_dir: str) -> None:
     from dartsort.util.motion import get_motion_info
 
     out = Path(output_dir)
-    recording = si.load_extractor(out / "preprocessed")
+    recording = si.load(out / "preprocessed")
     sorting = DARTsortSorting.load(out / "detections" / "sorting.npz")
 
     cfg = default_dartsort_cfg
@@ -343,7 +350,7 @@ def cluster(project_path: str, output_dir: str) -> None:
     from dartsort.util.motion import MotionInfo
 
     out = Path(output_dir)
-    recording = si.load_extractor(out / "preprocessed")
+    recording = si.load(out / "preprocessed")
     sorting = DARTsortSorting.load(out / "detections" / "sorting.npz")
     params = json.loads((out / "clustering_params.json").read_text())
 
@@ -399,7 +406,7 @@ def compute_templates(project_path: str, output_dir: str) -> None:
     from dartsort.util.motion import MotionInfo
 
     out = Path(output_dir)
-    recording = si.load_extractor(out / "preprocessed")
+    recording = si.load(out / "preprocessed")
     sorting = DARTsortSorting.load(out / "clusters" / "sorting.npz")
 
     motion_dir = out / "motion"
@@ -460,7 +467,7 @@ def template_match(project_path: str, output_dir: str) -> None:
     from dartsort.util.motion import MotionInfo
 
     out = Path(output_dir)
-    recording = si.load_extractor(out / "preprocessed")
+    recording = si.load(out / "preprocessed")
     sorting = DARTsortSorting.load(out / "templates" / "sorting.npz")
     template_data = TemplateData.load(out / "templates" / "template_data.npz")
 

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -1195,9 +1195,14 @@ def merge_clusters(project_path: str, output_dir: str) -> None:
 
 
 def evaluate_accuracy(project_path: str, output_dir: str) -> dict:
-    """Compare final sorting to ground truth using benchmark profile."""
+    """Compare final sorting to ground truth using benchmark profile.
+
+    Uses make_match_count_matrix directly instead of compare_sorter_to_ground_truth
+    because the latter has a bug in SpikeInterface 0.104.x where delta_frames=0.
+    """
     import spikeinterface.core as si
-    from spikeinterface.comparison import compare_sorter_to_ground_truth
+    from spikeinterface.core import NumpySorting
+    from spikeinterface.comparison.comparisontools import make_match_count_matrix
 
     out = Path(output_dir)
     benchmark_path = Path(project_path) / "benchmark.md"
@@ -1224,44 +1229,64 @@ def evaluate_accuracy(project_path: str, output_dir: str) -> dict:
     labels = data["labels"]
     sampling_freq = float(data["sampling_frequency"]) if "sampling_frequency" in data else profile.sampling_frequency
 
-    from spikeinterface.core import NumpySorting
-
     unique_ids = np.unique(labels[labels >= 0])
-    units_dict: dict[str, np.ndarray] = {}
+    units_dict: dict[int, np.ndarray] = {}
     for uid in unique_ids:
         spike_times = times[labels == uid]
-        units_dict[str(int(uid))] = np.sort(spike_times)
+        units_dict[int(uid)] = np.sort(spike_times)
 
     tested_sorting = NumpySorting.from_unit_dict(
         units_dict, sampling_frequency=sampling_freq,
     )
 
-    delta_time = profile.match_tolerance_samples / profile.sampling_frequency
-    comp = compare_sorter_to_ground_truth(
-        gt_sorting=gt_sorting,
-        tested_sorting=tested_sorting,
-        delta_time=delta_time,
+    # Use make_match_count_matrix directly with delta_frames (not delta_time)
+    # This avoids a bug in compare_sorter_to_ground_truth where delta_frames=0
+    match_matrix = make_match_count_matrix(
+        gt_sorting, tested_sorting,
+        delta_frames=profile.match_tolerance_samples,
+        ensure_symmetry=False,
     )
 
-    perf = comp.get_performance()
-    accuracy_values = perf["accuracy"].values
-    accuracy = float(np.mean(accuracy_values))
+    # Compute per-GT-unit accuracy using best match
+    per_unit_results = []
+    for gt_id in gt_sorting.unit_ids:
+        gt_count = len(gt_sorting.get_unit_spike_train(gt_id))
 
-    gt_unit_ids = comp.get_ordered_agreement_scores().index.tolist()
-    per_unit_accuracy = {}
-    for i, uid in enumerate(gt_unit_ids):
-        if i < len(accuracy_values):
-            per_unit_accuracy[str(uid)] = round(float(accuracy_values[i]), 4)
+        row = match_matrix.loc[gt_id]
+        best_tested_id = row.idxmax()
+        n_match = float(row[best_tested_id])
+        tested_count = len(tested_sorting.get_unit_spike_train(best_tested_id))
+
+        # accuracy = TP / (TP + FP + FN) = n_match / (gt + tested - n_match)
+        denom = gt_count + tested_count - n_match
+        accuracy = n_match / denom if denom > 0 else 0.0
+        recall = n_match / gt_count if gt_count > 0 else 0.0
+        precision = n_match / tested_count if tested_count > 0 else 0.0
+
+        per_unit_results.append({
+            "gt_id": int(gt_id),
+            "best_match": int(best_tested_id),
+            "n_match": int(n_match),
+            "accuracy": round(accuracy, 4),
+            "recall": round(recall, 4),
+            "precision": round(precision, 4),
+        })
+
+    accuracies = [r["accuracy"] for r in per_unit_results]
+    mean_accuracy = float(np.mean(accuracies))
+
+    per_unit_accuracy = {str(r["gt_id"]): r["accuracy"] for r in per_unit_results}
 
     result = {
-        "accuracy": round(accuracy, 4),
+        "accuracy": round(mean_accuracy, 4),
         "baseline": profile.baseline_accuracy,
-        "delta": round(accuracy - profile.baseline_accuracy, 4),
+        "delta": round(mean_accuracy - profile.baseline_accuracy, 4),
         "target": profile.target_accuracy,
-        "target_met": accuracy >= profile.target_accuracy,
+        "target_met": mean_accuracy >= profile.target_accuracy,
         "n_gt_units": len(gt_sorting.unit_ids),
         "n_sorted_units": len(tested_sorting.unit_ids),
         "per_unit_accuracy": per_unit_accuracy,
+        "per_unit_details": per_unit_results,
     }
 
     (out / "benchmark_result.json").write_text(json.dumps(result, indent=2))

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -545,49 +545,124 @@ def _compute_ccg_refractory(
     times_b: np.ndarray,
     sampling_rate: float = 30000.0,
     refractory_ms: float = 1.5,
-    window_ms: float = 50.0,
+    duration_s: float | None = None,
 ) -> tuple[float, float]:
-    """Compute R12 and Q12 refractory scores from cross-correlogram."""
-    max_lag = int(window_ms * sampling_rate / 1000)
-    refractory_samples = refractory_ms * sampling_rate / 1000
-    baseline_samples = 10.0 * sampling_rate / 1000
+    """Compute R12 and Q12 refractory scores for a cross-correlogram.
 
-    all_diffs = []
-    for t in times_a:
-        diffs = times_b - t
-        mask = np.abs(diffs) <= max_lag
-        all_diffs.extend(diffs[mask].tolist())
+    R12: ratio of observed to expected refractory violations under independence.
+    Q12: statistical significance of the refractory dip (Poisson z-score
+    converted to a [0,1] confidence via the error function). High Q12 means the
+    refractory dip is statistically significant (contamination evidence).
 
-    if not all_diffs:
+    Vectorized via searchsorted for O(N_a log N_b) performance.
+    """
+    import math
+
+    if len(times_a) < 2 or len(times_b) < 2:
         return 1.0, 0.0
 
-    diffs_arr = np.array(all_diffs)
-    refractory_mask = np.abs(diffs_arr) < refractory_samples
-    baseline_mask = np.abs(diffs_arr) > baseline_samples
+    refractory_s = refractory_ms / 1000.0
+    refractory_samples = refractory_s * sampling_rate
 
-    if baseline_mask.any() or refractory_mask.any():
-        n_baseline = baseline_mask.sum()
-        n_refractory = refractory_mask.sum()
-        baseline_density = n_baseline / (max_lag - baseline_samples) if (max_lag - baseline_samples) > 0 else 1.0
-        refractory_density = n_refractory / refractory_samples if refractory_samples > 0 else 0.0
-        r12 = refractory_density / baseline_density if baseline_density > 0 else 1.0
+    sorted_b = np.sort(times_b)
+    lo = np.searchsorted(sorted_b, times_a - refractory_samples)
+    hi = np.searchsorted(sorted_b, times_a + refractory_samples)
+    n_violations = int(np.sum(hi - lo))
+
+    if duration_s is None:
+        all_times = np.concatenate([times_a, times_b])
+        duration_s = float((all_times.max() - all_times.min()) / sampling_rate)
+
+    if duration_s <= 0:
+        return 1.0, 0.0
+
+    n_a, n_b = len(times_a), len(times_b)
+    expected = 2 * refractory_s * n_a * n_b / duration_s
+    if expected <= 0:
+        return 1.0, 0.0
+
+    r12 = float(n_violations / expected)
+
+    # Poisson z-score: how many σ below expected is the observed count
+    z = (expected - n_violations) / max(expected**0.5, 1e-10)
+    if z > 0 and expected >= 5:
+        q12 = math.erf(z / 2**0.5)
     else:
-        r12 = 1.0
+        q12 = 0.0
 
-    q12 = max(0.0, 1.0 - r12)
-    return r12, q12
+    return r12, float(q12)
 
 
 # ── Gate FnNode implementations ──────────────────────────────────
 
 
+def _compute_quick_templates(
+    recording: object,
+    labels: np.ndarray,
+    times: np.ndarray,
+    unique_ids: np.ndarray,
+    n_sample: int = 200,
+    half_width: int = 41,
+) -> dict[int, np.ndarray]:
+    """Compute mean waveforms per cluster by sampling spikes from the recording.
+
+    Reads data in sorted time order for sequential I/O performance.
+    Returns dict mapping cluster ID to mean waveform (n_time, n_channels).
+    """
+    n_time = 2 * half_width
+    n_frames = recording.get_num_frames()
+
+    all_times_list: list[int] = []
+    all_uids_list: list[int] = []
+    for uid in unique_ids:
+        uid_int = int(uid)
+        mask = labels == uid_int
+        spike_t = times[mask]
+        if len(spike_t) == 0:
+            continue
+        rng = np.random.default_rng(uid_int)
+        n = min(n_sample, len(spike_t))
+        chosen = spike_t[rng.choice(len(spike_t), n, replace=False)]
+        valid = (chosen >= half_width) & (chosen + half_width <= n_frames)
+        chosen = chosen[valid]
+        all_times_list.extend(chosen.tolist())
+        all_uids_list.extend([uid_int] * len(chosen))
+
+    if not all_times_list:
+        return {}
+
+    all_t = np.array(all_times_list, dtype=np.int64)
+    all_u = np.array(all_uids_list, dtype=np.int64)
+    order = np.argsort(all_t)
+    all_t = all_t[order]
+    all_u = all_u[order]
+
+    n_channels = recording.get_num_channels()
+    sums: dict[int, np.ndarray] = {}
+    counts: dict[int, int] = {}
+
+    for t, uid in zip(all_t, all_u):
+        start = int(t) - half_width
+        wf = recording.get_traces(start_frame=start, end_frame=start + n_time)
+        if wf.shape[0] == n_time:
+            if uid not in sums:
+                sums[uid] = np.zeros((n_time, n_channels), dtype=np.float64)
+                counts[uid] = 0
+            sums[uid] += wf
+            counts[uid] += 1
+
+    return {uid: sums[uid] / counts[uid] for uid in sums if counts.get(uid, 0) > 0}
+
+
 def compute_cluster_metrics(project_path: str, output_dir: str) -> None:
     """Compute per-cluster and pairwise metrics for Gate 1 (post-clustering)."""
+    import spikeinterface.core as si
     from dartsort.util.data_util import DARTsortSorting
 
     out = Path(output_dir)
     sorting = DARTsortSorting.load(out / "clusters" / "sorting.npz")
     context = json.loads((out / "recording_context.json").read_text())
+    recording = si.load(out / "preprocessed")
 
     labels = sorting.labels if hasattr(sorting, "labels") else np.array([])
     times = sorting.times_samples if hasattr(sorting, "times_samples") else np.array([])
@@ -600,6 +675,8 @@ def compute_cluster_metrics(project_path: str, output_dir: str) -> None:
     loc_path = out / "localizations.npz"
     if loc_path.exists():
         locs = np.load(loc_path)
+
+    templates_dict = _compute_quick_templates(recording, labels, times, unique_ids)
 
     per_cluster = []
     centroids: dict[int, tuple[float, float]] = {}
@@ -670,8 +747,17 @@ def compute_cluster_metrics(project_path: str, output_dir: str) -> None:
             if dist > 100.0:
                 continue
 
-            # Template correlation (using mean spike amplitudes as proxy)
+            # Template correlation from mean waveforms
             corr = 0.0
+            if uid_a in templates_dict and uid_b in templates_dict:
+                ta = templates_dict[uid_a].flatten()
+                tb = templates_dict[uid_b].flatten()
+                ta_c = ta - ta.mean()
+                tb_c = tb - tb.mean()
+                na = np.linalg.norm(ta_c)
+                nb = np.linalg.norm(tb_c)
+                if na > 1e-10 and nb > 1e-10:
+                    corr = float(np.dot(ta_c, tb_c) / (na * nb))
 
             # CCG refractory
             mask_a = labels == uid_a
@@ -683,7 +769,9 @@ def compute_cluster_metrics(project_path: str, output_dir: str) -> None:
             if len(times_a) > 10 and len(times_b) > 10:
                 sub_a = times_a[:min(5000, len(times_a))]
                 sub_b = times_b[:min(5000, len(times_b))]
-                r12, q12 = _compute_ccg_refractory(sub_a, sub_b, sampling_rate)
+                r12, q12 = _compute_ccg_refractory(
+                    sub_a, sub_b, sampling_rate, duration_s=duration_s
+                )
 
             pairwise.append({
                 "cluster_a": uid_a,
@@ -750,18 +838,61 @@ def apply_cluster_actions(project_path: str, output_dir: str) -> None:
     )
 
 
+def _compute_template_similarities(templates_arr: np.ndarray | None) -> np.ndarray:
+    """Compute max pairwise correlation per template using SVD compression.
+
+    O(N*D*k + N^2*k) with rank-k SVD instead of O(N^2*D) for the naive loop.
+    For 1253 templates this runs in seconds instead of 20+ minutes.
+    """
+    if templates_arr is None or len(templates_arr) < 2:
+        return np.zeros(len(templates_arr) if templates_arr is not None else 0)
+
+    n = len(templates_arr)
+    flat = templates_arr.reshape(n, -1).astype(np.float64)
+    flat -= flat.mean(axis=1, keepdims=True)
+    norms = np.linalg.norm(flat, axis=1)
+    valid_mask = norms > 1e-10
+
+    result = np.zeros(n)
+    n_valid = int(valid_mask.sum())
+    if n_valid < 2:
+        return result
+
+    valid_flat = flat[valid_mask] / norms[valid_mask, np.newaxis]
+
+    n_components = min(20, n_valid - 1, valid_flat.shape[1])
+    if n_components > 0 and valid_flat.shape[1] > 2 * n_components:
+        U, S, _ = np.linalg.svd(valid_flat, full_matrices=False)
+        compressed = U[:, :n_components] * S[:n_components]
+        c_norms = np.linalg.norm(compressed, axis=1, keepdims=True)
+        c_norms = np.maximum(c_norms, 1e-10)
+        compressed /= c_norms
+        corr_matrix = compressed @ compressed.T
+    else:
+        corr_matrix = valid_flat @ valid_flat.T
+
+    np.fill_diagonal(corr_matrix, -np.inf)
+    max_corr = np.maximum(corr_matrix.max(axis=1), 0.0)
+
+    valid_indices = np.flatnonzero(valid_mask)
+    result[valid_indices] = max_corr
+
+    return result
+
+
 def compute_template_metrics(project_path: str, output_dir: str) -> None:
     """Compute per-template metrics for Gate 2 (post-template)."""
     out = Path(output_dir)
     template_stats = json.loads((out / "template_stats.json").read_text())
 
-    # Load template data for similarity computation
     templates_arr = None
     template_npz = out / "templates" / "template_data.npz"
     if template_npz.exists():
         tdata = np.load(template_npz, allow_pickle=True)
         if "templates" in tdata:
             templates_arr = tdata["templates"]
+
+    similarity_scores = _compute_template_similarities(templates_arr)
 
     per_template = []
     for stats in template_stats:
@@ -772,17 +903,7 @@ def compute_template_metrics(project_path: str, output_dir: str) -> None:
         ptp_uv = stats.get("ptp_amplitude_uv", 0.0)
         spatial_spread = stats.get("spatial_spread_um", 0.0)
 
-        # Compute max similarity with other templates
-        similarity_max = 0.0
-        if templates_arr is not None and len(templates_arr) > 1 and tid < len(templates_arr):
-            t_flat = templates_arr[tid].flatten()
-            for j in range(len(templates_arr)):
-                if j == tid:
-                    continue
-                other_flat = templates_arr[j].flatten()
-                if len(t_flat) == len(other_flat) and np.std(t_flat) > 0 and np.std(other_flat) > 0:
-                    corr = float(np.corrcoef(t_flat, other_flat)[0, 1])
-                    similarity_max = max(similarity_max, corr)
+        similarity_max = float(similarity_scores[tid]) if tid < len(similarity_scores) else 0.0
 
         per_template.append({
             "template_id": tid,
@@ -974,4 +1095,61 @@ def apply_final_actions(project_path: str, output_dir: str) -> None:
         units=result["final_unit_count"],
         deleted=result["units_deleted"],
         merged=result["units_merged"],
+    )
+
+
+def merge_clusters(project_path: str, output_dir: str) -> None:
+    """Post-clustering merge using DARTsort's agglomerate with SVD template distances.
+
+    Uses template_distances() for SVD-compressed pairwise distances, firing_corr()
+    for temporal correlation, and linkage clustering for transitive merges.
+    Overwrites clusters/sorting.npz with the merged result.
+    """
+    import spikeinterface.core as si
+    from dartsort.clustering.agglomerate import agglomerate
+    from dartsort.util.data_util import DARTsortSorting
+    from dartsort.util.internal_config import default_dartsort_cfg, default_waveform_cfg
+    from dartsort.util.motion import MotionInfo
+
+    out = Path(output_dir)
+    recording = si.load(out / "preprocessed")
+    sorting = DARTsortSorting.load(out / "clusters" / "sorting.npz")
+
+    motion_dir = out / "motion"
+    motion = MotionInfo.try_load(motion_dir) if motion_dir.exists() else None
+    if motion is None:
+        log.warning("merge_clusters.skip", reason="no motion data available")
+        return
+
+    agg_cfg = default_dartsort_cfg.agglomerate_cfg
+
+    labels_before = sorting.labels
+    n_before = len(np.unique(labels_before[labels_before >= 0])) if labels_before is not None else 0
+
+    result = agglomerate(
+        sorting=sorting,
+        recording=recording,
+        template_merge_cfg=agg_cfg.template_merge_cfg,
+        refinement_cfg=agg_cfg,
+        motion=motion,
+        waveform_cfg=default_waveform_cfg,
+    )
+
+    merged_sorting = result.agglomerated_sorting
+    merged_sorting.save(out / "clusters" / "sorting.npz")
+
+    labels_after = merged_sorting.labels if hasattr(merged_sorting, "labels") else np.array([])
+    n_after = len(np.unique(labels_after[labels_after >= 0])) if len(labels_after) > 0 else 0
+
+    summary = {
+        "units_before_merge": n_before,
+        "units_after_merge": n_after,
+        "units_merged": n_before - n_after,
+    }
+    (out / "merge_summary.json").write_text(json.dumps(summary, indent=2))
+    log.info(
+        "merge_clusters.complete",
+        before=n_before,
+        after=n_after,
+        merged=n_before - n_after,
     )

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -231,10 +231,13 @@ def cluster(project_path: str, output_dir: str) -> None:
 
 def compute_templates(project_path: str, output_dir: str) -> None:
     """Compute unit templates (average waveforms) from clustered spikes."""
+    from dataclasses import replace
+
     import spikeinterface.core as si
     from dartsort.templates import estimate_template_library
     from dartsort.util.data_util import DARTsortSorting
     from dartsort.util.internal_config import (
+        WhiteningConfig,
         default_matching_cfg,
         default_template_cfg,
         default_waveform_cfg,
@@ -249,6 +252,10 @@ def compute_templates(project_path: str, output_dir: str) -> None:
     motion = MotionInfo.load(motion_dir) if motion_dir.exists() else None
 
     mcfg = default_matching_cfg
+    tcfg = replace(
+        default_template_cfg,
+        whitening=WhiteningConfig(strategy="prewhiten_postapply"),
+    )
     sorting, template_data = estimate_template_library(
         recording=recording,
         sorting=sorting,
@@ -256,7 +263,7 @@ def compute_templates(project_path: str, output_dir: str) -> None:
         min_template_ptp=mcfg.min_template_ptp,
         min_template_count=mcfg.min_template_count,
         waveform_cfg=default_waveform_cfg,
-        template_cfg=default_template_cfg,
+        template_cfg=tcfg,
     )
 
     (out / "templates").mkdir(exist_ok=True)

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import structlog
@@ -67,8 +68,145 @@ def preprocess(project_path: str, output_dir: str) -> None:
     )
 
 
+def detect_trial(project_path: str, output_dir: str) -> None:
+    """Run threshold sweep on a small subset to inform parameter selection.
+
+    Tests 3 candidate thresholds (3.5, 4.0, 4.5) with early termination.
+    Writes trial_results.json for the detect_params AgentNode.
+    """
+    import copy
+
+    import spikeinterface.core as si
+    from dartsort.main import threshold as ds_threshold
+    from dartsort.util.internal_config import (
+        default_featurization_cfg,
+        default_peeling_fit_sampling_cfg,
+        default_thresholding_cfg,
+        default_waveform_cfg,
+    )
+
+    out = Path(output_dir)
+    recording = si.load_extractor(out / "preprocessed")
+    noise_stats = json.loads((out / "noise_stats.json").read_text())
+
+    candidate_thresholds = [3.5, 4.0, 4.5]
+    trial_results: dict = {
+        "recording_duration_s": noise_stats["recording_duration_s"],
+        "n_channels": recording.get_num_channels(),
+        "thresholds": {},
+    }
+
+    for thresh in candidate_thresholds:
+        trial_dir = out / "trial_runs" / f"thresh_{thresh}"
+        trial_dir.mkdir(parents=True, exist_ok=True)
+
+        thresh_cfg = copy.deepcopy(default_thresholding_cfg)
+        thresh_cfg.voltage_threshold = thresh
+        thresh_cfg.peak_sign = "both"
+        thresh_cfg.dedup_temporal_radius = 11
+
+        log.info("detect_trial.start", threshold=thresh)
+        sorting = ds_threshold(
+            output_dir=trial_dir,
+            recording=recording,
+            waveform_cfg=default_waveform_cfg,
+            thresholding_cfg=thresh_cfg,
+            featurization_cfg=default_featurization_cfg,
+            sampling_cfg=default_peeling_fit_sampling_cfg,
+            hdf5_filename="trial.h5",
+            stop_after_n_spikes=10_000,
+            ensure_coverage=0.05,
+            overwrite=True,
+        )
+
+        n_spikes = sorting.count
+        duration = noise_stats["recording_duration_s"]
+
+        amplitudes: list[float] = []
+        if (
+            hasattr(sorting, "point_source_localizations")
+            and sorting.point_source_localizations is not None
+        ):
+            amplitudes = sorting.point_source_localizations[:, 3].tolist()
+        elif (
+            hasattr(sorting, "denoised_ptp_amplitudes")
+            and sorting.denoised_ptp_amplitudes is not None
+        ):
+            amplitudes = sorting.denoised_ptp_amplitudes.tolist()
+
+        amp_percentiles: dict[str, float] = {}
+        if amplitudes:
+            amp_arr = np.array(amplitudes)
+            amp_percentiles = {
+                "p10": float(np.percentile(amp_arr, 10)),
+                "p25": float(np.percentile(amp_arr, 25)),
+                "p50": float(np.percentile(amp_arr, 50)),
+                "p75": float(np.percentile(amp_arr, 75)),
+                "p90": float(np.percentile(amp_arr, 90)),
+            }
+
+        trial_results["thresholds"][str(thresh)] = {
+            "spike_count": int(n_spikes),
+            "spike_rate_hz": float(n_spikes / duration) if duration > 0 else 0.0,
+            "mean_amplitude": float(np.mean(amplitudes)) if amplitudes else None,
+            "amplitude_distribution_percentiles": amp_percentiles if amp_percentiles else None,
+        }
+        log.info(
+            "detect_trial.done",
+            threshold=thresh,
+            spikes=n_spikes,
+            rate_hz=trial_results["thresholds"][str(thresh)]["spike_rate_hz"],
+        )
+
+    (out / "trial_results.json").write_text(json.dumps(trial_results, indent=2))
+    log.info("detect_trial.complete", thresholds_tested=len(candidate_thresholds))
+
+
+def _load_denoiser() -> Any:
+    """Load the pretrained single-channel denoiser from DARTsort."""
+    import torch
+    from dartsort.transform.single_channel_denoiser import SingleChanDenoiser
+
+    denoiser = SingleChanDenoiser()
+    weights_path = Path(_DS_REF) / "pretrained" / "single_chan_denoiser.pt"
+    if not weights_path.exists():
+        weights_path = Path(_DS_REF) / "src" / "dartsort" / "pretrained" / "single_chan_denoiser.pt"
+    denoiser.load_state_dict(torch.load(weights_path, map_location="cpu", weights_only=True))
+    denoiser.eval()
+    log.info("denoiser.loaded", weights=str(weights_path))
+    return denoiser
+
+
+def _denoise_traces(traces: np.ndarray, denoiser: Any) -> np.ndarray:
+    """Apply single-channel denoiser to traces channel-by-channel."""
+    import torch
+
+    device = next(denoiser.parameters()).device
+    denoised = np.empty_like(traces)
+    n_channels = traces.shape[1]
+
+    with torch.no_grad():
+        for ch in range(n_channels):
+            ch_trace = (
+                torch.tensor(traces[:, ch], dtype=torch.float32, device=device)
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+            ch_denoised = denoiser(ch_trace)
+            denoised[:, ch] = ch_denoised.squeeze().cpu().numpy()
+
+    log.info("denoise.complete", channels=n_channels)
+    return denoised
+
+
 def detect(project_path: str, output_dir: str) -> None:
-    """Run threshold-crossing detection with LLM-selected parameters."""
+    """Run threshold-crossing detection with LLM-selected parameters.
+
+    Optionally applies the single-channel denoiser NN before threshold detection
+    when use_denoiser=True in detection_params.json.
+    """
+    import copy
+
     import spikeinterface.core as si
     from dartsort.main import threshold as ds_threshold
     from dartsort.util.internal_config import (
@@ -82,7 +220,29 @@ def detect(project_path: str, output_dir: str) -> None:
     recording = si.load_extractor(out / "preprocessed")
     params = json.loads((out / "detection_params.json").read_text())
 
-    thresh_cfg = default_thresholding_cfg
+    use_denoiser = params.get("use_denoiser", True)
+
+    if use_denoiser:
+        denoiser = _load_denoiser()
+        traces = recording.get_traces()
+        denoised_traces = _denoise_traces(traces, denoiser)
+
+        denoised_dir = out / "denoised"
+        denoised_dir.mkdir(exist_ok=True)
+        np.save(denoised_dir / "traces.npy", denoised_traces)
+
+        from spikeinterface.core import NumpyRecording
+
+        recording = NumpyRecording(
+            traces_list=[denoised_traces],
+            sampling_frequency=recording.get_sampling_frequency(),
+        )
+        recording.set_channel_locations(
+            si.load_extractor(out / "preprocessed").get_channel_locations()
+        )
+        log.info("detect.denoiser_applied")
+
+    thresh_cfg = copy.deepcopy(default_thresholding_cfg)
     thresh_cfg.voltage_threshold = params["voltage_threshold"]
     thresh_cfg.peak_sign = params["peak_sign"]
     thresh_cfg.dedup_temporal_radius = params["dedup_temporal_radius"]
@@ -102,10 +262,13 @@ def detect(project_path: str, output_dir: str) -> None:
         "spike_count": int(n_spikes),
         "spike_rate_hz": float(n_spikes / recording.get_total_duration()),
         "detection_params_used": params,
+        "denoiser_applied": use_denoiser,
     }
     (out / "detection_summary.json").write_text(json.dumps(summary, indent=2))
     sorting.save(out / "detections" / "sorting.npz")
-    log.info("detect.complete", spikes=n_spikes, rate_hz=summary["spike_rate_hz"])
+    log.info(
+        "detect.complete", spikes=n_spikes, rate_hz=summary["spike_rate_hz"], denoised=use_denoiser
+    )
 
 
 def localize(project_path: str, output_dir: str) -> None:

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import os
+import re
 import sys
 from pathlib import Path
 import numpy as np
@@ -23,6 +24,44 @@ log = structlog.get_logger()
 _DS_REF = os.environ.get("DS_REF_PATH", "/workspace/home/churwitz/ds_ref")
 if _DS_REF not in sys.path:
     sys.path.insert(0, _DS_REF)
+
+
+@dataclasses.dataclass
+class BenchmarkProfile:
+    """Benchmark configuration for spike sorting evaluation."""
+
+    data_path: str
+    ground_truth_path: str
+    duration_seconds: float | None
+    n_channels: int
+    sampling_frequency: float
+
+    baseline_accuracy: float
+    target_accuracy: float
+    match_tolerance_samples: int
+
+    @classmethod
+    def from_file(cls, path: Path) -> BenchmarkProfile:
+        """Parse benchmark.md YAML frontmatter."""
+        text = Path(path).read_text()
+        match = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+        if not match:
+            raise ValueError(f"No YAML frontmatter found in {path}")
+
+        import yaml  # lazy import — yaml not needed by other stages
+
+        data = yaml.safe_load(match.group(1))
+        duration = data.get("duration_seconds")
+        return cls(
+            data_path=str(data["data_path"]),
+            ground_truth_path=str(data["ground_truth_path"]),
+            duration_seconds=float(duration) if duration is not None else None,
+            n_channels=int(data["n_channels"]),
+            sampling_frequency=float(data["sampling_frequency"]),
+            baseline_accuracy=float(data["baseline_accuracy"]),
+            target_accuracy=float(data["target_accuracy"]),
+            match_tolerance_samples=int(data["match_tolerance_samples"]),
+        )
 
 
 def preprocess(project_path: str, output_dir: str) -> None:
@@ -1153,3 +1192,84 @@ def merge_clusters(project_path: str, output_dir: str) -> None:
         after=n_after,
         merged=n_before - n_after,
     )
+
+
+def evaluate_accuracy(project_path: str, output_dir: str) -> dict:
+    """Compare final sorting to ground truth using benchmark profile."""
+    import spikeinterface.core as si
+    from spikeinterface.comparison import compare_sorter_to_ground_truth
+
+    out = Path(output_dir)
+    benchmark_path = Path(project_path) / "benchmark.md"
+    if not benchmark_path.exists():
+        raise FileNotFoundError(
+            f"benchmark.md not found at {benchmark_path}. "
+            "Create one with YAML frontmatter to enable accuracy evaluation."
+        )
+
+    profile = BenchmarkProfile.from_file(benchmark_path)
+
+    gt_sorting = si.load(profile.ground_truth_path)
+    if profile.duration_seconds is not None:
+        n_frames = int(profile.duration_seconds * profile.sampling_frequency)
+        gt_sorting = gt_sorting.frame_slice(start_frame=0, end_frame=n_frames)
+
+    sorting_dir = out / "sorting_final"
+    sorting_npz = sorting_dir / "sorting.npz"
+    if not sorting_npz.exists():
+        raise FileNotFoundError(f"Final sorting not found at {sorting_npz}")
+
+    data = np.load(sorting_npz)
+    times = data["times_samples"]
+    labels = data["labels"]
+    sampling_freq = float(data["sampling_frequency"]) if "sampling_frequency" in data else profile.sampling_frequency
+
+    from spikeinterface.core import NumpySorting
+
+    unique_ids = np.unique(labels[labels >= 0])
+    units_dict: dict[str, np.ndarray] = {}
+    for uid in unique_ids:
+        spike_times = times[labels == uid]
+        units_dict[str(int(uid))] = np.sort(spike_times)
+
+    tested_sorting = NumpySorting.from_unit_dict(
+        units_dict, sampling_frequency=sampling_freq,
+    )
+
+    delta_time = profile.match_tolerance_samples / profile.sampling_frequency
+    comp = compare_sorter_to_ground_truth(
+        gt_sorting=gt_sorting,
+        tested_sorting=tested_sorting,
+        delta_time=delta_time,
+    )
+
+    perf = comp.get_performance()
+    accuracy_values = perf["accuracy"].values
+    accuracy = float(np.mean(accuracy_values))
+
+    gt_unit_ids = comp.get_ordered_agreement_scores().index.tolist()
+    per_unit_accuracy = {}
+    for i, uid in enumerate(gt_unit_ids):
+        if i < len(accuracy_values):
+            per_unit_accuracy[str(uid)] = round(float(accuracy_values[i]), 4)
+
+    result = {
+        "accuracy": round(accuracy, 4),
+        "baseline": profile.baseline_accuracy,
+        "delta": round(accuracy - profile.baseline_accuracy, 4),
+        "target": profile.target_accuracy,
+        "target_met": accuracy >= profile.target_accuracy,
+        "n_gt_units": len(gt_sorting.unit_ids),
+        "n_sorted_units": len(tested_sorting.unit_ids),
+        "per_unit_accuracy": per_unit_accuracy,
+    }
+
+    (out / "benchmark_result.json").write_text(json.dumps(result, indent=2))
+    log.info(
+        "evaluate_accuracy.complete",
+        accuracy=result["accuracy"],
+        baseline=result["baseline"],
+        delta=result["delta"],
+        target_met=result["target_met"],
+    )
+    return result

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -1,0 +1,346 @@
+"""FnNode stage implementations for the spike-sort workflow.
+
+Each function follows the signature:
+    def stage(project_path: str, output_dir: str, **kwargs) -> None
+
+- Reads inputs from {output_dir}/*.json or *.h5 (written by preceding nodes)
+- Writes outputs to {output_dir}/*.json or *.h5 (consumed by subsequent nodes)
+- Raises on failure (workflow executor catches and marks node as failed)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import structlog
+
+log = structlog.get_logger()
+
+_DS_REF = "/workspace/home/churwitz/ds_ref"
+if _DS_REF not in sys.path:
+    sys.path.insert(0, _DS_REF)
+
+
+def preprocess(project_path: str, output_dir: str) -> None:
+    """Bandpass filter, standardize, whiten. Write noise statistics for LLM."""
+    import spikeinterface.core as si
+    from dartsort.util.preprocess_util import preprocess as ds_preprocess
+    from dartsort.util.internal_config import default_dartsort_cfg
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    config = json.loads(Path(project_path, ".factory", "config.json").read_text())
+    recording_path = config["recording_path"]
+    recording = si.load_extractor(recording_path)
+
+    cfg = default_dartsort_cfg
+    rec_processed = ds_preprocess(recording, cfg.preprocessing, cfg.preprocessing_dtype)
+
+    si.save(rec_processed, out / "preprocessed", overwrite=True)
+
+    traces_sample = rec_processed.get_traces(
+        start_frame=0, end_frame=min(30000, rec_processed.get_num_frames())
+    )
+    mad_per_channel = (
+        np.median(np.abs(traces_sample - np.median(traces_sample, axis=0)), axis=0) * 1.4826
+    )
+
+    geom = recording.get_channel_locations()
+    noise_stats = {
+        "median_noise_uv": float(np.median(mad_per_channel)),
+        "mad_per_channel": mad_per_channel.tolist(),
+        "num_channels": recording.get_num_channels(),
+        "sampling_rate_hz": recording.get_sampling_frequency(),
+        "recording_duration_s": recording.get_total_duration(),
+        "probe_type": config.get("probe_type", "unknown"),
+        "channel_positions": geom.tolist(),
+    }
+    (out / "noise_stats.json").write_text(json.dumps(noise_stats, indent=2))
+    log.info(
+        "preprocess.complete",
+        channels=recording.get_num_channels(),
+        duration_s=noise_stats["recording_duration_s"],
+    )
+
+
+def detect(project_path: str, output_dir: str) -> None:
+    """Run threshold-crossing detection with LLM-selected parameters."""
+    import spikeinterface.core as si
+    from dartsort.main import threshold as ds_threshold
+    from dartsort.util.internal_config import (
+        default_featurization_cfg,
+        default_peeling_fit_sampling_cfg,
+        default_thresholding_cfg,
+        default_waveform_cfg,
+    )
+
+    out = Path(output_dir)
+    recording = si.load_extractor(out / "preprocessed")
+    params = json.loads((out / "detection_params.json").read_text())
+
+    thresh_cfg = default_thresholding_cfg
+    thresh_cfg.voltage_threshold = params["voltage_threshold"]
+    thresh_cfg.peak_sign = params["peak_sign"]
+    thresh_cfg.dedup_temporal_radius = params["dedup_temporal_radius"]
+
+    sorting = ds_threshold(
+        output_dir=out / "detections",
+        recording=recording,
+        waveform_cfg=default_waveform_cfg,
+        thresholding_cfg=thresh_cfg,
+        featurization_cfg=default_featurization_cfg,
+        sampling_cfg=default_peeling_fit_sampling_cfg,
+        hdf5_filename="detections.h5",
+    )
+
+    n_spikes = sorting.count
+    summary = {
+        "spike_count": int(n_spikes),
+        "spike_rate_hz": float(n_spikes / recording.get_total_duration()),
+        "detection_params_used": params,
+    }
+    (out / "detection_summary.json").write_text(json.dumps(summary, indent=2))
+    sorting.save(out / "detections" / "sorting.npz")
+    log.info("detect.complete", spikes=n_spikes, rate_hz=summary["spike_rate_hz"])
+
+
+def localize(project_path: str, output_dir: str) -> None:
+    """Point-source localization of detected spikes."""
+    import spikeinterface.core as si
+    from dartsort.util.data_util import DARTsortSorting
+    from dartsort.util.internal_config import default_dartsort_cfg
+    from dartsort.util.motion import get_motion_info
+
+    out = Path(output_dir)
+    recording = si.load_extractor(out / "preprocessed")
+    sorting = DARTsortSorting.load(out / "detections" / "sorting.npz")
+
+    cfg = default_dartsort_cfg
+    get_motion_info(
+        output_directory=out / "motion",
+        recording=recording,
+        sorting=sorting,
+        detect_new_peaks=True,
+        motion_cfg=cfg.motion_estimation_cfg,
+        computation_cfg=cfg.computation_cfg,
+        sampling_cfg=cfg.peeler_sampling_cfg,
+        waveform_cfg=cfg.waveform_cfg,
+        overwrite=True,
+    )
+
+    locs: dict[str, list[float]] = {}
+    if hasattr(sorting, "point_source_localizations"):
+        locs = {
+            "x": sorting.point_source_localizations[:, 0].tolist(),
+            "z_abs": sorting.point_source_localizations[:, 2].tolist(),
+        }
+
+    config = json.loads(Path(project_path, ".factory", "config.json").read_text())
+    detection_summary = json.loads((out / "detection_summary.json").read_text())
+    geom = recording.get_channel_locations()
+
+    z_values = np.array(locs.get("z_abs", [0.0]))
+    drift_magnitude = float(np.ptp(z_values)) if len(z_values) > 0 else 0.0
+
+    cluster_stats = {
+        "spike_count": detection_summary["spike_count"],
+        "drift_magnitude_um": drift_magnitude,
+        "feature_pca_variance_explained": [0.4, 0.15, 0.08, 0.05],
+        "spike_density_per_channel_per_s": float(
+            detection_summary["spike_count"]
+            / recording.get_num_channels()
+            / recording.get_total_duration()
+        ),
+        "depth_range_um": float(np.ptp(geom[:, 1])),
+        "probe_type": config.get("probe_type", "unknown"),
+        "channel_count": recording.get_num_channels(),
+    }
+    (out / "cluster_input_stats.json").write_text(json.dumps(cluster_stats, indent=2))
+    np.savez(out / "localizations.npz", **{k: np.array(v) for k, v in locs.items()})
+    log.info(
+        "localize.complete",
+        spikes=cluster_stats["spike_count"],
+        drift_um=drift_magnitude,
+    )
+
+
+def cluster(project_path: str, output_dir: str) -> None:
+    """Cluster spikes into putative units using LLM-selected strategy."""
+    import spikeinterface.core as si
+    from dartsort.main import cluster as ds_cluster
+    from dartsort.util.data_util import DARTsortSorting
+    from dartsort.util.internal_config import (
+        default_clustering_cfg,
+        default_clustering_features_cfg,
+    )
+    from dartsort.util.motion import MotionInfo
+
+    out = Path(output_dir)
+    recording = si.load_extractor(out / "preprocessed")
+    sorting = DARTsortSorting.load(out / "detections" / "sorting.npz")
+    params = json.loads((out / "clustering_params.json").read_text())
+
+    motion_dir = out / "motion"
+    motion = MotionInfo.load(motion_dir) if motion_dir.exists() else None
+
+    clust_cfg = default_clustering_cfg
+    clust_cfg.cluster_strategy = params["strategy"]
+    clust_cfg.grid_dx = params["grid_dx"]
+    clust_cfg.grid_dz = params["grid_dz"]
+    clust_cfg.n_waveforms_fit = params["n_waveforms_fit"]
+
+    result = ds_cluster(
+        recording=recording,
+        sorting=sorting,
+        motion=motion,
+        clustering_cfg=clust_cfg,
+        clustering_features_cfg=default_clustering_features_cfg,
+    )
+
+    (out / "clusters").mkdir(exist_ok=True)
+    result.save(out / "clusters" / "sorting.npz")
+
+    labels = result.labels if hasattr(result, "labels") else np.array([])
+    unique_labels = np.unique(labels[labels >= 0]) if len(labels) > 0 else np.array([])
+    sizes = [int(np.sum(labels == u)) for u in unique_labels]
+    summary = {
+        "unit_count": int(len(unique_labels)),
+        "median_unit_size": int(np.median(sizes)) if sizes else 0,
+        "min_unit_size": int(np.min(sizes)) if sizes else 0,
+        "max_unit_size": int(np.max(sizes)) if sizes else 0,
+        "noise_spike_count": int(np.sum(labels < 0)) if len(labels) > 0 else 0,
+        "clustering_params_used": params,
+    }
+    (out / "cluster_summary.json").write_text(json.dumps(summary, indent=2))
+    log.info(
+        "cluster.complete",
+        units=summary["unit_count"],
+        median_size=summary["median_unit_size"],
+    )
+
+
+def compute_templates(project_path: str, output_dir: str) -> None:
+    """Compute unit templates (average waveforms) from clustered spikes."""
+    import spikeinterface.core as si
+    from dartsort.templates import estimate_template_library
+    from dartsort.util.data_util import DARTsortSorting
+    from dartsort.util.internal_config import (
+        default_matching_cfg,
+        default_template_cfg,
+        default_waveform_cfg,
+    )
+    from dartsort.util.motion import MotionInfo
+
+    out = Path(output_dir)
+    recording = si.load_extractor(out / "preprocessed")
+    sorting = DARTsortSorting.load(out / "clusters" / "sorting.npz")
+
+    motion_dir = out / "motion"
+    motion = MotionInfo.load(motion_dir) if motion_dir.exists() else None
+
+    mcfg = default_matching_cfg
+    sorting, template_data = estimate_template_library(
+        recording=recording,
+        sorting=sorting,
+        motion=motion,
+        min_template_ptp=mcfg.min_template_ptp,
+        min_template_count=mcfg.min_template_count,
+        waveform_cfg=default_waveform_cfg,
+        template_cfg=default_template_cfg,
+    )
+
+    (out / "templates").mkdir(exist_ok=True)
+    template_data.save(out / "templates" / "template_data.npz")
+    sorting.save(out / "templates" / "sorting.npz")
+
+    templates_arr = template_data.templates if hasattr(template_data, "templates") else np.array([])
+    stats_list = []
+    for i in range(len(templates_arr)):
+        t = templates_arr[i]
+        ptp = float(np.ptp(t))
+        snr_est = ptp / 1.0
+        labels = sorting.labels if hasattr(sorting, "labels") else np.array([])
+        count = int(np.sum(labels == i)) if len(labels) > 0 else 0
+        spatial_extent = float(np.sum(np.any(np.abs(t) > 0.1 * ptp, axis=0)))
+        stats_list.append(
+            {
+                "template_id": i,
+                "snr": round(snr_est, 2),
+                "spike_count": count,
+                "ptp_amplitude_uv": round(ptp, 2),
+                "spatial_spread_um": round(spatial_extent * 25.0, 1),
+                "stability": 0.9,
+            }
+        )
+
+    (out / "template_stats.json").write_text(json.dumps(stats_list, indent=2))
+    log.info("templates.complete", n_templates=len(stats_list))
+
+
+def template_match(project_path: str, output_dir: str) -> None:
+    """Template matching refinement using QC-filtered templates."""
+    import spikeinterface.core as si
+    from dartsort.main import match as ds_match
+    from dartsort.templates import TemplateData
+    from dartsort.util.data_util import DARTsortSorting
+    from dartsort.util.internal_config import (
+        default_featurization_cfg,
+        default_matching_cfg,
+        default_peeling_fit_sampling_cfg,
+        default_template_cfg,
+        default_waveform_cfg,
+    )
+    from dartsort.util.motion import MotionInfo
+
+    out = Path(output_dir)
+    recording = si.load_extractor(out / "preprocessed")
+    sorting = DARTsortSorting.load(out / "templates" / "sorting.npz")
+    template_data = TemplateData.load(out / "templates" / "template_data.npz")
+
+    decisions = json.loads((out / "template_decisions.json").read_text())
+    keep_ids = {d["template_id"] for d in decisions["decisions"] if d["action"] == "keep"}
+    merge_map = {
+        d["template_id"]: d["merge_with"]
+        for d in decisions["decisions"]
+        if d["action"] == "merge" and d["merge_with"] is not None
+    }
+
+    motion_dir = out / "motion"
+    motion = MotionInfo.load(motion_dir) if motion_dir.exists() else None
+
+    final_sorting = ds_match(
+        output_dir=out / "sorting",
+        recording=recording,
+        sorting=sorting,
+        motion=motion,
+        waveform_cfg=default_waveform_cfg,
+        template_cfg=default_template_cfg,
+        featurization_cfg=default_featurization_cfg,
+        matching_cfg=default_matching_cfg,
+        sampling_cfg=default_peeling_fit_sampling_cfg,
+        template_data=template_data,
+        hdf5_filename="matching_final.h5",
+        model_subdir="matching_final_models",
+    )
+
+    final_sorting.save(out / "sorting" / "sorting.npz")
+
+    labels = final_sorting.labels if hasattr(final_sorting, "labels") else np.array([])
+    unique = np.unique(labels[labels >= 0]) if len(labels) > 0 else np.array([])
+    result = {
+        "final_unit_count": int(len(unique)),
+        "final_spike_count": int(len(labels)),
+        "templates_kept": len(keep_ids),
+        "templates_merged": len(merge_map),
+        "templates_discarded": len(decisions["decisions"]) - len(keep_ids) - len(merge_map),
+    }
+    (out / "sorting_result.json").write_text(json.dumps(result, indent=2))
+    log.info(
+        "match.complete",
+        units=result["final_unit_count"],
+        spikes=result["final_spike_count"],
+    )

--- a/skills/workflow-spike-sort/SKILL.annotations.yaml
+++ b/skills/workflow-spike-sort/SKILL.annotations.yaml
@@ -1,0 +1,273 @@
+preprocess:
+  type: FnNode
+  id: preprocess
+  command: ''
+  reads: []
+  writes:
+  - noise_stats.json
+  - preprocessed/
+  edges_out:
+  - target: detect_trial
+    condition: null
+detect_trial:
+  type: FnNode
+  id: detect_trial
+  command: ''
+  reads:
+  - noise_stats.json
+  - preprocessed/
+  writes:
+  - trial_results.json
+  edges_out:
+  - target: detect_params
+    condition: null
+detect_params:
+  type: AgentNode
+  id: detect_params
+  role: researcher
+  blocking: 'true'
+  reads:
+  - noise_stats.json
+  - trial_results.json
+  writes:
+  - detection_params.json
+  edges_out:
+  - target: detect
+    condition: null
+  slots:
+    task_prompt_detect_params: 'You are a spike detection parameter advisor for extracellular
+      neural recordings. Read the noise statistics at {output_dir}/noise_stats.json
+      and the trial detection results at {output_dir}/trial_results.json.
+
+
+      TRIAL RESULTS: A threshold sweep has already been run on a small subset of the
+      recording at thresholds 3.5, 4.0, and 4.5. The trial_results.json file contains
+      for each threshold: spike_count, spike_rate_hz, mean_amplitude, and amplitude_distribution_percentiles.
+      Use this empirical data to inform your threshold selection.
+
+
+      IMPORTANT: DARTsort''s detection operates on standardized (SNR-unit) traces.
+      The threshold 4.0 is the DARTsort-calibrated baseline, validated on Neuropixels
+      recordings with default preprocessing. A single-channel denoiser NN runs before
+      detection and recovers low-amplitude spikes, so you do NOT need an aggressive
+      (low) threshold to catch weak units. Prefer the default. Only deviate with clear
+      evidence from the trial results AND noise statistics.
+
+
+      Select detection parameters:
+
+      - voltage_threshold (3.0-6.0): SNR threshold in standardized units. Default:
+      4.0. Do NOT lower below 4.0 unless you have strong evidence that the recording
+      has exceptionally high SNR AND the denoiser is disabled. Raising above 4.0 is
+      safer than lowering — it reduces false positives with minimal loss of real spikes.
+
+      - peak_sign (''neg'', ''pos'', ''both''): Which polarity peaks to detect. ''both''
+      is standard for extracellular recordings.
+
+      - dedup_temporal_radius (5-20): Samples to deduplicate within. 11 is typical
+      at 30kHz.
+
+      - use_denoiser (true/false): Whether to apply the single-channel denoiser NN
+      before detection. Default: true. The denoiser cleans waveforms and improves
+      detection of low-amplitude spikes. Disable only if the recording has unusual
+      artifacts that the denoiser was not trained on.
+
+
+      Decision rules:
+
+      - Start with voltage_threshold=4.0 (the calibrated default).
+
+      - Compare trial results across thresholds: if 4.0 produces a reasonable spike
+      rate (20-200 Hz per channel) keep it. If the rate is extremely high (>500 Hz),
+      consider raising to 4.5 or 5.0.
+
+      - Very noisy data (median noise >20 µV after standardization): raise to 5.0-6.0.
+
+      - Clean data (<8 µV): keep 4.0 — the denoiser handles low-amplitude recovery.
+
+      - DO NOT lower the threshold to compensate for expected low-amplitude neurons.
+      The denoiser NN is designed for this.
+
+      - Neuropixels probes → ''both'' peak_sign.
+
+
+      In your reasoning field, explicitly state why you chose your threshold. Reference
+      the trial results — cite the spike counts and rates you observed. If you chose
+      anything other than 4.0, justify the deviation with specific evidence from the
+      trial data and noise_stats.json.
+
+
+      Output your selection as a DetectionParams JSON object with a reasoning field.
+
+      Read: noise_stats.json, trial_results.json
+
+      Write output to: detection_params.json'
+    timeout_detect_params: '60'
+detect:
+  type: FnNode
+  id: detect
+  command: ''
+  reads:
+  - detection_params.json
+  - preprocessed/
+  writes:
+  - denoised/
+  - detection_summary.json
+  - detections/
+  edges_out:
+  - target: localize
+    condition: null
+localize:
+  type: FnNode
+  id: localize
+  command: ''
+  reads:
+  - detections/
+  - preprocessed/
+  writes:
+  - cluster_input_stats.json
+  - localizations.npz
+  - motion/
+  edges_out:
+  - target: cluster_params
+    condition: null
+cluster_params:
+  type: AgentNode
+  id: cluster_params
+  role: strategist
+  blocking: 'true'
+  reads:
+  - cluster_input_stats.json
+  writes:
+  - clustering_params.json
+  edges_out:
+  - target: cluster
+    condition: null
+  slots:
+    task_prompt_cluster_params: 'You are a spike clustering strategy advisor. Read
+      the cluster input statistics at {output_dir}/cluster_input_stats.json.
+
+
+      Select a clustering strategy and parameters:
+
+      - strategy: ''channel_snap'' (fast, coarse — good for <20K spikes), ''grid_snap''
+      (spatial grid — good for high density), ''dpc'' (density peak clustering — slow
+      but accurate, best for >20K spikes with drift), ''none'' (skip clustering —
+      only for pre-sorted data).
+
+      - grid_dx, grid_dz (5-50 µm): Spatial grid resolution. Smaller = more clusters
+      initially. 15 µm is typical.
+
+      - initial_steps: Refinement sequence. [''split'', ''demolish'', ''demolish'']
+      is standard. Add ''merge'' if you expect many similar units.
+
+      - n_waveforms_fit (10K-100K): Subsample size for fitting. Higher = better but
+      slower. 40K is typical.
+
+
+      Decision tree:
+
+      - spike_count < 20K → channel_snap
+
+      - drift > 15 µm → dpc with drift correction
+
+      - spike_density > 1.0 spikes/ch/s → grid_snap
+
+      - Otherwise → dpc
+
+
+      Output your selection as a ClusteringParams JSON object with a reasoning field.
+
+      Read: cluster_input_stats.json
+
+      Write output to: clustering_params.json'
+    timeout_cluster_params: '120'
+cluster:
+  type: FnNode
+  id: cluster
+  command: ''
+  reads:
+  - clustering_params.json
+  - detections/
+  - motion/
+  - preprocessed/
+  writes:
+  - cluster_summary.json
+  - clusters/
+  edges_out:
+  - target: templates
+    condition: null
+templates:
+  type: FnNode
+  id: templates
+  command: ''
+  reads:
+  - clusters/
+  - motion/
+  - preprocessed/
+  writes:
+  - template_stats.json
+  - templates/
+  edges_out:
+  - target: qc_templates
+    condition: null
+qc_templates:
+  type: AgentNode
+  id: qc_templates
+  role: researcher
+  blocking: 'true'
+  reads:
+  - template_stats.json
+  writes:
+  - template_decisions.json
+  edges_out:
+  - target: match
+    condition: null
+  slots:
+    task_prompt_qc_templates: 'You are a spike sorting template quality control reviewer.
+      Read the template statistics at {output_dir}/template_stats.json.
+
+
+      For each template, decide: keep, discard, or merge.
+
+
+      Decision criteria:
+
+      - DISCARD if: SNR < 1.5 (noise unit), spike_count < 10 (too few spikes), or
+      ptp_amplitude < 5 µV (below noise floor).
+
+      - MERGE if: two templates have very similar spatial positions (within 25 µm)
+      AND similar PTP amplitudes (within 30%). Specify merge_with = template_id of
+      partner.
+
+      - KEEP otherwise.
+
+
+      Quality heuristics:
+
+      - Good units: SNR > 3, count > 50, stability > 0.7
+
+      - Marginal units: SNR 1.5-3, count 10-50 — keep if isolated
+
+      - High spatial_spread (>200 µm) may indicate multi-unit — flag for discard
+
+
+      Output a TemplateQCOutput JSON with decisions list and summary string.
+
+      Read: template_stats.json
+
+      Write output to: template_decisions.json'
+    timeout_qc_templates: '120'
+match:
+  type: FnNode
+  id: match
+  command: ''
+  reads:
+  - motion/
+  - preprocessed/
+  - template_decisions.json
+  - templates/
+  writes:
+  - sorting/
+  - sorting_result.json
+  edges_out: []

--- a/skills/workflow-spike-sort/SKILL.md
+++ b/skills/workflow-spike-sort/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: workflow-spike-sort
+description: "Spike sorting data pipeline with LLM-in-the-loop parameter selection. NOT a code-writing workflow — directly executes DARTsort algorithms (FnNodes) with LLM parameter advisors (AgentNodes) at three decision points: detection threshold, clustering strategy, and template QC. Input: SpikeInterface BaseRecording. Output: BaseSorting. Use with --mode spike-sort on a configured recording."
+disable-model-invocation: true
+argument-hint: "<project_path> --mode spike-sort"
+---
+
+# Spike Sort Workflow
+
+The user wants: **$ARGUMENTS**
+
+## Step: Preprocess
+
+Bandpass filter, standardize, whiten the raw recording. Writes preprocessed recording to {output_dir}/preprocessed/ and noise statistics to {output_dir}/noise_stats.json.
+
+```bash
+
+```
+
+## Step: Detect Trial
+
+Fast threshold sweep on a small subset of the recording. Runs dartsort.threshold() at 3 candidate thresholds (3.5, 4.0, 4.5) with early termination (stop_after_n_spikes=10000, ensure_coverage=0.05). Writes trial results to {output_dir}/trial_results.json for the detection parameter advisor to make a data-informed threshold choice.
+
+```bash
+
+```
+
+## Phase 1: Researcher — Detect Params
+
+```bash
+factory agent researcher --task "You are a spike detection parameter advisor for extracellular neural recordings. Read the noise statistics at {output_dir}/noise_stats.json and the trial detection results at {output_dir}/trial_results.json.
+
+TRIAL RESULTS: A threshold sweep has already been run on a small subset of the recording at thresholds 3.5, 4.0, and 4.5. The trial_results.json file contains for each threshold: spike_count, spike_rate_hz, mean_amplitude, and amplitude_distribution_percentiles. Use this empirical data to inform your threshold selection.
+
+IMPORTANT: DARTsort's detection operates on standardized (SNR-unit) traces. The threshold 4.0 is the DARTsort-calibrated baseline, validated on Neuropixels recordings with default preprocessing. A single-channel denoiser NN runs before detection and recovers low-amplitude spikes, so you do NOT need an aggressive (low) threshold to catch weak units. Prefer the default. Only deviate with clear evidence from the trial results AND noise statistics.
+
+Select detection parameters:
+- voltage_threshold (3.0-6.0): SNR threshold in standardized units. Default: 4.0. Do NOT lower below 4.0 unless you have strong evidence that the recording has exceptionally high SNR AND the denoiser is disabled. Raising above 4.0 is safer than lowering — it reduces false positives with minimal loss of real spikes.
+- peak_sign ('neg', 'pos', 'both'): Which polarity peaks to detect. 'both' is standard for extracellular recordings.
+- dedup_temporal_radius (5-20): Samples to deduplicate within. 11 is typical at 30kHz.
+- use_denoiser (true/false): Whether to apply the single-channel denoiser NN before detection. Default: true. The denoiser cleans waveforms and improves detection of low-amplitude spikes. Disable only if the recording has unusual artifacts that the denoiser was not trained on.
+
+Decision rules:
+- Start with voltage_threshold=4.0 (the calibrated default).
+- Compare trial results across thresholds: if 4.0 produces a reasonable spike rate (20-200 Hz per channel) keep it. If the rate is extremely high (>500 Hz), consider raising to 4.5 or 5.0.
+- Very noisy data (median noise >20 µV after standardization): raise to 5.0-6.0.
+- Clean data (<8 µV): keep 4.0 — the denoiser handles low-amplitude recovery.
+- DO NOT lower the threshold to compensate for expected low-amplitude neurons. The denoiser NN is designed for this.
+- Neuropixels probes → 'both' peak_sign.
+
+In your reasoning field, explicitly state why you chose your threshold. Reference the trial results — cite the spike counts and rates you observed. If you chose anything other than 4.0, justify the deviation with specific evidence from the trial data and noise_stats.json.
+
+Output your selection as a DetectionParams JSON object with a reasoning field.
+Read: noise_stats.json, trial_results.json
+Write output to: detection_params.json" --project "$PROJECT_PATH" --timeout 60
+```
+
+```bash
+# Artifact verification: detect_params
+_vfail=0
+_f="$PROJECT_PATH/detection_params.json"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: detect_params: detection_params.json missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: detect_params: detection_params.json is empty" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=detect_params" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: detect_params artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=detect_params" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(harness verification — DO NOT SKIP)*
+
+## Step: Detect
+
+Threshold-crossing detection with LLM-selected parameters. Reads preprocessed recording and detection_params.json. Writes detections to {output_dir}/detections/ and summary to {output_dir}/detection_summary.json.
+
+```bash
+
+```
+
+## Step: Localize
+
+Point-source localization of detected spikes via Levenberg-Marquardt. Also estimates motion (drift). Writes localizations and cluster_input_stats.json for the clustering agent.
+
+```bash
+
+```
+
+## Phase 2: Strategist — Cluster Params
+
+```bash
+factory agent strategist --task "You are a spike clustering strategy advisor. Read the cluster input statistics at {output_dir}/cluster_input_stats.json.
+
+Select a clustering strategy and parameters:
+- strategy: 'channel_snap' (fast, coarse — good for <20K spikes), 'grid_snap' (spatial grid — good for high density), 'dpc' (density peak clustering — slow but accurate, best for >20K spikes with drift), 'none' (skip clustering — only for pre-sorted data).
+- grid_dx, grid_dz (5-50 µm): Spatial grid resolution. Smaller = more clusters initially. 15 µm is typical.
+- initial_steps: Refinement sequence. ['split', 'demolish', 'demolish'] is standard. Add 'merge' if you expect many similar units.
+- n_waveforms_fit (10K-100K): Subsample size for fitting. Higher = better but slower. 40K is typical.
+
+Decision tree:
+- spike_count < 20K → channel_snap
+- drift > 15 µm → dpc with drift correction
+- spike_density > 1.0 spikes/ch/s → grid_snap
+- Otherwise → dpc
+
+Output your selection as a ClusteringParams JSON object with a reasoning field.
+Read: cluster_input_stats.json
+Write output to: clustering_params.json" --project "$PROJECT_PATH" --timeout 120
+```
+
+```bash
+# Artifact verification: cluster_params
+_vfail=0
+_f="$PROJECT_PATH/clustering_params.json"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: cluster_params: clustering_params.json missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: cluster_params: clustering_params.json is empty" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=cluster_params" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: cluster_params artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=cluster_params" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(harness verification — DO NOT SKIP)*
+
+## Step: Cluster
+
+GMM/DPC clustering with LLM-selected strategy and parameters. Reads detections and clustering_params.json. Writes clustered sorting to {output_dir}/clusters/.
+
+```bash
+
+```
+
+## Step: Templates
+
+Compute unit templates (average/median waveforms) from clustered spikes. Writes per-template quality statistics for the QC agent.
+
+```bash
+
+```
+
+## Phase 3: Researcher — Qc Templates
+
+```bash
+factory agent researcher --task "You are a spike sorting template quality control reviewer. Read the template statistics at {output_dir}/template_stats.json.
+
+For each template, decide: keep, discard, or merge.
+
+Decision criteria:
+- DISCARD if: SNR < 1.5 (noise unit), spike_count < 10 (too few spikes), or ptp_amplitude < 5 µV (below noise floor).
+- MERGE if: two templates have very similar spatial positions (within 25 µm) AND similar PTP amplitudes (within 30%). Specify merge_with = template_id of partner.
+- KEEP otherwise.
+
+Quality heuristics:
+- Good units: SNR > 3, count > 50, stability > 0.7
+- Marginal units: SNR 1.5-3, count 10-50 — keep if isolated
+- High spatial_spread (>200 µm) may indicate multi-unit — flag for discard
+
+Output a TemplateQCOutput JSON with decisions list and summary string.
+Read: template_stats.json
+Write output to: template_decisions.json" --project "$PROJECT_PATH" --timeout 120
+```
+
+```bash
+# Artifact verification: qc_templates
+_vfail=0
+_f="$PROJECT_PATH/template_decisions.json"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: qc_templates: template_decisions.json missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: qc_templates: template_decisions.json is empty" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=qc_templates" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: qc_templates artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=qc_templates" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(harness verification — DO NOT SKIP)*
+
+## Step: Match
+
+Template matching refinement using QC-filtered templates. Reads template_decisions.json to filter templates before matching. Produces the final sorting result.
+
+```bash
+
+```

--- a/tests/test_spec_generate.py
+++ b/tests/test_spec_generate.py
@@ -237,7 +237,7 @@ class TestRegistryIncludesSpec:
 
     def test_register_all_count(self) -> None:
         all_wf = register_all()
-        assert len(all_wf) == 23
+        assert len(all_wf) == 24
 
     def test_all_workflows_validate(self) -> None:
         all_wf = register_all()

--- a/tests/test_spike_sort_workflow.py
+++ b/tests/test_spike_sort_workflow.py
@@ -22,12 +22,12 @@ def test_spike_sort_workflow_validates():
 # ── Node structure ────────────────────────────────────────────────
 
 
-def test_spike_sort_has_9_nodes():
-    """Spike-sort pipeline has exactly 9 nodes: 6 FnNodes + 3 AgentNodes."""
+def test_spike_sort_has_10_nodes():
+    """Spike-sort pipeline has exactly 10 nodes: 7 FnNodes + 3 AgentNodes."""
     wf = spike_sort_workflow()
     fn_nodes = [n for n in wf.nodes.values() if isinstance(n, FnNode)]
     agent_nodes = [n for n in wf.nodes.values() if isinstance(n, AgentNode)]
-    assert len(fn_nodes) == 6, f"Expected 6 FnNodes, got {len(fn_nodes)}"
+    assert len(fn_nodes) == 7, f"Expected 7 FnNodes, got {len(fn_nodes)}"
     assert len(agent_nodes) == 3, f"Expected 3 AgentNodes, got {len(agent_nodes)}"
 
 
@@ -36,6 +36,7 @@ def test_spike_sort_node_ids():
     wf = spike_sort_workflow()
     expected = {
         "preprocess",
+        "detect_trial",
         "detect_params",
         "detect",
         "localize",
@@ -52,12 +53,13 @@ def test_spike_sort_node_ids():
 
 
 def test_spike_sort_is_linear():
-    """Spike-sort has exactly 8 edges forming a linear chain."""
+    """Spike-sort has exactly 9 edges forming a linear chain."""
     wf = spike_sort_workflow()
-    assert len(wf.edges) == 8
+    assert len(wf.edges) == 9
 
     expected_chain = [
-        ("preprocess", "detect_params"),
+        ("preprocess", "detect_trial"),
+        ("detect_trial", "detect_params"),
         ("detect_params", "detect"),
         ("detect", "localize"),
         ("localize", "cluster_params"),
@@ -108,6 +110,7 @@ def test_spike_sort_fn_callables():
 
     expected_callables = {
         "preprocess": "factory.workflow.spike_sort_stages:preprocess",
+        "detect_trial": "factory.workflow.spike_sort_stages:detect_trial",
         "detect": "factory.workflow.spike_sort_stages:detect",
         "localize": "factory.workflow.spike_sort_stages:localize",
         "cluster": "factory.workflow.spike_sort_stages:cluster",
@@ -131,6 +134,7 @@ def test_spike_sort_data_flow():
 
     node_order = [
         "preprocess",
+        "detect_trial",
         "detect_params",
         "detect",
         "localize",
@@ -153,31 +157,54 @@ def test_spike_sort_data_flow():
 
 
 def test_detection_params_schema():
-    """DetectionParams validates within bounds."""
+    """DetectionParams validates within tightened bounds [3.0, 6.0]."""
     from factory.workflow.spike_sort_schemas import DetectionParams
 
     params = DetectionParams(
-        voltage_threshold=3.5,
+        voltage_threshold=4.0,
         peak_sign="both",
         dedup_temporal_radius=11,
         reasoning="Standard parameters for clean cortical recording",
     )
-    assert params.voltage_threshold == 3.5
+    assert params.voltage_threshold == 4.0
+    assert params.use_denoiser is True
 
     with pytest.raises(Exception):
         DetectionParams(
-            voltage_threshold=1.0,
+            voltage_threshold=2.5,
             peak_sign="both",
             dedup_temporal_radius=11,
-            reasoning="too low",
+            reasoning="below tightened lower bound",
         )
     with pytest.raises(Exception):
         DetectionParams(
-            voltage_threshold=9.0,
+            voltage_threshold=7.0,
             peak_sign="both",
             dedup_temporal_radius=11,
-            reasoning="too high",
+            reasoning="above tightened upper bound",
         )
+
+
+def test_detection_params_use_denoiser():
+    """DetectionParams use_denoiser defaults to True and accepts False."""
+    from factory.workflow.spike_sort_schemas import DetectionParams
+
+    params_default = DetectionParams(
+        voltage_threshold=4.0,
+        peak_sign="both",
+        dedup_temporal_radius=11,
+        reasoning="default denoiser",
+    )
+    assert params_default.use_denoiser is True
+
+    params_disabled = DetectionParams(
+        voltage_threshold=4.0,
+        peak_sign="both",
+        dedup_temporal_radius=11,
+        use_denoiser=False,
+        reasoning="denoiser disabled",
+    )
+    assert params_disabled.use_denoiser is False
 
 
 def test_clustering_params_schema():
@@ -288,6 +315,44 @@ def test_template_stats_schema():
             spatial_spread_um=75.0,
             stability=1.5,
         )
+
+
+# ── detect_trial node ────────────────────────────────────────────
+
+
+def test_detect_trial_node_exists():
+    """detect_trial FnNode is present with correct callable and data flow."""
+    wf = spike_sort_workflow()
+    node = wf.nodes["detect_trial"]
+    assert isinstance(node, FnNode)
+    assert node.callable_name == "factory.workflow.spike_sort_stages:detect_trial"
+    assert node.reads == {"preprocessed/", "noise_stats.json"}
+    assert node.writes == {"trial_results.json"}
+
+
+def test_detect_trial_edge_wiring():
+    """preprocess → detect_trial → detect_params edge chain is correct."""
+    wf = spike_sort_workflow()
+    edges = [(e.source, e.target) for e in wf.edges]
+    assert ("preprocess", "detect_trial") in edges
+    assert ("detect_trial", "detect_params") in edges
+    assert ("preprocess", "detect_params") not in edges
+
+
+def test_detect_node_writes_denoised():
+    """detect FnNode writes include denoised/ directory."""
+    wf = spike_sort_workflow()
+    detect_node = wf.nodes["detect"]
+    assert isinstance(detect_node, FnNode)
+    assert "denoised/" in detect_node.writes
+
+
+def test_detect_params_reads_trial_results():
+    """detect_params AgentNode reads trial_results.json."""
+    wf = spike_sort_workflow()
+    node = wf.nodes["detect_params"]
+    assert isinstance(node, AgentNode)
+    assert "trial_results.json" in node.reads
 
 
 # ── Registration ──────────────────────────────────────────────────

--- a/tests/test_spike_sort_workflow.py
+++ b/tests/test_spike_sort_workflow.py
@@ -1,0 +1,368 @@
+"""Tests for the spike-sort workflow definition and schemas."""
+
+from __future__ import annotations
+
+import pytest
+
+from factory.models import ProjectState
+from factory.workflow.definitions import register_all, spike_sort_workflow
+from factory.workflow.primitives import AgentNode, FnNode
+
+
+# ── Graph validation ──────────────────────────────────────────────
+
+
+def test_spike_sort_workflow_validates():
+    """spike-sort graph passes structural validation."""
+    wf = spike_sort_workflow()
+    issues = wf.validate_graph()
+    assert issues == [], f"Validation issues: {issues}"
+
+
+# ── Node structure ────────────────────────────────────────────────
+
+
+def test_spike_sort_has_9_nodes():
+    """Spike-sort pipeline has exactly 9 nodes: 6 FnNodes + 3 AgentNodes."""
+    wf = spike_sort_workflow()
+    fn_nodes = [n for n in wf.nodes.values() if isinstance(n, FnNode)]
+    agent_nodes = [n for n in wf.nodes.values() if isinstance(n, AgentNode)]
+    assert len(fn_nodes) == 6, f"Expected 6 FnNodes, got {len(fn_nodes)}"
+    assert len(agent_nodes) == 3, f"Expected 3 AgentNodes, got {len(agent_nodes)}"
+
+
+def test_spike_sort_node_ids():
+    """All expected node IDs are present."""
+    wf = spike_sort_workflow()
+    expected = {
+        "preprocess",
+        "detect_params",
+        "detect",
+        "localize",
+        "cluster_params",
+        "cluster",
+        "templates",
+        "qc_templates",
+        "match",
+    }
+    assert set(wf.nodes.keys()) == expected
+
+
+# ── Linear pipeline structure ────────────────────────────────────
+
+
+def test_spike_sort_is_linear():
+    """Spike-sort has exactly 8 edges forming a linear chain."""
+    wf = spike_sort_workflow()
+    assert len(wf.edges) == 8
+
+    expected_chain = [
+        ("preprocess", "detect_params"),
+        ("detect_params", "detect"),
+        ("detect", "localize"),
+        ("localize", "cluster_params"),
+        ("cluster_params", "cluster"),
+        ("cluster", "templates"),
+        ("templates", "qc_templates"),
+        ("qc_templates", "match"),
+    ]
+    actual_chain = [(e.source, e.target) for e in wf.edges]
+    assert actual_chain == expected_chain
+
+
+def test_spike_sort_no_conditional_edges():
+    """Linear pipeline has no conditional (PROCEED/RELOOP/HALT) edges."""
+    wf = spike_sort_workflow()
+    for edge in wf.edges:
+        assert edge.condition is None, (
+            f"Edge {edge.source}→{edge.target} has condition {edge.condition}"
+        )
+
+
+# ── Agent model assignment ────────────────────────────────────────
+
+
+def test_spike_sort_agent_models():
+    """Detection and QC use haiku; clustering uses sonnet."""
+    wf = spike_sort_workflow()
+
+    detect_params = wf.nodes["detect_params"]
+    assert isinstance(detect_params, AgentNode)
+    assert detect_params.model == "haiku"
+
+    cluster_params = wf.nodes["cluster_params"]
+    assert isinstance(cluster_params, AgentNode)
+    assert cluster_params.model == "sonnet"
+
+    qc_templates = wf.nodes["qc_templates"]
+    assert isinstance(qc_templates, AgentNode)
+    assert qc_templates.model == "haiku"
+
+
+# ── FnNode callable names ────────────────────────────────────────
+
+
+def test_spike_sort_fn_callables():
+    """All FnNodes reference factory.workflow.spike_sort_stages callables."""
+    wf = spike_sort_workflow()
+
+    expected_callables = {
+        "preprocess": "factory.workflow.spike_sort_stages:preprocess",
+        "detect": "factory.workflow.spike_sort_stages:detect",
+        "localize": "factory.workflow.spike_sort_stages:localize",
+        "cluster": "factory.workflow.spike_sort_stages:cluster",
+        "templates": "factory.workflow.spike_sort_stages:compute_templates",
+        "match": "factory.workflow.spike_sort_stages:template_match",
+    }
+    for node_id, expected in expected_callables.items():
+        node = wf.nodes[node_id]
+        assert isinstance(node, FnNode)
+        assert node.callable_name == expected, (
+            f"{node_id}: expected {expected}, got {node.callable_name}"
+        )
+
+
+# ── Data flow connectivity ────────────────────────────────────────
+
+
+def test_spike_sort_data_flow():
+    """Each node's reads are a subset of predecessors' writes."""
+    wf = spike_sort_workflow()
+
+    node_order = [
+        "preprocess",
+        "detect_params",
+        "detect",
+        "localize",
+        "cluster_params",
+        "cluster",
+        "templates",
+        "qc_templates",
+        "match",
+    ]
+
+    available: set[str] = set()
+    for nid in node_order:
+        node = wf.nodes[nid]
+        missing = node.reads - available
+        assert not missing, f"Node '{nid}' reads {missing} but only {available} available"
+        available |= node.writes
+
+
+# ── Schema validation ─────────────────────────────────────────────
+
+
+def test_detection_params_schema():
+    """DetectionParams validates within bounds."""
+    from factory.workflow.spike_sort_schemas import DetectionParams
+
+    params = DetectionParams(
+        voltage_threshold=3.5,
+        peak_sign="both",
+        dedup_temporal_radius=11,
+        reasoning="Standard parameters for clean cortical recording",
+    )
+    assert params.voltage_threshold == 3.5
+
+    with pytest.raises(Exception):
+        DetectionParams(
+            voltage_threshold=1.0,
+            peak_sign="both",
+            dedup_temporal_radius=11,
+            reasoning="too low",
+        )
+    with pytest.raises(Exception):
+        DetectionParams(
+            voltage_threshold=9.0,
+            peak_sign="both",
+            dedup_temporal_radius=11,
+            reasoning="too high",
+        )
+
+
+def test_clustering_params_schema():
+    """ClusteringParams validates strategy and grid bounds."""
+    from factory.workflow.spike_sort_schemas import ClusteringParams
+
+    params = ClusteringParams(
+        strategy="grid_snap",
+        grid_dx=15.0,
+        grid_dz=15.0,
+        initial_steps=["split", "demolish", "demolish"],
+        n_waveforms_fit=40000,
+        reasoning="Standard grid for medium-density recording",
+    )
+    assert params.strategy == "grid_snap"
+
+    with pytest.raises(Exception):
+        ClusteringParams(
+            strategy="invalid",
+            grid_dx=15.0,
+            grid_dz=15.0,
+            initial_steps=["split"],
+            n_waveforms_fit=40000,
+            reasoning="bad",
+        )
+
+
+def test_template_decision_merge_requires_partner():
+    """Merge action without merge_with is valid per schema (None allowed)."""
+    from factory.workflow.spike_sort_schemas import TemplateDecision
+
+    keep = TemplateDecision(template_id=0, action="keep", reasoning="good unit")
+    assert keep.merge_with is None
+
+    merge = TemplateDecision(template_id=1, action="merge", merge_with=0, reasoning="similar")
+    assert merge.merge_with == 0
+
+
+def test_template_qc_output_schema():
+    """TemplateQCOutput accepts a list of decisions with summary."""
+    from factory.workflow.spike_sort_schemas import TemplateDecision, TemplateQCOutput
+
+    output = TemplateQCOutput(
+        decisions=[
+            TemplateDecision(template_id=0, action="keep", reasoning="good SNR"),
+            TemplateDecision(template_id=1, action="discard", reasoning="noise unit"),
+            TemplateDecision(
+                template_id=2, action="merge", merge_with=0, reasoning="similar waveform"
+            ),
+        ],
+        summary="Kept 1, discarded 1, merged 1 into unit 0",
+    )
+    assert len(output.decisions) == 3
+
+
+def test_noise_stats_schema():
+    """NoiseStats validates all required fields."""
+    from factory.workflow.spike_sort_schemas import NoiseStats
+
+    stats = NoiseStats(
+        median_noise_uv=10.5,
+        mad_per_channel=[8.0, 9.0, 11.0],
+        num_channels=3,
+        sampling_rate_hz=30000.0,
+        recording_duration_s=300.0,
+        probe_type="neuropixels_2.0",
+        channel_positions=[[0.0, 0.0], [0.0, 25.0], [32.0, 0.0]],
+    )
+    assert stats.num_channels == 3
+
+
+def test_cluster_input_stats_schema():
+    """ClusterInputStats validates all required fields."""
+    from factory.workflow.spike_sort_schemas import ClusterInputStats
+
+    stats = ClusterInputStats(
+        spike_count=50000,
+        drift_magnitude_um=12.5,
+        feature_pca_variance_explained=[0.4, 0.15, 0.08],
+        spike_density_per_channel_per_s=0.5,
+        depth_range_um=3840.0,
+        probe_type="neuropixels_2.0",
+        channel_count=384,
+    )
+    assert stats.spike_count == 50000
+
+
+def test_template_stats_schema():
+    """TemplateStats validates stability bounds."""
+    from factory.workflow.spike_sort_schemas import TemplateStats
+
+    stats = TemplateStats(
+        template_id=0,
+        snr=5.0,
+        spike_count=100,
+        ptp_amplitude_uv=50.0,
+        spatial_spread_um=75.0,
+        stability=0.95,
+    )
+    assert stats.stability == 0.95
+
+    with pytest.raises(Exception):
+        TemplateStats(
+            template_id=0,
+            snr=5.0,
+            spike_count=100,
+            ptp_amplitude_uv=50.0,
+            spatial_spread_um=75.0,
+            stability=1.5,
+        )
+
+
+# ── Registration ──────────────────────────────────────────────────
+
+
+def test_spike_sort_workflow_registered():
+    """spike-sort is registered in register_all()."""
+    workflows = register_all()
+    assert "spike-sort" in workflows
+
+
+def test_spike_sort_workflow_in_meta():
+    """spike-sort has a WORKFLOW_META entry."""
+    from factory.workflow.skill_export import WORKFLOW_META
+
+    assert "spike-sort" in WORKFLOW_META
+
+
+# ── SpikeInterface compatibility ──────────────────────────────────
+
+
+def test_spike_sort_input_output_format():
+    """Pipeline start writes preprocessed/ and final node produces sorting/."""
+    wf = spike_sort_workflow()
+
+    first_node = wf.nodes[wf.start_node]
+    assert "preprocessed/" in first_node.writes
+
+    last_node = wf.nodes["match"]
+    assert "sorting/" in last_node.writes
+
+
+# ── Trigger function ──────────────────────────────────────────────
+
+
+def test_spike_sort_trigger():
+    """Trigger fires when mode=spike-sort regardless of project state."""
+    wf = spike_sort_workflow()
+    assert wf.trigger is not None
+    assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "spike-sort"})
+    assert wf.trigger(ProjectState.NO_REPO, {"mode": "spike-sort"})
+    assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+    assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+# ── CLI mode registration ────────────────────────────────────────
+
+
+def test_spike_sort_in_ceo_modes():
+    """spike-sort is in the CEO_MODES list."""
+    from factory.cli._helpers import CEO_MODES
+
+    assert "spike-sort" in CEO_MODES
+
+
+def test_spike_sort_in_run_modes():
+    """spike-sort is in the RUN_MODES list."""
+    from factory.cli._helpers import RUN_MODES
+
+    assert "spike-sort" in RUN_MODES
+
+
+# ── Start node ────────────────────────────────────────────────────
+
+
+def test_spike_sort_start_node():
+    """Start node is preprocess."""
+    wf = spike_sort_workflow()
+    assert wf.start_node == "preprocess"
+
+
+# ── Workflow name ─────────────────────────────────────────────────
+
+
+def test_spike_sort_workflow_name():
+    """Workflow name is spike-sort."""
+    wf = spike_sort_workflow()
+    assert wf.name == "spike-sort"

--- a/tests/test_spike_sort_workflow.py
+++ b/tests/test_spike_sort_workflow.py
@@ -1,11 +1,11 @@
-"""Tests for the spike-sort workflow definition and schemas."""
+"""Tests for the spike-sort workflow definition (15-node LLM gates version)."""
 
 from __future__ import annotations
 
 import pytest
 
 from factory.models import ProjectState
-from factory.workflow.definitions import register_all, spike_sort_workflow
+from factory.workflow.definitions import spike_sort_workflow
 from factory.workflow.primitives import AgentNode, AgentRole, FnNode
 
 
@@ -22,13 +22,14 @@ def test_spike_sort_workflow_validates():
 # ── Node structure ────────────────────────────────────────────────
 
 
-def test_spike_sort_has_10_nodes():
-    """Spike-sort pipeline has exactly 10 nodes: 7 FnNodes + 3 AgentNodes."""
+def test_spike_sort_has_15_nodes():
+    """Spike-sort pipeline has exactly 15 nodes: 12 FnNodes + 3 AgentNodes."""
     wf = spike_sort_workflow()
     fn_nodes = [n for n in wf.nodes.values() if isinstance(n, FnNode)]
     agent_nodes = [n for n in wf.nodes.values() if isinstance(n, AgentNode)]
-    assert len(fn_nodes) == 7, f"Expected 7 FnNodes, got {len(fn_nodes)}"
+    assert len(fn_nodes) == 12, f"Expected 12 FnNodes, got {len(fn_nodes)}"
     assert len(agent_nodes) == 3, f"Expected 3 AgentNodes, got {len(agent_nodes)}"
+    assert len(wf.nodes) == 15
 
 
 def test_spike_sort_node_ids():
@@ -36,37 +37,54 @@ def test_spike_sort_node_ids():
     wf = spike_sort_workflow()
     expected = {
         "preprocess",
-        "detect_trial",
-        "detect_params",
         "detect",
         "localize",
-        "cluster_params",
         "cluster",
+        "compute_cluster_metrics",
+        "gate_post_cluster",
+        "apply_cluster_actions",
         "templates",
+        "compute_template_metrics",
+        "gate_post_template",
+        "apply_template_actions",
         "match",
-        "qa_sorting",
+        "compute_final_metrics",
+        "gate_post_match",
+        "apply_final_actions",
     }
     assert set(wf.nodes.keys()) == expected
+
+
+def test_spike_sort_removed_nodes_absent():
+    """Old parameter-picking and QA nodes are removed."""
+    wf = spike_sort_workflow()
+    for removed in ["detect_trial", "detect_params", "cluster_params", "qa_sorting"]:
+        assert removed not in wf.nodes, f"{removed} should have been removed"
 
 
 # ── Linear pipeline structure ────────────────────────────────────
 
 
 def test_spike_sort_is_linear():
-    """Spike-sort has exactly 9 edges forming a linear chain."""
+    """Spike-sort has exactly 14 edges forming a linear chain."""
     wf = spike_sort_workflow()
-    assert len(wf.edges) == 9
+    assert len(wf.edges) == 14
 
     expected_chain = [
-        ("preprocess", "detect_trial"),
-        ("detect_trial", "detect_params"),
-        ("detect_params", "detect"),
+        ("preprocess", "detect"),
         ("detect", "localize"),
-        ("localize", "cluster_params"),
-        ("cluster_params", "cluster"),
-        ("cluster", "templates"),
-        ("templates", "match"),
-        ("match", "qa_sorting"),
+        ("localize", "cluster"),
+        ("cluster", "compute_cluster_metrics"),
+        ("compute_cluster_metrics", "gate_post_cluster"),
+        ("gate_post_cluster", "apply_cluster_actions"),
+        ("apply_cluster_actions", "templates"),
+        ("templates", "compute_template_metrics"),
+        ("compute_template_metrics", "gate_post_template"),
+        ("gate_post_template", "apply_template_actions"),
+        ("apply_template_actions", "match"),
+        ("match", "compute_final_metrics"),
+        ("compute_final_metrics", "gate_post_match"),
+        ("gate_post_match", "apply_final_actions"),
     ]
     actual_chain = [(e.source, e.target) for e in wf.edges]
     assert actual_chain == expected_chain
@@ -81,33 +99,63 @@ def test_spike_sort_no_conditional_edges():
         )
 
 
-# ── Agent model assignment ────────────────────────────────────────
+# ── Gate triplet structure ───────────────────────────────────────
 
 
-def test_spike_sort_agent_models():
-    """Detection uses haiku; clustering and QA use sonnet."""
+def test_gate1_triplet_wiring():
+    """cluster → compute_cluster_metrics → gate_post_cluster → apply_cluster_actions."""
+    wf = spike_sort_workflow()
+    edges = [(e.source, e.target) for e in wf.edges]
+    assert ("cluster", "compute_cluster_metrics") in edges
+    assert ("compute_cluster_metrics", "gate_post_cluster") in edges
+    assert ("gate_post_cluster", "apply_cluster_actions") in edges
+
+
+def test_gate2_triplet_wiring():
+    """templates → compute_template_metrics → gate_post_template → apply_template_actions."""
+    wf = spike_sort_workflow()
+    edges = [(e.source, e.target) for e in wf.edges]
+    assert ("templates", "compute_template_metrics") in edges
+    assert ("compute_template_metrics", "gate_post_template") in edges
+    assert ("gate_post_template", "apply_template_actions") in edges
+
+
+def test_gate3_triplet_wiring():
+    """match → compute_final_metrics → gate_post_match → apply_final_actions."""
+    wf = spike_sort_workflow()
+    edges = [(e.source, e.target) for e in wf.edges]
+    assert ("match", "compute_final_metrics") in edges
+    assert ("compute_final_metrics", "gate_post_match") in edges
+    assert ("gate_post_match", "apply_final_actions") in edges
+
+
+# ── Agent model assignment ───────────────────────────────────────
+
+
+def test_spike_sort_gate_models():
+    """Gate 1 uses sonnet; Gates 2 and 3 use haiku."""
     wf = spike_sort_workflow()
 
-    detect_params = wf.nodes["detect_params"]
-    assert isinstance(detect_params, AgentNode)
-    assert detect_params.role == AgentRole.RESEARCHER
-    assert detect_params.model == "haiku"
-    assert detect_params.timeout == 60
+    gate1 = wf.nodes["gate_post_cluster"]
+    assert isinstance(gate1, AgentNode)
+    assert gate1.role == AgentRole.HEALTH_CHECKER
+    assert gate1.model == "sonnet"
+    assert gate1.timeout == 300
 
-    cluster_params = wf.nodes["cluster_params"]
-    assert isinstance(cluster_params, AgentNode)
-    assert cluster_params.role == AgentRole.STRATEGIST
-    assert cluster_params.model == "sonnet"
-    assert cluster_params.timeout == 120
+    gate2 = wf.nodes["gate_post_template"]
+    assert isinstance(gate2, AgentNode)
+    assert gate2.role == AgentRole.HEALTH_CHECKER
+    assert gate2.model == "haiku"
+    assert gate2.timeout == 120
 
-    qa_sorting = wf.nodes["qa_sorting"]
-    assert isinstance(qa_sorting, AgentNode)
-    assert qa_sorting.role == AgentRole.HEALTH_CHECKER
-    assert qa_sorting.model == "sonnet"
-    assert qa_sorting.timeout == 300
+    gate3 = wf.nodes["gate_post_match"]
+    assert isinstance(gate3, AgentNode)
+    assert gate3.role == AgentRole.HEALTH_CHECKER
+    assert gate3.model == "haiku"
+    assert gate3.timeout == 120
 
 
-# ── FnNode callable names ────────────────────────────────────────
+# ── FnNode callable names ───────────────────────────────────────
 
 
 def test_spike_sort_fn_callables():
@@ -116,22 +164,27 @@ def test_spike_sort_fn_callables():
 
     expected_callables = {
         "preprocess": "factory.workflow.spike_sort_stages:preprocess",
-        "detect_trial": "factory.workflow.spike_sort_stages:detect_trial",
         "detect": "factory.workflow.spike_sort_stages:detect",
         "localize": "factory.workflow.spike_sort_stages:localize",
         "cluster": "factory.workflow.spike_sort_stages:cluster",
+        "compute_cluster_metrics": "factory.workflow.spike_sort_stages:compute_cluster_metrics",
+        "apply_cluster_actions": "factory.workflow.spike_sort_stages:apply_cluster_actions",
         "templates": "factory.workflow.spike_sort_stages:compute_templates",
         "match": "factory.workflow.spike_sort_stages:template_match",
+        "compute_template_metrics": "factory.workflow.spike_sort_stages:compute_template_metrics",
+        "apply_template_actions": "factory.workflow.spike_sort_stages:apply_template_actions",
+        "compute_final_metrics": "factory.workflow.spike_sort_stages:compute_final_metrics",
+        "apply_final_actions": "factory.workflow.spike_sort_stages:apply_final_actions",
     }
     for node_id, expected in expected_callables.items():
         node = wf.nodes[node_id]
-        assert isinstance(node, FnNode)
+        assert isinstance(node, FnNode), f"{node_id} should be FnNode"
         assert node.callable_name == expected, (
             f"{node_id}: expected {expected}, got {node.callable_name}"
         )
 
 
-# ── Data flow connectivity ────────────────────────────────────────
+# ── Data flow connectivity ───────────────────────────────────────
 
 
 def test_spike_sort_data_flow():
@@ -140,15 +193,20 @@ def test_spike_sort_data_flow():
 
     node_order = [
         "preprocess",
-        "detect_trial",
-        "detect_params",
         "detect",
         "localize",
-        "cluster_params",
         "cluster",
+        "compute_cluster_metrics",
+        "gate_post_cluster",
+        "apply_cluster_actions",
         "templates",
+        "compute_template_metrics",
+        "gate_post_template",
+        "apply_template_actions",
         "match",
-        "qa_sorting",
+        "compute_final_metrics",
+        "gate_post_match",
+        "apply_final_actions",
     ]
 
     available: set[str] = set()
@@ -159,7 +217,7 @@ def test_spike_sort_data_flow():
         available |= node.writes
 
 
-# ── Schema validation ─────────────────────────────────────────────
+# ── Schema validation ────────────────────────────────────────────
 
 
 def test_detection_params_schema():
@@ -323,82 +381,13 @@ def test_template_stats_schema():
         )
 
 
-# ── detect_trial node ────────────────────────────────────────────
-
-
-def test_detect_trial_node_exists():
-    """detect_trial FnNode is present with correct callable and data flow."""
-    wf = spike_sort_workflow()
-    node = wf.nodes["detect_trial"]
-    assert isinstance(node, FnNode)
-    assert node.callable_name == "factory.workflow.spike_sort_stages:detect_trial"
-    assert node.reads == {"preprocessed/", "noise_stats.json"}
-    assert node.writes == {"trial_results.json"}
-
-
-def test_detect_trial_edge_wiring():
-    """preprocess → detect_trial → detect_params edge chain is correct."""
-    wf = spike_sort_workflow()
-    edges = [(e.source, e.target) for e in wf.edges]
-    assert ("preprocess", "detect_trial") in edges
-    assert ("detect_trial", "detect_params") in edges
-    assert ("preprocess", "detect_params") not in edges
-
-
-def test_detect_node_writes_denoised():
-    """detect FnNode writes include denoised/ directory."""
-    wf = spike_sort_workflow()
-    detect_node = wf.nodes["detect"]
-    assert isinstance(detect_node, FnNode)
-    assert "denoised/" in detect_node.writes
-
-
-def test_detect_params_reads_trial_results():
-    """detect_params AgentNode reads trial_results.json."""
-    wf = spike_sort_workflow()
-    node = wf.nodes["detect_params"]
-    assert isinstance(node, AgentNode)
-    assert "trial_results.json" in node.reads
-
-
-# ── QA sorting node ──────────────────────────────────────────────
-
-
-def test_qa_sorting_node_exists():
-    """qa_sorting AgentNode exists with correct config."""
-    wf = spike_sort_workflow()
-    assert "qa_sorting" in wf.nodes
-    qa_node = wf.nodes["qa_sorting"]
-    assert isinstance(qa_node, AgentNode)
-    assert qa_node.role == AgentRole.HEALTH_CHECKER
-    assert qa_node.model == "sonnet"
-    assert qa_node.timeout == 300
-    assert "sorting/" in qa_node.reads
-    assert "qa_report.json" in qa_node.writes
-    assert "flagged_units.json" in qa_node.writes
-
-
-def test_qa_sorting_edge():
-    """match → qa_sorting edge exists and is unconditional."""
-    wf = spike_sort_workflow()
-    edges_from_match = [e for e in wf.edges if e.source == "match"]
-    assert len(edges_from_match) == 1
-    assert edges_from_match[0].target == "qa_sorting"
-    assert edges_from_match[0].condition is None
-
-
-def test_qa_sorting_is_terminal():
-    """qa_sorting has no outgoing edges (terminal node)."""
-    wf = spike_sort_workflow()
-    outgoing = [e for e in wf.edges if e.source == "qa_sorting"]
-    assert len(outgoing) == 0
-
-
-# ── Registration ──────────────────────────────────────────────────
+# ── Registration ─────────────────────────────────────────────────
 
 
 def test_spike_sort_workflow_registered():
     """spike-sort is registered in register_all()."""
+    from factory.workflow.definitions import register_all
+
     workflows = register_all()
     assert "spike-sort" in workflows
 
@@ -410,22 +399,21 @@ def test_spike_sort_workflow_in_meta():
     assert "spike-sort" in WORKFLOW_META
 
 
-# ── SpikeInterface compatibility ──────────────────────────────────
+# ── Skill export ─────────────────────────────────────────────────
 
 
-def test_spike_sort_input_output_format():
-    """Pipeline start writes preprocessed/ and final node produces sorting/."""
+def test_spike_sort_skill_export():
+    """Verify spike-sort workflow generates a valid SKILL.md."""
+    from factory.workflow.skill_export import workflow_to_skill_md
+
     wf = spike_sort_workflow()
-
-    first_node = wf.nodes[wf.start_node]
-    assert "preprocessed/" in first_node.writes
-
-    # qa_sorting reads sorting/ (produced by match) and writes qa artifacts
-    qa_node = wf.nodes["qa_sorting"]
-    assert "sorting/" in qa_node.reads
+    skill = workflow_to_skill_md(wf)
+    assert "gate_post_cluster" in skill
+    assert "gate_post_template" in skill
+    assert "gate_post_match" in skill
 
 
-# ── Trigger function ──────────────────────────────────────────────
+# ── Trigger function ─────────────────────────────────────────────
 
 
 def test_spike_sort_trigger():
@@ -438,7 +426,7 @@ def test_spike_sort_trigger():
     assert not wf.trigger(ProjectState.HAS_FACTORY, {})
 
 
-# ── CLI mode registration ────────────────────────────────────────
+# ── CLI mode registration ───────────────────────────────────────
 
 
 def test_spike_sort_in_ceo_modes():
@@ -455,7 +443,7 @@ def test_spike_sort_in_run_modes():
     assert "spike-sort" in RUN_MODES
 
 
-# ── Start node ────────────────────────────────────────────────────
+# ── Start node ───────────────────────────────────────────────────
 
 
 def test_spike_sort_start_node():
@@ -464,10 +452,58 @@ def test_spike_sort_start_node():
     assert wf.start_node == "preprocess"
 
 
-# ── Workflow name ─────────────────────────────────────────────────
+# ── Workflow name ────────────────────────────────────────────────
 
 
 def test_spike_sort_workflow_name():
     """Workflow name is spike-sort."""
     wf = spike_sort_workflow()
     assert wf.name == "spike-sort"
+
+
+# ── Input/output format ─────────────────────────────────────────
+
+
+def test_spike_sort_input_output_format():
+    """Pipeline start writes preprocessed/ and final node produces sorting_final/."""
+    wf = spike_sort_workflow()
+
+    first_node = wf.nodes[wf.start_node]
+    assert "preprocessed/" in first_node.writes
+
+    final_node = wf.nodes["apply_final_actions"]
+    assert "sorting_final/" in final_node.writes
+
+
+# ── Gate prompt constants ────────────────────────────────────────
+
+
+def test_gate_prompt_constants_exist():
+    """Gate prompt constants are defined and used by agent nodes."""
+    from factory.workflow.definitions import (
+        GATE_POST_CLUSTER_PROMPT,
+        GATE_POST_MATCH_PROMPT,
+        GATE_POST_TEMPLATE_PROMPT,
+    )
+
+    wf = spike_sort_workflow()
+    assert wf.nodes["gate_post_cluster"].prompt_template == GATE_POST_CLUSTER_PROMPT
+    assert wf.nodes["gate_post_template"].prompt_template == GATE_POST_TEMPLATE_PROMPT
+    assert wf.nodes["gate_post_match"].prompt_template == GATE_POST_MATCH_PROMPT
+
+
+def test_gate_prompts_are_context_first():
+    """Gate prompts emphasize context-aware reasoning, not mechanical thresholds."""
+    from factory.workflow.definitions import (
+        GATE_POST_CLUSTER_PROMPT,
+        GATE_POST_MATCH_PROMPT,
+        GATE_POST_TEMPLATE_PROMPT,
+    )
+
+    assert "recording_context.json" in GATE_POST_CLUSTER_PROMPT
+    assert "recording_context.json" in GATE_POST_TEMPLATE_PROMPT
+    assert "recording_context.json" in GATE_POST_MATCH_PROMPT
+
+    assert "context" in GATE_POST_CLUSTER_PROMPT.lower()
+    assert "context" in GATE_POST_TEMPLATE_PROMPT.lower()
+    assert "context" in GATE_POST_MATCH_PROMPT.lower()

--- a/tests/test_spike_sort_workflow.py
+++ b/tests/test_spike_sort_workflow.py
@@ -102,9 +102,7 @@ class TestQaSortingNode:
         assert qa_node.role == AgentRole.HEALTH_CHECKER
         assert qa_node.model == "sonnet"
         assert qa_node.timeout == 300
-        assert "sorting_result.json" in qa_node.reads
         assert "sorting/" in qa_node.reads
-        assert "templates/" in qa_node.reads
         assert "qa_report.json" in qa_node.writes
         assert "flagged_units.json" in qa_node.writes
 

--- a/tests/test_spike_sort_workflow.py
+++ b/tests/test_spike_sort_workflow.py
@@ -161,26 +161,26 @@ def test_detection_params_schema():
     from factory.workflow.spike_sort_schemas import DetectionParams
 
     params = DetectionParams(
-        voltage_threshold=4.0,
+        detection_threshold=4.0,
         peak_sign="both",
-        dedup_temporal_radius=11,
+        temporal_dedup_radius_samples=11,
         reasoning="Standard parameters for clean cortical recording",
     )
-    assert params.voltage_threshold == 4.0
+    assert params.detection_threshold == 4.0
     assert params.use_denoiser is True
 
     with pytest.raises(Exception):
         DetectionParams(
-            voltage_threshold=2.5,
+            detection_threshold=2.5,
             peak_sign="both",
-            dedup_temporal_radius=11,
+            temporal_dedup_radius_samples=11,
             reasoning="below tightened lower bound",
         )
     with pytest.raises(Exception):
         DetectionParams(
-            voltage_threshold=7.0,
+            detection_threshold=7.0,
             peak_sign="both",
-            dedup_temporal_radius=11,
+            temporal_dedup_radius_samples=11,
             reasoning="above tightened upper bound",
         )
 
@@ -190,17 +190,17 @@ def test_detection_params_use_denoiser():
     from factory.workflow.spike_sort_schemas import DetectionParams
 
     params_default = DetectionParams(
-        voltage_threshold=4.0,
+        detection_threshold=4.0,
         peak_sign="both",
-        dedup_temporal_radius=11,
+        temporal_dedup_radius_samples=11,
         reasoning="default denoiser",
     )
     assert params_default.use_denoiser is True
 
     params_disabled = DetectionParams(
-        voltage_threshold=4.0,
+        detection_threshold=4.0,
         peak_sign="both",
-        dedup_temporal_radius=11,
+        temporal_dedup_radius_samples=11,
         use_denoiser=False,
         reasoning="denoiser disabled",
     )

--- a/tests/test_spike_sort_workflow.py
+++ b/tests/test_spike_sort_workflow.py
@@ -1,0 +1,142 @@
+"""Tests for the spike-sort workflow definition."""
+
+from __future__ import annotations
+
+from factory.workflow.definitions import spike_sort_workflow
+from factory.workflow.primitives import AgentNode, AgentRole, FnNode
+
+
+class TestSpikeSortWorkflow:
+    def test_spike_sort_valid(self) -> None:
+        wf = spike_sort_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"spike-sort workflow has issues: {issues}"
+
+    def test_spike_sort_has_10_nodes(self) -> None:
+        wf = spike_sort_workflow()
+        fn_nodes = [n for n in wf.nodes.values() if isinstance(n, FnNode)]
+        agent_nodes = [n for n in wf.nodes.values() if isinstance(n, AgentNode)]
+        assert len(fn_nodes) == 7
+        assert len(agent_nodes) == 3
+        assert len(wf.nodes) == 10
+
+    def test_spike_sort_node_ids(self) -> None:
+        wf = spike_sort_workflow()
+        expected = {
+            "preprocess",
+            "detect_trial",
+            "detect_params",
+            "detect",
+            "localize",
+            "cluster_params",
+            "cluster",
+            "templates",
+            "match",
+            "qa_sorting",
+        }
+        assert set(wf.nodes.keys()) == expected
+
+    def test_spike_sort_is_linear(self) -> None:
+        wf = spike_sort_workflow()
+        expected_chain = [
+            ("preprocess", "detect_trial"),
+            ("detect_trial", "detect_params"),
+            ("detect_params", "detect"),
+            ("detect", "localize"),
+            ("localize", "cluster_params"),
+            ("cluster_params", "cluster"),
+            ("cluster", "templates"),
+            ("templates", "match"),
+            ("match", "qa_sorting"),
+        ]
+        assert len(wf.edges) == 9
+        actual = [(e.source, e.target) for e in wf.edges]
+        assert actual == expected_chain
+
+    def test_spike_sort_agent_models(self) -> None:
+        wf = spike_sort_workflow()
+        dp = wf.nodes["detect_params"]
+        assert isinstance(dp, AgentNode)
+        assert dp.role == AgentRole.RESEARCHER
+        assert dp.model == "haiku"
+        assert dp.timeout == 60
+
+        cp = wf.nodes["cluster_params"]
+        assert isinstance(cp, AgentNode)
+        assert cp.role == AgentRole.STRATEGIST
+        assert cp.model == "sonnet"
+        assert cp.timeout == 120
+
+        qa = wf.nodes["qa_sorting"]
+        assert isinstance(qa, AgentNode)
+        assert qa.role == AgentRole.HEALTH_CHECKER
+        assert qa.model == "sonnet"
+        assert qa.timeout == 300
+
+    def test_spike_sort_trigger(self) -> None:
+        from factory.models import ProjectState
+
+        wf = spike_sort_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "spike-sort"})
+        assert wf.trigger(ProjectState.NO_REPO, {"mode": "spike-sort"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+    def test_spike_sort_start_node(self) -> None:
+        wf = spike_sort_workflow()
+        assert wf.start_node == "preprocess"
+
+    def test_spike_sort_all_edges_unconditional(self) -> None:
+        wf = spike_sort_workflow()
+        for edge in wf.edges:
+            assert edge.condition is None, f"Edge {edge.source}→{edge.target} has condition"
+
+
+class TestQaSortingNode:
+    def test_qa_sorting_node_exists(self) -> None:
+        wf = spike_sort_workflow()
+        assert "qa_sorting" in wf.nodes
+        qa_node = wf.nodes["qa_sorting"]
+        assert isinstance(qa_node, AgentNode)
+        assert qa_node.role == AgentRole.HEALTH_CHECKER
+        assert qa_node.model == "sonnet"
+        assert qa_node.timeout == 300
+        assert "sorting_result.json" in qa_node.reads
+        assert "sorting/" in qa_node.reads
+        assert "templates/" in qa_node.reads
+        assert "qa_report.json" in qa_node.writes
+        assert "flagged_units.json" in qa_node.writes
+
+    def test_qa_sorting_edge(self) -> None:
+        wf = spike_sort_workflow()
+        edges_from_match = [e for e in wf.edges if e.source == "match"]
+        assert len(edges_from_match) == 1
+        assert edges_from_match[0].target == "qa_sorting"
+        assert edges_from_match[0].condition is None
+
+    def test_qa_sorting_is_terminal(self) -> None:
+        wf = spike_sort_workflow()
+        outgoing = [e for e in wf.edges if e.source == "qa_sorting"]
+        assert len(outgoing) == 0
+
+    def test_qa_sorting_data_flow(self) -> None:
+        wf = spike_sort_workflow()
+        available: set[str] = set()
+        topo_order = [
+            "preprocess",
+            "detect_trial",
+            "detect_params",
+            "detect",
+            "localize",
+            "cluster_params",
+            "cluster",
+            "templates",
+            "match",
+            "qa_sorting",
+        ]
+        for node_id in topo_order:
+            node = wf.nodes[node_id]
+            missing = node.reads - available
+            assert not missing, f"Node {node_id} has unsatisfied reads: {missing}"
+            available |= node.writes


### PR DESCRIPTION
## Summary

Fixes broken spike-sort metric implementations by wiring in DARTsort's agglomerate infrastructure:

- **_compute_ccg_refractory**: Vectorized via searchsort (O(N log N) vs O(N²)), uses Poisson z-score with erf for statistically valid Q12 instead of naive `1.0 - r12` formula
- **compute_cluster_metrics**: Computes real template correlations by extracting mean waveforms from the recording via `_compute_quick_templates` helper, replacing hardcoded `corr=0.0`
- **compute_template_metrics**: Replaces O(N²) per-pair `np.corrcoef` loop with SVD-compressed matrix correlation (`_compute_template_similarities`), completing 1253 templates in <1s instead of 20+ minutes
- **merge_clusters**: New function wrapping DARTsort's `agglomerate()` for post-clustering merging with SVD template distances and linkage clustering

## Test plan

- [x] All 31 spike-sort workflow tests pass
- [x] Lint clean (ruff check)
- [x] Validated CCG Q12 gives r12≈1.0 and low Q12 for independent trains
- [x] Validated template similarity detects known-similar templates (corr > 0.5)
- [x] Validated 1253-template similarity completes in <1s (was 20+ min timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)