### PR TITLE
feat: add OpenCode runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,10 +172,22 @@ CODEX_API_KEY = "..."
 Then run: `factory ceo /path/to/project --profile codex`
 
 **OpenCode specifics:**
-- Requires `OPENAI_API_KEY` environment variable
-- The factory targets `opencode-ai/opencode` v0.x (uses `-p`, `-q`, `-c` flags). Install from source: `go install github.com/opencode-ai/opencode@latest`, or via the [GitHub release tarball](https://github.com/opencode-ai/opencode/releases)
-- Do NOT use the `curl` installer at `opencode.ai/install` — it installs the `anomalyco/opencode` fork (v1.x) which has an incompatible CLI interface
+- The factory targets `anomalyco/opencode` v1.x (TypeScript/Bun). Install via: `curl -fsSL https://opencode.ai/install | bash` or `npm i -g opencode-ai`
+- Auth: run `opencode auth login` (interactive), or set a provider env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_ACCESS_KEY_ID`, etc.)
+- Headless mode uses `opencode run '<prompt>' --format json --dir <cwd> --auto`
+- Model selection via `--model` flag (e.g., `anthropic/claude-sonnet-4-20250514`)
+- Session management: `--title <name>` (name a session), `--session <id>` (resume by ID), `--continue` (continue last session)
 - Dry-run mode: `FACTORY_OPENCODE_DRY_RUN=1`
+- Token guardrails: `FACTORY_OPENCODE_MAX_INVOCATIONS_PER_CYCLE` (default: 8), logged to `.factory/opencode_usage.jsonl`
+- Unsupported: `--bg` (no background mode), `--tmux-persist` (returns explicit error), CEO message events (no JSON streaming equivalent)
+
+**OpenCode config profile example** (`~/.factory/config.toml`):
+```toml
+[credentials.opencode]
+FACTORY_RUNNER = "opencode"
+ANTHROPIC_API_KEY = "sk-ant-..."
+```
+Then run: `factory ceo /path/to/project --profile opencode`
 
 **Important:** Target projects should add `.factory/` to their `.gitignore`. The factory writes experiment data, usage logs, and potentially sensitive auth files (`.factory/.bob_auth`) to this directory. These are project-local artifacts that should not be committed to version control.
 

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -67,6 +67,8 @@ def get_runner(name: str | None = None, project_path: Path | None = None) -> Run
 
     if resolved == "bob":
         return BobRunner(project_path=project_path)
+    if resolved == "opencode":
+        return OpenCodeRunner(project_path=project_path)
     return _RUNNERS[resolved]()
 
 

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -186,9 +186,12 @@ class OpenCodeRunner:
 
     def build_command(self, request: AgentRunRequest) -> tuple[list[str], dict[str, str], list[Path]]:
         """Build the OpenCode v1.x CLI command for headless execution."""
-        full_prompt = f"{request.prompt}\n\n---\n\n## Current Task\n\n{request.task}"
+        cwd = Path(request.cwd)
+        agents_md_path = cwd / "AGENTS.md"
+        agents_md_path.write_text(request.prompt)
+        temp_files: list[Path] = [agents_md_path]
 
-        cmd = ["opencode", "run", full_prompt, "--format", "json", "--dir", str(request.cwd)]
+        cmd = ["opencode", "run", request.task, "--format", "json", "--dir", str(request.cwd)]
 
         if request.skip_permissions:
             cmd.append("--auto")
@@ -206,13 +209,16 @@ class OpenCodeRunner:
             cmd.append("--continue")
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-        return cmd, env, []
+        return cmd, env, temp_files
 
     def build_interactive_command(self, request: AgentRunRequest) -> tuple[list[str], dict[str, str], list[Path]]:
         """Build the CLI command for interactive (TUI) mode."""
-        full_prompt = f"{request.prompt}\n\n---\n\n## Current Task\n\n{request.task}"
+        cwd = Path(request.cwd)
+        agents_md_path = cwd / "AGENTS.md"
+        agents_md_path.write_text(request.prompt)
+        temp_files: list[Path] = [agents_md_path]
 
-        cmd = ["opencode", "--prompt", full_prompt, "--dir", str(request.cwd)]
+        cmd = ["opencode", "--prompt", request.task, "--dir", str(request.cwd)]
 
         if request.model:
             cmd.extend(["--model", request.model])
@@ -224,7 +230,7 @@ class OpenCodeRunner:
             cmd.extend(["--session", request.resume_session_id])
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-        return cmd, env, []
+        return cmd, env, temp_files
 
     async def headless(self, request: AgentRunRequest) -> AgentRunResult:
         """Run a headless OpenCode v1.x invocation."""
@@ -261,22 +267,26 @@ class OpenCodeRunner:
             self._emit_ceiling_event(project_path, e)
             return AgentRunResult(stdout=str(e), return_code=1)
 
-        cmd, env, _ = self.build_command(request)
+        cmd, env, temp_files = self.build_command(request)
 
         log.info("opencode_headless", cwd=str(request.cwd), role=request.role, model=request.model)
 
         start_time = time.monotonic()
 
-        result = await run_subprocess(
-            cmd, cwd=str(request.cwd), env=env,
-            timeout=request.timeout, runner_name="opencode", role=request.role,
-            sanitize=True,
-        )
+        try:
+            result = await run_subprocess(
+                cmd, cwd=str(request.cwd), env=env,
+                timeout=request.timeout, runner_name="opencode", role=request.role,
+                sanitize=True,
+            )
 
-        duration = time.monotonic() - start_time
-        log_usage(project_path, request.role, request.cwd, duration, result.return_code, dry_run=False, runner_name=_RUNNER_NAME)
+            duration = time.monotonic() - start_time
+            log_usage(project_path, request.role, request.cwd, duration, result.return_code, dry_run=False, runner_name=_RUNNER_NAME)
 
-        return result
+            return result
+        finally:
+            for f in temp_files:
+                f.unlink(missing_ok=True)
 
     def interactive_run(self, request: AgentRunRequest) -> int:
         """Run an interactive OpenCode v1.x session as a subprocess."""
@@ -295,12 +305,16 @@ class OpenCodeRunner:
             print(f"ERROR: {e}")
             return 1
 
-        cmd, env, _ = self.build_interactive_command(request)
+        cmd, env, temp_files = self.build_interactive_command(request)
 
         log.info("opencode_interactive", cwd=str(request.cwd))
 
-        result = subprocess.run(cmd, cwd=request.cwd, env=env)
-        return result.returncode
+        try:
+            result = subprocess.run(cmd, cwd=request.cwd, env=env)
+            return result.returncode
+        finally:
+            for f in temp_files:
+                f.unlink(missing_ok=True)
 
     def _find_project_path(self, cwd: Path) -> Path:
         """Find the project root (directory containing .factory/)."""

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -223,9 +223,6 @@ class OpenCodeRunner:
         if request.model:
             cmd.extend(["--model", request.model])
 
-        if request.session_name:
-            cmd.extend(["--title", request.session_name])
-
         if request.resume_session_id:
             cmd.extend(["--session", request.resume_session_id])
 

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -218,7 +218,7 @@ class OpenCodeRunner:
         agents_md_path.write_text(request.prompt)
         temp_files: list[Path] = [agents_md_path]
 
-        cmd = ["opencode", "--prompt", request.task, "--dir", str(request.cwd)]
+        cmd = ["opencode", "--prompt", request.task, str(request.cwd)]
 
         if request.model:
             cmd.extend(["--model", request.model])

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -212,7 +212,7 @@ class OpenCodeRunner:
         """Build the CLI command for interactive (TUI) mode."""
         full_prompt = f"{request.prompt}\n\n---\n\n## Current Task\n\n{request.task}"
 
-        cmd = ["opencode", full_prompt, "--dir", str(request.cwd)]
+        cmd = ["opencode", "--prompt", full_prompt, "--dir", str(request.cwd)]
 
         if request.model:
             cmd.extend(["--model", request.model])

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -1,15 +1,23 @@
-"""OpenCodeRunner — OpenCode CLI backend implementation."""
+"""OpenCodeRunner — OpenCode v1.x (anomalyco/opencode) CLI backend."""
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import structlog
 
 from factory.runners._subprocess import run_subprocess
+from factory.runners.usage import (
+    CeilingExceededError,
+    check_ceilings,
+    log_usage,
+)
 
 if TYPE_CHECKING:
     from factory.models import AgentRunRequest, AgentRunResult
@@ -20,53 +28,55 @@ log = structlog.get_logger()
 _auth_checked = False
 _compat_checked = False
 
+_RUNNER_NAME = "opencode"
+
+_PROVIDER_ENV_VARS = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "AZURE_OPENAI_API_KEY",
+)
+
 
 class OpenCodeAuthError(Exception):
-    """Raised when OPENAI_API_KEY is not set."""
+    """Raised when no OpenCode auth is available."""
 
     def __init__(self) -> None:
         super().__init__(
-            "OPENAI_API_KEY environment variable is not set. "
-            "Set it directly or add it to a config.toml credential profile: "
-            "[credentials.opencode] OPENAI_API_KEY = \"...\""
+            "No OpenCode authentication found. "
+            "Run 'opencode auth login' to authenticate, "
+            "or set a provider API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.). "
+            "Alternatively, add keys to a config.toml credential profile: "
+            "[credentials.opencode] ANTHROPIC_API_KEY = \"...\""
         )
 
 
-def _can_source_key_from_shell() -> bool:
-    """Check if OPENAI_API_KEY can be sourced from ~/.zshrc."""
-    try:
-        result = subprocess.run(
-            ["zsh", "-c", "source ~/.zshrc 2>/dev/null && echo $OPENAI_API_KEY"],
-            capture_output=True, text=True, timeout=5,
-        )
-        return bool(result.stdout.strip())
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return False
+def _has_opencode_auth() -> bool:
+    """Check if OpenCode auth is available via config dir or provider env vars."""
+    opencode_dir = Path.home() / ".opencode"
+    if opencode_dir.is_dir():
+        return True
+    return any(os.environ.get(v) for v in _PROVIDER_ENV_VARS)
 
 
 def _check_auth() -> None:
-    """Check that OPENAI_API_KEY is available (env or shell profile, once per process)."""
+    """Check that OpenCode auth is available (once per process)."""
     global _auth_checked  # noqa: PLW0603
     if _auth_checked:
         return
     _check_binary_compat()
-    if os.environ.get("OPENAI_API_KEY"):
-        _auth_checked = True
-        return
-    if _can_source_key_from_shell():
+    if _has_opencode_auth():
         _auth_checked = True
         return
     raise OpenCodeAuthError()
 
 
 def _check_binary_compat() -> None:
-    """Warn if the opencode binary is the npm version instead of the Go version.
+    """Warn if the opencode binary is v0.x (archived Go version).
 
-    The OpenCode runner relies on CLI flags (-p, -c, -q) that only exist in the
-    Go binary (go install github.com/opencode-ai/opencode@latest).  The npm
-    package (opencode-ai) exposes a different CLI that silently ignores these
-    flags.  We detect the Go binary by running ``opencode version`` and checking
-    for output matching ``opencode version v<semver>``.
+    v1.x (anomalyco/opencode) outputs version strings like "1.18.14".
+    v0.x (opencode-ai/opencode) outputs "opencode version v0.x.x".
     """
     global _compat_checked  # noqa: PLW0603
     if _compat_checked:
@@ -77,80 +87,53 @@ def _check_binary_compat() -> None:
     import shutil
 
     if not shutil.which("opencode"):
-        # Binary not on PATH at all — _find_opencode_bin_dir will handle later.
         return
 
     try:
         result = subprocess.run(
-            ["opencode", "version"],
+            ["opencode", "--version"],
             capture_output=True,
             text=True,
             timeout=10,
         )
-        output = (result.stdout or "").strip() + (result.stderr or "").strip()
-        # Go binary outputs e.g. "opencode version v0.0.55" or "v0.1.0"
-        if re.search(r"v\d+\.\d+\.\d+", output):
-            log.debug("opencode_binary_compat_ok", output=output)
+        output = (getattr(result, "stdout", None) or "").strip() + (getattr(result, "stderr", None) or "").strip()
+        if re.search(r"\bv?0\.\d+\.\d+", output):
+            log.warning(
+                "opencode_binary_v0x_detected",
+                output=output,
+                hint=(
+                    "The opencode binary appears to be v0.x (archived). "
+                    "The factory requires OpenCode v1.x (anomalyco/opencode). "
+                    "Install via: curl -fsSL https://opencode.ai/install | bash "
+                    "or: npm i -g opencode-ai"
+                ),
+            )
             return
-        log.warning(
-            "opencode_binary_compat_mismatch",
-            output=output,
-            hint=(
-                "The opencode binary does not appear to be the Go version. "
-                "The factory OpenCode runner requires the Go binary "
-                "(go install github.com/opencode-ai/opencode@latest). "
-                "The npm package 'opencode-ai' has a different CLI and will "
-                "fail silently. Please install the Go version."
-            ),
-        )
+        log.debug("opencode_binary_compat_ok", output=output)
     except FileNotFoundError:
         pass
     except subprocess.TimeoutExpired:
         log.debug("opencode_version_check_timeout")
 
 
-def _find_opencode_bin_dir() -> str | None:
-    """Find the directory containing the opencode binary."""
-    import shutil
+def _parse_opencode_output(raw: str) -> tuple[str, str | None]:
+    """Try to parse --format json output from OpenCode v1.x.
 
-    oc_path = shutil.which("opencode")
-    if oc_path:
-        return str(Path(oc_path).parent)
-    candidates = [
-        Path.home() / "go" / "bin",
-        Path(os.environ.get("GOPATH", "")) / "bin" if os.environ.get("GOPATH") else None,
-    ]
-    for d in candidates:
-        if d is not None and (d / "opencode").is_file():
-            return str(d)
-    return None
-
-
-def _prepend_opencode_path(env: dict[str, str]) -> None:
-    """Prepend the opencode binary directory to PATH if found."""
-    bin_dir = _find_opencode_bin_dir()
-    if bin_dir:
-        current_path = env.get("PATH", "")
-        if not current_path.startswith(bin_dir):
-            env["PATH"] = f"{bin_dir}:{current_path}"
-            log.debug("opencode_path_prepended", dir=bin_dir)
-
-
-def _source_openai_key_from_shell(env: dict[str, str]) -> None:
-    """If OPENAI_API_KEY is missing, try sourcing it from ~/.zshrc into env (not os.environ)."""
-    if env.get("OPENAI_API_KEY"):
-        return
-    try:
-        result = subprocess.run(
-            ["zsh", "-c", "source ~/.zshrc 2>/dev/null && echo $OPENAI_API_KEY"],
-            capture_output=True, text=True, timeout=5,
-        )
-        key = result.stdout.strip()
-        if key:
-            env["OPENAI_API_KEY"] = key
-            log.debug("openai_key_sourced_from_zshrc")
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
+    Returns (text, session_id). Falls back to (raw, None) if not parseable.
+    """
+    for line in reversed(raw.strip().splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            text = data.get("content", data.get("text", data.get("message", "")))
+            session_id = data.get("sessionId", data.get("session_id"))
+            if text:
+                return str(text), session_id
+        except (json.JSONDecodeError, AttributeError):
+            continue
+    return raw, None
 
 
 def is_opencode_dry_run() -> bool:
@@ -162,9 +145,25 @@ def is_opencode_dry_run() -> bool:
 
 
 class OpenCodeRunner:
-    """Runner implementation for OpenCode CLI."""
+    """Runner implementation for OpenCode v1.x CLI (anomalyco/opencode)."""
 
     name: str = "opencode"
+
+    def __init__(
+        self,
+        cycle_start: datetime | None = None,
+        project_path: Path | None = None,
+    ) -> None:
+        if cycle_start is not None:
+            self.cycle_start = cycle_start
+        elif project_path is not None:
+            from factory.ceo_completion import read_cycle_state
+
+            state = read_cycle_state(project_path)
+            self.cycle_start = state.started_at if state else datetime.now(timezone.utc)
+        else:
+            self.cycle_start = datetime.now(timezone.utc)
+        self._role: str = "unknown"
 
     @classmethod
     def metadata(cls) -> RunnerMeta:
@@ -173,70 +172,128 @@ class OpenCodeRunner:
             name="opencode",
             display_name="OpenCode",
             binary="opencode",
-            install_hint="go install github.com/opencode-ai/opencode@latest",
-            required_env_vars=["OPENAI_API_KEY"],
-            supports_model_override=False,
+            install_hint="curl -fsSL https://opencode.ai/install | bash",
+            required_env_vars=[],
+            supports_model_override=True,
             supports_interactive=True,
             supports_streaming=True,
             supports_usage_telemetry=False,
-            supports_session_name=False,
+            supports_session_name=True,
+            supports_session_resume=True,
+            supports_background=False,
+            custom_auth_check=_has_opencode_auth,
         )
 
     def build_command(self, request: AgentRunRequest) -> tuple[list[str], dict[str, str], list[Path]]:
-        """Build the OpenCode CLI command and env dict."""
+        """Build the OpenCode v1.x CLI command for headless execution."""
         full_prompt = f"{request.prompt}\n\n---\n\n## Current Task\n\n{request.task}"
 
-        cmd = [
-            "opencode",
-            "-p", full_prompt,
-            "-c", str(request.cwd),
-            "-q",
-        ]
+        cmd = ["opencode", "run", full_prompt, "--format", "json", "--dir", str(request.cwd)]
+
+        if request.skip_permissions:
+            cmd.append("--auto")
+
+        if request.model:
+            cmd.extend(["--model", request.model])
+
+        if request.session_name:
+            cmd.extend(["--title", request.session_name])
+
+        if request.resume_session_id:
+            cmd.extend(["--session", request.resume_session_id])
+
+        if request.session_id:
+            cmd.append("--continue")
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-        _prepend_opencode_path(env)
-        _source_openai_key_from_shell(env)
+        return cmd, env, []
 
+    def build_interactive_command(self, request: AgentRunRequest) -> tuple[list[str], dict[str, str], list[Path]]:
+        """Build the CLI command for interactive (TUI) mode."""
+        full_prompt = f"{request.prompt}\n\n---\n\n## Current Task\n\n{request.task}"
+
+        cmd = ["opencode", full_prompt, "--dir", str(request.cwd)]
+
+        if request.model:
+            cmd.extend(["--model", request.model])
+
+        if request.session_name:
+            cmd.extend(["--title", request.session_name])
+
+        if request.resume_session_id:
+            cmd.extend(["--session", request.resume_session_id])
+
+        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
         return cmd, env, []
 
     async def headless(self, request: AgentRunRequest) -> AgentRunResult:
-        """Run a headless OpenCode invocation."""
+        """Run a headless OpenCode v1.x invocation."""
+        from factory.models import AgentRunResult
+
+        tmux_persist = request.extras.get("tmux_persist", False)
+        if tmux_persist:
+            return AgentRunResult(
+                stdout="Error: --tmux-persist is not supported with the opencode runner. Use --runner claude.",
+                return_code=1,
+            )
+
         background = request.extras.get("background", False)
         if background:
-            log.warning("opencode_bg_not_supported", hint="--bg is a claude-only feature")
+            return AgentRunResult(
+                stdout="Error: --bg is not supported with the opencode runner. Use --runner claude.",
+                return_code=1,
+            )
+
+        self._role = request.role
+        project_path = request.project_path or self._find_project_path(request.cwd)
+
         if is_opencode_dry_run():
             from factory.runners._subprocess import make_dry_run_result
-            return make_dry_run_result("opencode", request.role, request.cwd, request.task)
+            result = make_dry_run_result("opencode", request.role, request.cwd, request.task)
+            log_usage(project_path, request.role, request.cwd, 0.0, 0, dry_run=True, runner_name=_RUNNER_NAME)
+            return result
 
         _check_auth()
 
+        try:
+            check_ceilings(project_path, self.cycle_start, runner_name=_RUNNER_NAME)
+        except CeilingExceededError as e:
+            self._emit_ceiling_event(project_path, e)
+            return AgentRunResult(stdout=str(e), return_code=1)
+
         cmd, env, _ = self.build_command(request)
 
-        log.info("opencode_headless", cwd=str(request.cwd), role=request.role)
+        log.info("opencode_headless", cwd=str(request.cwd), role=request.role, model=request.model)
 
-        return await run_subprocess(
+        start_time = time.monotonic()
+
+        result = await run_subprocess(
             cmd, cwd=str(request.cwd), env=env,
             timeout=request.timeout, runner_name="opencode", role=request.role,
+            sanitize=True,
         )
 
-    def build_interactive_command(self, request: AgentRunRequest) -> tuple[list[str], dict[str, str], list[Path]]:
-        """Build the CLI command, env dict, and temp files for an interactive invocation."""
-        full_prompt = f"{request.prompt}\n\n---\n\n## Current Task\n\n{request.task}"
+        duration = time.monotonic() - start_time
+        log_usage(project_path, request.role, request.cwd, duration, result.return_code, dry_run=False, runner_name=_RUNNER_NAME)
 
-        cmd = ["opencode", "-p", full_prompt, "-c", str(request.cwd)]
-
-        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-        _prepend_opencode_path(env)
-        _source_openai_key_from_shell(env)
-
-        return cmd, env, []
+        return result
 
     def interactive_run(self, request: AgentRunRequest) -> int:
-        """Run an interactive OpenCode session as a subprocess."""
+        """Run an interactive OpenCode v1.x session as a subprocess."""
+        project_path = request.project_path or self._find_project_path(request.cwd)
+
         if is_opencode_dry_run():
             print("[DRY-RUN] Would exec: opencode (interactive)")
             print(f"[DRY-RUN] Task: {request.task[:200]}...")
             return 0
+
+        _check_auth()
+
+        try:
+            check_ceilings(project_path, self.cycle_start, runner_name=_RUNNER_NAME)
+        except CeilingExceededError as e:
+            print(f"ERROR: {e}")
+            return 1
 
         cmd, env, _ = self.build_interactive_command(request)
 
@@ -245,3 +302,29 @@ class OpenCodeRunner:
         result = subprocess.run(cmd, cwd=request.cwd, env=env)
         return result.returncode
 
+    def _find_project_path(self, cwd: Path) -> Path:
+        """Find the project root (directory containing .factory/)."""
+        path = cwd.resolve()
+        while path != path.parent:
+            if (path / ".factory").is_dir():
+                return path
+            path = path.parent
+        return cwd.resolve()
+
+    def _emit_ceiling_event(self, project_path: Path, error: CeilingExceededError) -> None:
+        """Emit a structured event when a ceiling is hit."""
+        try:
+            from factory.events import emit_event
+
+            emit_event(
+                project_path,
+                "opencode.ceiling_exceeded",
+                data={
+                    "ceiling": error.ceiling_name,
+                    "current": error.current,
+                    "limit": error.limit,
+                    "env_var": error.env_var,
+                },
+            )
+        except Exception:
+            log.debug("opencode_ceiling_event_failed", exc_info=True)

--- a/factory/runners/opencode.py
+++ b/factory/runners/opencode.py
@@ -218,13 +218,18 @@ class OpenCodeRunner:
         agents_md_path.write_text(request.prompt)
         temp_files: list[Path] = [agents_md_path]
 
-        cmd = ["opencode", "--prompt", request.task, str(request.cwd)]
+        cmd = ["opencode", "--prompt", request.task]
+
+        if request.skip_permissions:
+            cmd.append("--auto")
 
         if request.model:
             cmd.extend(["--model", request.model])
 
         if request.resume_session_id:
             cmd.extend(["--session", request.resume_session_id])
+
+        cmd.append(str(request.cwd))
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
         return cmd, env, temp_files

--- a/factory/runners/usage.py
+++ b/factory/runners/usage.py
@@ -1,4 +1,7 @@
-"""Bob usage tracking — log and ceiling enforcement."""
+"""Runner usage tracking — log and ceiling enforcement.
+
+Generalized for any runner (Bob, OpenCode, etc.) via runner_name parameter.
+"""
 
 from __future__ import annotations
 
@@ -12,8 +15,6 @@ import structlog
 
 log = structlog.get_logger()
 
-USAGE_LOG_NAME = "bob_usage.jsonl"
-
 
 class UsageEntry(TypedDict):
     timestamp: str
@@ -24,9 +25,9 @@ class UsageEntry(TypedDict):
     dry_run: bool
 
 
-def get_usage_log_path(project_path: Path) -> Path:
-    """Return the path to the bob usage log for a project."""
-    return project_path / ".factory" / USAGE_LOG_NAME
+def get_usage_log_path(project_path: Path, runner_name: str = "bob") -> Path:
+    """Return the path to the usage log for a project."""
+    return project_path / ".factory" / f"{runner_name}_usage.jsonl"
 
 
 def log_usage(
@@ -36,9 +37,10 @@ def log_usage(
     duration_seconds: float,
     exit_code: int,
     dry_run: bool = False,
+    runner_name: str = "bob",
 ) -> None:
-    """Append a usage entry to the project's bob_usage.jsonl."""
-    log_path = get_usage_log_path(project_path)
+    """Append a usage entry to the project's usage log."""
+    log_path = get_usage_log_path(project_path, runner_name)
     log_path.parent.mkdir(parents=True, exist_ok=True)
 
     entry: UsageEntry = {
@@ -54,15 +56,19 @@ def log_usage(
         f.write(json.dumps(entry) + "\n")
 
 
-def count_cycle_invocations(project_path: Path, cycle_start: datetime | None = None) -> int:
-    """Count non-dry-run bob invocations in the current cycle.
+def count_cycle_invocations(
+    project_path: Path,
+    cycle_start: datetime | None = None,
+    runner_name: str = "bob",
+) -> int:
+    """Count non-dry-run invocations in the current cycle.
 
     If cycle_start is None, returns 0 (no cycle tracking without explicit start).
     """
     if cycle_start is None:
         return 0
 
-    log_path = get_usage_log_path(project_path)
+    log_path = get_usage_log_path(project_path, runner_name)
     if not log_path.exists():
         return 0
 
@@ -85,23 +91,28 @@ def count_cycle_invocations(project_path: Path, cycle_start: datetime | None = N
     return count
 
 
-def get_cycle_ceiling() -> int:
+def get_cycle_ceiling(runner_name: str = "bob") -> int:
     """Get the per-cycle invocation ceiling from env var."""
     from factory.user_config import resolve
 
-    return int(resolve("bob_max_invocations_per_cycle", env_var="FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE", default="8") or "8")
+    upper = runner_name.upper()
+    env_var = f"FACTORY_{upper}_MAX_INVOCATIONS_PER_CYCLE"
+    config_key = f"{runner_name}_max_invocations_per_cycle"
+    return int(resolve(config_key, env_var=env_var, default="8") or "8")
 
 
 class CeilingExceededError(Exception):
-    """Raised when a bob invocation ceiling is exceeded."""
+    """Raised when a runner invocation ceiling is exceeded."""
 
-    def __init__(self, ceiling_name: str, current: int, limit: int, env_var: str) -> None:
+    def __init__(self, ceiling_name: str, current: int, limit: int, env_var: str, runner_name: str = "bob") -> None:
         self.ceiling_name = ceiling_name
         self.current = current
         self.limit = limit
         self.env_var = env_var
+        self.runner_name = runner_name
+        display = runner_name.capitalize()
         super().__init__(
-            f"Bob {ceiling_name} ceiling exceeded: {current}/{limit}. "
+            f"{display} {ceiling_name} ceiling exceeded: {current}/{limit}. "
             f"To increase, set {env_var}={limit + 5}"
         )
 
@@ -115,14 +126,14 @@ class CeilingWarning:
     limit: int
 
 
-def _emit_warning_event(project_path: Path, warning: CeilingWarning) -> None:
+def _emit_warning_event(project_path: Path, warning: CeilingWarning, runner_name: str = "bob") -> None:
     """Emit a warning event to .factory/events.jsonl."""
     try:
         from factory.events import emit_event
 
         emit_event(
             project_path,
-            "bob.ceiling_warning",
+            f"{runner_name}.ceiling_warning",
             data={
                 "ceiling": warning.ceiling_name,
                 "remaining": warning.remaining,
@@ -136,31 +147,33 @@ def _emit_warning_event(project_path: Path, warning: CeilingWarning) -> None:
 def check_ceilings(
     project_path: Path,
     cycle_start: datetime | None = None,
+    runner_name: str = "bob",
 ) -> CeilingWarning | None:
-    """Check per-cycle ceiling before a bob invocation.
+    """Check per-cycle ceiling before a runner invocation.
 
     Raises CeilingExceededError if the per-cycle ceiling is exceeded.
     Returns CeilingWarning if ≤2 invocations remain before the ceiling.
     """
-    # Check per-cycle ceiling
-    cycle_count = count_cycle_invocations(project_path, cycle_start)
-    cycle_limit = get_cycle_ceiling()
+    upper = runner_name.upper()
+    env_var = f"FACTORY_{upper}_MAX_INVOCATIONS_PER_CYCLE"
+
+    cycle_count = count_cycle_invocations(project_path, cycle_start, runner_name)
+    cycle_limit = get_cycle_ceiling(runner_name)
     if cycle_count >= cycle_limit:
         raise CeilingExceededError(
-            "per-cycle", cycle_count, cycle_limit, "FACTORY_BOB_MAX_INVOCATIONS_PER_CYCLE"
+            "per-cycle", cycle_count, cycle_limit, env_var, runner_name
         )
 
-    # Check for approaching ceiling (≤2 remaining)
     remaining = cycle_limit - cycle_count
     if remaining <= 2:
         warning = CeilingWarning("per-cycle", remaining, cycle_limit)
         log.warning(
-            "bob_ceiling_approaching",
+            f"{runner_name}_ceiling_approaching",
             ceiling=warning.ceiling_name,
             remaining=warning.remaining,
             limit=warning.limit,
         )
-        _emit_warning_event(project_path, warning)
+        _emit_warning_event(project_path, warning, runner_name)
         return warning
 
     return None

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -342,8 +342,8 @@ class TestBuildInteractiveCommand:
         assert "--prompt" in cmd
         prompt_idx = cmd.index("--prompt")
         assert cmd[prompt_idx + 1] == "Start session"
-        assert "--dir" in cmd
-        assert str(tmp_path) in cmd
+        assert "--dir" not in cmd
+        assert cmd[-1] == str(tmp_path)
 
         agents_md = tmp_path / "AGENTS.md"
         assert agents_md in temp_files
@@ -567,7 +567,8 @@ class TestOpenCodeInteractive:
                 cmd = mock_run.call_args[0][0]
                 assert cmd[0] == "opencode"
                 assert "run" not in cmd
-                assert "--dir" in cmd
+                assert "--dir" not in cmd
+                assert cmd[-1] == str(tmp_path)
                 assert "-p" not in cmd
                 assert "-c" not in cmd
 

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -231,6 +231,7 @@ class TestBuildCommand:
 
         assert cmd[0] == "opencode"
         assert cmd[1] == "run"
+        assert cmd[2] == "Run experiment"
         assert "--format" in cmd
         assert "json" in cmd
         assert "--dir" in cmd
@@ -239,11 +240,12 @@ class TestBuildCommand:
         assert "-p" not in cmd
         assert "-c" not in cmd
         assert "-q" not in cmd
-        full_prompt = cmd[2]
-        assert "You are the CEO." in full_prompt
-        assert "Run experiment" in full_prompt
-        assert temp_files == []
         assert "VIRTUAL_ENV" not in env
+
+        agents_md = tmp_path / "AGENTS.md"
+        assert agents_md in temp_files
+        assert agents_md.exists()
+        assert agents_md.read_text() == "You are the CEO."
 
     def test_model_override(self, tmp_path: Path) -> None:
         runner = OpenCodeRunner()
@@ -325,10 +327,10 @@ class TestBuildCommand:
 class TestBuildInteractiveCommand:
     def test_interactive_no_run_subcommand(self, tmp_path: Path) -> None:
         runner = OpenCodeRunner()
-        cmd, _, _ = runner.build_interactive_command(
+        cmd, _, temp_files = runner.build_interactive_command(
             AgentRunRequest(
-                prompt="test",
-                task="test",
+                prompt="You are a test agent.",
+                task="Start session",
                 cwd=tmp_path,
                 role="ceo",
             )
@@ -338,8 +340,15 @@ class TestBuildInteractiveCommand:
         assert "--format" not in cmd
         assert "--auto" not in cmd
         assert "--prompt" in cmd
+        prompt_idx = cmd.index("--prompt")
+        assert cmd[prompt_idx + 1] == "Start session"
         assert "--dir" in cmd
         assert str(tmp_path) in cmd
+
+        agents_md = tmp_path / "AGENTS.md"
+        assert agents_md in temp_files
+        assert agents_md.exists()
+        assert agents_md.read_text() == "You are a test agent."
 
     def test_interactive_model_override(self, tmp_path: Path) -> None:
         runner = OpenCodeRunner()

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -1,7 +1,9 @@
-"""Tests for factory/runners/opencode.py — OpenCodeRunner implementation."""
+"""Tests for factory/runners/opencode.py — OpenCode v1.x runner."""
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,12 +14,10 @@ from factory.models import AgentRunRequest, AgentRunResult
 from factory.runners.opencode import (
     OpenCodeAuthError,
     OpenCodeRunner,
-    _can_source_key_from_shell,
     _check_auth,
     _check_binary_compat,
-    _find_opencode_bin_dir,
-    _prepend_opencode_path,
-    _source_openai_key_from_shell,
+    _has_opencode_auth,
+    _parse_opencode_output,
     is_opencode_dry_run,
 )
 
@@ -37,41 +37,37 @@ def _reset_opencode_globals() -> None:
 class TestOpenCodeAuthError:
     def test_error_message(self) -> None:
         err = OpenCodeAuthError()
-        assert "OPENAI_API_KEY" in str(err)
+        assert "opencode auth login" in str(err)
+        assert "ANTHROPIC_API_KEY" in str(err)
         assert "config.toml" in str(err)
-        assert "[credentials.opencode]" in str(err)
 
 
 # ---------------------------------------------------------------------------
-# _can_source_key_from_shell
+# _has_opencode_auth
 # ---------------------------------------------------------------------------
 
 
-class TestCanSourceKeyFromShell:
-    def test_returns_true_when_key_found(self) -> None:
-        mock_result = MagicMock(stdout="sk-fake-key-123\n")
-        with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
-            assert _can_source_key_from_shell() is True
+class TestHasOpenCodeAuth:
+    def test_true_with_opencode_dir(self, tmp_path: Path) -> None:
+        with patch("factory.runners.opencode.Path.home", return_value=tmp_path):
+            (tmp_path / ".opencode").mkdir()
+            assert _has_opencode_auth() is True
 
-    def test_returns_false_when_empty(self) -> None:
-        mock_result = MagicMock(stdout="\n")
-        with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
-            assert _can_source_key_from_shell() is False
+    def test_true_with_anthropic_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        with patch("factory.runners.opencode.Path.home", return_value=Path("/nonexistent")):
+            assert _has_opencode_auth() is True
 
-    def test_returns_false_on_file_not_found(self) -> None:
-        with patch(
-            "factory.runners.opencode.subprocess.run", side_effect=FileNotFoundError
-        ):
-            assert _can_source_key_from_shell() is False
+    def test_true_with_openai_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        with patch("factory.runners.opencode.Path.home", return_value=Path("/nonexistent")):
+            assert _has_opencode_auth() is True
 
-    def test_returns_false_on_timeout(self) -> None:
-        import subprocess
-
-        with patch(
-            "factory.runners.opencode.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="zsh", timeout=5),
-        ):
-            assert _can_source_key_from_shell() is False
+    def test_false_without_anything(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in oc_module._PROVIDER_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        with patch("factory.runners.opencode.Path.home", return_value=Path("/nonexistent")):
+            assert _has_opencode_auth() is False
 
 
 # ---------------------------------------------------------------------------
@@ -82,27 +78,27 @@ class TestCanSourceKeyFromShell:
 class TestCheckAuth:
     def test_skips_when_already_checked(self) -> None:
         oc_module._auth_checked = True
-        # Should return immediately without raising
         _check_auth()
 
+    def test_passes_with_opencode_dir(self, tmp_path: Path) -> None:
+        with patch("factory.runners.opencode._check_binary_compat"):
+            with patch("factory.runners.opencode.Path.home", return_value=tmp_path):
+                (tmp_path / ".opencode").mkdir()
+                _check_auth()
+        assert oc_module._auth_checked is True
+
     def test_passes_with_env_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         with patch("factory.runners.opencode._check_binary_compat"):
             _check_auth()
         assert oc_module._auth_checked is True
 
-    def test_passes_with_shell_sourced_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    def test_raises_without_auth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in oc_module._PROVIDER_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
         with patch("factory.runners.opencode._check_binary_compat"):
-            with patch("factory.runners.opencode._can_source_key_from_shell", return_value=True):
-                _check_auth()
-        assert oc_module._auth_checked is True
-
-    def test_raises_without_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        with patch("factory.runners.opencode._check_binary_compat"):
-            with patch("factory.runners.opencode._can_source_key_from_shell", return_value=False):
-                with pytest.raises(OpenCodeAuthError, match="OPENAI_API_KEY"):
+            with patch("factory.runners.opencode.Path.home", return_value=Path("/nonexistent")):
+                with pytest.raises(OpenCodeAuthError, match="opencode auth login"):
                     _check_auth()
 
 
@@ -114,7 +110,6 @@ class TestCheckAuth:
 class TestCheckBinaryCompat:
     def test_skips_when_already_checked(self) -> None:
         oc_module._compat_checked = True
-        # Should return immediately
         _check_binary_compat()
 
     def test_returns_early_when_no_binary(self) -> None:
@@ -122,22 +117,15 @@ class TestCheckBinaryCompat:
             _check_binary_compat()
         assert oc_module._compat_checked is True
 
-    def test_go_binary_detected(self) -> None:
+    def test_v1x_detected_ok(self) -> None:
+        mock_result = MagicMock(stdout="1.18.14", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
+            with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
+                _check_binary_compat()
+        assert oc_module._compat_checked is True
+
+    def test_v0x_warns(self) -> None:
         mock_result = MagicMock(stdout="opencode version v0.0.55", stderr="")
-        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
-            with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
-                _check_binary_compat()
-        assert oc_module._compat_checked is True
-
-    def test_npm_binary_warns(self) -> None:
-        mock_result = MagicMock(stdout="some npm output", stderr="")
-        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
-            with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
-                _check_binary_compat()
-        assert oc_module._compat_checked is True
-
-    def test_version_in_stderr(self) -> None:
-        mock_result = MagicMock(stdout="", stderr="opencode version v0.1.0")
         with patch("shutil.which", return_value="/usr/local/bin/opencode"):
             with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
                 _check_binary_compat()
@@ -165,115 +153,63 @@ class TestCheckBinaryCompat:
 
 
 # ---------------------------------------------------------------------------
-# _find_opencode_bin_dir
+# _parse_opencode_output
 # ---------------------------------------------------------------------------
 
 
-class TestFindOpencodeBinDir:
-    def test_found_on_path(self) -> None:
-        with patch("shutil.which", return_value="/usr/local/bin/opencode"):
-            assert _find_opencode_bin_dir() == "/usr/local/bin"
+class TestParseOpenCodeOutput:
+    def test_parses_json_with_content(self) -> None:
+        raw = json.dumps({"content": "Hello world", "sessionId": "sess-123"})
+        text, session_id = _parse_opencode_output(raw)
+        assert text == "Hello world"
+        assert session_id == "sess-123"
 
-    def test_found_in_gopath(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("GOPATH", "/custom/go")
-        with patch("shutil.which", return_value=None):
-            with patch.object(Path, "is_file", return_value=True):
-                result = _find_opencode_bin_dir()
-        assert result is not None
+    def test_parses_json_with_text_field(self) -> None:
+        raw = json.dumps({"text": "Result", "session_id": "s1"})
+        text, session_id = _parse_opencode_output(raw)
+        assert text == "Result"
+        assert session_id == "s1"
 
-    def test_found_in_home_go_bin(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("GOPATH", raising=False)
-        with patch("shutil.which", return_value=None):
-            with patch.object(Path, "is_file", side_effect=lambda: True):
-                # The first candidate is Path.home() / "go" / "bin"
-                result = _find_opencode_bin_dir()
-        # Should find it or not depending on mocking; just verify no crash
-        assert result is None or isinstance(result, str)
+    def test_parses_json_with_message_field(self) -> None:
+        raw = json.dumps({"message": "Done"})
+        text, session_id = _parse_opencode_output(raw)
+        assert text == "Done"
+        assert session_id is None
 
-    def test_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("GOPATH", raising=False)
-        with patch("shutil.which", return_value=None):
-            with patch.object(Path, "is_file", return_value=False):
-                assert _find_opencode_bin_dir() is None
+    def test_falls_back_on_non_json(self) -> None:
+        raw = "plain text output"
+        text, session_id = _parse_opencode_output(raw)
+        assert text == raw
+        assert session_id is None
 
+    def test_multiline_parses_last_json(self) -> None:
+        raw = "some progress\nmore output\n" + json.dumps({"content": "final"})
+        text, session_id = _parse_opencode_output(raw)
+        assert text == "final"
 
-# ---------------------------------------------------------------------------
-# _prepend_opencode_path
-# ---------------------------------------------------------------------------
-
-
-class TestPrependOpencodePath:
-    def test_prepends_when_found(self) -> None:
-        env: dict[str, str] = {"PATH": "/usr/bin:/bin"}
-        with patch(
-            "factory.runners.opencode._find_opencode_bin_dir",
-            return_value="/home/user/go/bin",
-        ):
-            _prepend_opencode_path(env)
-        assert env["PATH"].startswith("/home/user/go/bin:")
-
-    def test_no_op_when_already_first(self) -> None:
-        env: dict[str, str] = {"PATH": "/home/user/go/bin:/usr/bin"}
-        with patch(
-            "factory.runners.opencode._find_opencode_bin_dir",
-            return_value="/home/user/go/bin",
-        ):
-            _prepend_opencode_path(env)
-        assert env["PATH"] == "/home/user/go/bin:/usr/bin"
-
-    def test_no_op_when_not_found(self) -> None:
-        env: dict[str, str] = {"PATH": "/usr/bin"}
-        with patch(
-            "factory.runners.opencode._find_opencode_bin_dir", return_value=None
-        ):
-            _prepend_opencode_path(env)
-        assert env["PATH"] == "/usr/bin"
+    def test_empty_content_falls_back(self) -> None:
+        raw = json.dumps({"content": "", "sessionId": "s1"})
+        text, session_id = _parse_opencode_output(raw)
+        assert text == raw.strip()
+        assert session_id is None
 
 
 # ---------------------------------------------------------------------------
-# _source_openai_key_from_shell
+# OpenCodeRunner.metadata
 # ---------------------------------------------------------------------------
 
 
-class TestSourceOpenaiKeyFromShell:
-    def test_no_op_when_key_exists(self) -> None:
-        env: dict[str, str] = {"OPENAI_API_KEY": "already-set"}
-        # Should not call subprocess at all
-        _source_openai_key_from_shell(env)
-        assert env["OPENAI_API_KEY"] == "already-set"
-
-    def test_sources_key_from_zshrc(self) -> None:
-        env: dict[str, str] = {}
-        mock_result = MagicMock(stdout="sk-sourced-key\n")
-        with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
-            _source_openai_key_from_shell(env)
-        assert env["OPENAI_API_KEY"] == "sk-sourced-key"
-
-    def test_no_key_from_zshrc(self) -> None:
-        env: dict[str, str] = {}
-        mock_result = MagicMock(stdout="\n")
-        with patch("factory.runners.opencode.subprocess.run", return_value=mock_result):
-            _source_openai_key_from_shell(env)
-        assert "OPENAI_API_KEY" not in env
-
-    def test_handles_file_not_found(self) -> None:
-        env: dict[str, str] = {}
-        with patch(
-            "factory.runners.opencode.subprocess.run", side_effect=FileNotFoundError
-        ):
-            _source_openai_key_from_shell(env)
-        assert "OPENAI_API_KEY" not in env
-
-    def test_handles_timeout(self) -> None:
-        import subprocess
-
-        env: dict[str, str] = {}
-        with patch(
-            "factory.runners.opencode.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="zsh", timeout=5),
-        ):
-            _source_openai_key_from_shell(env)
-        assert "OPENAI_API_KEY" not in env
+class TestMetadata:
+    def test_metadata_v1x(self) -> None:
+        meta = OpenCodeRunner.metadata()
+        assert meta.name == "opencode"
+        assert meta.supports_model_override is True
+        assert meta.supports_session_name is True
+        assert meta.supports_session_resume is True
+        assert meta.supports_background is False
+        assert meta.required_env_vars == []
+        assert "opencode.ai/install" in meta.install_hint
+        assert meta.custom_auth_check is not None
 
 
 # ---------------------------------------------------------------------------
@@ -282,30 +218,142 @@ class TestSourceOpenaiKeyFromShell:
 
 
 class TestBuildCommand:
-    def test_command_structure(self, tmp_path: Path) -> None:
+    def test_basic_command_structure(self, tmp_path: Path) -> None:
         runner = OpenCodeRunner()
-        with patch("factory.runners.opencode._prepend_opencode_path"):
-            with patch("factory.runners.opencode._source_openai_key_from_shell"):
-                cmd, env, temp_files = runner.build_command(
-                    AgentRunRequest(
-                        prompt="You are the CEO.",
-                        task="Run experiment",
-                        cwd=tmp_path,
-                        role="ceo",
-                    )
-                )
+        cmd, env, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="You are the CEO.",
+                task="Run experiment",
+                cwd=tmp_path,
+                role="ceo",
+            )
+        )
 
         assert cmd[0] == "opencode"
-        assert "-p" in cmd
-        assert "-c" in cmd
+        assert cmd[1] == "run"
+        assert "--format" in cmd
+        assert "json" in cmd
+        assert "--dir" in cmd
         assert str(tmp_path) in cmd
-        assert "-q" in cmd
-        full_prompt = cmd[cmd.index("-p") + 1]
+        assert "--auto" in cmd
+        assert "-p" not in cmd
+        assert "-c" not in cmd
+        assert "-q" not in cmd
+        full_prompt = cmd[2]
         assert "You are the CEO." in full_prompt
         assert "Run experiment" in full_prompt
-        assert "## Current Task" in full_prompt
         assert temp_files == []
         assert "VIRTUAL_ENV" not in env
+
+    def test_model_override(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                model="anthropic/claude-sonnet-4-20250514",
+            )
+        )
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "anthropic/claude-sonnet-4-20250514"
+
+    def test_session_name(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                session_name="my-session",
+            )
+        )
+        assert "--title" in cmd
+        idx = cmd.index("--title")
+        assert cmd[idx + 1] == "my-session"
+
+    def test_session_resume(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                resume_session_id="sess-abc",
+            )
+        )
+        assert "--session" in cmd
+        idx = cmd.index("--session")
+        assert cmd[idx + 1] == "sess-abc"
+
+    def test_session_continue(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                session_id="any",
+            )
+        )
+        assert "--continue" in cmd
+
+    def test_no_auto_without_skip_permissions(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                skip_permissions=False,
+            )
+        )
+        assert "--auto" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeRunner.build_interactive_command
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInteractiveCommand:
+    def test_interactive_no_run_subcommand(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+            )
+        )
+        assert cmd[0] == "opencode"
+        assert "run" not in cmd
+        assert "--format" not in cmd
+        assert "--auto" not in cmd
+        assert "--dir" in cmd
+        assert str(tmp_path) in cmd
+
+    def test_interactive_model_override(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                model="openai/gpt-4o",
+            )
+        )
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "openai/gpt-4o"
 
 
 # ---------------------------------------------------------------------------
@@ -318,20 +366,22 @@ class TestOpenCodeHeadless:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
-        runner = OpenCodeRunner()
+        (tmp_path / ".factory").mkdir()
+        runner = OpenCodeRunner(project_path=tmp_path)
         result = await runner.headless(
             AgentRunRequest(
                 prompt="Test prompt",
                 task="Test task",
                 cwd=tmp_path,
                 role="researcher",
+                project_path=tmp_path,
             )
         )
         assert result.return_code == 0
         assert "[DRY-RUN]" in result.stdout
         assert "researcher" in result.stdout
 
-    async def test_background_warning(
+    async def test_background_returns_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
@@ -345,58 +395,76 @@ class TestOpenCodeHeadless:
                 extras={"background": True},
             )
         )
-        assert result.return_code == 0
+        assert result.return_code == 1
+        assert "--bg is not supported" in result.stdout
+
+    async def test_tmux_persist_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        runner = OpenCodeRunner()
+        result = await runner.headless(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                role="ceo",
+                extras={"tmux_persist": True},
+            )
+        )
+        assert result.return_code == 1
+        assert "--tmux-persist is not supported" in result.stdout
 
     async def test_headless_calls_run_subprocess(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
+        (tmp_path / ".factory").mkdir()
 
-        runner = OpenCodeRunner()
+        runner = OpenCodeRunner(project_path=tmp_path)
         with patch("factory.runners.opencode._check_auth"):
-            with patch("factory.runners.opencode._prepend_opencode_path"):
-                with patch("factory.runners.opencode._source_openai_key_from_shell"):
-                    with patch(
-                        "factory.runners.opencode.run_subprocess",
-                        new_callable=AsyncMock,
-                    ) as mock_run:
-                        mock_run.return_value = AgentRunResult(
-                            stdout="output", return_code=0
-                        )
-                        result = await runner.headless(
-                            AgentRunRequest(
-                                prompt="You are a test agent.",
-                                task="Say hello",
-                                cwd=tmp_path,
-                                role="researcher",
-                                timeout=60.0,
-                            )
-                        )
+            with patch(
+                "factory.runners.opencode.run_subprocess",
+                new_callable=AsyncMock,
+            ) as mock_run:
+                mock_run.return_value = AgentRunResult(
+                    stdout="output", return_code=0
+                )
+                result = await runner.headless(
+                    AgentRunRequest(
+                        prompt="You are a test agent.",
+                        task="Say hello",
+                        cwd=tmp_path,
+                        role="researcher",
+                        timeout=60.0,
+                        project_path=tmp_path,
+                    )
+                )
 
-                        assert result.return_code == 0
-                        assert result.stdout == "output"
+                assert result.return_code == 0
+                assert result.stdout == "output"
 
-                        call_kwargs = mock_run.call_args.kwargs
-                        assert call_kwargs["runner_name"] == "opencode"
-                        assert call_kwargs["role"] == "researcher"
-                        assert call_kwargs["timeout"] == 60.0
-                        cmd = mock_run.call_args[0][0]
-                        assert cmd[0] == "opencode"
-                        assert "-q" in cmd
+                call_kwargs = mock_run.call_args.kwargs
+                assert call_kwargs["runner_name"] == "opencode"
+                assert call_kwargs["role"] == "researcher"
+                assert call_kwargs["timeout"] == 60.0
+                assert call_kwargs["sanitize"] is True
+                cmd = mock_run.call_args[0][0]
+                assert cmd[0] == "opencode"
+                assert cmd[1] == "run"
+                assert "--format" in cmd
+                assert "-q" not in cmd
 
-    async def test_headless_raises_without_key(
+    async def test_headless_raises_without_auth(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        for var in oc_module._PROVIDER_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
         monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
 
         runner = OpenCodeRunner()
         with patch("factory.runners.opencode._check_binary_compat"):
-            with patch(
-                "factory.runners.opencode._can_source_key_from_shell",
-                return_value=False,
-            ):
+            with patch("factory.runners.opencode.Path.home", return_value=Path("/nonexistent")):
                 with pytest.raises(OpenCodeAuthError):
                     await runner.headless(
                         AgentRunRequest(
@@ -406,6 +474,37 @@ class TestOpenCodeHeadless:
                             role="researcher",
                         )
                     )
+
+    async def test_ceiling_exceeded_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
+        (tmp_path / ".factory").mkdir()
+
+        from factory.runners.usage import CeilingExceededError
+
+        runner = OpenCodeRunner(project_path=tmp_path)
+        with patch("factory.runners.opencode._check_auth"):
+            with patch(
+                "factory.runners.opencode.check_ceilings",
+                side_effect=CeilingExceededError(
+                    "per-cycle", 8, 8,
+                    "FACTORY_OPENCODE_MAX_INVOCATIONS_PER_CYCLE",
+                    "opencode",
+                ),
+            ):
+                with patch.object(runner, "_emit_ceiling_event"):
+                    result = await runner.headless(
+                        AgentRunRequest(
+                            prompt="Test",
+                            task="Test",
+                            cwd=tmp_path,
+                            role="researcher",
+                            project_path=tmp_path,
+                        )
+                    )
+                    assert result.return_code == 1
+                    assert "ceiling exceeded" in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -438,26 +537,63 @@ class TestOpenCodeInteractive:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
-        runner = OpenCodeRunner()
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
+        (tmp_path / ".factory").mkdir()
 
-        with patch("factory.runners.opencode._prepend_opencode_path"):
-            with patch("factory.runners.opencode._source_openai_key_from_shell"):
-                with patch("factory.runners.opencode.subprocess.run") as mock_run:
-                    mock_run.return_value = MagicMock(returncode=0)
-                    code = runner.interactive_run(
-                        AgentRunRequest(
-                            prompt="You are the CEO.",
-                            task="Start session",
-                            cwd=tmp_path,
-                            role="ceo",
-                        )
+        runner = OpenCodeRunner(project_path=tmp_path)
+        with patch("factory.runners.opencode._check_auth"):
+            with patch("factory.runners.opencode.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                code = runner.interactive_run(
+                    AgentRunRequest(
+                        prompt="You are the CEO.",
+                        task="Start session",
+                        cwd=tmp_path,
+                        role="ceo",
+                        project_path=tmp_path,
                     )
-                    assert code == 0
-                    cmd = mock_run.call_args[0][0]
-                    assert cmd[0] == "opencode"
-                    assert "-p" in cmd
-                    assert "-c" in cmd
-                    assert "-q" not in cmd  # interactive does not use -q
+                )
+                assert code == 0
+                cmd = mock_run.call_args[0][0]
+                assert cmd[0] == "opencode"
+                assert "run" not in cmd
+                assert "--dir" in cmd
+                assert "-p" not in cmd
+                assert "-c" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# Token guardrails (usage integration)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenGuardrails:
+    def test_usage_logging_on_headless(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        runner = OpenCodeRunner(project_path=tmp_path)
+
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(
+            runner.headless(
+                AgentRunRequest(
+                    prompt="test",
+                    task="test",
+                    cwd=tmp_path,
+                    role="researcher",
+                    project_path=tmp_path,
+                )
+            )
+        )
+
+        usage_log = factory_dir / "opencode_usage.jsonl"
+        assert usage_log.exists()
+        entry = json.loads(usage_log.read_text().strip())
+        assert entry["role"] == "researcher"
+        assert entry["dry_run"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -481,3 +617,24 @@ class TestIsOpencodeDryRun:
     def test_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "yes")
         assert is_opencode_dry_run() is True
+
+
+# ---------------------------------------------------------------------------
+# OpenCodeRunner.__init__ (cycle_start resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeRunnerInit:
+    def test_init_with_explicit_cycle_start(self) -> None:
+        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        runner = OpenCodeRunner(cycle_start=ts)
+        assert runner.cycle_start == ts
+
+    def test_init_with_project_path(self, tmp_path: Path) -> None:
+        with patch("factory.runners.opencode.OpenCodeRunner.__init__.__wrapped__", create=True):
+            runner = OpenCodeRunner(project_path=tmp_path)
+            assert runner.cycle_start is not None
+
+    def test_init_default(self) -> None:
+        runner = OpenCodeRunner()
+        assert runner.cycle_start is not None

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -337,6 +337,7 @@ class TestBuildInteractiveCommand:
         assert "run" not in cmd
         assert "--format" not in cmd
         assert "--auto" not in cmd
+        assert "--prompt" in cmd
         assert "--dir" in cmd
         assert str(tmp_path) in cmd
 

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -333,6 +333,7 @@ class TestBuildInteractiveCommand:
                 task="Start session",
                 cwd=tmp_path,
                 role="ceo",
+                skip_permissions=False,
             )
         )
         assert cmd[0] == "opencode"
@@ -363,6 +364,32 @@ class TestBuildInteractiveCommand:
             )
         )
         assert "--title" not in cmd
+
+    def test_interactive_auto_with_skip_permissions(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                skip_permissions=True,
+            )
+        )
+        assert "--auto" in cmd
+
+    def test_interactive_no_auto_without_skip_permissions(self, tmp_path: Path) -> None:
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                skip_permissions=False,
+            )
+        )
+        assert "--auto" not in cmd
 
     def test_interactive_model_override(self, tmp_path: Path) -> None:
         runner = OpenCodeRunner()

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -350,6 +350,20 @@ class TestBuildInteractiveCommand:
         assert agents_md.exists()
         assert agents_md.read_text() == "You are a test agent."
 
+    def test_interactive_no_title_flag(self, tmp_path: Path) -> None:
+        """--title is only valid for 'opencode run', not the base TUI command."""
+        runner = OpenCodeRunner()
+        cmd, _, _ = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="test",
+                task="test",
+                cwd=tmp_path,
+                role="ceo",
+                session_name="factory: discover run-123",
+            )
+        )
+        assert "--title" not in cmd
+
     def test_interactive_model_override(self, tmp_path: Path) -> None:
         runner = OpenCodeRunner()
         cmd, _, _ = runner.build_interactive_command(

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1483,17 +1483,15 @@ class TestCeilingAccumulationAcrossInvocations:
 class TestRunnerBgWarnings:
     """Tests for background warning messages from non-claude runners."""
 
-    async def test_opencode_bg_warning(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """OpenCodeRunner logs a warning when extras['background']=True."""
-        monkeypatch.setenv("FACTORY_OPENCODE_DRY_RUN", "1")
-
+    async def test_opencode_bg_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OpenCodeRunner returns error when extras['background']=True."""
         runner = OpenCodeRunner()
-        with patch("factory.runners.opencode.log") as mock_log:
-            await runner.headless(AgentRunRequest(
-                prompt="Test", task="Test", cwd=tmp_path,
-                role="researcher", extras={"background": True},
-            ))
-            mock_log.warning.assert_any_call("opencode_bg_not_supported", hint="--bg is a claude-only feature")
+        result = await runner.headless(AgentRunRequest(
+            prompt="Test", task="Test", cwd=tmp_path,
+            role="researcher", extras={"background": True},
+        ))
+        assert result.return_code == 1
+        assert "--bg is not supported" in result.stdout
 
     async def test_bob_bg_warning(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """BobRunner logs a warning when extras['background']=True."""
@@ -1542,9 +1540,8 @@ class TestOpenCodeInteractive:
             assert code == 0
             cmd = mock_run.call_args[0][0]
             assert cmd[0] == "opencode"
-            assert "-p" in cmd
-            p_idx = cmd.index("-p")
-            full_prompt = cmd[p_idx + 1]
+            # v1.x uses positional prompt (cmd[1]), not -p flag
+            full_prompt = cmd[1]
             assert "You are the CEO." in full_prompt
             assert "Start session" in full_prompt
             assert "## Current Task" in full_prompt
@@ -1564,9 +1561,9 @@ class TestOpenCodeInteractive:
             ))
 
             cmd = mock_run.call_args[0][0]
-            assert "-c" in cmd
-            c_idx = cmd.index("-c")
-            assert cmd[c_idx + 1] == str(tmp_path)
+            assert "--dir" in cmd
+            dir_idx = cmd.index("--dir")
+            assert cmd[dir_idx + 1] == str(tmp_path)
 
     def test_interactive_run_dry_run(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -2105,14 +2102,13 @@ class TestOpenCodeBuildInteractiveCommand:
         ))
 
         assert cmd[0] == "opencode"
-        assert "-p" in cmd
-        p_idx = cmd.index("-p")
-        full_prompt = cmd[p_idx + 1]
+        # v1.x uses positional prompt (cmd[1]), not -p flag
+        full_prompt = cmd[1]
         assert "You are the CEO." in full_prompt
         assert "Start session" in full_prompt
-        assert "-c" in cmd
-        c_idx = cmd.index("-c")
-        assert cmd[c_idx + 1] == str(tmp_path)
+        assert "--dir" in cmd
+        dir_idx = cmd.index("--dir")
+        assert cmd[dir_idx + 1] == str(tmp_path)
         assert "-q" not in cmd
 
     def test_env_strips_virtual_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1560,9 +1560,8 @@ class TestOpenCodeInteractive:
             ))
 
             cmd = mock_run.call_args[0][0]
-            assert "--dir" in cmd
-            dir_idx = cmd.index("--dir")
-            assert cmd[dir_idx + 1] == str(tmp_path)
+            assert "--dir" not in cmd
+            assert cmd[-1] == str(tmp_path)
 
     def test_interactive_run_dry_run(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -2104,9 +2103,8 @@ class TestOpenCodeBuildInteractiveCommand:
         assert "--prompt" in cmd
         prompt_idx = cmd.index("--prompt")
         assert cmd[prompt_idx + 1] == "Start session"
-        assert "--dir" in cmd
-        dir_idx = cmd.index("--dir")
-        assert cmd[dir_idx + 1] == str(tmp_path)
+        assert "--dir" not in cmd
+        assert cmd[-1] == str(tmp_path)
         assert "-q" not in cmd
 
         agents_md = tmp_path / "AGENTS.md"

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1524,7 +1524,7 @@ class TestOpenCodeInteractive:
     """Tests for OpenCodeRunner.interactive_run() — prompt delivery."""
 
     def test_interactive_run_passes_prompt(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """interactive_run() passes --prompt flag with the prompt to OpenCode."""
+        """interactive_run() writes prompt to AGENTS.md and passes task via --prompt."""
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
         runner = OpenCodeRunner()
@@ -1540,13 +1540,10 @@ class TestOpenCodeInteractive:
             assert code == 0
             cmd = mock_run.call_args[0][0]
             assert cmd[0] == "opencode"
-            # v1.x uses --prompt flag, not positional arg
             assert "--prompt" in cmd
             prompt_idx = cmd.index("--prompt")
-            full_prompt = cmd[prompt_idx + 1]
-            assert "You are the CEO." in full_prompt
-            assert "Start session" in full_prompt
-            assert "## Current Task" in full_prompt
+            assert cmd[prompt_idx + 1] == "Start session"
+            assert not (tmp_path / "AGENTS.md").exists()
 
     def test_interactive_run_passes_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """interactive_run() passes --dir with the cwd."""
@@ -2097,23 +2094,25 @@ class TestOpenCodeBuildInteractiveCommand:
 
     def test_base_command_structure(self, tmp_path: Path) -> None:
         runner = OpenCodeRunner()
-        cmd, _, _ = runner.build_interactive_command(AgentRunRequest(
+        cmd, _, temp_files = runner.build_interactive_command(AgentRunRequest(
             prompt="You are the CEO.",
             task="Start session",
             cwd=tmp_path,
         ))
 
         assert cmd[0] == "opencode"
-        # v1.x uses --prompt flag, not positional arg
         assert "--prompt" in cmd
         prompt_idx = cmd.index("--prompt")
-        full_prompt = cmd[prompt_idx + 1]
-        assert "You are the CEO." in full_prompt
-        assert "Start session" in full_prompt
+        assert cmd[prompt_idx + 1] == "Start session"
         assert "--dir" in cmd
         dir_idx = cmd.index("--dir")
         assert cmd[dir_idx + 1] == str(tmp_path)
         assert "-q" not in cmd
+
+        agents_md = tmp_path / "AGENTS.md"
+        assert agents_md in temp_files
+        assert agents_md.exists()
+        assert agents_md.read_text() == "You are the CEO."
 
     def test_env_strips_virtual_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
@@ -2132,13 +2131,14 @@ class TestOpenCodeBuildInteractiveCommand:
 
         assert "-q" not in cmd
 
-    def test_empty_temp_files(self, tmp_path: Path) -> None:
+    def test_temp_files_contains_agents_md(self, tmp_path: Path) -> None:
         runner = OpenCodeRunner()
         _, _, temp_files = runner.build_interactive_command(AgentRunRequest(
             prompt="Test", task="Test", cwd=tmp_path,
         ))
 
-        assert temp_files == []
+        assert len(temp_files) == 1
+        assert temp_files[0] == tmp_path / "AGENTS.md"
 
 
 class TestGetRunnerChoices:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1524,7 +1524,7 @@ class TestOpenCodeInteractive:
     """Tests for OpenCodeRunner.interactive_run() — prompt delivery."""
 
     def test_interactive_run_passes_prompt(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """interactive_run() passes -p with the prompt to OpenCode."""
+        """interactive_run() passes --prompt flag with the prompt to OpenCode."""
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
         runner = OpenCodeRunner()
@@ -1540,14 +1540,16 @@ class TestOpenCodeInteractive:
             assert code == 0
             cmd = mock_run.call_args[0][0]
             assert cmd[0] == "opencode"
-            # v1.x uses positional prompt (cmd[1]), not -p flag
-            full_prompt = cmd[1]
+            # v1.x uses --prompt flag, not positional arg
+            assert "--prompt" in cmd
+            prompt_idx = cmd.index("--prompt")
+            full_prompt = cmd[prompt_idx + 1]
             assert "You are the CEO." in full_prompt
             assert "Start session" in full_prompt
             assert "## Current Task" in full_prompt
 
     def test_interactive_run_passes_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """interactive_run() passes -c with the cwd."""
+        """interactive_run() passes --dir with the cwd."""
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         monkeypatch.delenv("FACTORY_OPENCODE_DRY_RUN", raising=False)
         runner = OpenCodeRunner()
@@ -2102,8 +2104,10 @@ class TestOpenCodeBuildInteractiveCommand:
         ))
 
         assert cmd[0] == "opencode"
-        # v1.x uses positional prompt (cmd[1]), not -p flag
-        full_prompt = cmd[1]
+        # v1.x uses --prompt flag, not positional arg
+        assert "--prompt" in cmd
+        prompt_idx = cmd.index("--prompt")
+        full_prompt = cmd[prompt_idx + 1]
         assert "You are the CEO." in full_prompt
         assert "Start session" in full_prompt
         assert "--dir" in cmd


### PR DESCRIPTION

For people who want beautiful UI with factory :P (video speed is 2x)


https://github.com/user-attachments/assets/f46f9dbc-7058-49f9-aec9-8447c9fc1416





## Changes
- Removed `--title` flag from `build_interactive_command()` in `factory/runners/opencode.py` — `--title` is only valid for `opencode run` (headless mode), not the base TUI command
- Added `test_interactive_no_title_flag` test verifying `--title` is excluded when `session_name` is set in interactive mode
- `--title` remains in `build_command()` since `opencode run` supports it

## Test plan
- [x] `pytest tests/test_opencode_runner.py tests/test_runners.py -v` — 172 passed