### PR TITLE
feat: add benchmark split protocol for inner-outer optimization loop

### DIFF
--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -266,6 +266,8 @@ def add_self_evolution_parsers(sub: argparse._SubParsersAction) -> None:  # type
     p.add_argument("--git-ref", default=None, help="Git ref for Harbor agent (default: current branch)")
     p.add_argument("--docker-host", default=None, help="Docker host socket (default: from DOCKER_HOST env)")
     p.add_argument("--model", default="sonnet", help="Model for AgenticMutator (default: sonnet)")
+    p.add_argument("--split-seed", type=int, default=42, help="Seed for reproducible split generation (default: 42)")
+    p.add_argument("--splits-dir", default=None, help="Path to pre-generated JSONL split files")
 
 
 def add_configuration_parsers(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]

--- a/factory/cli/optimize.py
+++ b/factory/cli/optimize.py
@@ -18,6 +18,7 @@ def cmd_optimize(args: argparse.Namespace) -> int:
     from factory.optimization import AgenticMutator, LoopConfig, OptimizationLoop, Surface
     from factory.optimization.benchmarks.harbor import HarborBenchmark
     from factory.optimization.protocols import Evaluator, Executor
+    from factory.optimization.types import BenchmarkSplits
 
     benchmark = getattr(args, "benchmark", None) or "searchqa"
     benchmark_dir_str = getattr(args, "benchmark_dir", None)
@@ -26,6 +27,8 @@ def cmd_optimize(args: argparse.Namespace) -> int:
     concurrency = getattr(args, "concurrency", 5)
     steps = getattr(args, "steps", 3)
     epochs = getattr(args, "epochs", 1)
+    split_seed = getattr(args, "split_seed", 42)
+    splits_dir_str = getattr(args, "splits_dir", None)
 
     evaluator: Evaluator
     executor: Executor
@@ -63,7 +66,7 @@ def cmd_optimize(args: argparse.Namespace) -> int:
     else:
         match benchmark:
             case "searchqa":
-                from factory.optimization.benchmarks.searchqa import SearchQAEvaluator
+                from factory.optimization.benchmarks.searchqa import SearchQAEvaluator, create_searchqa_splits
 
                 model = getattr(args, "model", None) or "sonnet"
                 surface = Surface()
@@ -72,11 +75,32 @@ def cmd_optimize(args: argparse.Namespace) -> int:
                     sp = Path(skill_path)
                     if sp.exists():
                         surface.prompt_slots["skill"] = sp.read_text()
+
+                splits: BenchmarkSplits | None = None
+                if splits_dir_str:
+                    splits = BenchmarkSplits.from_jsonl_dir(Path(splits_dir_str).resolve())
+                else:
+                    auto_dir = project / ".factory" / "eval" / "benchmark" / "splits"
+                    if auto_dir.is_dir():
+                        splits = BenchmarkSplits.from_jsonl_dir(auto_dir)
+                    else:
+                        tasks_dir = project / "benchmarks" / "searchqa-harbor" / "train"
+                        if tasks_dir.is_dir():
+                            splits = create_searchqa_splits(tasks_dir, seed=split_seed)
+
+                if splits:
+                    warnings = splits.validate()
+                    for w in warnings:
+                        print(f"  Split warning: {w}", file=sys.stderr)
+                    print(f"Splits: train={len(splits.train_ids)} dev={len(splits.dev_ids)} "
+                          f"eval={len(splits.eval_ids)} test={len(splits.test_ids)}")
+
                 executor = HarborBenchmark(
                     git_ref=git_ref,
                     concurrency=concurrency,
                     docker_host=docker_host,
                     model=model,
+                    splits=splits,
                 )
                 evaluator = SearchQAEvaluator()
 
@@ -129,6 +153,10 @@ def cmd_optimize(args: argparse.Namespace) -> int:
             print(f"  Step {s.step_number}: {s.score_start:.4f} -> {s.score_end:.4f} ({delta}) verdict={s.verdict}")
     print(f"Best score: {result.best_score:.4f} (step {result.best_step})")
     print(f"Final score: {result.final_score:.4f}")
