### PR TITLE
feat: implement AgenticMutator for LLM-powered prompt optimization

### DIFF
--- a/factory/optimization/__init__.py
+++ b/factory/optimization/__init__.py
@@ -4,6 +4,7 @@ from factory.optimization.analyzer import StepAnalyzer as StepAnalyzer
 from factory.optimization.gate import evaluate_gate as evaluate_gate
 from factory.optimization.loop import OptimizationLoop as OptimizationLoop
 from factory.optimization.loop import TrainResult as TrainResult
+from factory.optimization.mutators.agentic import AgenticMutator as AgenticMutator
 from factory.optimization.protocols import Evaluator as Evaluator
 from factory.optimization.protocols import Executor as Executor
 from factory.optimization.protocols import Mutator as Mutator
@@ -15,8 +16,10 @@ from factory.optimization.types import LoopConfig as LoopConfig
 from factory.optimization.types import Patch as Patch
 from factory.optimization.types import SlotEdit as SlotEdit
 from factory.optimization.types import StepRecord as StepRecord
+from factory.optimization.types import TaskResult as TaskResult
 
 __all__ = [
+    "AgenticMutator",
     "Evaluator",
     "ExecutionResult",
     "Executor",
@@ -30,6 +33,7 @@ __all__ = [
     "StepAnalyzer",
     "StepRecord",
     "Surface",
+    "TaskResult",
     "TrainResult",
     "evaluate_gate",
 ]

--- a/factory/optimization/executors/harbor.py
+++ b/factory/optimization/executors/harbor.py
@@ -1,12 +1,14 @@
 """HarborExecutor — runs run-harbor.sh with skill injection via env var.
 
-Stub implementation: Harbor infrastructure may not be on this branch.
-The full implementation will inject the skill path into the subprocess
-environment and collect result artifacts from the Harbor output directory.
+Injects prompt skill content as base64-encoded env var, passes configuration
+via constructor params, and parses per-task results from reward.json.
 """
 
 from __future__ import annotations
 
+import base64
+import json
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -15,7 +17,7 @@ from typing import Any
 import structlog
 
 from factory.optimization.surface import Surface
-from factory.optimization.types import ExecutionResult
+from factory.optimization.types import ExecutionResult, TaskResult
 
 log = structlog.get_logger()
 
@@ -23,27 +25,50 @@ log = structlog.get_logger()
 class HarborExecutor:
     """Executor that runs a Harbor benchmark via ``run-harbor.sh``.
 
-    Injects the skill path into the subprocess environment so the Harbor
-    runner picks up the current prompt surface.
+    Injects skill content and configuration into the subprocess environment.
     """
 
     def __init__(
         self,
         harbor_script: str = "./run-harbor.sh",
         skill_env_var: str = "HARBOR_SKILL_PATH",
+        docker_host: str | None = None,
+        git_ref: str | None = None,
+        n_tasks: int | None = None,
+        concurrency: int | None = None,
+        split: str | None = None,
     ) -> None:
         self.harbor_script = harbor_script
         self.skill_env_var = skill_env_var
+        self.docker_host = docker_host
+        self.git_ref = git_ref
+        self.n_tasks = n_tasks
+        self.concurrency = concurrency
+        self.split = split
 
     def execute(
         self, project_dir: Path, surface: Surface, **kwargs: Any
     ) -> ExecutionResult:
-        import os
-
         env = os.environ.copy()
+
         skill_path = kwargs.get("skill_path", "")
         if skill_path:
             env[self.skill_env_var] = str(skill_path)
+
+        if "skill" in surface.prompt_slots:
+            encoded = base64.b64encode(surface.prompt_slots["skill"].encode()).decode()
+            env["SEARCHQA_SKILL_B64"] = encoded
+
+        if self.docker_host:
+            env["DOCKER_HOST"] = self.docker_host
+        if self.git_ref:
+            env["FACTORY_GIT_REF"] = self.git_ref
+        if self.n_tasks is not None:
+            env["FACTORY_N_TASKS"] = str(self.n_tasks)
+        if self.concurrency is not None:
+            env["FACTORY_CONCURRENCY"] = str(self.concurrency)
+        if self.split:
+            env["FACTORY_SPLIT"] = self.split
 
         script = project_dir / self.harbor_script
         if not script.exists():
@@ -60,13 +85,43 @@ class HarborExecutor:
         duration = time.monotonic() - start
 
         artifacts: list[str] = []
+        task_results: list[TaskResult] = []
         reward_path = project_dir / "reward.json"
         if reward_path.exists():
             artifacts.append(str(reward_path))
+            task_results = _parse_task_results(reward_path)
 
         log.info("executor.harbor.done", returncode=result.returncode, duration_s=round(duration, 1))
         return ExecutionResult(
             returncode=result.returncode,
             artifacts=artifacts,
             duration_s=duration,
+            task_results=task_results,
         )
+
+
+def _parse_task_results(reward_path: Path) -> list[TaskResult]:
+    """Parse per-task results from reward.json if 'tasks' key exists."""
+    try:
+        data = json.loads(reward_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+
+    tasks = data.get("tasks")
+    if not isinstance(tasks, list):
+        return []
+
+    results: list[TaskResult] = []
+    for entry in tasks:
+        if not isinstance(entry, dict):
+            continue
+        results.append(
+            TaskResult(
+                task_id=str(entry.get("task_id", "")),
+                reward=float(entry.get("reward", 0.0)),
+                predicted=str(entry.get("predicted", "")),
+                gold=str(entry.get("gold", "")),
+                question=str(entry.get("question", "")),
+            )
+        )
+    return results

--- a/factory/optimization/loop.py
+++ b/factory/optimization/loop.py
@@ -92,6 +92,10 @@ class OptimizationLoop:
             if score_end > self._best_score:
                 self._best_score = score_end
                 self._best_step = self._global_step
+            if patch:
+                for edit in patch.prompt_edits:
+                    if edit.slot_name in self.surface.prompt_slots:
+                        self.surface.prompt_slots[edit.slot_name] = edit.new_value
 
         record = StepRecord(
             step_number=self._global_step,

--- a/factory/optimization/mutators/__init__.py
+++ b/factory/optimization/mutators/__init__.py
@@ -1,10 +1,12 @@
 """Mutator implementations for the optimization loop."""
 
+from factory.optimization.mutators.agentic import AgenticMutator as AgenticMutator
 from factory.optimization.mutators.overwrite import OverwriteMutator as OverwriteMutator
 from factory.optimization.mutators.skillopt import SkillOptMutator as SkillOptMutator
 from factory.optimization.mutators.unified import UnifiedMutator as UnifiedMutator
 
 __all__ = [
+    "AgenticMutator",
     "OverwriteMutator",
     "SkillOptMutator",
     "UnifiedMutator",

--- a/factory/optimization/mutators/agentic.py
+++ b/factory/optimization/mutators/agentic.py
@@ -1,0 +1,169 @@
+"""AgenticMutator — LLM-powered prompt optimization via invoke_agent('strategist').
+
+Reflects on benchmark failures and proposes targeted prompt slot edits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+
+import structlog
+
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, Patch, SlotEdit, StepRecord
+
+log = structlog.get_logger()
+
+
+class AgenticMutator:
+    """Proposes prompt-slot edits by reflecting on benchmark failures via the strategist agent."""
+
+    def __init__(
+        self,
+        project_path: Path,
+        num_failures_to_show: int = 5,
+        model: str | None = None,
+    ) -> None:
+        self.project_path = Path(project_path)
+        self.num_failures_to_show = num_failures_to_show
+        self.model = model
+
+    def propose(
+        self,
+        surface: Surface,
+        execution_result: ExecutionResult,
+        history: list[StepRecord],
+    ) -> Patch:
+        failed = [t for t in execution_result.task_results if t.reward == 0]
+        if not failed:
+            log.info("mutator.agentic.no_failures", total_tasks=len(execution_result.task_results))
+            return Patch(reasoning="no failures to reflect on")
+
+        prompt = self._build_prompt(surface, failed[:self.num_failures_to_show], history)
+        log.info(
+            "mutator.agentic.invoke",
+            num_failures=len(failed),
+            num_shown=min(len(failed), self.num_failures_to_show),
+        )
+
+        try:
+            from factory.agents.runner import invoke_agent
+
+            stdout, returncode = asyncio.run(
+                invoke_agent(
+                    "strategist",
+                    task=prompt,
+                    project_path=self.project_path,
+                    model=self.model or "sonnet",
+                    timeout=120,
+                )
+            )
+        except Exception as exc:
+            log.error("mutator.agentic.invoke_failed", error=str(exc))
+            return Patch(reasoning=f"agent invocation failed: {exc}")
+
+        if returncode != 0:
+            log.warning("mutator.agentic.nonzero_exit", returncode=returncode)
+            return Patch(reasoning=f"agent invocation failed: exit code {returncode}")
+
+        return self._parse_response(stdout)
+
+    def _build_prompt(
+        self,
+        surface: Surface,
+        failed: list,
+        history: list[StepRecord],
+    ) -> str:
+        parts: list[str] = []
+        parts.append("You are optimizing prompt slots for a benchmark. Analyze the failures below and propose targeted edits to improve performance.")
+        parts.append("")
+
+        parts.append("## Current Prompt Slots")
+        for name, value in surface.prompt_slots.items():
+            parts.append(f"### {name}")
+            parts.append(value)
+            parts.append("")
+
+        parts.append("## Failed Tasks")
+        for t in failed:
+            parts.append(f"### Task: {t.task_id}")
+            if t.question:
+                parts.append(f"**Question:** {t.question}")
+            parts.append(f"**Predicted:** {t.predicted}")
+            parts.append(f"**Gold:** {t.gold}")
+            parts.append("")
+
+        recent = history[-3:] if len(history) >= 3 else history
+        if recent:
+            parts.append("## Recent History")
+            for rec in recent:
+                delta = f"{rec.score_delta:+.4f}" if rec.score_delta is not None else "n/a"
+                parts.append(
+                    f"- Step {rec.step_number}: {rec.score_start:.4f} → {rec.score_end:.4f} (delta {delta}, {rec.verdict})"
+                    if rec.score_start is not None and rec.score_end is not None
+                    else f"- Step {rec.step_number}: delta {delta}, {rec.verdict}"
+                )
+            parts.append("")
+
+        parts.append("## Response Format")
+        parts.append("Respond with a JSON object (no other text):")
+        parts.append('```json')
+        parts.append('{"edits": [{"slot": "<slot_name>", "old": "<text to replace>", "new": "<replacement text>"}], "reasoning": "<why these changes will help>"}')
+        parts.append('```')
+
+        return "\n".join(parts)
+
+    def _parse_response(self, stdout: str) -> Patch:
+        parsed = _parse_json(stdout)
+        if parsed is None:
+            log.warning("mutator.agentic.parse_failed", stdout_len=len(stdout))
+            return Patch(reasoning="agent invocation failed: could not parse JSON from response")
+
+        edits_raw = parsed.get("edits", [])
+        reasoning = parsed.get("reasoning", "")
+
+        slot_edits: list[SlotEdit] = []
+        for e in edits_raw:
+            if isinstance(e, dict) and "slot" in e:
+                slot_edits.append(
+                    SlotEdit(
+                        slot_name=e["slot"],
+                        old_value=e.get("old", ""),
+                        new_value=e.get("new", ""),
+                    )
+                )
+
+        log.info("mutator.agentic.parsed", num_edits=len(slot_edits), reasoning=reasoning[:80])
+        return Patch(prompt_edits=slot_edits, reasoning=reasoning)
+
+
+def _parse_json(text: str) -> dict | None:
+    """Three-tier JSON extraction: direct parse → markdown code blocks → regex search."""
+    try:
+        result = json.loads(text)
+        if isinstance(result, dict) and ("edits" in result or "reasoning" in result):
+            return result
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    code_block = re.search(r"```(?:json)?\s*\n(.*?)\n```", text, re.DOTALL)
+    if code_block:
+        try:
+            result = json.loads(code_block.group(1))
+            if isinstance(result, dict) and ("edits" in result or "reasoning" in result):
+                return result
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    for match in re.finditer(r"\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}", text):
+        try:
+            result = json.loads(match.group())
+            if isinstance(result, dict) and ("edits" in result or "reasoning" in result):
+                return result
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+    return None

--- a/factory/optimization/types.py
+++ b/factory/optimization/types.py
@@ -48,6 +48,17 @@ class Patch:
 
 
 @dataclass
+class TaskResult:
+    """Per-task result from a benchmark execution."""
+
+    task_id: str
+    reward: float
+    predicted: str = ""
+    gold: str = ""
+    question: str = ""
+
+
+@dataclass
 class ExecutionResult:
     """Result of running one optimization step via an Executor."""
 
@@ -55,6 +66,7 @@ class ExecutionResult:
     artifacts: list[str] = field(default_factory=list)
     duration_s: float = 0.0
     cost_usd: float = 0.0
+    task_results: list[TaskResult] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/test_optimization/test_agentic_mutator.py
+++ b/tests/test_optimization/test_agentic_mutator.py
@@ -1,0 +1,197 @@
+"""Tests for factory.optimization.mutators.agentic — AgenticMutator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+_INVOKE_AGENT = "factory.agents.runner.invoke_agent"
+
+from factory.optimization.mutators.agentic import AgenticMutator, _parse_json
+from factory.optimization.protocols import Mutator
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, Patch, StepRecord, TaskResult
+
+
+def _make_execution_result(
+    failed: list[dict] | None = None,
+    passed: list[dict] | None = None,
+) -> ExecutionResult:
+    tasks: list[TaskResult] = []
+    for f in (failed or []):
+        tasks.append(TaskResult(
+            task_id=f.get("task_id", "t1"),
+            reward=0.0,
+            predicted=f.get("predicted", "wrong"),
+            gold=f.get("gold", "right"),
+            question=f.get("question", "what?"),
+        ))
+    for p in (passed or []):
+        tasks.append(TaskResult(
+            task_id=p.get("task_id", "t2"),
+            reward=1.0,
+            predicted=p.get("predicted", "correct"),
+            gold=p.get("gold", "correct"),
+        ))
+    return ExecutionResult(returncode=0, task_results=tasks)
+
+
+class TestAgenticMutatorProtocol:
+    def test_conforms_to_mutator_protocol(self, tmp_path: Path) -> None:
+        m = AgenticMutator(project_path=tmp_path)
+        assert isinstance(m, Mutator)
+
+
+class TestAgenticMutatorNoFailures:
+    def test_empty_patch_when_no_failures(self, tmp_path: Path) -> None:
+        m = AgenticMutator(project_path=tmp_path)
+        result = _make_execution_result(passed=[{"task_id": "t1"}])
+        p = m.propose(Surface(), result, [])
+        assert p.prompt_edits == []
+        assert "no failures" in p.reasoning
+
+    def test_empty_patch_when_no_task_results(self, tmp_path: Path) -> None:
+        m = AgenticMutator(project_path=tmp_path)
+        result = ExecutionResult(returncode=0)
+        p = m.propose(Surface(), result, [])
+        assert p.prompt_edits == []
+
+
+class TestAgenticMutatorPromptConstruction:
+    def test_failed_tasks_appear_in_prompt(self, tmp_path: Path) -> None:
+        m = AgenticMutator(project_path=tmp_path)
+        surface = Surface(prompt_slots={"skill": "You are a search assistant."})
+        result = _make_execution_result(failed=[
+            {"task_id": "q42", "question": "Who wrote Hamlet?", "predicted": "Dickens", "gold": "Shakespeare"},
+        ])
+        prompt = m._build_prompt(surface, result.task_results[:1], [])
+        assert "q42" in prompt
+        assert "Who wrote Hamlet?" in prompt
+        assert "Dickens" in prompt
+        assert "Shakespeare" in prompt
+        assert "You are a search assistant." in prompt
+
+    def test_history_appears_in_prompt(self, tmp_path: Path) -> None:
+        m = AgenticMutator(project_path=tmp_path)
+        history = [
+            StepRecord(step_number=1, score_start=0.3, score_end=0.4, score_delta=0.1, verdict="keep"),
+            StepRecord(step_number=2, score_start=0.4, score_end=0.35, score_delta=-0.05, verdict="revert"),
+        ]
+        prompt = m._build_prompt(Surface(prompt_slots={"x": "val"}), [], history)
+        assert "Step 1" in prompt
+        assert "Step 2" in prompt
+
+
+class TestAgenticMutatorInvocation:
+    def test_successful_agent_response(self, tmp_path: Path) -> None:
+        response = json.dumps({
+            "edits": [{"slot": "skill", "old": "old text", "new": "new text"}],
+            "reasoning": "improved search instructions",
+        })
+        mock = AsyncMock(return_value=(response, 0))
+
+        m = AgenticMutator(project_path=tmp_path)
+        result = _make_execution_result(failed=[{"task_id": "t1"}])
+        surface = Surface(prompt_slots={"skill": "old text"})
+
+        with patch(_INVOKE_AGENT, mock):
+            p = m.propose(surface, result, [])
+
+        assert len(p.prompt_edits) == 1
+        assert p.prompt_edits[0].slot_name == "skill"
+        assert p.prompt_edits[0].old_value == "old text"
+        assert p.prompt_edits[0].new_value == "new text"
+        assert p.reasoning == "improved search instructions"
+
+    def test_agent_failure_returns_empty_patch(self, tmp_path: Path) -> None:
+        mock = AsyncMock(side_effect=RuntimeError("agent crashed"))
+
+        m = AgenticMutator(project_path=tmp_path)
+        result = _make_execution_result(failed=[{"task_id": "t1"}])
+
+        with patch(_INVOKE_AGENT, mock):
+            p = m.propose(Surface(prompt_slots={"skill": "x"}), result, [])
+
+        assert p.prompt_edits == []
+        assert "agent invocation failed" in p.reasoning
+
+    def test_nonzero_exit_returns_empty_patch(self, tmp_path: Path) -> None:
+        mock = AsyncMock(return_value=("error output", 1))
+
+        m = AgenticMutator(project_path=tmp_path)
+        result = _make_execution_result(failed=[{"task_id": "t1"}])
+
+        with patch(_INVOKE_AGENT, mock):
+            p = m.propose(Surface(prompt_slots={"skill": "x"}), result, [])
+
+        assert p.prompt_edits == []
+        assert "exit code 1" in p.reasoning
+
+
+class TestParseJson:
+    def test_direct_json(self) -> None:
+        data = {"edits": [], "reasoning": "ok"}
+        assert _parse_json(json.dumps(data)) == data
+
+    def test_markdown_code_block(self) -> None:
+        text = 'Here is my analysis:\n```json\n{"edits": [{"slot": "s", "old": "a", "new": "b"}], "reasoning": "test"}\n```\nDone.'
+        result = _parse_json(text)
+        assert result is not None
+        assert len(result["edits"]) == 1
+
+    def test_embedded_json_object(self) -> None:
+        text = 'Some preamble text. {"edits": [], "reasoning": "found it"} and more text.'
+        result = _parse_json(text)
+        assert result is not None
+        assert result["reasoning"] == "found it"
+
+    def test_no_json_returns_none(self) -> None:
+        assert _parse_json("no json here at all") is None
+
+    def test_json_without_edits_or_reasoning_ignored(self) -> None:
+        text = '{"unrelated": true}'
+        assert _parse_json(text) is None
+
+
+class TestSlotEditGeneration:
+    def test_multiple_edits(self, tmp_path: Path) -> None:
+        response = json.dumps({
+            "edits": [
+                {"slot": "skill", "old": "a", "new": "b"},
+                {"slot": "system", "old": "c", "new": "d"},
+            ],
+            "reasoning": "multi-edit",
+        })
+        mock = AsyncMock(return_value=(response, 0))
+
+        m = AgenticMutator(project_path=tmp_path)
+        result = _make_execution_result(failed=[{"task_id": "t1"}])
+        surface = Surface(prompt_slots={"skill": "a", "system": "c"})
+
+        with patch(_INVOKE_AGENT, mock):
+            p = m.propose(surface, result, [])
+
+        assert len(p.prompt_edits) == 2
+        assert p.prompt_edits[0].slot_name == "skill"
+        assert p.prompt_edits[1].slot_name == "system"
+
+    def test_malformed_edit_entry_skipped(self, tmp_path: Path) -> None:
+        response = json.dumps({
+            "edits": [
+                {"slot": "skill", "old": "a", "new": "b"},
+                "not a dict",
+                {"no_slot_key": True},
+            ],
+            "reasoning": "partial",
+        })
+        mock = AsyncMock(return_value=(response, 0))
+
+        m = AgenticMutator(project_path=tmp_path)
+        result = _make_execution_result(failed=[{"task_id": "t1"}])
+        surface = Surface(prompt_slots={"skill": "a"})
+
+        with patch(_INVOKE_AGENT, mock):
+            p = m.propose(surface, result, [])
+
+        assert len(p.prompt_edits) == 1

--- a/tests/test_optimization/test_executors.py
+++ b/tests/test_optimization/test_executors.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import base64
+import json
+
 from factory.optimization.executors import (
     FactoryCeoExecutor,
     HarborExecutor,
@@ -44,3 +47,102 @@ class TestHarborExecutor:
         from factory.optimization.surface import Surface
         result = e.execute(tmp_path, Surface())
         assert result.returncode == 1
+
+    def test_constructor_params(self) -> None:
+        e = HarborExecutor(
+            docker_host="unix:///run/user/1002/podman/podman.sock",
+            git_ref="abc123",
+            n_tasks=10,
+            concurrency=4,
+            split="test",
+        )
+        assert e.docker_host == "unix:///run/user/1002/podman/podman.sock"
+        assert e.git_ref == "abc123"
+        assert e.n_tasks == 10
+        assert e.concurrency == 4
+        assert e.split == "test"
+
+
+class TestHarborExecutorSkillInjection:
+    def test_skill_base64_in_env(self, tmp_path, monkeypatch) -> None:
+        """When surface has a 'skill' prompt slot, SEARCHQA_SKILL_B64 is set."""
+        from unittest.mock import patch as mock_patch
+        from factory.optimization.surface import Surface
+
+        script = tmp_path / "run-harbor.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        skill_content = "You are a search assistant."
+        surface = Surface(prompt_slots={"skill": skill_content})
+        e = HarborExecutor(harbor_script="run-harbor.sh")
+
+        captured_env = {}
+
+        def mock_run(cmd, cwd=None, env=None):
+            captured_env.update(env or {})
+            import subprocess
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run):
+            e.execute(tmp_path, surface)
+
+        assert "SEARCHQA_SKILL_B64" in captured_env
+        decoded = base64.b64decode(captured_env["SEARCHQA_SKILL_B64"]).decode()
+        assert decoded == skill_content
+
+
+class TestHarborExecutorTaskResultParsing:
+    def test_parses_task_results_from_reward_json(self, tmp_path) -> None:
+        from unittest.mock import patch as mock_patch
+        from factory.optimization.surface import Surface
+
+        script = tmp_path / "run-harbor.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        reward = {
+            "accuracy": 0.5,
+            "tasks": [
+                {"task_id": "q1", "reward": 1.0, "predicted": "Paris", "gold": "Paris", "question": "Capital of France?"},
+                {"task_id": "q2", "reward": 0.0, "predicted": "Berlin", "gold": "London", "question": "Capital of UK?"},
+            ],
+        }
+        (tmp_path / "reward.json").write_text(json.dumps(reward))
+
+        e = HarborExecutor(harbor_script="run-harbor.sh")
+
+        def mock_run(cmd, cwd=None, env=None):
+            import subprocess
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run):
+            result = e.execute(tmp_path, Surface())
+
+        assert len(result.task_results) == 2
+        assert result.task_results[0].task_id == "q1"
+        assert result.task_results[0].reward == 1.0
+        assert result.task_results[1].task_id == "q2"
+        assert result.task_results[1].reward == 0.0
+        assert result.task_results[1].question == "Capital of UK?"
+
+    def test_no_tasks_key_returns_empty(self, tmp_path) -> None:
+        from unittest.mock import patch as mock_patch
+        from factory.optimization.surface import Surface
+
+        script = tmp_path / "run-harbor.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        (tmp_path / "reward.json").write_text(json.dumps({"accuracy": 0.8}))
+
+        e = HarborExecutor(harbor_script="run-harbor.sh")
+
+        def mock_run(cmd, cwd=None, env=None):
+            import subprocess
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run):
+            result = e.execute(tmp_path, Surface())
+
+        assert result.task_results == []

--- a/tests/test_optimization/test_loop.py
+++ b/tests/test_optimization/test_loop.py
@@ -12,12 +12,13 @@ from factory.optimization.types import ExecutionResult, LoopConfig, Patch, StepR
 
 
 class _CountingExecutor:
-    def __init__(self) -> None:
+    def __init__(self, artifacts: list[str] | None = None) -> None:
         self.call_count = 0
+        self._artifacts = artifacts or []
 
     def execute(self, project_dir: Path, surface: Surface, **kwargs: Any) -> ExecutionResult:
         self.call_count += 1
-        return ExecutionResult(returncode=0, artifacts=[], duration_s=1.0)
+        return ExecutionResult(returncode=0, artifacts=self._artifacts, duration_s=1.0)
 
 
 class _FixedScoreEvaluator:
@@ -58,6 +59,25 @@ class _NoOpMutator:
         history: list[StepRecord],
     ) -> Patch:
         return Patch(reasoning="noop")
