### PR TITLE
feat: add deprecation warnings for non-create/non-design CLI modes

### DIFF
--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -22,6 +22,29 @@ CEO_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "m
 RUN_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "parallel-improve", "research", "swebench"]
 
 
+DEPRECATED_MODES: frozenset[str] = frozenset({
+    "build", "improve", "research", "meta", "discover",
+    "review", "refine", "parallel-improve", "interactive",
+})
+
+
+def warn_deprecated_mode(mode: str) -> None:
+    """Emit a deprecation warning if *mode* is in the deprecated set."""
+    if mode not in DEPRECATED_MODES:
+        return
+    replacement = "design"
+    extra = ""
+    if mode == "interactive":
+        extra = " ('interactive' is an alias for 'design')"
+    log.warning("deprecated_cli_mode", mode=mode, replacement=replacement)
+    print(
+        f"WARNING: --mode {mode} is deprecated{extra}. "
+        f"Use --mode {replacement} instead. "
+        f"This mode remains functional but will be removed in a future release.",
+        file=sys.stderr,
+    )
+
+
 def _run(coro):  # noqa: ANN001, ANN202
     """Run an async coroutine synchronously."""
     return asyncio.run(coro)

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -700,12 +700,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--mode",
         choices=CEO_MODES,
         default="auto",
