### PR TITLE
ci(review): add mihirathale98 to CEO review allowlist

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
-      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail"]'), github.event.comment.user.login)
+      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 


### PR DESCRIPTION
## Summary

- Adds `mihirathale98` to the `@ceo-review` allowlist in the GitHub Actions workflow

## Test plan

- [ ] Comment `@ceo-review` on a PR from the `mihirathale98` account and verify the workflow triggers