### PR TITLE
fix: apply SPEC Diff from strategy to SPEC.md in improve workflow

### DIFF
--- a/factory/cli/__init__.py
+++ b/factory/cli/__init__.py
@@ -111,6 +111,7 @@ from factory.cli.review import (
     cmd_review as cmd_review,
 )
 from factory.cli.spec import (
+    cmd_spec_apply_diff as cmd_spec_apply_diff,
     cmd_spec_generate as cmd_spec_generate,
     cmd_spec_impact as cmd_spec_impact,
     cmd_spec_scope as cmd_spec_scope,

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -705,7 +705,7 @@ def build_parser() -> argparse.ArgumentParser:
         "research (autonomous research optimization), review (on-demand PR review), "
         "qa (QA verification pipeline for PRs), "
         "or create (meta-mode for creating or updating factory modes — "
-        "use --focus \"mode_name: change\" to update an existing mode)",
+        'use --focus "mode_name: change" to update an existing mode)',
     )
     p.add_argument(
         "--focus",
@@ -1107,6 +1107,15 @@ def build_parser() -> argparse.ArgumentParser:
     p_spec_scope.add_argument("--experiment", type=int, default=None, help="Experiment ID to scope")
     p_spec_update = spec_sub.add_parser("update", help="Update the repo spec from recent changes")
     p_spec_update.add_argument("path", help="Path to the project")
+    p_spec_apply_diff = spec_sub.add_parser(
+        "apply-diff", help="Apply SPEC Diff from strategy to SPEC.md"
+    )
+    p_spec_apply_diff.add_argument("path", help="Path to the project")
+    p_spec_apply_diff.add_argument(
+        "--strategy",
+        default=None,
+        help="Path to strategy file (default: .factory/strategy/current.md)",
+    )
     p_spec_impact = spec_sub.add_parser("impact", help="Show impact subgraph for a module")
     p_spec_impact.add_argument("module", help="Module name to query")
     p_spec_impact.add_argument("--project", required=True, help="Path to the project")
@@ -1217,10 +1226,13 @@ def main(argv: list[str] | None = None) -> int:
             "validate": _cli.cmd_spec_validate,
             "scope": _cli.cmd_spec_scope,
             "update": _cli.cmd_spec_update,
+            "apply-diff": _cli.cmd_spec_apply_diff,
             "impact": _cli.cmd_spec_impact,
         }.get(
             str(getattr(a, "spec_command", "")),
-            lambda args: print("Usage: factory spec {generate,validate,scope,update,impact}") or 1,
+            lambda args: (
+                print("Usage: factory spec {generate,validate,scope,update,apply-diff,impact}") or 1
+            ),
         )(a),
         "workflow": lambda a: __import__(
             "factory.workflow.cli", fromlist=["cmd_workflow"]

--- a/factory/cli/spec.py
+++ b/factory/cli/spec.py
@@ -133,6 +133,33 @@ def cmd_spec_update(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_spec_apply_diff(args: argparse.Namespace) -> int:
+    """Apply a SPEC Diff from strategy to SPEC.md."""
+    from factory.spec.apply_diff import apply_spec_diff
+
+    project_path = Path(args.path).resolve()
+    if not project_path.is_dir():
+        print(f"Error: not a directory: {project_path}", file=sys.stderr)
+        return 1
+
+    _emit_cli_event(project_path, "spec.apply_diff.started", {"path": str(project_path)})
+
+    strategy_path = None
+    if hasattr(args, "strategy") and args.strategy:
+        strategy_path = Path(args.strategy).resolve()
+
+    applied = apply_spec_diff(project_path, strategy_path=strategy_path)
+
+    if applied:
+        _emit_cli_event(project_path, "spec.apply_diff.completed", {"applied": True})
+        print("SPEC Diff applied to SPEC.md")
+    else:
+        _emit_cli_event(project_path, "spec.apply_diff.completed", {"applied": False})
+        print("No SPEC Diff to apply (skipped)")
+
+    return 0
+
+
 def cmd_spec_impact(args: argparse.Namespace) -> int:
     """Print the impact subgraph for a module from the repo spec."""
     from factory.discovery.spec import resolve_spec

--- a/factory/spec/__init__.py
+++ b/factory/spec/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from factory.spec.apply_diff import apply_spec_diff
 from factory.spec.generate import collect_source_files, generate_spec, group_into_batches
 from factory.spec.ops import (
     get_impact,
@@ -24,6 +25,7 @@ def read_spec(project_path: Path) -> str:
 
 
 __all__ = [
+    "apply_spec_diff",
     "collect_source_files",
     "generate_spec",
     "get_impact",

--- a/factory/spec/apply_diff.py
+++ b/factory/spec/apply_diff.py
@@ -1,0 +1,197 @@
+"""Apply a SPEC Diff from strategy to SPEC.md."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+@dataclass
+class ModuleEntry:
+    name: str
+    body: str
+
+
+@dataclass
+class SpecDiff:
+    added: list[ModuleEntry] = field(default_factory=list)
+    modified: list[ModuleEntry] = field(default_factory=list)
+    removed: list[ModuleEntry] = field(default_factory=list)
+
+
+def extract_spec_diff(strategy_text: str) -> SpecDiff | None:
+    """Extract the ## SPEC Diff section from strategy text.
+
+    Returns None if no SPEC Diff section is found.
+    """
+    match = re.search(
+        r"^## SPEC Diff\s*\n(.*?)(?=\n## (?!#)|\Z)",
+        strategy_text,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return None
+
+    section = match.group(1)
+    diff = SpecDiff()
+
+    category_pattern = re.compile(
+        r"^### (ADDED|MODIFIED|REMOVED) Modules\s*\n(.*?)(?=\n### |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+
+    for cat_match in category_pattern.finditer(section):
+        category = cat_match.group(1)
+        content = cat_match.group(2)
+        modules = _parse_module_entries(content)
+
+        if category == "ADDED":
+            diff.added = modules
+        elif category == "MODIFIED":
+            diff.modified = modules
+        elif category == "REMOVED":
+            diff.removed = modules
+
+    return diff
+
+
+def _parse_module_entries(text: str) -> list[ModuleEntry]:
+    """Parse #### module `<name>` entries from a category section."""
+    entries: list[ModuleEntry] = []
+    pattern = re.compile(
+        r"^#### module `([^`]+)`\s*\n(.*?)(?=\n#### |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+
+    for m in pattern.finditer(text):
+        name = m.group(1).strip()
+        body = m.group(2).strip()
+        entries.append(ModuleEntry(name=name, body=body))
+
+    return entries
+
+
+def _find_module_section(spec_lines: list[str], module_name: str) -> tuple[int, int] | None:
+    """Find the start and end line indices of a module section in SPEC.md.
+
+    Looks for patterns like:
+      ### module `<name>`
+      ### `<name>`
+      ### <name>
+    """
+    pattern = re.compile(
+        rf"^###\s+(?:module\s+)?(?:`{re.escape(module_name)}`|{re.escape(module_name)})\s*$"
+    )
+    start = None
+    for i, line in enumerate(spec_lines):
+        if start is None:
+            if pattern.match(line.strip()):
+                start = i
+        else:
+            stripped = line.strip()
+            if stripped.startswith("### ") and not stripped.startswith("#### "):
+                return (start, i)
+
+    if start is not None:
+        return (start, len(spec_lines))
+
+    return None
+
+
+def _build_module_block(entry: ModuleEntry) -> str:
+    """Build a markdown block for a module entry."""
+    return f"### module `{entry.name}`\n\n{entry.body}\n"
+
+
+def apply_spec_diff(project_path: Path, strategy_path: Path | None = None) -> bool:
+    """Apply the SPEC Diff from strategy to SPEC.md.
+
+    Args:
+        project_path: Root of the target project.
+        strategy_path: Path to the strategy file containing the SPEC Diff.
+            Defaults to project_path / ".factory" / "strategy" / "current.md".
+
+    Returns:
+        True if changes were applied, False if no SPEC Diff section was found.
+    """
+    if strategy_path is None:
+        strategy_path = project_path / ".factory" / "strategy" / "current.md"
+
+    if not strategy_path.is_file():
+        log.info("spec.apply_diff.skip", reason="strategy file not found", path=str(strategy_path))
+        return False
+
+    strategy_text = strategy_path.read_text(encoding="utf-8")
+    diff = extract_spec_diff(strategy_text)
+
+    if diff is None:
+        log.info("spec.apply_diff.skip", reason="no SPEC Diff section found")
+        return False
+
+    if not diff.added and not diff.modified and not diff.removed:
+        log.info("spec.apply_diff.skip", reason="SPEC Diff section is empty")
+        return False
+
+    spec_path = project_path / "SPEC.md"
+
+    if spec_path.is_file():
+        spec_text = spec_path.read_text(encoding="utf-8")
+    else:
+        log.info("spec.apply_diff.create", path=str(spec_path))
+        spec_text = "# SPEC\n"
+
+    spec_lines = spec_text.splitlines(keepends=True)
+
+    removed_count = 0
+    for entry in diff.removed:
+        bounds = _find_module_section([line.rstrip("\n") for line in spec_lines], entry.name)
+        if bounds:
+            start, end = bounds
+            del spec_lines[start:end]
+            removed_count += 1
+            log.debug("spec.apply_diff.removed", module=entry.name)
+        else:
+            log.warning("spec.apply_diff.remove_miss", module=entry.name)
+
+    modified_count = 0
+    for entry in diff.modified:
+        plain_lines = [line.rstrip("\n") for line in spec_lines]
+        bounds = _find_module_section(plain_lines, entry.name)
+        if bounds:
+            start, end = bounds
+            replacement = _build_module_block(entry) + "\n"
+            spec_lines[start:end] = [replacement]
+            modified_count += 1
+            log.debug("spec.apply_diff.modified", module=entry.name)
+        else:
+            log.warning(
+                "spec.apply_diff.modify_miss",
+                module=entry.name,
+                action="appending as new section",
+            )
+            spec_lines.append("\n" + _build_module_block(entry) + "\n")
+            modified_count += 1
+
+    added_count = 0
+    for entry in diff.added:
+        block = "\n" + _build_module_block(entry) + "\n"
+        spec_lines.append(block)
+        added_count += 1
+        log.debug("spec.apply_diff.added", module=entry.name)
+
+    spec_path.write_text("".join(spec_lines), encoding="utf-8")
+
+    log.info(
+        "spec.apply_diff.complete",
+        added=added_count,
+        modified=modified_count,
+        removed=removed_count,
+        output=str(spec_path),
+    )
+
+    return True

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -172,7 +172,11 @@ def build_workflow() -> Workflow:
             "differentiation opportunities."
         ),
         writes={".factory/strategy/research-similar.md"},
-        post_checks=[ArtifactCheck(path=".factory/strategy/research-similar.md", must_exist=True, min_size=50)],
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-similar.md", must_exist=True, min_size=50
+            )
+        ],
     )
     nodes["researcher_techstack"] = AgentNode(
         id="researcher_techstack",
@@ -187,7 +191,11 @@ def build_workflow() -> Workflow:
             "framework comparisons."
         ),
         writes={".factory/strategy/research-techstack.md"},
-        post_checks=[ArtifactCheck(path=".factory/strategy/research-techstack.md", must_exist=True, min_size=50)],
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-techstack.md", must_exist=True, min_size=50
+            )
+        ],
     )
     nodes["researcher_pitfalls"] = AgentNode(
         id="researcher_pitfalls",
@@ -202,7 +210,11 @@ def build_workflow() -> Workflow:
             "lessons from similar past builds."
         ),
         writes={".factory/strategy/research-pitfalls.md"},
