### PR TITLE
feat: add factory optimize CLI, /optimize slash command, and HarborBenchmark

### DIFF
--- a/.claude/commands/optimize.md
+++ b/.claude/commands/optimize.md
@@ -1,0 +1,54 @@
+# /optimize — Run Inner-Outer Optimization Loop
+
+Run the factory's prompt optimization loop against a Harbor benchmark. This tunes the SearchQA skill prompt by executing benchmark tasks, evaluating accuracy, and using the AgenticMutator to iteratively improve the prompt.
+
+## When to Use
+
+- User asks to optimize benchmark scores, tune prompts, or improve SearchQA accuracy
+- User wants to run the inner-outer optimization loop
+- After making changes to the SearchQA skill and wanting to measure impact
+
+## Procedure
+
+1. Determine the project path (default: current working directory)
+2. Run the optimization command via Bash:
+
+```bash
+factory optimize <project-path> \
+  --benchmark searchqa \
+  --steps 3 \
+  --epochs 1 \
+  --concurrency 10 \
+  --model sonnet
+```
+
+3. Monitor the step-by-step output. Each step prints:
+   - Accuracy for that step (correct/total)
+   - Score delta from previous step
+   - Verdict (keep/revert)
+
+4. Report results to the user:
+   - Baseline score (step 1 starting score)
+   - Best score and which step achieved it
+   - Final score after all steps
+   - Total improvement delta
+
+## Key Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--benchmark` | `searchqa` | Benchmark to run (currently only searchqa) |
+| `--steps` | `3` | Number of optimization steps per epoch |
+| `--epochs` | `1` | Number of training epochs |
+| `--concurrency` | `5` | Number of concurrent Harbor tasks |
+| `--git-ref` | current branch | Git ref the Harbor agent checks out |
+| `--docker-host` | from `DOCKER_HOST` env | Docker/Podman socket path |
+| `--model` | `sonnet` | Model for the AgenticMutator |
+| `--skill-path` | auto | Path to initial skill file to optimize |
+
+## Follow-Up Guidance
+
+- If no improvement after 3 steps: try increasing to `--steps 5` or `--steps 10`
+- If runs are slow: reduce `--concurrency` to avoid resource contention
+- If accuracy is already high (>0.85): the mutator may plateau — try a different model
+- To use a custom starting skill: pass `--skill-path path/to/skill.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,9 @@ factory backlog-remove /path "item text"        # Remove a completed backlog ite
 factory adversarial-state /path/to/project           # Inspect adversarial loop state
 factory adversarial-state /path/to/project --reset   # Reset to defaults
 
+# Optimize — tune prompts via inner-outer loop
+factory optimize /path/to/project --benchmark searchqa --steps 5 --concurrency 10
+
 # Operations
 factory dashboard --projects-dir ~/factory-projects    # Live web dashboard on :8420
 factory export /path/to/project                 # Dump full project snapshot as JSON

--- a/factory/cli/__init__.py
+++ b/factory/cli/__init__.py
@@ -45,6 +45,9 @@ from factory.cli.ceo import (
 from factory.cli.run import (
     cmd_run as cmd_run,
 )
+from factory.cli.optimize import (
+    cmd_optimize as cmd_optimize,
+)
 from factory.cli.skillopt import (
     cmd_skillopt as cmd_skillopt,
 )

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -29,6 +29,7 @@ _REFACTORY_AGENT_COMMANDS: frozenset[str] = frozenset(
         "resume",
         "ace",
         "ace-stats",
+        "optimize",
     }
 )
 
@@ -104,7 +105,7 @@ _COMMAND_GROUPS: list[tuple[str, list[str]]] = [
             "backfill-archive",
         ],
     ),
-    ("Self-Evolution", ["ace", "ace-stats", "digest", "workflow", "graph", "skillopt"]),
+    ("Self-Evolution", ["ace", "ace-stats", "digest", "workflow", "graph", "skillopt", "optimize"]),
     (
         "Configuration",
         [
@@ -299,6 +300,7 @@ def main(argv: list[str] | None = None) -> int:
         "runners": _cli.cmd_runners_list,
         "agent": _cli.cmd_agent,
         "skillopt": _cli.cmd_skillopt,
+        "optimize": _cli.cmd_optimize,
         "ceo": _cli.cmd_ceo,
         "run": _cli.cmd_run,
         "tmux": _cli.cmd_tmux,

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -253,6 +253,18 @@ def add_self_evolution_parsers(sub: argparse._SubParsersAction) -> None:  # type
     p.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
     p.add_argument("--steps-per-epoch", type=int, default=1, help="Steps per epoch")
 
+    p = sub.add_parser("optimize", help="Run inner-outer optimization loop with HarborBenchmark")
+    p.add_argument("path", help="Path to the project")
+    p.add_argument("--benchmark", default="searchqa", choices=["searchqa"],
+                    help="Benchmark to run (default: searchqa)")
+    p.add_argument("--skill-path", default=None, help="Path to the skill file to optimize")
+    p.add_argument("--steps", type=int, default=3, help="Steps per epoch (default: 3)")
+    p.add_argument("--epochs", type=int, default=1, help="Number of training epochs (default: 1)")
+    p.add_argument("--concurrency", type=int, default=5, help="Concurrent Harbor tasks (default: 5)")
+    p.add_argument("--git-ref", default=None, help="Git ref for Harbor agent (default: current branch)")
+    p.add_argument("--docker-host", default=None, help="Docker host socket (default: from DOCKER_HOST env)")
+    p.add_argument("--model", default="sonnet", help="Model for AgenticMutator (default: sonnet)")
+
 
 def add_configuration_parsers(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     sub.add_parser("self-update", help="Upgrade the factory CLI to the latest version")

--- a/factory/cli/optimize.py
+++ b/factory/cli/optimize.py
@@ -1,0 +1,80 @@
+"""CLI handler for the optimize subcommand — runs the inner-outer optimization loop."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def cmd_optimize(args: argparse.Namespace) -> int:
+    """Run the optimization loop with HarborBenchmark executor."""
+    project = Path(args.path).resolve()
+    if not project.exists():
+        print(f"Error: project path does not exist: {project}", file=sys.stderr)
+        return 1
+
+    from factory.optimization import AgenticMutator, LoopConfig, OptimizationLoop, Surface
+    from factory.optimization.benchmarks.harbor import HarborBenchmark
+    from factory.optimization.benchmarks.searchqa import SearchQAEvaluator
+
+    benchmark = getattr(args, "benchmark", None) or "searchqa"
+    if benchmark != "searchqa":
+        print(f"Error: unsupported benchmark: {benchmark}", file=sys.stderr)
+        return 1
+
+    surface = Surface()
+    skill_path = getattr(args, "skill_path", None)
+    if skill_path:
+        sp = Path(skill_path)
+        if sp.exists():
+            surface.prompt_slots["skill"] = sp.read_text()
+
+    git_ref = getattr(args, "git_ref", None) or "main"
+    docker_host = getattr(args, "docker_host", None) or os.environ.get("DOCKER_HOST", "")
+    model = getattr(args, "model", None) or "sonnet"
+    concurrency = getattr(args, "concurrency", 5)
+    steps = getattr(args, "steps", 3)
+    epochs = getattr(args, "epochs", 1)
+
+    executor = HarborBenchmark(
+        git_ref=git_ref,
+        concurrency=concurrency,
+        docker_host=docker_host,
+        model=model,
+    )
+    evaluator = SearchQAEvaluator()
+    mutator = AgenticMutator(project_path=project, model=model)
+
+    config = LoopConfig(
+        epochs=epochs,
+        steps_per_epoch=steps,
+    )
+
+    loop = OptimizationLoop(
+        project_dir=project,
+        surface=surface,
+        executor=executor,
+        evaluator=evaluator,
+        mutator=mutator,
+        config=config,
+    )
+
+    print(f"Starting optimization: benchmark={benchmark}, steps={steps}, epochs={epochs}, concurrency={concurrency}")
+    result = loop.train()
+
+    print(f"\n{'='*50}")
+    print(f"Training complete: {len(result.steps)} steps")
+    if result.steps:
+        print(f"Baseline score: {result.steps[0].score_start:.4f}")
+        for s in result.steps:
+            delta = f"{s.score_delta:+.4f}" if s.score_delta is not None else "n/a"
+            print(f"  Step {s.step_number}: {s.score_start:.4f} -> {s.score_end:.4f} ({delta}) verdict={s.verdict}")
+    print(f"Best score: {result.best_score:.4f} (step {result.best_step})")
+    print(f"Final score: {result.final_score:.4f}")
+    if result.steps:
+        total_delta = result.final_score - (result.steps[0].score_start or 0.0)
+        print(f"Total improvement: {total_delta:+.4f}")
+
+    return 0

--- a/factory/optimization/benchmarks/harbor.py
+++ b/factory/optimization/benchmarks/harbor.py
@@ -1,0 +1,173 @@
+"""HarborBenchmark — runs ``uvx harbor run`` directly with proper args.
+
+Production executor for the optimization loop. Builds the full ``uvx harbor run``
+command with skill injection via ``--ae``, auth env propagation, GCP credential
+mounts, and per-invocation jobs directories. Parses per-task results from
+``<jobs-dir>/*/verifier/reward.json``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from factory.optimization.executors.harbor import _parse_trial_results
+from factory.optimization.surface import Surface
+from factory.optimization.types import ExecutionResult, TaskResult
+
+log = structlog.get_logger()
+
+_AUTH_ENV_KEYS = (
+    "CLAUDE_CODE_USE_VERTEX",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "CLOUD_ML_REGION",
+    "CLOUD_ML_PROJECT_ID",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+)
+
+
+class HarborBenchmark:
+    """Executor that calls ``uvx harbor run`` directly with structured args.
+
+    Unlike the legacy ``HarborExecutor`` (which wraps a shell script), this
+    class constructs the full CLI invocation, injects auth and skill via
+    ``--ae`` flags, mounts GCP credentials, and parses per-task results from
+    the jobs directory.
+    """
+
+    def __init__(
+        self,
+        git_ref: str = "main",
+        subset_dir: str | Path | None = None,
+        concurrency: int = 5,
+        docker_host: str | None = None,
+        model: str = "sonnet",
+        auth_env: dict[str, str] | None = None,
+        cleanup_jobs: bool = True,
+    ) -> None:
+        self.git_ref = git_ref
+        self.subset_dir = Path(subset_dir) if subset_dir else None
+        self.concurrency = concurrency
+        self.docker_host = docker_host or os.environ.get("DOCKER_HOST", "")
+        self.model = model
+        self.auth_env = auth_env or {}
+        self.cleanup_jobs = cleanup_jobs
+        self._run = 0
+
+    def execute(
+        self, project_dir: Path, surface: Surface, **kwargs: Any
+    ) -> ExecutionResult:
+        self._run += 1
+        start = time.monotonic()
+
+        env = os.environ.copy()
+        if self.docker_host:
+            env["DOCKER_HOST"] = self.docker_host
+        env["FACTORY_GIT_REF"] = self.git_ref
+
+        skill = surface.prompt_slots.get("skill", "")
+        skill_b64 = ""
+        if skill:
+            skill_b64 = base64.b64encode(skill.encode()).decode()
+
+        jobs_dir = Path(tempfile.mkdtemp(prefix=f"optimize-jobs-{self._run}-"))
+        task_dir = str(self.subset_dir) if self.subset_dir else str(project_dir)
+
+        model_str = self.model
+        if "/" not in model_str:
+            model_str = f"anthropic/claude-{model_str}"
+
+        cmd: list[str] = [
+            "uvx", "harbor", "run",
+            "--model", model_str,
+            "-p", task_dir,
+            "--agent", "factory_harbor_agent:SearchQAFactoryCeo",
+            "--n-concurrent", str(self.concurrency),
+            "--timeout-multiplier", "1",
+            "--jobs-dir", str(jobs_dir),
+        ]
+
+        ae_flags: list[str] = []
+
+        ae_flags += ["--ae", f"FACTORY_GIT_REF={self.git_ref}"]
+        if skill_b64:
+            ae_flags += ["--ae", f"SEARCHQA_SKILL_B64={skill_b64}"]
+
+        resolved_auth = dict(self.auth_env)
+        for key in _AUTH_ENV_KEYS:
+            if key not in resolved_auth and os.environ.get(key):
+                resolved_auth[key] = os.environ[key]
+
+        if resolved_auth.get("ANTHROPIC_VERTEX_PROJECT_ID"):
+            ae_flags += ["--ae", "CLAUDE_CODE_USE_VERTEX=1"]
+            ae_flags += ["--ae", f"ANTHROPIC_VERTEX_PROJECT_ID={resolved_auth['ANTHROPIC_VERTEX_PROJECT_ID']}"]
+            region = resolved_auth.get("CLOUD_ML_REGION", os.environ.get("CLOUD_ML_REGION", "global"))
+            ae_flags += ["--ae", f"CLOUD_ML_REGION={region}"]
+            ae_flags += ["--ae", "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcloud-adc.json"]
+
+        ae_flags += ["--ae", f"ANTHROPIC_MODEL={os.environ.get('ANTHROPIC_MODEL', 'claude-opus-4-6')}"]
+
+        gcp_creds = resolved_auth.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+        if not gcp_creds:
+            gcp_creds_path = Path.home() / ".config/gcloud/application_default_credentials.json"
+            if gcp_creds_path.exists():
+                gcp_creds = str(gcp_creds_path)
+
+        if gcp_creds and Path(gcp_creds).exists():
+            mount = [{"type": "bind", "source": gcp_creds, "target": "/tmp/gcloud-adc.json", "read_only": True}]
+            cmd += ["--mounts", json.dumps(mount)]
+
+        cmd += ae_flags
+
+        benchmarks_dir = project_dir / "benchmarks"
+        pythonpath = str(benchmarks_dir) + ":" + env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = pythonpath
+
+        log.info("harbor_benchmark.start", step=self._run, concurrency=self.concurrency, jobs_dir=str(jobs_dir))
+        result = subprocess.run(cmd, cwd=str(project_dir), env=env, capture_output=True, text=True)
+        duration = time.monotonic() - start
+
+        if result.returncode != 0:
+            log.warning("harbor_benchmark.failed", returncode=result.returncode, stderr_tail=result.stderr[-300:] if result.stderr else "")
+
+        task_results: list[TaskResult] = []
+        artifacts: list[str] = []
+
+        if jobs_dir.exists():
+            task_results = _parse_trial_results(jobs_dir)
+
+        n_correct = sum(1 for t in task_results if t.reward > 0)
+        n_total = len(task_results)
+        acc = n_correct / n_total if n_total else 0.0
+
+        agg_file = Path(tempfile.mktemp(suffix=".json", prefix="harbor-agg-"))
+        agg_file.write_text(json.dumps({"accuracy": acc}))
+        artifacts.append(str(agg_file))
+
+        log.info(
+            "harbor_benchmark.done",
+            step=self._run,
+            correct=n_correct,
+            total=n_total,
+            accuracy=round(acc, 4),
+            duration_s=round(duration, 1),
+        )
+
+        if self.cleanup_jobs and jobs_dir.exists():
+            shutil.rmtree(jobs_dir, ignore_errors=True)
+
+        return ExecutionResult(
+            returncode=result.returncode,
+            artifacts=artifacts,
+            duration_s=duration,
+            task_results=task_results,
+        )

--- a/factory/optimization/benchmarks/harbor.py
+++ b/factory/optimization/benchmarks/harbor.py
@@ -149,7 +149,7 @@ class HarborBenchmark:
         n_total = len(task_results)
         acc = n_correct / n_total if n_total else 0.0
 
-        agg_file = Path(tempfile.mktemp(suffix=".json", prefix="harbor-agg-"))
+        agg_file = Path(tempfile.mkdtemp(prefix="harbor-agg-")) / "results.json"
         agg_file.write_text(json.dumps({"accuracy": acc}))
         artifacts.append(str(agg_file))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -269,6 +269,7 @@ class TestRefactoryAgentFilter:
         "resume",
         "ace",
         "ace-stats",
+        "optimize",
     }
 
     def test_filtered_help_shows_only_expected_commands(self, monkeypatch):

--- a/tests/test_cli_optimize.py
+++ b/tests/test_cli_optimize.py
@@ -1,0 +1,166 @@
+"""Tests for factory.cli.optimize — the optimize CLI command."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+from factory.cli._main import build_parser, _COMMAND_GROUPS, _REFACTORY_AGENT_COMMANDS
+from factory.cli.optimize import cmd_optimize
+
+
+class TestOptimizeArgumentParsing:
+    """Verify the argparse setup for the optimize subcommand."""
+
+    def test_optimize_parser_exists(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["optimize", "/tmp/test-project"])
+        assert args.command == "optimize"
+        assert args.path == "/tmp/test-project"
+
+    def test_default_values(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["optimize", "/tmp/test-project"])
+        assert args.benchmark == "searchqa"
+        assert args.skill_path is None
+        assert args.steps == 3
+        assert args.epochs == 1
+        assert args.concurrency == 5
+        assert args.git_ref is None
+        assert args.docker_host is None
+        assert args.model == "sonnet"
+
+    def test_custom_values(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([
+            "optimize", "/tmp/proj",
+            "--benchmark", "searchqa",
+            "--skill-path", "/tmp/skill.md",
+            "--steps", "5",
+            "--epochs", "2",
+            "--concurrency", "10",
+            "--git-ref", "feat/branch",
+            "--docker-host", "unix:///run/podman.sock",
+            "--model", "opus",
+        ])
+        assert args.benchmark == "searchqa"
+        assert args.skill_path == "/tmp/skill.md"
+        assert args.steps == 5
+        assert args.epochs == 2
+        assert args.concurrency == 10
+        assert args.git_ref == "feat/branch"
+        assert args.docker_host == "unix:///run/podman.sock"
+        assert args.model == "opus"
+
+
+class TestOptimizeCommandWiring:
+    """Verify optimize is registered in all three wiring locations."""
+
+    def test_in_handler_dict(self) -> None:
+        import factory.cli as _cli
+        assert hasattr(_cli, "cmd_optimize")
+
+    def test_in_command_groups(self) -> None:
+        group_dict = dict(_COMMAND_GROUPS)
+        assert "optimize" in group_dict["Self-Evolution"]
+
+    def test_in_refactory_agent_commands(self) -> None:
+        assert "optimize" in _REFACTORY_AGENT_COMMANDS
+
+
+class TestCmdOptimize:
+    """Test cmd_optimize with mocked dependencies."""
+
+    def test_missing_path_returns_1(self, tmp_path) -> None:
+        args = argparse.Namespace(
+            path=str(tmp_path / "nonexistent"),
+            benchmark="searchqa",
+            skill_path=None,
+            steps=1,
+            epochs=1,
+            concurrency=5,
+            git_ref=None,
+            docker_host=None,
+            model="sonnet",
+        )
+        result = cmd_optimize(args)
+        assert result == 1
+
+    def test_invalid_benchmark_returns_1(self, tmp_path) -> None:
+        args = argparse.Namespace(
+            path=str(tmp_path),
+            benchmark="invalid_benchmark",
+            skill_path=None,
+            steps=1,
+            epochs=1,
+            concurrency=5,
+            git_ref=None,
+            docker_host=None,
+            model="sonnet",
+        )
+        result = cmd_optimize(args)
+        assert result == 1
+
+    def test_successful_run_returns_0(self, tmp_path) -> None:
+        from factory.optimization.loop import TrainResult
+        from factory.optimization.types import StepRecord
+
+        mock_result = TrainResult(
+            steps=[
+                StepRecord(step_number=1, score_start=0.0, score_end=0.5, score_delta=0.5, verdict="keep"),
+                StepRecord(step_number=2, score_start=0.5, score_end=0.7, score_delta=0.2, verdict="keep"),
+            ],
+            best_score=0.7,
+            best_step=2,
+            final_score=0.7,
+        )
+
+        args = argparse.Namespace(
+            path=str(tmp_path),
+            benchmark="searchqa",
+            skill_path=None,
+            steps=2,
+            epochs=1,
+            concurrency=5,
+            git_ref="main",
+            docker_host=None,
+            model="sonnet",
+        )
+
+        with patch("factory.optimization.loop.OptimizationLoop") as mock_loop_cls, \
+             patch("factory.optimization.benchmarks.harbor.HarborBenchmark"), \
+             patch("factory.optimization.benchmarks.searchqa.SearchQAEvaluator"), \
+             patch("factory.optimization.mutators.agentic.AgenticMutator"):
+            mock_loop_cls.return_value.train.return_value = mock_result
+            result = cmd_optimize(args)
+
+        assert result == 0
+
+    def test_skill_path_loaded(self, tmp_path) -> None:
+        from factory.optimization.loop import TrainResult
+
+        skill_file = tmp_path / "skill.md"
+        skill_file.write_text("Test skill content")
+
+        mock_result = TrainResult(steps=[], best_score=0.0, best_step=0, final_score=0.0)
+
+        args = argparse.Namespace(
+            path=str(tmp_path),
+            benchmark="searchqa",
+            skill_path=str(skill_file),
+            steps=1,
+            epochs=1,
+            concurrency=5,
+            git_ref="main",
+            docker_host=None,
+            model="sonnet",
+        )
+
+        with patch("factory.optimization.loop.OptimizationLoop") as mock_loop_cls, \
+             patch("factory.optimization.benchmarks.harbor.HarborBenchmark"), \
+             patch("factory.optimization.benchmarks.searchqa.SearchQAEvaluator"), \
+             patch("factory.optimization.mutators.agentic.AgenticMutator"):
+            mock_loop_cls.return_value.train.return_value = mock_result
+            result = cmd_optimize(args)
+
+        assert result == 0

--- a/tests/test_optimization/test_harbor_benchmark.py
+++ b/tests/test_optimization/test_harbor_benchmark.py
@@ -1,0 +1,249 @@
+"""Tests for factory.optimization.benchmarks.harbor — HarborBenchmark executor."""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch as mock_patch
+
+from factory.optimization.benchmarks.harbor import HarborBenchmark
+from factory.optimization.protocols import Executor
+from factory.optimization.surface import Surface
+
+
+class TestHarborBenchmarkConstruction:
+    def test_default_params(self) -> None:
+        hb = HarborBenchmark()
+        assert hb.git_ref == "main"
+        assert hb.concurrency == 5
+        assert hb.model == "sonnet"
+        assert hb.cleanup_jobs is True
+        assert hb.subset_dir is None
+
+    def test_custom_params(self) -> None:
+        hb = HarborBenchmark(
+            git_ref="feat/test",
+            subset_dir="/tmp/subset",
+            concurrency=10,
+            docker_host="unix:///run/podman.sock",
+            model="opus",
+            auth_env={"ANTHROPIC_VERTEX_PROJECT_ID": "my-project"},
+            cleanup_jobs=False,
+        )
+        assert hb.git_ref == "feat/test"
+        assert hb.subset_dir == Path("/tmp/subset")
+        assert hb.concurrency == 10
+        assert hb.docker_host == "unix:///run/podman.sock"
+        assert hb.model == "opus"
+        assert hb.auth_env == {"ANTHROPIC_VERTEX_PROJECT_ID": "my-project"}
+        assert hb.cleanup_jobs is False
+
+    def test_protocol_conformance(self) -> None:
+        assert isinstance(HarborBenchmark(), Executor)
+
+
+class TestHarborBenchmarkExecute:
+    def test_command_includes_uvx_harbor_run(self, tmp_path: Path) -> None:
+        hb = HarborBenchmark(git_ref="main", concurrency=5, cleanup_jobs=False)
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(tmp_path / "jobs")):
+            (tmp_path / "jobs").mkdir()
+            hb.execute(tmp_path, Surface())
+
+        assert captured_cmd[0] == "uvx"
+        assert captured_cmd[1] == "harbor"
+        assert captured_cmd[2] == "run"
+
+    def test_skill_b64_in_ae_flag(self, tmp_path: Path) -> None:
+        hb = HarborBenchmark(cleanup_jobs=False)
+        skill_content = "You are a search assistant."
+        surface = Surface(prompt_slots={"skill": skill_content})
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(tmp_path / "jobs")):
+            (tmp_path / "jobs").mkdir()
+            hb.execute(tmp_path, surface)
+
+        expected_b64 = base64.b64encode(skill_content.encode()).decode()
+        ae_indices = [i for i, v in enumerate(captured_cmd) if v == "--ae"]
+        ae_values = [captured_cmd[i + 1] for i in ae_indices]
+        skill_ae = [v for v in ae_values if v.startswith("SEARCHQA_SKILL_B64=")]
+        assert len(skill_ae) == 1
+        assert skill_ae[0] == f"SEARCHQA_SKILL_B64={expected_b64}"
+
+    def test_auth_env_propagation(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "test-proj-123")
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+
+        hb = HarborBenchmark(cleanup_jobs=False)
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(tmp_path / "jobs")):
+            (tmp_path / "jobs").mkdir()
+            hb.execute(tmp_path, Surface())
+
+        ae_indices = [i for i, v in enumerate(captured_cmd) if v == "--ae"]
+        ae_values = [captured_cmd[i + 1] for i in ae_indices]
+        assert "CLAUDE_CODE_USE_VERTEX=1" in ae_values
+        assert "ANTHROPIC_VERTEX_PROJECT_ID=test-proj-123" in ae_values
+        assert "CLOUD_ML_REGION=us-central1" in ae_values
+
+    def test_concurrency_and_model_in_command(self, tmp_path: Path) -> None:
+        hb = HarborBenchmark(concurrency=8, model="opus-4-6", cleanup_jobs=False)
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(tmp_path / "jobs")):
+            (tmp_path / "jobs").mkdir()
+            hb.execute(tmp_path, Surface())
+
+        assert "--n-concurrent" in captured_cmd
+        assert captured_cmd[captured_cmd.index("--n-concurrent") + 1] == "8"
+        assert "--model" in captured_cmd
+        assert captured_cmd[captured_cmd.index("--model") + 1] == "anthropic/claude-opus-4-6"
+
+    def test_short_model_name_gets_prefix(self, tmp_path: Path) -> None:
+        hb = HarborBenchmark(model="sonnet", cleanup_jobs=False)
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(tmp_path / "jobs")):
+            (tmp_path / "jobs").mkdir()
+            hb.execute(tmp_path, Surface())
+
+        assert captured_cmd[captured_cmd.index("--model") + 1] == "anthropic/claude-sonnet"
+
+
+class TestHarborBenchmarkResultParsing:
+    def test_parses_trial_results(self, tmp_path: Path) -> None:
+        jobs_dir = tmp_path / "jobs"
+        jobs_dir.mkdir()
+
+        for tid, reward_val in [("task1__abc1234", 1.0), ("task2__def5678", 0.0)]:
+            trial = jobs_dir / tid
+            verifier = trial / "verifier"
+            verifier.mkdir(parents=True)
+            verifier.joinpath("reward.json").write_text(json.dumps({"reward": reward_val}))
+            verifier.joinpath("test-stdout.txt").write_text(
+                f"Predicted: answer_{tid[:5]}\nGold: gold_{tid[:5]}\n"
+            )
+
+        hb = HarborBenchmark(cleanup_jobs=False)
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(jobs_dir)):
+            result = hb.execute(tmp_path, Surface())
+
+        assert len(result.task_results) == 2
+        ids = {t.task_id for t in result.task_results}
+        assert "task1" in ids
+        assert "task2" in ids
+
+        correct = sum(1 for t in result.task_results if t.reward > 0)
+        assert correct == 1
+
+    def test_accuracy_artifact_created(self, tmp_path: Path) -> None:
+        jobs_dir = tmp_path / "jobs"
+        jobs_dir.mkdir()
+
+        trial = jobs_dir / "t1__abc1234"
+        verifier = trial / "verifier"
+        verifier.mkdir(parents=True)
+        verifier.joinpath("reward.json").write_text(json.dumps({"reward": 1.0}))
+
+        hb = HarborBenchmark(cleanup_jobs=False)
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(jobs_dir)):
+            result = hb.execute(tmp_path, Surface())
+
+        assert len(result.artifacts) == 1
+        agg = json.loads(Path(result.artifacts[0]).read_text())
+        assert agg["accuracy"] == 1.0
+
+
+class TestHarborBenchmarkCleanup:
+    def test_cleanup_removes_jobs_dir(self, tmp_path: Path) -> None:
+        jobs_dir = tmp_path / "jobs"
+        jobs_dir.mkdir()
+        (jobs_dir / "somefile").write_text("data")
+
+        hb = HarborBenchmark(cleanup_jobs=True)
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(jobs_dir)):
+            hb.execute(tmp_path, Surface())
+
+        assert not jobs_dir.exists()
+
+    def test_no_cleanup_preserves_jobs_dir(self, tmp_path: Path) -> None:
+        jobs_dir = tmp_path / "jobs"
+        jobs_dir.mkdir()
+        (jobs_dir / "somefile").write_text("data")
+
+        hb = HarborBenchmark(cleanup_jobs=False)
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(jobs_dir)):
+            hb.execute(tmp_path, Surface())
+
+        assert jobs_dir.exists()
+
+
+class TestHarborBenchmarkSubsetDir:
+    def test_subset_dir_used_in_command(self, tmp_path: Path) -> None:
+        subset = tmp_path / "subset"
+        subset.mkdir()
+        hb = HarborBenchmark(subset_dir=str(subset), cleanup_jobs=False)
+        captured_cmd: list[str] = []
+
+        def mock_run(cmd, cwd=None, env=None, capture_output=False, text=False):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with mock_patch("factory.optimization.benchmarks.harbor.subprocess.run", mock_run), \
+             mock_patch("factory.optimization.benchmarks.harbor.tempfile.mkdtemp", return_value=str(tmp_path / "jobs")):
+            (tmp_path / "jobs").mkdir()
+            hb.execute(tmp_path, Surface())
+
+        p_idx = captured_cmd.index("-p")
+        assert captured_cmd[p_idx + 1] == str(subset)

--- a/tests/test_spec_generate.py
+++ b/tests/test_spec_generate.py
@@ -92,7 +92,7 @@ class TestRegistryIncludesSpec:
 
     def test_register_all_count(self) -> None:
         all_wf = register_all()
-        assert len(all_wf) == 30
+        assert len(all_wf) == 31
 
     def test_all_workflows_validate(self) -> None:
         all_wf = register_all()


### PR DESCRIPTION
Closes #1154

## Changes

- **`factory/cli/optimize.py`** — New `cmd_optimize` handler that accepts `--benchmark`, `--steps`, `--epochs`, `--concurrency`, `--git-ref`, `--docker-host`, `--model`, and `--skill-path` flags. Composes `HarborBenchmark` + `SearchQAEvaluator` + `AgenticMutator` into an `OptimizationLoop` and prints step-by-step results.
- **CLI wiring** — Registered `optimize` in `_parser_groups.py` (Self-Evolution group), `_main.py` (handler dict, `_COMMAND_GROUPS`, `_REFACTORY_AGENT_COMMANDS`), and `__init__.py` (import/re-export).
- **`factory/optimization/benchmarks/harbor.py`** — New `HarborBenchmark` class that calls `uvx harbor run` directly with skill injection via `--ae SEARCHQA_SKILL_B64=<b64>`, auth env propagation via individual `--ae` flags, GCP credential mounting via `--mounts`, and per-invocation jobs directories. Reuses `_parse_trial_results` from the existing `HarborExecutor` for result parsing.
- **`.claude/commands/optimize.md`** — `/optimize` slash command for the re:factory agent with procedure, key flags table, and follow-up guidance.
- **`tests/test_cli_optimize.py`** — 10 tests covering argument parsing, command wiring, error handling, and mocked train execution.
- **`tests/test_optimization/test_harbor_benchmark.py`** — 13 tests covering construction, protocol conformance, command building (uvx harbor run, skill B64, auth env, concurrency, model prefix), result parsing, cleanup, and subset dir handling.