### PR TITLE
feat(workflow): add plan mode with GitHub issue publishing

### DIFF
--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -16,7 +16,7 @@ log = structlog.get_logger()
 _WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
 
 
-CEO_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "design", "interactive", "parallel-improve", "research", "review", "deep-qa", "create", "swebench", "frontend-design", "frontend-design-scan"]
+CEO_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "design", "interactive", "parallel-improve", "plan", "research", "review", "deep-qa", "create", "swebench", "frontend-design", "frontend-design-scan"]
 
 
 RUN_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "parallel-improve", "research", "swebench", "frontend-design-scan"]

--- a/factory/cli/_task_builder.py
+++ b/factory/cli/_task_builder.py
@@ -45,6 +45,19 @@ def _mode_suffix(mode: str, discover_only: bool) -> str:
             "run --mode improve afterward to harden what works. "
             "The full step-by-step playbook is in your system prompt above."
         ),
+        "plan": (
+            "\n\nRun Plan mode: prior plan check + research + strategy + optional GitHub publishing "
+            "with NO implementation. "
+            "First check GitHub issues (plan label) and .factory/archive/ for prior plans matching "
+            "the focus topic — if found, ask the user whether to continue an existing plan or start fresh. "
+            "Run 3 parallel researchers (domain, practices, constraints), CEO review gate, then "
+            "synthesize a phased plan via the Strategist, then three sequential user gates: "
+            "1) Keep this plan? (yes → continue, no → discard and exit), "
+            "2) Publish to GitHub? (yes → post as issue, no → skip), "
+            "3) Seed backlog? (yes → extract phases to backlog.md with issue refs, no → done). "
+            "Do NOT transition to build or improve mode — plan mode is terminal. "
+            "If the user previously ran plan mode, check for prior plans before researching.\n"
+        ),
     }
     if mode == "discover":
         if discover_only:

--- a/factory/models.py
+++ b/factory/models.py
@@ -527,6 +527,7 @@ class CycleState(BaseModel):
         "improve",
         "meta",
         "parallel-improve",
+        "plan",
         "qa",
         "refine",
         "research",

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -61,6 +61,7 @@ __all__ = [
     "founder_workflow",
     "frontend_design_workflow",
     "frontend_design_scan_workflow",
+    "plan_workflow",
     "register_all",
 ]
 
@@ -3375,6 +3376,377 @@ def founder_workflow() -> Workflow:
     )
 
 
