### PR TITLE
feat: add workflow plugin system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ The same graph definition produces two execution formats:
 - **Headless:** `WorkflowExecutor` (`factory/workflow/executor.py`) walks the DAG deterministically — `factory workflow run <name> --project /path`
 - **Interactive:** `skill_export.py` converts graphs to Claude Code `SKILL.md` files under `skills/workflow-*/` — the CEO agent reads these at runtime as mode-specific playbooks
 
+**Workflow plugins:** Workflows can be extended via pip-installable packages registering under the `factory.workflows` entry_points group, or local `.py` files dropped into `~/.factory/workflows/` or `<project>/.factory/workflows/`. `WorkflowManifest` (`factory/workflow/manifest.py`) provides plugin metadata, namespace enforcement, version compatibility checks, and capability validation. Third-party plugins declaring the `agent_only` capability are restricted to `AgentNode`-only graphs (no `FnNode` shell execution). Discovery uses dual mechanisms: directory-scan for local files and `importlib.metadata.entry_points` for installed packages. The `WorkflowRegistry` (`factory/workflow/registry.py`) manages discovery, validation, and lookup across all sources.
+
 ### Layer 3: CEO Agent (`factory/agents/prompts/ceo.md` + `skills/workflow-*/SKILL.md`)
 
 The CEO prompt is split into two parts:
@@ -79,7 +81,8 @@ Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent 
 8. **Checkpoint** (`factory/checkpoint.py`): Saves and loads CEO state for crash-resilient resume
 9. **Analysis** (`factory/analysis.py`): Experiment comparison (`diff`) and FEEC analysis (`explain`)
 10. **Adversarial** (`factory/adversarial.py`): GAN-style adversarial eval loop state machine — phase transitions with hysteresis, per-role streak counters, convergence detection. State persisted at `.factory/adversarial_state.json`
-11. **Contained** (`factory/contained/` + `factory/podman.py` + `factory/cli/contained.py`): `factory contained [runtime flags] -- <any factory command>` runs the factory in a podman container (`--target local`) or a cluster pod (`--target k8s`). See "Contained runtimes" below.
+11. **Workflow plugins** (`factory/workflow/manifest.py` + `factory/workflow/registry.py`): `WorkflowManifest` model for plugin metadata and capability validation. `WorkflowRegistry` discovers workflows via dual mechanisms: directory-scan (`~/.factory/workflows/`, `<project>/.factory/workflows/`) and `importlib.metadata.entry_points(group="factory.workflows")` for pip-installed packages
+12. **Contained** (`factory/contained/` + `factory/podman.py` + `factory/cli/contained.py`): `factory contained [runtime flags] -- <any factory command>` runs the factory in a podman container (`--target local`) or a cluster pod (`--target k8s`). See "Contained runtimes" below.
 
 ### Target project's `.factory/` layout
 
@@ -105,7 +108,7 @@ Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent 
 
 ### Models
 
-All domain models live in `factory/models.py` as strict Pydantic v2 models. Key types: `ProjectState` (enum), `FactoryConfig`, `EvalProfile` / `EvalDimension`, `CompositeScore` / `EvalResult`, `ExperimentRecord`, `CrossProjectInsights`, `AgentVerdict`, `Observation`, `PerformanceReport`, `ProjectEntry` / `ProjectRegistry`, `AdversarialConfig` / `AdversarialComponent` / `AdversarialState` / `AdversarialPhaseRecord`. The `Notifier` protocol defines the async notification interface. `FactoryConfig` includes `clean_pr` (bool), `clean_pr_include` (list[str]), and `clean_pr_exclude` (list[str]) for Clean PR Mode — stripping non-essential artifacts from PRs before pushing to external repos. `FactoryConfig.adversarial` (`AdversarialConfig | None`) holds the GAN-style adversarial eval loop configuration parsed from `factory.md`.
+All domain models live in `factory/models.py` as strict Pydantic v2 models. Key types: `ProjectState` (enum), `FactoryConfig`, `EvalProfile` / `EvalDimension`, `CompositeScore` / `EvalResult`, `ExperimentRecord`, `CrossProjectInsights`, `AgentVerdict`, `Observation`, `PerformanceReport`, `ProjectEntry` / `ProjectRegistry`, `AdversarialConfig` / `AdversarialComponent` / `AdversarialState` / `AdversarialPhaseRecord`. `WorkflowManifest` lives in `factory/workflow/manifest.py` — plugin metadata, namespace, version compatibility, and capabilities (`agent_only`, `shell_exec`). The `Notifier` protocol defines the async notification interface. `FactoryConfig` includes `clean_pr` (bool), `clean_pr_include` (list[str]), and `clean_pr_exclude` (list[str]) for Clean PR Mode — stripping non-essential artifacts from PRs before pushing to external repos. `FactoryConfig.adversarial` (`AdversarialConfig | None`) holds the GAN-style adversarial eval loop configuration parsed from `factory.md`.
 
 ## Environment
 
@@ -249,6 +252,11 @@ factory backlog-remove /path "item text"        # Remove a completed backlog ite
 # Adversarial eval loops
 factory adversarial-state /path/to/project           # Inspect adversarial loop state
 factory adversarial-state /path/to/project --reset   # Reset to defaults
+
+# Workflow plugins
+factory workflow list --plugins          # List only plugin (non-builtin) workflows
+factory workflow list --format json      # Machine-readable output
+factory workflow doctor                  # Validate all discovered workflows
 
 # Operations
 factory dashboard --projects-dir ~/factory-projects    # Live web dashboard on :8420

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -28,7 +28,10 @@ def cmd_workflow(args: argparse.Namespace) -> int:
     """Dispatch workflow subcommands."""
     sub = getattr(args, "workflow_command", None)
     if not sub:
-        print("Usage: factory workflow {run,list,show,validate,export-skills,lint-contributed,tool}")
+        print(
+            "Usage: factory workflow "
+            "{run,list,show,validate,export-skills,lint-contributed,doctor,tool}"
+        )
         return 1
 
     handlers = {
@@ -38,6 +41,7 @@ def cmd_workflow(args: argparse.Namespace) -> int:
         "validate": _cmd_validate,
         "export-skills": _cmd_export_skills,
         "lint-contributed": _cmd_lint_contributed,
+        "doctor": _cmd_doctor,
         "tool": _cmd_tool,
     }
 
@@ -92,16 +96,42 @@ def _cmd_run(args: argparse.Namespace) -> int:
 def _cmd_list(args: argparse.Namespace) -> int:
     """List all registered workflows."""
     project_path = Path(getattr(args, "project_path", None) or ".").resolve()
-    entries = WorkflowRegistry.list_workflows(project_path)
+    plugins_only = getattr(args, "plugins", False)
+    output_format = getattr(args, "format", "table")
 
-    header = f"{'Name':<12} {'Nodes':>6} {'Edges':>6} {'Start Node':<20}"
+    entries = WorkflowRegistry.list_workflows(project_path, plugins_only=plugins_only)
+
+    if output_format == "json":
+        items = []
+        for entry in entries:
+            wf = WorkflowRegistry.get_workflow(entry.name)
+            item: dict[str, object] = {
+                "name": entry.name,
+                "source": entry.source,
+                "description": entry.description,
+                "path": entry.path,
+            }
+            if wf:
+                item["nodes"] = len(wf.nodes)
+                item["edges"] = len(wf.edges)
+                item["start_node"] = wf.start_node
+            if entry.package_name:
+                item["package_name"] = entry.package_name
+            items.append(item)
+        print(json.dumps(items, indent=2))
+        return 0
+
+    header = f"{'Name':<30} {'Source':<14} {'Nodes':>6} {'Edges':>6} {'Start Node':<20}"
     print(header)
     print("-" * len(header))
 
     for entry in entries:
         wf = WorkflowRegistry.get_workflow(entry.name)
         if wf:
-            print(f"{entry.name:<12} {len(wf.nodes):>6} {len(wf.edges):>6} {wf.start_node:<20}")
+            print(
+                f"{entry.name:<30} {entry.source:<14} "
+                f"{len(wf.nodes):>6} {len(wf.edges):>6} {wf.start_node:<20}"
+            )
 
     return 0
 
@@ -245,6 +275,35 @@ def _cmd_lint_contributed(args: argparse.Namespace) -> int:
     return 1
 
 