+
+
+class _PatchMutator:
+    """Returns a fixed patch with prompt edits."""
+
+    def __init__(self, edits: list[tuple[str, str, str]]) -> None:
+        self._edits = edits
+
+    def propose(
+        self,
+        surface: Surface,
+        execution_result: ExecutionResult,
+        history: list[StepRecord],
+    ) -> Patch:
+        from factory.optimization.types import SlotEdit
+        return Patch(
+            prompt_edits=[SlotEdit(slot_name=s, old_value=o, new_value=n) for s, o, n in self._edits],
+            reasoning="test patch",
+        )
 
 
 class TestOptimizationLoopStep:
@@ -116,3 +136,37 @@ class TestOptimizationLoopTrain:
         )
         result = loop.train()
         assert len(result.steps) == 1
+
+
+class TestPatchApplication:
+    def test_accepted_patch_modifies_prompt_slots(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "result.json"
+        artifact.write_text("{}")
+        surface = Surface(prompt_slots={"skill": "original prompt"})
+        mutator = _PatchMutator([("skill", "original prompt", "improved prompt")])
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=surface,
+            executor=_CountingExecutor(artifacts=[str(artifact)]),
+            evaluator=_FixedScoreEvaluator(score=0.8),
+            mutator=mutator,
+        )
+        record = loop.step()
+        assert record.verdict == "keep"
+        assert surface.prompt_slots["skill"] == "improved prompt"
+
+    def test_patch_ignores_unknown_slots(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "result.json"
+        artifact.write_text("{}")
+        surface = Surface(prompt_slots={"skill": "original"})
+        mutator = _PatchMutator([("nonexistent", "old", "new")])
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=surface,
+            executor=_CountingExecutor(artifacts=[str(artifact)]),
+            evaluator=_FixedScoreEvaluator(score=0.8),
+            mutator=mutator,
+        )
+        loop.step()
+        assert "nonexistent" not in surface.prompt_slots
+        assert surface.prompt_slots["skill"] == "original"


