### PR TITLE
feat: add --just-plan CLI flag to design mode

### DIFF
--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -54,7 +54,7 @@ log = structlog.get_logger()
 
 def _validate_ceo_flags(
     args: argparse.Namespace,
-) -> tuple[str, bool, bool, bool, str | None, str | None, str | None, str | None, bool, str | None] | int:
+) -> tuple[str, bool, bool, bool, str | None, str | None, str | None, str | None, bool, str | None, bool] | int:
     """Validate and resolve top-level CLI flags. Returns parsed values or an error code."""
     mode: str = getattr(args, "mode", "auto")
     if mode == "interactive":
@@ -71,6 +71,11 @@ def _validate_ceo_flags(
     dir_name: str | None = getattr(args, "dir", None)
     auto_approve: bool = getattr(args, "auto_approve", False)
     from_plan: str | None = getattr(args, "from_plan", None)
+    just_plan: bool = getattr(args, "just_plan", False)
+
+    if just_plan and mode != "design":
+        print("Error: --just-plan requires --mode design", file=sys.stderr)
+        return 1
 
     if auto_approve and mode != "design":
         print("Error: --auto-approve only applies to --mode design", file=sys.stderr)
@@ -171,7 +176,7 @@ def _validate_ceo_flags(
         )
         return 1
 
-    return (mode, headless, bg, bg_agents, prompt_file, focus, dir_name, refine_request, auto_approve, from_plan)
+    return (mode, headless, bg, bg_agents, prompt_file, focus, dir_name, refine_request, auto_approve, from_plan, just_plan)
 
 
 # ── project resolution ────────────────────────────────────────
@@ -372,6 +377,7 @@ def _execute_ceo(
     no_github: bool = False,
     raw_path: str = "",
     from_plan: str | None = None,
+    just_plan: bool = False,
 ) -> int:
     """Set up worktree, build task, and run the CEO agent."""
     from factory.agents.runner import begin_cycle_session, complete_cycle_session, resolve_prompt
@@ -515,6 +521,7 @@ def _execute_ceo(
         update_existing_mode=update_existing_mode,
         from_plan=resolved_plan.plan if resolved_plan else None,
         from_plan_feedback=resolved_plan.feedback if resolved_plan else None,
+        just_plan=just_plan,
     )
 
     session_name = _derive_session_name(

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -335,10 +335,10 @@ def _validate_late_flags(
         )
         return 1
 
-    if focus and mode not in ("improve", "research", "create", "evolve", "frontend-design", "frontend-design-discover", "plan") and not design_existing:
+    if focus and mode not in ("improve", "research", "create", "evolve", "frontend-design", "frontend-design-discover") and not design_existing:
         print(
             f"Error: --focus (targeted mode) only works in improve, research, create, evolve, frontend-design, "
-            f"frontend-design-discover, or plan mode, "
+            f"or frontend-design-discover mode, "
             f"got '{mode}'. The project must already be built before targeting specific items.",
             file=sys.stderr,
         )

--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -16,7 +16,7 @@ log = structlog.get_logger()
 _WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
 
 
-CEO_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "design", "interactive", "parallel-improve", "plan", "research", "review", "deep-qa", "create", "swebench", "frontend-design", "frontend-design-discover", "frontend-design-scan", "evolve"]
+CEO_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "design", "interactive", "parallel-improve", "research", "review", "deep-qa", "create", "swebench", "frontend-design", "frontend-design-discover", "frontend-design-scan", "evolve"]
 
 
 RUN_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "parallel-improve", "research", "swebench", "frontend-design-scan"]

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -450,6 +450,9 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
                     help="Load an existing plan into design mode instead of running research. "
                          "Accepts a local file path, GitHub issue URL, issue number, or fuzzy search string. "
                          "Requires --mode design; mutually exclusive with --focus and --prompt")
+    p.add_argument("--just-plan", action="store_true", default=False, dest="just_plan",
+                    help="Plan-only mode: research + strategy + approval + GitHub publish, no implementation. "
+                         "Requires --mode design.")
 
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
     p.add_argument("path", help="Project path, GitHub URL, idea file path, or prompt")

--- a/factory/cli/_task_builder.py
+++ b/factory/cli/_task_builder.py
@@ -107,6 +107,7 @@ def _build_ceo_task(
     update_existing_mode: str | None = None,
     from_plan: str | None = None,
     from_plan_feedback: list[str] | None = None,
+    just_plan: bool = False,
 ) -> str:
     """Build the CEO agent task string from mode and optional context."""
     shown_mode = display_mode if display_mode is not None else mode