+def _cmd_doctor(args: argparse.Namespace) -> int:
+    """Validate all discovered workflows and report status."""
+    project_path = Path(getattr(args, "project_path", None) or ".").resolve()
+    entries = WorkflowRegistry.list_workflows(project_path)
+
+    has_issues = False
+    for entry in entries:
+        wf = WorkflowRegistry.get_workflow(entry.name)
+        if wf is None:
+            print(f"[FAIL] {entry.name} — could not load workflow")
+            has_issues = True
+            continue
+
+        issues = wf.validate_graph()
+        if issues:
+            print(f"[FAIL] {entry.name} — {len(issues)} issue(s):")
+            for issue in issues:
+                print(f"       {issue}")
+            has_issues = True
+        else:
+            print(f"[ OK ] {entry.name}")
+
+    if has_issues:
+        return 1
+
+    print(f"\nAll {len(entries)} workflows valid.")
+    return 0
+
+
 def _cmd_tool(args: argparse.Namespace) -> int:
     """Dispatch tool subcommands for step-by-step workflow execution."""
     import sys
@@ -311,6 +370,11 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     # list
     p = wf_sub.add_parser("list", help="List all registered workflows")
     p.add_argument("--project-path", default=None, help="Project path for local workflow discovery")
+    p.add_argument("--plugins", action="store_true", help="Show only plugin (entry-point) workflows")
+    p.add_argument(
+        "--format", choices=["table", "json"], default="table",
+        help="Output format (default: table)",
+    )
 
     # show
     p = wf_sub.add_parser("show", help="Show workflow graph details")
@@ -335,6 +399,10 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     p.add_argument(
         "--path", default=None, help="Base directory to scan (default: factory/workflow/contributed/)"
     )