+# ── W₁₅: Plan Mode ───────────────────────────────────────────────
+
+
+def plan_workflow() -> Workflow:
+    """W₁₅: Plan Mode — prior plan check + research + strategy + approve + publish. Terminal.
+
+    CheckPriorPlans → [matches?] → GatePriorPlans(user) → Fork(3 researchers) →
+    Join → CEO gate → Strategist → GateKeepPlan(user) →
+      Keep (PROCEED):    GatePublishGitHub(user) →
+        Publish (PROCEED):   PublishGitHub → GateSeedBacklog(user) →
+          Seed (PROCEED):    SeedBacklog → done
+          No seed (HALT):    done
+        Skip (HALT):         GateSeedBacklog(user) →
+          Seed (PROCEED):    SeedBacklog → done
+          No seed (HALT):    done
+      Discard (HALT):    done
+
+    Planning-only mode. Produces a phased plan at .factory/strategy/current.md.
+    Optionally publishes to GitHub as an issue with the 'plan' label.
+    Does NOT chain to build/improve — user must explicitly invoke those modes
+    to execute the plan.
+    """
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # ── Prior plan detection ──────────────────────────────────
+
+    nodes["check_prior_plans"] = GateNode(
+        id="check_prior_plans",
+        evaluator_type="fn",
+        evaluator_command=(
+            ': > "{project_path}/.factory/strategy/prior-plans.md"; '
+            'if [ -n "$FOCUS" ]; then '
+            '  if gh auth status >/dev/null 2>&1 && git remote -v 2>/dev/null | grep -q .; then '
+            '    gh issue list --label plan --search "$FOCUS" --json number,title,url '
+            '      --jq ".[] | \\"#\\(.number) \\(.title) — \\(.url)\\"" '
+            '      > "{project_path}/.factory/strategy/prior-plans.md" 2>/dev/null || true; '
+            '  fi; '
+            '  if [ ! -s "{project_path}/.factory/strategy/prior-plans.md" ]; then '
+            '    grep -Frl "$FOCUS" "{project_path}/.factory/archive/" --include="plan-*.md" '
+            '      >> "{project_path}/.factory/strategy/prior-plans.md" 2>/dev/null || true; '
+            '  fi; '
+            'fi; '
+            '[ -s "{project_path}/.factory/strategy/prior-plans.md" ]'
+        ),
+        gate_prompt=(
+            "Check GitHub issues with plan label and .factory/archive/ for prior plans "
+            "matching the focus keywords. Write matching results to .factory/strategy/prior-plans.md "
+            "(GitHub issue URLs or local file paths). "
+            "PROCEED if matches exist (file is non-empty), HALT if no matches (skip to fresh research)."
+        ),
+        writes={".factory/strategy/prior-plans.md"},
+    )
+
+    nodes["gate_prior_plans"] = GateNode(
+        id="gate_prior_plans",
+        evaluator_type="user",
+        gate_prompt=(
+            "Prior plan(s) found matching this topic. "
+            "Present the matching plans from .factory/strategy/prior-plans.md to the user. "
+            "If one match: ask 'Found a prior plan on this topic. Continue this plan or start fresh?' "
+            "If multiple matches: list them and let user pick which to continue, or start fresh. "
+            "The selected prior plan (if any) will be passed as context to researchers and strategist."
+        ),
+        reads={".factory/strategy/prior-plans.md"},
+    )
+
+    # ── Research fork ─────────────────────────────────────────
+
+    nodes["fork_research"] = ForkNode(
+        id="fork_research",
+        targets=["researcher_domain", "researcher_practices", "researcher_constraints"],
+    )
+
+    nodes["researcher_domain"] = AgentNode(
+        id="researcher_domain",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Domain research. "
+            "Research the domain for this project. Investigate similar projects, "
+            "existing solutions, the state of the art, and market landscape. "
+            "If this is an existing project, study the codebase structure, "
+            "architecture, eval scores, experiment history, and .factory/archive/. "
+            "If .factory/strategy/backlog.md exists, read it for context on pending work. "
+            "If prior plans exist in .factory/archive/ on this topic "
+            "(listed in .factory/strategy/prior-plans.md if non-empty), "
+            "read and build on them rather than starting fresh. "
+            "Write findings to .factory/strategy/research-domain.md covering: "
+            "domain landscape, similar projects (with links), gaps and opportunities."
+        ),
+        reads={".factory/strategy/prior-plans.md"},
+        writes={".factory/strategy/research-domain.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-domain.md",
+                must_exist=True,
+                min_size=50,
+            )
+        ],
+    )
+
+    nodes["researcher_practices"] = AgentNode(
+        id="researcher_practices",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Best practices research. "
+            "Research best practices, design patterns, and proven approaches "
+            "for this type of project. Look for architecture patterns, "
+            "framework recommendations, and lessons from production systems. "
+            "Check .factory/archive/ for prior knowledge. "
+            "If prior plans exist in .factory/archive/ on this topic "
+            "(listed in .factory/strategy/prior-plans.md if non-empty), "
+            "read and build on them rather than starting fresh. "
+            "Write findings to .factory/strategy/research-practices.md covering: "
+            "recommended approaches, anti-patterns to avoid, proven patterns."
+        ),
+        reads={".factory/strategy/prior-plans.md"},
+        writes={".factory/strategy/research-practices.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-practices.md",
+                must_exist=True,
+                min_size=50,
+            )
+        ],
+    )
+
+    nodes["researcher_constraints"] = AgentNode(
+        id="researcher_constraints",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Constraints and risks research. "
+            "Research technical constraints, risks, and feasibility for this project. "
+            "Identify integration points, dependencies, scalability concerns, "
+            "security considerations, and potential blockers. "
+            "If this is an existing project, review current eval scores and "
+            "identify weakest dimensions. "
+            "If prior plans exist in .factory/archive/ on this topic "
+            "(listed in .factory/strategy/prior-plans.md if non-empty), "
+            "read and build on them rather than starting fresh. "
+            "Write findings to .factory/strategy/research-constraints.md covering: "
+            "technical constraints, risks, dependencies, feasibility assessment."
+        ),
+        reads={".factory/strategy/prior-plans.md"},
+        writes={".factory/strategy/research-constraints.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-constraints.md",
+                must_exist=True,
+                min_size=50,
+            )
+        ],
+    )
+
+    nodes["join_research"] = JoinNode(
+        id="join_research",
+        sources=["researcher_domain", "researcher_practices", "researcher_constraints"],
+        reads={
+            ".factory/strategy/research-domain.md",
+            ".factory/strategy/research-practices.md",
+            ".factory/strategy/research-constraints.md",
+        },
+        writes={".factory/strategy/research-combined.md"},
+    )
+
+    nodes["gate_research"] = GateNode(
+        id="gate_research",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Is the research comprehensive? Does it cover the domain landscape, "
+            "best practices, and technical constraints adequately? "
+            "Check for gaps in coverage. No calendar-time estimates allowed. "
+            "REDIRECT if any research dimension is thin or missing."
+        ),
+        reads={".factory/strategy/research-combined.md"},
+    )
+
+    # ── Strategist ────────────────────────────────────────────
+
+    nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Synthesize a phased implementation plan from research findings. "
+            "Read ALL tagged research files at .factory/strategy/research-*.md. "
+            "If .factory/strategy/backlog.md exists, read it for context on pending work. "
+            "If prior plans exist in .factory/archive/ on this topic "
+            "(listed in .factory/strategy/prior-plans.md if non-empty), "
+            "build on them rather than starting fresh — incorporate prior decisions, "
+            "learnings, and partially-completed work into the new plan. "
+            "Produce a structured plan with phased approach, dependencies, "
+            "success criteria, and open questions. "
+            "Each phase must be scoped to one PR's worth of work. "
+            "Include at least one growth-focused phase. "
+            "Write the plan to .factory/strategy/current.md."
+        ),
+        reads={
+            ".factory/strategy/research-combined.md",
+            ".factory/strategy/prior-plans.md",
+        },
+        writes={".factory/strategy/current.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/current.md",
+                must_exist=True,
+                min_size=200,
+            )
+        ],
+    )
+
+    # ── Three sequential binary user gates ────────────────────
+
+    nodes["gate_keep_plan"] = GateNode(
+        id="gate_keep_plan",
+        evaluator_type="user",
+        gate_prompt=(
+            "Present the plan to the user. Ask: 'Keep this plan? "
+            "(yes → archive it, no → discard)'\n"
+            "Map: yes → PROCEED, no → HALT"
+        ),
+        reads={".factory/strategy/current.md"},
+    )
+
+    nodes["gate_publish_github"] = GateNode(
+        id="gate_publish_github",
+        evaluator_type="user",
+        gate_prompt=(
+            "Ask the user: 'Publish this plan as a GitHub issue? "
+            "(yes → post to GitHub, no → skip publishing)'\n"
+            "Map: yes → PROCEED, no → HALT"
+        ),
+        reads={".factory/strategy/current.md"},
+    )
+
+    nodes["gate_seed_backlog"] = GateNode(
+        id="gate_seed_backlog",
+        evaluator_type="user",
+        gate_prompt=(
+            "Ask the user: 'Seed backlog? "
+            "(yes → commit phases as backlog items, no → done)'\n"
+            "Map: yes → PROCEED, no → HALT"
+        ),
+        reads={".factory/strategy/current.md"},
+    )
+
+    # ── GitHub publishing ─────────────────────────────────────
+
+    nodes["publish_github"] = FnNode(
+        id="publish_github",
+        command=(
+            'bash -c \''
+            'set -e; '
+            'echo "none" > "{project_path}/.factory/strategy/github-issue-ref.txt"; '
+            'if ! gh auth status >/dev/null 2>&1; then '
+            '  echo "SKIP: gh not authenticated"; exit 0; '
+            'fi; '
+            'if ! git remote -v 2>/dev/null | grep -q .; then '
+            '  echo "SKIP: no git remote configured"; exit 0; '
+            'fi; '
+            'gh label create plan --description "Approved plan" --color 0366d6 --force 2>/dev/null || true; '
+            'FOCUS="${FOCUS:-}"; '
+            'ISSUE_NUM=""; '
+            'if echo "$FOCUS" | grep -qE "^[0-9]+$"; then '
+            '  ISSUE_NUM="$FOCUS"; '
+            'elif echo "$FOCUS" | grep -qoE "#([0-9]+)"; then '
+            '  ISSUE_NUM=$(echo "$FOCUS" | grep -oE "[0-9]+" | tail -1); '
+            'fi; '
+            'if [ -n "$ISSUE_NUM" ]; then '
+            '  gh issue comment "$ISSUE_NUM" --body-file "{project_path}/.factory/strategy/current.md"; '
+            '  gh issue edit "$ISSUE_NUM" --add-label plan; '
+            '  echo "$ISSUE_NUM" > "{project_path}/.factory/strategy/github-issue-ref.txt"; '
+            '  echo "Plan posted to issue #$ISSUE_NUM"; '
+            'else '
+            '  TITLE="Plan: ${FOCUS:-project}"; '
+            '  ISSUE_URL=$(gh issue create --title "$TITLE" --body-file "{project_path}/.factory/strategy/current.md" --label plan); '
+            '  ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE "[0-9]+$"); '
+            '  echo "$ISSUE_NUM" > "{project_path}/.factory/strategy/github-issue-ref.txt"; '
+            '  echo "Created plan issue: $ISSUE_URL"; '
+            'fi'
+            '\''
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/strategy/github-issue-ref.txt"},
+        notes=(
+            "Publishes the approved plan to a GitHub issue. Two cases: "
+            "if --focus is an issue number, posts as a comment on that issue and adds the plan label. "
+            "Otherwise, creates a new issue titled 'Plan: <focus>'. "
+            "Writes the issue number to github-issue-ref.txt for downstream use by seed_backlog. "
+            "Graceful degradation: if gh is not authenticated or no git remote exists, "
+            "writes 'none' and exits cleanly."
+        ),
+    )
+
+    # ── Backlog seeding ───────────────────────────────────────
+
+    nodes["seed_backlog"] = FnNode(
+        id="seed_backlog",
+        command=(
+            'python3 -c "'
+            "import re, os; "
+            "project = '{project_path}'; "
+            "plan = open(f'{project}/.factory/strategy/current.md').read(); "
+            "ref_file = f'{project}/.factory/strategy/github-issue-ref.txt'; "
+            "issue_num = open(ref_file).read().strip() if os.path.exists(ref_file) else 'none'; "
+            "ref = f'(see #{issue_num})' if issue_num != 'none' else '(see .factory/strategy/current.md)'; "
+            "phases = re.findall(r'### Phase \\d+:.*', plan); "
+            "backlog_path = f'{project}/.factory/strategy/backlog.md'; "
+            "items = '\\n'.join(f'- [ ] {p[4:]} {ref}' for p in phases); "
+            "open(backlog_path, 'a').write('\\n' + items + '\\n') if items else None; "
+            "print(f'Seeded {len(phases)} backlog items from plan')"
+            '"'
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/strategy/backlog.md"},
+        notes=(
+            "Extracts phase headers from the approved plan at current.md and appends them "
+            "as backlog items to backlog.md. References GitHub issue number if publish_github "
+            "ran (reads github-issue-ref.txt), otherwise references current.md. "
+            "Example: '- [ ] Phase 1: Set up auth middleware (see #42)'"
+        ),
+    )
+
+    # ── Edges ─────────────────────────────────────────────────
+
+    edges = [
+        # Prior plan detection
+        Edge(source="check_prior_plans", target="gate_prior_plans", condition=VerdictType.PROCEED),
+        Edge(source="check_prior_plans", target="fork_research", condition=VerdictType.HALT),
+        # User chose (continue or fresh) → research
+        Edge(source="gate_prior_plans", target="fork_research", condition=VerdictType.PROCEED),
+        # Fork to researchers
+        Edge(source="fork_research", target="researcher_domain"),
+        Edge(source="fork_research", target="researcher_practices"),
+        Edge(source="fork_research", target="researcher_constraints"),
+        # Researchers to join
+        Edge(source="researcher_domain", target="join_research"),
+        Edge(source="researcher_practices", target="join_research"),
+        Edge(source="researcher_constraints", target="join_research"),
+        # Join → research gate
+        Edge(source="join_research", target="gate_research"),
+        # Research gate → strategist (proceed) or back to fork (reloop)
+        Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+        Edge(source="gate_research", target="fork_research", condition=VerdictType.RELOOP),
+        # Strategist → first user gate (keep or discard?)
+        Edge(source="strategist", target="gate_keep_plan"),
+        # Keep gate → publish gate
+        Edge(source="gate_keep_plan", target="gate_publish_github", condition=VerdictType.PROCEED),
+        # Publish gate → publish FnNode (user says yes)
+        Edge(source="gate_publish_github", target="publish_github", condition=VerdictType.PROCEED),
+        # Publish gate → skip to seed backlog gate (user says no)
+        Edge(source="gate_publish_github", target="gate_seed_backlog", condition=VerdictType.HALT),
+        # After publishing → seed backlog gate
+        Edge(source="publish_github", target="gate_seed_backlog"),
+        # Seed backlog gate
+        Edge(source="gate_seed_backlog", target="seed_backlog", condition=VerdictType.PROCEED),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "plan"
+
+    return Workflow(
+        name="plan",
+        nodes=nodes,
+        edges=edges,
+        start_node="check_prior_plans",
+        trigger=trigger,
+        terminal=True,
+    )
+
+
 def register_all() -> dict[str, Workflow]:
     """Build and return all workflow definitions."""
     from factory.workflow.deep_qa import workflow as deep_qa_workflow
@@ -3412,6 +3784,7 @@ def register_all() -> dict[str, Workflow]:
         "spec-generate": spec_generate_workflow(),
         "spec-update": spec_update_workflow(),
         "founder": founder_workflow(),
+        "plan": plan_workflow(),
         "frontend-design": frontend_design_workflow(),
         "frontend-design-scan": frontend_design_scan_workflow(),
     }

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -142,6 +142,18 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
         ),
         "argument_hint": '"mode description" or "existing_mode: change description"',
     },