@@ -180,6 +181,32 @@ def _build_ceo_task(
             f"After you approve the plan at the strategy gate, persist it to "
             f".factory/strategy/current.md — the workflow continues to "
             f"implementation automatically.\n"
+        )
+
+    if just_plan:
+        task += (
+            '\n\n## Plan Loop (Just Plan)\n\n'
+            '**just_plan: true**\n\n'
+            'Run the full Plan mode workflow: research + strategy + approval + GitHub publish.\n\n'
+            '1. Check for prior plans (GitHub issues with plan label, .factory/archive/)\n'
+            '2. Run 3 parallel researchers (domain, practices, constraints)\n'
+            '3. CEO review gate\n'
+            '4. Strategist synthesizes phased plan\n'
+            '5. Single user approval gate: Keep this plan?\n'
+            '6. On approval: publish to GitHub + seed backlog\n\n'
+            'Terminal mode — do NOT transition to build or improve.\n\n'
+            '### Post-Approval: GitHub Publish (MANDATORY)\n\n'
+            'After the user approves the plan, you MUST:\n\n'
+            '1. Create the `plan` label if it does not exist: '
+            '`gh label create plan --description "Approved plan" --color 0366d6 --force`\n'
+            '2. If --focus targets a GitHub issue number, post the plan as a comment on that issue '
+            'and add the plan label:\n'
+            '   - `gh issue comment <NUMBER> --body-file .factory/strategy/current.md`\n'
+            '   - `gh issue edit <NUMBER> --add-label plan`\n'
+            '3. Otherwise, create a new issue with the plan label:\n'
+            '   - `gh issue create --title "Plan: <focus>" --body-file .factory/strategy/current.md --label plan`\n'
+            '4. Seed the backlog: extract phase headers from current.md and append to backlog.md\n\n'
+            'Do NOT skip this step. Do NOT exit without publishing.\n'
         )
 
     if research_ideation:

--- a/factory/cli/_task_builder.py
+++ b/factory/cli/_task_builder.py
@@ -45,19 +45,6 @@ def _mode_suffix(mode: str, discover_only: bool) -> str:
             "run --mode improve afterward to harden what works. "
             "The full step-by-step playbook is in your system prompt above."
         ),
-        "plan": (
-            "\n\nRun Plan mode: prior plan check + research + strategy + optional GitHub publishing "
-            "with NO implementation. "
-            "First check GitHub issues (plan label) and .factory/archive/ for prior plans matching "
-            "the focus topic — if found, ask the user whether to continue an existing plan or start fresh. "
-            "Run 3 parallel researchers (domain, practices, constraints), CEO review gate, then "
-            "synthesize a phased plan via the Strategist, then a single user approval gate: "
-            "'Keep this plan? Approving will publish it as a comment on the GitHub issue "
-            "and seed the backlog with plan phases.' "
-            "RELOOP re-runs the Strategist with user feedback. HALT exits without publishing. "
-            "Do NOT transition to build or improve mode — plan mode is terminal. "
-            "If the user previously ran plan mode, check for prior plans before researching.\n"
-        ),
     }
     if mode == "discover":
         if discover_only:

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -36,7 +36,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     validated = _validate_ceo_flags(args)
     if isinstance(validated, int):
         return validated
-    mode, headless, bg, bg_agents, prompt_file, focus, dir_name, refine_request, auto_approve, from_plan = validated
+    mode, headless, bg, bg_agents, prompt_file, focus, dir_name, refine_request, auto_approve, from_plan, just_plan = validated
 
     assert raw_path is not None
 
@@ -129,6 +129,7 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         no_github=no_github,
         raw_path=raw_path,
         from_plan=from_plan,
+        just_plan=just_plan,
     )
 
 

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -3794,7 +3794,6 @@ def _get_builtin_registry() -> dict[str, Any]:
         "frontend-design-discover": frontend_design_discover_workflow,
         "frontend-design-scan": frontend_design_scan_workflow,
         "parallel-improve": parallel_improve_workflow,
-        "plan": plan_workflow,
         "evolve": evolve_workflow,
         "deep-qa": lambda: __import__(
             "factory.workflow.deep_qa", fromlist=["workflow"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -453,7 +453,7 @@ class TestCmdCeoDesign:
         )
         validated = _validate_ceo_flags(args)
         assert not isinstance(validated, int), f"Expected tuple, got error code {validated}"
-        _mode, headless, _bg, _bg_agents, _prompt, _focus, _dir, _refine, auto_approve, _from_plan = validated
+        _mode, headless, _bg, _bg_agents, _prompt, _focus, _dir, _refine, auto_approve, _from_plan, _just_plan = validated
         assert headless is True
         assert auto_approve is True
 
@@ -2792,7 +2792,7 @@ class TestFromPlanFlag:
         )
         validated = _validate_ceo_flags(args)
         assert not isinstance(validated, int)
-        *_, from_plan = validated
+        from_plan = validated[9]
         assert from_plan is None
 
     def test_from_plan_validation_passes_with_design_mode(self):
@@ -2815,8 +2815,103 @@ class TestFromPlanFlag:
         )
         validated = _validate_ceo_flags(args)
         assert not isinstance(validated, int), f"Expected tuple, got error code {validated}"
-        *_, from_plan = validated
+        from_plan = validated[9]
         assert from_plan == "plan.md"
