### PR TITLE
feat: workflow tool — stale file fix, overview/curr/dry-run, compact next

### DIFF
--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -65,15 +65,23 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         "\n"
         "You are executing the workflow using factory tool commands instead of "
         "following a SKILL.md playbook.\n"
-        "\n"
-        "## Commands\n"
+    )
+
+    if overview:
+        protocol += (
+            "\n## Workflow Map\n"
+            "\n"
+            f"{overview}\n"
+        )
+
+    protocol += (
+        "\n## Commands\n"
         "\n"
         f"  factory workflow tool next {p}\n"
         f"  factory workflow tool submit {p} --node <NODE_ID> <<'TOOL_OUTPUT'\n"
         "  <your output>\n"
         "  TOOL_OUTPUT\n"
         f"  factory workflow tool status {p}\n"
-        f"  factory workflow tool overview {p}\n"
         f"  factory workflow tool curr {p}\n"
         "\n"
         "## Protocol\n"
@@ -102,13 +110,6 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         "do not write code\n"
         '- Start by running "next" to get your first task\n'
     )
-
-    if overview:
-        protocol += (
-            "\n## Workflow Map\n"
-            "\n"
-            f"{overview}\n"
-        )
 
     return protocol
 

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -52,7 +52,15 @@ log = structlog.get_logger()
 def _tool_exec_protocol(wt_path: Path) -> str:
     """Return the tool-exec protocol section appended to the CEO prompt."""
     p = wt_path
