### PR TITLE
feat(workflow): add design_workflow_v2 recomposed with SubWorkflowNode

### DIFF
--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -45,6 +45,7 @@ __all__ = [
     "DOC_FRESHNESS_GATE_PROMPT",
     "build_workflow",
     "design_workflow",
+    "design_workflow_v2",
     "improve_workflow",
     "research_workflow",
     "meta_workflow",
@@ -4364,6 +4365,232 @@ def precheck_finalize_workflow() -> Workflow:
     )
 
 
+# ── W₂v₂: Design Mode (Recomposed) ────────────────────────────────
+
+
+def design_workflow_v2(just_plan: bool = False) -> Workflow:
+    """W₂v₂: Design Mode recomposed with SubWorkflowNode references.
+
+    Replaces inline nodes with sub-workflow references where possible:
+    - study + research-pipeline run IN PARALLEL via fork_observe/join_observe
+    - strategize is used inline (gate_type varies per mode)
+    - build-verify is a SubWorkflowNode reference
+    - Archivist and spec_generate remain as leaf nodes
+
+    When just_plan=True, truncates after strategy approval (no build phase).
+    """
+    from factory.workflow.primitives import SubWorkflowNode
+
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    # ── Entry gate: existing project vs new project ──
+    nodes["gate_has_factory"] = GateNode(
+        id="gate_has_factory",
+        evaluator_type="fn",
+        evaluator_command=(
+            'python3 -c "'
+            "from pathlib import Path; "
+            'exists = Path("{project_path}/.factory/config.json").exists(); '
+            'print("PROCEED" if exists else "HALT")'
+            '"'
+        ),
+        reads={".factory/config.json"},
+    )
+
+    nodes["discover"] = FnNode(
+        id="discover",
+        command="factory discover {project_path}",
+        writes={".factory/eval_profile.json"},
+    )
+
+    # ── Parallel observe: study + research pipeline ──
+    nodes["study"] = Study(
+        id="study",
+        command="factory study {project_path}",
+        writes={".factory/strategy/observations.md"},
+    )
+
+    nodes["sub_research"] = SubWorkflowNode(
+        id="sub_research",
+        workflow_name="research-pipeline",
+        writes={
+            ".factory/strategy/research-combined.md",
+            ".factory/strategy/research-similar.md",
+            ".factory/strategy/research-techstack.md",
+            ".factory/strategy/research-pitfalls.md",
+        },
+    )
+
+    nodes["fork_observe"] = ForkNode(
+        id="fork_observe",
+        targets=["study", "sub_research"],
+    )
+
+    nodes["join_observe"] = JoinNode(
+        id="join_observe",
+        sources=["study", "sub_research"],
+        reads={
+            ".factory/strategy/observations.md",
+            ".factory/strategy/research-combined.md",
+        },
+    )
+
+    # ── Strategist with user gate (design mode) ──
+    nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Synthesize a project specification from research. "
+            "Read ALL tagged research files at .factory/strategy/research-*.md. "
+            "Produce a complete phased build plan. Phase 1 must be project scaffold + eval harness. "
+            "Every Phase must have substantive What/Why/Expected impact fields. "
+            "Build EVERYTHING in this pass. Only defer items requiring human intervention. "
+            "Write the plan to .factory/strategy/current.md."
+        ),
+        reads={".factory/strategy/research-combined.md"},
+        writes={".factory/strategy/current.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/current.md",
+                must_exist=True,
+                min_size=200,
+                must_contain=["### Phase 1", "### Architecture"],
+            )
+        ],
+    )
+
+    nodes["gate_strategy"] = GateNode(
+        id="gate_strategy",
+        evaluator_type="user",
+        reads={".factory/strategy/current.md"},
+    )
+
+    # ── Archivist plan (async) ──
+    nodes["archivist_plan"] = AgentNode(
+        id="archivist_plan",
+        role=AgentRole.ARCHIVIST,
+        prompt_template="Archive the approved research and strategy.",
+        reads={".factory/strategy/current.md"},
+        writes={".factory/archive/plan.md"},
+        blocking=False,
+    )
+
+    if just_plan:
+        # ── Plan-only mode: no build phase ──
+        edges = [
+            Edge(source="gate_has_factory", target="fork_observe", condition=VerdictType.PROCEED),
+            Edge(source="gate_has_factory", target="discover", condition=VerdictType.HALT),
+            Edge(source="discover", target="fork_observe"),
+            # Fork parallel observe
+            Edge(source="fork_observe", target="study"),
+            Edge(source="fork_observe", target="sub_research"),
+            Edge(source="study", target="join_observe"),
+            Edge(source="sub_research", target="join_observe"),
+            # Join → strategist
+            Edge(source="join_observe", target="strategist"),
+            Edge(source="strategist", target="gate_strategy"),
+            Edge(source="gate_strategy", target="archivist_plan", condition=VerdictType.PROCEED),
+            Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        ]
+
+        wf_name = "plan-v2"
+        start = "gate_has_factory"
+        terminal = True
+
+        def plan_trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+            return ctx.get("just_plan") is True
+
+        return Workflow(
+            name=wf_name,
+            nodes=nodes,
+            edges=edges,
+            start_node=start,
+            terminal=terminal,
+            trigger=plan_trigger,
+        )
+
+    # ── Build-verify via SubWorkflowNode ──
+    nodes["sub_build_verify"] = SubWorkflowNode(
+        id="sub_build_verify",
+        workflow_name="build-verify",
+        writes={
+            ".factory/reviews/builder-latest.md",
+            ".factory/reviews/health-check.md",
+            ".factory/reviews/code-review.md",
+            ".factory/reviews/adversarial-qa.md",
+        },
+    )
+
+    # ── Precheck gate ──
+    nodes["gate_precheck"] = GateNode(
+        id="gate_precheck",
+        evaluator_type="fn",
+        evaluator_command="factory precheck {project_path} --score-before 0 --score-after 0",
+        reads={".factory/reviews/adversarial-qa.md"},
+    )
+
+    # ── Archivist build (async) ──
+    nodes["archivist_build"] = AgentNode(
+        id="archivist_build",
+        role=AgentRole.ARCHIVIST,
+        prompt_template="Archive the build phase results.",
+        reads={".factory/reviews/adversarial-qa.md"},
+        writes={".factory/archive/build.md"},
+        blocking=False,
+    )
+
+    # ── Spec generate (async) ──
+    nodes["spec_generate"] = FnNode(
+        id="spec_generate",
+        command="factory workflow run spec-generate {project_path}",
+        notes="Generate the project specification via the gated spec-generate workflow. Runs non-blocking after archival.",
+        blocking=False,
+    )
+
+    # ── Edges ──
+    edges = [
+        # Entry gate
+        Edge(source="gate_has_factory", target="fork_observe", condition=VerdictType.PROCEED),
+        Edge(source="gate_has_factory", target="discover", condition=VerdictType.HALT),
+        Edge(source="discover", target="fork_observe"),
+        # Fork parallel observe
+        Edge(source="fork_observe", target="study"),
+        Edge(source="fork_observe", target="sub_research"),
+        Edge(source="study", target="join_observe"),
+        Edge(source="sub_research", target="join_observe"),
+        # Join → strategist
+        Edge(source="join_observe", target="strategist"),
+        Edge(source="strategist", target="gate_strategy"),
+        Edge(source="gate_strategy", target="archivist_plan", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # Archivist → build-verify
+        Edge(source="archivist_plan", target="sub_build_verify"),
+        # Build-verify → precheck
+        Edge(source="sub_build_verify", target="gate_precheck"),
+        # Precheck → archivist build (proceed or halt)
+        Edge(source="gate_precheck", target="archivist_build", condition=VerdictType.PROCEED),
+        Edge(source="gate_precheck", target="archivist_build", condition=VerdictType.HALT),
+        # Archivist → spec generate
+        Edge(source="archivist_build", target="spec_generate"),
+    ]
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return state in {
+            ProjectState.NO_REPO,
+            ProjectState.REPO_INCOMPLETE,
+            ProjectState.HAS_FACTORY,
+        } and ctx.get("interactive", False)
+
+    return Workflow(
+        name="design-v2",
+        nodes=nodes,
+        edges=edges,
+        start_node="gate_has_factory",
+        trigger=trigger,
+    )
+
+
 # ── Registry ─────────────────────────────────────────────────────
 
 _BUILTIN_REGISTRY: dict[str, Any] | None = None
@@ -4377,6 +4604,7 @@ def _get_builtin_registry() -> dict[str, Any]:
     _BUILTIN_REGISTRY = {
         "build": build_workflow,
         "design": design_workflow,
+        "design-v2": design_workflow_v2,
         "discover": discover_workflow,
         "review": review_workflow,
         "improve": improve_workflow,
@@ -4398,6 +4626,8 @@ def _get_builtin_registry() -> dict[str, Any]:
         "evolve": evolve_workflow,
         "research-pipeline": research_pipeline_workflow,
         "strategize": strategize_workflow,
+        "strategize-user": lambda: strategize_workflow(gate_type="user"),
+        "strategize-agent": lambda: strategize_workflow(gate_type="agent"),
         "deep-qa": deep_qa_workflow,
         "build-verify": build_verify_workflow,
         "precheck-finalize": precheck_finalize_workflow,

--- a/tests/test_design_v2.py
+++ b/tests/test_design_v2.py
@@ -1,0 +1,242 @@
+"""Tests for design_workflow_v2 — Phase 4 recomposed design mode using SubWorkflowNode."""
+
+from __future__ import annotations
+
+import pytest
+
+from factory.workflow.definitions import (
+    _get_builtin_registry,
+    design_workflow,
+    design_workflow_v2,
+    register_all,
+)
+from factory.workflow.primitives import (
+    AgentNode,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    Study,
+    SubWorkflowNode,
+)
+
+
+class TestDesignV2Validation:
+    """design_workflow_v2 must pass graph validation."""
+
+    def test_validates_cleanly(self) -> None:
+        wf = design_workflow_v2()
+        issues = wf.validate_graph()
+        assert issues == [], f"design-v2 has issues: {issues}"
+
+    def test_just_plan_validates_cleanly(self) -> None:
+        wf = design_workflow_v2(just_plan=True)
+        issues = wf.validate_graph()
+        assert issues == [], f"design-v2 just_plan has issues: {issues}"
+
+
+class TestDesignV2NodeCount:
+    """design_workflow_v2 should have fewer total nodes than design_workflow (the point of decomposition)."""
+
+    def test_fewer_nodes_than_original(self) -> None:
+        original = design_workflow()
+        v2 = design_workflow_v2()
+        assert len(v2.nodes) < len(original.nodes), (
+            f"v2 has {len(v2.nodes)} nodes, original has {len(original.nodes)} — "
+            f"decomposition should reduce node count"
+        )
+
+
+class TestDesignV2SubWorkflowNodes:
+    """design_workflow_v2 must contain SubWorkflowNode instances."""
+
+    def test_has_sub_workflow_nodes(self) -> None:
+        wf = design_workflow_v2()
+        sub_nodes = [n for n in wf.nodes.values() if isinstance(n, SubWorkflowNode)]
+        assert len(sub_nodes) >= 2, (
+            f"Expected at least 2 SubWorkflowNode instances, found {len(sub_nodes)}"
+        )
+
+    def test_sub_research_references_research_pipeline(self) -> None:
+        wf = design_workflow_v2()
+        node = wf.nodes["sub_research"]
+        assert isinstance(node, SubWorkflowNode)
+        assert node.workflow_name == "research-pipeline"
+
+    def test_sub_build_verify_references_build_verify(self) -> None:
+        wf = design_workflow_v2()
+        node = wf.nodes["sub_build_verify"]
+        assert isinstance(node, SubWorkflowNode)
+        assert node.workflow_name == "build-verify"
+
+    def test_just_plan_has_no_build_verify(self) -> None:
+        wf = design_workflow_v2(just_plan=True)
+        assert "sub_build_verify" not in wf.nodes
+
+
+class TestDesignV2ParallelObserve:
+    """study and research must run in parallel via fork/join."""
+
+    def test_has_fork_observe(self) -> None:
+        wf = design_workflow_v2()
+        assert "fork_observe" in wf.nodes
+        assert isinstance(wf.nodes["fork_observe"], ForkNode)
+
+    def test_has_join_observe(self) -> None:
+        wf = design_workflow_v2()
+        assert "join_observe" in wf.nodes
+        assert isinstance(wf.nodes["join_observe"], JoinNode)
+
+    def test_fork_targets_study_and_research(self) -> None:
+        wf = design_workflow_v2()
+        fork = wf.nodes["fork_observe"]
+        assert isinstance(fork, ForkNode)
+        assert "study" in fork.targets
+        assert "sub_research" in fork.targets
+
+    def test_join_sources_study_and_research(self) -> None:
+        wf = design_workflow_v2()
+        join = wf.nodes["join_observe"]
+        assert isinstance(join, JoinNode)
+        assert "study" in join.sources
+        assert "sub_research" in join.sources
+
+
+class TestDesignV2IOChain:
+    """The IO contract chain must be valid across sub-workflows."""
+
+    def test_research_outputs_feed_strategize_inputs(self) -> None:
+        from factory.workflow.definitions import research_pipeline_workflow, strategize_workflow
+
+        research = research_pipeline_workflow()
+        strat = strategize_workflow(gate_type="user")
+        assert research.io is not None
+        assert strat.io is not None
+        assert strat.io.inputs.issubset(research.io.outputs)
+
+    def test_strategize_outputs_feed_build_verify_inputs(self) -> None:
+        from factory.workflow.definitions import build_verify_workflow, strategize_workflow
+
+        strat = strategize_workflow()
+        bv = build_verify_workflow()
+        assert strat.io is not None
+        assert bv.io is not None
+        assert bv.io.inputs.issubset(strat.io.outputs)
+
+    def test_study_node_writes_observations(self) -> None:
+        wf = design_workflow_v2()
+        study = wf.nodes["study"]
+        assert isinstance(study, Study)
+        assert ".factory/strategy/observations.md" in study.writes
+
+    def test_strategist_reads_research_combined(self) -> None:
+        wf = design_workflow_v2()
+        strategist = wf.nodes["strategist"]
+        assert isinstance(strategist, AgentNode)
+        assert ".factory/strategy/research-combined.md" in strategist.reads
+
+
+class TestDesignV2Regression:
+    """Existing design_workflow() must still validate after adding design_workflow_v2."""
+
+    def test_original_design_workflow_still_valid(self) -> None:
+        wf = design_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Original design_workflow has issues: {issues}"
+
+    def test_original_design_workflow_just_plan_still_valid(self) -> None:
+        wf = design_workflow(just_plan=True)
+        issues = wf.validate_graph()
+        assert issues == [], f"Original design_workflow(just_plan) has issues: {issues}"
+
+
+class TestDesignV2Registration:
+    """design_workflow_v2 must be registered and discoverable."""
+
+    def test_registered_in_builtin_registry(self) -> None:
+        registry = _get_builtin_registry()
+        assert "design-v2" in registry
+
+    def test_register_all_includes_design_v2(self) -> None:
+        all_workflows = register_all()
+        assert "design-v2" in all_workflows
+
+    def test_strategize_user_registered(self) -> None:
+        registry = _get_builtin_registry()
+        assert "strategize-user" in registry
+
+    def test_strategize_agent_registered(self) -> None:
+        registry = _get_builtin_registry()
+        assert "strategize-agent" in registry
+
+
+class TestDesignV2Structure:
+    """Verify key structural properties of the recomposed workflow."""
+
+    def test_start_node_is_gate_has_factory(self) -> None:
+        wf = design_workflow_v2()
+        assert wf.start_node == "gate_has_factory"
+
+    def test_name_is_design_v2(self) -> None:
+        wf = design_workflow_v2()
+        assert wf.name == "design-v2"
+
+    def test_just_plan_name_is_plan_v2(self) -> None:
+        wf = design_workflow_v2(just_plan=True)
+        assert wf.name == "plan-v2"
+
+    def test_just_plan_is_terminal(self) -> None:
+        wf = design_workflow_v2(just_plan=True)
+        assert wf.terminal is True
+
+    def test_full_is_not_terminal(self) -> None:
+        wf = design_workflow_v2()
+        assert wf.terminal is False
+
+    def test_has_gate_strategy_user_evaluator(self) -> None:
+        wf = design_workflow_v2()
+        gate = wf.nodes["gate_strategy"]
+        assert isinstance(gate, GateNode)
+        assert gate.evaluator_type == "user"
+
+    def test_has_archivist_plan_non_blocking(self) -> None:
+        wf = design_workflow_v2()
+        archivist = wf.nodes["archivist_plan"]
+        assert isinstance(archivist, AgentNode)
+        assert archivist.blocking is False
+
+    def test_has_spec_generate_non_blocking(self) -> None:
+        wf = design_workflow_v2()
+        spec = wf.nodes["spec_generate"]
+        assert isinstance(spec, FnNode)
+        assert spec.blocking is False
+
+
+class TestDesignV2DryRun:
+    """Dry-run execution must succeed."""
+
+    @pytest.fixture
+    def project_path(self, tmp_path):
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "strategy").mkdir(parents=True)
+        (factory_dir / "reviews").mkdir(parents=True)
+        (factory_dir / "experiments").mkdir(parents=True)
+        (factory_dir / "archive").mkdir(parents=True)
+        return tmp_path
+
+    async def test_dry_run_succeeds(self, project_path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        wf = design_workflow_v2()
+        executor = WorkflowExecutor(wf, str(project_path), dry_run=True)
+        result = await executor.execute()
+        assert result is not None
+
+    async def test_just_plan_dry_run_succeeds(self, project_path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        wf = design_workflow_v2(just_plan=True)
+        executor = WorkflowExecutor(wf, str(project_path), dry_run=True)
+        result = await executor.execute()
+        assert result is not None


### PR DESCRIPTION
Recompose design mode using SubWorkflowNode references instead of inline
nodes. Study and research-pipeline run IN PARALLEL via fork_observe/
join_observe. Build-verify is a single SubWorkflowNode reference.

The new workflow has fewer nodes than the original (~12 vs ~20+) while
preserving identical behavior. Registered as 'design-v2' alongside the
original 'design' workflow. Also registers 'strategize-user' and
'strategize-agent' as separate registry entries.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>