+    if result.dev_score is not None:
+        print(f"Dev score:   {result.dev_score:.4f}")
+    if result.test_score is not None:
+        print(f"Test score:  {result.test_score:.4f}")
     if result.steps:
         total_delta = result.final_score - (result.steps[0].score_start or 0.0)
         print(f"Total improvement: {total_delta:+.4f}")

--- a/factory/optimization/__init__.py
+++ b/factory/optimization/__init__.py
@@ -9,6 +9,7 @@ from factory.optimization.protocols import Evaluator as Evaluator
 from factory.optimization.protocols import Executor as Executor
 from factory.optimization.protocols import Mutator as Mutator
 from factory.optimization.surface import Surface as Surface
+from factory.optimization.types import BenchmarkSplits as BenchmarkSplits
 from factory.optimization.types import ExecutionResult as ExecutionResult
 from factory.optimization.types import GateResult as GateResult
 from factory.optimization.types import GraphMutation as GraphMutation
@@ -20,6 +21,7 @@ from factory.optimization.types import TaskResult as TaskResult
 
 __all__ = [
     "AgenticMutator",
+    "BenchmarkSplits",
     "Evaluator",
     "ExecutionResult",
     "Executor",

--- a/factory/optimization/benchmarks/harbor.py
+++ b/factory/optimization/benchmarks/harbor.py
@@ -22,7 +22,7 @@ import structlog
 
 from factory.optimization.executors.harbor import _parse_trial_results
 from factory.optimization.surface import Surface
-from factory.optimization.types import ExecutionResult, TaskResult
+from factory.optimization.types import BenchmarkSplits, ExecutionResult, SplitName, TaskResult
 
 log = structlog.get_logger()
 
@@ -55,6 +55,7 @@ class HarborBenchmark:
         cleanup_jobs: bool = True,
         agent_class: str = "factory_harbor_agent:SearchQAFactoryCeo",
         dataset: str = "searchqa",
+        splits: BenchmarkSplits | None = None,
     ) -> None:
         self.git_ref = git_ref
         self.subset_dir = Path(subset_dir) if subset_dir else None
@@ -65,10 +66,25 @@ class HarborBenchmark:
         self.cleanup_jobs = cleanup_jobs
         self.agent_class = agent_class
         self.dataset = dataset
+        self.splits = splits
         self._run = 0
 
+    def _create_split_dir(
+        self, project_dir: Path, task_ids: list[str], split: SplitName,
+    ) -> Path:
+        split_dir = Path(tempfile.mkdtemp(prefix=f"split-{split}-{self._run}-"))
+        source_dir = project_dir / "benchmarks" / f"{self.dataset}-harbor" / "train"
+        if not source_dir.is_dir():
+            source_dir = project_dir / "benchmarks" / f"{self.dataset}-harbor" / "tasks"
+        for tid in task_ids:
+            src = source_dir / tid
+            dst = split_dir / tid
+            if src.is_dir():
+                dst.symlink_to(src)
+        return split_dir
+
     def execute(
-        self, project_dir: Path, surface: Surface, **kwargs: Any
+        self, project_dir: Path, surface: Surface, split: SplitName | None = None, **kwargs: Any
     ) -> ExecutionResult:
         self._run += 1
         start = time.monotonic()
@@ -98,7 +114,12 @@ class HarborBenchmark:
             "--jobs-dir", str(jobs_dir),
         ]
 
-        if self.subset_dir:
+        split_tmp: Path | None = None
+        if self.splits and split is not None:
+            task_ids = self.splits.get_ids(split)
+            split_tmp = self._create_split_dir(project_dir, task_ids, split)
+            cmd += ["-p", str(split_tmp)]
+        elif self.subset_dir:
             cmd += ["-p", str(self.subset_dir)]
         else:
             task_dir = project_dir / "benchmarks" / f"{self.dataset}-harbor" / "train"
