### PR TITLE
fix: three bugs blocking inner-outer loop E2E prompt propagation

### DIFF
--- a/benchmarks/run-harbor.sh
+++ b/benchmarks/run-harbor.sh
@@ -399,6 +399,15 @@ else
     echo "    Auth mode:       Direct API (ANTHROPIC_API_KEY)"
 fi
 
+# Skill injection --ae flags (optimization loop injects these)
+SKILL_AE=()
+if [ -n "${FACTORY_SKILL_B64:-}" ]; then
+    SKILL_AE+=(--ae "FACTORY_SKILL_B64=${FACTORY_SKILL_B64}")
+fi
+if [ -n "${SEARCHQA_SKILL_B64:-}" ]; then
+    SKILL_AE+=(--ae "SEARCHQA_SKILL_B64=${SEARCHQA_SKILL_B64}")
+fi
+
 # Common --ae flags (written once)
 COMMON_AE=(
     --ae "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-opus-4-6[1m]}"
@@ -418,7 +427,7 @@ COMMON_AE=(
     --ae "FACTORY_INSTANCE_ID=${INSTANCE_ID}"
 )
 
-HARBOR_CMD+=(${AUTH_AE[@]+"${AUTH_AE[@]}"} "${COMMON_AE[@]}")
+HARBOR_CMD+=(${AUTH_AE[@]+"${AUTH_AE[@]}"} "${COMMON_AE[@]}" ${SKILL_AE[@]+"${SKILL_AE[@]}"})
 
 if [ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]; then
     HARBOR_CMD+=(--mounts '[{"type": "bind", "source": "'"${GCLOUD_ADC}"'", "target": "/tmp/gcloud-adc.json", "read_only": true}]')

--- a/factory/optimization/executors/harbor.py
+++ b/factory/optimization/executors/harbor.py
@@ -75,29 +75,117 @@ class HarborExecutor:
             log.warning("executor.harbor.script_missing", path=str(script))
             return ExecutionResult(returncode=1, artifacts=[], duration_s=0.0)
 
-        log.info("executor.harbor.start", script=str(script))
+        n_tasks = self.n_tasks if self.n_tasks is not None else 5
+        concurrency = self.concurrency if self.concurrency is not None else 2
+
+        cmd: list[str] = [
+            str(script), "searchqa", "--all",
+            "--limit", str(n_tasks),
+            "--concurrency", str(concurrency),
+            "--timeout", "120",
+            "--solver", "factory",
+            "--preserve",
+        ]
+        if self.split:
+            cmd.extend(["--split", self.split])
+
+        log.info("executor.harbor.start", script=str(script), n_tasks=n_tasks)
         start = time.monotonic()
-        result = subprocess.run(
-            [str(script)],
-            cwd=project_dir,
-            env=env,
-        )
+        result = subprocess.run(cmd, cwd=project_dir, env=env)
         duration = time.monotonic() - start
 
         artifacts: list[str] = []
         task_results: list[TaskResult] = []
+
+        jobs_dir = env.get("JOBS_DIR", "")
+        if not jobs_dir:
+            jobs_dir = _find_latest_jobs_dir()
+        if jobs_dir:
+            task_results = _parse_trial_results(Path(jobs_dir))
+            if task_results:
+                artifacts.append(jobs_dir)
+
         reward_path = project_dir / "reward.json"
         if reward_path.exists():
             artifacts.append(str(reward_path))
-            task_results = _parse_task_results(reward_path)
+            if not task_results:
+                task_results = _parse_task_results(reward_path)
 
-        log.info("executor.harbor.done", returncode=result.returncode, duration_s=round(duration, 1))
+        log.info(
+            "executor.harbor.done",
+            returncode=result.returncode,
+            duration_s=round(duration, 1),
+            tasks_parsed=len(task_results),
+        )
         return ExecutionResult(
             returncode=result.returncode,
             artifacts=artifacts,
             duration_s=duration,
             task_results=task_results,
         )
+
+
+def _find_latest_jobs_dir() -> str:
+    """Find the most recently modified searchqa jobs directory in /tmp."""
+    import glob as _glob
+
+    candidates = _glob.glob("/tmp/searchqa-jobs-*")
+    if not candidates:
+        return ""
+    candidates.sort(key=lambda p: Path(p).stat().st_mtime, reverse=True)
+    return candidates[0]
+
+
+def _strip_harbor_suffix(name: str) -> str:
+    """Strip the ``__<7char>`` Harbor suffix from a trial directory name."""
+    if len(name) > 9 and name[-8] == "_" and name[-9] == "_":
+        return name[:-9]
+    return name
+
+
+def _parse_trial_results(jobs_dir: Path) -> list[TaskResult]:
+    """Parse per-task verifier outputs from preserved trial directories."""
+    if not jobs_dir.is_dir():
+        return []
+
+    results: list[TaskResult] = []
+    for trial in sorted(jobs_dir.iterdir()):
+        if not trial.is_dir():
+            continue
+
+        reward_file = trial / "verifier" / "reward.json"
+        reward = 0.0
+        if reward_file.exists():
+            try:
+                data = json.loads(reward_file.read_text())
+                reward = float(data.get("reward", 0.0))
+            except (json.JSONDecodeError, OSError, ValueError):
+                pass
+
+        predicted = ""
+        gold = ""
+        stdout_file = trial / "verifier" / "test-stdout.txt"
+        if stdout_file.exists():
+            try:
+                for line in stdout_file.read_text().splitlines():
+                    if line.startswith("Predicted:"):
+                        predicted = line[len("Predicted:"):].strip()
+                    elif line.startswith("Gold:"):
+                        gold = line[len("Gold:"):].strip()
+            except OSError:
+                pass
+
+        task_id = _strip_harbor_suffix(trial.name)
+        results.append(
+            TaskResult(
+                task_id=task_id,
+                reward=reward,
+                predicted=predicted,
+                gold=gold,
+                question="",
+            )
+        )
+    return results
 
 
 def _parse_task_results(reward_path: Path) -> list[TaskResult]:

--- a/tests/test_optimization/test_executors.py
+++ b/tests/test_optimization/test_executors.py
@@ -10,6 +10,10 @@ from factory.optimization.executors import (
     HarborExecutor,
     WorkflowRunExecutor,
 )
+from factory.optimization.executors.harbor import (
+    _parse_trial_results,
+    _strip_harbor_suffix,
+)
 from factory.optimization.protocols import Executor
 
 
@@ -84,7 +88,8 @@ class TestHarborExecutorSkillInjection:
             import subprocess
             return subprocess.CompletedProcess(cmd, 0)
 
-        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run):
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.executors.harbor._find_latest_jobs_dir", return_value=""):
             e.execute(tmp_path, surface)
 
         assert "SEARCHQA_SKILL_B64" in captured_env
