### PR TITLE
feat(spike-sort): add low-SNR spike recovery and accuracy evaluation stages

### DIFF
--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -2763,13 +2763,14 @@ def spike_sort_workflow() -> Workflow:
 
     Architecture: Deterministic COMPUTE → LLM INTERPRET → Deterministic EXECUTE
 
-    15 nodes (12 FnNodes + 3 AgentNodes), 14 edges, linear chain:
+    17 nodes (14 FnNodes + 3 AgentNodes), 16 edges, linear chain:
 
     preprocess → detect → localize → cluster →
     compute_cluster_metrics → gate_post_cluster → apply_cluster_actions →
     templates → compute_template_metrics → gate_post_template →
     apply_template_actions → match → compute_final_metrics →
-    gate_post_match → apply_final_actions
+    gate_post_match → apply_final_actions →
+    recover_low_snr_spikes → evaluate_accuracy
     """
     nodes: dict[str, Any] = {}
 
@@ -2970,7 +2971,39 @@ def spike_sort_workflow() -> Workflow:
         writes={"sorting_final/", "sorting_result.json"},
     )
 
-    # ── Edges (14-edge linear pipeline) ───────────────────────────
+    # ── Stage 7: Low-SNR Recovery (deterministic) ────────────────
+
+    nodes["recover_low_snr_spikes"] = FnNode(
+        id="recover_low_snr_spikes",
+        callable_name="factory.workflow.spike_sort_stages:recover_low_snr_spikes",
+        notes=(
+            "Correlation-based recovery of unassigned and low-count spikes. "
+            "Identifies spikes with label=-1 and units with <500 spikes. "
+            "For each unassigned spike: correlates with templates, applies "
+            "lower threshold (0.6x normal) for low-count units, verifies "
+            "via residual energy (RMS(residual) < 0.3 * RMS(waveform)). "
+            "Updates sorting_final/ in-place with recovered assignments."
+        ),
+        reads={"preprocessed/", "sorting_final/", "templates_refined/"},
+        writes={"sorting_final/", "recovery_stats.json"},
+    )
+
+    # ── Stage 8: Accuracy Evaluation (deterministic) ─────────────
+
+    nodes["evaluate_accuracy"] = FnNode(
+        id="evaluate_accuracy",
+        callable_name="factory.workflow.spike_sort_stages:evaluate_accuracy",
+        notes=(
+            "Compare final sorting against ground truth benchmark. "
+            "Reads benchmark.md from project root for ground truth path "
+            "and accuracy targets. Computes per-unit accuracy, recall, "
+            "and precision. Writes benchmark_result.json."
+        ),
+        reads={"sorting_final/"},
+        writes={"benchmark_result.json"},
+    )
+
+    # ── Edges (16-edge linear pipeline) ───────────────────────────
 
     edges = [
         Edge(source="preprocess", target="detect"),
@@ -2987,6 +3020,8 @@ def spike_sort_workflow() -> Workflow:
         Edge(source="match", target="compute_final_metrics"),
         Edge(source="compute_final_metrics", target="gate_post_match"),
         Edge(source="gate_post_match", target="apply_final_actions"),
+        Edge(source="apply_final_actions", target="recover_low_snr_spikes"),
+        Edge(source="recover_low_snr_spikes", target="evaluate_accuracy"),
     ]
 
     # ── Trigger ───────────────────────────────────────────────────

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -162,10 +162,13 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
     },
     "spike-sort": {
         "description": (
-            "Spike sorting pipeline with LLM quality gates — executes DARTsort "
-            "algorithms with three quality gates (post-clustering, post-template, "
-            "post-matching) that compute metrics deterministically and use LLM agents "
-            "to interpret them in recording context. Use when invoked with --mode spike-sort."
+            "Spike sorting pipeline with LLM quality gates and low-SNR recovery — "
+            "executes DARTsort algorithms with three quality gates (post-clustering, "
+            "post-template, post-matching) that compute metrics deterministically and "
+            "use LLM agents to interpret them in recording context. Includes "
+            "correlation-based recovery of unassigned/low-count spikes with residual "
+            "verification, and benchmark accuracy evaluation against ground truth. "
+            "Use when invoked with --mode spike-sort."
         ),
         "argument_hint": "<project_path>",
     },

--- a/factory/workflow/spike_sort_stages.py
+++ b/factory/workflow/spike_sort_stages.py
@@ -1230,6 +1230,155 @@ def merge_clusters(project_path: str, output_dir: str) -> None:
     )
 
 
+def recover_low_snr_spikes(project_path: str, output_dir: str) -> None:
+    """Correlation-based recovery of unassigned and low-count spikes."""
+    import spikeinterface.core as si
+
+    out = Path(output_dir)
+
+    recording = si.load(out / "preprocessed")
+
+    sorting_npz = out / "sorting_final" / "sorting.npz"
+    data = np.load(sorting_npz)
+    times = data["times_samples"]
+    labels = data["labels"].copy()
+    sampling_freq = float(data["sampling_frequency"])
+
+    template_npz = out / "templates_refined" / "template_data.npz"
+    if not template_npz.exists():
+        template_npz = out / "templates" / "template_data.npz"
+    template_data = np.load(template_npz)
+    templates_arr = template_data["templates"]
+    template_unit_ids = template_data["unit_ids"]
+
+    unassigned_mask = labels < 0
+    unassigned_indices = np.flatnonzero(unassigned_mask)
+    n_unassigned = len(unassigned_indices)
+
+    unique_ids = np.unique(labels[labels >= 0])
+    unit_counts = {int(uid): int((labels == uid).sum()) for uid in unique_ids}
+    low_count_units = {uid for uid, count in unit_counts.items() if count < 500}
+
+    max_candidates = 10_000
+    if n_unassigned > max_candidates:
+        rng = np.random.default_rng(42)
+        candidate_indices = rng.choice(unassigned_indices, size=max_candidates, replace=False)
+    else:
+        candidate_indices = unassigned_indices
+
+    half_width = templates_arr.shape[1] // 2
+    n_recovered = 0
+    recovered_per_unit: dict[int, int] = {}
+
+    n_templates = len(templates_arr)
+    flat_templates = templates_arr.reshape(n_templates, -1).astype(np.float64)
+    template_means = flat_templates.mean(axis=1, keepdims=True)
+    flat_templates_centered = flat_templates - template_means
+    template_norms = np.linalg.norm(flat_templates_centered, axis=1)
+    valid_template_mask = template_norms > 1e-10
+
+    valid_flat = flat_templates_centered[valid_template_mask]
+    valid_norms = template_norms[valid_template_mask]
+    valid_flat_normed = valid_flat / valid_norms[:, np.newaxis]
+
+    n_valid = int(valid_template_mask.sum())
+    n_components = min(20, n_valid - 1, valid_flat_normed.shape[1])
+
+    if n_components > 0 and n_valid > 2:
+        U, S, Vt = np.linalg.svd(valid_flat_normed, full_matrices=False)
+        compressed_templates = U[:, :n_components] * S[:n_components]
+        c_norms = np.linalg.norm(compressed_templates, axis=1, keepdims=True)
+        compressed_templates /= np.maximum(c_norms, 1e-10)
+        projection_matrix = Vt[:n_components, :]
+    else:
+        compressed_templates = valid_flat_normed
+        projection_matrix = None
+
+    valid_unit_ids = template_unit_ids[valid_template_mask]
+
+    for idx in candidate_indices:
+        spike_time = times[idx]
+
+        start = spike_time - half_width
+        end = spike_time + half_width + 1
+        if start < 0 or end > recording.get_num_samples():
+            continue
+
+        waveform = recording.get_traces(start_frame=int(start), end_frame=int(end))
+        waveform_flat = waveform.flatten().astype(np.float64)
+        waveform_flat_centered = waveform_flat - waveform_flat.mean()
+        waveform_norm = np.linalg.norm(waveform_flat_centered)
+
+        if waveform_norm < 1e-10:
+            continue
+
+        waveform_normed = waveform_flat_centered / waveform_norm
+
+        if projection_matrix is not None:
+            waveform_projected = waveform_normed @ projection_matrix.T
+            wp_norm = np.linalg.norm(waveform_projected)
+            if wp_norm < 1e-10:
+                continue
+            waveform_projected /= wp_norm
+            correlations = compressed_templates @ waveform_projected
+        else:
+            correlations = compressed_templates @ waveform_normed
+
+        best_idx = int(np.argmax(correlations))
+        best_corr = float(correlations[best_idx])
+        best_unit_id = int(valid_unit_ids[best_idx])
+
+        base_threshold = 0.65
+        if best_unit_id in low_count_units:
+            threshold = base_threshold * 0.6
+        else:
+            threshold = base_threshold
+
+        if best_corr < threshold:
+            continue
+
+        orig_template_idx = np.flatnonzero(valid_template_mask)[best_idx]
+        best_template = templates_arr[orig_template_idx]
+        residual = waveform - best_template
+        residual_rms = float(np.sqrt(np.mean(residual ** 2)))
+        waveform_rms = float(np.sqrt(np.mean(waveform ** 2)))
+
+        if waveform_rms < 1e-10:
+            continue
+
+        if residual_rms >= 0.3 * waveform_rms:
+            continue
+
+        labels[idx] = best_unit_id
+        n_recovered += 1
+        recovered_per_unit[best_unit_id] = recovered_per_unit.get(best_unit_id, 0) + 1
+
+    np.savez(
+        sorting_npz,
+        times_samples=times,
+        labels=labels,
+        sampling_frequency=sampling_freq,
+    )
+
+    stats = {
+        "n_unassigned_before": int(n_unassigned),
+        "n_candidates_evaluated": int(len(candidate_indices)),
+        "n_recovered": n_recovered,
+        "recovery_rate": round(n_recovered / max(n_unassigned, 1), 4),
+        "n_low_count_units": len(low_count_units),
+        "per_unit_recovered": {str(k): v for k, v in recovered_per_unit.items()},
+    }
+    (out / "recovery_stats.json").write_text(json.dumps(stats, indent=2))
+
+    log.info(
+        "recover_low_snr_spikes.complete",
+        unassigned=n_unassigned,
+        recovered=n_recovered,
+        rate=stats["recovery_rate"],
+        low_count_units=len(low_count_units),
+    )
+
+
 def evaluate_accuracy(project_path: str, output_dir: str) -> dict:
     """Compare final sorting to ground truth using benchmark profile.
 