-    return (
+
+    overview = ""
+    try:
+        from factory.workflow.tool import tool_overview
+        overview = tool_overview(p, fmt="linear")
+    except Exception:
+        pass
+
+    protocol = (
         "\n\n# Tool-Based Execution Protocol\n"
         "\n"
         "You are executing the workflow using factory tool commands instead of "
@@ -65,6 +73,8 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         "  <your output>\n"
         "  TOOL_OUTPUT\n"
         f"  factory workflow tool status {p}\n"
+        f"  factory workflow tool overview {p}\n"
+        f"  factory workflow tool curr {p}\n"
         "\n"
         "## Protocol\n"
         "\n"
@@ -92,6 +102,15 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         "do not write code\n"
         '- Start by running "next" to get your first task\n'
     )
+
+    if overview:
+        protocol += (
+            "\n## Workflow Map\n"
+            "\n"
+            f"{overview}\n"
+        )
+
+    return protocol
 
 
 # ── flag validation ───────────────────────────────────────────

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -249,11 +249,19 @@ def _cmd_tool(args: argparse.Namespace) -> int:
     """Dispatch tool subcommands for step-by-step workflow execution."""
     import sys
 
-    from factory.workflow.tool import tool_finalize, tool_init, tool_next, tool_status, tool_submit
+    from factory.workflow.tool import (
+        tool_curr,
+        tool_finalize,
+        tool_init,
+        tool_next,
+        tool_overview,
+        tool_status,
+        tool_submit,
+    )
 
     sub = getattr(args, "tool_command", None)
     if not sub:
-        print("Usage: factory workflow tool {init,next,submit,status,finalize}")
+        print("Usage: factory workflow tool {init,next,submit,status,finalize,overview,curr}")
         return 1
 
     project_path = Path(args.project_path).resolve()
@@ -263,8 +271,8 @@ def _cmd_tool(args: argparse.Namespace) -> int:
         print(session_dir)
         return 0
     elif sub == "next":
-        fmt = getattr(args, "format", "linear")
-        print(tool_next(project_path, fmt=fmt))
+        dry_run = getattr(args, "dry_run", False)
+        print(tool_next(project_path, dry_run=dry_run))
         return 0
     elif sub == "submit":
         output = sys.stdin.read().strip()
@@ -277,6 +285,13 @@ def _cmd_tool(args: argparse.Namespace) -> int:
         return 0
     elif sub == "finalize":
         print(tool_finalize(project_path))
+        return 0
+    elif sub == "overview":
+        fmt = getattr(args, "format", "linear")
+        print(tool_overview(project_path, fmt=fmt))
+        return 0
+    elif sub == "curr":
+        print(tool_curr(project_path))
         return 0
 
     return 1
@@ -332,8 +347,8 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     p_tool_next = tool_sub.add_parser("next", help="Get next node task")
     p_tool_next.add_argument("project_path", help="Project path")
     p_tool_next.add_argument(
-        "--format", choices=["linear", "phased"], default="linear",
-        help="Output format (default: linear)",
+        "--dry-run", action="store_true", default=False,
+        help="Preview without advancing",
     )
 
     p_tool_submit = tool_sub.add_parser("submit", help="Submit node output")
@@ -349,3 +364,13 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
 
     p_tool_finalize = tool_sub.add_parser("finalize", help="Finalize session — mark remaining nodes complete")
     p_tool_finalize.add_argument("project_path", help="Project path")
+
+    p_tool_overview = tool_sub.add_parser("overview", help="Show full workflow map")
+    p_tool_overview.add_argument("project_path", help="Project path")
+    p_tool_overview.add_argument(
+        "--format", choices=["linear", "phased"], default="linear",
+        help="Output format (default: linear)",
+    )
+
+    p_tool_curr = tool_sub.add_parser("curr", help="Show current node (no advance)")
+    p_tool_curr.add_argument("project_path", help="Project path")

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -263,7 +263,8 @@ def _cmd_tool(args: argparse.Namespace) -> int:
         print(session_dir)
         return 0
     elif sub == "next":
-        print(tool_next(project_path))
+        fmt = getattr(args, "format", "linear")
+        print(tool_next(project_path, fmt=fmt))
         return 0
     elif sub == "submit":
         output = sys.stdin.read().strip()
@@ -271,7 +272,8 @@ def _cmd_tool(args: argparse.Namespace) -> int:
         print(result)
         return 0
     elif sub == "status":
-        print(tool_status(project_path))
+        fmt = getattr(args, "format", "linear")
+        print(tool_status(project_path, fmt=fmt))
         return 0
     elif sub == "finalize":
         print(tool_finalize(project_path))
@@ -329,6 +331,10 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
 
     p_tool_next = tool_sub.add_parser("next", help="Get next node task")
     p_tool_next.add_argument("project_path", help="Project path")
+    p_tool_next.add_argument(
+        "--format", choices=["linear", "phased"], default="linear",
+        help="Output format (default: linear)",
+    )
 
     p_tool_submit = tool_sub.add_parser("submit", help="Submit node output")
     p_tool_submit.add_argument("project_path", help="Project path")
@@ -336,6 +342,10 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
 
     p_tool_status = tool_sub.add_parser("status", help="Show session status")
     p_tool_status.add_argument("project_path", help="Project path")
+    p_tool_status.add_argument(
+        "--format", choices=["linear", "phased"], default="linear",
+        help="Output format (default: linear)",
+    )
 
     p_tool_finalize = tool_sub.add_parser("finalize", help="Finalize session — mark remaining nodes complete")
     p_tool_finalize.add_argument("project_path", help="Project path")

--- a/factory/workflow/tool.py
+++ b/factory/workflow/tool.py
@@ -267,7 +267,7 @@ def tool_init(workflow_name: str, project_path: Path) -> str:
     return str(session_dir)
 
 
-def tool_next(project_path: Path) -> str:
+def tool_next(project_path: Path, fmt: str = "linear") -> str:
     """Get the next node to execute.
 
     Auto-submits any pending node whose artifacts exist:
@@ -282,8 +282,9 @@ def tool_next(project_path: Path) -> str:
     state = _load_state(project_path)
 
     if state["status"] != "active":
+        progress = _format_progress(state, None, project_path, None, fmt=fmt)
         finalize_msg = tool_finalize(project_path)
-        return f"DONE\n{finalize_msg}"
+        return f"{progress}\n\nDONE\n{finalize_msg}"
 
     wf = _get_workflow_cached(state["workflow_name"], project_path)
     order = state["topo_order"]
@@ -336,21 +337,25 @@ def tool_next(project_path: Path) -> str:
     _save_state(project_path, state)
 
     if idx >= len(order):
+        progress = _format_progress(state, wf, project_path, None, fmt=fmt)
         finalize_msg = tool_finalize(project_path)
-        return f"DONE\n{finalize_msg}"
+        return f"{progress}\n\nDONE\n{finalize_msg}"
 
     nid = order[idx]
     node = wf.nodes[nid]
 
     _emit_event(project_path, "workflow.tool.next", node=nid, node_type=type(node).__name__)
 
+    progress = _format_progress(state, wf, project_path, nid, fmt=fmt)
+
     if isinstance(node, GateNode) and node.evaluator_type == "agent":
-        return f"GATE\n{_format_gate_task(nid, node, state, project_path)}"
+        gate_task = _format_gate_task(nid, node, state, project_path)
+        return f"{progress}\n\nGATE\n{gate_task}"
 
     if isinstance(node, GateNode) and node.evaluator_type == "user":
-        return f"APPROVAL_NEEDED\n{node.gate_prompt}"
+        return f"{progress}\n\nAPPROVAL_NEEDED\n{node.gate_prompt}"
 
-    return _format_node_task(nid, node, wf, state, project_path)
+    return progress
 
 
 def tool_submit(project_path: Path, node_id: str, output: str) -> str:
@@ -398,7 +403,7 @@ def tool_submit(project_path: Path, node_id: str, output: str) -> str:
     return "CONTINUE"
 
 
-def tool_status(project_path: Path) -> str:
+def tool_status(project_path: Path, fmt: str = "linear") -> str:
     """Get current session status."""
     state_path = project_path / ".factory" / "tool_session" / "state.json"
     if not state_path.exists():
@@ -411,6 +416,13 @@ def tool_status(project_path: Path) -> str:
     completed_count = len(state["completed"])
     total = len(order)
 
+    try:
+        wf = _get_workflow_cached(state["workflow_name"], project_path)
+    except Exception:
+        wf = None
+
+    current_nid = current if current != "DONE" else None
+
     lines = [
         f"Workflow: {state['workflow_name']}",
         f"Session:  {state['session_id']}",
@@ -422,13 +434,8 @@ def tool_status(project_path: Path) -> str:
     if state["gate_results"]:
         lines.append(f"Gates:    {json.dumps(state['gate_results'])}")
 
-    if state["completed"]:
-        lines.append("")
-        lines.append("Completed nodes:")
-        for nid in order:
-            if nid in state["completed"]:
-                preview = state["completed"][nid][:80].replace("\n", " ")
-                lines.append(f"  [{nid}] {preview}")
+    lines.append("")
+    lines.append(_format_progress(state, wf, project_path, current_nid, fmt=fmt))
 
     return "\n".join(lines)
 
@@ -471,6 +478,70 @@ def tool_finalize(project_path: Path) -> str:
 
 
 # ── helpers ─────────────────────────────────────────────────────
+
+
+def _phase_label(nid: str, node: object) -> str:
+    """Generate a human-readable phase label from node id and type."""
+    name = nid.replace("_", " ").title()
+
+    if isinstance(node, AgentNode):
+        role = node.role.value.replace("_", " ").title()
+        return role if role.lower() in name.lower() else f"{role} — {name}"
+    elif isinstance(node, GateNode):
+        gate_name = nid.replace("gate_", "").replace("_", " ").title()
+        return f"Gate — {gate_name}"
+    elif isinstance(node, Study):
+        return f"Observe ({nid})"
+    elif isinstance(node, ForkNode):
+        return f"Fork ({', '.join(node.targets)})"
+    elif isinstance(node, FnNode):
+        return name
+    return name
+
+
+def _format_progress(
+    state: dict,
+    wf: Workflow | None,
+    project_path: Path,
+    current_nid: str | None,
+    fmt: str = "linear",
+) -> str:
+    """Build a progress view of the workflow with completion markers."""
+    order = state["topo_order"]
+    completed = state["completed"]
+    lines: list[str] = []
+
+    for i, nid in enumerate(order):
+        node = wf.nodes.get(nid) if wf else None
+        is_current = nid == current_nid
+        is_done = nid in completed
+
+        if is_done:
+            marker = "✓"
+        elif is_current:
+            marker = "▶"
+        else:
+            marker = "○"
+
+        if fmt == "phased":
+            label = _phase_label(nid, node) if node else nid.replace("_", " ").title()
+            line = f"{marker} Phase {i + 1}: {label}"
+        else:
+            line = f"{marker} {nid}"
+
+        if is_current:
+            line += "    ← CURRENT"
+
+        lines.append(line)
+
+        if is_current and node is not None and wf is not None:
+            details = _format_node_task(nid, node, wf, state, project_path)
+            for detail_line in details.split("\n"):
+                if detail_line.startswith("Node:"):
+                    continue
+                lines.append(f"  {detail_line}")
+
+    return "\n".join(lines)
 
 
 def _format_node_task(

--- a/factory/workflow/tool.py
+++ b/factory/workflow/tool.py
@@ -290,8 +290,10 @@ def tool_next(project_path: Path, dry_run: bool = False) -> str:
         state = copy.deepcopy(state)
 
     if state["status"] != "active":
-        finalize_msg = tool_finalize(project_path)
-        return f"DONE\n{finalize_msg}"
+        if not dry_run:
+            finalize_msg = tool_finalize(project_path)
+            return f"DONE\n{finalize_msg}"
+        return "DONE"
 
     wf = _get_workflow_cached(state["workflow_name"], project_path)
     order = state["topo_order"]
@@ -349,8 +351,10 @@ def tool_next(project_path: Path, dry_run: bool = False) -> str:
         _save_state(project_path, state)
 
     if idx >= len(order):
-        finalize_msg = tool_finalize(project_path)
-        return f"DONE\n{finalize_msg}"
+        if not dry_run:
+            finalize_msg = tool_finalize(project_path)
+            return f"DONE\n{finalize_msg}"
+        return "DONE"
 
     nid = order[idx]
     node = wf.nodes[nid]

--- a/factory/workflow/tool.py
+++ b/factory/workflow/tool.py
@@ -204,6 +204,7 @@ def tool_init(workflow_name: str, project_path: Path) -> str:
         "workflow_name": workflow_name,
         "session_id": uuid.uuid4().hex[:12],
         "original_project": str(_resolve_original_project(project_path)),
+        "started_at": int(time.time()),
         "topo_order": order,
         "pointer_idx": 0,
         "completed": {},
@@ -267,7 +268,7 @@ def tool_init(workflow_name: str, project_path: Path) -> str:
     return str(session_dir)
 
 
-def tool_next(project_path: Path, fmt: str = "linear") -> str:
+def tool_next(project_path: Path, dry_run: bool = False) -> str:
     """Get the next node to execute.
 
     Auto-submits any pending node whose artifacts exist:
@@ -278,13 +279,19 @@ def tool_next(project_path: Path, fmt: str = "linear") -> str:
 
     The CEO never calls submit for agent/fn nodes — just next repeatedly.
     Submit is only needed for gate verdicts.
+
+    When dry_run=True, runs the auto-submit scan but does not persist state
+    changes or emit events.
     """
+    import copy
+
     state = _load_state(project_path)
+    if dry_run:
+        state = copy.deepcopy(state)
 
     if state["status"] != "active":
-        progress = _format_progress(state, None, project_path, None, fmt=fmt)
         finalize_msg = tool_finalize(project_path)
-        return f"{progress}\n\nDONE\n{finalize_msg}"
+        return f"DONE\n{finalize_msg}"
 
     wf = _get_workflow_cached(state["workflow_name"], project_path)
     order = state["topo_order"]
@@ -298,7 +305,9 @@ def tool_next(project_path: Path, fmt: str = "linear") -> str:
             continue
 
         node = wf.nodes[nid]
-        artifact = _detect_artifact(nid, node, project_path)
+        artifact = _detect_artifact(
+            nid, node, project_path, session_start=state.get("started_at", 0.0),
+        )
 
         if artifact is not None:
             state["completed"][nid] = artifact
@@ -309,7 +318,8 @@ def tool_next(project_path: Path, fmt: str = "linear") -> str:
                     if not out.exists():
                         out.write_text(artifact)
             log.info("tool.auto_submit", node=nid)
-            _emit_event(project_path, "workflow.tool.auto_submit", node=nid)
+            if not dry_run:
+                _emit_event(project_path, "workflow.tool.auto_submit", node=nid)
             idx += 1
             state["pointer_idx"] = idx
 
@@ -328,34 +338,33 @@ def tool_next(project_path: Path, fmt: str = "linear") -> str:
                         return gate_result
                     idx = state["pointer_idx"]
 
-            _save_state(project_path, state)
+            if not dry_run:
+                _save_state(project_path, state)
             continue
 
         break
 
     state["pointer_idx"] = idx
-    _save_state(project_path, state)
+    if not dry_run:
+        _save_state(project_path, state)
 
     if idx >= len(order):
-        progress = _format_progress(state, wf, project_path, None, fmt=fmt)
         finalize_msg = tool_finalize(project_path)
-        return f"{progress}\n\nDONE\n{finalize_msg}"
+        return f"DONE\n{finalize_msg}"
 
     nid = order[idx]
     node = wf.nodes[nid]
 
-    _emit_event(project_path, "workflow.tool.next", node=nid, node_type=type(node).__name__)
-
-    progress = _format_progress(state, wf, project_path, nid, fmt=fmt)
+    if not dry_run:
+        _emit_event(project_path, "workflow.tool.next", node=nid, node_type=type(node).__name__)
 
     if isinstance(node, GateNode) and node.evaluator_type == "agent":
-        gate_task = _format_gate_task(nid, node, state, project_path)
-        return f"{progress}\n\nGATE\n{gate_task}"
+        return f"GATE\n{_format_gate_task(nid, node, state, project_path)}"
 
     if isinstance(node, GateNode) and node.evaluator_type == "user":
-        return f"{progress}\n\nAPPROVAL_NEEDED\n{node.gate_prompt}"
+        return f"APPROVAL_NEEDED\n{node.gate_prompt}"
 
-    return progress
+    return _format_node_task(nid, node, wf, state, project_path)
 
 
 def tool_submit(project_path: Path, node_id: str, output: str) -> str:
@@ -455,7 +464,9 @@ def tool_finalize(project_path: Path) -> str:
         if nid in state["completed"]:
             continue
         node = wf.nodes[nid]
-        artifact = _detect_artifact(nid, node, project_path)
+        artifact = _detect_artifact(
+            nid, node, project_path, session_start=state.get("started_at", 0.0),
+        )
         if artifact is not None:
             state["completed"][nid] = artifact
             finalized.append(nid)
@@ -475,6 +486,31 @@ def tool_finalize(project_path: Path) -> str:
             f"Progress: {len(state['completed'])}/{len(order)}"
         )
     return f"No pending nodes to finalize. Progress: {len(state['completed'])}/{len(order)}"
+
+
+def tool_overview(project_path: Path, fmt: str = "linear") -> str:
+    """Render the full workflow map with completion markers. Does NOT advance."""
+    state = _load_state(project_path)
+    wf = _get_workflow_cached(state["workflow_name"], project_path)
+    order = state["topo_order"]
+    idx = state["pointer_idx"]
+    current_nid = order[idx] if idx < len(order) else None
+    return _format_progress(state, wf, project_path, current_nid, fmt=fmt)
+
+
+def tool_curr(project_path: Path) -> str:
+    """Show current node details without advancing or auto-submitting."""
+    state = _load_state(project_path)
+    wf = _get_workflow_cached(state["workflow_name"], project_path)
+    order = state["topo_order"]
+    idx = state["pointer_idx"]
+
+    if idx >= len(order):
+        return "DONE\nAll nodes completed."
+
+    nid = order[idx]
+    node = wf.nodes[nid]
+    return _format_node_task(nid, node, wf, state, project_path)
 
 
 # ── helpers ─────────────────────────────────────────────────────
@@ -628,28 +664,37 @@ def _format_gate_task(
     return "\n".join(lines)
 
 
-def _detect_artifact(nid: str, node: object, project_path: Path) -> str | None:
-    """Check if a node's output artifact exists. Returns content or None."""
+def _detect_artifact(
+    nid: str, node: object, project_path: Path, session_start: float = 0.0,
+) -> str | None:
+    """Check if a node's output artifact exists. Returns content or None.
+
+    When session_start > 0, files with mtime before that timestamp are
+    treated as stale leftovers from a prior run and ignored.
+    """
     reviews_dir = project_path / ".factory" / "reviews"
+
+    def _fresh(f: Path) -> bool:
+        return session_start <= 0 or f.stat().st_mtime >= session_start
 
     if isinstance(node, AgentNode):
         role = node.role.value
         tag = nid.replace(f"{role}_", "").replace(role, "")
         if tag and tag != nid:
             tagged_file = reviews_dir / f"{role}-{tag}-latest.md"
-            if tagged_file.exists():
+            if tagged_file.exists() and _fresh(tagged_file):
                 content = tagged_file.read_text().strip()
                 if content:
                     return content
         review_file = reviews_dir / f"{role}-latest.md"
-        if review_file.exists():
+        if review_file.exists() and _fresh(review_file):
             content = review_file.read_text().strip()
             if content:
                 return content
         if node.writes:
             for wp in node.writes:
                 f = project_path / wp
-                if f.exists():
+                if f.exists() and _fresh(f):
                     content = f.read_text().strip()
                     if content:
                         return content
@@ -657,7 +702,7 @@ def _detect_artifact(nid: str, node: object, project_path: Path) -> str | None:
 
     elif isinstance(node, Study):
         obs_file = project_path / ".factory" / "strategy" / "observations.md"
-        if obs_file.exists():
+        if obs_file.exists() and _fresh(obs_file):
             content = obs_file.read_text().strip()
             if content and len(content) > 50:
                 return content
@@ -665,7 +710,10 @@ def _detect_artifact(nid: str, node: object, project_path: Path) -> str | None:
 
     elif isinstance(node, FnNode):
         if node.writes:
-            all_exist = all((project_path / wp).exists() for wp in node.writes)
+            all_exist = all(
+                (project_path / wp).exists() and _fresh(project_path / wp)
+                for wp in node.writes
+            )
             if all_exist:
                 parts = []
                 for wp in node.writes:

--- a/tests/test_workflow_tool.py
+++ b/tests/test_workflow_tool.py
@@ -22,7 +22,9 @@ from factory.workflow.tool import (
     _find_reloop_target,
     _format_gate_task,
     _format_node_task,
+    _format_progress,
     _get_workflow_cached,
+    _phase_label,
     _rebuild_workflow,
     _resolve_original_project,
     _workflow_cache,
@@ -186,7 +188,7 @@ class TestToolNext:
 
         result = tool_next(tmp_path)
 
-        assert "Node: study" in result
+        assert "▶ study" in result
         assert "Type: Study" in result
 
     def test_next_returns_done_when_completed(self, tmp_path: Path) -> None:
@@ -204,7 +206,7 @@ class TestToolNext:
         )
 
         result = tool_next(tmp_path)
-        assert result.startswith("DONE")
+        assert "DONE" in result
 
     def test_next_completes_when_past_end(self, tmp_path: Path) -> None:
         wf = _simple_workflow()
@@ -425,7 +427,7 @@ class TestToolSubmit:
         assert result == "CONTINUE"
 
         next_result = tool_next(tmp_path)
-        assert next_result.startswith("APPROVAL_NEEDED")
+        assert "APPROVAL_NEEDED" in next_result
         assert "Approve this strategy?" in next_result
 
     def test_submit_returns_done_at_end(self, tmp_path: Path) -> None:
@@ -470,8 +472,7 @@ class TestToolStatus:
 
         result = tool_status(tmp_path)
         assert "Progress: 1/" in result
-        assert "[study]" in result
-        assert "Completed nodes:" in result
+        assert "✓ study" in result
 
     def test_status_with_gate_results(self, tmp_path: Path) -> None:
         wf = _fn_gate_workflow()
@@ -560,7 +561,7 @@ class TestAutoSubmit:
         )
         assert "study" in state["completed"]
         assert "researcher" in state["completed"]
