### PR TITLE
feat: add SWE-benchify-hard benchmark (284 synthetic Go instances)

### DIFF
--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -808,3 +808,21 @@ class TomsweFactoryCeo(FactoryCeo):
             ),
             env=env,
         )
+
+
+class SwebenchifyHardFactoryCeo(FactoryCeo):
+    """Runs the swebenchifyhard workflow for SWE-benchify-hard benchmark."""
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "swebenchifyhard-factory-ceo"
+
+    @override
+    def _get_factory_command(self) -> str:
+        return (
+            'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; '
+            'factory workflow run swebenchifyhard . '
+            '2>&1 </dev/null | tee /logs/agent/factory-ceo.txt'
+            '; exit 0'
+        )

--- a/benchmarks/run-swebenchifyhard.sh
+++ b/benchmarks/run-swebenchifyhard.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# benchmarks/run-swebench.sh — Standalone CI pipeline for SWE-bench.
+# Thin wrapper around Harbor, which handles the entire lifecycle:
+# container orchestration, agent execution, verification, and scoring.
+
+# ── Shared library ──
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# ── Configuration ──
+
+INSTANCE_ID="${1:-containers--image-90028}"
+SOLVER_TIMEOUT="${2:-3600}"
+HARBOR_DATASET="${3:-red-hat-ai/SWE-benchify-hard}"
+
+BENCHMARK="swebenchifyhard"
+RUN_ID="ci-swebenchifyhard-${TIMESTAMP}"
+RESULT_FILE="${CI_RESULTS_DIR}/${TIMESTAMP}-swebenchifyhard.json"
+
+JOBS_DIR=""
+
+PASSED=0
+RESOLVED=0
+TOTAL=1
+
+# ── Helpers ──
+
+cleanup() {
+    local exit_code=$?
+    if [ -n "${JOBS_DIR}" ] && [ -d "${JOBS_DIR}" ]; then
+        if [ "${PRESERVE_WORKSPACE:-}" = "1" ]; then
+            log "Preserving harbor jobs at ${JOBS_DIR} (PRESERVE_WORKSPACE=1)"
+        else
+            log "Cleaning up harbor jobs directory"
+            rm -rf "${JOBS_DIR}"
+        fi
+    fi
+    PASSED="${RESOLVED}"
+    DETAILS_JSON='{"solver": "'"${BENCHMARK_SOLVER:-factory}"'", "cost_usd": '"${COST_USD:-0}"', "input_tokens": '"${INPUT_TOKENS:-0}"', "output_tokens": '"${OUTPUT_TOKENS:-0}"', "cache_read_tokens": '"${CACHE_READ_TOKENS:-0}"', "cache_creation_tokens": '"${CACHE_CREATION_TOKENS:-0}"'}'
+    write_result
+    if [ "${STATUS}" = "success" ]; then
+        exit 0
+    else
+        exit "${exit_code:-1}"
+    fi
+}
+
+trap cleanup EXIT
+
+# ── Step 1: Parse and display configuration ──
+
+show_banner "SWE-benchify-hard"
+log "Step 1: Configuration"
+echo "    Instance ID:     ${INSTANCE_ID}"
+echo "    Dataset:         ${HARBOR_DATASET}"
+echo "    Solver timeout:  ${SOLVER_TIMEOUT}s ($(( SOLVER_TIMEOUT / 3600 ))h $(( (SOLVER_TIMEOUT % 3600) / 60 ))m)"
+echo "    Run ID:          ${RUN_ID}"
+echo "    Timestamp:       ${TIMESTAMP}"
+echo ""
+
+# ── Step 2: Validate prerequisites ──
+
+log "Step 2: Validating prerequisites"
+
+MISSING=()
+
+if ! command -v docker &>/dev/null && [ ! -x /usr/bin/docker ]; then
+    MISSING+=("docker (install from https://docs.docker.com/get-docker/)")
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "    ERROR: Missing prerequisites:"
+    for m in "${MISSING[@]}"; do
+        echo "      - ${m}"
+    done
+    exit 1
+fi
+
+echo "    docker: found"
+
+ensure_uvx
+
+echo "    harbor: checking availability via uvx..."
+if ! uvx harbor --version &>/dev/null 2>&1; then
+    echo "    harbor: installing via uvx..."
+    uvx harbor --version || {
+        echo "    ERROR: Failed to install/run harbor via uvx"
+        exit 1
+    }
+fi
+echo "    harbor: available"
+
+# API key configuration — Harbor's claude-code agent needs API access
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    echo "    ANTHROPIC_API_KEY: set"
+else
+    setup_vertex_env
+    if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+        echo "    Vertex AI: configured (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
+    else
+        echo "    WARNING: No ANTHROPIC_API_KEY or Vertex AI configuration found."
+        echo "    Harbor's claude-code agent requires API access."
+    fi
+fi
+
+echo "    All prerequisites satisfied."
+echo ""
+
+# ── Step 3: Run Harbor evaluation ──
+
+log "Step 3: Running Harbor evaluation"
+
+JOBS_DIR="$(mktemp -d /tmp/swebench-jobs-XXXXXX)"
+echo "    Jobs directory: ${JOBS_DIR}"
+echo "    Started at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+TIMEOUT_MULTIPLIER=$(( SOLVER_TIMEOUT / 120 ))
+[ "${TIMEOUT_MULTIPLIER}" -lt 1 ] && TIMEOUT_MULTIPLIER=1
+
+MODEL="anthropic/claude-opus-4-6"
+
+echo "    Model:           ${MODEL}"
+echo "    Timeout mult:    ${TIMEOUT_MULTIPLIER}x"
+echo "    Instance:        ${INSTANCE_ID}"
+echo ""
+
+cd "${HARNESS_DIR}"
+
+HARBOR_EXIT=0
+
+if [ "${BENCHMARK_SOLVER:-factory}" = "claude-code" ]; then
+    AGENT_ARGS=(--agent claude-code)
+    echo "    Agent:           claude-code (Harbor built-in)"
+else
+    AGENT_MODULE="${HARNESS_DIR}/benchmarks/factory_harbor_agent.py"
+    export PYTHONPATH="$(dirname "${AGENT_MODULE}"):${PYTHONPATH:-}"
+    AGENT_ARGS=(--agent-import-path factory_harbor_agent:SwebenchifyHardFactoryCeo)
+    echo "    Agent:           factory (FactoryCeo)"
+fi
+
+if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
+    GCLOUD_ADC="${GOOGLE_APPLICATION_CREDENTIALS:-${HOME}/.config/gcloud/application_default_credentials.json}"
+    echo "    Auth mode:       Vertex AI (project: ${ANTHROPIC_VERTEX_PROJECT_ID})"
+    uvx harbor run \
+        --dataset "${HARBOR_DATASET}" \
+        "${AGENT_ARGS[@]}" \
+        --model "${MODEL}" \
+        --include-task-name "*${INSTANCE_ID}" \
+        --n-concurrent 1 \
+        --jobs-dir "${JOBS_DIR}" \
+        --agent-timeout-multiplier "${TIMEOUT_MULTIPLIER}" \
+        --ae "CLAUDE_CODE_USE_VERTEX=1" \
+        --ae "ANTHROPIC_VERTEX_PROJECT_ID=${ANTHROPIC_VERTEX_PROJECT_ID}" \
+        --ae "CLOUD_ML_REGION=${CLOUD_ML_REGION:-us-east5}" \
+        --ae "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcloud-adc.json" \
+        --ae "CLAUDE_CODE_SUBAGENT_MODEL=${CLAUDE_CODE_SUBAGENT_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
+        --ae "ANTHROPIC_DEFAULT_OPUS_MODEL=${ANTHROPIC_DEFAULT_OPUS_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=${CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING:-1}" \
+        --ae "MAX_THINKING_TOKENS=${MAX_THINKING_TOKENS:-128000}" \
+        --ae "CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL:-XHIGH}" \
+        --mounts '[{"type": "bind", "source": "'"${GCLOUD_ADC}"'", "target": "/tmp/gcloud-adc.json", "read_only": true}]' \
+        2>&1 || HARBOR_EXIT=$?
+else
+    echo "    Auth mode:       Direct API (ANTHROPIC_API_KEY)"
+    uvx harbor run \
+        --dataset "${HARBOR_DATASET}" \
+        "${AGENT_ARGS[@]}" \
+        --model "${MODEL}" \
+        --include-task-name "*${INSTANCE_ID}" \
+        --n-concurrent 1 \
+        --jobs-dir "${JOBS_DIR}" \
+        --agent-timeout-multiplier "${TIMEOUT_MULTIPLIER}" \
+        --ae "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_SUBAGENT_MODEL=${CLAUDE_CODE_SUBAGENT_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
+        --ae "ANTHROPIC_DEFAULT_OPUS_MODEL=${ANTHROPIC_DEFAULT_OPUS_MODEL:-claude-opus-4-6[1m]}" \
+        --ae "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=${CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING:-1}" \
+        --ae "MAX_THINKING_TOKENS=${MAX_THINKING_TOKENS:-128000}" \
+        --ae "CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL:-XHIGH}" \
+        2>&1 || HARBOR_EXIT=$?
+fi
+
+if [ "${HARBOR_EXIT}" -ne 0 ]; then
+    echo "    Harbor exited with code ${HARBOR_EXIT}"
+fi
+
+# Temporarily allow failures — cost/reward extraction uses grep/find which return
+# non-zero on no match; pipefail would kill the script before reaching STATUS=success.
+set +e
+
+# Extract cost from Harbor result
+COST_USD=0
+INPUT_TOKENS=0
+OUTPUT_TOKENS=0
+CACHE_READ_TOKENS=0
+CACHE_CREATION_TOKENS=0
+
+HARBOR_RESULT=$(find "${JOBS_DIR}" -maxdepth 1 -name 'result.json' 2>/dev/null | head -1)
+if [ -n "${HARBOR_RESULT}" ]; then
+    COST_DATA=$(python3 -c "
+import json, sys
+with open('${HARBOR_RESULT}') as f:
+    data = json.load(f)
+stats = data.get('stats', {})
+cost = stats.get('cost_usd', 0) or 0
+input_t = stats.get('n_input_tokens', 0) or 0
+output_t = stats.get('n_output_tokens', 0) or 0
+cache_t = stats.get('n_cache_tokens', 0) or 0
+print(f'COST_USD={cost}')
+print(f'INPUT_TOKENS={input_t}')
+print(f'OUTPUT_TOKENS={output_t}')
+print(f'CACHE_READ_TOKENS={cache_t}')
+" 2>/dev/null)
+    eval "${COST_DATA}" 2>/dev/null || true
+fi
+
+if [ "${COST_USD}" = "0" ] || [ -z "${COST_USD}" ]; then
+    AGENT_LOG=$(find "${JOBS_DIR}" -name 'claude-code.txt' -o -name 'claude_code_stream_output.jsonl' -o -name 'factory-ceo.txt' 2>/dev/null | head -1)
+    if [ -n "${AGENT_LOG}" ]; then
+        COST_DATA=$(grep 'total_cost_usd' "${AGENT_LOG}" 2>/dev/null | tail -1 | python3 -c "
+import sys, json
+for line in sys.stdin:
+    try:
+        data = json.loads(line.strip())
+        if 'total_cost_usd' in data:
+            print(f'COST_USD={data[\"total_cost_usd\"]}')
+            u = data.get('usage', {})
+            print(f'INPUT_TOKENS={u.get(\"input_tokens\", 0)}')
+            print(f'OUTPUT_TOKENS={u.get(\"output_tokens\", 0)}')
+    except: pass
+" 2>/dev/null || true)
+        eval "${COST_DATA}" 2>/dev/null || true
+    fi
+fi
+
+echo "    Finished at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+# ── Step 4: Extract and report results ──
+
+log "Step 4: Extracting results"
+
+# Harbor writes reward files inside its jobs directory.
+# Path pattern: jobs/<name>/trials/<task>/attempt_<n>/logs/verifier/reward.txt
+REWARD_FILE=""
+
+for candidate in $(find "${JOBS_DIR}" -name 'reward.json' 2>/dev/null); do
+    if [ -f "${candidate}" ]; then
+        REWARD_FILE="${candidate}"
+        break
+    fi
+done
+
+if [ -z "${REWARD_FILE}" ]; then
+    for candidate in $(find "${JOBS_DIR}" -name 'reward.txt' 2>/dev/null); do
+        if [ -f "${candidate}" ]; then
+            REWARD_FILE="${candidate}"
+            break
+        fi
+    done
+fi
+
+if [ -n "${REWARD_FILE}" ] && [ -f "${REWARD_FILE}" ]; then
+    echo "    Reward file: ${REWARD_FILE}"
+
+    if [[ "${REWARD_FILE}" == *.json ]]; then
+        eval "$(python3 -c "
+import json
+with open('${REWARD_FILE}') as f:
+    data = json.load(f)
+if isinstance(data, dict):
+    values = [v for v in data.values() if isinstance(v, (int, float))]
+    score = sum(values) / len(values) if values else 0.0
+    resolved = 1 if score > 0.5 else 0
+elif isinstance(data, (int, float)):
+    resolved = 1 if float(data) > 0.5 else 0
+else:
+    resolved = 0
+print(f'RESOLVED={resolved}')
+print(f'TOTAL=1')
+")"
+    else
+        REWARD_VALUE="$(cat "${REWARD_FILE}" | tr -d '[:space:]')"
+        echo "    Reward value: ${REWARD_VALUE}"
+        if [ "${REWARD_VALUE}" = "1" ] || [ "${REWARD_VALUE}" = "1.0" ]; then
+            RESOLVED=1
+        else
+            RESOLVED=0
+        fi
+        TOTAL=1
+    fi
+else
+    SUMMARY_FILE=""
+    for candidate in $(find "${JOBS_DIR}" -name 'results*.json' -o -name 'summary*.json' 2>/dev/null); do
+        if [ -f "${candidate}" ]; then
+            SUMMARY_FILE="${candidate}"
+            break
+        fi
+    done
+
+    if [ -n "${SUMMARY_FILE}" ] && [ -f "${SUMMARY_FILE}" ]; then
+        echo "    Summary file: ${SUMMARY_FILE}"
+        eval "$(python3 -c "
+import json
+with open('${SUMMARY_FILE}') as f:
+    data = json.load(f)
+resolved = 0
+total = 1
+if isinstance(data, dict):
+    if 'reward' in data:
+        resolved = 1 if float(data['reward']) > 0.5 else 0
+    elif 'score' in data:
+        resolved = 1 if float(data['score']) > 0.5 else 0
+    elif 'results' in data:
+        results = data['results']
+        if isinstance(results, dict):
+            total = len(results)
+            resolved = sum(1 for v in results.values()
+                         if isinstance(v, dict) and v.get('reward', 0) > 0.5)
+        elif isinstance(results, list):
+            total = len(results)
+            resolved = sum(1 for v in results
+                         if isinstance(v, dict) and v.get('reward', 0) > 0.5)
+print(f'RESOLVED={resolved}')
+print(f'TOTAL={max(total, 1)}')
+")"
+    else
+        echo "    No results files found. Marking as unresolved."
+        echo "    Contents of jobs directory:"
+        find "${JOBS_DIR}" -type f 2>/dev/null | head -20 || echo "      (empty)"
+        RESOLVED=0
+        TOTAL=1
+    fi
+fi
+
+echo ""
+echo "============================================"
+if [ "${RESOLVED}" -gt 0 ]; then
+    echo "  Result: RESOLVED (${RESOLVED}/${TOTAL})"
+else
+    echo "  Result: NOT RESOLVED (${RESOLVED}/${TOTAL})"
+fi
+echo "============================================"
+echo ""
+
+set -e
+
+STATUS="success"
+
+# cleanup trap will write the final result JSON and exit 0

--- a/factory/workflow/contributed/swebenchifyhard/README.md
+++ b/factory/workflow/contributed/swebenchifyhard/README.md
@@ -1,0 +1,30 @@
+# SWE-benchify-hard Benchmark Workflow
+
+Minimal 4-node bug-fix pipeline for the SWE-benchify-hard dataset: 284 synthetic
+Go bug-fix instances where at least one of Claude Haiku, Sonnet, or Opus failed
+to solve the problem.
+
+## Dataset
+
+**Harbor:** `red-hat-ai/SWE-benchify-hard` ([Hub link](https://hub.harborframework.com/datasets/red-hat-ai/SWE-benchify-hard))
+
+- 284 instances across 6 Go repositories
+- Synthetic bugs introduced via AST mutation and LLM-guided semantic mutation
+- Validated with Docker F2P/P2P, N-run flake quarantine, and self-screening
+- Published by the SWE-benchify project (Red Hat AI Innovation Team)
+
+## Pipeline
+
+```
+study → builder → gate_verify → auto_merge
+                      ↑    ↓
+                      └────┘ RELOOP (max 3)
+```
+
+Same structure as the vanilla `swebench` workflow, adapted for Go projects.
+
+## Usage
+
+```bash
+factory workflow run swebenchifyhard .
+```

--- a/factory/workflow/contributed/swebenchifyhard/__init__.py
+++ b/factory/workflow/contributed/swebenchifyhard/__init__.py
@@ -1,0 +1,3 @@
+from .workflow import meta, workflow
+
+__all__ = ["meta", "workflow"]

--- a/factory/workflow/contributed/swebenchifyhard/test_workflow.py
+++ b/factory/workflow/contributed/swebenchifyhard/test_workflow.py
@@ -1,0 +1,170 @@
+"""Tests for the SWE-benchify-hard contributed workflow."""
+
+from __future__ import annotations
+
+from factory.models import ProjectState
+from factory.workflow.contributed.swebenchifyhard import meta, workflow
+from factory.workflow.definitions import register_all
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    FnNode,
+    GateNode,
+    VerdictType,
+)
+
+
+class TestSwebenchifyHardWorkflow:
+    """Tests for swebenchifyhard workflow graph structure."""
+
+    def test_workflow_name(self) -> None:
+        wf = workflow()
+        assert wf.name == "swebenchifyhard"
+
+    def test_node_count(self) -> None:
+        wf = workflow()
+        assert len(wf.nodes) == 4
+        assert set(wf.nodes.keys()) == {"study", "builder", "gate_verify", "auto_merge"}
+
+    def test_start_node(self) -> None:
+        wf = workflow()
+        assert wf.start_node == "study"
+
+    def test_graph_validates(self) -> None:
+        wf = workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Workflow has validation issues: {issues}"
+
+    def test_edge_count(self) -> None:
+        wf = workflow()
+        assert len(wf.edges) == 4
+
+    def test_study_node_is_fn(self) -> None:
+        wf = workflow()
+        node = wf.nodes["study"]
+        assert isinstance(node, FnNode)
+        assert "find" in node.command
+        assert "task-instruction" in node.command
+
+    def test_builder_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.BUILDER
+        assert node.max_iterations == 3
+        assert node.timeout == 7200
+        assert "MINIMAL" in node.prompt_template
+        assert "go test" in node.prompt_template.lower()
+
+    def test_gate_verify_is_fn_evaluator(self) -> None:
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert node.evaluator_command is not None
+        assert "pass:" in node.evaluator_command
+        assert "reloop:" in node.evaluator_command
+        assert "fail:" in node.evaluator_command
+
+    def test_auto_merge_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["auto_merge"]
+        assert isinstance(node, FnNode)
+        assert "git update-ref" in node.command
+
+    def test_proceed_edge_to_merge(self) -> None:
+        wf = workflow()
+        proceed_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "auto_merge"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(proceed_edges) == 1
+
+    def test_reloop_edge_exists(self) -> None:
+        wf = workflow()
+        reloop_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "builder"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(reloop_edges) == 1
+
+    def test_no_eval_infrastructure(self) -> None:
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "begin" not in node_ids
+        assert "finalize" not in node_ids
+        assert "gate_precheck" not in node_ids
+        for node in wf.nodes.values():
+            if isinstance(node, FnNode):
+                assert "factory eval" not in node.command
+                assert "factory finalize" not in node.command
+                assert "factory precheck" not in node.command
+                assert "factory begin" not in node.command
+
+    def test_no_deep_qa_nodes(self) -> None:
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "health_checker" not in node_ids
+        assert "code_reviewer" not in node_ids
+        assert "adversarial_tester" not in node_ids
+        assert "gate_review" not in node_ids
+
+    def test_no_research_strategy_nodes(self) -> None:
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "researcher" not in node_ids
+        assert "strategist" not in node_ids
+        assert "gate_research" not in node_ids
+        assert "gate_strategy" not in node_ids
+
+
+class TestSwebenchifyHardTrigger:
+
+    def test_trigger_matches_mode(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "swebenchifyhard"})
+
+    def test_trigger_matches_without_factory(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.NO_REPO, {"mode": "swebenchifyhard"})
+        assert wf.trigger(ProjectState.NO_FACTORY, {"mode": "swebenchifyhard"})
+
+    def test_trigger_rejects_other_modes(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "swebench"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+class TestSwebenchifyHardRegistration:
+
+    def test_registered_in_register_all(self) -> None:
+        workflows = register_all()
+        assert "swebenchifyhard" in workflows
+
+    def test_registered_workflow_valid(self) -> None:
+        workflows = register_all()
+        wf = workflows["swebenchifyhard"]
+        issues = wf.validate_graph()
+        assert issues == [], f"Registered workflow has issues: {issues}"
+
+    def test_registered_workflow_has_trigger(self) -> None:
+        workflows = register_all()
+        wf = workflows["swebenchifyhard"]
+        assert wf.trigger is not None
+
+
+class TestSwebenchifyHardMeta:
+
+    def test_meta_has_name(self) -> None:
+        assert meta["name"] == "swebenchifyhard"
+
+    def test_meta_has_description(self) -> None:
+        assert "benchify" in meta["description"].lower()

--- a/factory/workflow/contributed/swebenchifyhard/workflow.py
+++ b/factory/workflow/contributed/swebenchifyhard/workflow.py
@@ -1,0 +1,165 @@
+"""SWE-benchify-hard benchmark workflow — bug-fix pipeline for synthetic Go instances.
+
+4-node pipeline: study → builder → gate_verify → auto_merge
+RELOOP from gate_verify back to builder (max 3 iterations) on test failure.
+
+Uses the same structure as the swebench workflow. Designed for Harbor containers
+with the SWE-benchify-hard dataset (284 synthetic Go instances where at least one
+of Haiku/Sonnet/Opus failed to solve).
+
+Dataset: red-hat-ai/SWE-benchify-hard on Harbor Hub.
+"""
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Edge,
+    FnNode,
+    GateNode,
+    VerdictType,
+    Workflow,
+)
+
+meta = {
+    "name": "swebenchifyhard",
+    "description": (
+        "SWE-benchify-hard benchmark — 284 synthetic Go bug-fix instances "
+        "where at least one Claude model failed. study → builder → "
+        "gate_verify → auto_merge with RELOOP on test failure."
+    ),
+}
+
+
+def workflow() -> Workflow:
+    """Build the SWE-benchify-hard workflow."""
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # ── Node 1: Study ──────────────────────────────────────────────
+    nodes["study"] = FnNode(
+        id="study",
+        command=(
+            "mkdir -p {project_path}/.factory/reviews && "
+            "cd {project_path} && "
+            "("
+            "echo '=== Repository Structure ===' && "
+            "find . -type f -name '*.go' | head -200 && "
+            "echo '\\n=== Test Files ===' && "
+            "find . -type f -name '*_test.go' | head -50 && "
+            "echo '\\n=== Configuration Files ===' && "
+            "ls -la go.mod go.sum Makefile 2>/dev/null || true && "
+            "echo '\\n=== Task Instruction ===' && "
+            "cat /tmp/task-instruction.md 2>/dev/null || "
+            "echo 'No task instruction file found at /tmp/task-instruction.md'"
+            ") > .factory/reviews/study-output.md 2>&1"
+        ),
+        writes={".factory/reviews/study-output.md"},
+    )
+
+    # ── Node 2: Builder ────────────────────────────────────────────
+    nodes["builder"] = AgentNode(
+        id="builder",
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=7200,
+        max_iterations=3,
+        prompt_template=(
+            "You are fixing a bug in an open-source Go project for the "
+            "SWE-benchify-hard benchmark.\n\n"
+            "## Your Task\n\n"
+            "1. **Read the task instruction** — Read /tmp/task-instruction.md for the full "
+            "bug description and task requirements.\n\n"
+            "2. **Understand the codebase** — explore the repository structure. "
+            "Read relevant source files, test files, and configuration. "
+            "Identify the root cause of the bug described in the task.\n\n"
+            "3. **Implement the fix** — make the MINIMAL change that resolves the "
+            "issue. Do NOT refactor, modernize, or add unrelated improvements. "
+            "Fix ONLY the described bug.\n\n"
+            "4. **Run the project's own tests** — this is CRITICAL. Run `go test` "
+            "to verify your fix works AND existing tests still pass. "
+            "If specific test names are mentioned in the task, run those first.\n\n"
+            "5. **Commit your changes** — commit directly on the current branch "
+            "with a descriptive message referencing the issue. Do NOT create a "
+            "new branch. Do NOT create a PR.\n\n"
+            "## Rules\n\n"
+            "- MINIMAL fix only — smallest diff that resolves the issue\n"
+            "- MUST run tests before committing — never commit untested code\n"
+            "- Do NOT create branches or PRs — commit on current branch\n"
+            "- Do NOT run factory commands (factory eval, factory study, etc.)\n"
+            "- Do NOT modify test files unless the bug is IN the test infrastructure\n"
+            "- If tests fail after your fix, investigate and fix the issue\n"
+        ),
+        reads={".factory/reviews/study-output.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Node 3: Gate Verify ────────────────────────────────────────
+    nodes["gate_verify"] = GateNode(
+        id="gate_verify",
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            "CHANGES=$(git diff HEAD~1 --stat 2>/dev/null || echo 'NO_COMMITS') && "
+            "if [ \"$CHANGES\" = 'NO_COMMITS' ] || [ -z \"$CHANGES\" ]; then "
+            "echo 'fail: builder did not commit any changes'; "
+            "exit 0; fi && "
+            "BUILDER_OUTPUT=$(cat .factory/reviews/builder-latest.md 2>/dev/null || echo '') && "
+            "if echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(pass|succeed|ok|PASSED)'; then "
+            "echo 'pass: builder reports tests passing'; "
+            "elif echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(fail|error|FAILED)'; then "
+            "echo 'reloop: builder needs to retry — tests did not pass'; "
+            "else "
+            "echo 'pass: changes committed, no issues detected'; "
+            "fi"
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Node 4: Auto Merge ─────────────────────────────────────────
+    nodes["auto_merge"] = FnNode(
+        id="auto_merge",
+        command=(
+            "cd {project_path} && "
+            "CURRENT=$(git rev-parse --abbrev-ref HEAD) && "
+            "COMMON=$(git rev-parse --git-common-dir) && "
+            "BASE=$(git --git-dir=\"$COMMON\" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main) && "
+            "if [ \"$CURRENT\" = \"$BASE\" ]; then "
+            "echo \"Already on $BASE — no merge needed\"; "
+            "exit 0; fi && "
+            "git update-ref refs/heads/\"$BASE\" HEAD && "
+            "PARENT_WT=$(cd \"$COMMON/..\" && pwd) && "
+            "git diff-tree --no-commit-id --name-only -r HEAD HEAD~1 | "
+            "while read file; do "
+            "if [ -f \"$file\" ]; then "
+            "mkdir -p \"$PARENT_WT/$(dirname $file)\" && "
+            "cp \"$file\" \"$PARENT_WT/$file\"; "
+            "fi; done && "
+            "echo \"Updated $BASE to $(git rev-parse --short HEAD)\""
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Edges ──────────────────────────────────────────────────────
+
+    edges = [
+        Edge(source="study", target="builder"),
+        Edge(source="builder", target="gate_verify"),
+        Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
+        Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),
+    ]
+
+    # ── Trigger ────────────────────────────────────────────────────
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "swebenchifyhard"
+
+    return Workflow(
+        name="swebenchifyhard",
+        nodes=nodes,
+        edges=edges,
+        start_node="study",
+        trigger=trigger,
+    )

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -4460,6 +4460,7 @@ def register_all() -> dict[str, Workflow]:
     from factory.workflow.contributed.terminalbench import workflow as terminalbench_workflow
     from factory.workflow.contributed.tomswe import workflow as tomswe_workflow
     from factory.workflow.contributed.salitrap import workflow as salitrap_workflow
+    from factory.workflow.contributed.swebenchifyhard import workflow as swebenchifyhard_workflow
 
     return {
         "build": build_workflow(),
@@ -4492,4 +4493,5 @@ def register_all() -> dict[str, Workflow]:
         "frontend-design-discover": frontend_design_discover_workflow(),
         "frontend-design-scan": frontend_design_scan_workflow(),
         "evolve": evolve_workflow(),
+        "swebenchifyhard": swebenchifyhard_workflow(),
     }


### PR DESCRIPTION
## Summary

- Adds SWE-benchify-hard as a benchmark workflow using the vanilla SWE-bench flow structure
- Dataset: `red-hat-ai/SWE-benchify-hard` on [Harbor Hub](https://hub.harborframework.com/datasets/red-hat-ai/SWE-benchify-hard)
- 284 synthetic Go bug-fix instances across 6 repos where at least one of Haiku/Sonnet/Opus failed

## What's included

- `factory/workflow/contributed/swebenchifyhard/` -- 4-node workflow (study → builder → gate_verify → auto_merge with RELOOP)
- `benchmarks/factory_harbor_agent.py` -- `SwebenchifyHardFactoryCeo` subclass that runs `factory workflow run swebenchifyhard`
- `benchmarks/run-swebenchifyhard.sh` -- CI runner script
- `factory/workflow/definitions.py` -- registered in `register_all()`
- 22 passing tests

## Test plan

- [x] `pytest factory/workflow/contributed/swebenchifyhard/test_workflow.py` -- 22/22 passing
- [ ] Run a single instance via Harbor to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)