-        post_checks=[ArtifactCheck(path=".factory/strategy/research-pitfalls.md", must_exist=True, min_size=50)],
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-pitfalls.md", must_exist=True, min_size=50
+            )
+        ],
     )
 
     # Join
@@ -243,12 +255,14 @@ def build_workflow() -> Workflow:
         ),
         reads={".factory/strategy/research-combined.md"},
         writes={".factory/strategy/current.md"},
-        post_checks=[ArtifactCheck(
-            path=".factory/strategy/current.md",
-            must_exist=True,
-            min_size=200,
-            must_contain=["### Phase 1", "### Architecture"],
-        )],
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/current.md",
+                must_exist=True,
+                min_size=200,
+                must_contain=["### Phase 1", "### Architecture"],
+            )
+        ],
     )
 
     # CEO gate on strategy quality — HARD GATE
@@ -291,12 +305,14 @@ def build_workflow() -> Workflow:
         ),
         reads={".factory/strategy/current.md"},
         writes={".factory/reviews/builder-latest.md"},
-        post_checks=[ArtifactCheck(
-            path=".factory/reviews/builder-latest.md",
-            must_exist=True,
-            min_size=500,
-            must_contain=["commit"],
-        )],
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/reviews/builder-latest.md",
+                must_exist=True,
+                min_size=500,
+                must_contain=["commit"],
+            )
+        ],
     )
 
     nodes["gate_build"] = GateNode(
@@ -526,6 +542,15 @@ def improve_workflow() -> Workflow:
         reads={".factory/strategy/current.md"},
     )
 
