### PR TITLE
feat(worktree): add FACTORY_REMOVE_WORKTREE config for worktree retention

### DIFF
--- a/factory/user_config.py
+++ b/factory/user_config.py
@@ -37,6 +37,7 @@ _CONFIG_TEMPLATE = """\
 # tmux_persist = false                 # Launch agents in tmux windows
 # bg = false                           # Dispatch agents via claude --bg (agent view)
 # bg_agents = false                    # Background sub-agents only (CEO stays foreground)
+# remove_worktree = true               # Set to false to retain run worktrees after sessions
 
 # [credentials.vertex]
 # FACTORY_RUNNER = "claude"
@@ -54,17 +55,13 @@ _CONFIG_TEMPLATE = """\
 
 def _validate_profile_name(name: str) -> None:
     if not _PROFILE_NAME_RE.match(name):
-        raise ValueError(
-            f"Invalid profile name {name!r}: must match [a-zA-Z0-9_-]+"
-        )
+        raise ValueError(f"Invalid profile name {name!r}: must match [a-zA-Z0-9_-]+")
 
 
 def _validate_credential_keys(keys: dict[str, Any]) -> None:
     for k in keys:
         if not _CREDENTIAL_KEY_RE.match(k):
-            raise ValueError(
-                f"Invalid credential key {k!r}: must match [A-Z_][A-Z0-9_]*"
-            )
+            raise ValueError(f"Invalid credential key {k!r}: must match [A-Z_][A-Z0-9_]*")
 
 
 def ensure_config_file() -> Path:
@@ -104,10 +101,7 @@ def load_config(profile: str | None = None) -> dict:
         creds = data.get("credentials", {}).get(profile)
         if creds is None:
             available = list(data.get("credentials", {}).keys())
-            raise KeyError(
-                f"Profile {profile!r} not found in config.toml. "
-                f"Available: {available}"
-            )
+            raise KeyError(f"Profile {profile!r} not found in config.toml. Available: {available}")
         _validate_credential_keys(creds)
         for k, v in creds.items():
             os.environ.setdefault(k, str(v))
@@ -232,9 +226,7 @@ def migrate_env_to_config() -> str:
     try:
         import tomli_w  # type: ignore[import-untyped,import-not-found]
     except ImportError:
-        raise ImportError(
-            "tomli_w is required for migration: pip install tomli_w"
-        ) from None
+        raise ImportError("tomli_w is required for migration: pip install tomli_w") from None
 
     env_map = {
         "FACTORY_RUNNER": "runner",
@@ -249,6 +241,7 @@ def migrate_env_to_config() -> str:
         "FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE": "bob_max_invocations_per_cycle",
         "FACTORY_CEO_RESPAWN_DISABLED": "ceo_respawn_disabled",
         "FACTORY_CEO_MAX_RESPAWNS": "ceo_max_respawns",
+        "FACTORY_REMOVE_WORKTREE": "remove_worktree",
     }
 
     defaults: dict[str, str] = {}