-        assert result.startswith("GATE")
+        assert "GATE" in result
         assert "gate_research" in result
 
     def test_next_auto_evaluates_fn_gate(self, tmp_path: Path) -> None:
@@ -1028,7 +1029,7 @@ class TestWorkflowDiskCache:
         WorkflowRegistry.reset()
 
         result = tool_next(tmp_path)
-        assert "Node: study" in result
+        assert "▶ study" in result
 
     def test_rebuild_workflow_roundtrip(self, tmp_path: Path) -> None:
         """Serialized cache can be deserialized back into a valid Workflow."""
@@ -1100,6 +1101,109 @@ class TestInvokeAgentPromptOverride:
             ))
 
             mock_resolve.assert_called_once()
+
+
+class TestFormatProgress:
+    def test_format_progress_linear(self, tmp_path: Path) -> None:
+        """Linear format shows ✓/▶/○ markers and expands current node."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        state = json.loads(
+            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
+        )
+        state["completed"]["study"] = "done"
+        state["completed"]["researcher"] = "done"
+
+        result = _format_progress(state, wf, tmp_path, "gate_research", fmt="linear")
+
+        assert "✓ study" in result
+        assert "✓ researcher" in result
+        assert "▶ gate_research" in result
+        assert "← CURRENT" in result
+        assert "○ builder" in result
+        assert "Type: Gate" in result
+
+    def test_format_progress_phased(self, tmp_path: Path) -> None:
+        """Phased format shows 'Phase N:' labels with role/gate names."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        state = json.loads(
+            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
+        )
+        state["completed"]["study"] = "done"
+        state["completed"]["researcher"] = "done"
+
+        result = _format_progress(state, wf, tmp_path, "gate_research", fmt="phased")
+
+        assert "Phase 1:" in result
+        assert "Phase 2:" in result
+        assert "Phase 3:" in result
+        assert "Gate —" in result
+        assert "Observe" in result or "Researcher" in result
+
+    def test_next_linear_format(self, tmp_path: Path) -> None:
+        """tool_next with fmt='linear' includes ✓/▶/○ markers."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        # Complete study via artifact
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True, exist_ok=True)
+        (strategy_dir / "observations.md").write_text(
+            "Detailed observations about the project that exceed the minimum length threshold"
+        )
+
+        result = tool_next(tmp_path, fmt="linear")
+
+        assert "✓ study" in result
+        assert "▶ researcher" in result
+        assert "○" in result
+
+    def test_next_phased_format(self, tmp_path: Path) -> None:
+        """tool_next with fmt='phased' includes 'Phase' labels."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        result = tool_next(tmp_path, fmt="phased")
+
+        assert "Phase 1:" in result
+        assert "Phase" in result
+
+    def test_phase_label(self) -> None:
+        """_phase_label produces correct labels for each node type."""
+        agent = AgentNode(id="builder", role=AgentRole.BUILDER, prompt_template="build")
+        assert "Builder" in _phase_label("builder", agent)
+
+        gate = GateNode(id="gate_research", evaluator_type="agent", gate_prompt="review")
+        label = _phase_label("gate_research", gate)
+        assert "Gate —" in label
+        assert "Research" in label
+
+        study = Study(id="study", command="factory study")
+        label = _phase_label("study", study)
+        assert "Observe" in label
+        assert "study" in label
+
+        fn = FnNode(id="apply_spec", command="echo ok")
+        label = _phase_label("apply_spec", fn)
+        assert "Apply Spec" in label
+
+        from factory.workflow.primitives import ForkNode
+        fork = ForkNode(id="fork1", targets=["a", "b"])
+        label = _phase_label("fork1", fork)
+        assert "Fork" in label
+        assert "a" in label
+        assert "b" in label
 
 
 class TestDeterministicImpliesHeadless:

