### PR TITLE
feat: integrate DevOps Gym as contributed benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,6 +18,7 @@ on:
           - harborindex
           - tomswe
           - salitrap
+          - devopsgym
           - all
       instance_id:
         description: 'Instance ID (leave default for smoke test)'
@@ -96,6 +97,10 @@ jobs:
             solver: factory
             default_instance: 'salitrap-001'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'salitrap' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
+          - benchmark: devopsgym
+            solver: factory
+            default_instance: 'build-maven-dependency-resolution'
+            enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'devopsgym' || inputs.benchmark == 'all') && (inputs.solver != 'claude-code') }}
           # Claude Code solver entries — enabled on schedule, release, or workflow_dispatch with matching benchmark+solver
           - benchmark: swebench
             solver: claude-code
@@ -129,6 +134,10 @@ jobs:
             solver: claude-code
             default_instance: 'salitrap-001'
             enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'salitrap' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
+          - benchmark: devopsgym
+            solver: claude-code
+            default_instance: 'build-maven-dependency-resolution'
+            enabled: ${{ github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name != 'workflow_dispatch') || inputs.benchmark == 'devopsgym' || inputs.benchmark == 'all') && (inputs.solver == 'claude-code' || inputs.solver == 'both') }}
 
     steps:
       - name: Skip if not enabled

--- a/benchmarks/config.sh
+++ b/benchmarks/config.sh
@@ -4,7 +4,7 @@
 # benchmark_all_names, and benchmark_instance_id.
 
 benchmark_all_names() {
-    echo "swebench mini-swebench featurebench terminalbench programbench harborindex tomswe salitrap"
+    echo "swebench mini-swebench featurebench terminalbench programbench harborindex tomswe salitrap devopsgym"
 }
 
 benchmark_config() {
@@ -78,9 +78,15 @@ benchmark_config() {
             BENCH_AGENT_IMPORT_FLAG="--agent-import-path"
             BENCH_FILTER_STYLE="exact"
             ;;
+        devopsgym)
+            BENCH_DATASET="devops-gym/devops-gym-build"
+            BENCH_AGENT_CLASS="factory_harbor_agent:DevOpsGymFactoryCeo"
+            BENCH_AGENT_IMPORT_FLAG="--agent-import-path"
+            BENCH_FILTER_STYLE="glob"
+            ;;
         *)
             echo "ERROR: Unknown benchmark '${name}'"
-            echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe, salitrap"
+            echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe, salitrap, devopsgym"
             return 1
             ;;
     esac

--- a/benchmarks/factory_harbor_agent.py
+++ b/benchmarks/factory_harbor_agent.py
@@ -582,6 +582,24 @@ class LegacybenchFactoryCeo(FactoryCeo):
         )
 
 
+class DevOpsGymFactoryCeo(FactoryCeo):
+    """Runs the deterministic devopsgym workflow for DevOps Gym build/config tasks."""
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "devopsgym-factory-ceo"
+
+    @override
+    def _get_factory_command(self) -> str:
+        return (
+            'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"; '
+            'factory workflow run devopsgym . '
+            '2>&1 </dev/null | tee /logs/agent/factory-ceo.txt'
+            '; exit 0'
+        )
+
+
 class TerminalbenchFactoryCeo(FactoryCeo):
     """Runs the deterministic terminalbench workflow instead of generic factory ceo."""
 

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -23,7 +23,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ $# -lt 2 ]; then
     echo "Usage: benchmarks/run.sh <benchmark> <instance_id> [--timeout N] [--split S] [--preserve] [--solver S]"
     echo ""
-    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe"
+    echo "Benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe, devopsgym"
     exit 1
 fi
 
@@ -58,10 +58,10 @@ esac
 
 # Validate benchmark
 case "${BENCHMARK}" in
-    swebench|featurebench|terminalbench|programbench|legacybench|harborindex|tomswe) ;;
+    swebench|featurebench|terminalbench|programbench|legacybench|harborindex|tomswe|devopsgym) ;;
     *)
         echo "ERROR: Unknown benchmark '${BENCHMARK}'"
-        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe"
+        echo "Valid benchmarks: swebench, featurebench, terminalbench, programbench, legacybench, harborindex, tomswe, devopsgym"
         exit 1
         ;;
 esac