--- a/skills/workflow-spike-sort/SKILL.annotations.yaml
+++ b/skills/workflow-spike-sort/SKILL.annotations.yaml
@@ -7,111 +7,15 @@ preprocess:
   - noise_stats.json
   - preprocessed/
   edges_out:
-  - target: detect_trial
-    condition: null
-detect_trial:
-  type: FnNode
-  id: detect_trial
-  command: ''
-  reads:
-  - noise_stats.json
-  - preprocessed/
-  writes:
-  - trial_results.json
-  edges_out:
-  - target: detect_params
-    condition: null
-detect_params:
-  type: AgentNode
-  id: detect_params
-  role: researcher
-  blocking: 'true'
-  reads:
-  - noise_stats.json
-  - trial_results.json
-  writes:
-  - detection_params.json
-  edges_out:
   - target: detect
     condition: null
-  slots:
-    task_prompt_detect_params: 'You are a spike detection parameter advisor for extracellular
-      neural recordings. Read the noise statistics at {output_dir}/noise_stats.json
-      and the trial detection results at {output_dir}/trial_results.json.
-
-
-      TRIAL RESULTS: A threshold sweep has already been run on a small subset of the
-      recording at thresholds 3.5, 4.0, and 4.5. The trial_results.json file contains
-      for each threshold: spike_count, spike_rate_hz, mean_amplitude, and amplitude_distribution_percentiles.
-      Use this empirical data to inform your threshold selection.
-
-
-      IMPORTANT: DARTsort''s detection operates on standardized (SNR-unit) traces.
-      The threshold 4.0 is the DARTsort-calibrated baseline, validated on Neuropixels
-      recordings with default preprocessing. A single-channel denoiser NN runs before
-      detection and recovers low-amplitude spikes, so you do NOT need an aggressive
-      (low) threshold to catch weak units. Prefer the default. Only deviate with clear
-      evidence from the trial results AND noise statistics.
-
-
-      Select detection parameters:
-
-      - voltage_threshold (3.0-6.0): SNR threshold in standardized units. Default:
-      4.0. Do NOT lower below 4.0 unless you have strong evidence that the recording
-      has exceptionally high SNR AND the denoiser is disabled. Raising above 4.0 is
-      safer than lowering — it reduces false positives with minimal loss of real spikes.
-
-      - peak_sign (''neg'', ''pos'', ''both''): Which polarity peaks to detect. ''both''
-      is standard for extracellular recordings.
-
-      - dedup_temporal_radius (5-20): Samples to deduplicate within. 11 is typical
-      at 30kHz.
-
-      - use_denoiser (true/false): Whether to apply the single-channel denoiser NN
-      before detection. Default: true. The denoiser cleans waveforms and improves
-      detection of low-amplitude spikes. Disable only if the recording has unusual
-      artifacts that the denoiser was not trained on.
-
-
-      Decision rules:
-
-      - Start with voltage_threshold=4.0 (the calibrated default).
-
-      - Compare trial results across thresholds: if 4.0 produces a reasonable spike
-      rate (20-200 Hz per channel) keep it. If the rate is extremely high (>500 Hz),
-      consider raising to 4.5 or 5.0.
-
-      - Very noisy data (median noise >20 µV after standardization): raise to 5.0-6.0.
-
-      - Clean data (<8 µV): keep 4.0 — the denoiser handles low-amplitude recovery.
-
-      - DO NOT lower the threshold to compensate for expected low-amplitude neurons.
-      The denoiser NN is designed for this.
-
-      - Neuropixels probes → ''both'' peak_sign.
-
-
-      In your reasoning field, explicitly state why you chose your threshold. Reference
-      the trial results — cite the spike counts and rates you observed. If you chose
-      anything other than 4.0, justify the deviation with specific evidence from the
-      trial data and noise_stats.json.
-
-
-      Output your selection as a DetectionParams JSON object with a reasoning field.
-
-      Read: noise_stats.json, trial_results.json
-
-      Write output to: detection_params.json'
-    timeout_detect_params: '60'
 detect:
   type: FnNode
   id: detect
   command: ''
   reads:
-  - detection_params.json
   - preprocessed/
   writes:
-  - denoised/
   - detection_summary.json
   - detections/
   edges_out:
@@ -129,71 +33,111 @@ localize:
   - localizations.npz
   - motion/
   edges_out:
-  - target: cluster_params
-    condition: null
-cluster_params:
-  type: AgentNode
-  id: cluster_params
-  role: strategist
-  blocking: 'true'
-  reads:
-  - cluster_input_stats.json
-  writes:
-  - clustering_params.json
-  edges_out:
   - target: cluster
     condition: null