@@ -175,6 +196,8 @@ class HarborBenchmark:
 
         if self.cleanup_jobs and jobs_dir.exists():
             shutil.rmtree(jobs_dir, ignore_errors=True)
+        if self.cleanup_jobs and split_tmp and split_tmp.exists():
+            shutil.rmtree(split_tmp, ignore_errors=True)
 
         return ExecutionResult(
             returncode=result.returncode,

--- a/factory/optimization/benchmarks/searchqa.py
+++ b/factory/optimization/benchmarks/searchqa.py
@@ -8,6 +8,7 @@ and use SQuAD-style EM normalization for scoring.
 from __future__ import annotations
 
 import json
+import random
 from pathlib import Path
 
 import structlog
@@ -15,7 +16,7 @@ import structlog
 from factory.inner_loop import EvalResult
 from factory.optimization.executors.harbor import HarborExecutor
 from factory.optimization.surface import Surface
-from factory.optimization.types import LoopConfig
+from factory.optimization.types import BenchmarkSplits, LoopConfig
 
 log = structlog.get_logger()
 
@@ -53,6 +54,38 @@ class SearchQAEvaluator:
             "target": self.target,
             "metrics": ["accuracy", "em", "f1"],
         }
+
+
+def create_searchqa_splits(
+    tasks_dir: Path,
+    train_ratio: float = 0.6,
+    dev_ratio: float = 0.2,
+    eval_ratio: float = 0.1,
+    test_ratio: float = 0.1,
+    seed: int = 42,
+) -> BenchmarkSplits:
+    """Partition SearchQA task IDs into train/dev/eval/test splits."""
+    task_ids = sorted(d.name for d in tasks_dir.iterdir() if d.is_dir())
+    rng = random.Random(seed)
+    rng.shuffle(task_ids)
+    n = len(task_ids)
+    n_train = int(n * train_ratio)
+    n_dev = int(n * (train_ratio + dev_ratio)) - n_train
+    n_eval = int(n * (train_ratio + dev_ratio + eval_ratio)) - n_train - n_dev
+    idx = 0
+    train_ids = task_ids[idx : idx + n_train]
+    idx += n_train
+    dev_ids = task_ids[idx : idx + n_dev]
+    idx += n_dev
+    eval_ids = task_ids[idx : idx + n_eval]
+    idx += n_eval
+    test_ids = task_ids[idx:]
+    return BenchmarkSplits(
+        train_ids=train_ids,
+        dev_ids=dev_ids,
+        eval_ids=eval_ids,
+        test_ids=test_ids,
+    )
 
 
 def build_searchqa_surface(skill_path: Path | None = None) -> Surface:

--- a/factory/optimization/loop.py
+++ b/factory/optimization/loop.py
@@ -27,6 +27,9 @@ class TrainResult:
     best_score: float = 0.0
     best_step: int = 0
     final_score: float = 0.0
+    dev_score: float | None = None
+    eval_score: float | None = None
+    test_score: float | None = None
 
 
 class OptimizationLoop:
@@ -62,7 +65,7 @@ class OptimizationLoop:
         score_start = self._current_score
 
         execution_result = self.executor.execute(
-            self.project_dir, self.surface,
+            self.project_dir, self.surface, split="dev",
         )
 
         score_end = score_start
@@ -131,11 +134,30 @@ class OptimizationLoop:
                 best_score=round(self._best_score, 4),
             )
 
+        dev_score = self._current_score if self._history else None
+
+        test_score: float | None = None
+        try:
+            log.info("loop.test_split.start")
+            test_result = self.executor.execute(
+                self.project_dir, self.surface, split="test",
+            )
+            test_artifacts = [Path(a) for a in test_result.artifacts]
+            if test_artifacts:
+                test_eval = self.evaluator.parse_many(test_artifacts)
+                if test_eval.valid:
+                    test_score = test_eval.score
+            log.info("loop.test_split.done", test_score=round(test_score, 4) if test_score is not None else None)
+        except Exception:
+            log.warning("loop.test_split.failed", exc_info=True)
+
         return TrainResult(
             steps=list(self._history),
             best_score=self._best_score,
             best_step=self._best_step,
             final_score=self._current_score,
+            dev_score=dev_score,
+            test_score=test_score,
         )
 
     def history(self) -> list[StepRecord]:

