### PR TITLE
feat: add FeatureBench benchmark to inner-outer optimization loop

### DIFF
--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -255,7 +255,7 @@ def add_self_evolution_parsers(sub: argparse._SubParsersAction) -> None:  # type
 
     p = sub.add_parser("optimize", help="Run inner-outer optimization loop with HarborBenchmark")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--benchmark", default="searchqa", choices=["searchqa"],
+    p.add_argument("--benchmark", default="searchqa", choices=["searchqa", "featurebench"],
                     help="Benchmark to run (default: searchqa)")
     p.add_argument("--skill-path", default=None, help="Path to the skill file to optimize")
     p.add_argument("--steps", type=int, default=3, help="Steps per epoch (default: 3)")

--- a/factory/cli/optimize.py
+++ b/factory/cli/optimize.py
@@ -17,34 +17,59 @@ def cmd_optimize(args: argparse.Namespace) -> int:
 
     from factory.optimization import AgenticMutator, LoopConfig, OptimizationLoop, Surface
     from factory.optimization.benchmarks.harbor import HarborBenchmark
-    from factory.optimization.benchmarks.searchqa import SearchQAEvaluator
+    from factory.optimization.protocols import Evaluator, Executor
 
     benchmark = getattr(args, "benchmark", None) or "searchqa"
-    if benchmark != "searchqa":
-        print(f"Error: unsupported benchmark: {benchmark}", file=sys.stderr)
-        return 1
-
-    surface = Surface()
-    skill_path = getattr(args, "skill_path", None)
-    if skill_path:
-        sp = Path(skill_path)
-        if sp.exists():
-            surface.prompt_slots["skill"] = sp.read_text()
-
     git_ref = getattr(args, "git_ref", None) or "main"
     docker_host = getattr(args, "docker_host", None) or os.environ.get("DOCKER_HOST", "")
-    model = getattr(args, "model", None) or "sonnet"
     concurrency = getattr(args, "concurrency", 5)
     steps = getattr(args, "steps", 3)
     epochs = getattr(args, "epochs", 1)
 