-  slots:
-    task_prompt_cluster_params: 'You are a spike clustering strategy advisor. Read
-      the cluster input statistics at {output_dir}/cluster_input_stats.json.
-
-
-      Select a clustering strategy and parameters:
-
-      - strategy: ''channel_snap'' (fast, coarse — good for <20K spikes), ''grid_snap''
-      (spatial grid — good for high density), ''dpc'' (density peak clustering — slow
-      but accurate, best for >20K spikes with drift), ''none'' (skip clustering —
-      only for pre-sorted data).
-
-      - grid_dx, grid_dz (5-50 µm): Spatial grid resolution. Smaller = more clusters
-      initially. 15 µm is typical.
-
-      - initial_steps: Refinement sequence. [''split'', ''demolish'', ''demolish'']
-      is standard. Add ''merge'' if you expect many similar units.
-
-      - n_waveforms_fit (10K-100K): Subsample size for fitting. Higher = better but
-      slower. 40K is typical.
-
-
-      Decision tree:
-
-      - spike_count < 20K → channel_snap
-
-      - drift > 15 µm → dpc with drift correction
-
-      - spike_density > 1.0 spikes/ch/s → grid_snap
-
-      - Otherwise → dpc
-
-
-      Output your selection as a ClusteringParams JSON object with a reasoning field.
-
-      Read: cluster_input_stats.json
-
-      Write output to: clustering_params.json'
-    timeout_cluster_params: '120'
 cluster:
   type: FnNode
   id: cluster
   command: ''
   reads:
-  - clustering_params.json
   - detections/
   - motion/
   - preprocessed/
   writes:
   - cluster_summary.json
   - clusters/
+  - recording_context.json
+  edges_out:
+  - target: compute_cluster_metrics
+    condition: null
+compute_cluster_metrics:
+  type: FnNode
+  id: compute_cluster_metrics
+  command: ''
+  reads:
+  - clusters/
+  - localizations.npz
+  - recording_context.json
+  writes:
+  - cluster_metrics.json
+  edges_out:
+  - target: gate_post_cluster
+    condition: null
+gate_post_cluster:
+  type: AgentNode
+  id: gate_post_cluster
+  role: health_checker
+  blocking: 'true'
+  reads:
+  - cluster_metrics.json
+  - recording_context.json
+  writes:
+  - gate1_decision.json
+  edges_out:
+  - target: apply_cluster_actions
+    condition: null
+  slots:
+    task_prompt_gate_post_cluster: "You are a spike sorting quality gate for the POST-CLUSTERING\
+      \ stage. Your role is to make context-aware decisions about cluster merging,\
+      \ splitting, and deletion — decisions that require judgment, not just threshold\
+      \ checking.\n\n## Why You Exist\n\nIf we could just apply fixed thresholds,\
+      \ we'd use deterministic code. You exist because the same metric means different\
+      \ things in different contexts. A 5% ISI violation rate might be acceptable\
+      \ contamination in a fast-spiking interneuron or catastrophic in a sparse pyramidal\
+      \ cell. Your job is to reason about what the metrics mean for THIS recording.\n\
+      \n## Step 1: Understand the Recording Context\n\nRead {output_dir}/recording_context.json\
+      \ FIRST. Before looking at any metrics, understand:\n- **Brain region:** What\
+      \ cell types are expected? What firing rates?\n- **Drift magnitude:** High drift\
+      \ (>15µm) causes fragmentation — be more aggressive about merging\n- **Recording\
+      \ duration:** Affects what spike counts are reasonable\n- **Expected cell types:**\
+      \ Purkinje cells fire at 50-150Hz; pyramidal cells at 0.5-10Hz; fast interneurons\
+      \ at 20-100Hz\n\n## Step 2: Review Cluster Metrics\n\nRead {output_dir}/cluster_metrics.json.\
+      \ For each cluster and pair, interpret the metrics IN CONTEXT:\n\n**Per-cluster\
+      \ metrics:**\n- spike_count, firing_rate_hz — Is this plausible for the expected\
+      \ cell types?\n- isi_violation_rate — Raw fraction of ISIs < 1.5ms\n- isi_fp_estimate\
+      \ — Hill formula estimate accounting for firing rate (USE THIS, not raw ISI\
+      \ rate)\n- snr — Signal quality\n- amplitude_bimodality — Suggests two populations\
+      \ merged if high\n- spatial_centroid — Position on probe\n\n**Pairwise metrics\
+      \ (clusters within 100µm):**\n- template_correlation — Waveform similarity\n\
+      - spatial_distance_um — Physical proximity\n- ccg_refractory_r12, ccg_refractory_q12\
+      \ — CCG refractory dip scores. Low R12 (<0.25) with low Q12 (<0.05) suggests\
+      \ same neuron.\n\n## Step 3: Make Decisions\n\nFor each decision, reason about\
+      \ the specific context:\n\n### MERGE Decisions\nThe clustering algorithm deliberately\
+      \ oversplits — your primary job is to identify and merge fragments of the same\
+      \ neuron.\n\nStrong merge signal: CCG shows refractory dip (independent confirmation\
+      \ that spikes come from the same neuron). If CCG is refractory AND clusters\
+      \ are nearby AND templates are similar, merge.\n\nWeak merge signal without\
+      \ CCG: Template correlation alone is not enough — similar waveforms can come\
+      \ from different neurons. Require additional evidence (proximity, firing pattern\
+      \ continuity).\n\nDrift consideration: If drift is high, waveforms from the\
+      \ same neuron may differ across time. CCG refractory is more reliable than template\
+      \ correlation in drifting recordings.\n\n### DELETE Decisions\nDelete clusters\
+      \ that are clearly not single neurons. But interpret in context:\n\n- High ISI\
+      \ + high rate: Likely garbage collector (noise unit). But check brain region\
+      \ — cerebellar Purkinje cells legitimately fire at 100+ Hz.\n- High ISI + low\
+      \ rate: Use isi_fp_estimate, not raw ISI. A 1% ISI rate at 3Hz firing indicates\
+      \ ~50% contamination (delete), while 1% at 50Hz is ~3% contamination (keep).\n\
+      - Very low spike count: May be a real but sparse neuron, or may be noise. Check\
+      \ SNR — low count + low SNR = noise.\n\n### SPLIT Decisions\nSplit when evidence\
+      \ suggests two neurons were merged:\n- Bimodal amplitude distribution (two distinct\
+      \ sizes)\n- CCG shows NO refractory dip (neurons fire independently)\n- Spatial\
+      \ spread larger than expected for one neuron\n\n## Output\n\nWrite {output_dir}/gate1_decision.json:\n\
+      ```json\n{\n  \"merge_pairs\": [[id1, id2], ...],\n  \"split_clusters\": [id,\
+      \ ...],\n  \"delete_clusters\": [id, ...],\n  \"confidence\": 0.0-1.0,\n  \"\
+      reasoning\": \"...\"\n}\n```\n\nIn your reasoning, explain HOW CONTEXT influenced\
+      \ your decisions. Don't just cite threshold values — explain what the metrics\
+      \ mean for this specific recording and why your decisions make sense.\nRead:\
+      \ cluster_metrics.json, recording_context.json\nWrite output to: gate1_decision.json"
+    timeout_gate_post_cluster: '300'
+apply_cluster_actions:
+  type: FnNode
+  id: apply_cluster_actions
+  command: ''
+  reads:
+  - clusters/
+  - gate1_decision.json
+  writes:
+  - clusters_refined/
   edges_out:
   - target: templates
     condition: null
