### PR TITLE
chore: add abhi1092 to ceo-review callers

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
-      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98", "lukeinglis", "nehamalepati"]'), github.event.comment.user.login)
+      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98", "lukeinglis", "nehamalepati", "abhi1092"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -765,7 +765,7 @@ class TestCmdCeoMultiIssue:
             patch("factory.cli.ceo._execute_ceo", return_value=0) as mock_exec,
         ):
             mock_validate.return_value = (
-                "improve", False, False, False, None, "111 and 112", None, None,
+                "improve", False, False, False, None, "111 and 112", None, None, False,
             )
             mock_resolve.return_value = (
                 Path("/tmp/fake"), None, None, None,
@@ -821,7 +821,7 @@ class TestCmdCeoMultiIssue:
             patch("factory.cli.ceo._execute_ceo", return_value=0) as mock_exec,
         ):
             mock_validate.return_value = (
-                "improve", False, False, False, None, "42", None, None,
+                "improve", False, False, False, None, "42", None, None, False,
             )
             mock_resolve.return_value = (
                 Path("/tmp/fake"), None, None, None,
@@ -858,7 +858,7 @@ class TestCmdCeoMultiIssue:
             patch("factory.cli.ceo._resolve_ceo_project") as mock_resolve,
         ):
             mock_validate.return_value = (
-                "improve", False, False, False, None, "111 and 112", None, None,
+                "improve", False, False, False, None, "111 and 112", None, None, False,
             )
             mock_resolve.return_value = (
                 Path("/tmp/fake"), None, None, None,


### PR DESCRIPTION
## Summary
- Adds `abhi1092` to the allowed callers list for the `@ceo-review` workflow trigger

## Test plan
- [x] Verify the JSON array in `ceo-review.yml` is valid
- [ ] Confirm user can trigger `@ceo-review` on a PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)