--- a/factory/workflow/contributed/devopsgym/README.md
+++ b/factory/workflow/contributed/devopsgym/README.md
@@ -1,0 +1,24 @@
+# DevOps Gym Workflow
+
+4-node pipeline for solving build/configuration tasks — Maven, Gradle, Go modules, Make, Docker, CI/CD.
+
+## Graph
+
+```
+study (FnNode) → solver (AgentNode) → gate_verify (GateNode) → auto_merge (FnNode)
+                      ↑                        │
+                      └── RELOOP (max 3) ──────┘
+```
+
+- **study**: Scans workspace for build files (pom.xml, build.gradle, go.mod, Makefile, Dockerfile, CI/CD configs) and reads `/tmp/task-instruction.md`
+- **solver**: Fixes the described build/configuration issue while preserving the existing build system
+- **gate_verify**: Checks solver committed changes and attempts to build with the detected build system
+- **auto_merge**: Fast-forwards the base branch to include the fix
+
+## Usage
+
+```bash
+factory workflow run devopsgym --project /path/to/repo
+```
+
+Typically invoked inside a Harbor container. The benchmark uses hidden verification steps — solutions must implement general fixes, not hardcode outputs.

--- a/factory/workflow/contributed/devopsgym/__init__.py
+++ b/factory/workflow/contributed/devopsgym/__init__.py
@@ -1,0 +1,3 @@
+from .workflow import meta, workflow
+
+__all__ = ["meta", "workflow"]

