### PR TITLE
feat(workflow): add WorkflowIO, SubWorkflowNode, and parallel IO validation

### DIFF
--- a/factory/workflow/__init__.py
+++ b/factory/workflow/__init__.py
@@ -13,10 +13,12 @@ from factory.workflow.primitives import (
     JoinNode,
     SelectionNode,
     Study,
+    SubWorkflowNode,
     SubgraphForkNode,
     Verdict,
     VerdictType,
     Workflow,
+    WorkflowIO,
 )
 
 __all__ = [
@@ -32,9 +34,11 @@ __all__ = [
     "JoinNode",
     "SelectionNode",
     "Study",
+    "SubWorkflowNode",
     "SubgraphForkNode",
     "Verdict",
     "VerdictType",
     "Workflow",
     "WorkflowExecutor",
+    "WorkflowIO",
 ]

--- a/factory/workflow/events.py
+++ b/factory/workflow/events.py
@@ -88,6 +88,20 @@ class WorkflowHalted(WorkflowEvent):
     halted_at_node: str
 
 
+class HandoffEvent(BaseModel):
+    """Tracks file handoff between workflows or sub-workflows."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    workflow_name: str
+    run_id: str
+    source_node: str
+    target_workflow: str
+    files_handed: list[str] = []
+    files_missing: list[str] = []
+    timestamp: str = ""
+
+
 def emit_workflow_event(
     project_path: Any,
     event_type: str,

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -14,6 +14,7 @@ import structlog
 
 from factory.workflow.events import (
     GateVerdictEvent,
+    HandoffEvent,
     NodeCompleted,
     NodeFailed,
     NodeStarted,
@@ -33,6 +34,7 @@ from factory.workflow.primitives import (
     NodeType,
     SelectionNode,
     Study,
+    SubWorkflowNode,
     SubgraphForkNode,
     Verdict,
     VerdictType,
@@ -137,11 +139,13 @@ class WorkflowExecutor:
         node_timings: list[dict[str, Any]] = []
         for ev in self.result.events:
             if ev.get("type") == "node.completed" and "duration_ms" in ev:
-                node_timings.append({
-                    "id": ev.get("node_id", ""),
-                    "type": ev.get("node_type", ""),
-                    "duration_ms": round(ev["duration_ms"], 1),
-                })
+                node_timings.append(
+                    {
+                        "id": ev.get("node_id", ""),
+                        "type": ev.get("node_type", ""),
+                        "duration_ms": round(ev["duration_ms"], 1),
+                    }
+                )
         node_timings.sort(key=lambda n: n["duration_ms"], reverse=True)
         node_total_ms = sum(n["duration_ms"] for n in node_timings)
         log.info(
@@ -207,6 +211,13 @@ class WorkflowExecutor:
         if isinstance(node, JoinNode):
             self.result.nodes_executed += 1
             self.completed_files |= node.writes
+            next_id = self._next_unconditional(node_id)
+            if next_id:
+                await self._execute_from(next_id)
+            return
+
+        if isinstance(node, SubWorkflowNode):
+            await self._execute_sub_workflow(node)
             next_id = self._next_unconditional(node_id)
             if next_id:
                 await self._execute_from(next_id)
@@ -424,6 +435,16 @@ class WorkflowExecutor:
             target = self.workflow.nodes.get(target_id)
             if not target:
                 return
+
+            if isinstance(target, SubWorkflowNode):
+                try:
+                    await self._execute_sub_workflow(target)
+                except Exception as exc:
+                    if not self.result.halted:
+                        self.result.halt_reason = f"fork branch '{target_id}' failed: {exc}"
+                    self.result.halted = True
+                return
+
             node_type = type(target).__name__
             self._emit(
                 "node.started",
@@ -530,10 +551,14 @@ class WorkflowExecutor:
 
         # Collect subgraph node IDs by walking edges from entry to exit
         subgraph_ids = _collect_subgraph_nodes(
-            self.workflow, node.subgraph_entry, node.subgraph_exit,
+            self.workflow,
+            node.subgraph_entry,
+            node.subgraph_exit,
         )
         sub_workflow = self.workflow.subgraph(
-            subgraph_ids, name=f"{self.workflow.name}__branch", start_node=node.subgraph_entry,
+            subgraph_ids,
+            name=f"{self.workflow.name}__branch",
+            start_node=node.subgraph_entry,
         )
 
         branch_results: list[dict[str, Any]] = []
@@ -552,7 +577,9 @@ class WorkflowExecutor:
                 store = ExperimentStore(self.project_path)
                 exp_id = await store.begin(hypothesis)
                 wt_path, branch_name = create_experiment_worktree(
-                    self.project_path, exp_id, base_commit,
+                    self.project_path,
+                    exp_id,
+                    base_commit,
                 )
                 worktrees.append((wt_path, branch_name, exp_id))
 
@@ -588,9 +615,13 @@ class WorkflowExecutor:
         for r in results:
             if isinstance(r, BaseException):
                 log.warning("subgraph_branch_failed", error=str(r))
-                branch_results.append({
-                    "success": False, "halted": True, "halt_reason": str(r),
-                })
+                branch_results.append(
+                    {
+                        "success": False,
+                        "halted": True,
+                        "halt_reason": str(r),
+                    }
+                )
             else:
                 branch_results.append(r)  # type: ignore[arg-type]
 
@@ -646,7 +677,11 @@ class WorkflowExecutor:
                 continue
 
         if self.dry_run or not fork_output:
-            selection_result: dict[str, Any] = {"strategy": node.strategy, "winner": None, "reason": "dry-run"}
+            selection_result: dict[str, Any] = {
+                "strategy": node.strategy,
+                "winner": None,
+                "reason": "dry-run",
+            }
             self.result.node_outputs[node.id] = json.dumps(selection_result)
             self.completed_files |= node.writes
             elapsed = (time.monotonic() - start) * 1000
@@ -701,8 +736,14 @@ class WorkflowExecutor:
         winner_branch = best["branch"]
         try:
             sp.run(
-                ["git", "merge", winner_branch, "--no-edit", "-m",
-                 f"Merge parallel experiment winner (exp {best['exp_id']})"],
+                [
+                    "git",
+                    "merge",
+                    winner_branch,
+                    "--no-edit",
+                    "-m",
+                    f"Merge parallel experiment winner (exp {best['exp_id']})",
+                ],
                 cwd=self.project_path,
                 check=True,
                 capture_output=True,
@@ -724,9 +765,12 @@ class WorkflowExecutor:
 
             if branch is not best and exp_id is not None:
                 from factory.models import ExperimentRecord
+
                 record = ExperimentRecord(
                     id=exp_id,
-                    timestamp=__import__("datetime").datetime.now(tz=__import__("datetime").timezone.utc),
+                    timestamp=__import__("datetime").datetime.now(
+                        tz=__import__("datetime").timezone.utc
+                    ),
                     hypothesis=branch.get("hypothesis", ""),
                     change_summary="superseded by experiment " + str(best["exp_id"]),
                     issue_number=None,
@@ -776,6 +820,166 @@ class WorkflowExecutor:
         next_id = self._next_unconditional(node.id)
         if next_id:
             await self._execute_from(next_id)
+
+    async def _execute_sub_workflow(self, node: SubWorkflowNode) -> None:
+        """Resolve and execute a sub-workflow referenced by name."""
+        from factory.workflow.definitions import register_all
+
+        node_id = node.id
+        self._emit(
+            "node.started",
+            NodeStarted(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                node_id=node_id,
+                node_type="SubWorkflowNode",
+            ),
+        )
+
+        start = time.monotonic()
+        registry = register_all()
+        child_wf = registry.get(node.workflow_name)
+        if not child_wf:
+            self._emit(
+                "node.failed",
+                NodeFailed(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    node_id=node_id,
+                    node_type="SubWorkflowNode",
+                    error=f"workflow '{node.workflow_name}' not found in registry",
+                ),
+            )
+            self.result.halted = True
+            self.result.halt_reason = f"sub-workflow '{node.workflow_name}' not found in registry"
+            return
+
+        # Validate IO inputs
+        files_handed: list[str] = []
+        files_missing: list[str] = []
+        if child_wf.io and child_wf.io.inputs:
+            for required in child_wf.io.inputs:
+                if required in self.completed_files:
+                    files_handed.append(required)
+                elif (self.project_path / required).exists():
+                    files_handed.append(required)
+                else:
+                    files_missing.append(required)
+
+            if files_missing:
+                self._emit(
+                    "node.failed",
+                    NodeFailed(
+                        workflow_name=self.workflow.name,
+                        run_id=self.run_id,
+                        node_id=node_id,
+                        node_type="SubWorkflowNode",
+                        error=f"missing inputs for '{node.workflow_name}': {files_missing}",
+                    ),
+                )
+                self.result.halted = True
+                self.result.halt_reason = (
+                    f"sub-workflow '{node.workflow_name}' missing inputs: {files_missing}"
+                )
+                return
+
+        ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        self._emit(
+            "handoff.started",
+            HandoffEvent(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                source_node=node_id,
+                target_workflow=node.workflow_name,
+                files_handed=sorted(files_handed),
+                files_missing=sorted(files_missing),
+                timestamp=ts,
+            ),
+        )
+
+        # Create child executor
+        child_executor = WorkflowExecutor(
+            child_wf.model_copy(deep=True),
+            self.project_path,
+            agent_pool=self.agent_pool,
+            dry_run=self.dry_run,
+            auto_approve=self.auto_approve,
+        )
+
+        # Pass parent context to child
+        if node.pass_context:
+            child_executor.node_context.update(self.node_context)
+
+        # Pass parent completed_files so child can read them
+        child_executor.completed_files |= self.completed_files
+
+        child_result = await child_executor.execute()
+
+        # Propagate halt
+        if child_result.halted:
+            self._emit(
+                "node.failed",
+                NodeFailed(
+                    workflow_name=self.workflow.name,
+                    run_id=self.run_id,
+                    node_id=node_id,
+                    node_type="SubWorkflowNode",
+                    error=f"sub-workflow '{node.workflow_name}' halted: {child_result.halt_reason}",
+                ),
+            )
+            self.result.halted = True
+            self.result.halt_reason = (
+                f"sub-workflow '{node.workflow_name}' halted: {child_result.halt_reason}"
+            )
+            return
+
+        # Verify IO outputs
+        if child_wf.io and child_wf.io.outputs:
+            missing_outputs = []
+            for expected in child_wf.io.outputs:
+                if (
+                    expected not in child_result.completed_files
+                    and not (self.project_path / expected).exists()
+                ):
+                    missing_outputs.append(expected)
+            if missing_outputs:
+                log.warning(
+                    "sub_workflow.missing_outputs",
+                    workflow=node.workflow_name,
+                    missing=missing_outputs,
+                )
+
+        # Merge child state into parent
+        self.completed_files |= child_result.completed_files
+        self.completed_files |= node.writes
+        self.result.nodes_executed += 1
+
+        elapsed = (time.monotonic() - start) * 1000
+        self._emit(
+            "node.completed",
+            NodeCompleted(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                node_id=node_id,
+                node_type="SubWorkflowNode",
+                files_written=sorted(node.writes | child_result.completed_files),
+                duration_ms=elapsed,
+            ),
+        )
+
+        ts_end = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        self._emit(
+            "handoff.completed",
+            HandoffEvent(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                source_node=node_id,
+                target_workflow=node.workflow_name,
+                files_handed=sorted(child_result.completed_files),
+                files_missing=[],
+                timestamp=ts_end,
+            ),
+        )
 
     async def _run_node(self, node: NodeType) -> str:
         """Execute a single node and return its output."""
@@ -854,7 +1058,8 @@ class WorkflowExecutor:
         if node.evaluator_type == "fn":
             if node.evaluator_command:
                 cmd = node.evaluator_command.replace(
-                    "{project_path}", shlex.quote(str(self.project_path)),
+                    "{project_path}",
+                    shlex.quote(str(self.project_path)),
                 )
                 try:
                     output = await self._run_shell(cmd)
@@ -887,7 +1092,8 @@ class WorkflowExecutor:
         """Build the lightweight CEO gate prompt."""
         if node.gate_prompt:
             return node.gate_prompt.replace(
-                "{project_path}", str(self.project_path),
+                "{project_path}",
+                str(self.project_path),
             )
 
         output_files = sorted(node.reads) if node.reads else ["(no specific file)"]
@@ -939,7 +1145,9 @@ class WorkflowExecutor:
             if not target:
                 target = self._next_conditional(gate_id, VerdictType.RELOOP)
             if not target:
-                return Verdict.halt(reason=f"RELOOP verdict from gate '{gate_id}' missing target and no RELOOP edge defined")
+                return Verdict.halt(
+                    reason=f"RELOOP verdict from gate '{gate_id}' missing target and no RELOOP edge defined"
+                )
             feedback = feedback_match.group(1) if feedback_match else "needs improvement"
             return Verdict.reloop(target=target, feedback=feedback)
 
@@ -988,9 +1196,7 @@ class WorkflowExecutor:
 
         if proc.returncode != 0:
             stderr = stderr_bytes.decode() if stderr_bytes else ""
-            raise RuntimeError(
-                f"command failed (exit {proc.returncode}): {cmd}\n{stderr[:500]}"
-            )
+            raise RuntimeError(f"command failed (exit {proc.returncode}): {cmd}\n{stderr[:500]}")
 
         return stdout
 

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -209,6 +209,30 @@ class Study(FnNode):
     focus: str | None = None
 
 
+# ── workflow IO ─────────────────────────────────────────────────
+
+
+class WorkflowIO(BaseModel):
+    """Typed input/output contract for a workflow."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    inputs: set[str] = Field(default_factory=set)
+    outputs: set[str] = Field(default_factory=set)
+    optional_inputs: set[str] = Field(default_factory=set)
+    optional_outputs: set[str] = Field(default_factory=set)
+
+
+class SubWorkflowNode(Node):
+    """Node that invokes another registered workflow by name."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    workflow_name: str
+    input_mapping: dict[str, str] = Field(default_factory=dict)
+    pass_context: bool = True
+
+
 # ── edges ────────────────────────────────────────────────────────
 
 
@@ -226,7 +250,15 @@ class Edge(BaseModel):
 
 
 NodeType = (
-    AgentNode | FnNode | GateNode | ForkNode | JoinNode | SubgraphForkNode | SelectionNode | Study
+    AgentNode
+    | FnNode
+    | GateNode
+    | ForkNode
+    | JoinNode
+    | SubgraphForkNode
+    | SelectionNode
+    | Study
+    | SubWorkflowNode
 )
 
 
@@ -243,6 +275,7 @@ class Workflow(BaseModel):
     edges: list[Edge]
     start_node: str
     terminal: bool = False
+    io: WorkflowIO | None = None
     trigger: TriggerFn | None = Field(default=None, exclude=True)
 
     def validate_graph(self) -> list[str]:

--- a/factory/workflow/validation.py
+++ b/factory/workflow/validation.py
@@ -24,7 +24,9 @@ def _validate_edges(workflow: Workflow, issues: list[str]) -> None:
 
 
 def _validate_reachability(
-    g: nx.DiGraph, workflow: Workflow, issues: list[str],  # type: ignore[type-arg]
+    g: nx.DiGraph,
+    workflow: Workflow,
+    issues: list[str],  # type: ignore[type-arg]
 ) -> None:
     reachable = nx.descendants(g, workflow.start_node) | {workflow.start_node}
     unreachable = set(workflow.nodes.keys()) - reachable
@@ -33,7 +35,9 @@ def _validate_reachability(
 
 
 def _validate_cycles(
-    g: nx.DiGraph, workflow: Workflow, issues: list[str],  # type: ignore[type-arg]
+    g: nx.DiGraph,
+    workflow: Workflow,
+    issues: list[str],  # type: ignore[type-arg]
 ) -> None:
     cycles = list(nx.simple_cycles(g))
     for cycle in cycles:
@@ -59,7 +63,9 @@ def _validate_cycles(
 
 
 def _validate_data_dependencies(
-    g: nx.DiGraph, workflow: Workflow, issues: list[str],  # type: ignore[type-arg]
+    g: nx.DiGraph,
+    workflow: Workflow,
+    issues: list[str],  # type: ignore[type-arg]
 ) -> None:
     for nid, node in workflow.nodes.items():
         if node.reads:
@@ -73,9 +79,7 @@ def _validate_data_dependencies(
                     available_writes |= pred_node.writes
             missing = node.reads - available_writes
             if missing:
-                issues.append(
-                    f"node '{nid}' reads {missing} but no predecessor writes them"
-                )
+                issues.append(f"node '{nid}' reads {missing} but no predecessor writes them")
 
 
 def _validate_fork_join_nodes(workflow: Workflow, issues: list[str]) -> None:
@@ -97,6 +101,99 @@ def _validate_fork_join_nodes(workflow: Workflow, issues: list[str]) -> None:
                 issues.append(f"subgraph_fork '{nid}' entry '{entry}' not in nodes")
             if exit_node not in workflow.nodes:
                 issues.append(f"subgraph_fork '{nid}' exit '{exit_node}' not in nodes")
+
+
+def _validate_parallel_io(workflow: Workflow, issues: list[str]) -> None:
+    from factory.workflow.primitives import ForkNode, SubWorkflowNode
+
+    for nid, node in workflow.nodes.items():
+        if not isinstance(node, ForkNode):
+            continue
+
+        sub_outputs: list[tuple[str, set[str]]] = []
+        for target_id in node.targets:
+            target = workflow.nodes.get(target_id)
+            if not isinstance(target, SubWorkflowNode):
+                continue
+
+            from factory.workflow.definitions import register_all
+
+            registry = register_all()
+            wf = registry.get(target.workflow_name)
+            if wf and wf.io:
+                sub_outputs.append((target_id, wf.io.outputs))
+
+        for i, (id_a, out_a) in enumerate(sub_outputs):
+            for id_b, out_b in sub_outputs[i + 1 :]:
+                overlap = out_a & out_b
+                if overlap:
+                    issues.append(
+                        f"parallel conflict: {id_a} and {id_b} both write {sorted(overlap)}"
+                    )
+
+
+def _validate_sub_workflow_io(workflow: Workflow, issues: list[str]) -> None:
+    from factory.workflow.primitives import SubWorkflowNode
+
+    for nid, node in workflow.nodes.items():
+        if not isinstance(node, SubWorkflowNode):
+            continue
+
+        from factory.workflow.definitions import register_all
+
+        registry = register_all()
+        wf = registry.get(node.workflow_name)
+        if not wf:
+            issues.append(
+                f"sub_workflow '{nid}': referenced workflow '{node.workflow_name}' "
+                f"not found in registry"
+            )
+            continue
+
+        if not wf.io:
+            issues.append(
+                f"sub_workflow '{nid}': referenced workflow '{node.workflow_name}' "
+                f"has no io contract defined"
+            )
+
+
+def _validate_sub_workflow_cycles(workflow: Workflow, issues: list[str]) -> None:
+    from factory.workflow.primitives import SubWorkflowNode
+
+    from factory.workflow.definitions import register_all
+
+    registry = register_all()
+
+    def _check_circular(
+        wf_name: str,
+        visited: set[str],
+    ) -> str | None:
+        if wf_name in visited:
+            return wf_name
+        visited.add(wf_name)
+        wf = registry.get(wf_name)
+        if not wf:
+            return None
+        for node in wf.nodes.values():
+            if isinstance(node, SubWorkflowNode):
+                result = _check_circular(node.workflow_name, visited.copy())
+                if result:
+                    return result
+        return None
+
+    for nid, node in workflow.nodes.items():
+        if not isinstance(node, SubWorkflowNode):
+            continue
+        cycle_target = _check_circular(
+            node.workflow_name,
+            {workflow.name},
+        )
+        if cycle_target:
+            issues.append(
+                f"sub_workflow '{nid}': circular reference detected "
+                f"(workflow '{node.workflow_name}' transitively references "
+                f"'{cycle_target}')"
+            )
 
 
 def validate_workflow(workflow: Workflow) -> list[str]:
@@ -138,5 +235,9 @@ def validate_workflow(workflow: Workflow) -> list[str]:
                     issues.append(
                         f"subgraph_fork '{nid}': no path from entry '{entry}' to exit '{exit_node}'"
                     )
+
+    _validate_parallel_io(workflow, issues)
+    _validate_sub_workflow_io(workflow, issues)
+    _validate_sub_workflow_cycles(workflow, issues)
 
     return issues

--- a/tests/test_workflow_io.py
+++ b/tests/test_workflow_io.py
@@ -1,0 +1,582 @@
+"""Tests for WorkflowIO, SubWorkflowNode, and parallel IO safety validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from factory.workflow.events import HandoffEvent
+from factory.workflow.executor import WorkflowExecutor
+from factory.workflow.primitives import (
+    Edge,
+    FnNode,
+    ForkNode,
+    JoinNode,
+    SubWorkflowNode,
+    Workflow,
+    WorkflowIO,
+)
+
+
+# ── WorkflowIO model ───────────────────────────────────────────────
+
+
+class TestWorkflowIO:
+    def test_default_empty(self) -> None:
+        io = WorkflowIO()
+        assert io.inputs == set()
+        assert io.outputs == set()
+        assert io.optional_inputs == set()
+        assert io.optional_outputs == set()
+
+    def test_with_values(self) -> None:
+        io = WorkflowIO(
+            inputs={".factory/strategy/observations.md"},
+            outputs={".factory/strategy/research-combined.md"},
+            optional_inputs={".factory/archive/"},
+            optional_outputs={".factory/strategy/research-similar.md"},
+        )
+        assert ".factory/strategy/observations.md" in io.inputs
+        assert ".factory/strategy/research-combined.md" in io.outputs
+        assert ".factory/archive/" in io.optional_inputs
+        assert ".factory/strategy/research-similar.md" in io.optional_outputs
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkflowIO(bad_field="nope")  # type: ignore[call-arg]
+
+    def test_serialize_roundtrip(self) -> None:
+        io = WorkflowIO(
+            inputs={"a.txt", "b.txt"},
+            outputs={"c.txt"},
+        )
+        data = io.model_dump()
+        io2 = WorkflowIO.model_validate(data)
+        assert io2.inputs == io.inputs
+        assert io2.outputs == io.outputs
+
+
+# ── SubWorkflowNode model ──────────────────────────────────────────
+
+
+class TestSubWorkflowNode:
+    def test_creation(self) -> None:
+        node = SubWorkflowNode(
+            id="sub_research",
+            workflow_name="research",
+        )
+        assert node.workflow_name == "research"
+        assert node.input_mapping == {}
+        assert node.pass_context is True
+        assert node.blocking is True
+
+    def test_with_mapping(self) -> None:
+        node = SubWorkflowNode(
+            id="sub_build",
+            workflow_name="build-verify",
+            input_mapping={"plan.md": ".factory/strategy/current.md"},
+            pass_context=False,
+        )
+        assert node.input_mapping == {"plan.md": ".factory/strategy/current.md"}
+        assert node.pass_context is False
+
+    def test_reads_writes(self) -> None:
+        node = SubWorkflowNode(
+            id="sub_qa",
+            workflow_name="deep-qa",
+            reads={".factory/reviews/builder-latest.md"},
+            writes={".factory/reviews/qa-complete.md"},
+        )
+        assert ".factory/reviews/builder-latest.md" in node.reads
+        assert ".factory/reviews/qa-complete.md" in node.writes
+
+    def test_extra_fields_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            SubWorkflowNode(
+                id="sub",
+                workflow_name="test",
+                bad_field="nope",  # type: ignore[call-arg]
+            )
+
+    def test_serialize_roundtrip(self) -> None:
+        node = SubWorkflowNode(
+            id="sub_test",
+            workflow_name="test-wf",
+            input_mapping={"a": "b"},
+            pass_context=False,
+        )
+        data = node.model_dump()
+        node2 = SubWorkflowNode.model_validate(data)
+        assert node2.workflow_name == node.workflow_name
+        assert node2.input_mapping == node.input_mapping
+        assert node2.pass_context == node.pass_context
+
+
+# ── Workflow with IO ────────────────────────────────────────────────
+
+
+class TestWorkflowWithIO:
+    def test_workflow_io_none_by_default(self) -> None:
+        wf = Workflow(
+            name="test",
+            nodes={"a": FnNode(id="a", command="echo a")},
+            edges=[],
+            start_node="a",
+        )
+        assert wf.io is None
+
+    def test_workflow_with_io(self) -> None:
+        wf = Workflow(
+            name="test",
+            nodes={"a": FnNode(id="a", command="echo a", writes={"out.txt"})},
+            edges=[],
+            start_node="a",
+            io=WorkflowIO(
+                inputs={"in.txt"},
+                outputs={"out.txt"},
+            ),
+        )
+        assert wf.io is not None
+        assert "in.txt" in wf.io.inputs
+        assert "out.txt" in wf.io.outputs
+
+    def test_workflow_with_sub_workflow_node_validates(self) -> None:
+        wf = Workflow(
+            name="parent",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "sub": SubWorkflowNode(
+                    id="sub",
+                    workflow_name="child",
+                    reads={"a.txt"},
+                ),
+            },
+            edges=[Edge(source="a", target="sub")],
+            start_node="a",
+        )
+        # Graph validation succeeds structurally (registry checks are separate)
+        issues = [
+            i
+            for i in wf.validate_graph()
+            if "not found in registry" not in i and "no io contract" not in i
+        ]
+        assert issues == []
+
+
+# ── HandoffEvent ────────────────────────────────────────────────────
+
+
+class TestHandoffEvent:
+    def test_creation(self) -> None:
+        event = HandoffEvent(
+            workflow_name="design",
+            run_id="abc123",
+            source_node="sub_research",
+            target_workflow="research",
+            files_handed=["obs.md"],
+            files_missing=[],
+            timestamp="2026-01-01T00:00:00Z",
+        )
+        assert event.workflow_name == "design"
+        assert event.target_workflow == "research"
+        assert event.files_handed == ["obs.md"]
+        assert event.files_missing == []
+
+    def test_defaults(self) -> None:
+        event = HandoffEvent(
+            workflow_name="test",
+            run_id="123",
+            source_node="node",
+            target_workflow="child",
+        )
+        assert event.files_handed == []
+        assert event.files_missing == []
+        assert event.timestamp == ""
+
+
+# ── Parallel IO safety validation ──────────────────────────────────
+
+
+def _make_child_workflow(name: str, outputs: set[str]) -> Workflow:
+    return Workflow(
+        name=name,
+        nodes={"a": FnNode(id="a", command="echo a", writes=outputs)},
+        edges=[],
+        start_node="a",
+        io=WorkflowIO(outputs=outputs),
+    )
+
+
+class TestParallelIOValidation:
+    def test_non_overlapping_outputs_pass(self) -> None:
+        child_a = _make_child_workflow("wf_a", {"a.txt"})
+        child_b = _make_child_workflow("wf_b", {"b.txt"})
+
+        parent = Workflow(
+            name="parent",
+            nodes={
+                "fork": ForkNode(id="fork", targets=["sub_a", "sub_b"]),
+                "sub_a": SubWorkflowNode(id="sub_a", workflow_name="wf_a"),
+                "sub_b": SubWorkflowNode(id="sub_b", workflow_name="wf_b"),
+                "join": JoinNode(id="join", sources=["sub_a", "sub_b"]),
+            },
+            edges=[Edge(source="fork", target="join")],
+            start_node="fork",
+        )
+
+        registry = {"wf_a": child_a, "wf_b": child_b, "parent": parent}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            issues = [i for i in parent.validate_graph() if "parallel conflict" in i]
+            assert issues == []
+
+    def test_overlapping_outputs_fail(self) -> None:
+        child_a = _make_child_workflow("wf_a", {"shared.txt", "a.txt"})
+        child_b = _make_child_workflow("wf_b", {"shared.txt", "b.txt"})
+
+        parent = Workflow(
+            name="parent",
+            nodes={
+                "fork": ForkNode(id="fork", targets=["sub_a", "sub_b"]),
+                "sub_a": SubWorkflowNode(id="sub_a", workflow_name="wf_a"),
+                "sub_b": SubWorkflowNode(id="sub_b", workflow_name="wf_b"),
+                "join": JoinNode(id="join", sources=["sub_a", "sub_b"]),
+            },
+            edges=[Edge(source="fork", target="join")],
+            start_node="fork",
+        )
+
+        registry = {"wf_a": child_a, "wf_b": child_b, "parent": parent}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            issues = parent.validate_graph()
+            assert any("parallel conflict" in i and "shared.txt" in i for i in issues)
+
+    def test_io_completeness_missing_io(self) -> None:
+        child_no_io = Workflow(
+            name="no_io_wf",
+            nodes={"a": FnNode(id="a", command="echo a")},
+            edges=[],
+            start_node="a",
+        )
+
+        parent = Workflow(
+            name="parent",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="no_io_wf"),
+            },
+            edges=[],
+            start_node="sub",
+        )
+
+        registry = {"no_io_wf": child_no_io, "parent": parent}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            issues = parent.validate_graph()
+            assert any("no io contract" in i for i in issues)
+
+    def test_circular_reference_detected(self) -> None:
+        wf_a = Workflow(
+            name="wf_a",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="wf_b"),
+            },
+            edges=[],
+            start_node="sub",
+            io=WorkflowIO(),
+        )
+        wf_b = Workflow(
+            name="wf_b",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="wf_a"),
+            },
+            edges=[],
+            start_node="sub",
+            io=WorkflowIO(),
+        )
+
+        registry = {"wf_a": wf_a, "wf_b": wf_b}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            issues = wf_a.validate_graph()
+            assert any("circular reference" in i for i in issues)
+
+    def test_self_reference_detected(self) -> None:
+        wf = Workflow(
+            name="self_ref",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="self_ref"),
+            },
+            edges=[],
+            start_node="sub",
+            io=WorkflowIO(),
+        )
+
+        registry = {"self_ref": wf}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            issues = wf.validate_graph()
+            assert any("circular reference" in i for i in issues)
+
+    def test_missing_workflow_in_registry(self) -> None:
+        parent = Workflow(
+            name="parent",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="nonexistent"),
+            },
+            edges=[],
+            start_node="sub",
+        )
+
+        registry = {"parent": parent}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            issues = parent.validate_graph()
+            assert any("not found in registry" in i for i in issues)
+
+
+# ── Executor: _execute_sub_workflow dry-run ────────────────────────
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    factory_dir = tmp_path / ".factory"
+    factory_dir.mkdir()
+    (factory_dir / "strategy").mkdir()
+    (factory_dir / "reviews").mkdir()
+    (factory_dir / "experiments").mkdir()
+    (factory_dir / "archive").mkdir()
+    return tmp_path
+
+
+class TestExecuteSubWorkflowDryRun:
+    async def test_sub_workflow_executes(self, tmp_project: Path) -> None:
+        child_wf = Workflow(
+            name="child",
+            nodes={
+                "step": FnNode(id="step", command="echo done", writes={"child_out.txt"}),
+            },
+            edges=[],
+            start_node="step",
+            io=WorkflowIO(outputs={"child_out.txt"}),
+        )
+
+        parent_wf = Workflow(
+            name="parent",
+            nodes={
+                "pre": FnNode(id="pre", command="echo pre", writes={"pre.txt"}),
+                "sub": SubWorkflowNode(id="sub", workflow_name="child", reads={"pre.txt"}),
+            },
+            edges=[Edge(source="pre", target="sub")],
+            start_node="pre",
+        )
+
+        registry = {"child": child_wf, "parent": parent_wf}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            executor = WorkflowExecutor(parent_wf, tmp_project, dry_run=True)
+            result = await executor.execute()
+
+        assert result.success
+        assert not result.halted
+        assert "child_out.txt" in result.completed_files
+        assert "pre.txt" in result.completed_files
+
+    async def test_sub_workflow_missing_registry(self, tmp_project: Path) -> None:
+        parent_wf = Workflow(
+            name="parent",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="missing"),
+            },
+            edges=[],
+            start_node="sub",
+        )
+
+        with patch("factory.workflow.definitions.register_all", return_value={}):
+            executor = WorkflowExecutor(parent_wf, tmp_project, dry_run=True)
+            result = await executor.execute()
+
+        assert result.halted
+        assert "not found in registry" in result.halt_reason
+
+    async def test_sub_workflow_missing_inputs_halts(self, tmp_project: Path) -> None:
+        child_wf = Workflow(
+            name="child",
+            nodes={
+                "step": FnNode(id="step", command="echo done"),
+            },
+            edges=[],
+            start_node="step",
+            io=WorkflowIO(inputs={"required.txt"}),
+        )
+
+        parent_wf = Workflow(
+            name="parent",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="child"),
+            },
+            edges=[],
+            start_node="sub",
+        )
+
+        registry = {"child": child_wf}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            executor = WorkflowExecutor(parent_wf, tmp_project, dry_run=True)
+            result = await executor.execute()
+
+        assert result.halted
+        assert "missing inputs" in result.halt_reason
+
+    async def test_sub_workflow_inputs_satisfied_by_completed_files(
+        self, tmp_project: Path
+    ) -> None:
+        child_wf = Workflow(
+            name="child",
+            nodes={
+                "step": FnNode(
+                    id="step",
+                    command="echo done",
+                    reads={"pre.txt"},
+                    writes={"out.txt"},
+                ),
+            },
+            edges=[],
+            start_node="step",
+            io=WorkflowIO(inputs={"pre.txt"}, outputs={"out.txt"}),
+        )
+
+        parent_wf = Workflow(
+            name="parent",
+            nodes={
+                "pre": FnNode(id="pre", command="echo pre", writes={"pre.txt"}),
+                "sub": SubWorkflowNode(id="sub", workflow_name="child", reads={"pre.txt"}),
+            },
+            edges=[Edge(source="pre", target="sub")],
+            start_node="pre",
+        )
+
+        registry = {"child": child_wf}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            executor = WorkflowExecutor(parent_wf, tmp_project, dry_run=True)
+            result = await executor.execute()
+
+        assert result.success
+        assert "out.txt" in result.completed_files
+
+    async def test_sub_workflow_inputs_satisfied_by_disk(self, tmp_project: Path) -> None:
+        (tmp_project / "on_disk.txt").write_text("exists")
+
+        child_wf = Workflow(
+            name="child",
+            nodes={
+                "step": FnNode(id="step", command="echo done", writes={"out.txt"}),
+            },
+            edges=[],
+            start_node="step",
+            io=WorkflowIO(inputs={"on_disk.txt"}, outputs={"out.txt"}),
+        )
+
+        parent_wf = Workflow(
+            name="parent",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="child"),
+            },
+            edges=[],
+            start_node="sub",
+        )
+
+        registry = {"child": child_wf}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            executor = WorkflowExecutor(parent_wf, tmp_project, dry_run=True)
+            result = await executor.execute()
+
+        assert result.success
+
+    async def test_fork_with_sub_workflow_targets(self, tmp_project: Path) -> None:
+        child_a = Workflow(
+            name="wf_a",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+            },
+            edges=[],
+            start_node="a",
+            io=WorkflowIO(outputs={"a.txt"}),
+        )
+        child_b = Workflow(
+            name="wf_b",
+            nodes={
+                "b": FnNode(id="b", command="echo b", writes={"b.txt"}),
+            },
+            edges=[],
+            start_node="b",
+            io=WorkflowIO(outputs={"b.txt"}),
+        )
+
+        parent_wf = Workflow(
+            name="parent",
+            nodes={
+                "fork": ForkNode(id="fork", targets=["sub_a", "sub_b"]),
+                "sub_a": SubWorkflowNode(id="sub_a", workflow_name="wf_a"),
+                "sub_b": SubWorkflowNode(id="sub_b", workflow_name="wf_b"),
+                "join": JoinNode(
+                    id="join",
+                    sources=["sub_a", "sub_b"],
+                    reads={"a.txt", "b.txt"},
+                ),
+            },
+            edges=[Edge(source="fork", target="join")],
+            start_node="fork",
+        )
+
+        registry = {"wf_a": child_a, "wf_b": child_b}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            executor = WorkflowExecutor(parent_wf, tmp_project, dry_run=True)
+            result = await executor.execute()
+
+        assert result.success
+        assert "a.txt" in result.completed_files
+        assert "b.txt" in result.completed_files
+
+    async def test_handoff_events_emitted(self, tmp_project: Path) -> None:
+        child_wf = Workflow(
+            name="child",
+            nodes={
+                "step": FnNode(id="step", command="echo done", writes={"out.txt"}),
+            },
+            edges=[],
+            start_node="step",
+            io=WorkflowIO(outputs={"out.txt"}),
+        )
+
+        parent_wf = Workflow(
+            name="parent",
+            nodes={
+                "sub": SubWorkflowNode(id="sub", workflow_name="child"),
+            },
+            edges=[],
+            start_node="sub",
+        )
+
+        registry = {"child": child_wf}
+        with patch("factory.workflow.definitions.register_all", return_value=registry):
+            executor = WorkflowExecutor(parent_wf, tmp_project, dry_run=True)
+            result = await executor.execute()
+
+        handoff_events = [e for e in result.events if e["type"].startswith("handoff.")]
+        assert len(handoff_events) == 2
+        assert handoff_events[0]["type"] == "handoff.started"
+        assert handoff_events[1]["type"] == "handoff.completed"
+        assert handoff_events[0]["target_workflow"] == "child"
+
+
+# ── Existing workflows still validate ──────────────────────────────
+
+
+class TestExistingWorkflowsStillValid:
+    def test_all_registered_workflows_validate(self) -> None:
+        from factory.workflow.definitions import register_all
+
+        registry = register_all()
+        for name, wf in registry.items():
+            issues = [
+                i
+                for i in wf.validate_graph()
+                if "not found in registry" not in i and "no io contract" not in i
+            ]
+            assert issues == [], f"workflow '{name}' has validation issues: {issues}"


### PR DESCRIPTION
Phase 1 of modular workflow decomposition — adds primitives for
composable sub-workflows with typed IO contracts, without changing
any existing workflow behavior.

- WorkflowIO model: input/output file contracts for workflows
- SubWorkflowNode: references registered workflows by name
- io field on Workflow model (optional, defaults to None)
- HandoffEvent: tracks file handoff between parent/child workflows
- _execute_sub_workflow() in executor: resolves, validates IO, runs
  child executor, merges completed_files, emits handoff events
- ForkNode support for SubWorkflowNode targets (parallel execution)
- Validation: parallel IO disjointness, IO completeness, circular
  reference detection
- 28 new tests covering models, validation, and dry-run execution

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>