@@ -116,7 +121,8 @@ class TestHarborExecutorTaskResultParsing:
             import subprocess
             return subprocess.CompletedProcess(cmd, 0)
 
-        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run):
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.executors.harbor._find_latest_jobs_dir", return_value=""):
             result = e.execute(tmp_path, Surface())
 
         assert len(result.task_results) == 2
@@ -142,7 +148,205 @@ class TestHarborExecutorTaskResultParsing:
             import subprocess
             return subprocess.CompletedProcess(cmd, 0)
 
-        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run):
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.executors.harbor._find_latest_jobs_dir", return_value=""):
             result = e.execute(tmp_path, Surface())
 
         assert result.task_results == []
+
+
+class TestHarborExecutorCommand:
+    """Tests for full command construction with arguments."""
+
+    def test_default_command_args(self, tmp_path) -> None:
+        from unittest.mock import patch as mock_patch
+        from factory.optimization.surface import Surface
+
+        script = tmp_path / "run-harbor.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        e = HarborExecutor(harbor_script="run-harbor.sh")
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None):
+            captured_cmd.extend(cmd)
+            import subprocess
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.executors.harbor._find_latest_jobs_dir", return_value=""):
+            e.execute(tmp_path, Surface())
+
+        assert captured_cmd[1] == "searchqa"
+        assert "--all" in captured_cmd
+        assert "--limit" in captured_cmd
+        assert captured_cmd[captured_cmd.index("--limit") + 1] == "5"
+        assert "--concurrency" in captured_cmd
+        assert captured_cmd[captured_cmd.index("--concurrency") + 1] == "2"
+        assert "--timeout" in captured_cmd
+        assert captured_cmd[captured_cmd.index("--timeout") + 1] == "120"
+        assert "--solver" in captured_cmd
+        assert captured_cmd[captured_cmd.index("--solver") + 1] == "factory"
+        assert "--preserve" in captured_cmd
+
+    def test_custom_n_tasks_and_concurrency(self, tmp_path) -> None:
+        from unittest.mock import patch as mock_patch
+        from factory.optimization.surface import Surface
+
+        script = tmp_path / "run-harbor.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        e = HarborExecutor(harbor_script="run-harbor.sh", n_tasks=20, concurrency=8)
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None):
+            captured_cmd.extend(cmd)
+            import subprocess
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.executors.harbor._find_latest_jobs_dir", return_value=""):
+            e.execute(tmp_path, Surface())
+
+        assert captured_cmd[captured_cmd.index("--limit") + 1] == "20"
+        assert captured_cmd[captured_cmd.index("--concurrency") + 1] == "8"
+
+    def test_split_flag_included(self, tmp_path) -> None:
+        from unittest.mock import patch as mock_patch
+        from factory.optimization.surface import Surface
+
+        script = tmp_path / "run-harbor.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        e = HarborExecutor(harbor_script="run-harbor.sh", split="dev")
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None):
+            captured_cmd.extend(cmd)
+            import subprocess
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.executors.harbor._find_latest_jobs_dir", return_value=""):
+            e.execute(tmp_path, Surface())
+
+        assert "--split" in captured_cmd
+        assert captured_cmd[captured_cmd.index("--split") + 1] == "dev"
+
+    def test_no_split_omits_flag(self, tmp_path) -> None:
+        from unittest.mock import patch as mock_patch
+        from factory.optimization.surface import Surface
+
+        script = tmp_path / "run-harbor.sh"
+        script.write_text("#!/bin/bash\necho ok")
+        script.chmod(0o755)
+
+        e = HarborExecutor(harbor_script="run-harbor.sh")
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None):
+            captured_cmd.extend(cmd)
+            import subprocess
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with mock_patch("factory.optimization.executors.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.executors.harbor._find_latest_jobs_dir", return_value=""):
+            e.execute(tmp_path, Surface())
+
+        assert "--split" not in captured_cmd
+
+
+class TestStripHarborSuffix:
+    """Tests for _strip_harbor_suffix helper."""
+
+    def test_strips_7char_suffix(self) -> None:
+        assert _strip_harbor_suffix("my-task__abc1234") == "my-task"
+
+    def test_preserves_name_without_suffix(self) -> None:
+        assert _strip_harbor_suffix("my-task") == "my-task"
+
+    def test_preserves_single_underscore(self) -> None:
+        assert _strip_harbor_suffix("my_task") == "my_task"
+
+    def test_handles_complex_task_id(self) -> None:
+        assert _strip_harbor_suffix("nq-train-12345__xf9g2h1") == "nq-train-12345"
+
+    def test_short_name_not_stripped(self) -> None:
+        assert _strip_harbor_suffix("a__b1c2d3e") == "a"
+
+    def test_too_short_returns_unchanged(self) -> None:
+        assert _strip_harbor_suffix("__abc1234") == "__abc1234"
+
+
+class TestParseTrialResults:
+    """Tests for _parse_trial_results — parsing per-task verifier outputs."""
+
+    def test_parses_reward_and_stdout(self, tmp_path) -> None:
+        trial = tmp_path / "task-001__abc1234"
+        verifier = trial / "verifier"
+        verifier.mkdir(parents=True)
+        verifier.joinpath("reward.json").write_text(json.dumps({"reward": 1.0}))
+        verifier.joinpath("test-stdout.txt").write_text(
+            "Running test...\nPredicted: Paris\nGold: ['Paris']\nPASS\n"
+        )
+
+        results = _parse_trial_results(tmp_path)
+        assert len(results) == 1
+        assert results[0].task_id == "task-001"
+        assert results[0].reward == 1.0
+        assert results[0].predicted == "Paris"
+        assert results[0].gold == "['Paris']"
+        assert results[0].question == ""
+
+    def test_missing_reward_defaults_zero(self, tmp_path) -> None:
+        trial = tmp_path / "task-002__xyz5678"
+        trial.mkdir(parents=True)
+
+        results = _parse_trial_results(tmp_path)
+        assert len(results) == 1
+        assert results[0].task_id == "task-002"
+        assert results[0].reward == 0.0
+
+    def test_missing_stdout_empty_strings(self, tmp_path) -> None:
+        trial = tmp_path / "task-003__abc1234"
+        verifier = trial / "verifier"
+        verifier.mkdir(parents=True)
+        verifier.joinpath("reward.json").write_text(json.dumps({"reward": 0.5}))
+
+        results = _parse_trial_results(tmp_path)
+        assert len(results) == 1
+        assert results[0].predicted == ""
+        assert results[0].gold == ""
+
+    def test_multiple_trials(self, tmp_path) -> None:
+        for i, (task, reward) in enumerate([("q1", 1.0), ("q2", 0.0), ("q3", 0.5)]):
+            trial = tmp_path / f"{task}__abcdef{i}"
+            verifier = trial / "verifier"
+            verifier.mkdir(parents=True)
+            verifier.joinpath("reward.json").write_text(json.dumps({"reward": reward}))
+
+        results = _parse_trial_results(tmp_path)
+        assert len(results) == 3
+        rewards = {r.task_id: r.reward for r in results}
+        assert rewards["q1"] == 1.0
+        assert rewards["q2"] == 0.0
+        assert rewards["q3"] == 0.5
+
+    def test_empty_dir_returns_empty(self, tmp_path) -> None:
+        assert _parse_trial_results(tmp_path) == []
+
+    def test_nonexistent_dir_returns_empty(self, tmp_path) -> None:
+        assert _parse_trial_results(tmp_path / "nonexistent") == []
+
+    def test_invalid_reward_json(self, tmp_path) -> None:
+        trial = tmp_path / "task-bad__abc1234"
+        verifier = trial / "verifier"
+        verifier.mkdir(parents=True)
+        verifier.joinpath("reward.json").write_text("not json")
+
+        results = _parse_trial_results(tmp_path)
+        assert len(results) == 1
+        assert results[0].reward == 0.0