--- a/factory/workflow/contributed/devopsgym/test_workflow.py
+++ b/factory/workflow/contributed/devopsgym/test_workflow.py
@@ -1,0 +1,214 @@
+"""Tests for the DevOps Gym contributed workflow."""
+
+from __future__ import annotations
+
+from factory.models import ProjectState
+from factory.workflow.contributed.devopsgym import meta, workflow
+from factory.workflow.definitions import register_all
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    FnNode,
+    GateNode,
+    VerdictType,
+)
+
+
+class TestDevopsgymWorkflow:
+    """Tests for devopsgym workflow graph structure."""
+
+    def test_workflow_name(self) -> None:
+        wf = workflow()
+        assert wf.name == "devopsgym"
+
+    def test_node_count(self) -> None:
+        """Workflow has exactly 4 nodes: study, solver, gate_verify, auto_merge."""
+        wf = workflow()
+        assert len(wf.nodes) == 4
+        assert set(wf.nodes.keys()) == {"study", "solver", "gate_verify", "auto_merge"}
+
+    def test_start_node(self) -> None:
+        wf = workflow()
+        assert wf.start_node == "study"
+
+    def test_graph_validates(self) -> None:
+        """Graph passes structural validation (DAG check, edge consistency)."""
+        wf = workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Workflow has validation issues: {issues}"
+
+    def test_edge_count(self) -> None:
+        """4 edges: study->solver, solver->gate, gate->merge, gate->solver RELOOP."""
+        wf = workflow()
+        assert len(wf.edges) == 4
+
+    def test_study_node_is_fn(self) -> None:
+        wf = workflow()
+        node = wf.nodes["study"]
+        assert isinstance(node, FnNode)
+        assert "task-instruction" in node.command
+
+    def test_study_scans_build_files(self) -> None:
+        """Study node scans for build system files (pom.xml, build.gradle, go.mod, etc.)."""
+        wf = workflow()
+        node = wf.nodes["study"]
+        assert isinstance(node, FnNode)
+        assert "pom.xml" in node.command
+        assert "build.gradle" in node.command
+        assert "go.mod" in node.command
+        assert "Makefile" in node.command
+        assert "Dockerfile" in node.command
+
+    def test_solver_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["solver"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.BUILDER
+        assert node.max_iterations == 3
+        assert node.timeout == 7200
+
+    def test_gate_verify_is_fn_evaluator(self) -> None:
+        """Gate uses fn evaluator (not agent) for speed and determinism."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+        assert node.evaluator_command is not None
+        assert "pass:" in node.evaluator_command
+        assert "reloop:" in node.evaluator_command
+        assert "fail:" in node.evaluator_command
+
+    def test_gate_verify_checks_build_systems(self) -> None:
+        """Gate attempts builds with detected build system (Maven, Gradle, Go, Make)."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_command is not None
+        assert "mvn" in node.evaluator_command
+        assert "gradle" in node.evaluator_command
+        assert "go build" in node.evaluator_command
+        assert "make" in node.evaluator_command
+
+    def test_auto_merge_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["auto_merge"]
+        assert isinstance(node, FnNode)
+        assert "git update-ref" in node.command
+
+    def test_proceed_edge_to_merge(self) -> None:
+        """gate_verify has a PROCEED edge to auto_merge."""
+        wf = workflow()
+        proceed_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "auto_merge"
+            and e.condition == VerdictType.PROCEED
+        ]
+        assert len(proceed_edges) == 1
+
+    def test_reloop_edge_exists(self) -> None:
+        """gate_verify has a RELOOP edge back to solver."""
+        wf = workflow()
+        reloop_edges = [
+            e for e in wf.edges
+            if e.source == "gate_verify"
+            and e.target == "solver"
+            and e.condition == VerdictType.RELOOP
+        ]
+        assert len(reloop_edges) == 1
+
+    def test_no_eval_infrastructure(self) -> None:
+        """No factory eval nodes (begin, finalize, precheck, study)."""
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "begin" not in node_ids
+        assert "finalize" not in node_ids
+        assert "gate_precheck" not in node_ids
+        for node in wf.nodes.values():
+            if isinstance(node, FnNode):
+                assert "factory eval" not in node.command
+                assert "factory finalize" not in node.command
+                assert "factory precheck" not in node.command
+                assert "factory begin" not in node.command
+
+    def test_no_deep_qa_nodes(self) -> None:
+        """No deep-QA pipeline nodes."""
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "health_checker" not in node_ids
+        assert "code_reviewer" not in node_ids
+        assert "adversarial_tester" not in node_ids
+        assert "gate_review" not in node_ids
+
+    def test_no_research_strategy_nodes(self) -> None:
+        """No researcher or strategist nodes."""
+        wf = workflow()
+        node_ids = set(wf.nodes.keys())
+        assert "researcher" not in node_ids
+        assert "strategist" not in node_ids
+        assert "gate_research" not in node_ids
+        assert "gate_strategy" not in node_ids
+
+
+class TestDevopsgymTerminal:
+    """Tests for the terminal flag on devopsgym workflow."""
+
+    def test_workflow_is_terminal(self) -> None:
+        wf = workflow()
+        assert wf.terminal is True
+
+    def test_registered_workflow_is_terminal(self) -> None:
+        workflows = register_all()
+        assert workflows["devopsgym"].terminal is True
+
+
+class TestDevopsgymTrigger:
+    """Tests for the trigger function."""
+
+    def test_trigger_matches_devopsgym_mode(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "devopsgym"})
+
+    def test_trigger_matches_without_factory(self) -> None:
+        """Trigger fires on mode alone, regardless of project state."""
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.NO_REPO, {"mode": "devopsgym"})
+        assert wf.trigger(ProjectState.NO_FACTORY, {"mode": "devopsgym"})
+
+    def test_trigger_rejects_other_modes(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "build"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+
+class TestDevopsgymRegistration:
+    """Tests for registration in the global workflow registry."""
+
+    def test_registered_in_register_all(self) -> None:
+        workflows = register_all()
+        assert "devopsgym" in workflows
+
+    def test_registered_workflow_valid(self) -> None:
+        workflows = register_all()
+        wf = workflows["devopsgym"]
+        issues = wf.validate_graph()
+        assert issues == [], f"Registered devopsgym workflow has issues: {issues}"
+
+    def test_registered_workflow_has_trigger(self) -> None:
+        workflows = register_all()
+        wf = workflows["devopsgym"]
+        assert wf.trigger is not None
+
+
+class TestDevopsgymMeta:
+    """Tests for the module-level meta dict."""
+
+    def test_meta_has_name(self) -> None:
+        assert meta["name"] == "devopsgym"
+
+    def test_meta_has_description(self) -> None:
+        assert "devops" in meta["description"].lower()

--- a/factory/workflow/contributed/devopsgym/workflow.py
+++ b/factory/workflow/contributed/devopsgym/workflow.py
@@ -1,0 +1,213 @@
+"""DevOps Gym benchmark workflow — lean pipeline for build/configuration tasks.
+
+4-node pipeline: study -> solver -> gate_verify -> auto_merge
+RELOOP from gate_verify back to solver (max 3 iterations) on failure.
+
+Designed for Harbor containers where:
+- Task instruction is at /tmp/task-instruction.md
+- Targets DevOps build/configuration: Maven, Gradle, Go modules, Make, Docker, CI/CD
+- Harbor's verifier is the FINAL authority on pass/fail
+- Harbor checks the MAIN branch for changes
+- No .factory/ infrastructure (no eval, no experiments, no deep-QA)
+"""
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Edge,
+    FnNode,
+    GateNode,
+    VerdictType,
+    Workflow,
+)
+
+meta = {
+    "name": "devopsgym",
+    "description": (
+        "DevOps Gym benchmark mode — 4-node pipeline for solving "
+        "build/configuration tasks (Maven, Gradle, Go modules, Make, Docker, CI/CD). "
+        "study -> solver -> gate_verify -> auto_merge with RELOOP on failure."
+    ),
+}
+
+
+def workflow() -> Workflow:
+    """Build the DevOps Gym workflow as a lean 4-node pipeline."""
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # -- Node 1: Study --
+    nodes["study"] = FnNode(
+        id="study",
+        command=(
+            "mkdir -p {project_path}/.factory/reviews && "
+            "cd {project_path} && "
+            "("
+            "echo '=== Workspace ===' && "
+            "ls -la && "
+            "echo '\\n=== Build Files ===' && "
+            "find . -type f \\( "
+            "-name 'pom.xml' -o -name 'build.gradle' -o -name 'build.gradle.kts' "
+            "-o -name 'go.mod' -o -name 'go.sum' "
+            "-o -name 'Makefile' -o -name 'CMakeLists.txt' "
+            "-o -name 'Dockerfile' -o -name 'docker-compose.yml' -o -name 'docker-compose.yaml' "
+            "-o -name 'Jenkinsfile' -o -name 'Cargo.toml' "
+            "-o -name 'package.json' -o -name 'requirements.txt' -o -name 'setup.py' "
+            "\\) | head -100 && "
+            "echo '\\n=== CI/CD Config ===' && "
+            "find . -type f \\( "
+            "-name '*.yml' -o -name '*.yaml' "
+            "\\) -path '*/.github/workflows/*' | head -50 && "
+            "find . -type f -name '.gitlab-ci.yml' | head -10 && "
+            "echo '\\n=== Source Files ===' && "
+            "find . -type f \\( "
+            "-name '*.java' -o -name '*.go' -o -name '*.py' "
+            "-o -name '*.rs' -o -name '*.c' -o -name '*.cpp' "
+            "-o -name '*.sh' -o -name '*.bash' "
+            "\\) | head -100 && "
+            "echo '\\n=== Git ===' && "
+            "git status 2>/dev/null || echo 'Not a git repository' && "
+            "git log --oneline -10 2>/dev/null || true && "
+            "echo '\\n=== Task ===' && "
+            "cat /tmp/task-instruction.md 2>/dev/null || "
+            "echo 'No task instruction found at /tmp/task-instruction.md' && "
+            "echo '\\n=== Build System Detection ===' && "
+            "echo 'Attempting to identify and run build...' && "
+            "([ -f pom.xml ] && echo 'Detected: Maven' && mvn --version 2>/dev/null || true) && "
+            "([ -f build.gradle ] || [ -f build.gradle.kts ] && echo 'Detected: Gradle' && gradle --version 2>/dev/null || true) && "
+            "([ -f go.mod ] && echo 'Detected: Go modules' && go version 2>/dev/null || true) && "
+            "([ -f Makefile ] && echo 'Detected: Make' || true) && "
+            "([ -f Dockerfile ] && echo 'Detected: Docker' || true)"
+            ") > .factory/reviews/study-output.md 2>&1"
+        ),
+        writes={".factory/reviews/study-output.md"},
+    )
+
+    # -- Node 2: Solver (Builder) --
+    nodes["solver"] = AgentNode(
+        id="solver",
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=7200,
+        max_iterations=3,
+        prompt_template=(
+            "You are solving a DevOps build/configuration task from the DevOps Gym benchmark.\n\n"
+            "## Your Task\n\n"
+            "1. **Read the task instruction** — Read /tmp/task-instruction.md carefully. "
+            "Understand exactly what build or configuration issue needs to be fixed and "
+            "what the expected behavior should be.\n\n"
+            "2. **Understand the project** — Check the study output at "
+            ".factory/reviews/study-output.md for a structural overview. Examine build "
+            "files (pom.xml, build.gradle, go.mod, Makefile, Dockerfile, CI/CD configs), "
+            "source files, and any error logs.\n\n"
+            "3. **Analyze the build system** — Identify which build system is in use "
+            "(Maven, Gradle, Go modules, Make, Docker, etc.). Understand the project's "
+            "dependency structure, build targets, and configuration.\n\n"
+            "4. **Fix the issue** — Implement the fix described in the task instruction. "
+            "This may involve modifying build configuration, fixing dependency declarations, "
+            "updating CI/CD pipelines, fixing Dockerfiles, or adjusting build scripts.\n\n"
+            "5. **Verify the fix** — Attempt to build the project using the appropriate "
+            "build tool. Verify the build succeeds and the configuration is correct.\n\n"
+            "6. **Commit your changes** — Commit directly on the current branch "
+            "with a descriptive message. Do NOT create a new branch. Do NOT create a PR.\n\n"
+            "## Rules\n\n"
+            "- Act AUTONOMOUSLY — do NOT ask for confirmation or input\n"
+            "- PRESERVE the existing build system — do NOT switch build tools or "
+            "modernize the build configuration unless explicitly asked. Fix ONLY the "
+            "specific issue described in the task instruction.\n"
+            "- HIDDEN TESTS: The benchmark uses hidden verification steps. Do NOT "
+            "hardcode outputs. Implement the general fix that solves the problem "
+            "for any valid build configuration.\n"
+            "- Do NOT create branches or PRs — commit on current branch\n"
+            "- Do NOT run factory commands (factory eval, factory study, etc.)\n"
+            "- If something fails, investigate root cause and try alternative approaches\n"
+        ),
+        reads={".factory/reviews/study-output.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    # -- Node 3: Gate Verify --
+    nodes["gate_verify"] = GateNode(
+        id="gate_verify",
+        evaluator_type="fn",
+        evaluator_command=(
+            "cd {project_path} && "
+            "CHANGES=$(git diff HEAD~1 --stat 2>/dev/null || echo 'NO_COMMITS') && "
+            "if [ \"$CHANGES\" = 'NO_COMMITS' ] || [ -z \"$CHANGES\" ]; then "
+            "echo 'fail: solver did not commit any changes'; "
+            "exit 0; fi && "
+            "if [ ! -f .factory/reviews/builder-latest.md ]; then "
+            "echo 'fail: solver output missing'; "
+            "exit 0; fi && "
+            "BUILD_OK=0 && "
+            "if [ -f pom.xml ]; then "
+            "timeout 600 mvn compile -q 2>&1 && BUILD_OK=1 || "
+            "{ TAIL=$(timeout 600 mvn compile 2>&1 | tail -50); "
+            "echo \"reloop: Maven build failed — $TAIL\"; exit 0; }; fi && "
+            "if [ -f build.gradle ] || [ -f build.gradle.kts ]; then "
+            "timeout 600 gradle build -q 2>&1 && BUILD_OK=1 || "
+            "{ TAIL=$(timeout 600 gradle build 2>&1 | tail -50); "
+            "echo \"reloop: Gradle build failed — $TAIL\"; exit 0; }; fi && "
+            "if [ -f go.mod ]; then "
+            "timeout 600 go build ./... 2>&1 && BUILD_OK=1 || "
+            "{ TAIL=$(timeout 600 go build ./... 2>&1 | tail -50); "
+            "echo \"reloop: Go build failed — $TAIL\"; exit 0; }; fi && "
+            "if [ -f Makefile ]; then "
+            "timeout 600 make 2>&1 && BUILD_OK=1 || "
+            "{ TAIL=$(timeout 600 make 2>&1 | tail -50); "
+            "echo \"reloop: Make build failed — $TAIL\"; exit 0; }; fi && "
+            "if [ $BUILD_OK -eq 0 ]; then "
+            "echo 'pass: no recognized build system — deferring to Harbor verifier'; "
+            "exit 0; fi && "
+            "echo 'pass: build succeeded'"
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # -- Node 4: Auto Merge --
+    nodes["auto_merge"] = FnNode(
+        id="auto_merge",
+        command=(
+            "cd {project_path} && "
+            "CURRENT=$(git rev-parse --abbrev-ref HEAD) && "
+            "COMMON=$(git rev-parse --git-common-dir) && "
+            "BASE=$(git --git-dir=\"$COMMON\" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main) && "
+            "if [ \"$CURRENT\" = \"$BASE\" ]; then "
+            "echo \"Already on $BASE — no merge needed\"; "
+            "exit 0; fi && "
+            "git update-ref refs/heads/\"$BASE\" HEAD && "
+            "PARENT_WT=$(cd \"$COMMON/..\" && pwd) && "
+            "git diff-tree --no-commit-id --name-only -r HEAD HEAD~1 | "
+            "while read file; do "
+            "if [ -f \"$file\" ]; then "
+            "mkdir -p \"$PARENT_WT/$(dirname $file)\" && "
+            "cp \"$file\" \"$PARENT_WT/$file\"; "
+            "fi; done && "
+            "echo \"Updated $BASE to $(git rev-parse --short HEAD)\""
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # -- Edges --
+    edges = [
+        Edge(source="study", target="solver"),
+        Edge(source="solver", target="gate_verify"),
+        Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
+        Edge(source="gate_verify", target="solver", condition=VerdictType.RELOOP),
+    ]
+
+    # -- Trigger --
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "devopsgym"
+
+    return Workflow(
+        name="devopsgym",
+        nodes=nodes,
+        edges=edges,
+        start_node="study",
+        terminal=True,
+        trigger=trigger,
+    )

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -4015,6 +4015,9 @@ def _get_builtin_registry() -> dict[str, Any]:
         "mini-swebench": lambda: __import__(
             "factory.workflow.contributed.mini_swebench", fromlist=["workflow"]
         ).workflow(),
+        "devopsgym": lambda: __import__(
+            "factory.workflow.contributed.devopsgym", fromlist=["workflow"]
+        ).workflow(),
     }
     return _BUILTIN_REGISTRY
 

--- a/tests/test_spec_generate.py
+++ b/tests/test_spec_generate.py
@@ -92,7 +92,7 @@ class TestRegistryIncludesSpec:
 
     def test_register_all_count(self) -> None:
         all_wf = register_all()
-        assert len(all_wf) == 33
+        assert len(all_wf) == 34
 
     def test_all_workflows_validate(self) -> None:
         all_wf = register_all()


### PR DESCRIPTION
Closes #1152

## Changes

- **`factory/workflow/contributed/devopsgym/`** — New 4-node pipeline workflow (study → solver → gate_verify → auto_merge) for DevOps Gym build/configuration tasks. Study node scans for build files (pom.xml, build.gradle, go.mod, Makefile, Dockerfile, CI/CD configs). Solver uses builder role with 7200s timeout and 3 max iterations. Gate verify attempts build with detected build system (Maven, Gradle, Go, Make).
- **`benchmarks/factory_harbor_agent.py`** — Added `DevOpsGymFactoryCeo` class extending `FactoryCeo`, running `factory workflow run devopsgym .`
- **`benchmarks/config.sh`** — Added `devopsgym` case with dataset `devops-gym/devops-gym-build`, glob filter style
- **`benchmarks/run.sh`** — Added `devopsgym` to validation allowlist
- **`factory/workflow/definitions.py`** — Imported and registered devopsgym workflow in `register_all()`
- **`.github/workflows/benchmark.yml`** — Added devopsgym matrix entries for both factory and claude-code solvers with `build-maven-dependency-resolution` default instance
- **26 structural tests** — Graph validation, trigger matching, registration, terminal flag, node types, build system detection