--- a/factory/optimization/protocols.py
+++ b/factory/optimization/protocols.py
@@ -7,7 +7,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from factory.inner_loop import EvalResult
 from factory.optimization.surface import Surface
-from factory.optimization.types import ExecutionResult, Patch, StepRecord
+from factory.optimization.types import ExecutionResult, Patch, SplitName, StepRecord
 
 
 @runtime_checkable
@@ -15,7 +15,7 @@ class Executor(Protocol):
     """Runs one inner-loop cycle and returns structured results."""
 
     def execute(
-        self, project_dir: Path, surface: Surface, **kwargs: Any
+        self, project_dir: Path, surface: Surface, split: SplitName | None = None, **kwargs: Any
     ) -> ExecutionResult: ...
 
 

--- a/factory/optimization/types.py
+++ b/factory/optimization/types.py
@@ -8,12 +8,72 @@ Absorbs concepts from:
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from factory.models import AggregateMethod
+
+SplitName = Literal["train", "dev", "eval", "test"]
+
+_SPLIT_NAMES: tuple[SplitName, ...] = ("train", "dev", "eval", "test")
+
+
+@dataclass
+class BenchmarkSplits:
+    """Task-ID partitions for train/dev/eval/test splits."""
+
+    train_ids: list[str] = field(default_factory=list)
+    dev_ids: list[str] = field(default_factory=list)
+    eval_ids: list[str] = field(default_factory=list)
+    test_ids: list[str] = field(default_factory=list)
+
+    def get_ids(self, split: SplitName) -> list[str]:
+        return list(getattr(self, f"{split}_ids"))
+
+    def validate(self) -> list[str]:
+        warnings: list[str] = []
+        splits = {name: set(self.get_ids(name)) for name in _SPLIT_NAMES}
+        for i, (n1, s1) in enumerate(splits.items()):
+            for n2, s2 in list(splits.items())[i + 1 :]:
+                overlap = s1 & s2
+                if overlap:
+                    warnings.append(
+                        f"overlap between {n1} and {n2}: {sorted(overlap)}"
+                    )
+        if not self.dev_ids:
+            warnings.append("dev split is empty")
+        if not self.test_ids:
+            warnings.append("test split is empty")
+        return warnings
+
+    @classmethod
+    def from_jsonl_dir(cls, splits_dir: Path) -> BenchmarkSplits:
+        kwargs: dict[str, list[str]] = {}
+        for name in _SPLIT_NAMES:
+            fpath = splits_dir / f"{name}.jsonl"
+            ids: list[str] = []
+            if fpath.exists():
+                for line in fpath.read_text().splitlines():
+                    line = line.strip()
+                    if line:
+                        ids.append(json.loads(line)["id"])
+            kwargs[f"{name}_ids"] = ids
+        return cls(**kwargs)
+
+    def to_jsonl_dir(self, splits_dir: Path) -> None:
+        splits_dir.mkdir(parents=True, exist_ok=True)
+        for name in _SPLIT_NAMES:
+            ids = self.get_ids(name)
+            fpath = splits_dir / f"{name}.jsonl"
+            fpath.write_text(
+                "\n".join(json.dumps({"id": tid}) for tid in ids) + "\n"
+                if ids
+                else ""
+            )
 
 
 @dataclass