--- a/tests/test_workflow_tool.py
+++ b/tests/test_workflow_tool.py
@@ -28,9 +28,11 @@ from factory.workflow.tool import (
     _rebuild_workflow,
     _resolve_original_project,
     _workflow_cache,
+    tool_curr,
     tool_finalize,
     tool_init,
     tool_next,
+    tool_overview,
     tool_status,
     tool_submit,
 )
@@ -188,7 +190,7 @@ class TestToolNext:
 
         result = tool_next(tmp_path)
 
-        assert "▶ study" in result
+        assert "Node: study" in result
         assert "Type: Study" in result
 
     def test_next_returns_done_when_completed(self, tmp_path: Path) -> None:
@@ -1029,7 +1031,7 @@ class TestWorkflowDiskCache:
         WorkflowRegistry.reset()
 
         result = tool_next(tmp_path)
-        assert "▶ study" in result
+        assert "Node: study" in result
 
     def test_rebuild_workflow_roundtrip(self, tmp_path: Path) -> None:
         """Serialized cache can be deserialized back into a valid Workflow."""
@@ -1147,34 +1149,30 @@ class TestFormatProgress:
         assert "Gate —" in result
         assert "Observe" in result or "Researcher" in result
 
-    def test_next_linear_format(self, tmp_path: Path) -> None:
-        """tool_next with fmt='linear' includes ✓/▶/○ markers."""
+    def test_overview_linear_format(self, tmp_path: Path) -> None:
+        """tool_overview with fmt='linear' includes ✓/▶/○ markers."""
         wf = _simple_workflow()
         _register_workflow(wf)
         (tmp_path / ".factory").mkdir()
         tool_init("test-simple", tmp_path)
 