@@ -266,8 +259,7 @@ def migrate_env_to_config() -> str:
         fd = os.open(str(CONFIG_PATH), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError:
         raise FileExistsError(
-            f"Config file already exists at {CONFIG_PATH}. "
-            "Remove it first or edit manually."
+            f"Config file already exists at {CONFIG_PATH}. Remove it first or edit manually."
         ) from None
     try:
         content = tomli_w.dumps(data)

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -1,4 +1,5 @@
 """Git worktree lifecycle management for experiment isolation."""
+
 from __future__ import annotations
 
 import json
@@ -9,6 +10,7 @@ from pathlib import Path
 from typing import Final
 
 import structlog
+
 
 log = structlog.get_logger()
 
@@ -101,12 +103,17 @@ def create_worktree(
 
     try:
         from factory.events import emit_event
-        emit_event(project_path, "worktree.created", data={
-            "run_id": run_id,
-            "worktree_path": str(wt_dir),
-            "branch": branch,
-            "base_branch": base_branch,
-        })
+
+        emit_event(
+            project_path,
+            "worktree.created",
+            data={
+                "run_id": run_id,
+                "worktree_path": str(wt_dir),
+                "branch": branch,
+                "base_branch": base_branch,
+            },
+        )
     except Exception:
         pass
 
@@ -149,12 +156,17 @@ def create_experiment_worktree(
 
     try:
         from factory.events import emit_event
-        emit_event(project_path, "experiment_worktree.created", data={
-            "exp_id": exp_id,
-            "worktree_path": str(wt_dir),
-            "branch": branch,
-            "base_commit": base_commit,
-        })
+
+        emit_event(
+            project_path,
+            "experiment_worktree.created",
+            data={
+                "exp_id": exp_id,
+                "worktree_path": str(wt_dir),
+                "branch": branch,
+                "base_commit": base_commit,
+            },
+        )
     except Exception:
         pass
 
@@ -232,11 +244,27 @@ def _has_active_sessions(worktree_path: Path) -> bool:
         if not isinstance(sessions, list):
             return False
         return any(
-            isinstance(s, dict) and s.get("state") in ("working", "blocked")
-            for s in sessions
+            isinstance(s, dict) and s.get("state") in ("working", "blocked") for s in sessions
         )
     except (subprocess.TimeoutExpired, json.JSONDecodeError, ValueError, OSError):
         return False
+
+
+def _should_remove_worktree(branch: str) -> bool:
+    """Check whether a worktree should be removed based on config.
+
+    Experiment branches (factory/exp-*) are always removed regardless of config.
+    For run branches, consults FACTORY_REMOVE_WORKTREE (default: true).
+    """
+    if branch.startswith("factory/exp-"):
+        return True
+
+    from factory import user_config
+
+    value = user_config.resolve(
+        "remove_worktree", env_var="FACTORY_REMOVE_WORKTREE", default="true"
+    )
+    return (value or "true").lower() in ("true", "1", "yes")
 
 
 def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> None:
@@ -244,14 +272,6 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
     log.info("worktree_remove", branch=branch, path=str(worktree_path))
 
     run_id = branch.removeprefix("factory/run-")
-    try:
-        from factory.events import emit_event
-        emit_event(project_path, "worktree.removed", data={
-            "run_id": run_id,
-            "branch": branch,
-        })
-    except Exception:
-        pass
 
     if worktree_path.exists():
         if _has_active_sessions(worktree_path):
@@ -262,8 +282,51 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
                 branch=branch,
             )
             return
+        if not _should_remove_worktree(branch):
+            log.info(
+                "worktree_remove_skipped",
+                reason="retention_enabled",
+                path=str(worktree_path),
+                branch=branch,
+            )
+            try:
+                from factory.events import emit_event
+
+                emit_event(
+                    project_path,
+                    "worktree.retained",
+                    data={
+                        "run_id": run_id,
+                        "branch": branch,
+                        "worktree_path": str(worktree_path),
+                    },
+                )
+            except Exception:
+                pass
+            import sys
+
+            print(
+                f"Worktree retained: {worktree_path}\n"
+                f"To clean up: git worktree remove {worktree_path} && git branch -D {branch}",
+                file=sys.stderr,
+            )
+            return
         _preserve_telemetry(worktree_path, project_path)
         shutil.rmtree(worktree_path)
+
+    try:
+        from factory.events import emit_event
+
+        emit_event(
+            project_path,
+            "worktree.removed",
+            data={
+                "run_id": run_id,
+                "branch": branch,
+            },
+        )
+    except Exception:
+        pass
 
     subprocess.run(
         ["git", "worktree", "prune"],
@@ -310,6 +373,9 @@ def prune_stale(project_path: Path) -> list[str]:
                     branch = f"factory/{name}"
                 else:
                     branch = f"factory/run-{name.removeprefix('run-')}"
+                    if not _should_remove_worktree(branch):
+                        log.info("worktree_prune_skipped", reason="retention_enabled", name=name)
+                        continue
                 shutil.rmtree(d)
                 pruned.append(f"Removed orphaned directory: {name}")
                 log.info("worktree_pruned_orphan", name=name)
@@ -418,7 +484,5 @@ def _list_active_worktrees(project_path: Path) -> set[str]:
         text=True,
     )
     return {
-        line.split(" ", 1)[1]
-        for line in result.stdout.splitlines()
-        if line.startswith("worktree ")
+        line.split(" ", 1)[1] for line in result.stdout.splitlines() if line.startswith("worktree ")
     }

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -43,7 +43,10 @@ def git_project(tmp_path: Path) -> Path:
     subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
     subprocess.run(
         ["git", "commit", "-m", "initial"],
-        cwd=project, capture_output=True, check=True, env=env,
+        cwd=project,
+        capture_output=True,
+        check=True,
+        env=env,
     )
 
     factory_dir = project / ".factory"
@@ -81,7 +84,9 @@ class TestCreateWorktree:
 
         result = subprocess.run(
             ["git", "branch", "--show-current"],
-            cwd=wt_path, capture_output=True, text=True,
+            cwd=wt_path,
+            capture_output=True,
+            text=True,
         )
         assert result.stdout.strip() == branch
 
@@ -96,17 +101,24 @@ class TestCreateWorktree:
         }
         subprocess.run(
             ["git", "checkout", "-b", "develop"],
-            cwd=git_project, capture_output=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            check=True,
         )
         (git_project / "extra.txt").write_text("dev")
         subprocess.run(["git", "add", "."], cwd=git_project, capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "-m", "dev commit"],
-            cwd=git_project, capture_output=True, check=True, env=env,
+            cwd=git_project,
+            capture_output=True,
+            check=True,
+            env=env,
         )
         subprocess.run(
             ["git", "checkout", "main"],
-            cwd=git_project, capture_output=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            check=True,
         )
 
         wt_path, _ = create_worktree(git_project, base_branch="develop")