@@ -202,62 +146,77 @@ templates:
   id: templates
   command: ''
   reads:
-  - clusters/
+  - clusters_refined/
   - motion/
   - preprocessed/
   writes:
   - template_stats.json
   - templates/
   edges_out:
-  - target: qc_templates
+  - target: compute_template_metrics
     condition: null
-qc_templates:
-  type: AgentNode
-  id: qc_templates
-  role: researcher
-  blocking: 'true'
+compute_template_metrics:
+  type: FnNode
+  id: compute_template_metrics
+  command: ''
   reads:
   - template_stats.json
+  - templates/
   writes:
-  - template_decisions.json
+  - template_metrics.json
+  edges_out:
+  - target: gate_post_template
+    condition: null
+gate_post_template:
+  type: AgentNode
+  id: gate_post_template
+  role: health_checker
+  blocking: 'true'
+  reads:
+  - recording_context.json
+  - template_metrics.json
+  writes:
+  - gate2_decision.json
+  edges_out:
+  - target: apply_template_actions
+    condition: null
+  slots:
+    task_prompt_gate_post_template: "You are a spike sorting quality gate for the\
+      \ POST-TEMPLATE stage.\n\n## Context First\n\nRead {output_dir}/recording_context.json.\
+      \ Key factors:\n- **Drift:** High drift makes templates less stable — instability\
+      \ may be drift, not noise\n- **Recording duration:** Affects expected spike\
+      \ counts per template\n\n## Template Metrics\n\nRead {output_dir}/template_metrics.json:\n\
+      - template_spike_count — More spikes = more reliable template\n- template_snr\
+      \ — Signal quality\n- template_stability — Variance over time (lower = more\
+      \ stable)\n- template_similarity_max — Correlation with most similar other template\n\
+      - template_amplitude_uv, template_spatial_spread_um\n\n## Decision Guidance\n\
+      \n**DELETE:** Templates that will cause matching problems:\n- Very few spikes\
+      \ AND low SNR — noise template, will match noise\n- But consider: a template\
+      \ with few spikes but high SNR might be a real sparse neuron, not noise\n\n\
+      **MERGE:** Near-duplicate templates:\n- Very high similarity (>0.95) suggests\
+      \ same neuron split into two templates\n- But check spatial locations — similar\
+      \ waveforms from distant sites are different neurons\n\n**Context matters:**\n\
+      - If many templates look bad, that's an upstream clustering problem, not a template\
+      \ problem — note this\n- Low stability in high-drift recordings is expected,\
+      \ not a delete signal\n\n## Output\n\nWrite {output_dir}/gate2_decision.json:\n\
+      ```json\n{\n  \"merge_pairs\": [[id1, id2], ...],\n  \"delete_templates\": [id,\
+      \ ...],\n  \"confidence\": 0.0-1.0,\n  \"reasoning\": \"...\"\n}\n```\n\nThis\
+      \ is a lighter gate. If templates look reasonable for the recording context,\
+      \ output empty action lists.\nRead: recording_context.json, template_metrics.json\n\
+      Write output to: gate2_decision.json"
+    timeout_gate_post_template: '120'
+apply_template_actions:
+  type: FnNode
+  id: apply_template_actions
+  command: ''
+  reads:
+  - gate2_decision.json
+  - templates/
+  writes:
+  - templates_refined/
   edges_out:
   - target: match
     condition: null
-  slots:
-    task_prompt_qc_templates: 'You are a spike sorting template quality control reviewer.
-      Read the template statistics at {output_dir}/template_stats.json.
-
-
-      For each template, decide: keep, discard, or merge.
-
-
-      Decision criteria:
-
-      - DISCARD if: SNR < 1.5 (noise unit), spike_count < 10 (too few spikes), or
-      ptp_amplitude < 5 µV (below noise floor).
-
-      - MERGE if: two templates have very similar spatial positions (within 25 µm)
-      AND similar PTP amplitudes (within 30%). Specify merge_with = template_id of
-      partner.
-
-      - KEEP otherwise.
-
-
-      Quality heuristics:
-
-      - Good units: SNR > 3, count > 50, stability > 0.7
-
-      - Marginal units: SNR 1.5-3, count 10-50 — keep if isolated
-
-      - High spatial_spread (>200 µm) may indicate multi-unit — flag for discard
-
-
-      Output a TemplateQCOutput JSON with decisions list and summary string.
-
-      Read: template_stats.json
-
-      Write output to: template_decisions.json'
-    timeout_qc_templates: '120'
 match:
   type: FnNode
   id: match
@@ -265,9 +224,94 @@ match:
   reads:
   - motion/
   - preprocessed/
-  - template_decisions.json
-  - templates/
+  - templates_refined/
   writes:
   - sorting/
   - sorting_result.json
+  edges_out:
+  - target: compute_final_metrics
+    condition: null
+compute_final_metrics:
+  type: FnNode
+  id: compute_final_metrics
+  command: ''
+  reads:
+  - sorting/
+  writes:
+  - final_metrics.json
+  edges_out:
+  - target: gate_post_match
+    condition: null
+gate_post_match:
+  type: AgentNode
+  id: gate_post_match
+  role: health_checker
+  blocking: 'true'
+  reads:
+  - final_metrics.json
+  - recording_context.json
+  writes:
+  - gate3_decision.json
+  edges_out:
+  - target: apply_final_actions
+    condition: null
+  slots:
+    task_prompt_gate_post_match: "You are a spike sorting quality gate for the POST-MATCHING\
+      \ stage. This is final cleanup — you cannot recover lost accuracy, only remove\
+      \ clear garbage.\n\n## Context First\n\nRead {output_dir}/recording_context.json.\
+      \ Critical:\n- **Expected cell types:** What firing rates are biologically plausible?\n\
+      - **Brain region:** Cerebellum allows 100+ Hz; cortex typically <50 Hz\n\n##\
+      \ Final Metrics\n\nRead {output_dir}/final_metrics.json:\n- final_spike_count,\
+      \ final_firing_rate_hz\n- final_isi_violation_rate (raw) vs final_isi_fp_estimate\
+      \ (rate-adjusted)\n- amplitude_cutoff, presence_ratio, snr\n\n## Decision Guidance\n\
+      \n**DELETE with confidence:**\n- Obvious garbage collectors: implausibly high\
+      \ rate + high ISI + low SNR\n- But ALWAYS check brain region first — 150 Hz\
+      \ is garbage in cortex, normal in cerebellum\n\n**DELETE with caution:**\n-\
+      \ Low spike count — might be sparse neuron, check SNR and presence_ratio\n-\
+      \ High ISI at low rate — use isi_fp_estimate to assess true contamination\n\n\
+      **MERGE conservatively:**\n- At this stage, prefer keeping units separate for\
+      \ human review\n- Only merge with overwhelming evidence (high correlation +\
+      \ refractory CCG + proximity)\n- Merging two different neurons is worse than\
+      \ keeping one neuron split\n\n## Output\n\nWrite {output_dir}/gate3_decision.json:\n\
+      ```json\n{\n  \"merge_pairs\": [[id1, id2], ...],\n  \"delete_units\": [id,\
+      \ ...],\n  \"confidence\": 0.0-1.0,\n  \"reasoning\": \"...\"\n}\n```\n\nExplain\
+      \ your reasoning in context. Don't just cite numbers — explain why this unit\
+      \ is/isn't plausible for the recording context.\nRead: final_metrics.json, recording_context.json\n\
+      Write output to: gate3_decision.json"
+    timeout_gate_post_match: '120'
+apply_final_actions:
+  type: FnNode
+  id: apply_final_actions
+  command: ''
+  reads:
+  - gate3_decision.json
+  - sorting/
+  writes:
+  - sorting_final/
+  - sorting_result.json
+  edges_out:
+  - target: recover_low_snr_spikes
+    condition: null
+recover_low_snr_spikes:
+  type: FnNode
+  id: recover_low_snr_spikes
+  command: ''
+  reads:
+  - preprocessed/
+  - sorting_final/
+  - templates_refined/
+  writes:
+  - recovery_stats.json
+  - sorting_final/
+  edges_out:
+  - target: evaluate_accuracy
+    condition: null
+evaluate_accuracy:
+  type: FnNode
+  id: evaluate_accuracy
+  command: ''
+  reads:
+  - sorting_final/
+  writes:
+  - benchmark_result.json
   edges_out: []