+    "plan": {
+        "description": (
+            "Plan mode — prior plan check + research + strategy + keep/publish/seed approve, "
+            "with NO implementation. Checks for prior plans on GitHub issues (plan label) and "
+            "local archive before researching. Produces a phased plan at .factory/strategy/current.md. "
+            "Three sequential gates: Keep plan? → Publish to GitHub? → Seed backlog? "
+            "Terminal — does not chain to build or improve. Use when the user says 'plan X', "
+            "'just plan', 'research and plan but don't build', or wants strategic analysis "
+            "without code changes."
+        ),
+        "argument_hint": "<project_path> [--focus <topic>]",
+    },
     "founder": {
         "description": (
             "Founder mode — rapid prototyping pipeline for fast hypothesis iteration. "

--- a/tests/test_plan_workflow.py
+++ b/tests/test_plan_workflow.py
@@ -1,0 +1,171 @@
+"""Tests for plan_workflow — W₁₅: Plan Mode."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from factory.workflow.definitions import plan_workflow
+from factory.workflow.primitives import (
+    AgentNode,
+    FnNode,
+    GateNode,
+    VerdictType,
+)
+
+
+@pytest.fixture()
+def wf():
+    return plan_workflow()
+
+
+# ── Structure tests ──────────────────────────────────────────────
+
+
+def test_plan_workflow_structure(wf):
+    """Verify node and edge counts match the expected topology."""
+    assert len(wf.nodes) == 14
+    assert len(wf.edges) == 18
+    assert wf.name == "plan"
+    assert wf.start_node == "check_prior_plans"
+    assert wf.terminal is True
+
+
+def test_plan_workflow_no_archivist_in_build_path(wf):
+    """Verify no archivist node exists — replaced by GitHub publishing."""
+    assert "archivist_plan" not in wf.nodes
+    for node in wf.nodes.values():
+        if isinstance(node, AgentNode):
+            assert node.role.value != "archivist"
+
+
+def test_plan_workflow_edge_coverage(wf):
+    """Verify all expected edges exist with correct conditions."""
+    edge_tuples = [
+        (e.source, e.target, e.condition)
+        for e in wf.edges
+    ]
+    expected = [
+        ("check_prior_plans", "gate_prior_plans", VerdictType.PROCEED),
+        ("check_prior_plans", "fork_research", VerdictType.HALT),
+        ("gate_prior_plans", "fork_research", VerdictType.PROCEED),
+        ("fork_research", "researcher_domain", None),
+        ("fork_research", "researcher_practices", None),
+        ("fork_research", "researcher_constraints", None),
+        ("researcher_domain", "join_research", None),
+        ("researcher_practices", "join_research", None),
+        ("researcher_constraints", "join_research", None),
+        ("join_research", "gate_research", None),
+        ("gate_research", "strategist", VerdictType.PROCEED),
+        ("gate_research", "fork_research", VerdictType.RELOOP),
+        ("strategist", "gate_keep_plan", None),
+        ("gate_keep_plan", "gate_publish_github", VerdictType.PROCEED),
+        ("gate_publish_github", "publish_github", VerdictType.PROCEED),
+        ("gate_publish_github", "gate_seed_backlog", VerdictType.HALT),
+        ("publish_github", "gate_seed_backlog", None),
+        ("gate_seed_backlog", "seed_backlog", VerdictType.PROCEED),
+    ]
+    assert edge_tuples == expected
+
+
+# ── Node-specific tests ─────────────────────────────────────────
+
+
+def test_plan_publish_github_node_exists(wf):
+    """Verify publish_github FnNode exists with correct reads/writes."""
+    node = wf.nodes["publish_github"]
+    assert isinstance(node, FnNode)
+    assert ".factory/strategy/current.md" in node.reads
+    assert ".factory/strategy/github-issue-ref.txt" in node.writes
+
+
+def test_plan_gate_publish_github_exists(wf):
+    """Verify gate_publish_github GateNode exists with user evaluator."""
+    node = wf.nodes["gate_publish_github"]
+    assert isinstance(node, GateNode)
+    assert node.evaluator_type == "user"
+
+
+def test_plan_no_archivist_node(wf):
+    """Verify archivist_plan is NOT in workflow nodes."""
+    assert "archivist_plan" not in wf.nodes
+
+
+def test_plan_publish_github_edges(wf):
+    """Verify the publish path edges are correctly wired."""
+    edges_from_keep = [
+        (e.target, e.condition)
+        for e in wf.edges if e.source == "gate_keep_plan"
+    ]
+    assert ("gate_publish_github", VerdictType.PROCEED) in edges_from_keep
+
+    edges_from_publish_gate = [
+        (e.target, e.condition)
+        for e in wf.edges if e.source == "gate_publish_github"
+    ]
+    assert ("publish_github", VerdictType.PROCEED) in edges_from_publish_gate
+    assert ("gate_seed_backlog", VerdictType.HALT) in edges_from_publish_gate
+
+    edges_from_publish = [
+        (e.target, e.condition)
+        for e in wf.edges if e.source == "publish_github"
+    ]
+    assert ("gate_seed_backlog", None) in edges_from_publish
+
+
+def test_plan_seed_backlog_no_archive_ref(wf):
+    """Verify seed_backlog references github-issue-ref.txt, not .factory/archive/."""
+    node = wf.nodes["seed_backlog"]
+    assert isinstance(node, FnNode)
+    assert "github-issue-ref.txt" in node.command
+    assert ".factory/archive/" not in node.command
+
+
+def test_plan_check_prior_plans_github_search(wf):
+    """Verify check_prior_plans searches GitHub issues first."""
+    node = wf.nodes["check_prior_plans"]
+    assert isinstance(node, GateNode)
+    assert "gh issue list --label plan" in node.evaluator_command
+
+
+def test_plan_check_prior_plans_local_fallback(wf):
+    """Verify check_prior_plans falls back to local grep."""
+    node = wf.nodes["check_prior_plans"]
+    assert isinstance(node, GateNode)
+    assert "grep -Frl" in node.evaluator_command
+
+
+def test_plan_publish_github_graceful_degradation(wf):
+    """Verify publish_github checks gh auth status for graceful degradation."""
+    node = wf.nodes["publish_github"]
+    assert isinstance(node, FnNode)
+    assert "gh auth status" in node.command
+
+
+def test_plan_publish_github_body_file(wf):
+    """Verify publish_github uses --body-file, not --body."""
+    node = wf.nodes["publish_github"]
+    assert isinstance(node, FnNode)
+    assert "--body-file" in node.command
+
+
+def test_plan_workflow_validates():
+    """Run factory workflow validate plan and assert no errors."""
+    result = subprocess.run(
+        ["factory", "workflow", "validate", "plan"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"Validation failed: {result.stderr}"
+
+
+def test_plan_skill_export(wf):
+    """Verify skill export produces valid SKILL.md content."""
+    from factory.workflow.skill_export import workflow_to_skill_md
+
+    skill = workflow_to_skill_md(wf)
+    assert "workflow-plan" in skill
+    assert "Publish" in skill
+    assert "archivist" not in skill.lower() or "archivist_plan" not in skill


### PR DESCRIPTION
Closes #1105

## Changes

- **`factory/workflow/definitions.py`**: Added `plan_workflow()` (W₁₅) — a terminal, interactive planning mode with 14 nodes and 18 edges. Includes `gate_publish_github` (user gate), `publish_github` (FnNode for posting to GitHub issues), modified `check_prior_plans` (GitHub-first search with local fallback), and modified `seed_backlog` (references GitHub issue numbers). No `archivist_plan` node — replaced by GitHub publishing.
- **`factory/workflow/skill_export.py`**: Added `WORKFLOW_META` entry for plan mode describing GitHub publishing and three sequential gates.
- **`factory/cli/_task_builder.py`**: Added plan mode suffix describing the GitHub-first workflow.
- **`factory/cli/_helpers.py`**: Added `"plan"` to `CEO_MODES`.
- **`factory/models.py`**: Added `"plan"` to `CycleState.mode` Literal type.
- **`tests/test_plan_workflow.py`**: 14 tests covering structure, node-specific checks, edge coverage, GitHub integration, graceful degradation, and skill export.