+
+
+class TestJustPlanFlag:
+    """Tests for the --just-plan CLI flag."""
+
+    def test_just_plan_rejected_without_design_mode(self, capsys):
+        """--just-plan without --mode design is rejected."""
+        result = main(["ceo", "/some/path", "--mode", "improve", "--just-plan"])
+        assert result == 1
+        assert "--just-plan requires --mode design" in capsys.readouterr().err
+
+    def test_just_plan_accepted_with_design_mode(self, tmp_path):
+        """--just-plan with --mode design succeeds."""
+        with _mock_foreground() as mock_run:
+            main(["ceo", str(tmp_path), "--mode", "design", "--just-plan"])
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        dsp_idx = cmd.index("--dangerously-skip-permissions")
+        task = cmd[dsp_idx + 1]
+        assert "## Plan Loop (Just Plan)" in task
+        assert "just_plan: true" in task
+
+    def test_just_plan_task_has_github_publish(self, tmp_path):
+        """--just-plan injects GitHub publish instructions into the task."""
+        task = _build_ceo_task(tmp_path, "design", design_existing=True, just_plan=True)
+        assert "### Post-Approval: GitHub Publish (MANDATORY)" in task
+        assert "gh label create plan" in task
+        assert "gh issue comment" in task
+        assert "gh issue create" in task
+        assert "Seed the backlog" in task
+        assert "Terminal mode" in task
+
+    def test_just_plan_task_without_flag(self, tmp_path):
+        """Without --just-plan, no Just Plan section is emitted."""
+        task = _build_ceo_task(tmp_path, "design", design_existing=True)
+        assert "## Plan Loop (Just Plan)" not in task
+
+    def test_just_plan_validation_returns_true(self):
+        """just_plan=True is correctly returned in the validation tuple."""
+        from factory.cli._ceo_helpers import _validate_ceo_flags
+
+        args = argparse.Namespace(
+            path="some idea",
+            mode="design",
+            bg=False,
+            bg_agents=False,
+            headless=False,
+            prompt=None,
+            focus=None,
+            dir=None,
+            no_github=False,
+            refine=None,
+            auto_approve=False,
+            from_plan=None,
+            just_plan=True,
+        )
+        validated = _validate_ceo_flags(args)
+        assert not isinstance(validated, int), f"Expected tuple, got error code {validated}"
+        just_plan = validated[10]
+        assert just_plan is True
+
+    def test_just_plan_default_false(self):
+        """just_plan defaults to False when flag is omitted."""
+        from factory.cli._ceo_helpers import _validate_ceo_flags
+
+        args = argparse.Namespace(
+            path="some idea",
+            mode="design",
+            bg=False,
+            bg_agents=False,
+            headless=False,
+            prompt=None,
+            focus=None,
+            dir=None,
+            no_github=False,
+            refine=None,
+            auto_approve=False,
+            from_plan=None,
+        )
+        validated = _validate_ceo_flags(args)
+        assert not isinstance(validated, int)
+        just_plan = validated[10]
+        assert just_plan is False
+
+    def test_just_plan_parser_flag(self):
+        """Parser accepts --just-plan flag on ceo subcommand."""
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path", "--mode", "design", "--just-plan"])
+        assert args.just_plan is True
+
+    def test_just_plan_parser_default(self):
+        """Parser defaults just_plan to False."""
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/some/path", "--mode", "design"])
+        assert args.just_plan is False
 
 
 class TestResolvePlanSource:

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -765,7 +765,7 @@ class TestCmdCeoMultiIssue:
             patch("factory.cli.ceo._execute_ceo", return_value=0) as mock_exec,
         ):
             mock_validate.return_value = (
-                "improve", False, False, False, None, "111 and 112", None, None, False, None,
+                "improve", False, False, False, None, "111 and 112", None, None, False, None, False,
             )
             mock_resolve.return_value = (
                 Path("/tmp/fake"), None, None, None,
@@ -821,7 +821,7 @@ class TestCmdCeoMultiIssue:
             patch("factory.cli.ceo._execute_ceo", return_value=0) as mock_exec,
         ):
             mock_validate.return_value = (
-                "improve", False, False, False, None, "42", None, None, False, None,
+                "improve", False, False, False, None, "42", None, None, False, None, False,
             )
             mock_resolve.return_value = (
                 Path("/tmp/fake"), None, None, None,
@@ -858,7 +858,7 @@ class TestCmdCeoMultiIssue:
             patch("factory.cli.ceo._resolve_ceo_project") as mock_resolve,
         ):
             mock_validate.return_value = (
-                "improve", False, False, False, None, "111 and 112", None, None, False, None,
+                "improve", False, False, False, None, "111 and 112", None, None, False, None, False,
             )
             mock_resolve.return_value = (
                 Path("/tmp/fake"), None, None, None,


### PR DESCRIPTION
Closes #1139

## Changes

- Added `--just-plan` flag to the `ceo` subparser in `_parser_groups.py`, requiring `--mode design`
- Added validation in `_validate_ceo_flags()` that rejects `--just-plan` without `--mode design`
- Plumbed `just_plan` through the return tuple in `_validate_ceo_flags()`, destructuring in `ceo.py`, `_execute_ceo()`, and into `_build_ceo_task()`
- When `just_plan=True`, appends a `## Plan Loop (Just Plan)` section to the CEO task with explicit GitHub publish + backlog seeding instructions (create `plan` label, post as issue comment or new issue, seed backlog from phase headers)
- Added 8 tests covering parser flag, validation, task content, and default behavior