### PR TITLE
fix: prevent CEO auto-approval of user gates in skill_export.py

### DIFF
--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -460,9 +460,15 @@ def _gate_to_checkpoint(
         lines.append("")
         lines.append(f"### Steering Point — {gate_name} (User Approval)")
         lines.append("")
-        lines.append("Present findings to the user. Wait for approval or feedback.")
-        lines.append("- **Approve** → proceed to next step")
-        lines.append("- **Feedback** → re-run the previous step with corrections")
+        lines.append("**This is a USER approval gate, NOT a CEO review gate. Do NOT self-approve.**")
+        lines.append("")
+        lines.append("Present the strategy/findings to the user by summarizing key points in your output.")
+        lines.append('Then explicitly ask the user: "Do you approve this plan, or do you have feedback?"')
+        lines.append("")
+        lines.append("**You MUST wait for the user's response before proceeding.**")
+        lines.append("- The user says \"approve\", \"yes\", \"looks good\", or similar → proceed to next step")
+        lines.append("- The user provides feedback or corrections → re-run the previous step incorporating their feedback")
+        lines.append("- Do NOT write a verdict file and auto-proceed — this gate requires human input")
     elif node.evaluator_type == "fn":
         evaluator_cmd = ""
         if node.evaluator_command:

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -249,7 +249,18 @@ class TestGateToCheckpoint:
         wf = _minimal_workflow(nodes={"gate_strategy": gate}, start="gate_strategy")
         result = _gate_to_checkpoint(gate, [], wf)
         assert "User Approval" in result
-        assert "Approve" in result
+        assert "Do NOT self-approve" in result
+        assert "MUST wait for the user" in result
+
+    def test_user_gate_anti_self_approval(self) -> None:
+        gate = GateNode(id="gate_approval", evaluator_type="user")
+        wf = _minimal_workflow(nodes={"gate_approval": gate}, start="gate_approval")
+        result = _gate_to_checkpoint(gate, [], wf)
+        assert "Do NOT self-approve" in result
+        assert "MUST wait for the user" in result
+        assert "Do you approve this plan" in result
+        assert "Do NOT write a verdict file" in result
+        assert "CEO Review" not in result
 
     def test_fn_gate_with_command(self) -> None:
         gate = GateNode(


### PR DESCRIPTION
Closes the user gate auto-approval issue.

## Changes

- Modified `_gate_to_checkpoint()` in `factory/workflow/skill_export.py` to render explicit anti-self-approval instructions for user gates (`evaluator_type == 'user'`), replacing the vague text that the CEO misinterpreted as a CEO review gate
- Updated existing `test_user_gate` test to verify new text ("Do NOT self-approve", "MUST wait for the user")
- Added `test_user_gate_anti_self_approval` test verifying all anti-self-approval phrases and confirming "CEO Review" does NOT appear in user gates
- Regenerated all SKILL.md files — the fix propagates to all 4 modes with user gates (design, create, frontend-design, meta)