### PR TITLE
fix: increase ceo-review workflow timeout from 30m to 2h

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -16,7 +16,7 @@ jobs:
       contains(github.event.comment.body, '@ceo-review') &&
       contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 120
 
     steps:
       - name: React with eyes


### PR DESCRIPTION
## Summary
- Increases the GitHub Actions job timeout for the `ceo-review` workflow from 30 minutes to 120 minutes (2 hours)
- The Python-level timeout was already set to 7200s (2h), but the GHA job was killing the run at 30m
- See failed run: https://github.com/akashgit/remote-factory/actions/runs/30850595616

Closes #1094

## Test plan
- [x] Verify the workflow YAML change is correct (`timeout-minutes: 120`)
- [ ] Trigger a `@ceo-review` on a PR and confirm it no longer times out prematurely

🤖 Generated with [Claude Code](https://claude.com/claude-code)