### PR TITLE
fix: handle long prompts in design mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,7 @@ factory ceo "Build a weather CLI" --dir my-app  # Explicit dir name override
 factory ceo ~/ideas/spec.md                     # Spec file → new project
 factory ceo https://github.com/user/repo        # Clone and improve
 factory ceo "distributed eval runner" --mode design  # Brainstorm → build
+factory ceo ~/ideas/detailed-spec.md --mode design   # Long idea from file (no length limit)
 factory ceo /path/to/project --mode design           # Discuss what to work on → improve
 factory ceo /path/to/project --mode design --focus "auth"  # Discuss a specific topic
 factory ceo "weather CLI" --mode design --auto-approve  # Design without user approval gate

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ uv run factory ceo "distributed eval runner" --mode design
 uv run factory ceo "Build a REST API for bookmark management" --mode design
 ```
 
-**From a spec file** — read and discuss before building:
+**From a spec file** — for longer, more detailed descriptions, write your idea to a `.md` file and pass the path:
+
+> **Tip:** For detailed ideas with multiple paragraphs, requirements, or research notes, use a spec file instead of a quoted string. There's no length limit on file content.
 
 ```bash
 uv run factory ceo ~/ideas/weather-dashboard.md --mode design

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -219,7 +219,7 @@ def _resolve_ceo_project(
         design_existing = True
     elif mode == "design":
         resolved_file = Path(raw_path).expanduser()
-        if resolved_file.is_file():
+        if _safe_is_file(resolved_file):
             design_idea = resolved_file.read_text()
             slug = (
                 _slugify(dir_name)


### PR DESCRIPTION
## Summary
- Bare `Path.is_file()` on long prompt strings crashes with `[Errno 63] File name too long` on macOS (255-byte filename limit). Wrapped with `_safe_is_file()` which catches `OSError` and falls through to the raw-prompt branch.
- Updated README and CLAUDE.md to document using spec files for longer idea descriptions.

## Test plan
- [x] `pytest -k "path_resolver or ceo"` — 311 passed
- [x] Verified the original failing command now works

🤖 Generated with [Claude Code](https://claude.com/claude-code)