@@ -153,7 +165,9 @@ class TestRemoveWorktree:
 
         result = subprocess.run(
             ["git", "branch", "--list", branch],
-            cwd=git_project, capture_output=True, text=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
         )
         assert branch not in result.stdout
 
@@ -168,7 +182,9 @@ class TestRemoveWorktree:
 
         result = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
-            cwd=git_project, capture_output=True, text=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
         )
         assert str(wt_path) not in result.stdout
 
@@ -259,6 +275,7 @@ class TestPruneStale:
         """Simulate a crash: create worktree, delete dir manually, then prune."""
         wt_path, branch = create_worktree(git_project)
         import shutil
+
         shutil.rmtree(wt_path)
 
         pruned = prune_stale(git_project)
@@ -266,7 +283,9 @@ class TestPruneStale:
 
         result = subprocess.run(
             ["git", "worktree", "list", "--porcelain"],
-            cwd=git_project, capture_output=True, text=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
         )
         assert str(wt_path) not in result.stdout
 
@@ -292,7 +311,10 @@ def git_project_master(tmp_path: Path) -> Path:
     subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
     subprocess.run(
         ["git", "commit", "-m", "initial"],
-        cwd=project, capture_output=True, check=True, env=env,
+        cwd=project,
+        capture_output=True,
+        check=True,
+        env=env,
     )
 
     factory_dir = project / ".factory"
@@ -330,13 +352,18 @@ class TestDetectDefaultBranch:
 
         subprocess.run(
             ["git", "init", "-b", "develop"],
-            cwd=project, capture_output=True, check=True,
+            cwd=project,
+            capture_output=True,
+            check=True,
         )
         (project / "README.md").write_text("hello")
         subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "-m", "initial"],
-            cwd=project, capture_output=True, check=True, env=env,
+            cwd=project,
+            capture_output=True,
+            check=True,
+            env=env,
         )
 
         assert detect_default_branch(project) == "develop"
@@ -358,14 +385,20 @@ class TestSHAResolution:
         """create_worktree('HEAD') resolves to the current commit SHA."""
         expected_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt_path, branch = create_worktree(git_project, "HEAD")
 
         wt_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=wt_path, capture_output=True, text=True, check=True,
+            cwd=wt_path,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         assert wt_sha == expected_sha
@@ -385,18 +418,27 @@ class TestSHAResolution:
         subprocess.run(["git", "add", "."], cwd=git_project, capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "--amend", "--no-edit"],
-            cwd=git_project, capture_output=True, check=True, env=env,
+            cwd=git_project,
+            capture_output=True,
+            check=True,
+            env=env,
         )
         amended_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt_path, branch = create_worktree(git_project, "HEAD")
 
         wt_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=wt_path, capture_output=True, text=True, check=True,