--- a/skills/workflow-spike-sort/SKILL.md
+++ b/skills/workflow-spike-sort/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: workflow-spike-sort
-description: "Spike sorting data pipeline with LLM-in-the-loop parameter selection. NOT a code-writing workflow — directly executes DARTsort algorithms (FnNodes) with LLM parameter advisors (AgentNodes) at three decision points: detection threshold, clustering strategy, and template QC. Input: SpikeInterface BaseRecording. Output: BaseSorting. Use with --mode spike-sort on a configured recording."
+description: "Spike sorting pipeline with LLM quality gates and low-SNR recovery — executes DARTsort algorithms with three quality gates (post-clustering, post-template, post-matching) that compute metrics deterministically and use LLM agents to interpret them in recording context. Includes correlation-based recovery of unassigned/low-count spikes with residual verification, and benchmark accuracy evaluation against ground truth. Use when invoked with --mode spike-sort."
 disable-model-invocation: true
-argument-hint: "<project_path> --mode spike-sort"
+argument-hint: "<project_path>"
 ---
 
 # Spike Sort Workflow
@@ -17,59 +17,9 @@ Bandpass filter, standardize, whiten the raw recording. Writes preprocessed reco
 
 ```
 
-## Step: Detect Trial
-
-Fast threshold sweep on a small subset of the recording. Runs dartsort.threshold() at 3 candidate thresholds (3.5, 4.0, 4.5) with early termination (stop_after_n_spikes=10000, ensure_coverage=0.05). Writes trial results to {output_dir}/trial_results.json for the detection parameter advisor to make a data-informed threshold choice.
-
-```bash
-
-```
-
-## Phase 1: Researcher — Detect Params
-
-```bash
-factory agent researcher --task "You are a spike detection parameter advisor for extracellular neural recordings. Read the noise statistics at {output_dir}/noise_stats.json and the trial detection results at {output_dir}/trial_results.json.
-
-TRIAL RESULTS: A threshold sweep has already been run on a small subset of the recording at thresholds 3.5, 4.0, and 4.5. The trial_results.json file contains for each threshold: spike_count, spike_rate_hz, mean_amplitude, and amplitude_distribution_percentiles. Use this empirical data to inform your threshold selection.
-
-IMPORTANT: DARTsort's detection operates on standardized (SNR-unit) traces. The threshold 4.0 is the DARTsort-calibrated baseline, validated on Neuropixels recordings with default preprocessing. A single-channel denoiser NN runs before detection and recovers low-amplitude spikes, so you do NOT need an aggressive (low) threshold to catch weak units. Prefer the default. Only deviate with clear evidence from the trial results AND noise statistics.
-
-Select detection parameters:
-- voltage_threshold (3.0-6.0): SNR threshold in standardized units. Default: 4.0. Do NOT lower below 4.0 unless you have strong evidence that the recording has exceptionally high SNR AND the denoiser is disabled. Raising above 4.0 is safer than lowering — it reduces false positives with minimal loss of real spikes.
-- peak_sign ('neg', 'pos', 'both'): Which polarity peaks to detect. 'both' is standard for extracellular recordings.
-- dedup_temporal_radius (5-20): Samples to deduplicate within. 11 is typical at 30kHz.
-- use_denoiser (true/false): Whether to apply the single-channel denoiser NN before detection. Default: true. The denoiser cleans waveforms and improves detection of low-amplitude spikes. Disable only if the recording has unusual artifacts that the denoiser was not trained on.
-
-Decision rules:
-- Start with voltage_threshold=4.0 (the calibrated default).
-- Compare trial results across thresholds: if 4.0 produces a reasonable spike rate (20-200 Hz per channel) keep it. If the rate is extremely high (>500 Hz), consider raising to 4.5 or 5.0.
-- Very noisy data (median noise >20 µV after standardization): raise to 5.0-6.0.
-- Clean data (<8 µV): keep 4.0 — the denoiser handles low-amplitude recovery.
-- DO NOT lower the threshold to compensate for expected low-amplitude neurons. The denoiser NN is designed for this.
-- Neuropixels probes → 'both' peak_sign.
-
-In your reasoning field, explicitly state why you chose your threshold. Reference the trial results — cite the spike counts and rates you observed. If you chose anything other than 4.0, justify the deviation with specific evidence from the trial data and noise_stats.json.
-
-Output your selection as a DetectionParams JSON object with a reasoning field.
-Read: noise_stats.json, trial_results.json
-Write output to: detection_params.json" --project "$PROJECT_PATH" --timeout 60
-```
-
-```bash
-# Artifact verification: detect_params
-_vfail=0
-_f="$PROJECT_PATH/detection_params.json"
-[ ! -f "$_f" ] && echo "VERIFY FAIL: detect_params: detection_params.json missing" && _vfail=1
-[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: detect_params: detection_params.json is empty" && _vfail=1
-[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=detect_params" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
-echo "VERIFY OK: detect_params artifacts validated"
-echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=detect_params" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
-```
-*(harness verification — DO NOT SKIP)*
-
 ## Step: Detect
 
-Threshold-crossing detection with LLM-selected parameters. Reads preprocessed recording and detection_params.json. Writes detections to {output_dir}/detections/ and summary to {output_dir}/detection_summary.json.
+Subtraction-based spike detection (SubtractionPeeler) with DARTsort defaults: detection_threshold=3.0, peak_sign='both'. No longer reads detection_params.json — parameters are hardcoded.
 
 ```bash
 
@@ -77,49 +27,121 @@ Threshold-crossing detection with LLM-selected parameters. Reads preprocessed re
 
 ## Step: Localize
 
-Point-source localization of detected spikes via Levenberg-Marquardt. Also estimates motion (drift). Writes localizations and cluster_input_stats.json for the clustering agent.
+Point-source localization of detected spikes via Levenberg-Marquardt. Also estimates motion (drift).
 
 ```bash
 
 ```
-
-## Phase 2: Strategist — Cluster Params
-
-```bash
-factory agent strategist --task "You are a spike clustering strategy advisor. Read the cluster input statistics at {output_dir}/cluster_input_stats.json.
-
-Select a clustering strategy and parameters:
-- strategy: 'channel_snap' (fast, coarse — good for <20K spikes), 'grid_snap' (spatial grid — good for high density), 'dpc' (density peak clustering — slow but accurate, best for >20K spikes with drift), 'none' (skip clustering — only for pre-sorted data).
-- grid_dx, grid_dz (5-50 µm): Spatial grid resolution. Smaller = more clusters initially. 15 µm is typical.
-- initial_steps: Refinement sequence. ['split', 'demolish', 'demolish'] is standard. Add 'merge' if you expect many similar units.
-- n_waveforms_fit (10K-100K): Subsample size for fitting. Higher = better but slower. 40K is typical.
-
-Decision tree:
-- spike_count < 20K → channel_snap
-- drift > 15 µm → dpc with drift correction
-- spike_density > 1.0 spikes/ch/s → grid_snap
-- Otherwise → dpc
-
-Output your selection as a ClusteringParams JSON object with a reasoning field.
-Read: cluster_input_stats.json
-Write output to: clustering_params.json" --project "$PROJECT_PATH" --timeout 120
-```
-
-```bash
-# Artifact verification: cluster_params
-_vfail=0
-_f="$PROJECT_PATH/clustering_params.json"
-[ ! -f "$_f" ] && echo "VERIFY FAIL: cluster_params: clustering_params.json missing" && _vfail=1
-[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: cluster_params: clustering_params.json is empty" && _vfail=1
-[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=cluster_params" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
-echo "VERIFY OK: cluster_params artifacts validated"
-echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=cluster_params" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
-```
-*(harness verification — DO NOT SKIP)*
 
 ## Step: Cluster
 
-GMM/DPC clustering with LLM-selected strategy and parameters. Reads detections and clustering_params.json. Writes clustered sorting to {output_dir}/clusters/.
+DPC clustering with hardcoded defaults: strategy='dpc', grid_dx=15.0, grid_dz=15.0. No longer reads clustering_params.json. Creates recording_context.json from config + computed drift.
+
+```bash
+
+```
+
+## Step: Compute Cluster Metrics
+
+Compute per-cluster and pairwise metrics for Gate 1. Per-cluster: spike_count, firing_rate_hz, isi_violation_rate, isi_fp_estimate (Hill formula), snr, amplitude_bimodality (Hartigan dip), spatial_centroid. Pairwise (clusters within 100um): template_correlation, spatial_distance_um, ccg_refractory_r12, ccg_refractory_q12.
+
+```bash
+
+```
+
+## Phase 1: Health Checker — Gate Post Cluster
+
+```bash
+factory agent health_checker --task "You are a spike sorting quality gate for the POST-CLUSTERING stage. Your role is to make context-aware decisions about cluster merging, splitting, and deletion — decisions that require judgment, not just threshold checking.
+
+## Why You Exist
+
+If we could just apply fixed thresholds, we'd use deterministic code. You exist because the same metric means different things in different contexts. A 5% ISI violation rate might be acceptable contamination in a fast-spiking interneuron or catastrophic in a sparse pyramidal cell. Your job is to reason about what the metrics mean for THIS recording.
+
+## Step 1: Understand the Recording Context
+
+Read {output_dir}/recording_context.json FIRST. Before looking at any metrics, understand:
+- **Brain region:** What cell types are expected? What firing rates?
+- **Drift magnitude:** High drift (>15µm) causes fragmentation — be more aggressive about merging
+- **Recording duration:** Affects what spike counts are reasonable
+- **Expected cell types:** Purkinje cells fire at 50-150Hz; pyramidal cells at 0.5-10Hz; fast interneurons at 20-100Hz
+
+## Step 2: Review Cluster Metrics
+
+Read {output_dir}/cluster_metrics.json. For each cluster and pair, interpret the metrics IN CONTEXT:
+
+**Per-cluster metrics:**
+- spike_count, firing_rate_hz — Is this plausible for the expected cell types?
+- isi_violation_rate — Raw fraction of ISIs < 1.5ms
+- isi_fp_estimate — Hill formula estimate accounting for firing rate (USE THIS, not raw ISI rate)
+- snr — Signal quality
+- amplitude_bimodality — Suggests two populations merged if high
+- spatial_centroid — Position on probe
+
+**Pairwise metrics (clusters within 100µm):**
+- template_correlation — Waveform similarity
+- spatial_distance_um — Physical proximity
+- ccg_refractory_r12, ccg_refractory_q12 — CCG refractory dip scores. Low R12 (<0.25) with low Q12 (<0.05) suggests same neuron.
+
+## Step 3: Make Decisions
+
+For each decision, reason about the specific context:
+
+### MERGE Decisions
+The clustering algorithm deliberately oversplits — your primary job is to identify and merge fragments of the same neuron.
+
+Strong merge signal: CCG shows refractory dip (independent confirmation that spikes come from the same neuron). If CCG is refractory AND clusters are nearby AND templates are similar, merge.
+
+Weak merge signal without CCG: Template correlation alone is not enough — similar waveforms can come from different neurons. Require additional evidence (proximity, firing pattern continuity).
+
+Drift consideration: If drift is high, waveforms from the same neuron may differ across time. CCG refractory is more reliable than template correlation in drifting recordings.
+
+### DELETE Decisions
+Delete clusters that are clearly not single neurons. But interpret in context:
+
+- High ISI + high rate: Likely garbage collector (noise unit). But check brain region — cerebellar Purkinje cells legitimately fire at 100+ Hz.
+- High ISI + low rate: Use isi_fp_estimate, not raw ISI. A 1% ISI rate at 3Hz firing indicates ~50% contamination (delete), while 1% at 50Hz is ~3% contamination (keep).
+- Very low spike count: May be a real but sparse neuron, or may be noise. Check SNR — low count + low SNR = noise.
+
+### SPLIT Decisions
+Split when evidence suggests two neurons were merged:
+- Bimodal amplitude distribution (two distinct sizes)
+- CCG shows NO refractory dip (neurons fire independently)
+- Spatial spread larger than expected for one neuron
+
+## Output
+
+Write {output_dir}/gate1_decision.json:
+```json
+{
+  "merge_pairs": [[id1, id2], ...],
+  "split_clusters": [id, ...],
+  "delete_clusters": [id, ...],
+  "confidence": 0.0-1.0,
+  "reasoning": "..."
+}
+```
+
+In your reasoning, explain HOW CONTEXT influenced your decisions. Don't just cite threshold values — explain what the metrics mean for this specific recording and why your decisions make sense.
+Read: cluster_metrics.json, recording_context.json
+Write output to: gate1_decision.json" --project "$PROJECT_PATH" --timeout 300
+```
+
+```bash
+# Artifact verification: gate_post_cluster
+_vfail=0
+_f="$PROJECT_PATH/gate1_decision.json"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: gate_post_cluster: gate1_decision.json missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: gate_post_cluster: gate1_decision.json is empty" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=gate_post_cluster" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: gate_post_cluster artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=gate_post_cluster" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(harness verification — DO NOT SKIP)*
+
+## Step: Apply Cluster Actions
+
+Execute Gate 1 decisions. MERGE: agglomerate refinement (merge_distance_threshold=0.3). SPLIT: TMM refinement (mixture_steps=['split']). DELETE: labels[np.isin(labels, delete_clusters)] = -1.
 
 ```bash
 
@@ -127,49 +149,188 @@ GMM/DPC clustering with LLM-selected strategy and parameters. Reads detections a
 
 ## Step: Templates
 
-Compute unit templates (average/median waveforms) from clustered spikes. Writes per-template quality statistics for the QC agent.
+Compute unit templates (average/median waveforms) from refined clusters. Reads clusters_refined/ if present, else clusters/.
 
 ```bash
 
 ```
 
-## Phase 3: Researcher — Qc Templates
+## Step: Compute Template Metrics
+
+Compute per-template metrics for Gate 2. Metrics: template_spike_count, template_snr, template_stability, template_similarity_max, template_amplitude_uv, template_spatial_spread_um.
 
 ```bash
-factory agent researcher --task "You are a spike sorting template quality control reviewer. Read the template statistics at {output_dir}/template_stats.json.
 
-For each template, decide: keep, discard, or merge.
+```
 
-Decision criteria:
-- DISCARD if: SNR < 1.5 (noise unit), spike_count < 10 (too few spikes), or ptp_amplitude < 5 µV (below noise floor).
-- MERGE if: two templates have very similar spatial positions (within 25 µm) AND similar PTP amplitudes (within 30%). Specify merge_with = template_id of partner.
-- KEEP otherwise.
+## Phase 2: Health Checker — Gate Post Template
 
-Quality heuristics:
-- Good units: SNR > 3, count > 50, stability > 0.7
-- Marginal units: SNR 1.5-3, count 10-50 — keep if isolated
-- High spatial_spread (>200 µm) may indicate multi-unit — flag for discard
+```bash
+factory agent health_checker --task "You are a spike sorting quality gate for the POST-TEMPLATE stage.
 
-Output a TemplateQCOutput JSON with decisions list and summary string.
-Read: template_stats.json
-Write output to: template_decisions.json" --project "$PROJECT_PATH" --timeout 120
+## Context First
+
+Read {output_dir}/recording_context.json. Key factors:
+- **Drift:** High drift makes templates less stable — instability may be drift, not noise
+- **Recording duration:** Affects expected spike counts per template
+
+## Template Metrics
+
+Read {output_dir}/template_metrics.json:
+- template_spike_count — More spikes = more reliable template
+- template_snr — Signal quality
+- template_stability — Variance over time (lower = more stable)
+- template_similarity_max — Correlation with most similar other template
+- template_amplitude_uv, template_spatial_spread_um
+
+## Decision Guidance
+
+**DELETE:** Templates that will cause matching problems:
+- Very few spikes AND low SNR — noise template, will match noise
+- But consider: a template with few spikes but high SNR might be a real sparse neuron, not noise
+
+**MERGE:** Near-duplicate templates:
+- Very high similarity (>0.95) suggests same neuron split into two templates
+- But check spatial locations — similar waveforms from distant sites are different neurons
+
+**Context matters:**
+- If many templates look bad, that's an upstream clustering problem, not a template problem — note this
+- Low stability in high-drift recordings is expected, not a delete signal
+
+## Output
+
+Write {output_dir}/gate2_decision.json:
+```json
+{
+  "merge_pairs": [[id1, id2], ...],
+  "delete_templates": [id, ...],
+  "confidence": 0.0-1.0,
+  "reasoning": "..."
+}
+```
+
+This is a lighter gate. If templates look reasonable for the recording context, output empty action lists.
+Read: recording_context.json, template_metrics.json
+Write output to: gate2_decision.json" --project "$PROJECT_PATH" --timeout 120
 ```
 
 ```bash
-# Artifact verification: qc_templates
+# Artifact verification: gate_post_template
 _vfail=0
-_f="$PROJECT_PATH/template_decisions.json"
-[ ! -f "$_f" ] && echo "VERIFY FAIL: qc_templates: template_decisions.json missing" && _vfail=1
-[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: qc_templates: template_decisions.json is empty" && _vfail=1
-[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=qc_templates" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
-echo "VERIFY OK: qc_templates artifacts validated"
-echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=qc_templates" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+_f="$PROJECT_PATH/gate2_decision.json"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: gate_post_template: gate2_decision.json missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: gate_post_template: gate2_decision.json is empty" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=gate_post_template" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: gate_post_template artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=gate_post_template" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
 ```
 *(harness verification — DO NOT SKIP)*
 
+## Step: Apply Template Actions
+
+Execute Gate 2 decisions. DELETE: remove templates from set. MERGE: average similar templates, update mapping.
+
+```bash
+
+```
+
 ## Step: Match
 
-Template matching refinement using QC-filtered templates. Reads template_decisions.json to filter templates before matching. Produces the final sorting result.
+Template matching refinement with post-match agglomeration. Reads templates_refined/ if present, else templates/. Produces the final sorting result.
+
+```bash
+
+```
+
+## Step: Compute Final Metrics
+
+Compute final unit metrics for Gate 3. Metrics: final_spike_count, final_firing_rate_hz, final_isi_violation_rate, final_isi_fp_estimate, amplitude_cutoff, presence_ratio, snr.
+
+```bash
+
+```
+
+## Phase 3: Health Checker — Gate Post Match
+
+```bash
+factory agent health_checker --task "You are a spike sorting quality gate for the POST-MATCHING stage. This is final cleanup — you cannot recover lost accuracy, only remove clear garbage.
+
+## Context First
+
+Read {output_dir}/recording_context.json. Critical:
+- **Expected cell types:** What firing rates are biologically plausible?
+- **Brain region:** Cerebellum allows 100+ Hz; cortex typically <50 Hz
+
+## Final Metrics
+
+Read {output_dir}/final_metrics.json:
+- final_spike_count, final_firing_rate_hz
+- final_isi_violation_rate (raw) vs final_isi_fp_estimate (rate-adjusted)
+- amplitude_cutoff, presence_ratio, snr
+
+## Decision Guidance
+
+**DELETE with confidence:**
+- Obvious garbage collectors: implausibly high rate + high ISI + low SNR
+- But ALWAYS check brain region first — 150 Hz is garbage in cortex, normal in cerebellum
+
+**DELETE with caution:**
+- Low spike count — might be sparse neuron, check SNR and presence_ratio
+- High ISI at low rate — use isi_fp_estimate to assess true contamination
+
+**MERGE conservatively:**
+- At this stage, prefer keeping units separate for human review
+- Only merge with overwhelming evidence (high correlation + refractory CCG + proximity)
+- Merging two different neurons is worse than keeping one neuron split
+
+## Output
+
+Write {output_dir}/gate3_decision.json:
+```json
+{
+  "merge_pairs": [[id1, id2], ...],
+  "delete_units": [id, ...],
+  "confidence": 0.0-1.0,
+  "reasoning": "..."
+}
+```
+
+Explain your reasoning in context. Don't just cite numbers — explain why this unit is/isn't plausible for the recording context.
+Read: final_metrics.json, recording_context.json
+Write output to: gate3_decision.json" --project "$PROJECT_PATH" --timeout 120
+```
+
+```bash
+# Artifact verification: gate_post_match
+_vfail=0
+_f="$PROJECT_PATH/gate3_decision.json"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: gate_post_match: gate3_decision.json missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: gate_post_match: gate3_decision.json is empty" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=gate_post_match" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: gate_post_match artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=gate_post_match" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(harness verification — DO NOT SKIP)*
+
+## Step: Apply Final Actions
+
+Execute Gate 3 decisions. DELETE: labels[labels == unit_id] = -1. MERGE: labels[labels == unit_b] = unit_a. Writes final cleaned sorting.
+
+```bash
+
+```
+
+## Step: Recover Low Snr Spikes
+
+Correlation-based recovery of unassigned and low-count spikes. Identifies spikes with label=-1 and units with <500 spikes. For each unassigned spike: correlates with templates, applies lower threshold (0.6x normal) for low-count units, verifies via residual energy (RMS(residual) < 0.3 * RMS(waveform)). Updates sorting_final/ in-place with recovered assignments.
+
+```bash
+
+```
+
+## Step: Evaluate Accuracy
+
+Compare final sorting against ground truth benchmark. Reads benchmark.md from project root for ground truth path and accuracy targets. Computes per-unit accuracy, recall, and precision. Writes benchmark_result.json.
 
 ```bash
 

--- a/tests/test_spike_sort_workflow.py
+++ b/tests/test_spike_sort_workflow.py
@@ -1,4 +1,4 @@
-"""Tests for the spike-sort workflow definition (15-node LLM gates version)."""
+"""Tests for the spike-sort workflow definition (17-node LLM gates version)."""
 
 from __future__ import annotations
 
@@ -22,14 +22,14 @@ def test_spike_sort_workflow_validates():
 # ── Node structure ────────────────────────────────────────────────
 
 
-def test_spike_sort_has_15_nodes():
-    """Spike-sort pipeline has exactly 15 nodes: 12 FnNodes + 3 AgentNodes."""
+def test_spike_sort_has_17_nodes():
+    """Spike-sort pipeline has exactly 17 nodes: 14 FnNodes + 3 AgentNodes."""
     wf = spike_sort_workflow()
     fn_nodes = [n for n in wf.nodes.values() if isinstance(n, FnNode)]
     agent_nodes = [n for n in wf.nodes.values() if isinstance(n, AgentNode)]
-    assert len(fn_nodes) == 12, f"Expected 12 FnNodes, got {len(fn_nodes)}"
+    assert len(fn_nodes) == 14, f"Expected 14 FnNodes, got {len(fn_nodes)}"
     assert len(agent_nodes) == 3, f"Expected 3 AgentNodes, got {len(agent_nodes)}"
-    assert len(wf.nodes) == 15
+    assert len(wf.nodes) == 17
 
 
 def test_spike_sort_node_ids():
@@ -51,6 +51,8 @@ def test_spike_sort_node_ids():
         "compute_final_metrics",
         "gate_post_match",
         "apply_final_actions",
+        "recover_low_snr_spikes",
+        "evaluate_accuracy",
     }
     assert set(wf.nodes.keys()) == expected
 
@@ -66,9 +68,9 @@ def test_spike_sort_removed_nodes_absent():
 
 
 def test_spike_sort_is_linear():
-    """Spike-sort has exactly 14 edges forming a linear chain."""
+    """Spike-sort has exactly 16 edges forming a linear chain."""
     wf = spike_sort_workflow()
-    assert len(wf.edges) == 14
+    assert len(wf.edges) == 16
 
     expected_chain = [
         ("preprocess", "detect"),
@@ -85,6 +87,8 @@ def test_spike_sort_is_linear():
         ("match", "compute_final_metrics"),
         ("compute_final_metrics", "gate_post_match"),
         ("gate_post_match", "apply_final_actions"),
+        ("apply_final_actions", "recover_low_snr_spikes"),
+        ("recover_low_snr_spikes", "evaluate_accuracy"),
     ]
     actual_chain = [(e.source, e.target) for e in wf.edges]
     assert actual_chain == expected_chain
@@ -175,6 +179,8 @@ def test_spike_sort_fn_callables():
         "apply_template_actions": "factory.workflow.spike_sort_stages:apply_template_actions",
         "compute_final_metrics": "factory.workflow.spike_sort_stages:compute_final_metrics",
         "apply_final_actions": "factory.workflow.spike_sort_stages:apply_final_actions",
+        "recover_low_snr_spikes": "factory.workflow.spike_sort_stages:recover_low_snr_spikes",
+        "evaluate_accuracy": "factory.workflow.spike_sort_stages:evaluate_accuracy",
     }
     for node_id, expected in expected_callables.items():
         node = wf.nodes[node_id]
