### PR TITLE
chore: add lukeinglis and nehamalepati to ceo-review callers

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
-      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98"]'), github.event.comment.user.login)
+      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98", "lukeinglis", "nehamalepati"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 120
 


### PR DESCRIPTION
## Summary
- Adds `lukeinglis` and `nehamalepati` to the allowed callers list for the `@ceo-review` workflow trigger

## Test plan
- [x] Verify the JSON array in `ceo-review.yml` is valid
- [ ] Confirm both users can trigger `@ceo-review` on a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)