+            cwd=wt_path,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         assert wt_sha == amended_sha
@@ -427,7 +469,10 @@ class TestSessionGuard:
     def test_active_session_detected(self, tmp_path: Path) -> None:
         sessions = [{"state": "working", "id": "abc"}]
         result = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout=json.dumps(sessions), stderr="",
+            args=[],
+            returncode=0,
+            stdout=json.dumps(sessions),
+            stderr="",
         )
         with patch("factory.worktree.subprocess.run", return_value=result):
             assert _has_active_sessions(tmp_path) is True
@@ -435,7 +480,10 @@ class TestSessionGuard:
     def test_blocked_session_detected(self, tmp_path: Path) -> None:
         sessions = [{"state": "blocked", "id": "def"}]
         result = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout=json.dumps(sessions), stderr="",
+            args=[],
+            returncode=0,
+            stdout=json.dumps(sessions),
+            stderr="",
         )
         with patch("factory.worktree.subprocess.run", return_value=result):
             assert _has_active_sessions(tmp_path) is True
@@ -443,21 +491,30 @@ class TestSessionGuard:
     def test_no_active_sessions(self, tmp_path: Path) -> None:
         sessions = [{"state": "completed", "id": "xyz"}]
         result = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout=json.dumps(sessions), stderr="",
+            args=[],
+            returncode=0,
+            stdout=json.dumps(sessions),
+            stderr="",
         )
         with patch("factory.worktree.subprocess.run", return_value=result):
             assert _has_active_sessions(tmp_path) is False
 
     def test_empty_session_list(self, tmp_path: Path) -> None:
         result = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="[]", stderr="",
+            args=[],
+            returncode=0,
+            stdout="[]",
+            stderr="",
         )
         with patch("factory.worktree.subprocess.run", return_value=result):
             assert _has_active_sessions(tmp_path) is False
 
     def test_command_failure_returns_false(self, tmp_path: Path) -> None:
         result = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="", stderr="error",
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="error",
         )
         with patch("factory.worktree.subprocess.run", return_value=result):
             assert _has_active_sessions(tmp_path) is False
@@ -471,14 +528,20 @@ class TestSessionGuard:
 
     def test_invalid_json_returns_false(self, tmp_path: Path) -> None:
         result = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="not json", stderr="",
+            args=[],
+            returncode=0,
+            stdout="not json",
+            stderr="",
         )
         with patch("factory.worktree.subprocess.run", return_value=result):
             assert _has_active_sessions(tmp_path) is False
 
     def test_non_list_json_returns_false(self, tmp_path: Path) -> None:
         result = subprocess.CompletedProcess(
-            args=[], returncode=0, stdout='{"state": "working"}', stderr="",
+            args=[],
+            returncode=0,
+            stdout='{"state": "working"}',
+            stderr="",
         )
         with patch("factory.worktree.subprocess.run", return_value=result):
             assert _has_active_sessions(tmp_path) is False
@@ -538,7 +601,10 @@ class TestCreateExperimentWorktree:
     def test_creates_experiment_worktree(self, git_project: Path) -> None:
         head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt_path, branch = create_experiment_worktree(git_project, 1, head_sha)
@@ -552,7 +618,10 @@ class TestCreateExperimentWorktree:
     def test_experiment_worktree_has_independent_factory_dir(self, git_project: Path) -> None:
         head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt_path, _ = create_experiment_worktree(git_project, 2, head_sha)
@@ -565,7 +634,10 @@ class TestCreateExperimentWorktree:
     def test_experiment_worktree_has_project_files(self, git_project: Path) -> None:
         head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt_path, _ = create_experiment_worktree(git_project, 3, head_sha)
@@ -576,21 +648,29 @@ class TestCreateExperimentWorktree:
     def test_experiment_branch_checked_out(self, git_project: Path) -> None:
         head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt_path, branch = create_experiment_worktree(git_project, 4, head_sha)
 
         result = subprocess.run(
             ["git", "branch", "--show-current"],
-            cwd=wt_path, capture_output=True, text=True,
+            cwd=wt_path,
+            capture_output=True,
+            text=True,
         )
         assert result.stdout.strip() == branch
 
     def test_multiple_experiment_worktrees_coexist(self, git_project: Path) -> None:
         head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt1, br1 = create_experiment_worktree(git_project, 5, head_sha)