@@ -207,6 +213,8 @@ def test_spike_sort_data_flow():
         "compute_final_metrics",
         "gate_post_match",
         "apply_final_actions",
+        "recover_low_snr_spikes",
+        "evaluate_accuracy",
     ]
 
     available: set[str] = set()
@@ -465,14 +473,14 @@ def test_spike_sort_workflow_name():
 
 
 def test_spike_sort_input_output_format():
-    """Pipeline start writes preprocessed/ and final node produces sorting_final/."""
+    """Pipeline start writes preprocessed/ and final node produces benchmark_result.json."""
     wf = spike_sort_workflow()
 
     first_node = wf.nodes[wf.start_node]
     assert "preprocessed/" in first_node.writes
 
-    final_node = wf.nodes["apply_final_actions"]
-    assert "sorting_final/" in final_node.writes
+    final_node = wf.nodes["evaluate_accuracy"]
+    assert "benchmark_result.json" in final_node.writes
 
 
 # ── Gate prompt constants ────────────────────────────────────────
@@ -507,3 +515,50 @@ def test_gate_prompts_are_context_first():
     assert "context" in GATE_POST_CLUSTER_PROMPT.lower()
     assert "context" in GATE_POST_TEMPLATE_PROMPT.lower()
     assert "context" in GATE_POST_MATCH_PROMPT.lower()