+    # Apply SPEC Diff from strategy to SPEC.md (no-op if absent)
+    nodes["apply_spec_diff"] = FnNode(
+        id="apply_spec_diff",
+        command="factory spec apply-diff {project_path}",
+        notes="Apply the SPEC Diff section from the strategist's plan to SPEC.md. No-op if no SPEC Diff section exists.",
+        reads={".factory/strategy/current.md"},
+        writes={"SPEC.md"},
+    )
+
     # Per-hypothesis: begin → builder → gate → deep-QA → gate_qa(max 3) → precheck → finalize → archivist
     nodes["begin"] = FnNode(
         id="begin",
@@ -642,9 +667,11 @@ def improve_workflow() -> Workflow:
         Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
         # Strategist → strategy gate
         Edge(source="strategist", target="gate_strategy"),
-        # Strategy gate
-        Edge(source="gate_strategy", target="begin", condition=VerdictType.PROCEED),
+        # Strategy gate → apply spec diff → begin
+        Edge(source="gate_strategy", target="apply_spec_diff", condition=VerdictType.PROCEED),
         Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # apply_spec_diff → begin
+        Edge(source="apply_spec_diff", target="begin"),
         # begin → builder
         Edge(source="begin", target="builder"),
         # Builder → build gate
@@ -865,10 +892,12 @@ def research_workflow() -> Workflow:
         Edge(source="researcher", target="gate_research"),
         Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
         Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
-        # Strategist → strategy gate
+        # Strategist → strategy gate → apply spec diff → begin
         Edge(source="strategist", target="gate_strategy"),
-        Edge(source="gate_strategy", target="begin", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="apply_spec_diff", condition=VerdictType.PROCEED),
         Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # apply_spec_diff → begin
+        Edge(source="apply_spec_diff", target="begin"),
         # begin → builder
         Edge(source="begin", target="builder"),
         # Builder → build gate
@@ -2442,11 +2471,13 @@ def parallel_improve_workflow() -> Workflow:
         new_node = node.model_copy(update={"id": new_id})
         exp_dq_nodes[new_id] = new_node
     for edge in dq_edges:
-        exp_dq_edges.append(Edge(
-            source=dq_rename[edge.source],
-            target=dq_rename[edge.target],
-            condition=edge.condition,
-        ))
+        exp_dq_edges.append(
+            Edge(
+                source=dq_rename[edge.source],
+                target=dq_rename[edge.target],
+                condition=edge.condition,
+            )
+        )
     nodes.update(exp_dq_nodes)
 
     nodes["exp_gate_qa"] = GateNode(
@@ -2537,25 +2568,31 @@ def parallel_improve_workflow() -> Workflow:
     ]
 
     # Per-experiment subgraph edges
-    edges.extend([
-        Edge(source="exp_begin", target="exp_builder"),
-        Edge(source="exp_builder", target="exp_gate_build"),
-        Edge(source="exp_gate_build", target="exp_health_checker", condition=VerdictType.PROCEED),
-        Edge(source="exp_gate_build", target="exp_builder", condition=VerdictType.RELOOP),
-        *exp_dq_edges,
-        Edge(source="exp_adversarial_tester", target="exp_gate_qa"),
-        Edge(source="exp_gate_qa", target="exp_gate_precheck", condition=VerdictType.PROCEED),
-        Edge(source="exp_gate_qa", target="exp_builder", condition=VerdictType.RELOOP),
-        Edge(source="exp_gate_precheck", target="exp_eval", condition=VerdictType.PROCEED),
-        Edge(source="exp_gate_precheck", target="exp_eval", condition=VerdictType.HALT),
-    ])
+    edges.extend(
+        [
+            Edge(source="exp_begin", target="exp_builder"),
+            Edge(source="exp_builder", target="exp_gate_build"),
+            Edge(
+                source="exp_gate_build", target="exp_health_checker", condition=VerdictType.PROCEED
+            ),
+            Edge(source="exp_gate_build", target="exp_builder", condition=VerdictType.RELOOP),
+            *exp_dq_edges,
+            Edge(source="exp_adversarial_tester", target="exp_gate_qa"),
+            Edge(source="exp_gate_qa", target="exp_gate_precheck", condition=VerdictType.PROCEED),
+            Edge(source="exp_gate_qa", target="exp_builder", condition=VerdictType.RELOOP),
+            Edge(source="exp_gate_precheck", target="exp_eval", condition=VerdictType.PROCEED),
+            Edge(source="exp_gate_precheck", target="exp_eval", condition=VerdictType.HALT),
+        ]
+    )
 
     # Fork → Join → Select → Archive
-    edges.extend([
-        Edge(source="fork_experiments", target="join_experiments"),
-        Edge(source="join_experiments", target="select_best"),
-        Edge(source="select_best", target="archivist"),
-    ])
+    edges.extend(
+        [
+            Edge(source="fork_experiments", target="join_experiments"),
+            Edge(source="join_experiments", target="select_best"),
+            Edge(source="select_best", target="archivist"),
+        ]
+    )
 
     def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
         return state == ProjectState.HAS_FACTORY and ctx.get("mode") == "parallel-improve"

--- a/tests/test_spec_apply_diff.py
+++ b/tests/test_spec_apply_diff.py
@@ -1,0 +1,288 @@
+"""Tests for factory.spec.apply_diff — SPEC Diff application from strategy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+from factory.spec.apply_diff import (
+    apply_spec_diff,
+    extract_spec_diff,
+)
+from factory.workflow.definitions import improve_workflow
+from factory.workflow.primitives import FnNode
+
+
+# ── extract_spec_diff ──────────────────────────────────────────
+
+
+class TestExtractSpecDiff:
+    def test_no_spec_diff_section(self) -> None:
+        text = "## Strategy\n\nSome strategy content.\n\n## Hypotheses\n\nH1 stuff."
+        assert extract_spec_diff(text) is None
+
+    def test_empty_spec_diff(self) -> None:
+        text = "## SPEC Diff\n\n## Hypotheses\n\nH1 stuff."
+        diff = extract_spec_diff(text)
+        assert diff is not None
+        assert diff.added == []
+        assert diff.modified == []
+        assert diff.removed == []
+
+    def test_added_modules(self) -> None:
+        text = (
+            "## SPEC Diff\n\n"
+            "### ADDED Modules\n\n"
+            "#### module `auth`\n"
+            "- **Path:** `factory/auth.py`\n"
+            "- **Role:** Authentication module\n"
+            "- **Depends on:** `store`\n\n"
+            "#### module `cache`\n"
+            "- **Path:** `factory/cache.py`\n"
+            "- **Role:** Caching layer\n"
+            "- **Depends on:** `store`\n\n"
+            "## Hypotheses\n\nH1 stuff."
+        )
+        diff = extract_spec_diff(text)
+        assert diff is not None
+        assert len(diff.added) == 2
+        assert diff.added[0].name == "auth"
+        assert "factory/auth.py" in diff.added[0].body
+        assert diff.added[1].name == "cache"
+
+    def test_modified_modules(self) -> None:
+        text = (
+            "## SPEC Diff\n\n"
+            "### MODIFIED Modules\n\n"
+            "#### module `store`\n"
+            "- **Previously:** Handles experiment data\n"
+            "- **Now:** Handles experiment data and caching\n"
+            "- **Rationale:** Added cache support\n\n"
+            "## Hypotheses\n"
+        )
+        diff = extract_spec_diff(text)
+        assert diff is not None
+        assert len(diff.modified) == 1
+        assert diff.modified[0].name == "store"
+        assert "caching" in diff.modified[0].body
+
+    def test_removed_modules(self) -> None:
+        text = (
+            "## SPEC Diff\n\n"
+            "### REMOVED Modules\n\n"
+            "#### module `legacy`\n"
+            "- **Previously:** Old compatibility layer\n"
+            "- **Rationale:** No longer needed\n\n"
+            "## Hypotheses\n"
+        )
+        diff = extract_spec_diff(text)
+        assert diff is not None
+        assert len(diff.removed) == 1
+        assert diff.removed[0].name == "legacy"
+
+    def test_all_categories(self) -> None:
+        text = (
+            "## SPEC Diff\n\n"
+            "### ADDED Modules\n\n"
+            "#### module `new_mod`\n"
+            "- **Path:** `factory/new_mod.py`\n"
+            "- **Role:** New module\n\n"
+            "### MODIFIED Modules\n\n"
+            "#### module `existing`\n"
+            "- **Previously:** Old behavior\n"
+            "- **Now:** New behavior\n"
+            "- **Rationale:** Improvement\n\n"
+            "### REMOVED Modules\n\n"
+            "#### module `old_mod`\n"
+            "- **Previously:** Legacy module\n"
+            "- **Rationale:** Deprecated\n\n"
+            "## Hypotheses\n"
+        )
+        diff = extract_spec_diff(text)
+        assert diff is not None
+        assert len(diff.added) == 1
+        assert len(diff.modified) == 1
+        assert len(diff.removed) == 1
+
+
+# ── apply_spec_diff ────────────────────────────────────────────
+
+
+class TestApplySpecDiff:
+    def test_no_strategy_file(self, tmp_path: Path) -> None:
+        result = apply_spec_diff(tmp_path)
+        assert result is False
+
+    def test_no_spec_diff_section_returns_false(self, tmp_path: Path) -> None:
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "## Strategy\n\nSome content.\n\n## Hypotheses\n\nH1."
+        )
+        result = apply_spec_diff(tmp_path)
+        assert result is False
+
+    def test_added_modules_appended(self, tmp_path: Path) -> None:
+        spec_path = tmp_path / "SPEC.md"
+        spec_path.write_text("# SPEC\n\n### module `existing`\n\nExisting content.\n")
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "## SPEC Diff\n\n"
+            "### ADDED Modules\n\n"
+            "#### module `auth`\n"
+            "- **Path:** `factory/auth.py`\n"
+            "- **Role:** Auth module\n\n"
+            "## Hypotheses\n"
+        )
+
+        result = apply_spec_diff(tmp_path)
+        assert result is True
+
+        spec_text = spec_path.read_text()
+        assert "### module `auth`" in spec_text
+        assert "factory/auth.py" in spec_text
+        assert "### module `existing`" in spec_text
+
+    def test_modified_modules_replaced(self, tmp_path: Path) -> None:
+        spec_path = tmp_path / "SPEC.md"
+        spec_path.write_text(
+            "# SPEC\n\n"
+            "### module `store`\n\nOld store content.\n\n"
+            "### module `cli`\n\nCLI content.\n"
+        )
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "## SPEC Diff\n\n"
+            "### MODIFIED Modules\n\n"
+            "#### module `store`\n"
+            "- **Previously:** Old store content\n"
+            "- **Now:** New store with caching\n"
+            "- **Rationale:** Performance\n\n"
+            "## Hypotheses\n"
+        )
+
+        result = apply_spec_diff(tmp_path)
+        assert result is True
+
+        spec_text = spec_path.read_text()
+        assert "New store with caching" in spec_text
+        assert "\nOld store content.\n" not in spec_text
+        assert "### module `cli`" in spec_text
+
+    def test_removed_modules_deleted(self, tmp_path: Path) -> None:
+        spec_path = tmp_path / "SPEC.md"
+        spec_path.write_text(
+            "# SPEC\n\n### module `legacy`\n\nLegacy stuff.\n\n### module `cli`\n\nCLI content.\n"
+        )
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "## SPEC Diff\n\n"
+            "### REMOVED Modules\n\n"
+            "#### module `legacy`\n"
+            "- **Previously:** Legacy stuff\n"
+            "- **Rationale:** Deprecated\n\n"
+            "## Hypotheses\n"
+        )
+
+        result = apply_spec_diff(tmp_path)
+        assert result is True
+
+        spec_text = spec_path.read_text()
+        assert "### module `legacy`" not in spec_text
+        assert "### module `cli`" in spec_text
+
+    def test_missing_spec_creates_new_file(self, tmp_path: Path) -> None:
+        spec_path = tmp_path / "SPEC.md"
+        assert not spec_path.exists()
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "## SPEC Diff\n\n"
+            "### ADDED Modules\n\n"
+            "#### module `new_mod`\n"
+            "- **Path:** `factory/new_mod.py`\n"
+            "- **Role:** Brand new module\n\n"
+            "## Hypotheses\n"
+        )
+
+        result = apply_spec_diff(tmp_path)
+        assert result is True
+        assert spec_path.exists()
+
+        spec_text = spec_path.read_text()
+        assert "### module `new_mod`" in spec_text
+        assert "Brand new module" in spec_text
+
+    def test_custom_strategy_path(self, tmp_path: Path) -> None:
+        custom_strategy = tmp_path / "my_strategy.md"
+        custom_strategy.write_text(
+            "## SPEC Diff\n\n"
+            "### ADDED Modules\n\n"
+            "#### module `custom`\n"
+            "- **Path:** `custom.py`\n"
+            "- **Role:** Custom module\n\n"
+            "## End\n"
+        )
+
+        result = apply_spec_diff(tmp_path, strategy_path=custom_strategy)
+        assert result is True
+
+        spec_text = (tmp_path / "SPEC.md").read_text()
+        assert "### module `custom`" in spec_text
+
+    def test_modify_missing_module_appends(self, tmp_path: Path) -> None:
+        spec_path = tmp_path / "SPEC.md"
+        spec_path.write_text("# SPEC\n\n### module `cli`\n\nCLI content.\n")
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True)
+        (strategy_dir / "current.md").write_text(
+            "## SPEC Diff\n\n"
+            "### MODIFIED Modules\n\n"
+            "#### module `nonexistent`\n"
+            "- **Previously:** N/A\n"
+            "- **Now:** New behavior\n"
+            "- **Rationale:** Module was missing from spec\n\n"
+            "## Hypotheses\n"
+        )
+
+        result = apply_spec_diff(tmp_path)
+        assert result is True
+
+        spec_text = spec_path.read_text()
+        assert "### module `nonexistent`" in spec_text
+        assert "New behavior" in spec_text
+
+
+# ── Improve workflow integration ───────────────────────────────
+
+
+class TestImproveWorkflowIntegration:
+    def test_apply_spec_diff_node_exists(self) -> None:
+        wf = improve_workflow()
+        assert "apply_spec_diff" in wf.nodes
+        node = wf.nodes["apply_spec_diff"]
+        assert isinstance(node, FnNode)
+        assert "apply-diff" in node.command
+
+    def test_apply_spec_diff_wired_after_gate_strategy(self) -> None:
+        wf = improve_workflow()
+        gate_strategy_targets = [e.target for e in wf.edges if e.source == "gate_strategy"]
+        assert "apply_spec_diff" in gate_strategy_targets
+
+    def test_apply_spec_diff_wired_before_begin(self) -> None:
+        wf = improve_workflow()
+        apply_targets = [e.target for e in wf.edges if e.source == "apply_spec_diff"]
+        assert "begin" in apply_targets
+
+    def test_improve_workflow_still_valid(self) -> None:
+        wf = improve_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"improve workflow has issues: {issues}"


### PR DESCRIPTION
Closes #1064

## Changes

- Add `factory/spec/apply_diff.py` with `apply_spec_diff(project_path, strategy_path)` that extracts the `## SPEC Diff` section from the strategist's plan, parses ADDED/MODIFIED/REMOVED module entries, and applies them to `SPEC.md`
- Wire as a `FnNode` (`apply_spec_diff`) between `gate_strategy` and `begin` in both the improve and research workflow graphs
- Add `factory spec apply-diff <path>` CLI subcommand for standalone use
- Add 18 tests covering extraction, application (add/modify/remove), missing SPEC.md creation, no-op when no SPEC Diff section, and workflow graph integration
- Regenerate SKILL.md files via `factory workflow export-skills`

## Test plan

- [x] `pytest tests/test_spec_apply_diff.py` — 18 tests pass
- [x] `pytest tests/test_workflow_definitions.py` — 136 tests pass (graph validation)
- [x] `ruff check factory/` — clean
- [x] `mypy factory/spec/apply_diff.py factory/cli/spec.py` — clean
- [x] `factory workflow export-skills` — regenerated successfully