### PR TITLE
fix: sanitize subprocess output to prevent Claude Code rendering corruption (#1123)

### DIFF
--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -166,6 +166,8 @@ _BRAILLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇"
 
 def _show_spinner(stop_event: threading.Event) -> None:
     """Braille spinner on stderr. Respects NO_COLOR."""
+    if not sys.stderr.isatty():
+        return
     use_color = not os.environ.get("NO_COLOR") and sys.stderr.isatty()
     idx = 0
     while not stop_event.is_set():

--- a/factory/runners/_stream.py
+++ b/factory/runners/_stream.py
@@ -47,8 +47,10 @@ _ANSI_ESCAPE_RE = re.compile(
 
 
 def strip_ansi(data: bytes) -> bytes:
-    r"""Remove ANSI/VT escape sequences. Leaves \r, \n and plain text intact."""
-    return _ANSI_ESCAPE_RE.sub(b"", data)
+    r"""Remove ANSI/VT escape sequences and bare carriage returns."""
+    data = _ANSI_ESCAPE_RE.sub(b"", data)
+    data = data.replace(b"\r\n", b"\n").replace(b"\r", b"")
+    return data
 
 
 def should_stream() -> bool:

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -192,6 +192,7 @@ class ClaudeRunner:
                 runner_name="claude",
                 role=request.role,
                 on_line=on_line,
+                sanitize=True,
             )
 
             usage = None

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1072,11 +1072,12 @@ class TestAnsiSanitization:
         assert strip_ansi(b"\x1bMup") == b"up"  # RI (reverse line feed)
 
     def test_strip_ansi_preserves_plaintext_and_newlines(self) -> None:
-        r"""Plain text, \r, \n and UTF-8 multibyte content are left intact."""
+        r"""Plain text, \n and UTF-8 multibyte content are left intact. Bare \r is stripped."""
         from factory.runners._stream import strip_ansi
 
         assert strip_ansi(b"plain text\n") == b"plain text\n"
-        assert strip_ansi(b"a\rb\n") == b"a\rb\n"
+        assert strip_ansi(b"a\rb\n") == b"ab\n"
+        assert strip_ansi(b"a\r\nb\r\n") == b"a\nb\n"
         # UTF-8 multibyte must not be clipped (guards the \x9C omission)
         utf8 = "café — 日本語".encode()
         assert strip_ansi(utf8) == utf8
@@ -1266,10 +1267,10 @@ class TestAnsiSanitization:
 
 
 
-    async def test_claude_runner_does_not_sanitize(
+    async def test_claude_runner_sanitizes(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """ClaudeRunner.headless() does not sanitize (default False)."""
+        """ClaudeRunner.headless() passes sanitize=True to run_subprocess."""
         monkeypatch.delenv("FACTORY_RUNNER_QUIET", raising=False)
 
         runner = ClaudeRunner()
@@ -1290,7 +1291,7 @@ class TestAnsiSanitization:
             ))
 
             mock_run.assert_called_once()
-            assert mock_run.call_args.kwargs.get("sanitize", False) is False
+            assert mock_run.call_args.kwargs.get("sanitize", False) is True
 
 
 class TestInactivityTimeout:


### PR DESCRIPTION
Closes #1123

## Changes

- **factory/runners/claude.py** — Added `sanitize=True` to the `run_subprocess()` call in `headless()`, matching the Bob runner's existing pattern. This strips ANSI/VT escape sequences from streamed subprocess output before they reach Claude Code's Ink renderer, preventing render state desynchronization.

- **factory/cli/_helpers.py** — Added an early-return TTY guard at the top of `_show_spinner()`: `if not sys.stderr.isatty(): return`. This prevents the spinner's carriage-return writes from reaching Claude Code's Ink renderer when stderr is a pipe, eliminating cursor position desynchronization.

- **factory/runners/_stream.py** — Extended `strip_ansi()` with a carriage-return stripping post-pass after the existing ANSI regex substitution. `data.replace(b"\r\n", b"\n").replace(b"\r", b"")` preserves Windows-style CRLF as LF while stripping bare CR that would corrupt Ink's cursor tracking from subprocess progress bars.

- **tests/test_runners.py** — Updated `test_strip_ansi_preserves_plaintext_and_newlines` to expect bare CR stripping, and renamed `test_claude_runner_does_not_sanitize` to `test_claude_runner_sanitizes` to match the new behavior.