-        # Complete study via artifact
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text(
-            "Detailed observations about the project that exceed the minimum length threshold"
-        )
+        # Complete study via submit so it shows as ✓
+        tool_submit(tmp_path, "study", "Observations done")
 
-        result = tool_next(tmp_path, fmt="linear")
+        result = tool_overview(tmp_path, fmt="linear")
 
         assert "✓ study" in result
         assert "▶ researcher" in result
         assert "○" in result
 
-    def test_next_phased_format(self, tmp_path: Path) -> None:
-        """tool_next with fmt='phased' includes 'Phase' labels."""
+    def test_overview_phased_format(self, tmp_path: Path) -> None:
+        """tool_overview with fmt='phased' includes 'Phase' labels."""
         wf = _simple_workflow()
         _register_workflow(wf)
         (tmp_path / ".factory").mkdir()
         tool_init("test-simple", tmp_path)
 
-        result = tool_next(tmp_path, fmt="phased")
+        result = tool_overview(tmp_path, fmt="phased")
 
         assert "Phase 1:" in result
         assert "Phase" in result
@@ -1242,3 +1240,157 @@ class TestDeterministicImpliesHeadless:
         assert headless is True
         assert "WARNING" in captured.getvalue()
         assert "--engine deterministic" in captured.getvalue()