--- a/tests/test_optimization/test_benchmark_splits.py
+++ b/tests/test_optimization/test_benchmark_splits.py
@@ -1,0 +1,117 @@
+"""Tests for BenchmarkSplits — construction, validation, JSONL round-trip, get_ids."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from factory.optimization.types import BenchmarkSplits
+
+
+class TestBenchmarkSplitsConstruction:
+    def test_defaults_empty(self) -> None:
+        splits = BenchmarkSplits()
+        assert splits.train_ids == []
+        assert splits.dev_ids == []
+        assert splits.eval_ids == []
+        assert splits.test_ids == []
+
+    def test_explicit_ids(self) -> None:
+        splits = BenchmarkSplits(
+            train_ids=["a", "b"],
+            dev_ids=["c"],
+            eval_ids=["d"],
+            test_ids=["e"],
+        )
+        assert splits.train_ids == ["a", "b"]
+        assert splits.test_ids == ["e"]
+
+
+class TestGetIds:
+    def test_get_ids_returns_copy(self) -> None:
+        splits = BenchmarkSplits(train_ids=["a", "b"])
+        result = splits.get_ids("train")
+        result.append("c")
+        assert splits.train_ids == ["a", "b"]
+
+    def test_get_ids_all_splits(self) -> None:
+        splits = BenchmarkSplits(
+            train_ids=["t1"],
+            dev_ids=["d1"],
+            eval_ids=["e1"],
+            test_ids=["s1"],
+        )
+        assert splits.get_ids("train") == ["t1"]
+        assert splits.get_ids("dev") == ["d1"]
+        assert splits.get_ids("eval") == ["e1"]
+        assert splits.get_ids("test") == ["s1"]
+
+
+class TestValidation:
+    def test_no_warnings_for_valid_splits(self) -> None:
+        splits = BenchmarkSplits(
+            train_ids=["a", "b"],
+            dev_ids=["c"],
+            eval_ids=["d"],
+            test_ids=["e"],
+        )
+        assert splits.validate() == []
+
+    def test_overlap_detected(self) -> None:
+        splits = BenchmarkSplits(
+            train_ids=["a", "b"],
+            dev_ids=["b", "c"],
+            test_ids=["d"],
+        )
+        warnings = splits.validate()
+        assert any("overlap" in w for w in warnings)
+        assert any("train" in w and "dev" in w for w in warnings)
+
+    def test_empty_dev_warning(self) -> None:
+        splits = BenchmarkSplits(train_ids=["a"], test_ids=["b"])
+        warnings = splits.validate()
+        assert any("dev split is empty" in w for w in warnings)
+
+    def test_empty_test_warning(self) -> None:
+        splits = BenchmarkSplits(train_ids=["a"], dev_ids=["b"])
+        warnings = splits.validate()
+        assert any("test split is empty" in w for w in warnings)
+
+    def test_multiple_overlaps(self) -> None:
+        splits = BenchmarkSplits(
+            train_ids=["x"],
+            dev_ids=["x"],
+            eval_ids=["x"],
+            test_ids=["x"],
+        )
+        warnings = splits.validate()
+        overlap_warnings = [w for w in warnings if "overlap" in w]
+        assert len(overlap_warnings) >= 3
+
+
+class TestJsonlRoundTrip:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        original = BenchmarkSplits(
+            train_ids=["a", "b", "c"],
+            dev_ids=["d", "e"],
+            eval_ids=["f"],
+            test_ids=["g", "h"],
+        )
+        original.to_jsonl_dir(tmp_path / "splits")
+        loaded = BenchmarkSplits.from_jsonl_dir(tmp_path / "splits")
+        assert loaded.train_ids == original.train_ids
+        assert loaded.dev_ids == original.dev_ids
+        assert loaded.eval_ids == original.eval_ids
+        assert loaded.test_ids == original.test_ids
+
+    def test_empty_splits_round_trip(self, tmp_path: Path) -> None:
+        original = BenchmarkSplits(train_ids=["a"], dev_ids=["b"])
+        original.to_jsonl_dir(tmp_path / "splits")
+        loaded = BenchmarkSplits.from_jsonl_dir(tmp_path / "splits")
+        assert loaded.eval_ids == []
+        assert loaded.test_ids == []
+
+    def test_from_jsonl_dir_missing_files(self, tmp_path: Path) -> None:
+        (tmp_path / "splits").mkdir()
+        loaded = BenchmarkSplits.from_jsonl_dir(tmp_path / "splits")
+        assert loaded.train_ids == []
+        assert loaded.dev_ids == []

--- a/tests/test_optimization/test_harbor_splits.py
+++ b/tests/test_optimization/test_harbor_splits.py
@@ -1,0 +1,98 @@
+"""Tests for HarborBenchmark split support — symlink creation and split-aware execute."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from factory.optimization.benchmarks.harbor import HarborBenchmark
+from factory.optimization.surface import Surface
+from factory.optimization.types import BenchmarkSplits
+
+
+class TestCreateSplitDir:
+    def test_creates_symlinks(self, tmp_path: Path) -> None:
+        source = tmp_path / "benchmarks" / "searchqa-harbor" / "train"
+        source.mkdir(parents=True)
+        for tid in ["task_001", "task_002", "task_003"]:
+            (source / tid).mkdir()
+            (source / tid / "data.json").write_text("{}")
+
+        splits = BenchmarkSplits(dev_ids=["task_001", "task_003"], test_ids=["task_002"])
+        hb = HarborBenchmark(splits=splits, cleanup_jobs=False)
+        hb._run = 1
+
+        split_dir = hb._create_split_dir(tmp_path, ["task_001", "task_003"], "dev")
+        assert (split_dir / "task_001").is_symlink()
+        assert (split_dir / "task_003").is_symlink()
+        assert not (split_dir / "task_002").exists()
+        assert (split_dir / "task_001" / "data.json").exists()
+
+    def test_skips_missing_tasks(self, tmp_path: Path) -> None:
+        source = tmp_path / "benchmarks" / "searchqa-harbor" / "train"
+        source.mkdir(parents=True)
+        (source / "task_001").mkdir()
+
+        splits = BenchmarkSplits(dev_ids=["task_001", "task_missing"])
+        hb = HarborBenchmark(splits=splits, cleanup_jobs=False)
+        hb._run = 1
+
+        split_dir = hb._create_split_dir(tmp_path, ["task_001", "task_missing"], "dev")
+        assert (split_dir / "task_001").is_symlink()
+        assert not (split_dir / "task_missing").exists()
+
+    def test_falls_back_to_tasks_dir(self, tmp_path: Path) -> None:
+        source = tmp_path / "benchmarks" / "searchqa-harbor" / "tasks"
+        source.mkdir(parents=True)
+        (source / "t1").mkdir()
+
+        hb = HarborBenchmark(splits=BenchmarkSplits(dev_ids=["t1"]), cleanup_jobs=False)
+        hb._run = 1
+
+        split_dir = hb._create_split_dir(tmp_path, ["t1"], "dev")
+        assert (split_dir / "t1").is_symlink()
+
+
+class TestExecuteWithSplits:
+    @patch("factory.optimization.benchmarks.harbor.subprocess.run")
+    def test_split_passes_p_flag(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        source = tmp_path / "benchmarks" / "searchqa-harbor" / "train"
+        source.mkdir(parents=True)
+        (source / "t1").mkdir()
+        (source / "t2").mkdir()
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        splits = BenchmarkSplits(dev_ids=["t1"], test_ids=["t2"])
+        hb = HarborBenchmark(splits=splits, cleanup_jobs=False)
+        hb.execute(tmp_path, Surface(), split="dev")
+
+        cmd = mock_run.call_args[0][0]
+        assert "-p" in cmd
+        p_idx = cmd.index("-p")
+        p_val = cmd[p_idx + 1]
+        assert "split-dev" in p_val
+
+    @patch("factory.optimization.benchmarks.harbor.subprocess.run")
+    def test_no_split_uses_legacy(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        hb = HarborBenchmark(cleanup_jobs=False)
+        hb.execute(tmp_path, Surface(), split=None)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--dataset" in cmd
+
+    @patch("factory.optimization.benchmarks.harbor.subprocess.run")
+    def test_subset_dir_takes_precedence_when_no_splits(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        subset = tmp_path / "subset"
+        subset.mkdir()
+
+        hb = HarborBenchmark(subset_dir=subset, cleanup_jobs=False)
+        hb.execute(tmp_path, Surface())
+
+        cmd = mock_run.call_args[0][0]
+        assert "-p" in cmd
+        p_idx = cmd.index("-p")
+        assert cmd[p_idx + 1] == str(subset)

--- a/tests/test_optimization/test_loop.py
+++ b/tests/test_optimization/test_loop.py
@@ -15,9 +15,11 @@ class _CountingExecutor:
     def __init__(self, artifacts: list[str] | None = None) -> None:
         self.call_count = 0
         self._artifacts = artifacts or []
+        self.split_args: list[str | None] = []
 
-    def execute(self, project_dir: Path, surface: Surface, **kwargs: Any) -> ExecutionResult:
+    def execute(self, project_dir: Path, surface: Surface, split: str | None = None, **kwargs: Any) -> ExecutionResult:
         self.call_count += 1
+        self.split_args.append(split)
         return ExecutionResult(returncode=0, artifacts=self._artifacts, duration_s=1.0)
 
 
@@ -124,7 +126,7 @@ class TestOptimizationLoopTrain:
         result = loop.train()
         assert isinstance(result, TrainResult)
         assert len(result.steps) == 6
-        assert executor.call_count == 6
+        assert executor.call_count == 7  # 6 dev steps + 1 test split
 
     def test_train_default_config(self, tmp_path: Path) -> None:
         loop = OptimizationLoop(
@@ -170,3 +172,50 @@ class TestPatchApplication:
         loop.step()
         assert "nonexistent" not in surface.prompt_slots
         assert surface.prompt_slots["skill"] == "original"
+
+
+class TestSplitAwareExecution:
+    def test_step_passes_dev_split(self, tmp_path: Path) -> None:
+        executor = _CountingExecutor()
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=Surface(),
+            executor=executor,
+            evaluator=_FixedScoreEvaluator(),
+            mutator=_NoOpMutator(),
+        )
+        loop.step()
+        assert executor.split_args == ["dev"]
+
+    def test_train_passes_dev_then_test(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "result.json"
+        artifact.write_text("{}")
+        executor = _CountingExecutor(artifacts=[str(artifact)])
+        config = LoopConfig(epochs=1, steps_per_epoch=2)
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=Surface(),
+            executor=executor,
+            evaluator=_FixedScoreEvaluator(score=0.5),
+            mutator=_NoOpMutator(),
+            config=config,
+        )
+        result = loop.train()
+        assert executor.split_args == ["dev", "dev", "test"]
+        assert result.dev_score is not None
+        assert result.test_score is not None
+
+    def test_train_result_has_dev_and_test_scores(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "result.json"
+        artifact.write_text("{}")
+        executor = _CountingExecutor(artifacts=[str(artifact)])
+        loop = OptimizationLoop(
+            project_dir=tmp_path,
+            surface=Surface(),
+            executor=executor,
+            evaluator=_FixedScoreEvaluator(score=0.75),
+            mutator=_NoOpMutator(),
+        )
+        result = loop.train()
+        assert result.dev_score == 0.75
+        assert result.test_score == 0.75

--- a/tests/test_optimization/test_searchqa_splits.py
+++ b/tests/test_optimization/test_searchqa_splits.py
@@ -1,0 +1,67 @@
+"""Tests for create_searchqa_splits — deterministic partitioning."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from factory.optimization.benchmarks.searchqa import create_searchqa_splits
+
+
+def _make_tasks(tmp_path: Path, n: int) -> Path:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for i in range(n):
+        (tasks_dir / f"task_{i:03d}").mkdir()
+    return tasks_dir
+
+
+class TestCreateSearchqaSplits:
+    def test_correct_sizes_100_tasks(self, tmp_path: Path) -> None:
+        tasks_dir = _make_tasks(tmp_path, 100)
+        splits = create_searchqa_splits(tasks_dir)
+        assert len(splits.train_ids) == 60
+        assert len(splits.dev_ids) == 20
+        assert len(splits.eval_ids) == 10
+        assert len(splits.test_ids) == 10
+
+    def test_all_ids_accounted_for(self, tmp_path: Path) -> None:
+        tasks_dir = _make_tasks(tmp_path, 50)
+        splits = create_searchqa_splits(tasks_dir)
+        all_ids = splits.train_ids + splits.dev_ids + splits.eval_ids + splits.test_ids
+        assert len(all_ids) == 50
+        assert len(set(all_ids)) == 50
+
+    def test_deterministic_same_seed(self, tmp_path: Path) -> None:
+        tasks_dir = _make_tasks(tmp_path, 30)
+        s1 = create_searchqa_splits(tasks_dir, seed=42)
+        s2 = create_searchqa_splits(tasks_dir, seed=42)
+        assert s1.train_ids == s2.train_ids
+        assert s1.dev_ids == s2.dev_ids
+        assert s1.test_ids == s2.test_ids
+
+    def test_different_seed_different_partition(self, tmp_path: Path) -> None:
+        tasks_dir = _make_tasks(tmp_path, 30)
+        s1 = create_searchqa_splits(tasks_dir, seed=42)
+        s2 = create_searchqa_splits(tasks_dir, seed=99)
+        assert s1.train_ids != s2.train_ids
+
+    def test_no_cross_split_overlap(self, tmp_path: Path) -> None:
+        tasks_dir = _make_tasks(tmp_path, 100)
+        splits = create_searchqa_splits(tasks_dir)
+        assert splits.validate() == []
+
+    def test_custom_ratios(self, tmp_path: Path) -> None:
+        tasks_dir = _make_tasks(tmp_path, 100)
+        splits = create_searchqa_splits(
+            tasks_dir, train_ratio=0.5, dev_ratio=0.3, eval_ratio=0.1, test_ratio=0.1,
+        )
+        assert len(splits.train_ids) == 50
+        assert len(splits.dev_ids) == 30
+        assert len(splits.eval_ids) == 10
+        assert len(splits.test_ids) == 10
+
+    def test_small_dataset(self, tmp_path: Path) -> None:
+        tasks_dir = _make_tasks(tmp_path, 5)
+        splits = create_searchqa_splits(tasks_dir)
+        all_ids = splits.train_ids + splits.dev_ids + splits.eval_ids + splits.test_ids
+        assert len(all_ids) == 5


### PR DESCRIPTION
Closes the benchmark split protocol backlog items.

## Changes
- Added `SplitName` type alias and `BenchmarkSplits` dataclass to `factory/optimization/types.py` with `get_ids()`, `validate()`, `from_jsonl_dir()`, `to_jsonl_dir()` methods
- Extended `Executor` protocol with `split: SplitName | None = None` parameter (backward compatible)
- Updated `HarborBenchmark` to accept `splits` parameter with symlink-based `_create_split_dir()` for split-aware execution
- Updated `OptimizationLoop.step()` to pass `split='dev'` and `train()` to run a final `split='test'` evaluation, with `dev_score`/`test_score` in `TrainResult`
- Added `create_searchqa_splits()` helper with configurable ratios (60/20/10/10 default) and deterministic seed
- Added `--split-seed` and `--splits-dir` CLI args to `factory optimize`; auto-detects splits from `.factory/eval/benchmark/splits/`; prints split sizes and dev/test scores
- 22 new tests across 3 files (`test_benchmark_splits.py`, `test_harbor_splits.py`, `test_searchqa_splits.py`) + 3 updated tests in `test_loop.py`

All 181 optimization tests pass.