### PR DESCRIPTION
Closes #1149

## Changes

- **benchmarks/run-harbor.sh**: Add `SKILL_AE` array that checks for `FACTORY_SKILL_B64` and `SEARCHQA_SKILL_B64` env vars and passes them as `--ae` flags to Harbor containers. Appended to `HARBOR_CMD` alongside `AUTH_AE` and `COMMON_AE`.
- **factory/optimization/executors/harbor.py**: Build full command array with `searchqa`, `--all`, `--limit`, `--concurrency`, `--timeout`, `--solver`, `--preserve` flags instead of bare `[str(script)]`. Parse preserved per-task verifier outputs from trial directories (`verifier/reward.json` for reward scores, `verifier/test-stdout.txt` for Predicted/Gold lines). Falls back to `reward.json` at project root if no trial dirs found.
- **factory/workflow/contributed/searchqa/workflow.py**: Verified `_resolve_prompt()` is called fresh each invocation via `WorkflowRegistry.get_workflow()` — no caching issue, no code change needed.
- **tests/test_optimization/test_executors.py**: Added 17 new tests covering full command construction, `--split` flag, `_strip_harbor_suffix`, `_parse_trial_results` (reward parsing, stdout parsing, multiple trials, edge cases). Fixed existing tests to mock `_find_latest_jobs_dir` for isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)