+
+
+class TestStaleFileDetection:
+    def test_stale_file_ignored(self, tmp_path: Path) -> None:
+        """Review files from before the session start are ignored."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+
+        reviews_dir = tmp_path / ".factory" / "reviews"
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        stale_file = reviews_dir / "researcher-latest.md"
+        stale_file.write_text("Stale findings from prior run")
+        import os
+        os.utime(stale_file, (1000000, 1000000))
+
+        tool_init("test-simple", tmp_path)
+        tool_submit(tmp_path, "study", "Observations done")
+
+        result = tool_next(tmp_path)
+
+        state = json.loads(
+            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
+        )
+        assert "researcher" not in state["completed"]
+        assert "Node: researcher" in result
+
+    def test_fresh_file_detected(self, tmp_path: Path) -> None:
+        """Review files created after session start are auto-submitted."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        tool_submit(tmp_path, "study", "Observations done")
+
+        reviews_dir = tmp_path / ".factory" / "reviews"
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        (reviews_dir / "researcher-latest.md").write_text("Fresh research findings")
+
+        result = tool_next(tmp_path)
+
+        state = json.loads(
+            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
+        )
+        assert "researcher" in state["completed"]
+        assert "GATE" in result
+
+
+class TestToolOverview:
+    def test_overview_shows_all_nodes(self, tmp_path: Path) -> None:
+        """tool_overview lists all nodes with completion markers."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        result = tool_overview(tmp_path)
+
+        assert "study" in result
+        assert "researcher" in result
+        assert "gate_research" in result
+        assert "builder" in result
+        assert "▶" in result or "○" in result
+
+
+class TestToolCurr:
+    def test_curr_shows_current(self, tmp_path: Path) -> None:
+        """tool_curr shows first node details without advancing."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        result = tool_curr(tmp_path)
+
+        assert "Node: study" in result
+        assert "Type: Study" in result
+
+    def test_curr_done(self, tmp_path: Path) -> None:
+        """tool_curr returns DONE when all nodes completed."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        state = json.loads(
+            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
+        )
+        state["pointer_idx"] = len(state["topo_order"])
+        (tmp_path / ".factory" / "tool_session" / "state.json").write_text(
+            json.dumps(state)
+        )
+
+        result = tool_curr(tmp_path)
+        assert "DONE" in result
+
+
+class TestNextDryRun:
+    def test_next_dry_run(self, tmp_path: Path) -> None:
+        """dry_run=True returns the node but does NOT advance the pointer."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        result = tool_next(tmp_path, dry_run=True)
+
+        assert "Node: study" in result
+
+        state = json.loads(
+            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
+        )
+        assert state["pointer_idx"] == 0
+
+    def test_next_dry_run_auto_submit_no_persist(self, tmp_path: Path) -> None:
+        """dry_run scans for artifacts but does not persist completions."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        strategy_dir = tmp_path / ".factory" / "strategy"
+        strategy_dir.mkdir(parents=True, exist_ok=True)
+        (strategy_dir / "observations.md").write_text(
+            "Detailed observations about the project that exceed the minimum length threshold"
+        )
+
+        result = tool_next(tmp_path, dry_run=True)
+
+        assert "researcher" in result
+
+        state = json.loads(
+            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
+        )
+        assert state["pointer_idx"] == 0
+        assert "study" not in state["completed"]
+
+
+class TestNextCompactOutput:
+    def test_next_compact_output(self, tmp_path: Path) -> None:
+        """tool_next returns compact node details, not progress markers."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        result = tool_next(tmp_path)
+
+        assert "✓" not in result
+        assert "○" not in result
+        assert "▶" not in result
+        assert "Node: study" in result
+        assert "Type: Study" in result

