### PR TITLE
feat: add dynamic benchmark loader to factory optimize

### DIFF
--- a/.claude/commands/optimize.md
+++ b/.claude/commands/optimize.md
@@ -37,7 +37,8 @@ factory optimize <project-path> \
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--benchmark` | `searchqa` | Benchmark to run (currently only searchqa) |
+| `--benchmark` | `searchqa` | Benchmark to run (`searchqa`, `featurebench`, or `auto`) |
+| `--benchmark-dir` | none | Path to a custom benchmark directory (config.json + executor.py + evaluator.py) |
 | `--steps` | `3` | Number of optimization steps per epoch |
 | `--epochs` | `1` | Number of training epochs |
 | `--concurrency` | `5` | Number of concurrent Harbor tasks |
@@ -45,6 +46,22 @@ factory optimize <project-path> \
 | `--docker-host` | from `DOCKER_HOST` env | Docker/Podman socket path |
 | `--model` | `sonnet` | Model for the AgenticMutator |
 | `--skill-path` | auto | Path to initial skill file to optimize |
+
+## Dynamic Benchmarks
+
+Use `--benchmark auto` to load a benchmark from the project's `.factory/eval/benchmark/` directory, or `--benchmark-dir /path/to/dir` to load from any directory. The directory must contain:
+
+- `config.json` — benchmark metadata (must have `name`; optional `executor_params` and `evaluator_params` dicts)
+- `executor.py` — module with an `Executor` class that has an `execute` method
+- `evaluator.py` — module with an `Evaluator` class that has `parse`, `parse_many`, and `get_info` methods
+
+```bash
+# Auto-detect from project's .factory/eval/benchmark/
+factory optimize /path/to/project --benchmark auto --steps 5
+
+# Explicit directory
+factory optimize /path/to/project --benchmark-dir /path/to/my-benchmark --steps 3
+```
 
 ## Follow-Up Guidance
 

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -255,8 +255,10 @@ def add_self_evolution_parsers(sub: argparse._SubParsersAction) -> None:  # type
 
     p = sub.add_parser("optimize", help="Run inner-outer optimization loop with HarborBenchmark")
     p.add_argument("path", help="Path to the project")
-    p.add_argument("--benchmark", default="searchqa", choices=["searchqa", "featurebench"],
+    p.add_argument("--benchmark", default="searchqa", choices=["searchqa", "featurebench", "auto"],
                     help="Benchmark to run (default: searchqa)")
+    p.add_argument("--benchmark-dir", default=None,
+                    help="Path to benchmark directory with config.json, executor.py, evaluator.py")
     p.add_argument("--skill-path", default=None, help="Path to the skill file to optimize")
     p.add_argument("--steps", type=int, default=3, help="Steps per epoch (default: 3)")
     p.add_argument("--epochs", type=int, default=1, help="Number of training epochs (default: 1)")

--- a/factory/cli/optimize.py
+++ b/factory/cli/optimize.py
@@ -20,6 +20,7 @@ def cmd_optimize(args: argparse.Namespace) -> int:
     from factory.optimization.protocols import Evaluator, Executor
 
     benchmark = getattr(args, "benchmark", None) or "searchqa"
+    benchmark_dir_str = getattr(args, "benchmark_dir", None)
     git_ref = getattr(args, "git_ref", None) or "main"
     docker_host = getattr(args, "docker_host", None) or os.environ.get("DOCKER_HOST", "")
     concurrency = getattr(args, "concurrency", 5)
@@ -30,45 +31,75 @@ def cmd_optimize(args: argparse.Namespace) -> int:
     executor: Executor
     model: str
 
-    match benchmark:
-        case "searchqa":
-            from factory.optimization.benchmarks.searchqa import SearchQAEvaluator
+    use_dynamic = benchmark_dir_str is not None or benchmark == "auto"
 
-            model = getattr(args, "model", None) or "sonnet"
-            surface = Surface()
-            skill_path = getattr(args, "skill_path", None)
-            if skill_path:
-                sp = Path(skill_path)
-                if sp.exists():
-                    surface.prompt_slots["skill"] = sp.read_text()
-            executor = HarborBenchmark(
-                git_ref=git_ref,
-                concurrency=concurrency,
-                docker_host=docker_host,
-                model=model,
-            )
-            evaluator = SearchQAEvaluator()
+    if use_dynamic:
+        from factory.optimization.benchmarks.loader import load_benchmark
 
-        case "featurebench":
-            from factory.optimization.benchmarks.featurebench import (
-                FeatureBenchEvaluator,
-                build_featurebench_executor,
-                build_featurebench_surface,
-            )
+        if benchmark_dir_str:
+            benchmark_dir = Path(benchmark_dir_str).resolve()
+        else:
+            benchmark_dir = project / ".factory" / "eval" / "benchmark"
 
-            model = getattr(args, "model", None) or "opus"
-            surface = build_featurebench_surface()
-            executor = build_featurebench_executor(
-                git_ref=git_ref,
-                concurrency=concurrency,
-                docker_host=docker_host,
-                model=model,
-            )
-            evaluator = FeatureBenchEvaluator()
-
-        case _:
-            print(f"Error: unsupported benchmark: {benchmark}", file=sys.stderr)
+        if not benchmark_dir.is_dir():
+            print(f"Error: benchmark directory does not exist: {benchmark_dir}", file=sys.stderr)
             return 1
+
+        try:
+            defn = load_benchmark(benchmark_dir)
+        except ValueError as exc:
+            print(f"Error: failed to load benchmark: {exc}", file=sys.stderr)
+            return 1
+
+        model = getattr(args, "model", None) or "sonnet"
+        surface = Surface()
+        executor_params = defn.config.get("executor_params", {})
+        evaluator_params = defn.config.get("evaluator_params", {})
+        executor = defn.executor_cls(**executor_params)
+        evaluator = defn.evaluator_cls(**evaluator_params)
+        benchmark = defn.name
+        print(f"Loaded dynamic benchmark: {defn.name} (from {benchmark_dir})")
+
+    else:
+        match benchmark:
+            case "searchqa":
+                from factory.optimization.benchmarks.searchqa import SearchQAEvaluator
+
+                model = getattr(args, "model", None) or "sonnet"
+                surface = Surface()
+                skill_path = getattr(args, "skill_path", None)
+                if skill_path:
+                    sp = Path(skill_path)
+                    if sp.exists():
+                        surface.prompt_slots["skill"] = sp.read_text()
+                executor = HarborBenchmark(
+                    git_ref=git_ref,
+                    concurrency=concurrency,
+                    docker_host=docker_host,
+                    model=model,
+                )
+                evaluator = SearchQAEvaluator()
+
+            case "featurebench":
+                from factory.optimization.benchmarks.featurebench import (
+                    FeatureBenchEvaluator,
+                    build_featurebench_executor,
+                    build_featurebench_surface,
+                )
+
+                model = getattr(args, "model", None) or "opus"
+                surface = build_featurebench_surface()
+                executor = build_featurebench_executor(
+                    git_ref=git_ref,
+                    concurrency=concurrency,
+                    docker_host=docker_host,
+                    model=model,
+                )
+                evaluator = FeatureBenchEvaluator()
+
+            case _:
+                print(f"Error: unsupported benchmark: {benchmark}", file=sys.stderr)
+                return 1
 
     mutator = AgenticMutator(project_path=project, model=model)
 

--- a/factory/optimization/benchmarks/loader.py
+++ b/factory/optimization/benchmarks/loader.py
@@ -1,0 +1,99 @@
+"""Dynamic benchmark loader — imports executor/evaluator from a directory at runtime."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class BenchmarkDefinition:
+    """A dynamically loaded benchmark with its executor and evaluator classes."""
+
+    name: str
+    executor_cls: type
+    evaluator_cls: type
+    config: dict[str, Any] = field(default_factory=dict)
+    source: str = "dynamic"
+
+
+def load_benchmark(benchmark_dir: Path) -> BenchmarkDefinition:
+    """Load a benchmark from a directory containing config.json, executor.py, and evaluator.py.
+
+    Raises ValueError on missing files, malformed JSON, missing classes,
+    or protocol violations.
+    """
+    benchmark_dir = benchmark_dir.resolve()
+
+    config_path = benchmark_dir / "config.json"
+    if not config_path.is_file():
+        raise ValueError(f"Missing config.json in {benchmark_dir}")
+
+    try:
+        config = json.loads(config_path.read_text())
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"Malformed config.json in {benchmark_dir}: {exc}") from exc
+
+    executor_path = benchmark_dir / "executor.py"
+    if not executor_path.is_file():
+        raise ValueError(f"Missing executor.py in {benchmark_dir}")
+
+    evaluator_path = benchmark_dir / "evaluator.py"
+    if not evaluator_path.is_file():
+        raise ValueError(f"Missing evaluator.py in {benchmark_dir}")
+
+    executor_cls = _load_class_from_file(executor_path, "Executor")
+    _validate_protocol(executor_cls, "execute")
+
+    evaluator_cls = _load_class_from_file(evaluator_path, "Evaluator")
+    _validate_protocol(evaluator_cls, ["parse", "parse_many", "get_info"])
+
+    name = config.get("name", benchmark_dir.name)
+
+    return BenchmarkDefinition(
+        name=name,
+        executor_cls=executor_cls,
+        evaluator_cls=evaluator_cls,
+        config=config,
+        source="dynamic",
+    )
+
+
+def _load_class_from_file(path: Path, class_name: str) -> type:
+    """Import a single class from a Python file using importlib."""
+    module_name = f"factory_benchmark_{path.stem}_{id(path)}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Cannot create module spec from {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:
+        sys.modules.pop(module_name, None)
+        raise ValueError(f"Failed to load {path}: {exc}") from exc
+
+    cls = getattr(module, class_name, None)
+    sys.modules.pop(module_name, None)
+
+    if cls is None:
+        raise ValueError(f"{path} does not contain a class named '{class_name}'")
+
+    return cls
+
+
+def _validate_protocol(cls: type, methods: str | list[str]) -> None:
+    """Check that cls has the required callable methods."""
+    if isinstance(methods, str):
+        methods = [methods]
+    for method in methods:
+        attr = getattr(cls, method, None)
+        if attr is None or not callable(attr):
+            raise ValueError(
+                f"{cls.__name__} is missing required method '{method}'"
+            )

--- a/tests/test_cli_optimize.py
+++ b/tests/test_cli_optimize.py
@@ -68,6 +68,38 @@ class TestOptimizeCommandWiring:
         assert "optimize" in _REFACTORY_AGENT_COMMANDS
 
 
+class TestOptimizeDynamicArgs:
+    """Verify --benchmark auto and --benchmark-dir argparse setup."""
+
+    def test_benchmark_auto_choice(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["optimize", "/tmp/proj", "--benchmark", "auto"])
+        assert args.benchmark == "auto"
+
+    def test_benchmark_dir_arg(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([
+            "optimize", "/tmp/proj", "--benchmark-dir", "/some/path",
+        ])
+        assert args.benchmark_dir == "/some/path"
+
+    def test_benchmark_auto_no_dir_errors(self, tmp_path) -> None:
+        args = argparse.Namespace(
+            path=str(tmp_path),
+            benchmark="auto",
+            benchmark_dir=None,
+            skill_path=None,
+            steps=1,
+            epochs=1,
+            concurrency=5,
+            git_ref=None,
+            docker_host=None,
+            model="sonnet",
+        )
+        result = cmd_optimize(args)
+        assert result == 1
+
+
 class TestCmdOptimize:
     """Test cmd_optimize with mocked dependencies."""
 

--- a/tests/test_optimization/test_loader.py
+++ b/tests/test_optimization/test_loader.py
@@ -1,0 +1,103 @@
+"""Tests for factory.optimization.benchmarks.loader — dynamic benchmark loading."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from factory.optimization.benchmarks.loader import BenchmarkDefinition, load_benchmark
+
+
+EXECUTOR_PY = """\
+class Executor:
+    def execute(self, project_dir, surface, **kwargs):
+        return {}
+"""
+
+EVALUATOR_PY = """\
+class Evaluator:
+    def parse(self, artifact_path):
+        return {}
+    def parse_many(self, artifact_paths):
+        return {}
+    def get_info(self):
+        return {}
+"""
+
+CONFIG_JSON = json.dumps({"name": "test-bench", "executor_params": {}, "evaluator_params": {}})
+
+
+def _write_benchmark(tmp_path, *, config=CONFIG_JSON, executor=EXECUTOR_PY, evaluator=EVALUATOR_PY):
+    """Write a complete benchmark directory, returning the path."""
+    if config is not None:
+        (tmp_path / "config.json").write_text(config)
+    if executor is not None:
+        (tmp_path / "executor.py").write_text(executor)
+    if evaluator is not None:
+        (tmp_path / "evaluator.py").write_text(evaluator)
+    return tmp_path
+
+
+class TestLoadValidBenchmark:
+    def test_returns_benchmark_definition(self, tmp_path) -> None:
+        _write_benchmark(tmp_path)
+        defn = load_benchmark(tmp_path)
+        assert isinstance(defn, BenchmarkDefinition)
+        assert defn.name == "test-bench"
+        assert defn.source == "dynamic"
+        assert defn.config["name"] == "test-bench"
+        assert hasattr(defn.executor_cls, "execute")
+        assert hasattr(defn.evaluator_cls, "parse")
+
+
+class TestMissingConfigJson:
+    def test_raises_valueerror(self, tmp_path) -> None:
+        _write_benchmark(tmp_path, config=None)
+        with pytest.raises(ValueError, match="Missing config.json"):
+            load_benchmark(tmp_path)
+
+
+class TestMissingExecutorPy:
+    def test_raises_valueerror(self, tmp_path) -> None:
+        _write_benchmark(tmp_path, executor=None)
+        with pytest.raises(ValueError, match="Missing executor.py"):
+            load_benchmark(tmp_path)
+
+
+class TestMissingEvaluatorPy:
+    def test_raises_valueerror(self, tmp_path) -> None:
+        _write_benchmark(tmp_path, evaluator=None)
+        with pytest.raises(ValueError, match="Missing evaluator.py"):
+            load_benchmark(tmp_path)
+
+
+class TestMalformedConfigJson:
+    def test_raises_valueerror(self, tmp_path) -> None:
+        _write_benchmark(tmp_path, config="{not valid json")
+        with pytest.raises(ValueError, match="Malformed config.json"):
+            load_benchmark(tmp_path)
+
+
+class TestExecutorMissingExecuteMethod:
+    def test_raises_valueerror(self, tmp_path) -> None:
+        bad_executor = "class Executor:\n    pass\n"
+        _write_benchmark(tmp_path, executor=bad_executor)
+        with pytest.raises(ValueError, match="missing required method 'execute'"):
+            load_benchmark(tmp_path)
+
+
+class TestEvaluatorMissingParseMethod:
+    def test_raises_valueerror(self, tmp_path) -> None:
+        bad_evaluator = "class Evaluator:\n    def get_info(self):\n        return {}\n"
+        _write_benchmark(tmp_path, evaluator=bad_evaluator)
+        with pytest.raises(ValueError, match="missing required method 'parse'"):
+            load_benchmark(tmp_path)
+
+
+class TestClassNotFoundInModule:
+    def test_raises_valueerror(self, tmp_path) -> None:
+        wrong_name = "class MyExecutor:\n    def execute(self): pass\n"
+        _write_benchmark(tmp_path, executor=wrong_name)
+        with pytest.raises(ValueError, match="does not contain a class named 'Executor'"):
+            load_benchmark(tmp_path)


### PR DESCRIPTION
Closes the dynamic benchmark loader backlog item.

## Changes

- **New `factory/optimization/benchmarks/loader.py`**: `BenchmarkDefinition` dataclass + `load_benchmark()` entry point that validates directory structure (config.json, executor.py, evaluator.py), imports classes via `importlib.util.spec_from_file_location()`, and checks protocol compliance (`execute` for Executor; `parse`, `parse_many`, `get_info` for Evaluator). Cleans up `sys.modules` after loading (matches WorkflowRegistry pattern).
- **Updated `factory/cli/optimize.py`**: Added dynamic loading path — if `--benchmark-dir` is set or `--benchmark auto`, calls `load_benchmark()` and instantiates executor/evaluator from `BenchmarkDefinition` config params.
- **Updated `factory/cli/_parser_groups.py`**: Added `--benchmark-dir` optional argument and `auto` to `--benchmark` choices.
- **New `tests/test_optimization/test_loader.py`**: 8 test cases covering valid loading, missing files, malformed JSON, protocol violations, and class-not-found errors.
- **Updated `tests/test_cli_optimize.py`**: 3 new tests for `--benchmark auto`, `--benchmark-dir`, and auto-without-directory error handling.
- **Updated `.claude/commands/optimize.md`**: Documented `--benchmark-dir` and `--benchmark auto` usage with examples.