+
+
+# ── Recovery and accuracy node tests ──────────────────────────────
+
+
+def test_spike_sort_recovery_node_properties():
+    """Verify recover_low_snr_spikes node has correct reads/writes."""
+    wf = spike_sort_workflow()
+
+    recovery = wf.nodes["recover_low_snr_spikes"]
+    assert isinstance(recovery, FnNode)
+    assert recovery.callable_name == "factory.workflow.spike_sort_stages:recover_low_snr_spikes"
+    assert "preprocessed/" in recovery.reads
+    assert "sorting_final/" in recovery.reads
+    assert "templates_refined/" in recovery.reads
+    assert "sorting_final/" in recovery.writes
+    assert "recovery_stats.json" in recovery.writes
+
+
+def test_spike_sort_evaluate_accuracy_node_properties():
+    """Verify evaluate_accuracy node has correct reads/writes."""
+    wf = spike_sort_workflow()
+
+    eval_node = wf.nodes["evaluate_accuracy"]
+    assert isinstance(eval_node, FnNode)
+    assert eval_node.callable_name == "factory.workflow.spike_sort_stages:evaluate_accuracy"
+    assert "sorting_final/" in eval_node.reads
+    assert "benchmark_result.json" in eval_node.writes
+
+
+def test_spike_sort_recovery_edges():
+    """Verify recovery and eval nodes are correctly wired."""
+    wf = spike_sort_workflow()
+
+    edge_pairs = [(e.source, e.target) for e in wf.edges]
+    assert ("apply_final_actions", "recover_low_snr_spikes") in edge_pairs
+    assert ("recover_low_snr_spikes", "evaluate_accuracy") in edge_pairs
+
+
+def test_spike_sort_pipeline_ends_at_evaluate_accuracy():
+    """Verify the pipeline terminates at evaluate_accuracy."""
+    wf = spike_sort_workflow()
+
+    outgoing = [e for e in wf.edges if e.source == "evaluate_accuracy"]
+    assert len(outgoing) == 0
+
+    assert wf.start_node == "preprocess"


### PR DESCRIPTION
## Changes

- Add `recover_low_snr_spikes` FnNode: SVD-compressed correlation matching of unassigned spikes (label=-1) and low-count units (<500 spikes) against templates, with dual threshold (0.65 base, 0.39 for low-count) and residual RMS verification
- Add `evaluate_accuracy` FnNode: wires existing benchmark evaluation function into the workflow graph
- Pipeline grows from 15 nodes/14 edges to 17 nodes/16 edges (all existing nodes/edges unchanged)
- Update WORKFLOW_META description to mention low-SNR recovery
- Regenerate SKILL.md with new stages
- Update all tests for new node/edge counts and add 4 new test cases

## Verification

- `factory workflow validate spike-sort` passes (17 nodes, 16 edges)
- `pytest tests/test_spike_sort_workflow.py` — 35/35 tests pass
- `pytest tests/test_workflow_definitions.py` — 136/136 tests pass
- `ruff check` clean on all modified files