### PR TITLE
fix: propagate resolved base_branch to CEO task instead of raw CLI flag

### DIFF
--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -388,11 +388,11 @@ def _execute_ceo(
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
 
+    base_branch = branch or _read_target_branch(project_path)
     if no_worktree:
         wt_path = project_path
         wt_branch = None
     else:
-        base_branch = branch or _read_target_branch(project_path)
         wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
 
     from factory.skill_cache import ensure_skills
@@ -437,7 +437,7 @@ def _execute_ceo(
         prompt_file=prompt_file,
         min_growth=min_growth,
         max_new=max_new,
-        branch=branch,
+        branch=base_branch,
         discover_only=discover_only,
         no_github=no_github,
         design_idea=design_idea,

--- a/factory/cli/run.py
+++ b/factory/cli/run.py
@@ -89,11 +89,11 @@ def _run_single_cycle(
     pending = read_pending(project_path)
     pending_ids = [m.id for m in pending]
 
+    base_branch = branch or _read_target_branch(project_path)
     if no_worktree:
         wt_path = project_path
         wt_branch = None
     else:
-        base_branch = branch or _read_target_branch(project_path)
         wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
 
     from factory.skill_cache import ensure_skills
@@ -109,7 +109,7 @@ def _run_single_cycle(
             prompt_file=prompt_file,
             min_growth=min_growth,
             max_new=max_new,
-            branch=branch,
+            branch=base_branch,
             discover_only=discover_only,
             no_github=no_github,
             messages=pending,

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -1,4 +1,5 @@
 """Git worktree lifecycle management for experiment isolation."""
+from __future__ import annotations
 
 import json
 import secrets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Shared pytest fixtures for remote-factory tests."""
+from __future__ import annotations
 
 import os
 from pathlib import Path

--- a/tests/test_branch_override.py
+++ b/tests/test_branch_override.py
@@ -1,0 +1,99 @@
+"""Tests for branch override propagation — ensures resolved base_branch
+reaches _build_ceo_task, not the raw CLI --branch flag."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from factory.cli._task_builder import _build_ceo_task
+from factory.cli._helpers import _read_target_branch
+
+
+class TestBuildCeoTaskBranch:
+    """_build_ceo_task emits a Branch Override section only when branch is set."""
+
+    def test_branch_override_appears_when_set(self, tmp_path: Path):
+        task = _build_ceo_task(tmp_path, "improve", branch="develop")
+        assert "## Branch Override" in task
+        assert "`develop`" in task
+
+    def test_branch_override_absent_when_none(self, tmp_path: Path):
+        task = _build_ceo_task(tmp_path, "improve", branch=None)
+        assert "## Branch Override" not in task
+
+    def test_branch_override_absent_when_empty_string(self, tmp_path: Path):
+        task = _build_ceo_task(tmp_path, "improve", branch="")
+        assert "## Branch Override" not in task
+
+
+class TestReadTargetBranch:
+    """_read_target_branch reads from config.json, falling back to git."""
+
+    def test_reads_from_config(self, tmp_path: Path):
+        config_dir = tmp_path / ".factory"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(json.dumps({"target_branch": "release/v2"}))
+        assert _read_target_branch(tmp_path) == "release/v2"
+
+    def test_falls_back_to_git(self, tmp_path: Path):
+        with patch("factory.worktree.detect_default_branch", return_value="main"):
+            assert _read_target_branch(tmp_path) == "main"
+
+    def test_ignores_malformed_config(self, tmp_path: Path):
+        config_dir = tmp_path / ".factory"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text("{bad json")
+        with patch("factory.worktree.detect_default_branch", return_value="main"):
+            assert _read_target_branch(tmp_path) == "main"
+
+
+class TestBranchPropagation:
+    """Integration: verify the resolution logic used by _execute_ceo and _run_single_cycle.
+
+    The actual callers use ``base_branch = branch or _read_target_branch(project_path)``
+    and pass base_branch (not the raw branch flag) to _build_ceo_task.
+    """
+
+    def test_config_branch_resolves_when_flag_is_none(self, tmp_path: Path):
+        """When --branch is None, base_branch resolves from factory config."""
+        config_dir = tmp_path / ".factory"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps({"target_branch": "staging"})
+        )
+
+        branch = None
+        base_branch = branch or _read_target_branch(tmp_path)
+        assert base_branch == "staging"
+
+        task = _build_ceo_task(tmp_path, "improve", branch=base_branch)
+        assert "## Branch Override" in task
+        assert "`staging`" in task
+
+    def test_explicit_flag_takes_precedence_over_config(self, tmp_path: Path):
+        """When --branch is explicitly set, it wins over config."""
+        config_dir = tmp_path / ".factory"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps({"target_branch": "staging"})
+        )
+
+        branch = "feature/custom"
+        base_branch = branch or _read_target_branch(tmp_path)
+        assert base_branch == "feature/custom"
+
+        task = _build_ceo_task(tmp_path, "improve", branch=base_branch)
+        assert "`feature/custom`" in task
+
+    def test_git_fallback_when_no_config(self, tmp_path: Path):
+        """When no config exists, base_branch falls back to git default branch."""
+        with patch("factory.worktree.detect_default_branch", return_value="main"):
+            branch = None
+            base_branch = branch or _read_target_branch(tmp_path)
+            assert base_branch == "main"
+
+            task = _build_ceo_task(tmp_path, "improve", branch=base_branch)
+            assert "## Branch Override" in task
+            assert "`main`" in task


### PR DESCRIPTION
Closes #1046

## Changes

- **factory/cli/_ceo_helpers.py**: Hoisted `base_branch = branch or _read_target_branch(project_path)` above the `if no_worktree` conditional in `_execute_ceo()`, then changed `branch=branch` to `branch=base_branch` in the `_build_ceo_task()` call
- **factory/cli/run.py**: Same fix in `_run_single_cycle()` — hoisted `base_branch` resolution and passed it to `_build_ceo_task()`
- **factory/worktree.py** + **tests/conftest.py**: Added `from __future__ import annotations` to fix Python 3.9 runtime type hint compat (pre-existing issue)
- **tests/test_branch_override.py**: 9 tests covering `_build_ceo_task` branch emission, `_read_target_branch` config/git resolution, and end-to-end propagation logic

## Root Cause

The `branch` parameter (raw CLI `--branch` flag, often `None`) was passed directly to `_build_ceo_task()` instead of the resolved `base_branch`. This meant the `## Branch Override` section in the CEO task only appeared when `--branch` was explicitly used on the command line. When the target branch came from `factory.md` config (`target_branch`) or git detection, the Builder received no branch context and committed on whatever branch the worktree happened to be on.