### PR DESCRIPTION
Closes #1174

## Changes

- **`factory/optimization/mutators/agentic.py`** (NEW): `AgenticMutator` class implementing the `Mutator` protocol. Reflects on benchmark failures via `invoke_agent('strategist')` and proposes targeted prompt slot edits. Uses three-tier JSON fallback (direct parse → markdown code blocks → regex search) for robust response handling.

- **`factory/optimization/types.py`** (MODIFIED): Added `TaskResult` dataclass with `task_id`, `reward`, `predicted`, `gold`, `question` fields. Extended `ExecutionResult` with `task_results: list[TaskResult]` field for per-task benchmark data.

- **`factory/optimization/loop.py`** (MODIFIED): After gate acceptance, accepted patches now apply their `prompt_edits` to `surface.prompt_slots`, closing the feedback loop so improvements compound across optimization steps.

- **`factory/optimization/executors/harbor.py`** (MODIFIED): Added `SEARCHQA_SKILL_B64` env var injection (base64-encoded skill content from surface prompt_slots), `docker_host`/`git_ref`/`n_tasks`/`concurrency`/`split` constructor params, and per-task result parsing from `reward.json` into `TaskResult` objects.

- **`factory/optimization/mutators/__init__.py`** + **`factory/optimization/__init__.py`** (MODIFIED): Export `AgenticMutator` and `TaskResult` from public API.

- **Tests**: New `test_agentic_mutator.py` (protocol conformance, prompt construction, JSON parsing all 3 tiers, empty patch on no failures, SlotEdit generation, error handling). Extended `test_loop.py` (patch application to surface) and `test_executors.py` (skill injection, task result parsing).

All 103 optimization tests pass. Lint and mypy clean.