### PR TITLE
feat: add --overwrite flag for runtime workflow mutation

### DIFF
--- a/factory/agents/skills/workflow-tune.md
+++ b/factory/agents/skills/workflow-tune.md
@@ -1,0 +1,80 @@
+# /workflow-tune — Iterative Workflow Tuning
+
+Observe a CEO run, identify workflow issues from the transcript, and fix them via `--overwrite`.
+
+## When to Use
+
+- After a CEO run produces suboptimal results (missed tests, skipped steps, wrong agent order)
+- When you want to systematically improve a workflow mode's pipeline
+- When the user asks to tune or optimize a workflow
+
+## Procedure
+
+### Step 1: Dispatch Baseline Run
+
+```bash
+factory tmux <project_path> --mode <mode>
+```
+
+Wait for the session to complete. Monitor progress:
+
+```bash
+factory tmux-capture <project_path> --lines -200
+```
+
+### Step 2: Analyze Transcript
+
+Once the session completes, capture the full output:
+
+```bash
+factory tmux-capture <project_path> --lines -500
+```
+
+Read the results:
+
+```bash
+cat <project_path>/.factory/reviews/health-check.md
+cat <project_path>/.factory/reviews/adversarial-qa.md
+factory history <project_path>
+```
+
+Identify what went wrong or could be improved. Common patterns:
+- Builder didn't run tests -> overwrite to add test instructions
+- QA was skipped -> overwrite to enforce QA step
+- Wrong agent order -> overwrite to reorder edges
+- Missing verification -> overwrite to add a gate node
+
+### Step 3: Formulate Overwrite
+
+Write a natural-language directive describing the fix:
+
+```bash
+factory tmux <project_path> --mode <mode> --overwrite 'The builder must run pytest after implementing. Add test verification to the builder prompt.'
+```
+
+### Step 4: Compare Results
+
+After the overwrite run completes:
+
+```bash
+factory eval <project_path>
+factory history <project_path>
+```
+
+Compare the baseline and overwrite runs:
+- Did the identified issue get fixed?
+- Did eval scores improve or regress?
+- Were there any new failures?
+
+### Step 5: Iterate or Stop
+
+- If the overwrite improved results, record the successful overwrite text
+- If it regressed, try a different overwrite formulation
+- Stop when the workflow produces satisfactory results
+
+## Tips
+
+- Start with small, focused overwrites (one change at a time)
+- The overwrite is interpreted by a strategist agent into structured mutations
+- Valid mutations: update_node (change fields), remove_node, add_edge, remove_edge
+- The overwrite only affects the current session — it does not persist

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -407,6 +407,18 @@ def _execute_ceo(
     if is_graphify_installed():
         extract_graph(wt_path)
 
+    overwrite = getattr(args, "overwrite", None)
+    if overwrite and mode and mode != "auto":
+        from factory.workflow.definitions import register_all
+        from factory.workflow.overwrite import apply_overwrite, generate_session_skill
+
+        workflows = register_all()
+        if mode in workflows:
+            mutated = apply_overwrite(workflows[mode], overwrite, wt_path)
+            generate_session_skill(mutated, mode, wt_path)
+        else:
+            log.warning("overwrite.mode_not_found", mode=mode)
+
     verification_settings = wt_path / ".factory" / "hooks" / f"settings-{mode}.json"
     _verification_settings_file = (
         str(verification_settings) if verification_settings.exists() else None

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -441,6 +441,9 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     p.add_argument("--no-worktree", action="store_true", default=False, dest="no_worktree",
                     help="Run directly in the project directory without creating a worktree "
                          "(useful for testing in-flight branch changes)")
+    p.add_argument("--overwrite", default=None, metavar="TEXT",
+                    help="Natural-language directive to mutate the workflow for this session "
+                         "(e.g. 'skip adversarial testing', 'add a lint step after build')")
 
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
     p.add_argument("path", help="Project path, GitHub URL, idea file path, or prompt")
@@ -514,6 +517,8 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     p.add_argument("--no-worktree", action="store_true", default=False, dest="no_worktree",
                     help="Run directly in the project directory without creating a worktree "
                          "(useful for testing in-flight branch changes)")
+    p.add_argument("--overwrite", default=None, metavar="TEXT",
+                    help="Natural-language directive to mutate the workflow for this session")
 
     p = sub.add_parser("tmux", help="Launch factory run in a detached tmux session")
     p.add_argument("path", help="Path to the project")
@@ -570,6 +575,8 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
     p.add_argument("--use-profile", action="store_true", default=False,
                     help="Inject user profile (~/.factory/profile.md) into agent prompts")
+    p.add_argument("--overwrite", default=None, metavar="TEXT",
+                    help="Natural-language directive to mutate the workflow for this session")
 
     p = sub.add_parser("tmux-ls", help="List running factory tmux sessions")
     p.add_argument("--json", action="store_true", default=False, dest="json_output",
@@ -595,6 +602,8 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
                     help="Reset session (new session ID, fresh start)")
     p.add_argument("--model", default=None,
                     help="Claude model override")
+    p.add_argument("--loop", action="store_true", default=False,
+                    help="Enable workflow-tune loop: adds /workflow-tune skill for iterative tuning")
 
     from factory.workflow.cli import add_workflow_parser
     add_workflow_parser(sub)  # type: ignore[arg-type]

--- a/factory/cli/_tmux_commands.py
+++ b/factory/cli/_tmux_commands.py
@@ -100,6 +100,8 @@ def _build_tmux_run_args(args: argparse.Namespace, project_path: Path, model: st
         parts.append("--tmux-persist")
     if getattr(args, "use_profile", False):
         parts.append("--use-profile")
+    if getattr(args, "overwrite", None):
+        parts.append(f"--overwrite {shlex.quote(args.overwrite)}")
     return " ".join(parts)
 
 

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -133,6 +133,15 @@ def cmd_refactory(args: argparse.Namespace) -> int:
     project_path = Path(getattr(args, "path", None) or Path.cwd()).resolve()
 
     setup_workspace(project_path)
+
+    loop = getattr(args, "loop", False)
+    if loop:
+        tune_skill_src = Path(__file__).parent.parent / "agents" / "skills" / "workflow-tune.md"
+        if tune_skill_src.is_file():
+            commands_dir = project_path / ".claude" / "commands"
+            commands_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(tune_skill_src, commands_dir / "workflow-tune.md")
+
     reset = getattr(args, "reset", False)
     session_file = project_path / ".refactory" / "session.json"
     is_new_session = reset or not session_file.exists()

--- a/factory/cli/run.py
+++ b/factory/cli/run.py
@@ -74,6 +74,7 @@ def _run_single_cycle(
     background: bool = False,
     run_id: str | None = None,
     no_worktree: bool = False,
+    overwrite: str | None = None,
 ) -> int:
     """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
     from factory.agents.runner import invoke_agent
@@ -99,6 +100,15 @@ def _run_single_cycle(
     from factory.skill_cache import ensure_skills
 
     ensure_skills(wt_path)
+
+    if overwrite and mode and mode != "auto":
+        from factory.workflow.definitions import register_all
+        from factory.workflow.overwrite import apply_overwrite, generate_session_skill
+
+        workflows = register_all()
+        if mode in workflows:
+            mutated = apply_overwrite(workflows[mode], overwrite, wt_path)
+            generate_session_skill(mutated, mode, wt_path)
 
     try:
         task = _build_ceo_task(
@@ -438,6 +448,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch)
     skip_improve = mode in ("improve", "meta") or discover_only
 
+    overwrite = getattr(args, "overwrite", None)
+
     if not loop:
         code = _run_single_cycle(
             project_path,
@@ -456,6 +468,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             background=background,
             run_id=run_id,
             no_worktree=no_worktree,
+            overwrite=overwrite,
             **budget_kwargs,
         )
         if code != 0:

--- a/factory/workflow/overwrite.py
+++ b/factory/workflow/overwrite.py
@@ -1,0 +1,176 @@
+"""Runtime workflow mutation via natural-language overwrite directives.
+
+The overwrite pipeline: parse directive -> strategist interprets as JSON
+mutations -> apply to Workflow -> validate -> generate session-local SKILL.md.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import structlog
+
+from factory.workflow.primitives import Edge, Workflow
+
+log = structlog.get_logger()
+
+
+def apply_overwrite(
+    workflow: Workflow,
+    overwrite_text: str,
+    project_path: Path,
+) -> Workflow:
+    """Interpret a natural-language overwrite and apply it to a workflow.
+
+    Returns the mutated workflow. Raises on validation failure.
+    """
+    log.info("overwrite.start", workflow=workflow.name, text=overwrite_text[:80])
+    mutations = _interpret_overwrite(workflow, overwrite_text, project_path)
+    mutated = _apply_mutations(workflow, mutations)
+    issues = mutated.validate_graph()
+    if issues:
+        raise ValueError(f"Mutated workflow has validation errors: {issues}")
+    log.info("overwrite.done", mutations=len(mutations))
+    return mutated
+
+
+def _interpret_overwrite(
+    workflow: Workflow,
+    overwrite_text: str,
+    project_path: Path,
+) -> list[dict]:
+    """Call headless strategist to interpret overwrite text as structured mutations."""
+    import asyncio
+
+    from factory.agents.runner import invoke_agent
+
+    node_summary = json.dumps(
+        {nid: {"type": type(n).__name__, "fields": list(type(n).model_fields.keys())}
+         for nid, n in workflow.nodes.items()},
+        indent=2,
+    )
+    edge_summary = json.dumps(
+        [{"source": e.source, "target": e.target, "condition": e.condition.value if e.condition else None}
+         for e in workflow.edges],
+        indent=2,
+    )
+
+    task = f"""You are interpreting a workflow overwrite directive.
+
+## Current workflow: {workflow.name}
+
+### Nodes
+{node_summary}
+
+### Edges
+{edge_summary}
+
+## Overwrite directive
+{overwrite_text}
+
+## Instructions
+Return ONLY a JSON array of mutation operations. No markdown, no explanation.
+Each mutation is one of:
+
+- {{"op": "update_node", "node_id": "<id>", "field": "<field_name>", "value": "<new_value>"}}
+- {{"op": "remove_node", "node_id": "<id>"}}
+- {{"op": "add_edge", "source": "<node_id>", "target": "<node_id>"}}
+- {{"op": "remove_edge", "source": "<node_id>", "target": "<node_id>"}}
+
+For update_node, valid fields depend on the node type (e.g. prompt_template, timeout, model for AgentNode).
+Return the minimal set of mutations that implements the directive."""
+
+    stdout, _code = asyncio.run(invoke_agent(
+        role="strategist",
+        task=task,
+        project_path=project_path,
+        timeout=120,
+        model="sonnet",
+    ))
+    return _parse_mutations(stdout)
+
+
+def _parse_mutations(raw: str) -> list[dict]:
+    """Extract JSON mutation array from agent output."""
+    start = raw.find("[")
+    end = raw.rfind("]")
+    if start == -1 or end == -1:
+        raise ValueError(f"No JSON array found in strategist output: {raw[:200]}")
+    return json.loads(raw[start : end + 1])
+
+
+def _apply_mutations(workflow: Workflow, mutations: list[dict]) -> Workflow:
+    """Apply a list of mutations to a workflow, returning a new Workflow."""
+    nodes = {nid: n.model_copy(deep=True) for nid, n in workflow.nodes.items()}
+    edges = [e.model_copy(deep=True) for e in workflow.edges]
+
+    for mut in mutations:
+        op = mut["op"]
+
+        if op == "update_node":
+            node_id = mut["node_id"]
+            if node_id not in nodes:
+                raise KeyError(f"Node '{node_id}' not found in workflow")
+            field = mut["field"]
+            value = mut["value"]
+            node = nodes[node_id]
+            if field not in type(node).model_fields:
+                raise KeyError(f"Field '{field}' not found on node '{node_id}' ({type(node).__name__})")
+            updated = node.model_copy(update={field: value})
+            nodes[node_id] = updated
+
+        elif op == "remove_node":
+            node_id = mut["node_id"]
+            if node_id not in nodes:
+                raise KeyError(f"Node '{node_id}' not found in workflow")
+            del nodes[node_id]
+            edges = [e for e in edges if e.source != node_id and e.target != node_id]
+
+        elif op == "add_edge":
+            src, tgt = mut["source"], mut["target"]
+            edges.append(Edge(source=src, target=tgt))
+
+        elif op == "remove_edge":
+            src, tgt = mut["source"], mut["target"]
+            before = len(edges)
+            edges = [e for e in edges if not (e.source == src and e.target == tgt)]
+            if len(edges) == before:
+                log.warning("overwrite.edge_not_found", source=src, target=tgt)
+
+        else:
+            raise ValueError(f"Unknown mutation op: {op}")
+
+    start_node = workflow.start_node if workflow.start_node in nodes else next(iter(nodes))
+    return Workflow(
+        name=workflow.name,
+        nodes=nodes,
+        edges=edges,
+        start_node=start_node,
+        terminal=workflow.terminal,
+        trigger=workflow.trigger,
+    )
+
+
+def generate_session_skill(
+    workflow: Workflow,
+    mode: str,
+    wt_path: Path,
+) -> Path:
+    """Generate SKILL.md from a mutated workflow into the worktree's skills/ dir."""
+    from factory.workflow.skill_export import export_all_skills
+
+    with tempfile.TemporaryDirectory(prefix="factory-overwrite-") as tmp:
+        tmp_path = Path(tmp)
+        export_all_skills(tmp_path, {mode: workflow})
+        src_dir = tmp_path / f"workflow-{mode}"
+        if not src_dir.exists():
+            raise FileNotFoundError(f"Expected skill dir {src_dir} not generated")
+        dst_dir = wt_path / "skills" / f"workflow-{mode}"
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src_dir, dst_dir, dirs_exist_ok=True)
+        skill_md = dst_dir / "SKILL.md"
+        log.info("overwrite.skill_generated", path=str(skill_md))
+        return skill_md

--- a/tests/test_workflow_overwrite.py
+++ b/tests/test_workflow_overwrite.py
@@ -1,0 +1,215 @@
+"""Tests for factory/workflow/overwrite.py — runtime workflow mutation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from factory.workflow.overwrite import _apply_mutations, _parse_mutations, generate_session_skill
+from factory.workflow.primitives import AgentNode, AgentRole, Edge, FnNode, Workflow
+
+
+def _minimal_workflow() -> Workflow:
+    """A minimal workflow with a builder whose prompt omits 'run tests'."""
+    return Workflow(
+        name="test-tune",
+        nodes={
+            "study": FnNode(id="study", command="factory study $PROJECT_PATH"),
+            "builder": AgentNode(
+                id="builder",
+                role=AgentRole.BUILDER,
+                prompt_template="Implement the feature. Commit changes.",
+            ),
+            "archivist": AgentNode(
+                id="archivist",
+                role=AgentRole.ARCHIVIST,
+                prompt_template="Archive results.",
+                model="haiku",
+            ),
+        },
+        edges=[
+            Edge(source="study", target="builder"),
+            Edge(source="builder", target="archivist"),
+        ],
+        start_node="study",
+    )
+
+
+class TestApplyMutationsUpdateNode:
+    def test_update_prompt_template(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [
+            {"op": "update_node", "node_id": "builder", "field": "prompt_template",
+             "value": "Implement the feature. Run pytest. Commit changes."},
+        ]
+        result = _apply_mutations(wf, mutations)
+        node = result.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert "Run pytest" in node.prompt_template
+
+    def test_update_timeout(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [
+            {"op": "update_node", "node_id": "builder", "field": "timeout", "value": 900},
+        ]
+        result = _apply_mutations(wf, mutations)
+        node = result.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert node.timeout == 900
+
+    def test_update_nonexistent_node_raises(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [
+            {"op": "update_node", "node_id": "nonexistent", "field": "timeout", "value": 900},
+        ]
+        with pytest.raises(KeyError, match="nonexistent"):
+            _apply_mutations(wf, mutations)
+
+    def test_update_nonexistent_field_raises(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [
+            {"op": "update_node", "node_id": "builder", "field": "bogus_field", "value": "x"},
+        ]
+        with pytest.raises(KeyError, match="bogus_field"):
+            _apply_mutations(wf, mutations)
+
+
+class TestApplyMutationsRemoveNode:
+    def test_remove_node_and_edges(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [{"op": "remove_node", "node_id": "archivist"}]
+        result = _apply_mutations(wf, mutations)
+        assert "archivist" not in result.nodes
+        for edge in result.edges:
+            assert edge.source != "archivist"
+            assert edge.target != "archivist"
+
+    def test_remove_nonexistent_node_raises(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [{"op": "remove_node", "node_id": "ghost"}]
+        with pytest.raises(KeyError, match="ghost"):
+            _apply_mutations(wf, mutations)
+
+
+class TestApplyMutationsAddEdge:
+    def test_add_edge(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [{"op": "add_edge", "source": "study", "target": "archivist"}]
+        result = _apply_mutations(wf, mutations)
+        added = [e for e in result.edges if e.source == "study" and e.target == "archivist"]
+        assert len(added) == 1
+
+
+class TestApplyMutationsRemoveEdge:
+    def test_remove_existing_edge(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [{"op": "remove_edge", "source": "builder", "target": "archivist"}]
+        result = _apply_mutations(wf, mutations)
+        removed = [e for e in result.edges if e.source == "builder" and e.target == "archivist"]
+        assert len(removed) == 0
+
+    def test_remove_nonexistent_edge_warns(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [{"op": "remove_edge", "source": "study", "target": "archivist"}]
+        result = _apply_mutations(wf, mutations)
+        assert len(result.edges) == 2
+
+
+class TestApplyMutationsUnknownOp:
+    def test_unknown_op_raises(self) -> None:
+        wf = _minimal_workflow()
+        mutations = [{"op": "teleport_node", "node_id": "builder"}]
+        with pytest.raises(ValueError, match="Unknown mutation op"):
+            _apply_mutations(wf, mutations)
+
+
+class TestParseMutations:
+    def test_parse_clean_json(self) -> None:
+        raw = '[{"op": "update_node", "node_id": "builder", "field": "timeout", "value": 300}]'
+        result = _parse_mutations(raw)
+        assert len(result) == 1
+        assert result[0]["op"] == "update_node"
+
+    def test_parse_json_with_surrounding_text(self) -> None:
+        raw = 'Here are the mutations:\n[{"op": "remove_node", "node_id": "archivist"}]\nDone.'
+        result = _parse_mutations(raw)
+        assert len(result) == 1
+
+    def test_parse_no_json_raises(self) -> None:
+        with pytest.raises(ValueError, match="No JSON array"):
+            _parse_mutations("no json here")
+
+
+class TestGenerateSessionSkill:
+    def test_generates_skill_md(self, tmp_path: Path) -> None:
+        wf = _minimal_workflow()
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        result = generate_session_skill(wf, "test-tune", tmp_path)
+        assert result.exists()
+        assert result.name == "SKILL.md"
+        content = result.read_text()
+        assert len(content) > 50
+
+
+class TestOverwriteForwardedThroughTmux:
+    def test_build_tmux_run_args_includes_overwrite(self) -> None:
+        import argparse
+
+        from factory.cli._tmux_commands import _build_tmux_run_args
+
+        args = argparse.Namespace(
+            mode="improve",
+            no_github=False,
+            profile=None,
+            focus=None,
+            refine=None,
+            clean_pr=None,
+            runner=None,
+            prompt=None,
+            branch=None,
+            min_growth=None,
+            max_new=None,
+            discover_only=False,
+            bg_agents=False,
+            tmux_persist=False,
+            use_profile=False,
+            overwrite="skip adversarial testing",
+        )
+        result = _build_tmux_run_args(args, Path("/tmp/proj"), model=None)
+        assert "--overwrite" in result
+        assert "skip adversarial testing" in result
+
+
+class TestTuneWorkflow:
+    """E2E test: a tune loop discovers missing test instructions and fixes them."""
+
+    def test_tune_workflow(self, tmp_path: Path) -> None:
+        wf = _minimal_workflow()
+        assert "run tests" not in wf.nodes["builder"].prompt_template  # type: ignore[union-attr]
+
+        mock_stdout = (
+            '[{"op": "update_node", "node_id": "builder", '
+            '"field": "prompt_template", '
+            '"value": "Implement the feature. Run tests with pytest -v. Commit changes."}]'
+        )
+
+        with patch("factory.agents.runner.invoke_agent", new_callable=AsyncMock, return_value=(mock_stdout, 0)):
+            from factory.workflow.overwrite import apply_overwrite
+
+            mutated = apply_overwrite(
+                wf,
+                "The builder should always run tests after implementing",
+                tmp_path,
+            )
+
+        builder = mutated.nodes["builder"]
+        assert isinstance(builder, AgentNode)
+        assert "Run tests" in builder.prompt_template
+        assert "pytest" in builder.prompt_template
+
+        skill_path = generate_session_skill(mutated, "test-tune", tmp_path)
+        skill_content = skill_path.read_text()
+        assert "Run tests" in skill_content or "pytest" in skill_content


### PR DESCRIPTION
## Summary
- Add `factory ceo --overwrite '<text>'` to mutate workflow pipelines at runtime via natural language
- A headless strategist interprets the directive into structured JSON mutations (update_node, remove_node, add_edge, remove_edge), applies them to the Workflow Pydantic model, validates the graph, and generates a session-local SKILL.md
- Add `factory refactory --loop` flag that installs the /workflow-tune slash command for iterative tuning
- Forward `--overwrite` through tmux dispatch (`_build_tmux_run_args`)

## New files
- `factory/workflow/overwrite.py` — mutation pipeline (apply_overwrite, _interpret_overwrite, _apply_mutations, generate_session_skill)
- `factory/agents/skills/workflow-tune.md` — /workflow-tune skill procedure
- `tests/test_workflow_overwrite.py` — 16 tests (mutation ops, parse edge cases, session skill gen, tmux forwarding, E2E tune loop)

## Test plan
- [x] `pytest tests/test_workflow_overwrite.py -v` — 16/16 pass
- [x] `ruff check` — clean
- [x] `mypy factory/workflow/overwrite.py` — clean
- [x] E2E: `test_tune_workflow` verifies that a workflow with a builder missing test instructions gets fixed via overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)