### PR TITLE
feat: add factory/optimization/ — unified inner-outer loop v1

### DIFF
--- a/factory/cli/__init__.py
+++ b/factory/cli/__init__.py
@@ -45,6 +45,9 @@ from factory.cli.ceo import (
 from factory.cli.run import (
     cmd_run as cmd_run,
 )
+from factory.cli.skillopt import (
+    cmd_skillopt as cmd_skillopt,
+)
 from factory.cli.graph import (
     cmd_graph_extract as cmd_graph_extract,
     cmd_graph_status as cmd_graph_status,

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -104,7 +104,7 @@ _COMMAND_GROUPS: list[tuple[str, list[str]]] = [
             "backfill-archive",
         ],
     ),
-    ("Self-Evolution", ["ace", "ace-stats", "digest", "workflow", "graph"]),
+    ("Self-Evolution", ["ace", "ace-stats", "digest", "workflow", "graph", "skillopt"]),
     (
         "Configuration",
         [
@@ -298,6 +298,7 @@ def main(argv: list[str] | None = None) -> int:
         "usage": _cli.cmd_usage,
         "runners": _cli.cmd_runners_list,
         "agent": _cli.cmd_agent,
+        "skillopt": _cli.cmd_skillopt,
         "ceo": _cli.cmd_ceo,
         "run": _cli.cmd_run,
         "tmux": _cli.cmd_tmux,

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -246,6 +246,13 @@ def add_self_evolution_parsers(sub: argparse._SubParsersAction) -> None:  # type
     p.add_argument("--date", default=None, help="Show activity for a specific date (YYYY-MM-DD)")
     p.add_argument("--days", type=int, default=7, help="Number of days to look back (default: 7)")
 
+    p = sub.add_parser("skillopt", help="Run unified optimization loop for prompt/graph tuning")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--benchmark", default=None, help="Benchmark adapter (e.g. searchqa)")
+    p.add_argument("--skill-path", default=None, help="Path to the skill file to optimize")
+    p.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
+    p.add_argument("--steps-per-epoch", type=int, default=1, help="Steps per epoch")
+
 
 def add_configuration_parsers(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     sub.add_parser("self-update", help="Upgrade the factory CLI to the latest version")

--- a/factory/cli/skillopt.py
+++ b/factory/cli/skillopt.py
@@ -1,0 +1,60 @@
+"""CLI handler for the skillopt subcommand — unified optimization loop."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def cmd_skillopt(args: argparse.Namespace) -> int:
+    """Run the unified optimization loop."""
+    project = Path(args.path).resolve()
+    if not project.exists():
+        print(f"Error: project path does not exist: {project}", file=sys.stderr)
+        return 1
+
+    from factory.optimization import OptimizationLoop, Surface
+    from factory.optimization.executors import FactoryCeoExecutor
+    from factory.optimization.mutators import UnifiedMutator
+    from factory.optimization.types import LoopConfig
+
+    config = LoopConfig(
+        epochs=args.epochs,
+        steps_per_epoch=args.steps_per_epoch,
+    )
+
+    surface = Surface()
+    if args.skill_path:
+        skill = Path(args.skill_path)
+        if skill.exists():
+            surface.prompt_slots["skill"] = skill.read_text()
+
+    if args.benchmark == "searchqa":
+        from factory.optimization.benchmarks.searchqa import (
+            SearchQAEvaluator,
+            build_searchqa_executor,
+        )
+        executor = build_searchqa_executor()
+        evaluator = SearchQAEvaluator()
+    else:
+        from factory.inner_loop import CirclePackingEvaluator
+        executor = FactoryCeoExecutor()
+        evaluator = CirclePackingEvaluator()
+
+    mutator = UnifiedMutator()
+
+    loop = OptimizationLoop(
+        project_dir=project,
+        surface=surface,
+        executor=executor,
+        evaluator=evaluator,
+        mutator=mutator,
+        config=config,
+    )
+
+    result = loop.train()
+    print(f"Training complete: {len(result.steps)} steps")
+    print(f"Best score: {result.best_score:.4f} (step {result.best_step})")
+    print(f"Final score: {result.final_score:.4f}")
+    return 0

--- a/factory/cli/skillopt.py
+++ b/factory/cli/skillopt.py
@@ -17,6 +17,7 @@ def cmd_skillopt(args: argparse.Namespace) -> int:
     from factory.optimization import OptimizationLoop, Surface
     from factory.optimization.executors import FactoryCeoExecutor
     from factory.optimization.mutators import UnifiedMutator
+    from factory.optimization.protocols import Evaluator, Executor
     from factory.optimization.types import LoopConfig
 
     config = LoopConfig(
@@ -30,6 +31,8 @@ def cmd_skillopt(args: argparse.Namespace) -> int:
         if skill.exists():
             surface.prompt_slots["skill"] = skill.read_text()
 
+    executor: Executor
+    evaluator: Evaluator
     if args.benchmark == "searchqa":
         from factory.optimization.benchmarks.searchqa import (
             SearchQAEvaluator,

--- a/factory/cycle_analyzer.py
+++ b/factory/cycle_analyzer.py
@@ -3,6 +3,9 @@
 Assembles what happened in each inner-loop cycle: what agents ran, in what order,
 what each produced, what the evaluator said, and whether it helped. Mode-agnostic —
 works with evolve, improve, research, refine, or any experiment-producing workflow.
+
+Note: ``factory.optimization.analyzer.StepAnalyzer`` is the canonical path for new
+code that needs optimizer-focused step records. This module remains functional.
 """
 
 from __future__ import annotations

--- a/factory/inner_loop.py
+++ b/factory/inner_loop.py
@@ -1,5 +1,11 @@
 """InnerLoop — model-like wrapper for mode + evaluator that an outer-loop optimizer calls.
 
+.. deprecated::
+    This module is superseded by ``factory.optimization``. New code should use
+    ``factory.optimization.OptimizationLoop``, ``factory.optimization.Executor``,
+    ``factory.optimization.Evaluator``, and ``factory.optimization.Surface`` instead.
+    This module is kept for backward compatibility and will be removed in a future release.
+
 CycleAnalyzer handles execution tracing (what agents ran, costs, verdicts).
 Evaluator handles score interpretation (parses evaluator-specific output artifacts).
 InnerLoop composes both.

--- a/factory/optimization/__init__.py
+++ b/factory/optimization/__init__.py
@@ -1,0 +1,35 @@
+"""Unified optimization loop — pluggable Executor, Evaluator, Mutator protocols."""
+
+from factory.optimization.analyzer import StepAnalyzer as StepAnalyzer
+from factory.optimization.gate import evaluate_gate as evaluate_gate
+from factory.optimization.loop import OptimizationLoop as OptimizationLoop
+from factory.optimization.loop import TrainResult as TrainResult
+from factory.optimization.protocols import Evaluator as Evaluator
+from factory.optimization.protocols import Executor as Executor
+from factory.optimization.protocols import Mutator as Mutator
+from factory.optimization.surface import Surface as Surface
+from factory.optimization.types import ExecutionResult as ExecutionResult
+from factory.optimization.types import GateResult as GateResult
+from factory.optimization.types import GraphMutation as GraphMutation
+from factory.optimization.types import LoopConfig as LoopConfig
+from factory.optimization.types import Patch as Patch
+from factory.optimization.types import SlotEdit as SlotEdit
+from factory.optimization.types import StepRecord as StepRecord
+
+__all__ = [
+    "Evaluator",
+    "ExecutionResult",
+    "Executor",
+    "GateResult",
+    "GraphMutation",
+    "LoopConfig",
+    "Mutator",
+    "OptimizationLoop",
+    "Patch",
+    "SlotEdit",
+    "StepAnalyzer",
+    "StepRecord",
+    "Surface",
+    "TrainResult",
+    "evaluate_gate",
+]

--- a/factory/optimization/analyzer.py
+++ b/factory/optimization/analyzer.py
@@ -1,0 +1,72 @@
+"""Slimmed CycleAnalyzer producing StepRecord for the optimization loop.
+
+Keeps the 4-tier artifact reading pattern from cycle_analyzer.py:
+1. events.jsonl — agent invocations and cycle events
+2. results.tsv — experiment scores and verdicts
+3. eval artifacts — per-experiment eval output files
+4. DAG node trace — workflow node-to-artifact mapping
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from factory.cycle_analyzer import CycleAnalyzer
+from factory.optimization.types import StepRecord
+from factory.workflow.primitives import Workflow
+
+
+class StepAnalyzer:
+    """Reads .factory/ artifacts and produces StepRecord for optimizers."""
+
+    def __init__(
+        self,
+        factory_dir: Path,
+        workflow: Workflow | None = None,
+    ) -> None:
+        self.factory_dir = Path(factory_dir)
+        self.workflow = workflow
+        self._inner = CycleAnalyzer(factory_dir, workflow=workflow)
+
+    def latest(self) -> StepRecord | None:
+        """Read the latest cycle and convert to a StepRecord."""
+        record = self._inner.latest()
+        if record is None:
+            return None
+        return StepRecord(
+            step_number=record.cycle_number,
+            score_start=record.score_start,
+            score_end=record.score_end,
+            score_delta=record.score_delta,
+            duration_s=record.duration_s,
+            cost_usd=record.total_cost_usd,
+            verdict=self._summarize_verdict(record.kept, record.reverted, record.errored),
+            artifacts=record.eval_artifacts,
+        )
+
+    def all_steps(self) -> list[StepRecord]:
+        """Read all cycles and convert to StepRecords."""
+        records = self._inner.analyze()
+        return [
+            StepRecord(
+                step_number=r.cycle_number,
+                score_start=r.score_start,
+                score_end=r.score_end,
+                score_delta=r.score_delta,
+                duration_s=r.duration_s,
+                cost_usd=r.total_cost_usd,
+                verdict=self._summarize_verdict(r.kept, r.reverted, r.errored),
+                artifacts=r.eval_artifacts,
+            )
+            for r in records
+        ]
+
+    @staticmethod
+    def _summarize_verdict(kept: int, reverted: int, errored: int) -> str | None:
+        if kept + reverted + errored == 0:
+            return None
+        if errored > 0:
+            return "error"
+        if kept > reverted:
+            return "keep"
+        return "revert"

--- a/factory/optimization/benchmarks/__init__.py
+++ b/factory/optimization/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark adapters for the optimization loop."""

--- a/factory/optimization/benchmarks/searchqa.py
+++ b/factory/optimization/benchmarks/searchqa.py
@@ -1,0 +1,78 @@
+"""SearchQA benchmark adapter — composes HarborExecutor + SearchQA evaluator.
+
+Stub implementation that validates the type composition works.
+The full adapter will connect to Harbor's SearchQA benchmark (400 train / 200 val)
+and use SQuAD-style EM normalization for scoring.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import structlog
+
+from factory.inner_loop import EvalResult
+from factory.optimization.executors.harbor import HarborExecutor
+from factory.optimization.surface import Surface
+from factory.optimization.types import LoopConfig
+
+log = structlog.get_logger()
+
+
+class SearchQAEvaluator:
+    """Parses SearchQA benchmark results from reward.json."""
+
+    def __init__(self, target: float = 0.85) -> None:
+        self.target = target
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        try:
+            data = json.loads(artifact_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return EvalResult(score=0.0, valid=False)
+        score = float(data.get("accuracy", data.get("score", 0.0)))
+        return EvalResult(
+            score=score,
+            metrics={k: float(v) for k, v in data.items() if isinstance(v, (int, float))},
+            valid=True,
+            artifacts=[str(artifact_path)],
+        )
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        best = EvalResult(score=0.0, valid=False)
+        for p in artifact_paths:
+            result = self.parse(p)
+            if result.score > best.score:
+                best = result
+        return best
+
+    def get_info(self) -> dict:
+        return {
+            "benchmark": "searchqa",
+            "target": self.target,
+            "metrics": ["accuracy", "em", "f1"],
+        }
+
+
+def build_searchqa_surface(skill_path: Path | None = None) -> Surface:
+    """Build a Surface configured for SearchQA optimization."""
+    prompt_slots: dict[str, str] = {}
+    if skill_path and skill_path.exists():
+        prompt_slots["skill"] = skill_path.read_text()
+    return Surface(prompt_slots=prompt_slots)
+
+
+def build_searchqa_config(
+    epochs: int = 3,
+    steps_per_epoch: int = 5,
+) -> LoopConfig:
+    """Build a LoopConfig for SearchQA optimization."""
+    return LoopConfig(epochs=epochs, steps_per_epoch=steps_per_epoch)
+
+
+def build_searchqa_executor(
+    harbor_script: str = "./run-harbor.sh",
+) -> HarborExecutor:
+    """Build a HarborExecutor configured for SearchQA."""
+    return HarborExecutor(harbor_script=harbor_script)

--- a/factory/optimization/executors/__init__.py
+++ b/factory/optimization/executors/__init__.py
@@ -1,0 +1,13 @@
+"""Executor implementations for the optimization loop."""
+
+from factory.optimization.executors.ceo import FactoryCeoExecutor as FactoryCeoExecutor
+from factory.optimization.executors.harbor import HarborExecutor as HarborExecutor
+from factory.optimization.executors.workflow_run import (
+    WorkflowRunExecutor as WorkflowRunExecutor,
+)
+
+__all__ = [
+    "FactoryCeoExecutor",
+    "HarborExecutor",
+    "WorkflowRunExecutor",
+]

--- a/factory/optimization/executors/ceo.py
+++ b/factory/optimization/executors/ceo.py
@@ -1,0 +1,45 @@
+"""FactoryCeoExecutor — runs factory ceo as a subprocess."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult
+
+log = structlog.get_logger()
+
+
+class FactoryCeoExecutor:
+    """Executor that runs ``factory ceo`` as a blocking subprocess.
+
+    Absorbs the subprocess call pattern from InnerLoop.step().
+    """
+
+    def __init__(self, mode: str = "improve", extra_args: list[str] | None = None) -> None:
+        self.mode = mode
+        self.extra_args = extra_args or []
+
+    def execute(
+        self, project_dir: Path, surface: Surface, **kwargs: Any
+    ) -> ExecutionResult:
+        cmd = [
+            sys.executable, "-m", "factory", "ceo", str(project_dir),
+            "--mode", self.mode, "--no-worktree",
+            *self.extra_args,
+        ]
+        log.info("executor.ceo.start", project=str(project_dir), mode=self.mode)
+        start = time.monotonic()
+        result = subprocess.run(cmd, cwd=project_dir)
+        duration = time.monotonic() - start
+        log.info("executor.ceo.done", returncode=result.returncode, duration_s=round(duration, 1))
+        return ExecutionResult(
+            returncode=result.returncode,
+            duration_s=duration,
+        )

--- a/factory/optimization/executors/harbor.py
+++ b/factory/optimization/executors/harbor.py
@@ -1,0 +1,72 @@
+"""HarborExecutor — runs run-harbor.sh with skill injection via env var.
+
+Stub implementation: Harbor infrastructure may not be on this branch.
+The full implementation will inject the skill path into the subprocess
+environment and collect result artifacts from the Harbor output directory.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult
+
+log = structlog.get_logger()
+
+
+class HarborExecutor:
+    """Executor that runs a Harbor benchmark via ``run-harbor.sh``.
+
+    Injects the skill path into the subprocess environment so the Harbor
+    runner picks up the current prompt surface.
+    """
+
+    def __init__(
+        self,
+        harbor_script: str = "./run-harbor.sh",
+        skill_env_var: str = "HARBOR_SKILL_PATH",
+    ) -> None:
+        self.harbor_script = harbor_script
+        self.skill_env_var = skill_env_var
+
+    def execute(
+        self, project_dir: Path, surface: Surface, **kwargs: Any
+    ) -> ExecutionResult:
+        import os
+
+        env = os.environ.copy()
+        skill_path = kwargs.get("skill_path", "")
+        if skill_path:
+            env[self.skill_env_var] = str(skill_path)
+
+        script = project_dir / self.harbor_script
+        if not script.exists():
+            log.warning("executor.harbor.script_missing", path=str(script))
+            return ExecutionResult(returncode=1, artifacts=[], duration_s=0.0)
+
+        log.info("executor.harbor.start", script=str(script))
+        start = time.monotonic()
+        result = subprocess.run(
+            [str(script)],
+            cwd=project_dir,
+            env=env,
+        )
+        duration = time.monotonic() - start
+
+        artifacts: list[str] = []
+        reward_path = project_dir / "reward.json"
+        if reward_path.exists():
+            artifacts.append(str(reward_path))
+
+        log.info("executor.harbor.done", returncode=result.returncode, duration_s=round(duration, 1))
+        return ExecutionResult(
+            returncode=result.returncode,
+            artifacts=artifacts,
+            duration_s=duration,
+        )

--- a/factory/optimization/executors/workflow_run.py
+++ b/factory/optimization/executors/workflow_run.py
@@ -1,0 +1,44 @@
+"""WorkflowRunExecutor — wraps ``factory workflow run`` for deterministic headless execution."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult
+
+log = structlog.get_logger()
+
+
+class WorkflowRunExecutor:
+    """Executor that runs ``factory workflow run <name>`` as a subprocess."""
+
+    def __init__(self, workflow_name: str) -> None:
+        self.workflow_name = workflow_name
+
+    def execute(
+        self, project_dir: Path, surface: Surface, **kwargs: Any
+    ) -> ExecutionResult:
+        cmd = [
+            sys.executable, "-m", "factory", "workflow", "run",
+            self.workflow_name, str(project_dir),
+        ]
+        log.info("executor.workflow_run.start", workflow=self.workflow_name)
+        start = time.monotonic()
+        result = subprocess.run(cmd, cwd=project_dir)
+        duration = time.monotonic() - start
+        log.info(
+            "executor.workflow_run.done",
+            returncode=result.returncode,
+            duration_s=round(duration, 1),
+        )
+        return ExecutionResult(
+            returncode=result.returncode,
+            duration_s=duration,
+        )

--- a/factory/optimization/gate.py
+++ b/factory/optimization/gate.py
@@ -1,0 +1,30 @@
+"""Accept/reject gate for optimization steps."""
+
+from __future__ import annotations
+
+from factory.optimization.types import GateResult
+
+
+def evaluate_gate(
+    candidate_score: float,
+    current_score: float,
+    best_score: float,
+    best_step: int,
+    global_step: int,
+) -> GateResult:
+    """Decide whether to accept a candidate based on score comparison."""
+    if candidate_score > current_score:
+        return GateResult(
+            accepted=True,
+            reason=f"Candidate {candidate_score:.4f} > current {current_score:.4f}",
+            candidate_score=candidate_score,
+            current_score=current_score,
+            best_score=max(best_score, candidate_score),
+        )
+    return GateResult(
+        accepted=False,
+        reason=f"Candidate {candidate_score:.4f} <= current {current_score:.4f}",
+        candidate_score=candidate_score,
+        current_score=current_score,
+        best_score=best_score,
+    )

--- a/factory/optimization/loop.py
+++ b/factory/optimization/loop.py
@@ -1,0 +1,139 @@
+"""OptimizationLoop — composable train loop for inner-outer optimization.
+
+Composes Executor + Evaluator + Mutator with epoch/step structure,
+history tracking, and gate evaluation per step.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import structlog
+
+from factory.optimization.gate import evaluate_gate
+from factory.optimization.protocols import Evaluator, Executor, Mutator
+from factory.optimization.surface import Surface
+from factory.optimization.types import LoopConfig, Patch, StepRecord
+
+log = structlog.get_logger()
+
+
+@dataclass
+class TrainResult:
+    """Outcome of a full training run."""
+
+    steps: list[StepRecord] = field(default_factory=list)
+    best_score: float = 0.0
+    best_step: int = 0
+    final_score: float = 0.0
+
+
+class OptimizationLoop:
+    """Unified optimization loop composing Executor + Evaluator + Mutator.
+
+    Runs an epoch/step training structure with per-step gate evaluation.
+    """
+
+    def __init__(
+        self,
+        project_dir: Path,
+        surface: Surface,
+        executor: Executor,
+        evaluator: Evaluator,
+        mutator: Mutator,
+        config: LoopConfig | None = None,
+    ) -> None:
+        self.project_dir = Path(project_dir).resolve()
+        self.surface = surface
+        self.executor = executor
+        self.evaluator = evaluator
+        self.mutator = mutator
+        self.config = config or LoopConfig()
+        self._history: list[StepRecord] = []
+        self._global_step = 0
+        self._current_score = 0.0
+        self._best_score = 0.0
+        self._best_step = 0
+
+    def step(self) -> StepRecord:
+        """Run one optimization step: execute → evaluate → mutate → gate."""
+        self._global_step += 1
+        score_start = self._current_score
+
+        execution_result = self.executor.execute(
+            self.project_dir, self.surface,
+        )
+
+        score_end = score_start
+        eval_artifacts = [Path(a) for a in execution_result.artifacts]
+        if eval_artifacts:
+            eval_result = self.evaluator.parse_many(eval_artifacts)
+            if eval_result.valid:
+                score_end = eval_result.score
+
+        patch: Patch | None = None
+        if execution_result.returncode == 0:
+            patch = self.mutator.propose(
+                self.surface, execution_result, self._history,
+            )
+
+        gate = evaluate_gate(
+            candidate_score=score_end,
+            current_score=self._current_score,
+            best_score=self._best_score,
+            best_step=self._best_step,
+            global_step=self._global_step,
+        )
+
+        verdict = "keep" if gate.accepted else "revert"
+        if gate.accepted:
+            self._current_score = score_end
+            if score_end > self._best_score:
+                self._best_score = score_end
+                self._best_step = self._global_step
+
+        record = StepRecord(
+            step_number=self._global_step,
+            score_start=score_start,
+            score_end=score_end,
+            score_delta=score_end - score_start,
+            duration_s=execution_result.duration_s,
+            cost_usd=execution_result.cost_usd,
+            verdict=verdict,
+            artifacts=execution_result.artifacts,
+            patch=patch,
+        )
+        self._history.append(record)
+        log.info(
+            "loop.step",
+            step=self._global_step,
+            score_start=round(score_start, 4),
+            score_end=round(score_end, 4),
+            verdict=verdict,
+        )
+        return record
+
+    def train(self) -> TrainResult:
+        """Full training loop with epochs and steps."""
+        for epoch in range(self.config.epochs):
+            log.info("loop.epoch.start", epoch=epoch + 1, total=self.config.epochs)
+            for step_in_epoch in range(self.config.steps_per_epoch):
+                self.step()
+            log.info(
+                "loop.epoch.end",
+                epoch=epoch + 1,
+                current_score=round(self._current_score, 4),
+                best_score=round(self._best_score, 4),
+            )
+
+        return TrainResult(
+            steps=list(self._history),
+            best_score=self._best_score,
+            best_step=self._best_step,
+            final_score=self._current_score,
+        )
+
+    def history(self) -> list[StepRecord]:
+        """All step records from this session."""
+        return list(self._history)

--- a/factory/optimization/mutators/__init__.py
+++ b/factory/optimization/mutators/__init__.py
@@ -1,0 +1,11 @@
+"""Mutator implementations for the optimization loop."""
+
+from factory.optimization.mutators.overwrite import OverwriteMutator as OverwriteMutator
+from factory.optimization.mutators.skillopt import SkillOptMutator as SkillOptMutator
+from factory.optimization.mutators.unified import UnifiedMutator as UnifiedMutator
+
+__all__ = [
+    "OverwriteMutator",
+    "SkillOptMutator",
+    "UnifiedMutator",
+]

--- a/factory/optimization/mutators/overwrite.py
+++ b/factory/optimization/mutators/overwrite.py
@@ -1,0 +1,58 @@
+"""OverwriteMutator — produces GraphMutation objects from overwrite directives.
+
+Absorbs the mutation structure from factory/workflow/overwrite.py and wraps
+raw dicts into typed GraphMutation Pydantic models.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from factory.optimization.surface import Surface
+from factory.optimization.types import (
+    ExecutionResult,
+    GraphMutation,
+    Patch,
+    StepRecord,
+)
+
+log = structlog.get_logger()
+
+
+class OverwriteMutator:
+    """Proposes graph mutations based on an overwrite directive.
+
+    Wraps the mutation dict structure from workflow/overwrite.py into typed
+    GraphMutation objects. The actual NL interpretation is delegated to the
+    strategist agent via factory/workflow/overwrite.py — this mutator provides
+    the typed interface for the optimization loop.
+    """
+
+    def __init__(self, overwrite_text: str = "") -> None:
+        self.overwrite_text = overwrite_text
+
+    def propose(
+        self,
+        surface: Surface,
+        execution_result: ExecutionResult,
+        history: list[StepRecord],
+    ) -> Patch:
+        if not self.overwrite_text or surface.workflow is None:
+            log.info("mutator.overwrite.skip", reason="no overwrite text or workflow")
+            return Patch(reasoning="No overwrite directive provided")
+
+        mutable = surface.mutable_nodes()
+        log.info(
+            "mutator.overwrite.propose",
+            mutable_nodes=len(mutable),
+            overwrite_len=len(self.overwrite_text),
+        )
+        return Patch(
+            graph_mutations=[],
+            reasoning=f"OverwriteMutator: directive='{self.overwrite_text[:80]}'",
+        )
+
+    @staticmethod
+    def mutations_from_dicts(raw: list[dict]) -> list[GraphMutation]:
+        """Convert raw mutation dicts (from overwrite.py) to typed GraphMutation objects."""
+        return [GraphMutation(**m) for m in raw]

--- a/factory/optimization/mutators/skillopt.py
+++ b/factory/optimization/mutators/skillopt.py
@@ -1,0 +1,32 @@
+"""SkillOptMutator — proposes prompt-slot edits.
+
+Stub: the full reflect/merge/clip pipeline is deferred to when PR #1013 merges.
+This implementation reads prompt_slots from the Surface and returns an empty Patch.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, Patch, StepRecord
+
+log = structlog.get_logger()
+
+
+class SkillOptMutator:
+    """Proposes SlotEdit changes to prompt slots on the Surface.
+
+    The full pipeline (reflect → aggregate → clip) will be wired
+    when the SkillOpt PR merges. For now, returns an empty patch.
+    """
+
+    def propose(
+        self,
+        surface: Surface,
+        execution_result: ExecutionResult,
+        history: list[StepRecord],
+    ) -> Patch:
+        slots = surface.mutable_prompt_slots()
+        log.info("mutator.skillopt.propose", num_slots=len(slots))
+        return Patch(reasoning="SkillOptMutator stub — no edits proposed")

--- a/factory/optimization/mutators/unified.py
+++ b/factory/optimization/mutators/unified.py
@@ -1,0 +1,51 @@
+"""UnifiedMutator — composes SkillOptMutator + OverwriteMutator."""
+
+from __future__ import annotations
+
+import structlog
+
+from factory.optimization.mutators.overwrite import OverwriteMutator
+from factory.optimization.mutators.skillopt import SkillOptMutator
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, Patch, StepRecord
+
+log = structlog.get_logger()
+
+
+class UnifiedMutator:
+    """Composes prompt-slot edits and graph mutations, respecting frozen_nodes."""
+
+    def __init__(
+        self,
+        skillopt: SkillOptMutator | None = None,
+        overwrite: OverwriteMutator | None = None,
+    ) -> None:
+        self.skillopt = skillopt or SkillOptMutator()
+        self.overwrite = overwrite or OverwriteMutator()
+
+    def propose(
+        self,
+        surface: Surface,
+        execution_result: ExecutionResult,
+        history: list[StepRecord],
+    ) -> Patch:
+        prompt_patch = self.skillopt.propose(surface, execution_result, history)
+        graph_patch = self.overwrite.propose(surface, execution_result, history)
+
+        frozen = surface.frozen_nodes
+        filtered_mutations = [
+            m for m in graph_patch.graph_mutations
+            if m.node_id is None or m.node_id not in frozen
+        ]
+
+        combined = Patch(
+            prompt_edits=prompt_patch.prompt_edits,
+            graph_mutations=filtered_mutations,
+            reasoning=f"Unified: {prompt_patch.reasoning} | {graph_patch.reasoning}",
+        )
+        log.info(
+            "mutator.unified.propose",
+            prompt_edits=len(combined.prompt_edits),
+            graph_mutations=len(combined.graph_mutations),
+        )
+        return combined

--- a/factory/optimization/protocols.py
+++ b/factory/optimization/protocols.py
@@ -1,0 +1,46 @@
+"""Three pluggable protocols defining the optimization loop contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from factory.inner_loop import EvalResult
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, Patch, StepRecord
+
+
+@runtime_checkable
+class Executor(Protocol):
+    """Runs one inner-loop cycle and returns structured results."""
+
+    def execute(
+        self, project_dir: Path, surface: Surface, **kwargs: Any
+    ) -> ExecutionResult: ...
+
+
+@runtime_checkable
+class Evaluator(Protocol):
+    """Parses evaluator-specific output artifacts into scores.
+
+    Mirrors the protocol from factory.inner_loop — same method signatures
+    so existing implementations (CirclePackingEvaluator) satisfy both.
+    """
+
+    def parse(self, artifact_path: Path) -> EvalResult: ...
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult: ...
+
+    def get_info(self) -> dict: ...
+
+
+@runtime_checkable
+class Mutator(Protocol):
+    """Proposes changes to a Surface based on execution results and history."""
+
+    def propose(
+        self,
+        surface: Surface,
+        execution_result: ExecutionResult,
+        history: list[StepRecord],
+    ) -> Patch: ...

--- a/factory/optimization/surface.py
+++ b/factory/optimization/surface.py
@@ -1,0 +1,77 @@
+"""Surface — unified mutable surface for optimization loops.
+
+Composes frozen_nodes (from InnerLoop), prompt_slots (for SkillOpt),
+and inner/outer_surfaces (from OuterLoopConfig) into a single descriptor.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+
+from factory.models import FactoryConfig
+from factory.workflow.primitives import Workflow
+
+
+@dataclass
+class Surface:
+    """Describes what an optimization loop can mutate."""
+
+    workflow: Workflow | None = None
+    frozen_nodes: frozenset[str] = frozenset()
+    prompt_slots: dict[str, str] = field(default_factory=dict)
+    inner_surfaces: list[str] = field(default_factory=list)
+    outer_surfaces: list[str] = field(default_factory=list)
+
+    def mutable_prompt_slots(self) -> dict[str, str]:
+        """Return all prompt slots (all are mutable for now)."""
+        return dict(self.prompt_slots)
+
+    def mutable_nodes(self) -> set[str]:
+        """Return the set of node IDs the outer loop may modify."""
+        if self.workflow is None:
+            return set()
+        return set(self.workflow.nodes.keys()) - self.frozen_nodes
+
+    def validate(self) -> list[str]:
+        """Check frozen_nodes against workflow, return list of issues."""
+        issues: list[str] = []
+        if not self.frozen_nodes or self.workflow is None:
+            return issues
+        invalid = self.frozen_nodes - self.workflow.nodes.keys()
+        if invalid:
+            issues.append(
+                f"frozen_nodes contains IDs not in workflow.nodes: {sorted(invalid)}"
+            )
+        if self.workflow and len(self.frozen_nodes) == len(self.workflow.nodes):
+            issues.append("All nodes are frozen — outer loop has no mutable surface")
+            warnings.warn(
+                "All nodes are frozen — outer loop has no mutable surface",
+                stacklevel=2,
+            )
+        return issues
+
+    @classmethod
+    def from_config(
+        cls,
+        config: FactoryConfig,
+        workflow: Workflow | None = None,
+    ) -> Surface:
+        """Build a Surface from a FactoryConfig."""
+        frozen: frozenset[str] = frozenset()
+        inner: list[str] = []
+        outer: list[str] = []
+
+        if config.inner_loop and hasattr(config.inner_loop, "frozen_nodes"):
+            frozen = frozenset(getattr(config.inner_loop, "frozen_nodes", []))
+
+        if config.outer_loop:
+            inner = list(config.outer_loop.inner_surfaces)
+            outer = list(config.outer_loop.outer_surfaces)
+
+        return cls(
+            workflow=workflow,
+            frozen_nodes=frozen,
+            inner_surfaces=inner,
+            outer_surfaces=outer,
+        )

--- a/factory/optimization/types.py
+++ b/factory/optimization/types.py
@@ -1,0 +1,101 @@
+"""Value types for the unified optimization loop.
+
+Absorbs concepts from:
+- CycleRecord (cycle_analyzer.py) → StepRecord
+- overwrite.py mutation dicts → GraphMutation
+- InnerLoopConfig/OuterLoopConfig (models.py) → LoopConfig
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from factory.models import AggregateMethod
+
+
+@dataclass
+class SlotEdit:
+    """A single prompt-slot mutation."""
+
+    slot_name: str
+    old_value: str
+    new_value: str
+
+
+class GraphMutation(BaseModel):
+    """Typed version of the raw mutation dicts from workflow/overwrite.py."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    op: Literal["update_node", "remove_node", "add_edge", "remove_edge"]
+    node_id: str | None = None
+    field: str | None = None
+    value: Any | None = None
+    source: str | None = None
+    target: str | None = None
+
+
+@dataclass
+class Patch:
+    """Proposed changes to a Surface: prompt edits + graph mutations."""
+
+    prompt_edits: list[SlotEdit] = field(default_factory=list)
+    graph_mutations: list[GraphMutation] = field(default_factory=list)
+    reasoning: str = ""
+
+
+@dataclass
+class ExecutionResult:
+    """Result of running one optimization step via an Executor."""
+
+    returncode: int
+    artifacts: list[str] = field(default_factory=list)
+    duration_s: float = 0.0
+    cost_usd: float = 0.0
+
+
+@dataclass
+class GateResult:
+    """Accept/reject decision from the gate."""
+
+    accepted: bool
+    reason: str
+    candidate_score: float
+    current_score: float
+    best_score: float
+
+
+@dataclass
+class StepRecord:
+    """What an outer-loop optimizer sees after one step.
+
+    Slimmed version of CycleRecord focused on optimizer needs.
+    """
+
+    step_number: int
+    score_start: float | None = None
+    score_end: float | None = None
+    score_delta: float | None = None
+    duration_s: float = 0.0
+    cost_usd: float = 0.0
+    verdict: str | None = None
+    artifacts: list[str] = field(default_factory=list)
+    patch: Patch | None = None
+
+
+class LoopConfig(BaseModel):
+    """Unified loop configuration composing InnerLoopConfig + OuterLoopConfig fields."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    epochs: int = 1
+    steps_per_epoch: int = 1
+    plateau_threshold: int = 3
+    aggregate: AggregateMethod = AggregateMethod.mean
+    inner_surfaces: list[str] = []
+    outer_surfaces: list[str] = []
+    frozen_nodes: frozenset[str] = frozenset()
+    max_inner_runs_per_cycle: int | None = None

--- a/tests/test_cli_skillopt.py
+++ b/tests/test_cli_skillopt.py
@@ -1,0 +1,182 @@
+"""Tests for factory.cli.skillopt — skillopt CLI subcommand."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from factory.cli import build_parser
+from factory.cli.skillopt import cmd_skillopt
+from factory.optimization.loop import TrainResult
+from factory.optimization.types import StepRecord
+
+
+def _make_args(
+    path: str = "/tmp/project",
+    benchmark: str | None = None,
+    skill_path: str | None = None,
+    epochs: int = 1,
+    steps_per_epoch: int = 1,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        path=path,
+        benchmark=benchmark,
+        skill_path=skill_path,
+        epochs=epochs,
+        steps_per_epoch=steps_per_epoch,
+    )
+
+
+class TestSkilloptParsing:
+    def test_parses_path(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["skillopt", "/some/path"])
+        assert args.command == "skillopt"
+        assert args.path == "/some/path"
+
+    def test_parses_benchmark(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["skillopt", "/p", "--benchmark", "searchqa"])
+        assert args.benchmark == "searchqa"
+
+    def test_parses_skill_path(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["skillopt", "/p", "--skill-path", "/s/skill.md"])
+        assert args.skill_path == "/s/skill.md"
+
+    def test_parses_epochs(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["skillopt", "/p", "--epochs", "5"])
+        assert args.epochs == 5
+
+    def test_parses_steps_per_epoch(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["skillopt", "/p", "--steps-per-epoch", "10"])
+        assert args.steps_per_epoch == 10
+
+    def test_default_benchmark_is_none(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["skillopt", "/p"])
+        assert args.benchmark is None
+
+    def test_default_epochs(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["skillopt", "/p"])
+        assert args.epochs == 1
+
+    def test_default_steps_per_epoch(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["skillopt", "/p"])
+        assert args.steps_per_epoch == 1
+
+
+class TestSkilloptExecution:
+    def test_nonexistent_path_returns_error(self) -> None:
+        args = _make_args(path="/nonexistent/path/that/does/not/exist")
+        rc = cmd_skillopt(args)
+        assert rc == 1
+
+    def test_default_benchmark(self, tmp_path: Path) -> None:
+        fake_result = TrainResult(
+            steps=[StepRecord(step_number=1)],
+            best_score=0.75,
+            best_step=1,
+            final_score=0.70,
+        )
+        mock_loop = MagicMock()
+        mock_loop.train.return_value = fake_result
+
+        with patch("factory.optimization.OptimizationLoop", return_value=mock_loop) as mock_cls:
+            rc = cmd_skillopt(_make_args(path=str(tmp_path)))
+
+        assert rc == 0
+        mock_loop.train.assert_called_once()
+        call_kwargs = mock_cls.call_args
+        from factory.optimization.executors import FactoryCeoExecutor
+        from factory.inner_loop import CirclePackingEvaluator
+        assert isinstance(call_kwargs.kwargs["executor"], FactoryCeoExecutor)
+        assert isinstance(call_kwargs.kwargs["evaluator"], CirclePackingEvaluator)
+
+    def test_searchqa_benchmark(self, tmp_path: Path) -> None:
+        fake_result = TrainResult(
+            steps=[StepRecord(step_number=1)],
+            best_score=0.85,
+            best_step=1,
+            final_score=0.80,
+        )
+        mock_loop = MagicMock()
+        mock_loop.train.return_value = fake_result
+
+        with (
+            patch("factory.optimization.OptimizationLoop", return_value=mock_loop) as mock_cls,
+            patch(
+                "factory.optimization.benchmarks.searchqa.build_searchqa_executor",
+            ) as mock_build_exec,
+        ):
+            mock_executor = MagicMock()
+            mock_build_exec.return_value = mock_executor
+            rc = cmd_skillopt(_make_args(path=str(tmp_path), benchmark="searchqa"))
+
+        assert rc == 0
+        mock_build_exec.assert_called_once()
+        from factory.optimization.benchmarks.searchqa import SearchQAEvaluator
+        assert isinstance(mock_cls.call_args.kwargs["evaluator"], SearchQAEvaluator)
+
+    def test_skill_path_loading(self, tmp_path: Path) -> None:
+        skill = tmp_path / "skill.md"
+        skill.write_text("optimize this prompt")
+
+        fake_result = TrainResult(steps=[], best_score=0.0, best_step=0, final_score=0.0)
+        mock_loop = MagicMock()
+        mock_loop.train.return_value = fake_result
+
+        with patch("factory.optimization.OptimizationLoop", return_value=mock_loop) as mock_cls:
+            cmd_skillopt(_make_args(path=str(tmp_path), skill_path=str(skill)))
+
+        surface = mock_cls.call_args.kwargs["surface"]
+        assert surface.prompt_slots["skill"] == "optimize this prompt"
+
+    def test_nonexistent_skill_path_ignored(self, tmp_path: Path) -> None:
+        fake_result = TrainResult(steps=[], best_score=0.0, best_step=0, final_score=0.0)
+        mock_loop = MagicMock()
+        mock_loop.train.return_value = fake_result
+
+        with patch("factory.optimization.OptimizationLoop", return_value=mock_loop) as mock_cls:
+            cmd_skillopt(_make_args(path=str(tmp_path), skill_path="/no/such/skill.md"))
+
+        surface = mock_cls.call_args.kwargs["surface"]
+        assert surface.prompt_slots == {}
+
+    def test_config_passed_correctly(self, tmp_path: Path) -> None:
+        fake_result = TrainResult(steps=[], best_score=0.0, best_step=0, final_score=0.0)
+        mock_loop = MagicMock()
+        mock_loop.train.return_value = fake_result
+
+        with patch("factory.optimization.OptimizationLoop", return_value=mock_loop) as mock_cls:
+            cmd_skillopt(_make_args(path=str(tmp_path), epochs=3, steps_per_epoch=7))
+
+        config = mock_cls.call_args.kwargs["config"]
+        assert config.epochs == 3
+        assert config.steps_per_epoch == 7
+
+    def test_output_format(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        fake_result = TrainResult(
+            steps=[StepRecord(step_number=1), StepRecord(step_number=2)],
+            best_score=0.9123,
+            best_step=2,
+            final_score=0.8567,
+        )
+        mock_loop = MagicMock()
+        mock_loop.train.return_value = fake_result
+
+        with patch("factory.optimization.OptimizationLoop", return_value=mock_loop):
+            cmd_skillopt(_make_args(path=str(tmp_path)))
+
+        captured = capsys.readouterr()
+        assert "2 steps" in captured.out
+        assert "0.9123" in captured.out
+        assert "step 2" in captured.out
+        assert "0.8567" in captured.out

--- a/tests/test_optimization/test_analyzer.py
+++ b/tests/test_optimization/test_analyzer.py
@@ -1,0 +1,59 @@
+"""Tests for factory.optimization.analyzer — StepRecord production."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from factory.optimization.analyzer import StepAnalyzer
+
+
+class TestStepAnalyzer:
+    def test_empty_factory_dir(self, tmp_path: Path) -> None:
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        analyzer = StepAnalyzer(factory_dir)
+        result = analyzer.latest()
+        # CycleAnalyzer still returns a record for empty dirs (cycle_number=1)
+        # StepAnalyzer wraps it, so it returns a StepRecord
+        assert result is not None
+        assert result.step_number == 1
+
+    def test_all_steps_from_empty_dir(self, tmp_path: Path) -> None:
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        analyzer = StepAnalyzer(factory_dir)
+        steps = analyzer.all_steps()
+        # CycleAnalyzer.analyze() returns one record even for empty dirs
+        assert len(steps) == 1
+
+    def test_with_events(self, tmp_path: Path) -> None:
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+
+        events = [
+            {"type": "experiment.begin", "timestamp": "2026-01-01T00:00:00Z",
+             "data": {"exp_id": 1}},
+            {"type": "agent.started", "timestamp": "2026-01-01T00:00:01Z",
+             "agent": "builder", "data": {}},
+            {"type": "agent.completed", "timestamp": "2026-01-01T00:01:00Z",
+             "agent": "builder", "data": {"total_cost_usd": 0.5}},
+            {"type": "experiment.finalize", "timestamp": "2026-01-01T00:02:00Z",
+             "data": {"exp_id": 1, "verdict": "keep"}},
+        ]
+        (factory_dir / "events.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in events)
+        )
+
+        analyzer = StepAnalyzer(factory_dir)
+        record = analyzer.latest()
+        assert record is not None
+        assert record.step_number == 1
+
+    def test_summarize_verdict(self) -> None:
+        assert StepAnalyzer._summarize_verdict(1, 0, 0) == "keep"
+        assert StepAnalyzer._summarize_verdict(0, 1, 0) == "revert"
+        assert StepAnalyzer._summarize_verdict(0, 0, 1) == "error"
+        assert StepAnalyzer._summarize_verdict(0, 0, 0) is None
+        assert StepAnalyzer._summarize_verdict(2, 1, 0) == "keep"
+        assert StepAnalyzer._summarize_verdict(1, 2, 0) == "revert"

--- a/tests/test_optimization/test_executors.py
+++ b/tests/test_optimization/test_executors.py
@@ -1,0 +1,46 @@
+"""Tests for factory.optimization.executors — protocol conformance and basic behavior."""
+
+from __future__ import annotations
+
+from factory.optimization.executors import (
+    FactoryCeoExecutor,
+    HarborExecutor,
+    WorkflowRunExecutor,
+)
+from factory.optimization.protocols import Executor
+
+
+class TestExecutorProtocolConformance:
+    def test_ceo_executor(self) -> None:
+        assert isinstance(FactoryCeoExecutor(), Executor)
+
+    def test_harbor_executor(self) -> None:
+        assert isinstance(HarborExecutor(), Executor)
+
+    def test_workflow_run_executor(self) -> None:
+        assert isinstance(WorkflowRunExecutor("test"), Executor)
+
+
+class TestFactoryCeoExecutor:
+    def test_defaults(self) -> None:
+        e = FactoryCeoExecutor()
+        assert e.mode == "improve"
+        assert e.extra_args == []
+
+    def test_custom_mode(self) -> None:
+        e = FactoryCeoExecutor(mode="research", extra_args=["--headless"])
+        assert e.mode == "research"
+        assert e.extra_args == ["--headless"]
+
+
+class TestHarborExecutor:
+    def test_defaults(self) -> None:
+        e = HarborExecutor()
+        assert e.harbor_script == "./run-harbor.sh"
+        assert e.skill_env_var == "HARBOR_SKILL_PATH"
+
+    def test_missing_script_returns_error(self, tmp_path) -> None:
+        e = HarborExecutor(harbor_script="nonexistent.sh")
+        from factory.optimization.surface import Surface
+        result = e.execute(tmp_path, Surface())
+        assert result.returncode == 1

--- a/tests/test_optimization/test_gate.py
+++ b/tests/test_optimization/test_gate.py
@@ -1,0 +1,72 @@
+"""Tests for factory.optimization.gate — accept/reject gate."""
+
+from __future__ import annotations
+
+from factory.optimization.gate import evaluate_gate
+
+
+class TestEvaluateGate:
+    def test_accept_when_better(self) -> None:
+        result = evaluate_gate(
+            candidate_score=0.8,
+            current_score=0.7,
+            best_score=0.7,
+            best_step=1,
+            global_step=2,
+        )
+        assert result.accepted is True
+        assert result.candidate_score == 0.8
+        assert result.best_score == 0.8
+
+    def test_reject_when_worse(self) -> None:
+        result = evaluate_gate(
+            candidate_score=0.5,
+            current_score=0.7,
+            best_score=0.7,
+            best_step=1,
+            global_step=2,
+        )
+        assert result.accepted is False
+        assert result.best_score == 0.7
+
+    def test_reject_when_equal(self) -> None:
+        result = evaluate_gate(
+            candidate_score=0.7,
+            current_score=0.7,
+            best_score=0.7,
+            best_step=1,
+            global_step=2,
+        )
+        assert result.accepted is False
+
+    def test_zero_scores(self) -> None:
+        result = evaluate_gate(
+            candidate_score=0.0,
+            current_score=0.0,
+            best_score=0.0,
+            best_step=0,
+            global_step=1,
+        )
+        assert result.accepted is False
+
+    def test_best_score_preserved_on_reject(self) -> None:
+        result = evaluate_gate(
+            candidate_score=0.3,
+            current_score=0.5,
+            best_score=0.9,
+            best_step=5,
+            global_step=10,
+        )
+        assert result.accepted is False
+        assert result.best_score == 0.9
+
+    def test_reason_contains_scores(self) -> None:
+        result = evaluate_gate(
+            candidate_score=0.85,
+            current_score=0.80,
+            best_score=0.80,
+            best_step=1,
+            global_step=2,
+        )
+        assert "0.85" in result.reason
+        assert "0.80" in result.reason

--- a/tests/test_optimization/test_loop.py
+++ b/tests/test_optimization/test_loop.py
@@ -1,0 +1,118 @@
+"""Tests for factory.optimization.loop — OptimizationLoop step and train."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from factory.inner_loop import EvalResult
+from factory.optimization.loop import OptimizationLoop, TrainResult
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, LoopConfig, Patch, StepRecord
+
+
+class _CountingExecutor:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def execute(self, project_dir: Path, surface: Surface, **kwargs: Any) -> ExecutionResult:
+        self.call_count += 1
+        return ExecutionResult(returncode=0, artifacts=[], duration_s=1.0)
+
+
+class _FixedScoreEvaluator:
+    def __init__(self, score: float = 0.5) -> None:
+        self.score = score
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        return EvalResult(score=self.score)
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        return EvalResult(score=self.score)
+
+    def get_info(self) -> dict:
+        return {"name": "fixed"}
+
+
+class _IncreasingScoreEvaluator:
+    def __init__(self) -> None:
+        self._call = 0
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        self._call += 1
+        return EvalResult(score=0.1 * self._call)
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        self._call += 1
+        return EvalResult(score=0.1 * self._call)
+
+    def get_info(self) -> dict:
+        return {"name": "increasing"}
+
+
+class _NoOpMutator:
+    def propose(
+        self,
+        surface: Surface,
+        execution_result: ExecutionResult,
+        history: list[StepRecord],
+    ) -> Patch:
+        return Patch(reasoning="noop")
+
+
+class TestOptimizationLoopStep:
+    def test_single_step(self, tmp_path: Path) -> None:
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=Surface(),
+            executor=_CountingExecutor(),
+            evaluator=_FixedScoreEvaluator(),
+            mutator=_NoOpMutator(),
+        )
+        record = loop.step()
+        assert record.step_number == 1
+        assert record.verdict in ("keep", "revert")
+        assert record.duration_s > 0
+
+    def test_history_accumulates(self, tmp_path: Path) -> None:
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=Surface(),
+            executor=_CountingExecutor(),
+            evaluator=_FixedScoreEvaluator(),
+            mutator=_NoOpMutator(),
+        )
+        loop.step()
+        loop.step()
+        assert len(loop.history()) == 2
+        assert loop.history()[0].step_number == 1
+        assert loop.history()[1].step_number == 2
+
+
+class TestOptimizationLoopTrain:
+    def test_train_runs_correct_steps(self, tmp_path: Path) -> None:
+        executor = _CountingExecutor()
+        config = LoopConfig(epochs=2, steps_per_epoch=3)
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=Surface(),
+            executor=executor,
+            evaluator=_FixedScoreEvaluator(),
+            mutator=_NoOpMutator(),
+            config=config,
+        )
+        result = loop.train()
+        assert isinstance(result, TrainResult)
+        assert len(result.steps) == 6
+        assert executor.call_count == 6
+
+    def test_train_default_config(self, tmp_path: Path) -> None:
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=Surface(),
+            executor=_CountingExecutor(),
+            evaluator=_FixedScoreEvaluator(),
+            mutator=_NoOpMutator(),
+        )
+        result = loop.train()
+        assert len(result.steps) == 1

--- a/tests/test_optimization/test_mutators.py
+++ b/tests/test_optimization/test_mutators.py
@@ -1,0 +1,58 @@
+"""Tests for factory.optimization.mutators — protocol conformance and behavior."""
+
+from __future__ import annotations
+
+from factory.optimization.mutators import (
+    OverwriteMutator,
+    SkillOptMutator,
+    UnifiedMutator,
+)
+from factory.optimization.protocols import Mutator
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, GraphMutation
+
+
+class TestMutatorProtocolConformance:
+    def test_skillopt_mutator(self) -> None:
+        assert isinstance(SkillOptMutator(), Mutator)
+
+    def test_overwrite_mutator(self) -> None:
+        assert isinstance(OverwriteMutator(), Mutator)
+
+    def test_unified_mutator(self) -> None:
+        assert isinstance(UnifiedMutator(), Mutator)
+
+
+class TestSkillOptMutator:
+    def test_returns_empty_patch(self) -> None:
+        m = SkillOptMutator()
+        surface = Surface(prompt_slots={"p1": "v1"})
+        result = m.propose(surface, ExecutionResult(returncode=0), [])
+        assert result.prompt_edits == []
+        assert "stub" in result.reasoning.lower()
+
+
+class TestOverwriteMutator:
+    def test_no_overwrite_text(self) -> None:
+        m = OverwriteMutator()
+        result = m.propose(Surface(), ExecutionResult(returncode=0), [])
+        assert result.graph_mutations == []
+
+    def test_mutations_from_dicts(self) -> None:
+        raw = [
+            {"op": "update_node", "node_id": "n1", "field": "prompt", "value": "new"},
+            {"op": "remove_node", "node_id": "n2"},
+        ]
+        mutations = OverwriteMutator.mutations_from_dicts(raw)
+        assert len(mutations) == 2
+        assert isinstance(mutations[0], GraphMutation)
+        assert mutations[0].op == "update_node"
+        assert mutations[1].op == "remove_node"
+
+
+class TestUnifiedMutator:
+    def test_composes_both(self) -> None:
+        m = UnifiedMutator()
+        result = m.propose(Surface(), ExecutionResult(returncode=0), [])
+        assert isinstance(result.prompt_edits, list)
+        assert isinstance(result.graph_mutations, list)

--- a/tests/test_optimization/test_protocols.py
+++ b/tests/test_optimization/test_protocols.py
@@ -1,0 +1,73 @@
+"""Tests for factory.optimization.protocols — runtime_checkable verification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from factory.inner_loop import CirclePackingEvaluator, EvalResult
+from factory.optimization.protocols import Evaluator, Executor, Mutator
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, Patch, StepRecord
+
+
+class _StubExecutor:
+    def execute(self, project_dir: Path, surface: Surface, **kwargs: Any) -> ExecutionResult:
+        return ExecutionResult(returncode=0)
+
+
+class _StubEvaluator:
+    def parse(self, artifact_path: Path) -> EvalResult:
+        return EvalResult(score=0.5)
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        return EvalResult(score=0.5)
+
+    def get_info(self) -> dict:
+        return {}
+
+
+class _StubMutator:
+    def propose(
+        self,
+        surface: Surface,
+        execution_result: ExecutionResult,
+        history: list[StepRecord],
+    ) -> Patch:
+        return Patch()
+
+
+class _NotAnExecutor:
+    pass
+
+
+class _NotAnEvaluator:
+    def parse(self, path: Path) -> None:
+        pass
+
+
+class TestExecutorProtocol:
+    def test_stub_satisfies(self) -> None:
+        assert isinstance(_StubExecutor(), Executor)
+
+    def test_non_executor_rejected(self) -> None:
+        assert not isinstance(_NotAnExecutor(), Executor)
+
+
+class TestEvaluatorProtocol:
+    def test_stub_satisfies(self) -> None:
+        assert isinstance(_StubEvaluator(), Evaluator)
+
+    def test_circle_packing_satisfies(self) -> None:
+        assert isinstance(CirclePackingEvaluator(), Evaluator)
+
+    def test_incomplete_rejected(self) -> None:
+        assert not isinstance(_NotAnEvaluator(), Evaluator)
+
+
+class TestMutatorProtocol:
+    def test_stub_satisfies(self) -> None:
+        assert isinstance(_StubMutator(), Mutator)
+
+    def test_non_mutator_rejected(self) -> None:
+        assert not isinstance(object(), Mutator)

--- a/tests/test_optimization/test_searchqa.py
+++ b/tests/test_optimization/test_searchqa.py
@@ -1,0 +1,124 @@
+"""Tests for factory.optimization.benchmarks.searchqa — SearchQA benchmark adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from factory.inner_loop import EvalResult
+from factory.optimization.benchmarks.searchqa import (
+    SearchQAEvaluator,
+    build_searchqa_config,
+    build_searchqa_executor,
+    build_searchqa_surface,
+)
+from factory.optimization.executors.harbor import HarborExecutor
+from factory.optimization.protocols import Evaluator
+from factory.optimization.surface import Surface
+from factory.optimization.types import LoopConfig
+
+
+class TestSearchQAEvaluator:
+    def test_parse_valid_json_with_accuracy(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "reward.json"
+        artifact.write_text(json.dumps({"accuracy": 0.82, "em": 0.75, "f1": 0.88}))
+        result = SearchQAEvaluator().parse(artifact)
+        assert result.score == 0.82
+        assert result.valid is True
+        assert result.metrics == {"accuracy": 0.82, "em": 0.75, "f1": 0.88}
+        assert str(artifact) in result.artifacts
+
+    def test_parse_valid_json_with_score_fallback(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "reward.json"
+        artifact.write_text(json.dumps({"score": 0.65}))
+        result = SearchQAEvaluator().parse(artifact)
+        assert result.score == 0.65
+        assert result.valid is True
+
+    def test_parse_invalid_json(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "reward.json"
+        artifact.write_text("not json {{{")
+        result = SearchQAEvaluator().parse(artifact)
+        assert result.score == 0.0
+        assert result.valid is False
+
+    def test_parse_missing_file(self, tmp_path: Path) -> None:
+        result = SearchQAEvaluator().parse(tmp_path / "nonexistent.json")
+        assert result.score == 0.0
+        assert result.valid is False
+
+    def test_parse_many_selects_best(self, tmp_path: Path) -> None:
+        for i, score in enumerate([0.3, 0.9, 0.6]):
+            p = tmp_path / f"reward_{i}.json"
+            p.write_text(json.dumps({"accuracy": score}))
+        paths = [tmp_path / f"reward_{i}.json" for i in range(3)]
+        result = SearchQAEvaluator().parse_many(paths)
+        assert result.score == 0.9
+        assert result.valid is True
+
+    def test_parse_many_empty_list(self) -> None:
+        result = SearchQAEvaluator().parse_many([])
+        assert result.score == 0.0
+        assert result.valid is False
+
+    def test_parse_many_single_item(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "reward.json"
+        artifact.write_text(json.dumps({"accuracy": 0.55}))
+        result = SearchQAEvaluator().parse_many([artifact])
+        assert result.score == 0.55
+
+    def test_get_info_structure(self) -> None:
+        info = SearchQAEvaluator(target=0.90).get_info()
+        assert info["benchmark"] == "searchqa"
+        assert info["target"] == 0.90
+        assert isinstance(info["metrics"], list)
+        assert "accuracy" in info["metrics"]
+
+    def test_protocol_conformance(self) -> None:
+        assert isinstance(SearchQAEvaluator(), Evaluator)
+
+    def test_custom_target(self) -> None:
+        ev = SearchQAEvaluator(target=0.95)
+        assert ev.target == 0.95
+
+
+class TestBuildSearchqaSurface:
+    def test_no_skill(self) -> None:
+        surface = build_searchqa_surface()
+        assert isinstance(surface, Surface)
+        assert surface.prompt_slots == {}
+
+    def test_with_skill_path(self, tmp_path: Path) -> None:
+        skill = tmp_path / "skill.md"
+        skill.write_text("my prompt template")
+        surface = build_searchqa_surface(skill_path=skill)
+        assert surface.prompt_slots["skill"] == "my prompt template"
+
+    def test_nonexistent_skill_path(self, tmp_path: Path) -> None:
+        surface = build_searchqa_surface(skill_path=tmp_path / "missing.md")
+        assert surface.prompt_slots == {}
+
+
+class TestBuildSearchqaConfig:
+    def test_defaults(self) -> None:
+        config = build_searchqa_config()
+        assert isinstance(config, LoopConfig)
+        assert config.epochs == 3
+        assert config.steps_per_epoch == 5
+
+    def test_custom_values(self) -> None:
+        config = build_searchqa_config(epochs=10, steps_per_epoch=20)
+        assert config.epochs == 10
+        assert config.steps_per_epoch == 20
+
+
+class TestBuildSearchqaExecutor:
+    def test_default(self) -> None:
+        executor = build_searchqa_executor()
+        assert isinstance(executor, HarborExecutor)
+        assert executor.harbor_script == "./run-harbor.sh"
+
+    def test_custom_script(self) -> None:
+        executor = build_searchqa_executor(harbor_script="/opt/bench/run.sh")
+        assert isinstance(executor, HarborExecutor)
+        assert executor.harbor_script == "/opt/bench/run.sh"

--- a/tests/test_optimization/test_surface.py
+++ b/tests/test_optimization/test_surface.py
@@ -1,0 +1,120 @@
+"""Tests for factory.optimization.surface — Surface construction and validation."""
+
+from __future__ import annotations
+
+import warnings
+
+from factory.models import FactoryConfig, OuterLoopConfig
+from factory.optimization.surface import Surface
+from factory.workflow.primitives import AgentNode, AgentRole, Edge, Workflow
+
+
+def _make_workflow(node_ids: list[str]) -> Workflow:
+    nodes = {
+        nid: AgentNode(id=nid, role=AgentRole.RESEARCHER, reads=set(), writes=set())
+        for nid in node_ids
+    }
+    edges = [
+        Edge(source=node_ids[i], target=node_ids[i + 1])
+        for i in range(len(node_ids) - 1)
+    ] if len(node_ids) > 1 else []
+    return Workflow(
+        name="test",
+        nodes=nodes,
+        edges=edges,
+        start_node=node_ids[0],
+    )
+
+
+class TestSurfaceConstruction:
+    def test_defaults(self) -> None:
+        s = Surface()
+        assert s.workflow is None
+        assert s.frozen_nodes == frozenset()
+        assert s.prompt_slots == {}
+        assert s.inner_surfaces == []
+        assert s.outer_surfaces == []
+
+    def test_with_workflow(self) -> None:
+        wf = _make_workflow(["a", "b"])
+        s = Surface(workflow=wf, frozen_nodes=frozenset({"a"}))
+        assert s.workflow is wf
+        assert s.frozen_nodes == frozenset({"a"})
+
+
+class TestMutableNodes:
+    def test_no_workflow(self) -> None:
+        s = Surface()
+        assert s.mutable_nodes() == set()
+
+    def test_all_mutable(self) -> None:
+        wf = _make_workflow(["a", "b", "c"])
+        s = Surface(workflow=wf)
+        assert s.mutable_nodes() == {"a", "b", "c"}
+
+    def test_with_frozen(self) -> None:
+        wf = _make_workflow(["a", "b", "c"])
+        s = Surface(workflow=wf, frozen_nodes=frozenset({"b"}))
+        assert s.mutable_nodes() == {"a", "c"}
+
+
+class TestMutablePromptSlots:
+    def test_returns_all(self) -> None:
+        s = Surface(prompt_slots={"p1": "v1", "p2": "v2"})
+        assert s.mutable_prompt_slots() == {"p1": "v1", "p2": "v2"}
+
+
+class TestValidate:
+    def test_no_issues_without_frozen(self) -> None:
+        s = Surface()
+        assert s.validate() == []
+
+    def test_invalid_frozen_node_ids(self) -> None:
+        wf = _make_workflow(["a", "b"])
+        s = Surface(workflow=wf, frozen_nodes=frozenset({"a", "x", "y"}))
+        issues = s.validate()
+        assert len(issues) == 1
+        assert "x" in issues[0] or "y" in issues[0]
+
+    def test_all_frozen_warns(self) -> None:
+        wf = _make_workflow(["a", "b"])
+        s = Surface(workflow=wf, frozen_nodes=frozenset({"a", "b"}))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            issues = s.validate()
+        assert len(issues) == 1
+        assert "All nodes are frozen" in issues[0]
+        assert any("All nodes are frozen" in str(warning.message) for warning in w)
+
+
+class TestFromConfig:
+    def test_minimal_config(self) -> None:
+        config = FactoryConfig(
+            goal="test", scope=[], guards=[], eval_command="echo ok",
+            eval_threshold=0.8, constraints=[],
+        )
+        s = Surface.from_config(config)
+        assert s.workflow is None
+        assert s.inner_surfaces == []
+
+    def test_with_outer_loop(self) -> None:
+        config = FactoryConfig(
+            goal="test", scope=[], guards=[], eval_command="echo ok",
+            eval_threshold=0.8, constraints=[],
+            outer_loop=OuterLoopConfig(
+                inner_surfaces=["prompts/*.md"],
+                outer_surfaces=["src/**/*.py"],
+            ),
+        )
+        s = Surface.from_config(config)
+        assert s.inner_surfaces == ["prompts/*.md"]
+        assert s.outer_surfaces == ["src/**/*.py"]
+
+    def test_with_workflow(self) -> None:
+        config = FactoryConfig(
+            goal="test", scope=[], guards=[], eval_command="echo ok",
+            eval_threshold=0.8, constraints=[],
+        )
+        wf = _make_workflow(["a", "b"])
+        s = Surface.from_config(config, workflow=wf)
+        assert s.workflow is wf

--- a/tests/test_optimization/test_types.py
+++ b/tests/test_optimization/test_types.py
@@ -1,0 +1,148 @@
+"""Tests for factory.optimization.types — construction and validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from factory.models import AggregateMethod
+from factory.optimization.types import (
+    ExecutionResult,
+    GateResult,
+    GraphMutation,
+    LoopConfig,
+    Patch,
+    SlotEdit,
+    StepRecord,
+)
+
+
+class TestSlotEdit:
+    def test_construction(self) -> None:
+        edit = SlotEdit(slot_name="prompt", old_value="old", new_value="new")
+        assert edit.slot_name == "prompt"
+        assert edit.old_value == "old"
+        assert edit.new_value == "new"
+
+
+class TestGraphMutation:
+    def test_update_node(self) -> None:
+        m = GraphMutation(op="update_node", node_id="n1", field="prompt", value="new")
+        assert m.op == "update_node"
+        assert m.node_id == "n1"
+
+    def test_remove_node(self) -> None:
+        m = GraphMutation(op="remove_node", node_id="n2")
+        assert m.op == "remove_node"
+
+    def test_add_edge(self) -> None:
+        m = GraphMutation(op="add_edge", source="a", target="b")
+        assert m.source == "a"
+        assert m.target == "b"
+
+    def test_remove_edge(self) -> None:
+        m = GraphMutation(op="remove_edge", source="a", target="b")
+        assert m.op == "remove_edge"
+
+    def test_invalid_op_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            GraphMutation(op="invalid_op")  # type: ignore[arg-type]
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            GraphMutation(op="update_node", node_id="n1", bogus="x")  # type: ignore[call-arg]
+
+
+class TestPatch:
+    def test_empty_patch(self) -> None:
+        p = Patch()
+        assert p.prompt_edits == []
+        assert p.graph_mutations == []
+        assert p.reasoning == ""
+
+    def test_with_edits(self) -> None:
+        edit = SlotEdit("s", "a", "b")
+        mut = GraphMutation(op="remove_node", node_id="n1")
+        p = Patch(prompt_edits=[edit], graph_mutations=[mut], reasoning="test")
+        assert len(p.prompt_edits) == 1
+        assert len(p.graph_mutations) == 1
+        assert p.reasoning == "test"
+
+
+class TestExecutionResult:
+    def test_defaults(self) -> None:
+        r = ExecutionResult(returncode=0)
+        assert r.returncode == 0
+        assert r.artifacts == []
+        assert r.duration_s == 0.0
+        assert r.cost_usd == 0.0
+
+    def test_with_values(self) -> None:
+        r = ExecutionResult(returncode=1, artifacts=["a.json"], duration_s=5.5, cost_usd=0.1)
+        assert r.returncode == 1
+        assert r.artifacts == ["a.json"]
+
+
+class TestGateResult:
+    def test_accepted(self) -> None:
+        g = GateResult(accepted=True, reason="better", candidate_score=0.8, current_score=0.7, best_score=0.8)
+        assert g.accepted is True
+
+    def test_rejected(self) -> None:
+        g = GateResult(accepted=False, reason="worse", candidate_score=0.5, current_score=0.7, best_score=0.7)
+        assert g.accepted is False
+
+
+class TestStepRecord:
+    def test_defaults(self) -> None:
+        r = StepRecord(step_number=1)
+        assert r.step_number == 1
+        assert r.score_start is None
+        assert r.verdict is None
+        assert r.artifacts == []
+        assert r.patch is None
+
+    def test_with_values(self) -> None:
+        r = StepRecord(
+            step_number=3,
+            score_start=0.5,
+            score_end=0.7,
+            score_delta=0.2,
+            duration_s=10.0,
+            cost_usd=0.5,
+            verdict="keep",
+            artifacts=["eval.json"],
+        )
+        assert r.score_delta == 0.2
+        assert r.verdict == "keep"
+
+
+class TestLoopConfig:
+    def test_defaults(self) -> None:
+        c = LoopConfig()
+        assert c.epochs == 1
+        assert c.steps_per_epoch == 1
+        assert c.plateau_threshold == 3
+        assert c.aggregate == AggregateMethod.mean
+        assert c.inner_surfaces == []
+        assert c.outer_surfaces == []
+        assert c.frozen_nodes == frozenset()
+        assert c.max_inner_runs_per_cycle is None
+
+    def test_custom_values(self) -> None:
+        c = LoopConfig(
+            epochs=5,
+            steps_per_epoch=10,
+            plateau_threshold=5,
+            aggregate=AggregateMethod.median,
+            inner_surfaces=["a.md"],
+            outer_surfaces=["b.py"],
+            frozen_nodes=frozenset({"n1"}),
+            max_inner_runs_per_cycle=3,
+        )
+        assert c.epochs == 5
+        assert c.frozen_nodes == frozenset({"n1"})
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            LoopConfig(bad_field="x")  # type: ignore[call-arg]


### PR DESCRIPTION
Closes #1135

## Changes

- **Phase 1 — Foundation types & protocols:** Created `factory/optimization/` package with `types.py` (SlotEdit, GraphMutation, Patch, ExecutionResult, GateResult, StepRecord, LoopConfig), `protocols.py` (Executor, Evaluator, Mutator — all `@runtime_checkable`), `surface.py` (Surface with `mutable_nodes()`, `validate()`, `from_config()`), `gate.py` (accept/reject gate)
- **Phase 2 — Executor implementations:** `FactoryCeoExecutor` (runs `factory ceo` subprocess), `HarborExecutor` (runs `run-harbor.sh` with skill injection), `WorkflowRunExecutor` (wraps `factory workflow run`)
- **Phase 3 — Mutator implementations:** `SkillOptMutator` (stub for PR #1013), `OverwriteMutator` (typed GraphMutation from overwrite.py dicts), `UnifiedMutator` (composes both, respects frozen_nodes)
- **Phase 4 — Core loop:** `OptimizationLoop` with `step()` and `train()` methods composing Executor + Evaluator + Mutator with epoch/step structure. `StepAnalyzer` wraps CycleAnalyzer to produce StepRecords.
- **Phase 5 — SearchQA benchmark:** `SearchQAEvaluator` + builder helpers for SearchQA optimization surface and config
- **Phase 6 — CLI wiring:** `factory skillopt` subcommand with `--benchmark`, `--skill-path`, `--epochs`, `--steps-per-epoch` flags
- **Phase 7 — Deprecation:** Added deprecation markers to `inner_loop.py` and `cycle_analyzer.py` pointing to `factory/optimization/`

65 new tests across 8 test modules. All 95 existing inner_outer_loop + cycle_analyzer tests pass unchanged.