@@ -607,7 +687,10 @@ class TestCreateExperimentWorktree:
 
         head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt1, _ = create_experiment_worktree(git_project, 10, head_sha)
@@ -624,7 +707,10 @@ class TestCreateExperimentWorktree:
     def test_remove_experiment_worktree(self, git_project: Path) -> None:
         head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         wt_path, branch = create_experiment_worktree(git_project, 7, head_sha)
@@ -635,7 +721,9 @@ class TestCreateExperimentWorktree:
         assert not wt_path.exists()
         result = subprocess.run(
             ["git", "branch", "--list", branch],
-            cwd=git_project, capture_output=True, text=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
         )
         assert branch not in result.stdout
 
@@ -758,7 +846,9 @@ class TestBootstrapUnbornRepo:
 
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=unborn_repo, capture_output=True, text=True,
+            cwd=unborn_repo,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 0
 
@@ -776,7 +866,9 @@ class TestBootstrapUnbornRepo:
 
         result = subprocess.run(
             ["git", "log", "--oneline", "-1"],
-            cwd=unborn_repo, capture_output=True, text=True,
+            cwd=unborn_repo,
+            capture_output=True,
+            text=True,
         )
         assert "init (factory bootstrap)" in result.stdout
 
@@ -809,11 +901,15 @@ class TestDetectDefaultBranchRemoteHead:
         """detect_default_branch returns the remote HEAD ref when origin is configured."""
         subprocess.run(
             ["git", "remote", "add", "origin", str(git_project)],
-            cwd=git_project, capture_output=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            check=True,
         )
         subprocess.run(
             ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
-            cwd=git_project, capture_output=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            check=True,
         )
 
         assert detect_default_branch(git_project) == "main"
@@ -849,7 +945,10 @@ class TestEventEmissionFailure:
         """create_experiment_worktree swallows event emission errors."""
         head_sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            cwd=git_project, capture_output=True, text=True, check=True,
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
 
         with patch("factory.events.emit_event", side_effect=RuntimeError("event bus down")):
@@ -898,7 +997,10 @@ class TestCreateWorktreeExistingFactory:
         subprocess.run(["git", "add", "."], cwd=project, capture_output=True, check=True)
         subprocess.run(
             ["git", "commit", "-m", "initial with .factory"],
-            cwd=project, capture_output=True, check=True, env=env,
+            cwd=project,
+            capture_output=True,
+            check=True,
+            env=env,
         )
 
         wt_path, _ = create_worktree(project)
@@ -925,9 +1027,15 @@ class TestDetectDefaultBranchFallback:
         project.mkdir()
         subprocess.run(["git", "init"], cwd=project, capture_output=True, check=True)
 
-        with patch("factory.worktree.subprocess.run", return_value=subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="", stderr="",
-        )):
+        with patch(
+            "factory.worktree.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="",
+            ),
+        ):
             assert detect_default_branch(project) == "main"
 
 
@@ -943,8 +1051,133 @@ class TestDetectDefaultBranchUnborn:
         project.mkdir()
         subprocess.run(
             ["git", "init", "-b", "trunk"],
-            cwd=project, capture_output=True, check=True,
+            cwd=project,
+            capture_output=True,
+            check=True,
         )
 
         result = detect_default_branch(project)
         assert result == "trunk"