-    executor = HarborBenchmark(
-        git_ref=git_ref,
-        concurrency=concurrency,
-        docker_host=docker_host,
-        model=model,
-    )
-    evaluator = SearchQAEvaluator()
+    evaluator: Evaluator
+    executor: Executor
+    model: str
+
+    match benchmark:
+        case "searchqa":
+            from factory.optimization.benchmarks.searchqa import SearchQAEvaluator
+
+            model = getattr(args, "model", None) or "sonnet"
+            surface = Surface()
+            skill_path = getattr(args, "skill_path", None)
+            if skill_path:
+                sp = Path(skill_path)
+                if sp.exists():
+                    surface.prompt_slots["skill"] = sp.read_text()
+            executor = HarborBenchmark(
+                git_ref=git_ref,
+                concurrency=concurrency,
+                docker_host=docker_host,
+                model=model,
+            )
+            evaluator = SearchQAEvaluator()
+
+        case "featurebench":
+            from factory.optimization.benchmarks.featurebench import (
+                FeatureBenchEvaluator,
+                build_featurebench_executor,
+                build_featurebench_surface,
+            )
+
+            model = getattr(args, "model", None) or "opus"
+            surface = build_featurebench_surface()
+            executor = build_featurebench_executor(
+                git_ref=git_ref,
+                concurrency=concurrency,
+                docker_host=docker_host,
+                model=model,
+            )
+            evaluator = FeatureBenchEvaluator()
+
+        case _:
+            print(f"Error: unsupported benchmark: {benchmark}", file=sys.stderr)
+            return 1
+
     mutator = AgenticMutator(project_path=project, model=model)
 
     config = LoopConfig(

--- a/factory/optimization/benchmarks/featurebench.py
+++ b/factory/optimization/benchmarks/featurebench.py
@@ -1,0 +1,90 @@
+"""FeatureBench benchmark adapter — evaluator, surface, config, and executor builders.
+
+Mirrors the SearchQA adapter pattern but targets the FeatureBench Harbor benchmark
+(feature implementation in Python codebases). Uses ``resolved_rate`` as the primary
+metric instead of ``accuracy``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import structlog
+
+from factory.inner_loop import EvalResult
+from factory.optimization.benchmarks.harbor import HarborBenchmark
+from factory.optimization.surface import Surface
+from factory.optimization.types import LoopConfig
+from factory.workflow.contributed.featurebench import workflow as featurebench_workflow
+
+log = structlog.get_logger()
+
+
+class FeatureBenchEvaluator:
+    """Parses FeatureBench benchmark results from verifier output."""
+
+    def __init__(self, target: float = 0.85) -> None:
+        self.target = target
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        try:
+            data = json.loads(artifact_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return EvalResult(score=0.0, valid=False)
+        score = float(data.get("resolved_rate", data.get("score", 0.0)))
+        return EvalResult(
+            score=score,
+            metrics={k: float(v) for k, v in data.items() if isinstance(v, (int, float))},
+            valid=True,
+            artifacts=[str(artifact_path)],
+        )
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        best = EvalResult(score=0.0, valid=False)
+        for p in artifact_paths:
+            result = self.parse(p)
+            if result.score > best.score:
+                best = result
+        return best
+
+    def get_info(self) -> dict:
+        return {
+            "benchmark": "featurebench",
+            "target": self.target,
+            "metrics": ["resolved_rate", "test_pass_rate"],
+        }
+
+
+def build_featurebench_surface(workflow_path: Path | None = None) -> Surface:
+    """Build a Surface configured for FeatureBench optimization."""
+    wf = featurebench_workflow()
+    frozen = frozenset({"study", "auto_merge"})
+    return Surface(workflow=wf, frozen_nodes=frozen, prompt_slots={})
+
+
+def build_featurebench_config(
+    epochs: int = 3,
+    steps_per_epoch: int = 5,
+) -> LoopConfig:
+    """Build a LoopConfig for FeatureBench optimization."""
+    return LoopConfig(epochs=epochs, steps_per_epoch=steps_per_epoch)
+
+
+def build_featurebench_executor(
+    git_ref: str = "main",
+    subset_dir: str | Path | None = None,
+    concurrency: int = 5,
+    docker_host: str | None = None,
+    model: str = "opus",
+) -> HarborBenchmark:
+    """Build a HarborBenchmark configured for FeatureBench."""
+    return HarborBenchmark(
+        git_ref=git_ref,
+        subset_dir=subset_dir,
+        concurrency=concurrency,
+        docker_host=docker_host,
+        model=model,
+        agent_class="factory_harbor_agent:FeaturebenchFactoryCeo",
+        dataset="featurebench",
+    )

--- a/factory/optimization/benchmarks/harbor.py
+++ b/factory/optimization/benchmarks/harbor.py
@@ -53,6 +53,8 @@ class HarborBenchmark:
         model: str = "sonnet",
         auth_env: dict[str, str] | None = None,
         cleanup_jobs: bool = True,
+        agent_class: str = "factory_harbor_agent:SearchQAFactoryCeo",
+        dataset: str = "searchqa",
     ) -> None:
         self.git_ref = git_ref
         self.subset_dir = Path(subset_dir) if subset_dir else None
@@ -61,6 +63,8 @@ class HarborBenchmark:
         self.model = model
         self.auth_env = auth_env or {}
         self.cleanup_jobs = cleanup_jobs
+        self.agent_class = agent_class
+        self.dataset = dataset
         self._run = 0
 
     def execute(
@@ -90,7 +94,8 @@ class HarborBenchmark:
             "uvx", "harbor", "run",
             "--model", model_str,
             "-p", task_dir,
-            "--agent", "factory_harbor_agent:SearchQAFactoryCeo",
+            "--agent", self.agent_class,
+            "--dataset", self.dataset,
             "--n-concurrent", str(self.concurrency),
             "--timeout-multiplier", "1",
             "--jobs-dir", str(jobs_dir),

--- a/tests/test_optimization/test_featurebench.py
+++ b/tests/test_optimization/test_featurebench.py
@@ -1,0 +1,106 @@
+"""Tests for factory.optimization.benchmarks.featurebench — FeatureBench benchmark adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from factory.optimization.benchmarks.featurebench import (
+    FeatureBenchEvaluator,
+    build_featurebench_config,
+    build_featurebench_executor,
+    build_featurebench_surface,
+)
+from factory.optimization.benchmarks.harbor import HarborBenchmark
+from factory.optimization.protocols import Evaluator
+from factory.optimization.surface import Surface
+from factory.optimization.types import LoopConfig
+
+
+class TestFeatureBenchEvaluator:
+    def test_parse_valid_resolved_rate(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "results.json"
+        artifact.write_text(json.dumps({"resolved_rate": 0.75, "test_pass_rate": 0.9}))
+        result = FeatureBenchEvaluator().parse(artifact)
+        assert result.score == 0.75
+        assert result.valid is True
+        assert result.metrics == {"resolved_rate": 0.75, "test_pass_rate": 0.9}
+        assert str(artifact) in result.artifacts
+
+    def test_parse_fallback_score_key(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "results.json"
+        artifact.write_text(json.dumps({"score": 0.6}))
+        result = FeatureBenchEvaluator().parse(artifact)
+        assert result.score == 0.6
+        assert result.valid is True
+
+    def test_parse_malformed_json(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "results.json"
+        artifact.write_text("not json {{{")
+        result = FeatureBenchEvaluator().parse(artifact)
+        assert result.score == 0.0
+        assert result.valid is False
+
+    def test_parse_missing_file(self, tmp_path: Path) -> None:
+        result = FeatureBenchEvaluator().parse(tmp_path / "nonexistent.json")
+        assert result.score == 0.0
+        assert result.valid is False
+
+    def test_parse_many_returns_best(self, tmp_path: Path) -> None:
+        for i, score in enumerate([0.4, 0.85, 0.6]):
+            p = tmp_path / f"results_{i}.json"
+            p.write_text(json.dumps({"resolved_rate": score}))
+        paths = [tmp_path / f"results_{i}.json" for i in range(3)]
+        result = FeatureBenchEvaluator().parse_many(paths)
+        assert result.score == 0.85
+        assert result.valid is True
+
+    def test_get_info(self) -> None:
+        info = FeatureBenchEvaluator(target=0.90).get_info()
+        assert info["benchmark"] == "featurebench"
+        assert info["target"] == 0.90
+        assert isinstance(info["metrics"], list)
+        assert "resolved_rate" in info["metrics"]
+        assert "test_pass_rate" in info["metrics"]
+
+    def test_protocol_conformance(self) -> None:
+        assert isinstance(FeatureBenchEvaluator(), Evaluator)
+
+
+class TestBuildFeaturebenchSurface:
+    def test_build_surface(self) -> None:
+        surface = build_featurebench_surface()
+        assert isinstance(surface, Surface)
+        assert surface.workflow is not None
+        assert surface.frozen_nodes == frozenset({"study", "auto_merge"})
+        assert surface.prompt_slots == {}
+        mutable = surface.mutable_nodes()
+        assert "builder" in mutable
+        assert "gate_verify" in mutable
+        assert "study" not in mutable
+        assert "auto_merge" not in mutable
+
+
+class TestBuildFeaturebenchConfig:
+    def test_build_config(self) -> None:
+        config = build_featurebench_config()
+        assert isinstance(config, LoopConfig)
+        assert config.epochs == 3
+        assert config.steps_per_epoch == 5
+
+    def test_custom_values(self) -> None:
+        config = build_featurebench_config(epochs=10, steps_per_epoch=20)
+        assert config.epochs == 10
+        assert config.steps_per_epoch == 20
+
+
+class TestBuildFeaturebenchExecutor:
+    def test_build_executor(self) -> None:
+        executor = build_featurebench_executor()
+        assert isinstance(executor, HarborBenchmark)
+        assert executor.agent_class == "factory_harbor_agent:FeaturebenchFactoryCeo"
+        assert executor.dataset == "featurebench"
+
+    def test_build_executor_default_model(self) -> None:
+        executor = build_featurebench_executor()
+        assert executor.model == "opus"


### PR DESCRIPTION
Closes #1098

## Changes

- **New `factory/optimization/benchmarks/featurebench.py`**: FeatureBenchEvaluator (parses `resolved_rate` metric with `score` fallback), `build_featurebench_surface()` (workflow graph with frozen `study`/`auto_merge` nodes), `build_featurebench_config()`, and `build_featurebench_executor()` (HarborBenchmark configured for FeatureBench agent class and dataset, defaults to `opus` model)
- **Parameterized `HarborBenchmark`**: Added `agent_class` and `dataset` constructor params with backward-compatible defaults (`SearchQAFactoryCeo`/`searchqa`), replacing hardcoded values in `execute()`
- **CLI wiring**: Replaced `if benchmark != "searchqa"` guard with `match` dispatch in `factory/cli/optimize.py`, supporting `searchqa`, `featurebench`, and an error fallback
- **12 unit tests**: Evaluator parsing (valid, fallback, malformed, missing), `parse_many`, `get_info`, protocol conformance, surface/config/executor builder validation