-        help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
-        "build, discover, improve, meta, design (research + brainstorm → spec → build), "
-        "research (autonomous research optimization), review (on-demand PR review), "
-        "qa (QA verification pipeline for PRs), "
-        "or create (meta-mode for creating or updating factory modes — "
-        'use --focus "mode_name: change" to update an existing mode)',
+        help="Operating mode. Only 'create' and 'design' are actively supported; "
+        "other modes (build, improve, research, meta, discover, review, refine, "
+        "parallel-improve, interactive) are deprecated — use --mode design instead",
     )
     p.add_argument(
         "--focus",
@@ -848,8 +845,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--mode",
         choices=RUN_MODES,
         default="auto",
-        help="Run mode: auto (default, respects in-flight cycle), auto-fresh (ignores in-flight cycle), "
-        "build, discover, improve, meta, or research",
+        help="Operating mode. Only 'create' and 'design' are actively supported; "
+        "other modes (build, improve, research, meta, discover, parallel-improve) "
+        "are deprecated — use --mode design instead",
     )
     p.add_argument(
         "--focus",

--- a/factory/cli/_wizard.py
+++ b/factory/cli/_wizard.py
@@ -392,11 +392,28 @@ def _substitute_answers(
     return result
 
 
+def _warn_wizard_deprecated() -> None:
+    """Emit a deprecation warning for the welcome wizard."""
+    log.warning(
+        "deprecated_wizard",
+        replacement="factory ceo --mode design <path>",
+    )
+    print(
+        "WARNING: The welcome wizard is deprecated. "
+        "Use 'factory ceo --mode design <path>' for new projects or "
+        "'factory ceo --mode create <idea>' to build from an idea. "
+        "The wizard remains functional but will be removed in a future release.",
+        file=sys.stderr,
+    )
+
+
 def _welcome_wizard() -> int:
     """Interactive welcome: banner -> input -> classify -> present -> dispatch."""
     from factory.cli.ceo import cmd_ceo
 
     no_color = bool(os.environ.get("NO_COLOR")) or not sys.stderr.isatty()
+
+    _warn_wizard_deprecated()
 
     _print_banner("welcome")
 

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -30,6 +30,7 @@ from factory.cli._helpers import (
     _run,
     _safe_is_dir,
     _safe_is_file,
+    warn_deprecated_mode,
 )
 from factory.cli._wizard import (
     _CLI_REF as _CLI_REF,
@@ -67,6 +68,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     mode = getattr(args, "mode", "auto")
     if mode == "interactive":
         mode = "design"
+    warn_deprecated_mode(getattr(args, "mode", "auto"))
     bg = getattr(args, "bg", False)
     bg_agents = _resolve_bg_agents(args)
     if bg and bg_agents:
@@ -2176,6 +2178,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             title, context, issue_number, issue_url = issue_resolved
             focus = f"{title} (issue #{issue_number})"
     mode = getattr(args, "mode", "auto")
+    warn_deprecated_mode(mode)
     force_fresh = mode == "auto-fresh"
     if mode in ("auto", "auto-fresh"):
         mode = _auto_detect_mode(

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -8,6 +8,7 @@ import pytest
 import structlog
 
 from factory.cli._helpers import DEPRECATED_MODES, CEO_MODES, RUN_MODES, warn_deprecated_mode
+from factory.cli._wizard import _warn_wizard_deprecated
 
 
 EXPECTED_DEPRECATED = frozenset({
@@ -110,3 +111,23 @@ class TestWarnDeprecatedMode:
             warn_deprecated_mode(mode)
         captured = capsys.readouterr()
         assert f"--mode {mode} is deprecated" in captured.err
+
+
+class TestWarnWizardDeprecated:
+    def test_wizard_deprecation_emits_structlog(self):
+        with patch("factory.cli._wizard.log") as mock_log:
+            _warn_wizard_deprecated()
+        mock_log.warning.assert_called_once_with(
+            "deprecated_wizard",
+            replacement="factory ceo --mode design <path>",
+        )
+
+    def test_wizard_deprecation_prints_stderr(self, capsys):
+        with patch("factory.cli._wizard.log"):
+            _warn_wizard_deprecated()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "welcome wizard is deprecated" in captured.err
+        assert "factory ceo --mode design" in captured.err
+        assert "factory ceo --mode create" in captured.err
+        assert "remains functional" in captured.err

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,112 @@
+"""Tests for CLI mode deprecation warnings."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import structlog
+
+from factory.cli._helpers import DEPRECATED_MODES, CEO_MODES, RUN_MODES, warn_deprecated_mode
+
+
+EXPECTED_DEPRECATED = frozenset({
+    "build", "improve", "research", "meta", "discover",
+    "review", "refine", "parallel-improve", "interactive",
+})
+
+
+def test_deprecated_modes_exact_set():
+    assert DEPRECATED_MODES == EXPECTED_DEPRECATED
+
+
+def test_deprecated_modes_subset_of_known_modes():
+    all_known = set(CEO_MODES) | set(RUN_MODES) | {"interactive", "refine", "review"}
+    for mode in DEPRECATED_MODES:
+        assert mode in all_known, f"{mode} is deprecated but not a known CLI mode"
+
+
+class TestWarnDeprecatedMode:
+    def test_deprecated_mode_emits_structlog(self):
+        cfg = structlog.get_config()
+        old_processors = cfg.get("processors", [])
+        try:
+            structlog.configure(processors=[structlog.dev.ConsoleRenderer()])
+            log = structlog.get_logger()
+            with patch.object(log, "warning") as mock_warn:
+                from factory.cli import _helpers
+                orig_log = _helpers.log
+                _helpers.log = log
+                try:
+                    warn_deprecated_mode("build")
+                finally:
+                    _helpers.log = orig_log
+            mock_warn.assert_called_once_with(
+                "deprecated_cli_mode", mode="build", replacement="design"
+            )
+        finally:
+            structlog.configure(processors=old_processors)
+
+    def test_deprecated_mode_prints_stderr(self, capsys):
+        with patch("factory.cli._helpers.log"):
+            warn_deprecated_mode("build")
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "--mode build is deprecated" in captured.err
+        assert "--mode design instead" in captured.err
+        assert "remains functional" in captured.err
+
+    def test_interactive_has_alias_note(self, capsys):
+        with patch("factory.cli._helpers.log"):
+            warn_deprecated_mode("interactive")
+        captured = capsys.readouterr()
+        assert "alias for 'design'" in captured.err
+
+    def test_create_not_deprecated(self, capsys):
+        with patch("factory.cli._helpers.log") as mock_log:
+            warn_deprecated_mode("create")
+        mock_log.warning.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_design_not_deprecated(self, capsys):
+        with patch("factory.cli._helpers.log") as mock_log:
+            warn_deprecated_mode("design")
+        mock_log.warning.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_auto_not_deprecated(self, capsys):
+        with patch("factory.cli._helpers.log") as mock_log:
+            warn_deprecated_mode("auto")
+        mock_log.warning.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_swebench_not_deprecated(self, capsys):
+        with patch("factory.cli._helpers.log") as mock_log:
+            warn_deprecated_mode("swebench")
+        mock_log.warning.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_qa_not_deprecated(self, capsys):
+        with patch("factory.cli._helpers.log") as mock_log:
+            warn_deprecated_mode("qa")
+        mock_log.warning.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_deep_qa_not_deprecated(self, capsys):
+        with patch("factory.cli._helpers.log") as mock_log:
+            warn_deprecated_mode("deep-qa")
+        mock_log.warning.assert_not_called()
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    @pytest.mark.parametrize("mode", sorted(EXPECTED_DEPRECATED))
+    def test_all_deprecated_modes_warn(self, mode, capsys):
+        with patch("factory.cli._helpers.log"):
+            warn_deprecated_mode(mode)
+        captured = capsys.readouterr()
+        assert f"--mode {mode} is deprecated" in captured.err


### PR DESCRIPTION
Closes the deprecation warning task from the design workflow.

## Changes

- **`factory/cli/_helpers.py`**: Added `DEPRECATED_MODES` frozenset (9 modes: build, improve, research, meta, discover, review, refine, parallel-improve, interactive) and `warn_deprecated_mode()` function that emits a structlog `deprecated_cli_mode` event and prints a stderr warning with migration guidance
- **`factory/cli/ceo.py`**: Calls `warn_deprecated_mode()` in both `cmd_ceo()` (after interactive→design alias mapping) and `cmd_run()` (after mode resolution from args), before mode-specific dispatch
- **`factory/cli/_main.py`**: Updated `--mode` help text for both `factory ceo` and `factory run` to note deprecated modes
- **`tests/test_deprecation.py`**: 20 tests covering: exact deprecated set membership, structlog event emission, stderr output, alias note for interactive, and verification that create/design/auto/qa/swebench are NOT deprecated

Excluded from deprecation (per user scope correction):
- Community modes: qa, deep-qa, swebench, legacybench, featurebench, programbench, terminalbench, tomswe
- Internal routing: auto, auto-fresh, skill-refine, doc-generate, doc-update, spec-generate, spec-update