+
+
+class TestWorktreeRetention:
+    """Tests for FACTORY_REMOVE_WORKTREE config and _should_remove_worktree()."""
+
+    def test_remove_worktree_default_removes(
+        self, git_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_REMOVE_WORKTREE", raising=False)
+        wt_path, branch = create_worktree(git_project)
+        assert wt_path.exists()
+
+        with patch("factory.worktree._has_active_sessions", return_value=False):
+            remove_worktree(git_project, wt_path, branch)
+
+        assert not wt_path.exists()
+
+    def test_remove_worktree_false_retains(
+        self, git_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_REMOVE_WORKTREE", "false")
+        wt_path, branch = create_worktree(git_project)
+        assert wt_path.exists()
+
+        with patch("factory.worktree._has_active_sessions", return_value=False):
+            remove_worktree(git_project, wt_path, branch)
+
+        assert wt_path.exists()
+
+    def test_remove_worktree_zero_retains(
+        self, git_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_REMOVE_WORKTREE", "0")
+        wt_path, branch = create_worktree(git_project)
+        assert wt_path.exists()
+
+        with patch("factory.worktree._has_active_sessions", return_value=False):
+            remove_worktree(git_project, wt_path, branch)
+
+        assert wt_path.exists()
+
+    def test_remove_worktree_no_retains(
+        self, git_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_REMOVE_WORKTREE", "no")
+        wt_path, branch = create_worktree(git_project)
+        assert wt_path.exists()
+
+        with patch("factory.worktree._has_active_sessions", return_value=False):
+            remove_worktree(git_project, wt_path, branch)
+
+        assert wt_path.exists()
+
+    def test_experiment_worktree_always_removed(
+        self, git_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_REMOVE_WORKTREE", "false")
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=git_project,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        wt_path, branch = create_experiment_worktree(git_project, 5, head_sha)
+        assert wt_path.exists()
+        assert branch == "factory/exp-5"
+
+        remove_worktree(git_project, wt_path, branch)
+
+        assert not wt_path.exists()
+
+    def test_retained_emits_event(self, git_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_REMOVE_WORKTREE", "false")
+        wt_path, branch = create_worktree(git_project)
+        run_id = branch.removeprefix("factory/run-")
+
+        with (
+            patch("factory.worktree._has_active_sessions", return_value=False),
+            patch("factory.events.emit_event") as mock_emit,
+        ):
+            remove_worktree(git_project, wt_path, branch)
+
+        mock_emit.assert_called_once_with(
+            git_project,
+            "worktree.retained",
+            data={
+                "run_id": run_id,
+                "branch": branch,
+                "worktree_path": str(wt_path),
+            },
+        )
+
+    def test_prune_stale_respects_retention_for_run(
+        self, git_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_REMOVE_WORKTREE", "false")
+        wt_dir = git_project / ".factory-worktrees"
+        wt_dir.mkdir(parents=True, exist_ok=True)
+        orphan = wt_dir / "run-deadbeef"
+        orphan.mkdir()
+        (orphan / "some_file.txt").write_text("stale")
+
+        pruned = prune_stale(git_project)
+
+        assert orphan.exists()
+        assert not any("run-deadbeef" in msg for msg in pruned)
+
+    def test_prune_stale_always_cleans_exp(
+        self, git_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_REMOVE_WORKTREE", "false")
+        wt_dir = git_project / ".factory-worktrees"
+        wt_dir.mkdir(parents=True, exist_ok=True)
+        orphan = wt_dir / "exp-99"
+        orphan.mkdir()
+        (orphan / "some_file.txt").write_text("stale")
+
+        pruned = prune_stale(git_project)
+
+        assert not orphan.exists()
+        assert any("exp-99" in msg for msg in pruned)


### PR DESCRIPTION
Closes #1082

## Changes

- Add `FACTORY_REMOVE_WORKTREE` config option (default `true`) — set to `false` to retain run worktrees after sessions for post-mortem debugging and manual follow-up
- Add `_should_remove_worktree(branch)` helper in `factory/worktree.py` using `user_config.resolve()` with 5-tier precedence
- Guard `remove_worktree()` with retention check after the existing `_has_active_sessions()` guard — emits `worktree.retained` event and prints cleanup instructions to stderr when retention is enabled
- Guard `prune_stale()` to skip `run-*` orphan directories when retention is enabled, while still always cleaning `exp-*` experiment orphans
- Fix existing bug: move `worktree.removed` event emission to after actual removal (previously fired even when removal was skipped by `_has_active_sessions()`)
- Register `FACTORY_REMOVE_WORKTREE` in `user_config.py` env_map for `factory config migrate` and add commented template entry
- Add 8 test cases in `TestWorktreeRetention` class covering default behavior, false/0/no values, experiment branch exemption, event emission, and prune_stale guards

Zero call-site changes — the guard is fully centralized inside `remove_worktree()` and `prune_stale()`.