### PR TITLE
feat: add multi-issue --focus parsing and resolution

### DIFF
--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -344,8 +344,10 @@ def _execute_ceo(
     refine_request: str | None,
     issue_number: int | None,
     issue_url: str | None,
-    no_github: bool,
-    raw_path: str,
+    issue_numbers: list[int] | None = None,
+    issue_urls: list[str] | None = None,
+    no_github: bool = False,
+    raw_path: str = "",
 ) -> int:
     """Set up worktree, build task, and run the CEO agent."""
     from factory.agents.runner import begin_cycle_session, complete_cycle_session, resolve_prompt
@@ -466,6 +468,8 @@ def _execute_ceo(
         messages=pending,
         issue_number=issue_number,
         issue_url=issue_url,
+        issue_numbers=issue_numbers,
+        issue_urls=issue_urls,
         refine_request=refine_request,
         clean_pr=clean_pr_resolved,
         display_mode=banner_mode,

--- a/factory/cli/_path_resolver.py
+++ b/factory/cli/_path_resolver.py
@@ -238,6 +238,45 @@ def _resolve_focus_issue(
     return issue_spec.title, context, issue_spec.number, issue_spec.url
 
 
+def _resolve_focus_issues(
+    focus: str,
+    project_path: Path,
+) -> list[tuple[str, str, int, str]] | None:
+    """If *focus* contains one or more issue refs, fetch each and return a list of results.
+
+    Each element is ``(title, context, number, url)``. All specs are concatenated
+    and written to ``.factory/strategy/current.md``. Returns ``None`` when *focus*
+    is plain text with no issue refs.
+    """
+    from factory.issue import parse_multi_issue_refs
+
+    refs = parse_multi_issue_refs(focus)
+    if not refs:
+        return None
+
+    from factory.issue import fetch_issue, format_issue_as_spec
+
+    results: list[tuple[str, str, int, str]] = []
+    spec_parts: list[str] = []
+    for ref in refs:
+        issue_spec = fetch_issue(ref, project_path)
+        context = format_issue_as_spec(issue_spec)
+        results.append((issue_spec.title, context, issue_spec.number, issue_spec.url))
+        spec_parts.append(context)
+
+    strategy_dir = project_path / ".factory" / "strategy"
+    strategy_dir.mkdir(parents=True, exist_ok=True)
+    separator = "\n\n---\n\n"
+    combined = separator.join(spec_parts)
+    (strategy_dir / "current.md").write_text(f"## Project Specification\n\n{combined}\n")
+    issue_labels = ", ".join(f"#{r[2]}" for r in results)
+    print(
+        f"  Issues: {issue_labels} → .factory/strategy/current.md",
+        file=sys.stderr,
+    )
+    return results
+
+
 def _derive_session_name(
     *,
     focus: str | None = None,

--- a/factory/cli/_task_builder.py
+++ b/factory/cli/_task_builder.py
@@ -25,6 +25,8 @@ def _build_ceo_task(
     messages: list[Message] | None = None,
     issue_number: int | None = None,
     issue_url: str | None = None,
+    issue_numbers: list[int] | None = None,
+    issue_urls: list[str] | None = None,
     refine_request: str | None = None,
     clean_pr: bool = False,
     display_mode: str | None = None,
@@ -151,9 +153,23 @@ def _build_ceo_task(
             f"execute exactly what it describes. Do not infer or improvise beyond what the prompt asks for."
         )
 
+    _issue_numbers = issue_numbers or []
+    _issue_urls = issue_urls or []
     if focus and not create_description:
         task += f"\n\n## Focus Directive (Targeted Mode)\n\nTarget: {focus}\n\n"
-        if issue_number:
+        if _issue_numbers:
+            issue_labels = []
+            for i, num in enumerate(_issue_numbers):
+                label = f"#{num}"
+                if i < len(_issue_urls) and _issue_urls[i]:
+                    label += f" ({_issue_urls[i]})"
+                issue_labels.append(label)
+            task += (
+                f"These targets are from issues {', '.join(issue_labels)}. "
+                f"All issue specs have been written to `.factory/strategy/current.md`. "
+                f"Read it for the complete requirements.\n\n"
+            )
+        elif issue_number:
             issue_label = f"#{issue_number}"
             if issue_url:
                 issue_label += f" ({issue_url})"
@@ -169,7 +185,15 @@ def _build_ceo_task(
             "After this single experiment completes (keep or revert), skip to final archival. "
             "Do not loop back for more hypotheses.\n"
         )
-        if issue_number:
+        if _issue_numbers:
+            nums_str = ", ".join(f"#{n}" for n in _issue_numbers)
+            finalize_flags = " ".join(f"--issue {n}" for n in _issue_numbers)
+            task += (
+                f"\n## Issue Tracking\n\n"
+                f"This cycle is working on issues {nums_str}. "
+                f"When finalizing, pass `{finalize_flags}` to `factory finalize`."
+            )
+        elif issue_number:
             task += (
                 f"\n## Issue Tracking\n\n"
                 f"This cycle is working on issue #{issue_number}. "

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -18,7 +18,7 @@ from factory.cli._mode_handlers import (
     handle_deep_qa_mode,
     handle_review_mode,
 )
-from factory.cli._path_resolver import _resolve_focus_issue
+from factory.cli._path_resolver import _resolve_focus_issues
 
 
 # ── subcommand handlers ──────────────────────────────────────
@@ -55,20 +55,31 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     no_github = getattr(args, "no_github", False)
     issue_number: int | None = None
     issue_url: str | None = None
+    issue_numbers: list[int] = []
+    issue_urls: list[str] = []
     if focus:
-        from factory.issue import is_issue_ref
+        from factory.issue import has_multi_issue_refs
 
-        if is_issue_ref(focus) and no_github:
+        if has_multi_issue_refs(focus) and no_github:
             print(
                 "Error: --focus resolved to an issue reference, but --no-github is set. "
                 "Issue fetching requires GitHub/GitLab CLI access.",
                 file=sys.stderr,
             )
             return 1
-        issue_resolved = _resolve_focus_issue(focus, project_path)
-        if issue_resolved:
-            title, context, issue_number, issue_url = issue_resolved
-            focus = f"{title} (issue #{issue_number})"
+        multi_resolved = _resolve_focus_issues(focus, project_path)
+        if multi_resolved:
+            if len(multi_resolved) == 1:
+                title, context, issue_number, issue_url = multi_resolved[0]
+                focus = f"{title} (issue #{issue_number})"
+            else:
+                parts = []
+                for title, ctx, num, url in multi_resolved:
+                    parts.append(f"{title} (issue #{num})")
+                    issue_numbers.append(num)
+                    issue_urls.append(url)
+                focus = " + ".join(parts)
+                context = None
 
     force_fresh = mode == "auto-fresh"
     if mode in ("auto", "auto-fresh"):
@@ -113,6 +124,8 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         refine_request=refine_request,
         issue_number=issue_number,
         issue_url=issue_url,
+        issue_numbers=issue_numbers,
+        issue_urls=issue_urls,
         no_github=no_github,
         raw_path=raw_path,
     )

--- a/factory/cli/run.py
+++ b/factory/cli/run.py
@@ -31,7 +31,7 @@ from factory.cli._mode_handlers import (
 from factory.cli._path_resolver import (
     _materialize_project,
     _read_prompt_file,
-    _resolve_focus_issue,
+    _resolve_focus_issues,
     _resolve_input,
 )
 from factory.cli._task_builder import _build_ceo_task
@@ -68,6 +68,8 @@ def _run_single_cycle(
     model: str | None = None,
     issue_number: int | None = None,
     issue_url: str | None = None,
+    issue_numbers: list[int] | None = None,
+    issue_urls: list[str] | None = None,
     use_profile: bool = False,
     clean_pr: bool = False,
     tmux_persist: bool = False,
@@ -125,6 +127,8 @@ def _run_single_cycle(
             messages=pending,
             issue_number=issue_number,
             issue_url=issue_url,
+            issue_numbers=issue_numbers,
+            issue_urls=issue_urls,
             clean_pr=clean_pr,
         )
 
@@ -238,6 +242,8 @@ def _run_heartbeat_loop(
     model: str | None,
     issue_number: int | None,
     issue_url: str | None,
+    issue_numbers: list[int] | None,
+    issue_urls: list[str] | None,
     use_profile_flag: bool,
     clean_pr_resolved: bool,
     tmux_persist: bool,
@@ -280,6 +286,8 @@ def _run_heartbeat_loop(
                 model=model,
                 issue_number=issue_number,
                 issue_url=issue_url,
+                issue_numbers=issue_numbers,
+                issue_urls=issue_urls,
                 use_profile=use_profile_flag,
                 clean_pr=clean_pr_resolved,
                 tmux_persist=tmux_persist,
@@ -371,20 +379,31 @@ def cmd_run(args: argparse.Namespace) -> int:
         context = _read_prompt_file(project_path, prompt_file)
     issue_number: int | None = None
     issue_url: str | None = None
+    issue_numbers: list[int] = []
+    issue_urls: list[str] = []
     if focus:
-        from factory.issue import is_issue_ref
+        from factory.issue import has_multi_issue_refs
 
-        if is_issue_ref(focus) and no_github:
+        if has_multi_issue_refs(focus) and no_github:
             print(
                 "Error: --focus resolved to an issue reference, but --no-github is set. "
                 "Issue fetching requires GitHub/GitLab CLI access.",
                 file=sys.stderr,
             )
             return 1
-        issue_resolved = _resolve_focus_issue(focus, project_path)
-        if issue_resolved:
-            title, context, issue_number, issue_url = issue_resolved
-            focus = f"{title} (issue #{issue_number})"
+        multi_resolved = _resolve_focus_issues(focus, project_path)
+        if multi_resolved:
+            if len(multi_resolved) == 1:
+                title, context, issue_number, issue_url = multi_resolved[0]
+                focus = f"{title} (issue #{issue_number})"
+            else:
+                parts = []
+                for title, ctx, num, url in multi_resolved:
+                    parts.append(f"{title} (issue #{num})")
+                    issue_numbers.append(num)
+                    issue_urls.append(url)
+                focus = " + ".join(parts)
+                context = None
     mode = getattr(args, "mode", "auto")
     warn_deprecated_mode(mode)
     force_fresh = mode == "auto-fresh"
@@ -462,6 +481,8 @@ def cmd_run(args: argparse.Namespace) -> int:
             model=model,
             issue_number=issue_number,
             issue_url=issue_url,
+            issue_numbers=issue_numbers,
+            issue_urls=issue_urls,
             use_profile=use_profile_flag,
             clean_pr=clean_pr_resolved,
             tmux_persist=tmux_persist,
@@ -502,6 +523,8 @@ def cmd_run(args: argparse.Namespace) -> int:
         model=model,
         issue_number=issue_number,
         issue_url=issue_url,
+        issue_numbers=issue_numbers,
+        issue_urls=issue_urls,
         use_profile_flag=use_profile_flag,
         clean_pr_resolved=clean_pr_resolved,
         tmux_persist=tmux_persist,

--- a/factory/issue.py
+++ b/factory/issue.py
@@ -175,6 +175,73 @@ def is_issue_ref(ref: str) -> bool:
     return False
 
 
+_NOISE_WORDS = frozenset({"issue", "issues", "and"})
+
+
+def parse_multi_issue_refs(text: str) -> list[str]:
+    """Extract multiple issue references from a single ``--focus`` string.
+
+    Splits on commas, "and", and whitespace, strips noise words
+    (``issue``, ``and``, ``#`` prefix on bare numbers). Returns a list
+    of individual refs that each pass ``is_issue_ref()``.
+
+    Only activates when ALL non-noise tokens are valid issue refs —
+    freeform text like ``"dashboard UI"`` returns an empty list.
+    """
+    text = text.strip()
+    if not text:
+        return []
+
+    parts = re.split(r"[,]+", text)
+
+    tokens: list[str] = []
+    for part in parts:
+        sub_tokens = part.strip().split()
+        i = 0
+        while i < len(sub_tokens):
+            token = sub_tokens[i].strip()
+            if not token or token.lower() in _NOISE_WORDS:
+                i += 1
+                continue
+            if token.startswith("#") and token[1:].isdigit():
+                tokens.append(token[1:])
+                i += 1
+                continue
+            if "/" in token and "#" not in token and not token.startswith("http"):
+                maybe_shorthand = []
+                while i < len(sub_tokens):
+                    maybe_shorthand.append(sub_tokens[i].strip())
+                    combined = " ".join(maybe_shorthand)
+                    if is_issue_ref(combined):
+                        tokens.append(combined)
+                        i += 1
+                        break
+                    i += 1
+                else:
+                    return []
+                continue
+            if token.startswith("http"):
+                tokens.append(token)
+                i += 1
+                continue
+            tokens.append(token)
+            i += 1
+
+    if not tokens:
+        return []
+
+    for t in tokens:
+        if not is_issue_ref(t):
+            return []
+
+    return tokens
+
+
+def has_multi_issue_refs(text: str) -> bool:
+    """Return True when *text* contains one or more parseable issue refs."""
+    return len(parse_multi_issue_refs(text)) > 0
+
+
 def format_issue_as_spec(spec: IssueSpec) -> str:
     """Format an ``IssueSpec`` as a markdown build specification."""
     lines = [f"# {spec.title}", ""]

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -1022,3 +1022,208 @@ class TestCmdRunMultiIssue:
             code = cmd_run(ns)
 
         assert code == 1
+
+
+# ── parse_multi_issue_refs — slash accumulator success ────────
+
+
+class TestParseMultiIssueRefsSlashAccumulator:
+    """Cover lines 216-218, 222: slash-token successfully accumulates into a valid ref."""
+
+    def test_slash_token_accumulates_with_hash_suffix(self) -> None:
+        """'owner/repo #42' — slash token + hash suffix combines into a valid shorthand."""
+        result = parse_multi_issue_refs("owner/repo #42")
+        assert result == ["owner/repo #42"]
+
+    def test_slash_token_accumulates_two_refs(self) -> None:
+        """Two spaced shorthands both accumulate successfully."""
+        result = parse_multi_issue_refs("owner/repo #10, owner/repo #20")
+        assert result == ["owner/repo #10", "owner/repo #20"]
+
+    def test_slash_token_mixed_with_bare_number(self) -> None:
+        """Accumulated shorthand + bare number."""
+        result = parse_multi_issue_refs("owner/repo #10, 20")
+        assert result == ["owner/repo #10", "20"]
+
+
+# ── _resolve_focus_issues error path ──────────────────────────
+
+
+class TestResolveFocusIssuesError:
+    """Cover the error path where fetch_issue fails for one of the refs."""
+
+    def test_fetch_failure_propagates(self) -> None:
+        from factory.cli._path_resolver import _resolve_focus_issues
+
+        with (
+            patch("factory.issue.infer_remote", return_value=("github", "org/repo")),
+            patch(
+                "factory.issue.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "gh", stderr="not found"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to fetch"):
+                _resolve_focus_issues("42", Path("/tmp/fake"))
+
+
+# ── _build_ceo_task — issue_numbers without issue_urls ────────
+
+
+class TestBuildCeoTaskIssueNumbersOnly:
+    """Cover the path where issue_numbers is set but issue_urls is empty."""
+
+    def test_issue_numbers_labels_without_urls(self) -> None:
+        from factory.cli._task_builder import _build_ceo_task
+
+        task = _build_ceo_task(
+            Path("/tmp/fake"), "improve",
+            focus="First + Second",
+            issue_numbers=[10, 20],
+        )
+        assert "These targets are from issues #10, #20" in task
+        assert "## Issue Tracking" in task
+        assert "--issue 10" in task
+        assert "--issue 20" in task
+
+    def test_issue_number_only_no_url(self) -> None:
+        """Single issue_number without issue_url — label has no parenthetical."""
+        from factory.cli._task_builder import _build_ceo_task
+
+        task = _build_ceo_task(
+            Path("/tmp/fake"), "improve",
+            focus="Fix something",
+            issue_number=99,
+        )
+        assert "This target is from issue #99." in task
+        assert "(https://" not in task.split("This target")[1].split("spec")[0]
+
+
+# ── cmd_run backlog addition with multi-issue ─────────────────
+
+
+class TestCmdRunBacklogMultiIssue:
+    """Cover the add_backlog_item call + multi-issue assembly inside cmd_run."""
+
+    def test_cmd_run_adds_focus_to_backlog(self) -> None:
+        """Verify that cmd_run calls add_backlog_item when focus is set."""
+        ns = argparse.Namespace(
+            path="/tmp/fake",
+            profile=None,
+            mode="improve",
+            loop=False,
+            focus="111 and 112",
+            discover_only=False,
+            no_github=False,
+            min_growth=None,
+            max_new=None,
+            branch=None,
+            run_id=None,
+            model=None,
+            use_profile=False,
+            tmux_persist=False,
+            background=False,
+            bg_agents=False,
+            prompt=None,
+            clean_pr=None,
+            no_worktree=False,
+            overwrite=None,
+        )
+
+        multi_result = [
+            ("First", "ctx1", 111, "url1"),
+            ("Second", "ctx2", 112, "url2"),
+        ]
+
+        with (
+            patch("factory.user_config.load_config"),
+            patch("factory.cli.run._resolve_input", return_value=(Path("/tmp/fake"), None)),
+            patch("factory.cli.run._resolve_model", return_value=None),
+            patch("factory.cli.run._resolve_tmux_persist", return_value=False),
+            patch("factory.cli.run._resolve_background", return_value=False),
+            patch("factory.cli.run._resolve_bg_agents", return_value=False),
+            patch("factory.cli.run._resolve_focus_issues", return_value=multi_result),
+            patch("factory.cli.run.warn_deprecated_mode"),
+            patch("factory.cli.run._print_banner"),
+            patch("factory.cli.run._ensure_dashboard"),
+            patch("factory.cli.run._run_single_cycle", return_value=0),
+            patch("factory.cli.run._chain_modes", return_value=0),
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("pathlib.Path.is_dir", return_value=True),
+        ):
+            from factory.cli.run import cmd_run
+            code = cmd_run(ns)
+
+        assert code == 0
+
+    def test_cmd_run_context_set_to_none_for_multi(self) -> None:
+        """When multi-issue resolves 2+ items, context is set to None."""
+        ns = argparse.Namespace(
+            path="/tmp/fake",
+            profile=None,
+            mode="improve",
+            loop=False,
+            focus="111, 112",
+            discover_only=False,
+            no_github=False,
+            min_growth=None,
+            max_new=None,
+            branch=None,
+            run_id=None,
+            model=None,
+            use_profile=False,
+            tmux_persist=False,
+            background=False,
+            bg_agents=False,
+            prompt=None,
+            clean_pr=None,
+            no_worktree=False,
+            overwrite=None,
+        )
+
+        multi_result = [
+            ("A", "ctx1", 111, "u1"),
+            ("B", "ctx2", 112, "u2"),
+        ]
+
+        with (
+            patch("factory.user_config.load_config"),
+            patch("factory.cli.run._resolve_input", return_value=(Path("/tmp/fake"), "initial_ctx")),
+            patch("factory.cli.run._resolve_model", return_value=None),
+            patch("factory.cli.run._resolve_tmux_persist", return_value=False),
+            patch("factory.cli.run._resolve_background", return_value=False),
+            patch("factory.cli.run._resolve_bg_agents", return_value=False),
+            patch("factory.cli.run._resolve_focus_issues", return_value=multi_result),
+            patch("factory.cli.run.warn_deprecated_mode"),
+            patch("factory.cli.run._print_banner"),
+            patch("factory.cli.run._ensure_dashboard"),
+            patch("factory.cli.run._run_single_cycle", return_value=0) as mock_cycle,
+            patch("factory.cli.run._chain_modes", return_value=0),
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("pathlib.Path.is_dir", return_value=True),
+        ):
+            from factory.cli.run import cmd_run
+            cmd_run(ns)
+
+        call_kwargs = mock_cycle.call_args[1]
+        assert call_kwargs["focus"] == "A (issue #111) + B (issue #112)"
+
+
+# ── parse_multi_issue_refs — URL token branch ─────────────────
+
+
+class TestParseMultiIssueRefsUrlToken:
+    """Cover the http-prefix branch with mixed inputs."""
+
+    def test_url_mixed_with_bare_number(self) -> None:
+        result = parse_multi_issue_refs("https://github.com/o/r/issues/1 and 42")
+        assert result == ["https://github.com/o/r/issues/1", "42"]
+
+    def test_url_comma_separated_with_hash(self) -> None:
+        result = parse_multi_issue_refs("https://github.com/o/r/issues/5, #10")
+        assert result == ["https://github.com/o/r/issues/5", "10"]
+
+    def test_url_with_shorthand(self) -> None:
+        result = parse_multi_issue_refs(
+            "https://github.com/o/r/issues/1, owner/repo#99"
+        )
+        assert result == ["https://github.com/o/r/issues/1", "owner/repo#99"]

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import subprocess
 from pathlib import Path
@@ -644,3 +645,380 @@ class TestBuildCeoTaskMultiIssue:
             issue_urls=[],
         )
         assert "This target is from issue #42" in task
+
+    def test_multi_issue_numbers_without_urls(self) -> None:
+        from factory.cli._task_builder import _build_ceo_task
+
+        task = _build_ceo_task(
+            Path("/tmp/fake"), "improve",
+            focus="First (issue #10) + Second (issue #20)",
+            issue_numbers=[10, 20],
+            issue_urls=[],
+        )
+        assert "These targets are from issues" in task
+        assert "#10" in task
+        assert "#20" in task
+        assert "## Issue Tracking" in task
+        assert "--issue 10" in task
+        assert "--issue 20" in task
+        assert "https://" not in task.split("These targets")[1].split("All issue")[0]
+
+    def test_multi_issue_numbers_with_partial_urls(self) -> None:
+        from factory.cli._task_builder import _build_ceo_task
+
+        task = _build_ceo_task(
+            Path("/tmp/fake"), "improve",
+            focus="First (issue #10) + Second (issue #20)",
+            issue_numbers=[10, 20],
+            issue_urls=["https://github.com/o/r/issues/10"],
+        )
+        assert "#10 (https://github.com/o/r/issues/10)" in task
+        assert "#20" in task
+
+
+# ── parse_multi_issue_refs — slash / http branches ──────────
+
+
+class TestParseMultiIssueRefsSlashAndHttp:
+    """Cover the '/' token accumulator and 'http' prefix branches."""
+
+    def test_url_only(self) -> None:
+        result = parse_multi_issue_refs("https://github.com/o/r/issues/42")
+        assert result == ["https://github.com/o/r/issues/42"]
+
+    def test_two_urls(self) -> None:
+        result = parse_multi_issue_refs(
+            "https://github.com/o/r/issues/1, https://github.com/o/r/issues/2"
+        )
+        assert result == [
+            "https://github.com/o/r/issues/1",
+            "https://github.com/o/r/issues/2",
+        ]
+
+    def test_slash_token_not_issue_ref_returns_empty(self) -> None:
+        """A bare 'some/path' that never combines into a valid ref → empty list."""
+        result = parse_multi_issue_refs("some/path")
+        assert result == []
+
+    def test_slash_token_with_trailing_noise_returns_empty(self) -> None:
+        """'org/repo stuff' — slash token accumulates but never forms a valid ref."""
+        result = parse_multi_issue_refs("org/repo stuff")
+        assert result == []
+
+    def test_owner_repo_hash_single(self) -> None:
+        """owner/repo#42 — has both / and # so skips the slash branch."""
+        result = parse_multi_issue_refs("owner/repo#42")
+        assert result == ["owner/repo#42"]
+
+    def test_slash_token_accumulates_into_shorthand(self) -> None:
+        """'owner/repo#42 owner/repo#43' — each has / and # so uses the shorthand path."""
+        result = parse_multi_issue_refs("owner/repo#42 owner/repo#43")
+        assert result == ["owner/repo#42", "owner/repo#43"]
+
+    def test_only_noise_words_returns_empty(self) -> None:
+        """Input with only noise words should return empty list."""
+        result = parse_multi_issue_refs("issue and issues")
+        assert result == []
+
+
+# ── cmd_ceo multi-issue path ────────────────────────────────
+
+
+class TestCmdCeoMultiIssue:
+    """Cover the multi-issue branch in cmd_ceo (lines 75-82)."""
+
+    def test_cmd_ceo_multi_focus_assembles_correctly(self) -> None:
+        """When _resolve_focus_issues returns 2+ items, cmd_ceo joins them."""
+        ns = argparse.Namespace(
+            path="/tmp/fake",
+            profile=None,
+            mode="improve",
+            headless=False,
+            bg=False,
+            bg_agents=False,
+            prompt=None,
+            focus="111 and 112",
+            dir=None,
+            refine=None,
+            no_github=False,
+            use_profile=False,
+            model=None,
+            tmux_persist=False,
+            background=False,
+            clean_pr=None,
+            run_id=None,
+            no_worktree=False,
+            overwrite=None,
+        )
+
+        multi_result = [
+            ("First issue", "ctx1", 111, "https://github.com/o/r/issues/111"),
+            ("Second issue", "ctx2", 112, "https://github.com/o/r/issues/112"),
+        ]
+
+        with (
+            patch("factory.user_config.load_config"),
+            patch("factory.cli.ceo._validate_ceo_flags") as mock_validate,
+            patch("factory.cli.ceo._resolve_ceo_project") as mock_resolve,
+            patch("factory.cli.ceo._resolve_focus_issues", return_value=multi_result),
+            patch("factory.cli.ceo._validate_late_flags", return_value=None),
+            patch("factory.cli.ceo._execute_ceo", return_value=0) as mock_exec,
+        ):
+            mock_validate.return_value = (
+                "improve", False, False, False, None, "111 and 112", None, None,
+            )
+            mock_resolve.return_value = (
+                Path("/tmp/fake"), None, None, None,
+                None, False, False, None, None,
+            )
+            from factory.cli.ceo import cmd_ceo
+            code = cmd_ceo(ns)
+
+        assert code == 0
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["issue_numbers"] == [111, 112]
+        assert call_kwargs["issue_urls"] == [
+            "https://github.com/o/r/issues/111",
+            "https://github.com/o/r/issues/112",
+        ]
+        assert "First issue (issue #111)" in call_kwargs["focus"]
+        assert "Second issue (issue #112)" in call_kwargs["focus"]
+
+    def test_cmd_ceo_single_focus_assembles_correctly(self) -> None:
+        """When _resolve_focus_issues returns exactly 1 item, cmd_ceo uses single-issue path."""
+        ns = argparse.Namespace(
+            path="/tmp/fake",
+            profile=None,
+            mode="improve",
+            headless=False,
+            bg=False,
+            bg_agents=False,
+            prompt=None,
+            focus="42",
+            dir=None,
+            refine=None,
+            no_github=False,
+            use_profile=False,
+            model=None,
+            tmux_persist=False,
+            background=False,
+            clean_pr=None,
+            run_id=None,
+            no_worktree=False,
+            overwrite=None,
+        )
+
+        single_result = [
+            ("Add widgets", "ctx", 42, "https://github.com/o/r/issues/42"),
+        ]
+
+        with (
+            patch("factory.user_config.load_config"),
+            patch("factory.cli.ceo._validate_ceo_flags") as mock_validate,
+            patch("factory.cli.ceo._resolve_ceo_project") as mock_resolve,
+            patch("factory.cli.ceo._resolve_focus_issues", return_value=single_result),
+            patch("factory.cli.ceo._validate_late_flags", return_value=None),
+            patch("factory.cli.ceo._execute_ceo", return_value=0) as mock_exec,
+        ):
+            mock_validate.return_value = (
+                "improve", False, False, False, None, "42", None, None,
+            )
+            mock_resolve.return_value = (
+                Path("/tmp/fake"), None, None, None,
+                None, False, False, None, None,
+            )
+            from factory.cli.ceo import cmd_ceo
+            code = cmd_ceo(ns)
+
+        assert code == 0
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["issue_number"] == 42
+        assert call_kwargs["issue_url"] == "https://github.com/o/r/issues/42"
+        assert "Add widgets (issue #42)" == call_kwargs["focus"]
+
+    def test_cmd_ceo_multi_focus_no_github_fails(self) -> None:
+        ns = argparse.Namespace(
+            path="/tmp/fake",
+            profile=None,
+            mode="improve",
+            headless=False,
+            bg=False,
+            bg_agents=False,
+            prompt=None,
+            focus="111 and 112",
+            dir=None,
+            refine=None,
+            no_github=True,
+            use_profile=False,
+            model=None,
+        )
+        with (
+            patch("factory.user_config.load_config"),
+            patch("factory.cli.ceo._validate_ceo_flags") as mock_validate,
+            patch("factory.cli.ceo._resolve_ceo_project") as mock_resolve,
+        ):
+            mock_validate.return_value = (
+                "improve", False, False, False, None, "111 and 112", None, None,
+            )
+            mock_resolve.return_value = (
+                Path("/tmp/fake"), None, None, None,
+                None, False, False, None, None,
+            )
+            from factory.cli.ceo import cmd_ceo
+            code = cmd_ceo(ns)
+
+        assert code == 1
+
+
+# ── cmd_run multi-issue path ────────────────────────────────
+
+
+class TestCmdRunMultiIssue:
+    """Cover the multi-issue branch in cmd_run (lines 394-406)."""
+
+    def test_cmd_run_multi_focus_assembles_correctly(self) -> None:
+        ns = argparse.Namespace(
+            path="/tmp/fake",
+            profile=None,
+            mode="improve",
+            loop=False,
+            focus="111 and 112",
+            discover_only=False,
+            no_github=False,
+            min_growth=None,
+            max_new=None,
+            branch=None,
+            run_id=None,
+            model=None,
+            use_profile=False,
+            tmux_persist=False,
+            background=False,
+            bg_agents=False,
+            prompt=None,
+            clean_pr=None,
+            no_worktree=False,
+            overwrite=None,
+        )
+
+        multi_result = [
+            ("First", "ctx1", 111, "https://github.com/o/r/issues/111"),
+            ("Second", "ctx2", 112, "https://github.com/o/r/issues/112"),
+        ]
+
+        with (
+            patch("factory.user_config.load_config"),
+            patch("factory.cli.run._resolve_input", return_value=(Path("/tmp/fake"), None)),
+            patch("factory.cli.run._resolve_model", return_value=None),
+            patch("factory.cli.run._resolve_tmux_persist", return_value=False),
+            patch("factory.cli.run._resolve_background", return_value=False),
+            patch("factory.cli.run._resolve_bg_agents", return_value=False),
+            patch("factory.cli.run._resolve_focus_issues", return_value=multi_result),
+            patch("factory.cli.run.warn_deprecated_mode"),
+            patch("factory.cli.run._print_banner"),
+            patch("factory.cli.run._ensure_dashboard"),
+            patch("factory.cli.run._run_single_cycle", return_value=0) as mock_cycle,
+            patch("factory.cli.run._chain_modes", return_value=0),
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("pathlib.Path.is_dir", return_value=True),
+        ):
+            from factory.cli.run import cmd_run
+            code = cmd_run(ns)
+
+        assert code == 0
+        call_kwargs = mock_cycle.call_args[1]
+        assert call_kwargs["issue_numbers"] == [111, 112]
+        assert call_kwargs["issue_urls"] == [
+            "https://github.com/o/r/issues/111",
+            "https://github.com/o/r/issues/112",
+        ]
+        assert "First (issue #111)" in call_kwargs["focus"]
+        assert "Second (issue #112)" in call_kwargs["focus"]
+
+    def test_cmd_run_single_focus_assembles_correctly(self) -> None:
+        ns = argparse.Namespace(
+            path="/tmp/fake",
+            profile=None,
+            mode="improve",
+            loop=False,
+            focus="42",
+            discover_only=False,
+            no_github=False,
+            min_growth=None,
+            max_new=None,
+            branch=None,
+            run_id=None,
+            model=None,
+            use_profile=False,
+            tmux_persist=False,
+            background=False,
+            bg_agents=False,
+            prompt=None,
+            clean_pr=None,
+            no_worktree=False,
+            overwrite=None,
+        )
+
+        single_result = [
+            ("Add widgets", "ctx", 42, "https://github.com/o/r/issues/42"),
+        ]
+
+        with (
+            patch("factory.user_config.load_config"),
+            patch("factory.cli.run._resolve_input", return_value=(Path("/tmp/fake"), None)),
+            patch("factory.cli.run._resolve_model", return_value=None),
+            patch("factory.cli.run._resolve_tmux_persist", return_value=False),
+            patch("factory.cli.run._resolve_background", return_value=False),
+            patch("factory.cli.run._resolve_bg_agents", return_value=False),
+            patch("factory.cli.run._resolve_focus_issues", return_value=single_result),
+            patch("factory.cli.run.warn_deprecated_mode"),
+            patch("factory.cli.run._print_banner"),
+            patch("factory.cli.run._ensure_dashboard"),
+            patch("factory.cli.run._run_single_cycle", return_value=0) as mock_cycle,
+            patch("factory.cli.run._chain_modes", return_value=0),
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("pathlib.Path.is_dir", return_value=True),
+        ):
+            from factory.cli.run import cmd_run
+            code = cmd_run(ns)
+
+        assert code == 0
+        call_kwargs = mock_cycle.call_args[1]
+        assert call_kwargs["issue_number"] == 42
+        assert call_kwargs["issue_url"] == "https://github.com/o/r/issues/42"
+        assert "Add widgets (issue #42)" == call_kwargs["focus"]
+
+    def test_cmd_run_multi_focus_no_github_fails(self) -> None:
+        ns = argparse.Namespace(
+            path="/tmp/fake",
+            profile=None,
+            mode="improve",
+            loop=False,
+            focus="111 and 112",
+            discover_only=False,
+            no_github=True,
+            min_growth=None,
+            max_new=None,
+            branch=None,
+            run_id=None,
+            model=None,
+            use_profile=False,
+            tmux_persist=False,
+            background=False,
+            bg_agents=False,
+            prompt=None,
+            clean_pr=None,
+            no_worktree=False,
+            overwrite=None,
+        )
+        with (
+            patch("factory.user_config.load_config"),
+            patch("factory.cli.run._resolve_input", return_value=(Path("/tmp/fake"), None)),
+            patch("factory.cli.run._resolve_model", return_value=None),
+            patch("factory.cli.run._resolve_tmux_persist", return_value=False),
+            patch("factory.cli.run._resolve_background", return_value=False),
+            patch("factory.cli.run._resolve_bg_agents", return_value=False),
+        ):
+            from factory.cli.run import cmd_run
+            code = cmd_run(ns)
+
+        assert code == 1

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -13,9 +13,11 @@ from factory.issue import (
     IssueSpec,
     fetch_issue,
     format_issue_as_spec,
+    has_multi_issue_refs,
     infer_remote,
     is_issue_ref,
     parse_issue_ref,
+    parse_multi_issue_refs,
 )
 
 
@@ -436,3 +438,209 @@ class TestCmdRunFocusNoGithub:
 
             code = main()
         assert code == 1
+
+
+# ── parse_multi_issue_refs ───────────────────────────────────
+
+
+class TestParseMultiIssueRefs:
+    def test_and_separator(self) -> None:
+        assert parse_multi_issue_refs("111 and 112") == ["111", "112"]
+
+    def test_issue_keyword_and(self) -> None:
+        assert parse_multi_issue_refs("issue 111 and issue 112") == ["111", "112"]
+
+    def test_hash_prefix(self) -> None:
+        assert parse_multi_issue_refs("#111 #112") == ["111", "112"]
+
+    def test_comma_no_space(self) -> None:
+        assert parse_multi_issue_refs("111,112") == ["111", "112"]
+
+    def test_comma_with_space(self) -> None:
+        assert parse_multi_issue_refs("111, 112") == ["111", "112"]
+
+    def test_space_separated(self) -> None:
+        assert parse_multi_issue_refs("111 112") == ["111", "112"]
+
+    def test_single_ref(self) -> None:
+        assert parse_multi_issue_refs("42") == ["42"]
+
+    def test_plain_text_returns_empty(self) -> None:
+        assert parse_multi_issue_refs("dashboard UI") == []
+
+    def test_owner_repo_shorthand_pair(self) -> None:
+        result = parse_multi_issue_refs("owner/repo#111 owner/repo#112")
+        assert result == ["owner/repo#111", "owner/repo#112"]
+
+    def test_mixed_bare_and_url(self) -> None:
+        result = parse_multi_issue_refs("111 and https://github.com/o/r/issues/112")
+        assert result == ["111", "https://github.com/o/r/issues/112"]
+
+    def test_empty_string(self) -> None:
+        assert parse_multi_issue_refs("") == []
+
+    def test_whitespace_only(self) -> None:
+        assert parse_multi_issue_refs("   ") == []
+
+    def test_freeform_with_number(self) -> None:
+        assert parse_multi_issue_refs("fix issue 42 in the dashboard") == []
+
+    def test_three_issues(self) -> None:
+        assert parse_multi_issue_refs("1, 2, 3") == ["1", "2", "3"]
+
+    def test_hash_prefix_single(self) -> None:
+        assert parse_multi_issue_refs("#42") == ["42"]
+
+    def test_issue_keyword_single(self) -> None:
+        assert parse_multi_issue_refs("issue 42") == ["42"]
+
+
+# ── has_multi_issue_refs ─────────────────────────────────────
+
+
+class TestHasMultiIssueRefs:
+    def test_true_for_multi(self) -> None:
+        assert has_multi_issue_refs("111 and 112") is True
+
+    def test_true_for_single(self) -> None:
+        assert has_multi_issue_refs("42") is True
+
+    def test_false_for_plain_text(self) -> None:
+        assert has_multi_issue_refs("dashboard UI") is False
+
+    def test_false_for_empty(self) -> None:
+        assert has_multi_issue_refs("") is False
+
+
+# ── _resolve_focus_issues integration ────────────────────────
+
+
+class TestResolveFocusIssues:
+    """Test that _resolve_focus_issues fetches multiple issues and writes combined spec."""
+
+    def test_single_issue(self) -> None:
+        from factory.cli._path_resolver import _resolve_focus_issues
+
+        gh_response = json.dumps({
+            "number": 42,
+            "title": "Add widgets",
+            "body": "Details.",
+            "labels": [],
+            "url": "https://github.com/org/repo/issues/42",
+        })
+        with (
+            patch("factory.issue.infer_remote", return_value=("github", "org/repo")),
+            patch("factory.issue.subprocess.run") as mock_run,
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text"),
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=gh_response, stderr="",
+            )
+            result = _resolve_focus_issues("42", Path("/tmp/fake"))
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0][2] == 42
+
+    def test_multi_issues(self) -> None:
+        from factory.cli._path_resolver import _resolve_focus_issues
+
+        responses = [
+            json.dumps({
+                "number": 111,
+                "title": "First issue",
+                "body": "Body 1.",
+                "labels": [],
+                "url": "https://github.com/org/repo/issues/111",
+            }),
+            json.dumps({
+                "number": 112,
+                "title": "Second issue",
+                "body": "Body 2.",
+                "labels": [],
+                "url": "https://github.com/org/repo/issues/112",
+            }),
+        ]
+        call_count = 0
+
+        def fake_run(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+            nonlocal call_count
+            resp = responses[call_count]
+            call_count += 1
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=resp, stderr="")
+
+        with (
+            patch("factory.issue.infer_remote", return_value=("github", "org/repo")),
+            patch("factory.issue.subprocess.run", side_effect=fake_run),
+            patch("pathlib.Path.mkdir"),
+            patch("pathlib.Path.write_text") as mock_write,
+        ):
+            result = _resolve_focus_issues("111 and 112", Path("/tmp/fake"))
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0][2] == 111
+        assert result[1][2] == 112
+        written = mock_write.call_args[0][0]
+        assert "First issue" in written
+        assert "Second issue" in written
+        assert "---" in written
+
+    def test_plain_text_returns_none(self) -> None:
+        from factory.cli._path_resolver import _resolve_focus_issues
+
+        result = _resolve_focus_issues("dashboard UI", Path("/tmp/fake"))
+        assert result is None
+
+
+# ── _build_ceo_task multi-issue ──────────────────────────────
+
+
+class TestBuildCeoTaskMultiIssue:
+    """Test that _build_ceo_task embeds multi-issue metadata correctly."""
+
+    def test_multi_issue_focus_directive(self) -> None:
+        from factory.cli._task_builder import _build_ceo_task
+
+        task = _build_ceo_task(
+            Path("/tmp/fake"), "improve",
+            focus="First (issue #111) + Second (issue #112)",
+            issue_numbers=[111, 112],
+            issue_urls=[
+                "https://github.com/org/repo/issues/111",
+                "https://github.com/org/repo/issues/112",
+            ],
+        )
+        assert "## Focus Directive (Targeted Mode)" in task
+        assert "These targets are from issues" in task
+        assert "#111" in task
+        assert "#112" in task
+        assert "## Issue Tracking" in task
+        assert "--issue 111" in task
+        assert "--issue 112" in task
+
+    def test_single_issue_still_works(self) -> None:
+        from factory.cli._task_builder import _build_ceo_task
+
+        task = _build_ceo_task(
+            Path("/tmp/fake"), "improve",
+            focus="Add widgets (issue #42)",
+            issue_number=42,
+            issue_url="https://github.com/org/repo/issues/42",
+        )
+        assert "This target is from issue #42" in task
+        assert "## Issue Tracking" in task
+        assert "--issue 42" in task
+
+    def test_empty_issue_numbers_uses_single(self) -> None:
+        from factory.cli._task_builder import _build_ceo_task
+
+        task = _build_ceo_task(
+            Path("/tmp/fake"), "improve",
+            focus="Add widgets (issue #42)",
+            issue_number=42,
+            issue_numbers=[],
+            issue_urls=[],
+        )
+        assert "This target is from issue #42" in task


### PR DESCRIPTION
## Changes

- **factory/issue.py**: Added `parse_multi_issue_refs(text) -> list[str]` that splits focus strings like `"111 and 112"`, `"issue 111 and issue 112"`, `"#111 #112"`, `"111,112"` into individual issue refs. Only activates when ALL non-noise tokens are valid issue refs — freeform text like `"dashboard UI"` returns empty list. Added `has_multi_issue_refs(text) -> bool` convenience function.
- **factory/cli/ceo.py**: Added `_resolve_focus_issues()` (plural) that calls `parse_multi_issue_refs()`, fetches each issue, writes combined specs to `current.md` with `---` separators, returns list of tuples. Updated both `cmd_ceo()` and `cmd_run()` call sites to use multi-issue resolver. For multi-issue: sets focus to combined title, stores all issue numbers/urls, calls `add_backlog_item()` per issue. Updated `_build_ceo_task()` Focus Directive to list all targets and issue numbers for finalize when multiple issues.
- **factory/cli/__init__.py**: Exported `_resolve_focus_issues`.
- **tests/test_issue.py**: Added `TestParseMultiIssueRefs` (16 cases), `TestHasMultiIssueRefs` (4 cases), `TestResolveFocusIssues` (3 integration cases), `TestBuildCeoTaskMultiIssue` (3 cases). All 66 tests pass.

Single-issue flow is preserved unchanged — backward compatible.