--- a/tests/test_workflow_tool.py
+++ b/tests/test_workflow_tool.py
@@ -1378,6 +1378,70 @@ class TestNextDryRun:
         assert state["pointer_idx"] == 0
         assert "study" not in state["completed"]
 
+    def test_dry_run_no_events_emitted(self, tmp_path: Path) -> None:
+        """dry_run=True must not emit any events to events.jsonl."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        events_file = tmp_path / ".factory" / "events.jsonl"
+        events_before = events_file.read_text() if events_file.exists() else ""
+
+        tool_next(tmp_path, dry_run=True)
+
+        events_after = events_file.read_text() if events_file.exists() else ""
+        assert events_before == events_after, "dry_run should not emit events"
+
+    def test_dry_run_completed_status_no_finalize(self, tmp_path: Path) -> None:
+        """dry_run=True with status='completed' must not call finalize."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        state_path = tmp_path / ".factory" / "tool_session" / "state.json"
+        state = json.loads(state_path.read_text())
+        state["status"] = "completed"
+        state_path.write_text(json.dumps(state))
+
+        state_before = state_path.read_text()
+        events_file = tmp_path / ".factory" / "events.jsonl"
+        events_before = events_file.read_text() if events_file.exists() else ""
+
+        result = tool_next(tmp_path, dry_run=True)
+
+        assert "DONE" in result
+        assert state_path.read_text() == state_before, "dry_run should not mutate state"
+        events_after = events_file.read_text() if events_file.exists() else ""
+        assert events_before == events_after, "dry_run should not emit events"
+
+    def test_dry_run_pointer_past_end_no_finalize(self, tmp_path: Path) -> None:
+        """dry_run=True with pointer past end must not call finalize."""
+        wf = _simple_workflow()
+        _register_workflow(wf)
+        (tmp_path / ".factory").mkdir()
+        tool_init("test-simple", tmp_path)
+
+        state_path = tmp_path / ".factory" / "tool_session" / "state.json"
+        state = json.loads(state_path.read_text())
+        order = state["topo_order"]
+        state["pointer_idx"] = len(order)
+        for nid in order:
+            state["completed"][nid] = "done"
+        state_path.write_text(json.dumps(state))
+
+        state_before = state_path.read_text()
+        events_file = tmp_path / ".factory" / "events.jsonl"
+        events_before = events_file.read_text() if events_file.exists() else ""
+
+        result = tool_next(tmp_path, dry_run=True)
+
+        assert "DONE" in result
+        assert state_path.read_text() == state_before, "dry_run should not mutate state"
+        events_after = events_file.read_text() if events_file.exists() else ""
+        assert events_before == events_after, "dry_run should not emit events"
+
 
 class TestNextCompactOutput:
     def test_next_compact_output(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #222

## Changes

- **Fix stale file bug**: `tool_init` records `started_at` timestamp in state.json. `_detect_artifact` checks file mtime against session start, ignoring leftover files from prior runs.
- **New `tool_overview` subcommand**: Renders the full workflow map with ✓/▶/○ completion markers. Does not advance the pointer.
- **New `tool_curr` subcommand**: Shows current node details without advancing or auto-submitting.
- **`--dry-run` for `tool next`**: Runs the auto-submit scan but does not persist state changes or emit events. Preview what next would do.
- **Compact `tool next` output**: Returns only the current node task details (via `_format_node_task`) instead of the full progress map. The progress map lives in `overview` now.
- **Inject overview into system prompt**: `_tool_exec_protocol` now appends the workflow map so the CEO has full visibility at session start.
- **6 new tests**: stale file ignored, fresh file detected, overview shows all nodes, curr shows current, next dry-run, next compact output.