### PR TITLE
fix: load MCP config from .refactory/.mcp.json for refactory agent

### DIFF
--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -198,6 +198,10 @@ def cmd_refactory(args: argparse.Namespace) -> int:
     if model:
         cmd.extend(["--model", model])
 
+    mcp_config = project_path / ".refactory" / ".mcp.json"
+    if mcp_config.exists():
+        cmd.extend(["--mcp-config", str(mcp_config), "--strict-mcp-config"])
+
     os.chdir(project_path)
     os.execvp("claude", cmd)
     return 0


### PR DESCRIPTION
## Summary

- The refactory agent now uses `--mcp-config` and `--strict-mcp-config` Claude Code flags to load MCP servers exclusively from `.refactory/.mcp.json`
- This prevents CEO sessions and subagents from inheriting MCP servers (like `instant-connect`) that are meant only for the supervisor agent
- Requires moving `.mcp.json` from the project root to `.refactory/.mcp.json` (done locally, not tracked by git)

## Test plan

- [x] Verify `cmd_refactory()` adds `--mcp-config` and `--strict-mcp-config` when `.refactory/.mcp.json` exists
- [ ] Launch refactory agent and confirm it loads instant-connect from `.refactory/.mcp.json`
- [ ] Launch a CEO session and confirm it does NOT load instant-connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)