+
+    # doctor
+    p = wf_sub.add_parser("doctor", help="Validate all workflows and report status")
+    p.add_argument("--project-path", default=None, help="Project path for local workflow discovery")
 
     # tool
     p_tool = wf_sub.add_parser("tool", help="Tool-based workflow execution")

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -41,6 +41,9 @@ from factory.workflow.primitives import (
 
 log = structlog.get_logger()
 
+MAX_GLOBAL_RELOOPS = 20
+MAX_NODE_TIMEOUT = 3600
+
 CEO_GATE_PROMPT = """\
 You are reviewing the output of the {step_name} step in the {workflow_name} workflow.
 The output is at: {output_file}
@@ -95,6 +98,7 @@ class WorkflowExecutor:
         self.iteration_counts: dict[tuple[str, str], int] = {}
         self.background_tasks: list[asyncio.Task[Any]] = []
         self.result = ExecutionResult()
+        self._global_reloop_count = 0
         self._edge_index: dict[str, list[Edge]] = {}
         for edge in workflow.edges:
             self._edge_index.setdefault(edge.source, []).append(edge)
@@ -380,6 +384,14 @@ class WorkflowExecutor:
             if not target:
                 self.result.halted = True
                 self.result.halt_reason = "reloop verdict missing target"
+                return
+
+            self._global_reloop_count += 1
+            if self._global_reloop_count > MAX_GLOBAL_RELOOPS:
+                self.result.halted = True
+                self.result.halt_reason = (
+                    f"global reloop ceiling ({MAX_GLOBAL_RELOOPS}) exceeded"
+                )
                 return
 
             key = (node_id, target)
@@ -828,12 +840,22 @@ class WorkflowExecutor:
             if pool_entry:
                 timeout = pool_entry.timeout
 
+        effective_timeout = float(timeout) if timeout is not None else 600.0
+        if effective_timeout > MAX_NODE_TIMEOUT:
+            log.warning(
+                "executor.timeout_capped",
+                node=node.id,
+                requested=effective_timeout,
+                capped_to=MAX_NODE_TIMEOUT,
+            )
+            effective_timeout = float(MAX_NODE_TIMEOUT)
+
         stdout, code = await invoke_agent(
             node.role.value,  # type: ignore[arg-type]
             task,
             self.project_path,
             model=model or None,
-            timeout=float(timeout) if timeout is not None else 600.0,
+            timeout=effective_timeout,
         )
 
         if code != 0:

--- a/factory/workflow/manifest.py
+++ b/factory/workflow/manifest.py
@@ -1,0 +1,153 @@
+"""Plugin manifest validation and namespace enforcement for workflow plugins."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Literal
+
+import structlog
+from pydantic import BaseModel, ConfigDict, model_validator
+
+log = structlog.get_logger()
+
+
+class WorkflowManifest(BaseModel):
+    """Strict manifest for workflow plugins."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str
+    description: str
+    schema_version: int = 1
+    min_factory_version: str | None = None
+    capabilities: list[Literal["agent_only", "shell_exec"]] = []
+    author: str = ""
+    url: str = ""
+
+    @model_validator(mode="after")
+    def _validate_name(self) -> WorkflowManifest:
+        if not self.name:
+            raise ValueError("manifest name must be non-empty")
+        return self
+
+
+def validate_namespace(name: str, source: str) -> list[str]:
+    """Validate that a workflow name follows namespace conventions.
+
+    Built-in, user, and project sources may use bare names.
+    Entry-point (plugin) sources must use 'prefix:name' format.
+
+    Returns a list of issues (empty = valid).
+    """
+    issues: list[str] = []
+    if source == "entry_point":
+        if ":" not in name:
+            issues.append(
+                f"plugin workflow '{name}' must use namespaced format 'prefix:name'"
+            )
+        else:
+            prefix, _, suffix = name.partition(":")
+            if not prefix or not suffix:
+                issues.append(
+                    f"plugin workflow '{name}' has invalid namespace — "
+                    "both prefix and name must be non-empty"
+                )
+    return issues
+
+
+def check_version_compatibility(manifest: WorkflowManifest) -> list[str]:
+    """Check if the manifest's min_factory_version is compatible.
+
+    Returns a list of issues (empty = compatible).
+    """
+    if not manifest.min_factory_version:
+        return []
+
+    issues: list[str] = []
+    try:
+        from packaging.specifiers import SpecifierSet
+        from packaging.version import Version
+
+        current = _get_factory_version()
+        spec = SpecifierSet(f">={manifest.min_factory_version}")
+        if Version(current) not in spec:
+            issues.append(
+                f"workflow '{manifest.name}' requires factory >={manifest.min_factory_version}, "
+                f"current is {current}"
+            )
+    except ImportError:
+        log.warning(
+            "manifest.packaging_missing",
+            msg="packaging library not available, skipping version check",
+        )
+    except Exception as exc:
+        issues.append(f"version compatibility check failed: {exc}")
+
+    return issues
+
+
+def _get_factory_version() -> str:
+    """Get the current factory version from package metadata."""
+    try:
+        from importlib.metadata import version
+        return version("remote-factory")
+    except Exception:
+        return "0.0.0"
+
+
+def validate_capabilities(
+    manifest: WorkflowManifest,
+    node_types: set[str],
+) -> list[str]:
+    """Validate that workflow nodes comply with declared capabilities.
+
+    If 'agent_only' is declared, FnNode is not allowed.
+
+    Returns a list of issues (empty = valid).
+    """
+    issues: list[str] = []
+    if "agent_only" in manifest.capabilities and "FnNode" in node_types:
+        issues.append(
+            f"workflow '{manifest.name}' declares 'agent_only' capability "
+            "but contains FnNode(s)"
+        )
+    return issues
+
+
+def manifest_from_meta(meta: dict[str, object], *, strict: bool = True) -> WorkflowManifest:
+    """Create a WorkflowManifest from a legacy meta dict.
+
+    When strict=False (for builtin/user/project sources), missing fields
+    get defaults and a deprecation warning is emitted.
+    """
+    if strict:
+        return WorkflowManifest.model_validate(meta)
+
+    name = meta.get("name", "")
+    description = meta.get("description", "")
+    if not isinstance(name, str) or not name:
+        raise ValueError("meta dict must have a non-empty 'name' string")
+    if not isinstance(description, str):
+        description = str(description) if description else ""
+
+    has_manifest_fields = any(
+        k in meta for k in ("schema_version", "capabilities", "min_factory_version", "author", "url")
+    )
+
+    if not has_manifest_fields:
+        warnings.warn(
+            f"Workflow '{name}' uses bare meta dict without manifest fields. "
+            "Add schema_version, capabilities, etc. for full plugin support.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    return WorkflowManifest(
+        name=str(name),
+        description=str(description),
+        schema_version=int(meta.get("schema_version", 1)),  # type: ignore[arg-type]
+        min_factory_version=meta.get("min_factory_version"),  # type: ignore[arg-type]
+        capabilities=list(meta.get("capabilities", [])),  # type: ignore[arg-type]
+        author=str(meta.get("author", "")),
+        url=str(meta.get("url", "")),
+    )

--- a/factory/workflow/manifest.py
+++ b/factory/workflow/manifest.py
@@ -142,12 +142,15 @@ def manifest_from_meta(meta: dict[str, object], *, strict: bool = True) -> Workf
             stacklevel=2,
         )
 
+    raw_sv = meta.get("schema_version", 1)
+    raw_caps = meta.get("capabilities", [])
+
     return WorkflowManifest(
         name=str(name),
         description=str(description),
-        schema_version=int(meta.get("schema_version", 1)),  # type: ignore[arg-type]
+        schema_version=int(raw_sv) if isinstance(raw_sv, (int, float, str)) else 1,
         min_factory_version=meta.get("min_factory_version"),  # type: ignore[arg-type]
-        capabilities=list(meta.get("capabilities", [])),  # type: ignore[arg-type]
+        capabilities=list(raw_caps) if isinstance(raw_caps, list) else [],
         author=str(meta.get("author", "")),
         url=str(meta.get("url", "")),
     )

--- a/factory/workflow/registry.py
+++ b/factory/workflow/registry.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import structlog
 
+from factory.workflow.manifest import WorkflowManifest
 from factory.workflow.primitives import Workflow
 
 log = structlog.get_logger()
@@ -30,7 +31,9 @@ class WorkflowEntry:
     name: str
     description: str
     path: str
-    source: str  # "builtin", "user", "project"
+    source: str  # "builtin", "user", "project", "entry_point"
+    manifest: WorkflowManifest | None = None
+    package_name: str | None = None
     _workflow_fn: Any = field(default=None, repr=False)
 
 
@@ -40,6 +43,8 @@ class WorkflowRegistry:
     Search paths are scanned for .py files with a `meta` dict and
     `workflow()` function. Built-in workflows from `definitions.py`
     are always available as the lowest-priority source.
+
+    Priority: project > user > entry-points > builtin
     """
 
     _entries: dict[str, WorkflowEntry] = {}
@@ -96,7 +101,7 @@ class WorkflowRegistry:
         Returns
         -------
         dict[str, WorkflowEntry]
-            Name → entry mapping. Project shadows user shadows built-in.
+            Name → entry mapping. Project shadows user shadows entry-point shadows built-in.
         """
         cls._ensure_initialized()
         cls._entries.clear()
@@ -104,18 +109,21 @@ class WorkflowRegistry:
         # Layer 1: built-in workflows (lowest priority)
         cls._load_builtins()
 
-        # Layer 2: user-global workflows
+        # Layer 2: entry-point workflows
+        cls._discover_entry_points()
+
+        # Layer 3: user-global workflows
         for search_path, source in cls._search_paths:
             if source == "user":
                 cls._discover_in_directory(search_path, source)
 
-        # Layer 3: project-local workflows (highest priority)
+        # Layer 4: project-local workflows (highest priority)
         if project_path:
             project_wf_dir = project_path / ".factory" / "workflows"
             if project_wf_dir.is_dir():
                 cls._discover_in_directory(str(project_wf_dir), "project")
 
-        # Layer 4: any explicitly registered paths
+        # Layer 5: any explicitly registered paths
         for search_path, source in cls._search_paths:
             if source not in ("user",):
                 cls._discover_in_directory(search_path, source)
@@ -144,6 +152,107 @@ class WorkflowRegistry:
             )
 
     @classmethod
+    def _discover_entry_points(cls) -> None:
+        """Discover workflows from installed packages via entry points."""
+        try:
+            from importlib.metadata import entry_points
+            eps = entry_points(group="factory.workflows")
+        except Exception:
+            return
+
+        for ep in eps:
+            try:
+                module = ep.load()
+                meta = getattr(module, "meta", None)
+                workflow_fn = getattr(module, "workflow", None)
+
+                if not isinstance(meta, dict) or "name" not in meta:
+                    log.debug(
+                        "workflow_registry.entry_point_skip",
+                        entry_point=ep.name,
+                        reason="missing meta dict with name",
+                    )
+                    continue
+
+                if not callable(workflow_fn):
+                    log.debug(
+                        "workflow_registry.entry_point_skip",
+                        entry_point=ep.name,
+                        reason="missing workflow() function",
+                    )
+                    continue
+
+                name = meta["name"]
+
+                from factory.workflow.manifest import (
+                    check_version_compatibility,
+                    manifest_from_meta,
+                    validate_namespace,
+                )
+
+                ns_issues = validate_namespace(name, "entry_point")
+                if ns_issues:
+                    for issue in ns_issues:
+                        log.warning("workflow_registry.namespace_violation", issue=issue)
+                    continue
+
+                manifest = manifest_from_meta(meta, strict=False)
+                version_issues = check_version_compatibility(manifest)
+                if version_issues:
+                    for issue in version_issues:
+                        log.warning("workflow_registry.version_incompatible", issue=issue)
+                    continue
+
+                # Validate graph at discovery time
+                graph_issues = _validate_workflow_graph(workflow_fn, name)
+                if graph_issues:
+                    for issue in graph_issues:
+                        log.warning("workflow_registry.graph_invalid", name=name, issue=issue)
+                    continue
+
+                # Validate capabilities
+                node_types = _get_node_types(workflow_fn, name)
+                from factory.workflow.manifest import validate_capabilities
+                cap_issues = validate_capabilities(manifest, node_types)
+                if cap_issues:
+                    for issue in cap_issues:
+                        log.warning("workflow_registry.capability_violation", issue=issue)
+                    continue
+
+                prev = cls._entries.get(name)
+                if prev and prev.source not in ("builtin",):
+                    log.warning(
+                        "workflow_registry.shadow",
+                        name=name,
+                        new_source="entry_point",
+                        old_source=prev.source,
+                    )
+
+                pkg_name = ep.dist.name if ep.dist else None
+
+                cls._entries[name] = WorkflowEntry(
+                    name=name,
+                    description=meta.get("description", ""),
+                    path=f"<entry_point:{ep.name}>",
+                    source="entry_point",
+                    manifest=manifest,
+                    package_name=pkg_name,
+                    _workflow_fn=workflow_fn,
+                )
+                log.debug(
+                    "workflow_registry.entry_point_loaded",
+                    name=name,
+                    entry_point=ep.name,
+                    package=pkg_name,
+                )
+            except Exception as exc:
+                log.debug(
+                    "workflow_registry.entry_point_error",
+                    entry_point=ep.name,
+                    error=str(exc),
+                )
+
+    @classmethod
     def _discover_in_directory(cls, directory: str, source: str) -> None:
         """Discover workflow files in a directory."""
         path = Path(directory)
@@ -156,6 +265,42 @@ class WorkflowRegistry:
             try:
                 meta, workflow_fn = _load_workflow_file(py_file)
                 name = meta["name"]
+
+                from factory.workflow.manifest import (
+                    check_version_compatibility,
+                    manifest_from_meta,
+                    validate_namespace,
+                )
+
+                ns_issues = validate_namespace(name, source)
+                if ns_issues:
+                    for issue in ns_issues:
+                        log.warning("workflow_registry.namespace_violation", issue=issue)
+                    continue
+
+                is_strict = source == "entry_point"
+                manifest = manifest_from_meta(meta, strict=is_strict)
+
+                version_issues = check_version_compatibility(manifest)
+                if version_issues:
+                    for issue in version_issues:
+                        log.warning("workflow_registry.version_incompatible", issue=issue)
+                    continue
+
+                graph_issues = _validate_workflow_graph(workflow_fn, name)
+                if graph_issues:
+                    for issue in graph_issues:
+                        log.warning("workflow_registry.graph_invalid", name=name, issue=issue)
+                    continue
+
+                node_types = _get_node_types(workflow_fn, name)
+                from factory.workflow.manifest import validate_capabilities
+                cap_issues = validate_capabilities(manifest, node_types)
+                if cap_issues:
+                    for issue in cap_issues:
+                        log.warning("workflow_registry.capability_violation", issue=issue)
+                    continue
+
                 prev = cls._entries.get(name)
                 if prev and prev.source != "builtin":
                     log.warning(
@@ -169,6 +314,7 @@ class WorkflowRegistry:
                     description=meta.get("description", ""),
                     path=str(py_file),
                     source=source,
+                    manifest=manifest,
                     _workflow_fn=workflow_fn,
                 )
                 log.debug(
@@ -199,11 +345,25 @@ class WorkflowRegistry:
         return entry._workflow_fn()
 
     @classmethod
-    def list_workflows(cls, project_path: Path | None = None) -> list[WorkflowEntry]:
-        """List all discovered workflows."""
+    def list_workflows(
+        cls,
+        project_path: Path | None = None,
+        *,
+        plugins_only: bool = False,
+    ) -> list[WorkflowEntry]:
+        """List all discovered workflows.
+
+        Parameters
+        ----------
+        plugins_only : bool
+            If True, only return entry-point (plugin) workflows.
+        """
         if not cls._entries:
             cls.discover(project_path)
-        return sorted(cls._entries.values(), key=lambda e: (e.source != "builtin", e.name))
+        entries = cls._entries.values()
+        if plugins_only:
+            entries = [e for e in entries if e.source == "entry_point"]
+        return sorted(entries, key=lambda e: (e.source != "builtin", e.name))
 
 
 def _load_workflow_file(path: Path) -> tuple[dict[str, Any], Any]:
@@ -244,3 +404,25 @@ def _get_builtin_description(name: str) -> str:
 
     meta = WORKFLOW_META.get(name, {})
     return str(meta.get("description", f"Built-in {name} workflow"))
+
+
+def _validate_workflow_graph(workflow_fn: Any, name: str) -> list[str]:
+    """Validate the workflow graph at discovery time. Returns issues."""
+    try:
+        wf = workflow_fn()
+        if not isinstance(wf, Workflow):
+            return [f"workflow() for '{name}' did not return a Workflow object"]
+        return wf.validate_graph()
+    except Exception as exc:
+        return [f"workflow() for '{name}' raised: {exc}"]
+
+
+def _get_node_types(workflow_fn: Any, name: str) -> set[str]:
+    """Get the set of node type names in a workflow."""
+    try:
+        wf = workflow_fn()
+        if not isinstance(wf, Workflow):
+            return set()
+        return {type(node).__name__ for node in wf.nodes.values()}
+    except Exception:
+        return set()

--- a/factory/workflow/registry.py
+++ b/factory/workflow/registry.py
@@ -360,10 +360,10 @@ class WorkflowRegistry:
         """
         if not cls._entries:
             cls.discover(project_path)
-        entries = cls._entries.values()
+        result = list(cls._entries.values())
         if plugins_only:
-            entries = [e for e in entries if e.source == "entry_point"]
-        return sorted(entries, key=lambda e: (e.source != "builtin", e.name))
+            result = [e for e in result if e.source == "entry_point"]
+        return sorted(result, key=lambda e: (e.source != "builtin", e.name))
 
 
 def _load_workflow_file(path: Path) -> tuple[dict[str, Any], Any]:

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -846,7 +846,8 @@ def export_all_skills(
         templatized = workflow_to_skill_md(wf)
         clean_md, annotations = split_skill(templatized)
 
-        skill_dir = output_dir / f"workflow-{name}"
+        dir_name = f"workflow-{name.replace(':', '-')}"
+        skill_dir = output_dir / dir_name
         skill_dir.mkdir(parents=True, exist_ok=True)
 
         skill_path = skill_dir / "SKILL.md"

--- a/tests/test_workflow_plugins.py
+++ b/tests/test_workflow_plugins.py
@@ -4,7 +4,6 @@ capability enforcement, entry-point discovery, safety ceilings, CLI, and backwar
 from __future__ import annotations
 
 import argparse
-import asyncio
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
@@ -371,7 +370,7 @@ class TestPriorityOrdering:
 
 
 class TestGlobalReloopCeiling:
-    def test_global_reloop_ceiling_enforced(self) -> None:
+    async def test_global_reloop_ceiling_enforced(self) -> None:
         gate = GateNode(
             id="gate",
             evaluator_type="fn",
@@ -389,17 +388,9 @@ class TestGlobalReloopCeiling:
         )
 
         executor = WorkflowExecutor(wf, Path("/tmp"), dry_run=True)
-        # Simulate exceeding the global reloop ceiling
-        executor._global_reloop_count = MAX_GLOBAL_RELOOPS + 1
-
-        async def _test() -> None:
-            # Manually call gate execution logic
-            executor._global_reloop_count = MAX_GLOBAL_RELOOPS
-            # One more reloop should trigger ceiling
-            executor._global_reloop_count += 1
-            assert executor._global_reloop_count > MAX_GLOBAL_RELOOPS
-
-        asyncio.get_event_loop().run_until_complete(_test())
+        executor._global_reloop_count = MAX_GLOBAL_RELOOPS
+        executor._global_reloop_count += 1
+        assert executor._global_reloop_count > MAX_GLOBAL_RELOOPS
 
     def test_max_global_reloops_value(self) -> None:
         assert MAX_GLOBAL_RELOOPS == 20
@@ -412,7 +403,7 @@ class TestNodeTimeoutCeiling:
     def test_max_node_timeout_value(self) -> None:
         assert MAX_NODE_TIMEOUT == 3600
 
-    def test_timeout_capping_in_executor(self) -> None:
+    async def test_timeout_capping_in_executor(self) -> None:
         agent = AgentNode(
             id="slow",
             role=AgentRole.BUILDER,
@@ -426,7 +417,7 @@ class TestNodeTimeoutCeiling:
         )
         executor = WorkflowExecutor(wf, Path("/tmp"), dry_run=True)
 
-        result = asyncio.get_event_loop().run_until_complete(executor.execute())
+        result = await executor.execute()
         assert result.success
 
 

--- a/tests/test_workflow_plugins.py
+++ b/tests/test_workflow_plugins.py
@@ -4,10 +4,12 @@ capability enforcement, entry-point discovery, safety ceilings, CLI, and backwar
 from __future__ import annotations
 
 import argparse
+import json
+import sys
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -18,6 +20,7 @@ from factory.workflow.executor import (
 )
 from factory.workflow.manifest import (
     WorkflowManifest,
+    _get_factory_version,
     check_version_compatibility,
     manifest_from_meta,
     validate_capabilities,
@@ -27,11 +30,18 @@ from factory.workflow.primitives import (
     AgentNode,
     AgentRole,
     Edge,
+    FnNode,
     GateNode,
+    Verdict,
     VerdictType,
     Workflow,
 )
-from factory.workflow.registry import WorkflowEntry, WorkflowRegistry
+from factory.workflow.registry import (
+    WorkflowEntry,
+    WorkflowRegistry,
+    _get_node_types,
+    _validate_workflow_graph,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -581,3 +591,466 @@ class TestSkillExportNamespaced:
         assert len(generated) == 1
         assert (tmp_path / "workflow-mypkg-custom").is_dir()
         assert (tmp_path / "workflow-mypkg-custom" / "SKILL.md").exists()
+
+
+# ── Manifest edge cases ──────────────────────────────────────────
+
+
+class TestManifestEdgeCases:
+    def test_check_version_no_packaging_module(self) -> None:
+        m = WorkflowManifest(
+            name="test", description="test", min_factory_version="1.0.0"
+        )
+        with patch.dict(
+            sys.modules,
+            {"packaging": None, "packaging.specifiers": None, "packaging.version": None},
+        ):
+            issues = check_version_compatibility(m)
+        assert issues == []
+
+    def test_get_factory_version_fallback_to_zero(self) -> None:
+        with patch("importlib.metadata.version", side_effect=Exception("not installed")):
+            result = _get_factory_version()
+        assert result == "0.0.0"
+
+    def test_manifest_from_meta_non_string_description(self) -> None:
+        meta: dict[str, object] = {
+            "name": "test",
+            "description": 42,
+            "schema_version": 1,
+        }
+        m = manifest_from_meta(meta, strict=False)
+        assert m.description == "42"
+
+    def test_manifest_from_meta_none_description(self) -> None:
+        meta: dict[str, object] = {
+            "name": "test",
+            "description": None,
+            "schema_version": 1,
+        }
+        m = manifest_from_meta(meta, strict=False)
+        assert m.description == ""
+
+    def test_manifest_from_meta_schema_version_suppresses_warning(self) -> None:
+        meta: dict[str, object] = {
+            "name": "test",
+            "description": "desc",
+            "schema_version": 1,
+        }
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m = manifest_from_meta(meta, strict=False)
+            deprecation = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation) == 0
+        assert m.schema_version == 1
+
+
+# ── Registry entry-point edge cases ──────────────────────────────
+
+
+class TestEntryPointEdgeCases:
+    def _make_valid_workflow(self, name: str = "ep:test") -> Workflow:
+        return Workflow(
+            name=name,
+            nodes={"start": AgentNode(id="start", role=AgentRole.BUILDER)},
+            edges=[],
+            start_node="start",
+        )
+
+    def test_workflow_fn_not_callable(self) -> None:
+        module = SimpleNamespace(
+            meta={"name": "ep:notcallable", "description": "has non-callable workflow"},
+            workflow="not a function",
+        )
+        mock_ep = MagicMock()
+        mock_ep.name = "notcallable_ep"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "pkg"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+        assert "ep:notcallable" not in entries
+
+    def test_version_incompatible(self) -> None:
+        wf = self._make_valid_workflow("ep:oldver")
+        module = SimpleNamespace(
+            meta={
+                "name": "ep:oldver",
+                "description": "needs future version",
+                "min_factory_version": "999.0.0",
+            },
+            workflow=lambda: wf,
+        )
+        mock_ep = MagicMock()
+        mock_ep.name = "oldver_ep"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "oldver-pkg"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+        assert "ep:oldver" not in entries
+
+    def test_graph_validation_failure(self) -> None:
+        def bad_graph() -> Workflow:
+            return Workflow(
+                name="ep:badgraph",
+                nodes={"a": AgentNode(id="a", role=AgentRole.BUILDER)},
+                edges=[Edge(source="a", target="missing")],
+                start_node="a",
+            )
+
+        module = SimpleNamespace(
+            meta={"name": "ep:badgraph", "description": "invalid graph"},
+            workflow=bad_graph,
+        )
+        mock_ep = MagicMock()
+        mock_ep.name = "badgraph_ep"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "badgraph-pkg"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+        assert "ep:badgraph" not in entries
+
+    def test_capability_violation(self) -> None:
+        def agent_only_with_fn() -> Workflow:
+            return Workflow(
+                name="ep:capfail",
+                nodes={"start": FnNode(id="start", command="echo hi")},
+                edges=[],
+                start_node="start",
+            )
+
+        module = SimpleNamespace(
+            meta={
+                "name": "ep:capfail",
+                "description": "agent_only but has FnNode",
+                "schema_version": 1,
+                "capabilities": ["agent_only"],
+            },
+            workflow=agent_only_with_fn,
+        )
+        mock_ep = MagicMock()
+        mock_ep.name = "capfail_ep"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "capfail-pkg"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+        assert "ep:capfail" not in entries
+
+    def test_shadowing_non_builtin(self) -> None:
+        wf = self._make_valid_workflow("ep:dup")
+
+        def make_ep(ep_name: str, pkg_name: str) -> MagicMock:
+            module = SimpleNamespace(
+                meta={"name": "ep:dup", "description": f"from {pkg_name}"},
+                workflow=lambda: wf,
+            )
+            mock_ep = MagicMock()
+            mock_ep.name = ep_name
+            mock_ep.load.return_value = module
+            mock_ep.dist = MagicMock()
+            mock_ep.dist.name = pkg_name
+            return mock_ep
+
+        ep1 = make_ep("dup1", "pkg-a")
+        ep2 = make_ep("dup2", "pkg-b")
+
+        with patch("importlib.metadata.entry_points", return_value=[ep1, ep2]):
+            entries = WorkflowRegistry.discover()
+        assert entries["ep:dup"].package_name == "pkg-b"
+
+    def test_entry_points_exception(self) -> None:
+        with patch(
+            "importlib.metadata.entry_points", side_effect=Exception("broken")
+        ):
+            entries = WorkflowRegistry.discover()
+        assert "improve" in entries
+
+
+# ── Registry directory discovery edge cases ──────────────────────
+
+
+class TestDirectoryDiscoveryEdgeCases:
+    def test_version_check_failure(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "vfail.py").write_text(
+            "from factory.workflow.primitives import Workflow, AgentNode, AgentRole\n"
+            "\n"
+            "meta = {\n"
+            "    'name': 'vfail',\n"
+            "    'description': 'needs future version',\n"
+            "    'schema_version': 1,\n"
+            "    'min_factory_version': '999.0.0',\n"
+            "}\n"
+            "\n"
+            "def workflow():\n"
+            "    return Workflow(\n"
+            "        name='vfail',\n"
+            "        nodes={'s': AgentNode(id='s', role=AgentRole.BUILDER)},\n"
+            "        edges=[],\n"
+            "        start_node='s',\n"
+            "    )\n"
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert "vfail" not in entries
+
+    def test_capability_check_failure(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "capfail.py").write_text(
+            "from factory.workflow.primitives import Workflow, FnNode\n"
+            "\n"
+            "meta = {\n"
+            "    'name': 'capfail',\n"
+            "    'description': 'agent_only with FnNode',\n"
+            "    'schema_version': 1,\n"
+            "    'capabilities': ['agent_only'],\n"
+            "}\n"
+            "\n"
+            "def workflow():\n"
+            "    return Workflow(\n"
+            "        name='capfail',\n"
+            "        nodes={'s': FnNode(id='s', command='echo hi')},\n"
+            "        edges=[],\n"
+            "        start_node='s',\n"
+            "    )\n"
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert "capfail" not in entries
+
+    def test_load_exception_skipped(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "broken.py").write_text("raise RuntimeError('import bomb')\n")
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert "broken" not in entries
+
+
+# ── Registry graph/node validation helpers ───────────────────────
+
+
+class TestRegistryValidationHelpers:
+    def test_validate_workflow_graph_raises(self) -> None:
+        def exploding() -> Workflow:
+            raise RuntimeError("boom")
+
+        issues = _validate_workflow_graph(exploding, "test")
+        assert len(issues) == 1
+        assert "raised" in issues[0]
+
+    def test_validate_workflow_graph_non_workflow(self) -> None:
+        issues = _validate_workflow_graph(lambda: "not a workflow", "test")
+        assert len(issues) == 1
+        assert "did not return a Workflow" in issues[0]
+
+    def test_get_node_types_raises(self) -> None:
+        def exploding() -> Workflow:
+            raise RuntimeError("boom")
+
+        result = _get_node_types(exploding, "test")
+        assert result == set()
+
+    def test_get_node_types_non_workflow(self) -> None:
+        result = _get_node_types(lambda: "not a workflow", "test")
+        assert result == set()
+
+
+# ── CLI list command formats ─────────────────────────────────────
+
+
+class TestCmdListFormats:
+    def test_list_json_format(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from factory.workflow.cli import _cmd_list
+
+        args = argparse.Namespace(project_path=None, plugins=False, format="json")
+        rc = _cmd_list(args)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "name" in data[0]
+        assert "source" in data[0]
+        assert "nodes" in data[0]
+        assert "edges" in data[0]
+        assert "start_node" in data[0]
+        assert rc == 0
+
+    def test_list_json_with_package_name(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from factory.workflow.cli import _cmd_list
+
+        WorkflowRegistry._entries["ep:myplugin"] = WorkflowEntry(
+            name="ep:myplugin",
+            description="a plugin",
+            path="<entry_point>",
+            source="entry_point",
+            package_name="my-plugin-pkg",
+            _workflow_fn=lambda: Workflow(
+                name="ep:myplugin",
+                nodes={"s": AgentNode(id="s", role=AgentRole.BUILDER)},
+                edges=[],
+                start_node="s",
+            ),
+        )
+
+        args = argparse.Namespace(project_path=None, plugins=False, format="json")
+        rc = _cmd_list(args)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        plugin_entry = next(d for d in data if d["name"] == "ep:myplugin")
+        assert plugin_entry["package_name"] == "my-plugin-pkg"
+        assert "nodes" in plugin_entry
+        assert rc == 0
+
+    def test_list_plugins_filter(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from factory.workflow.cli import _cmd_list
+
+        args = argparse.Namespace(project_path=None, plugins=True, format="table")
+        rc = _cmd_list(args)
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "builtin" not in captured.out.lower().split("\n")[-1] or captured.out.strip() == ""
+
+    def test_list_table_default(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from factory.workflow.cli import _cmd_list
+
+        args = argparse.Namespace(project_path=None, plugins=False, format="table")
+        rc = _cmd_list(args)
+        captured = capsys.readouterr()
+        assert "Name" in captured.out
+        assert "Source" in captured.out
+        assert "Nodes" in captured.out
+        assert rc == 0
+
+
+# ── CLI doctor with graph validation issues ──────────────────────
+
+
+class TestCmdDoctorGraphIssues:
+    def test_doctor_reports_graph_issues(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from factory.workflow.cli import _cmd_doctor
+
+        def wf_with_issues() -> Workflow:
+            return Workflow(
+                name="has_issues",
+                nodes={"a": AgentNode(id="a", role=AgentRole.BUILDER)},
+                edges=[Edge(source="a", target="nonexistent")],
+                start_node="a",
+            )
+
+        WorkflowRegistry._entries["has_issues"] = WorkflowEntry(
+            name="has_issues",
+            description="graph with issues",
+            path="<test>",
+            source="project",
+            _workflow_fn=wf_with_issues,
+        )
+
+        args = argparse.Namespace(project_path=None)
+        rc = _cmd_doctor(args)
+        captured = capsys.readouterr()
+        assert "[FAIL]" in captured.out
+        assert "issue(s)" in captured.out
+        assert rc == 1
+
+
+# ── Argparse registration ────────────────────────────────────────
+
+
+class TestArgparseRegistration:
+    def test_list_flags_parsed(self) -> None:
+        from factory.workflow.cli import add_workflow_parser
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        add_workflow_parser(sub)
+        args = parser.parse_args(["workflow", "list", "--plugins", "--format", "json"])
+        assert args.plugins is True
+        assert args.format == "json"
+
+    def test_doctor_project_path_parsed(self) -> None:
+        from factory.workflow.cli import add_workflow_parser
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        add_workflow_parser(sub)
+        args = parser.parse_args(["workflow", "doctor", "--project-path", "/tmp/test"])
+        assert args.project_path == "/tmp/test"
+
+
+# ── Executor gate reloop ceiling enforcement ─────────────────────
+
+
+class TestExecutorGateReloopEnforcement:
+    async def test_global_reloop_ceiling_halts_execution(self) -> None:
+        gate = GateNode(
+            id="gate",
+            evaluator_type="fn",
+            evaluator_command="echo test",
+        )
+        agent = AgentNode(id="agent", role=AgentRole.BUILDER)
+        wf = Workflow(
+            name="reloop_ceil",
+            nodes={"agent": agent, "gate": gate},
+            edges=[
+                Edge(source="agent", target="gate"),
+                Edge(source="gate", target="agent", condition=VerdictType.RELOOP),
+            ],
+            start_node="agent",
+        )
+        executor = WorkflowExecutor(wf, Path("/tmp"), dry_run=True)
+        executor._global_reloop_count = MAX_GLOBAL_RELOOPS
+
+        with patch.object(
+            executor,
+            "_evaluate_gate",
+            new_callable=AsyncMock,
+            return_value=Verdict.reloop(target="agent", feedback="test"),
+        ):
+            await executor._execute_gate(gate)
+
+        assert executor.result.halted
+        assert "global reloop ceiling" in executor.result.halt_reason
+        assert str(MAX_GLOBAL_RELOOPS) in executor.result.halt_reason
+
+
+# ── Executor timeout capping ─────────────────────────────────────
+
+
+class TestExecutorTimeoutCapping:
+    async def test_timeout_capped_with_warning(self) -> None:
+        agent = AgentNode(
+            id="slow_agent",
+            role=AgentRole.BUILDER,
+            timeout=MAX_NODE_TIMEOUT + 1000,
+        )
+        wf = Workflow(
+            name="timeout_cap",
+            nodes={"slow_agent": agent},
+            edges=[],
+            start_node="slow_agent",
+        )
+        executor = WorkflowExecutor(wf, Path("/tmp"), dry_run=False)
+
+        with patch(
+            "factory.agents.runner.invoke_agent",
+            new_callable=AsyncMock,
+            return_value=("output", 0),
+        ) as mock_invoke:
+            result = await executor._run_agent(agent)
+
+        assert result == "output"
+        assert mock_invoke.call_args.kwargs["timeout"] == float(MAX_NODE_TIMEOUT)

--- a/tests/test_workflow_plugins.py
+++ b/tests/test_workflow_plugins.py
@@ -1,0 +1,592 @@
+"""Tests for the workflow plugin system — manifest, namespace, version compat,
+capability enforcement, entry-point discovery, safety ceilings, CLI, and backward compat."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import warnings
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from factory.workflow.executor import (
+    MAX_GLOBAL_RELOOPS,
+    MAX_NODE_TIMEOUT,
+    WorkflowExecutor,
+)
+from factory.workflow.manifest import (
+    WorkflowManifest,
+    check_version_compatibility,
+    manifest_from_meta,
+    validate_capabilities,
+    validate_namespace,
+)
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Edge,
+    GateNode,
+    VerdictType,
+    Workflow,
+)
+from factory.workflow.registry import WorkflowEntry, WorkflowRegistry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    WorkflowRegistry.reset()
+    yield
+    WorkflowRegistry.reset()
+
+
+# ── Manifest validation ────────────────────────────────────────────
+
+
+class TestManifestValidation:
+    def test_valid_manifest(self) -> None:
+        m = WorkflowManifest(
+            name="test:example",
+            description="A test workflow",
+            schema_version=1,
+            capabilities=["agent_only"],
+            author="test",
+            url="https://example.com",
+        )
+        assert m.name == "test:example"
+        assert m.schema_version == 1
+
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            WorkflowManifest(name="", description="test")
+
+    def test_extra_fields_rejected(self) -> None:
+        with pytest.raises(Exception):
+            WorkflowManifest(name="test", description="test", unknown_field="bad")  # type: ignore[call-arg]
+
+    def test_invalid_capability(self) -> None:
+        with pytest.raises(Exception):
+            WorkflowManifest(
+                name="test", description="test", capabilities=["not_real"]  # type: ignore[list-item]
+            )
+
+    def test_manifest_from_meta_strict(self) -> None:
+        meta = {
+            "name": "ns:wf",
+            "description": "desc",
+            "schema_version": 1,
+            "capabilities": ["shell_exec"],
+        }
+        m = manifest_from_meta(meta, strict=True)
+        assert m.name == "ns:wf"
+        assert m.capabilities == ["shell_exec"]
+
+    def test_manifest_from_meta_lenient(self) -> None:
+        meta = {"name": "simple", "description": "bare meta"}
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            m = manifest_from_meta(meta, strict=False)
+            assert m.name == "simple"
+            assert len(w) == 1
+            assert "bare meta dict" in str(w[0].message)
+
+    def test_manifest_from_meta_missing_name(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            manifest_from_meta({"description": "no name"}, strict=False)
+
+
+# ── Namespace enforcement ──────────────────────────────────────────
+
+
+class TestNamespaceEnforcement:
+    def test_builtin_bare_name_ok(self) -> None:
+        assert validate_namespace("improve", "builtin") == []
+
+    def test_user_bare_name_ok(self) -> None:
+        assert validate_namespace("my-workflow", "user") == []
+
+    def test_project_bare_name_ok(self) -> None:
+        assert validate_namespace("local", "project") == []
+
+    def test_plugin_bare_name_rejected(self) -> None:
+        issues = validate_namespace("bare-name", "entry_point")
+        assert len(issues) == 1
+        assert "prefix:name" in issues[0]
+
+    def test_plugin_namespaced_ok(self) -> None:
+        assert validate_namespace("mypkg:workflow", "entry_point") == []
+
+    def test_plugin_empty_prefix_rejected(self) -> None:
+        issues = validate_namespace(":workflow", "entry_point")
+        assert len(issues) == 1
+        assert "non-empty" in issues[0]
+
+    def test_plugin_empty_suffix_rejected(self) -> None:
+        issues = validate_namespace("prefix:", "entry_point")
+        assert len(issues) == 1
+        assert "non-empty" in issues[0]
+
+
+# ── Version compatibility ──────────────────────────────────────────
+
+
+class TestVersionCompatibility:
+    def test_no_version_constraint(self) -> None:
+        m = WorkflowManifest(name="test", description="test")
+        assert check_version_compatibility(m) == []
+
+    def test_compatible_version(self) -> None:
+        m = WorkflowManifest(
+            name="test", description="test", min_factory_version="0.0.1"
+        )
+        issues = check_version_compatibility(m)
+        assert issues == []
+
+    def test_incompatible_version(self) -> None:
+        m = WorkflowManifest(
+            name="test", description="test", min_factory_version="99.0.0"
+        )
+        issues = check_version_compatibility(m)
+        assert len(issues) == 1
+        assert "99.0.0" in issues[0]
+
+
+# ── Capability enforcement ─────────────────────────────────────────
+
+
+class TestCapabilityEnforcement:
+    def test_agent_only_with_fn_node_rejected(self) -> None:
+        m = WorkflowManifest(
+            name="test", description="test", capabilities=["agent_only"]
+        )
+        issues = validate_capabilities(m, {"AgentNode", "FnNode"})
+        assert len(issues) == 1
+        assert "agent_only" in issues[0]
+        assert "FnNode" in issues[0]
+
+    def test_agent_only_without_fn_node_ok(self) -> None:
+        m = WorkflowManifest(
+            name="test", description="test", capabilities=["agent_only"]
+        )
+        assert validate_capabilities(m, {"AgentNode", "GateNode"}) == []
+
+    def test_shell_exec_allows_fn_node(self) -> None:
+        m = WorkflowManifest(
+            name="test", description="test", capabilities=["shell_exec"]
+        )
+        assert validate_capabilities(m, {"FnNode", "AgentNode"}) == []
+
+    def test_no_capabilities_allows_everything(self) -> None:
+        m = WorkflowManifest(name="test", description="test")
+        assert validate_capabilities(m, {"FnNode", "AgentNode"}) == []
+
+
+# ── Discovery-time graph validation ───────────────────────────────
+
+
+class TestDiscoveryGraphValidation:
+    def test_invalid_graph_skipped_on_discover(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "bad_graph.py").write_text(
+            "from factory.workflow.primitives import Workflow, AgentNode, AgentRole, Edge\n"
+            "\n"
+            "meta = {'name': 'bad_graph', 'description': 'invalid graph'}\n"
+            "\n"
+            "def workflow():\n"
+            "    return Workflow(\n"
+            "        name='bad_graph',\n"
+            "        nodes={'a': AgentNode(id='a', role=AgentRole.BUILDER)},\n"
+            "        edges=[Edge(source='a', target='nonexistent')],\n"
+            "        start_node='a',\n"
+            "    )\n"
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir))
+        entries = WorkflowRegistry.discover()
+        assert "bad_graph" not in entries
+
+
+# ── Entry points discovery ─────────────────────────────────────────
+
+
+class TestEntryPointsDiscovery:
+    def _make_ep_module(self, meta: dict[str, object], workflow_fn: object) -> object:
+        module = SimpleNamespace(meta=meta, workflow=workflow_fn)
+        return module
+
+    def _make_valid_workflow(self) -> Workflow:
+        return Workflow(
+            name="ep:test",
+            nodes={"start": AgentNode(id="start", role=AgentRole.BUILDER)},
+            edges=[],
+            start_node="start",
+        )
+
+    def test_entry_point_discovery(self) -> None:
+        wf = self._make_valid_workflow()
+        module = self._make_ep_module(
+            {"name": "ep:test", "description": "test plugin"},
+            lambda: wf,
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "ep_test"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "my-plugin-package"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+
+        assert "ep:test" in entries
+        assert entries["ep:test"].source == "entry_point"
+        assert entries["ep:test"].package_name == "my-plugin-package"
+
+    def test_entry_point_bare_name_rejected(self) -> None:
+        wf = Workflow(
+            name="bare",
+            nodes={"start": AgentNode(id="start", role=AgentRole.BUILDER)},
+            edges=[],
+            start_node="start",
+        )
+        module = self._make_ep_module(
+            {"name": "bare", "description": "no namespace"},
+            lambda: wf,
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "bare_ep"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "some-pkg"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+
+        assert "bare" not in entries
+
+    def test_entry_point_missing_meta_skipped(self) -> None:
+        module = SimpleNamespace(workflow=lambda: None)
+
+        mock_ep = MagicMock()
+        mock_ep.name = "no_meta"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "pkg"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+
+        assert "no_meta" not in entries
+
+    def test_entry_point_load_failure_skipped(self) -> None:
+        mock_ep = MagicMock()
+        mock_ep.name = "broken_ep"
+        mock_ep.load.side_effect = ImportError("cannot import")
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+
+        # Should still have builtins
+        assert "improve" in entries
+
+
+# ── Priority ordering ──────────────────────────────────────────────
+
+
+class TestPriorityOrdering:
+    def test_project_shadows_entry_point(self, tmp_path: Path) -> None:
+        wf = Workflow(
+            name="ep:custom",
+            nodes={"start": AgentNode(id="start", role=AgentRole.BUILDER)},
+            edges=[],
+            start_node="start",
+        )
+        module = SimpleNamespace(
+            meta={"name": "ep:custom", "description": "entry-point"},
+            workflow=lambda: wf,
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "custom_ep"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "custom-pkg"
+
+        # Create a project-local workflow with the same name
+        wf_dir = tmp_path / ".factory" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "custom.py").write_text(
+            "from factory.workflow.primitives import Workflow, AgentNode, AgentRole\n"
+            "\n"
+            "meta = {'name': 'ep:custom', 'description': 'project-local override'}\n"
+            "\n"
+            "def workflow():\n"
+            "    return Workflow(\n"
+            "        name='ep:custom',\n"
+            "        nodes={'start': AgentNode(id='start', role=AgentRole.BUILDER)},\n"
+            "        edges=[],\n"
+            "        start_node='start',\n"
+            "    )\n"
+        )
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover(project_path=tmp_path)
+
+        assert "ep:custom" in entries
+        assert entries["ep:custom"].source == "project"
+        assert entries["ep:custom"].description == "project-local override"
+
+    def test_entry_point_shadows_builtin(self) -> None:
+        wf = Workflow(
+            name="ep:improve",
+            nodes={"start": AgentNode(id="start", role=AgentRole.BUILDER)},
+            edges=[],
+            start_node="start",
+        )
+        module = SimpleNamespace(
+            meta={"name": "ep:improve", "description": "ep improve"},
+            workflow=lambda: wf,
+        )
+
+        mock_ep = MagicMock()
+        mock_ep.name = "improve_ep"
+        mock_ep.load.return_value = module
+        mock_ep.dist = MagicMock()
+        mock_ep.dist.name = "improve-pkg"
+
+        with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+            entries = WorkflowRegistry.discover()
+
+        assert "ep:improve" in entries
+        assert entries["ep:improve"].source == "entry_point"
+        # builtin "improve" should still exist as a separate entry
+        assert "improve" in entries
+        assert entries["improve"].source == "builtin"
+
+
+# ── Global reloop ceiling ──────────────────────────────────────────
+
+
+class TestGlobalReloopCeiling:
+    def test_global_reloop_ceiling_enforced(self) -> None:
+        gate = GateNode(
+            id="gate",
+            evaluator_type="fn",
+            evaluator_command="echo FAIL",
+        )
+        agent = AgentNode(id="agent", role=AgentRole.BUILDER)
+        wf = Workflow(
+            name="reloop_test",
+            nodes={"agent": agent, "gate": gate},
+            edges=[
+                Edge(source="agent", target="gate"),
+                Edge(source="gate", target="agent", condition=VerdictType.RELOOP),
+            ],
+            start_node="agent",
+        )
+
+        executor = WorkflowExecutor(wf, Path("/tmp"), dry_run=True)
+        # Simulate exceeding the global reloop ceiling
+        executor._global_reloop_count = MAX_GLOBAL_RELOOPS + 1
+
+        async def _test() -> None:
+            # Manually call gate execution logic
+            executor._global_reloop_count = MAX_GLOBAL_RELOOPS
+            # One more reloop should trigger ceiling
+            executor._global_reloop_count += 1
+            assert executor._global_reloop_count > MAX_GLOBAL_RELOOPS
+
+        asyncio.get_event_loop().run_until_complete(_test())
+
+    def test_max_global_reloops_value(self) -> None:
+        assert MAX_GLOBAL_RELOOPS == 20
+
+
+# ── Per-node timeout ceiling ──────────────────────────────────────
+
+
+class TestNodeTimeoutCeiling:
+    def test_max_node_timeout_value(self) -> None:
+        assert MAX_NODE_TIMEOUT == 3600
+
+    def test_timeout_capping_in_executor(self) -> None:
+        agent = AgentNode(
+            id="slow",
+            role=AgentRole.BUILDER,
+            timeout=9999,
+        )
+        wf = Workflow(
+            name="timeout_test",
+            nodes={"slow": agent},
+            edges=[],
+            start_node="slow",
+        )
+        executor = WorkflowExecutor(wf, Path("/tmp"), dry_run=True)
+
+        result = asyncio.get_event_loop().run_until_complete(executor.execute())
+        assert result.success
+
+
+# ── list --plugins filtering ──────────────────────────────────────
+
+
+class TestListPluginsFilter:
+    def test_plugins_only_filters(self) -> None:
+        entries = WorkflowRegistry.list_workflows(plugins_only=True)
+        assert all(e.source == "entry_point" for e in entries)
+
+    def test_plugins_only_empty_with_no_plugins(self) -> None:
+        entries = WorkflowRegistry.list_workflows(plugins_only=True)
+        assert len(entries) == 0  # no plugins installed by default
+
+
+# ── doctor ─────────────────────────────────────────────────────────
+
+
+class TestDoctor:
+    def test_doctor_all_valid(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from factory.workflow.cli import _cmd_doctor
+        args = argparse.Namespace(project_path=None)
+        rc = _cmd_doctor(args)
+        captured = capsys.readouterr()
+        assert "[ OK ]" in captured.out
+        assert rc == 0
+
+    def test_doctor_reports_invalid(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from factory.workflow.cli import _cmd_doctor
+
+        # Register a workflow that returns None from get_workflow
+        WorkflowRegistry._entries["bad"] = WorkflowEntry(
+            name="bad",
+            description="broken",
+            path="<test>",
+            source="project",
+            _workflow_fn=None,
+        )
+
+        args = argparse.Namespace(project_path=str(tmp_path))
+        rc = _cmd_doctor(args)
+        captured = capsys.readouterr()
+        assert "[FAIL]" in captured.out
+        assert rc == 1
+
+
+# ── Backward compat for existing contributed workflows ────────────
+
+
+class TestBackwardCompat:
+    def test_bare_meta_loads_with_deprecation_warning(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "legacy.py").write_text(
+            "from factory.workflow.primitives import Workflow, AgentNode, AgentRole\n"
+            "\n"
+            "meta = {'name': 'legacy', 'description': 'old-style workflow'}\n"
+            "\n"
+            "def workflow():\n"
+            "    return Workflow(\n"
+            "        name='legacy',\n"
+            "        nodes={'start': AgentNode(id='start', role=AgentRole.BUILDER)},\n"
+            "        edges=[],\n"
+            "        start_node='start',\n"
+            "    )\n"
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir), source="user")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            entries = WorkflowRegistry.discover()
+
+        assert "legacy" in entries
+        assert entries["legacy"].source == "user"
+        assert entries["legacy"].manifest is not None
+        assert entries["legacy"].manifest.name == "legacy"
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) >= 1
+        assert "bare meta dict" in str(deprecation_warnings[0].message)
+
+    def test_manifest_fields_suppress_deprecation(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "workflows"
+        wf_dir.mkdir()
+        (wf_dir / "modern.py").write_text(
+            "from factory.workflow.primitives import Workflow, AgentNode, AgentRole\n"
+            "\n"
+            "meta = {\n"
+            "    'name': 'modern',\n"
+            "    'description': 'new-style workflow',\n"
+            "    'schema_version': 1,\n"
+            "    'capabilities': ['shell_exec'],\n"
+            "}\n"
+            "\n"
+            "def workflow():\n"
+            "    return Workflow(\n"
+            "        name='modern',\n"
+            "        nodes={'start': AgentNode(id='start', role=AgentRole.BUILDER)},\n"
+            "        edges=[],\n"
+            "        start_node='start',\n"
+            "    )\n"
+        )
+        WorkflowRegistry.register_search_path(str(wf_dir), source="user")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            entries = WorkflowRegistry.discover()
+
+        assert "modern" in entries
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) == 0
+
+
+# ── WorkflowEntry fields ──────────────────────────────────────────
+
+
+class TestWorkflowEntryFields:
+    def test_manifest_field_exists(self) -> None:
+        entry = WorkflowEntry(
+            name="test",
+            description="test",
+            path="<test>",
+            source="builtin",
+            manifest=WorkflowManifest(name="test", description="test"),
+        )
+        assert entry.manifest is not None
+        assert entry.manifest.name == "test"
+
+    def test_package_name_field(self) -> None:
+        entry = WorkflowEntry(
+            name="test",
+            description="test",
+            path="<test>",
+            source="entry_point",
+            package_name="my-package",
+        )
+        assert entry.package_name == "my-package"
+
+    def test_fields_default_none(self) -> None:
+        entry = WorkflowEntry(
+            name="test", description="test", path="<test>", source="builtin"
+        )
+        assert entry.manifest is None
+        assert entry.package_name is None
+
+
+# ── Skill export with namespaced names ────────────────────────────
+
+
+class TestSkillExportNamespaced:
+    def test_namespaced_workflow_creates_correct_dir(self, tmp_path: Path) -> None:
+        from factory.workflow.skill_export import export_all_skills
+
+        wf = Workflow(
+            name="mypkg:custom",
+            nodes={"start": AgentNode(id="start", role=AgentRole.BUILDER)},
+            edges=[],
+            start_node="start",
+        )
+        generated = export_all_skills(tmp_path, {"mypkg:custom": wf})
+        assert len(generated) == 1
+        assert (tmp_path / "workflow-mypkg-custom").is_dir()
+        assert (tmp_path / "workflow-mypkg-custom" / "SKILL.md").exists()

--- a/tests/test_workflow_plugins.py
+++ b/tests/test_workflow_plugins.py
@@ -150,7 +150,8 @@ class TestVersionCompatibility:
         m = WorkflowManifest(
             name="test", description="test", min_factory_version="0.0.1"
         )
-        issues = check_version_compatibility(m)
+        with patch("factory.workflow.manifest._get_factory_version", return_value="1.0.0"):
+            issues = check_version_compatibility(m)
         assert issues == []
 
     def test_incompatible_version(self) -> None:
@@ -873,7 +874,8 @@ class TestCmdListFormats:
         from factory.workflow.cli import _cmd_list
 
         args = argparse.Namespace(project_path=None, plugins=False, format="json")
-        rc = _cmd_list(args)
+        with patch("factory.workflow.registry.log"), patch("factory.workflow.cli.log"):
+            rc = _cmd_list(args)
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert isinstance(data, list)
@@ -905,7 +907,8 @@ class TestCmdListFormats:
         )
 
         args = argparse.Namespace(project_path=None, plugins=False, format="json")
-        rc = _cmd_list(args)
+        with patch("factory.workflow.registry.log"), patch("factory.workflow.cli.log"):
+            rc = _cmd_list(args)
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         plugin_entry = next(d for d in data if d["name"] == "ep:myplugin")


### PR DESCRIPTION
Closes #1099

## Changes

### Phase 1 — Plugin Manifest + Namespace Enforcement
- Create `factory/workflow/manifest.py` with strict Pydantic `WorkflowManifest` model (name, description, schema_version, min_factory_version, capabilities, author, url)
- `validate_namespace()` — entry-point plugins must use `prefix:name` format; builtin/user/project sources allow bare names
- `check_version_compatibility()` using `packaging.specifiers.SpecifierSet` for PEP 440 version checking
- `validate_capabilities()` — `agent_only` plugins with `FnNode` are rejected
- `manifest_from_meta()` with backward-compat deprecation warnings for existing bare meta dicts
- Modified `WorkflowRegistry._discover_in_directory()` to validate manifests, enforce namespaces, and validate graphs at discovery time
- Added `WorkflowEntry.manifest` field

### Phase 2 — Entry Points Discovery + Safety Ceilings
- Added `_discover_entry_points()` to `WorkflowRegistry` using `importlib.metadata.entry_points(group='factory.workflows')`
- Priority order: project > user > entry-points > builtin
- Added `WorkflowEntry.package_name` field
- Added hard safety ceilings to `WorkflowExecutor`: `MAX_GLOBAL_RELOOPS = 20`, `MAX_NODE_TIMEOUT = 3600`
- Global reloop tracking that caps iterations regardless of what plugin graphs declare
- Per-node timeout capping with warning log when exceeded

### Phase 3 — CLI UX + Skill Export
- Enhanced `factory workflow list` with `--plugins` filter and `--format json`
- Added `factory workflow doctor` subcommand (validates all workflows, `[OK]`/`[FAIL]` per workflow, exit code 1 on issues)
- Updated `skill_export.py` to handle plugin workflows (namespaced output paths `skills/workflow-{namespace}-{name}/`)
- Registered `doctor` in `cmd_workflow()` handler dict

### Tests
- 42 new tests in `tests/test_workflow_plugins.py` covering: manifest validation, namespace enforcement, version compatibility, capability enforcement, discovery-time graph validation, entry-point discovery with mocks, priority ordering, global reloop ceiling, per-node timeout ceiling, list --plugins filtering, doctor with valid/invalid workflows, backward compat for bare meta dicts, skill export with namespaced names