### PR TITLE
feat: add factory/compress/ package with CompressEvaluator, CompressInnerLoop, CompressOuterLoop

### DIFF
--- a/factory/compress/__init__.py
+++ b/factory/compress/__init__.py
@@ -1,0 +1,7 @@
+"""Compression research inner/outer loop package."""
+
+from factory.compress.evaluator import CompressEvaluator
+from factory.compress.inner_loop import CompressInnerLoop
+from factory.compress.outer_loop import CompressOuterLoop
+
+__all__ = ["CompressEvaluator", "CompressInnerLoop", "CompressOuterLoop"]

--- a/factory/compress/evaluator.py
+++ b/factory/compress/evaluator.py
@@ -1,0 +1,95 @@
+"""CompressEvaluator — parses compression result artifacts and computes combined score."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import structlog
+
+from factory.inner_loop import EvalResult
+
+log = structlog.get_logger()
+
+
+class CompressEvaluator:
+    """Parses compression result JSON artifacts.
+
+    Expected artifact schema:
+        {compression_ratio, quality_retention, inference_latency, technique}
+    """
+
+    def __init__(
+        self,
+        compression_weight: float = 0.4,
+        quality_weight: float = 0.5,
+        latency_weight: float = 0.1,
+    ) -> None:
+        self.compression_weight = compression_weight
+        self.quality_weight = quality_weight
+        self.latency_weight = latency_weight
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        try:
+            data = json.loads(Path(artifact_path).read_text())
+        except (json.JSONDecodeError, OSError):
+            log.warning("compress_parse_failed", path=str(artifact_path))
+            return EvalResult(score=0.0, valid=False)
+
+        compression_ratio = data.get("compression_ratio")
+        quality_retention = data.get("quality_retention")
+        if compression_ratio is None or quality_retention is None:
+            log.warning("compress_missing_fields", path=str(artifact_path))
+            return EvalResult(score=0.0, valid=False)
+
+        inference_latency = data.get("inference_latency", 0.0)
+        score = self._compute_combined_score(
+            float(compression_ratio),
+            float(quality_retention),
+            float(inference_latency),
+        )
+
+        metrics = {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+        return EvalResult(
+            score=score,
+            metrics=metrics,
+            valid=True,
+            artifacts=[str(artifact_path)],
+        )
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        best = EvalResult(score=0.0, valid=False)
+        for p in artifact_paths:
+            result = self.parse(p)
+            if result.score > best.score:
+                best = result
+        return best
+
+    def get_info(self) -> dict:
+        return {
+            "benchmark": "compression",
+            "weights": {
+                "compression_ratio": self.compression_weight,
+                "quality_retention": self.quality_weight,
+                "latency": self.latency_weight,
+            },
+            "metrics": [
+                "compression_ratio",
+                "quality_retention",
+                "inference_latency",
+                "technique",
+            ],
+        }
+
+    def _compute_combined_score(
+        self,
+        compression_ratio: float,
+        quality_retention: float,
+        inference_latency: float,
+    ) -> float:
+        latency_penalty = 1.0 / (1.0 + inference_latency / 1000.0)
+        return (
+            compression_ratio * self.compression_weight
+            + quality_retention * self.quality_weight
+            - (1.0 - latency_penalty) * self.latency_weight
+        )

--- a/factory/compress/inner_loop.py
+++ b/factory/compress/inner_loop.py
@@ -1,0 +1,124 @@
+"""CompressInnerLoop — inner loop for model compression research."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import structlog
+
+from factory.compress.evaluator import CompressEvaluator
+from factory.inner_loop import InnerLoop
+from factory.workflow.primitives import Workflow
+
+log = structlog.get_logger()
+
+_DEFAULT_FROZEN_NODES: frozenset[str] = frozenset({
+    "study",
+    "gate_research",
+    "gate_strategy",
+    "gate_build",
+    "gate_qa",
+    "gate_doc_freshness",
+    "gate_precheck",
+    "finalize",
+})
+
+
+class CompressInnerLoop(InnerLoop):
+    """Inner loop for model compression research.
+
+    Inherits step/collect/history from InnerLoop. Adds compression-specific
+    tracking: technique history, best technique, compression trajectory.
+    """
+
+    def __init__(
+        self,
+        project_dir: Path,
+        evaluator: CompressEvaluator | None = None,
+        workflow: Workflow | None = None,
+        frozen_nodes: frozenset[str] | None = None,
+    ) -> None:
+        if evaluator is None:
+            evaluator = CompressEvaluator()
+        if frozen_nodes is None:
+            frozen_nodes = _DEFAULT_FROZEN_NODES
+        super().__init__(
+            project_dir=project_dir,
+            mode="compress",
+            evaluator=evaluator,
+            workflow=workflow,
+            frozen_nodes=frozen_nodes,
+        )
+
+    def technique_history(self) -> list[dict]:
+        """Per-cycle {cycle, technique, score} from eval artifacts."""
+        results: list[dict] = []
+        for record in self._history:
+            technique = None
+            score = record.score_end
+            if record.experiments:
+                for exp in record.experiments:
+                    for artifact_path in exp.eval_artifacts:
+                        technique = self._extract_technique(Path(artifact_path))
+                        if technique:
+                            break
+                    if technique:
+                        break
+            results.append({
+                "cycle": record.cycle_number,
+                "technique": technique,
+                "score": score,
+            })
+        return results
+
+    def best_technique(self) -> dict | None:
+        """Highest-scoring technique from history."""
+        history = self.technique_history()
+        if not history:
+            return None
+        scored = [h for h in history if h["score"] is not None]
+        if not scored:
+            return None
+        return max(scored, key=lambda h: h["score"])
+
+    def compression_trajectory(self) -> list[dict]:
+        """Per-cycle {ratio, quality, technique} from eval artifacts."""
+        results: list[dict] = []
+        for record in self._history:
+            ratio = None
+            quality = None
+            technique = None
+            if record.experiments:
+                for exp in record.experiments:
+                    for artifact_path in exp.eval_artifacts:
+                        data = self._read_artifact(Path(artifact_path))
+                        if data:
+                            ratio = data.get("compression_ratio")
+                            quality = data.get("quality_retention")
+                            technique = data.get("technique")
+                            break
+                    if ratio is not None:
+                        break
+            results.append({
+                "ratio": ratio,
+                "quality": quality,
+                "technique": technique,
+            })
+        return results
+
+    @staticmethod
+    def _extract_technique(artifact_path: Path) -> str | None:
+        try:
+            import json
+            data = json.loads(artifact_path.read_text())
+            return data.get("technique")
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    @staticmethod
+    def _read_artifact(artifact_path: Path) -> dict | None:
+        try:
+            import json
+            return json.loads(artifact_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None

--- a/factory/compress/outer_loop.py
+++ b/factory/compress/outer_loop.py
@@ -1,0 +1,125 @@
+"""CompressOuterLoop — outer loop for compression optimization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import structlog
+
+from factory.compress.inner_loop import CompressInnerLoop
+from factory.strategy import detect_research_plateau
+
+log = structlog.get_logger()
+
+_NO_IMPROVEMENT_LIMIT = 3
+
+
+@dataclass
+class OuterLoopResult:
+    """Summary of a completed outer loop run."""
+
+    best_technique: dict | None
+    trajectory: list[dict]
+    total_cost: float
+    convergence_reason: str
+    cycles_completed: int = 0
+    plateau_count: int = 0
+
+
+class CompressOuterLoop:
+    """Outer loop wrapping CompressInnerLoop with plateau detection and directive escalation."""
+
+    def __init__(
+        self,
+        inner: CompressInnerLoop,
+        budget: int = 20,
+    ) -> None:
+        self.inner = inner
+        self.budget = budget
+        self._cycle = 0
+        self._plateau_count = 0
+        self._best_score: float | None = None
+
+    def run(self) -> OuterLoopResult:
+        """Run inner loop cycles until convergence or budget exhaustion."""
+        while not self._converged():
+            plateau = self._detect_plateau()
+            directives = self._analyze_and_steer(plateau)
+            self.inner.step(directives=directives if directives else None)
+            self._cycle += 1
+
+            trajectory = self.inner.score_trajectory()
+            if trajectory:
+                current = trajectory[-1]
+                if self._best_score is None or current > self._best_score:
+                    self._best_score = current
+
+            log.info(
+                "compress_outer_cycle",
+                cycle=self._cycle,
+                plateau_count=self._plateau_count,
+                best_score=self._best_score,
+            )
+
+        return self._summarize()
+
+    def _analyze_and_steer(self, plateau_detected: bool) -> dict:
+        """Analyze technique history and generate directives based on plateau state."""
+        if not plateau_detected:
+            return {}
+
+        self._plateau_count += 1
+        log.info("compress_plateau_escalation", plateau_count=self._plateau_count)
+
+        if self._plateau_count == 1:
+            return {
+                "focus": "Try alternative compression techniques",
+                "escalation": "inner",
+                "prioritize": "quality_retention",
+            }
+
+        if self._plateau_count == 2:
+            return {
+                "focus": "Restructure evaluation approach",
+                "escalation": "outer",
+                "prioritize": "compression_ratio",
+            }
+
+        return {
+            "focus": "Converging — exhausted mutation surfaces",
+            "escalation": "converge",
+        }
+
+    def _converged(self) -> bool:
+        if self._cycle >= self.budget:
+            return True
+        if self._plateau_count >= 3:
+            return True
+        return False
+
+    def _detect_plateau(self) -> bool:
+        history = self.inner.technique_history()
+        if len(history) < 2:
+            return False
+        summaries = [
+            {"metric_value": h["score"]}
+            for h in history
+            if h["score"] is not None
+        ]
+        return detect_research_plateau(summaries, threshold=_NO_IMPROVEMENT_LIMIT)
+
+    def _summarize(self) -> OuterLoopResult:
+        reason = "budget_exhausted"
+        if self._plateau_count >= 3:
+            reason = "converged"
+        elif self._cycle >= self.budget:
+            reason = "max_cycles"
+
+        return OuterLoopResult(
+            best_technique=self.inner.best_technique(),
+            trajectory=self.inner.compression_trajectory(),
+            total_cost=self.inner.total_cost(),
+            convergence_reason=reason,
+            cycles_completed=self._cycle,
+            plateau_count=self._plateau_count,
+        )

--- a/tests/test_compress_inner_outer.py
+++ b/tests/test_compress_inner_outer.py
@@ -1,0 +1,333 @@
+"""Tests for factory.compress package: CompressEvaluator, CompressInnerLoop, CompressOuterLoop."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from factory.compress.evaluator import CompressEvaluator
+from factory.compress.inner_loop import CompressInnerLoop, _DEFAULT_FROZEN_NODES
+from factory.compress.outer_loop import CompressOuterLoop, OuterLoopResult
+from factory.cycle_analyzer import CycleRecord, ExperimentRecord
+
+
+# ── CompressEvaluator ─────────────────────────────────────────────
+
+
+class TestCompressEvaluatorParse:
+    def test_parse_valid_artifact(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({
+            "compression_ratio": 4.0,
+            "quality_retention": 0.95,
+            "inference_latency": 50.0,
+            "technique": "pruning",
+        }))
+        evaluator = CompressEvaluator()
+        result = evaluator.parse(artifact)
+
+        assert result.valid is True
+        assert result.score > 0.0
+        assert result.metrics["compression_ratio"] == 4.0
+        assert result.metrics["quality_retention"] == 0.95
+        assert str(artifact) in result.artifacts
+
+    def test_parse_missing_file(self, tmp_path: Path) -> None:
+        evaluator = CompressEvaluator()
+        result = evaluator.parse(tmp_path / "nonexistent.json")
+
+        assert result.valid is False
+        assert result.score == 0.0
+
+    def test_parse_malformed_json(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "bad.json"
+        artifact.write_text("not valid json {{{")
+        evaluator = CompressEvaluator()
+        result = evaluator.parse(artifact)
+
+        assert result.valid is False
+        assert result.score == 0.0
+
+    def test_parse_missing_fields(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "incomplete.json"
+        artifact.write_text(json.dumps({"technique": "pruning"}))
+        evaluator = CompressEvaluator()
+        result = evaluator.parse(artifact)
+
+        assert result.valid is False
+        assert result.score == 0.0
+
+    def test_parse_many_best_score(self, tmp_path: Path) -> None:
+        low = tmp_path / "low.json"
+        low.write_text(json.dumps({
+            "compression_ratio": 2.0,
+            "quality_retention": 0.8,
+            "inference_latency": 100.0,
+        }))
+        high = tmp_path / "high.json"
+        high.write_text(json.dumps({
+            "compression_ratio": 8.0,
+            "quality_retention": 0.98,
+            "inference_latency": 10.0,
+        }))
+        evaluator = CompressEvaluator()
+        result = evaluator.parse_many([low, high])
+
+        assert result.valid is True
+        high_score = evaluator.parse(high).score
+        assert result.score == pytest.approx(high_score)
+
+    def test_get_info(self) -> None:
+        evaluator = CompressEvaluator()
+        info = evaluator.get_info()
+
+        assert info["benchmark"] == "compression"
+        assert "compression_ratio" in info["weights"]
+        assert "quality_retention" in info["weights"]
+        assert "latency" in info["weights"]
+        assert "compression_ratio" in info["metrics"]
+
+    def test_combined_score_formula(self) -> None:
+        evaluator = CompressEvaluator(
+            compression_weight=0.4,
+            quality_weight=0.5,
+            latency_weight=0.1,
+        )
+        # compression_ratio=4.0, quality_retention=0.95, latency=0.0
+        # latency_penalty = 1/(1+0/1000) = 1.0
+        # score = 4.0*0.4 + 0.95*0.5 - (1.0 - 1.0)*0.1 = 1.6 + 0.475 - 0.0 = 2.075
+        score = evaluator._compute_combined_score(4.0, 0.95, 0.0)
+        assert score == pytest.approx(2.075)
+
+        # with latency=500ms: penalty = 1/(1+500/1000) = 1/1.5 = 0.6667
+        # score = 1.6 + 0.475 - (1.0 - 0.6667)*0.1 = 2.075 - 0.03333 = 2.04167
+        score_latency = evaluator._compute_combined_score(4.0, 0.95, 500.0)
+        assert score_latency < score
+        expected = 4.0 * 0.4 + 0.95 * 0.5 - (1.0 - 1.0 / 1.5) * 0.1
+        assert score_latency == pytest.approx(expected)
+
+    def test_custom_weights(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({
+            "compression_ratio": 4.0,
+            "quality_retention": 0.95,
+            "inference_latency": 0.0,
+        }))
+        default_eval = CompressEvaluator()
+        custom_eval = CompressEvaluator(compression_weight=0.8, quality_weight=0.2, latency_weight=0.0)
+
+        default_score = default_eval.parse(artifact).score
+        custom_score = custom_eval.parse(artifact).score
+        assert default_score != custom_score
+
+
+# ── CompressInnerLoop ─────────────────────────────────────────────
+
+
+class TestCompressInnerLoopInit:
+    def test_defaults(self, tmp_path: Path) -> None:
+        loop = CompressInnerLoop(project_dir=tmp_path)
+
+        assert loop.mode == "compress"
+        assert loop.frozen_nodes == _DEFAULT_FROZEN_NODES
+        assert isinstance(loop.evaluator, CompressEvaluator)
+
+    def test_custom_evaluator(self, tmp_path: Path) -> None:
+        custom = CompressEvaluator(compression_weight=0.8)
+        loop = CompressInnerLoop(project_dir=tmp_path, evaluator=custom)
+
+        assert loop.evaluator is custom
+
+    def test_frozen_nodes_override(self, tmp_path: Path) -> None:
+        custom_frozen = frozenset({"study", "finalize"})
+        loop = CompressInnerLoop(project_dir=tmp_path, frozen_nodes=custom_frozen)
+
+        assert loop.frozen_nodes == custom_frozen
+
+    def test_frozen_nodes_validation_with_workflow(self, tmp_path: Path) -> None:
+        from factory.workflow.primitives import Workflow, FnNode
+
+        wf = Workflow(
+            name="test",
+            nodes={
+                "study": FnNode(id="study", command="echo study"),
+                "finalize": FnNode(id="finalize", command="echo finalize"),
+            },
+            edges=[],
+            start_node="study",
+        )
+        loop = CompressInnerLoop(
+            project_dir=tmp_path,
+            workflow=wf,
+            frozen_nodes=frozenset({"study"}),
+        )
+        assert loop.is_mutable("finalize")
+        assert not loop.is_mutable("study")
+
+
+class TestCompressInnerLoopMethods:
+    def _make_loop_with_history(self, tmp_path: Path) -> CompressInnerLoop:
+        """Create a loop with fake history records containing eval artifacts."""
+        loop = CompressInnerLoop(project_dir=tmp_path)
+
+        artifact_dir = tmp_path / "artifacts"
+        artifact_dir.mkdir()
+        for i, (ratio, quality, technique) in enumerate([
+            (2.0, 0.9, "pruning"),
+            (4.0, 0.85, "quantization"),
+            (6.0, 0.92, "distillation"),
+        ]):
+            artifact = artifact_dir / f"eval_{i}.json"
+            artifact.write_text(json.dumps({
+                "compression_ratio": ratio,
+                "quality_retention": quality,
+                "inference_latency": 50.0,
+                "technique": technique,
+            }))
+            record = CycleRecord(
+                cycle_number=i + 1,
+                mode="compress",
+                started_at=None,
+                ended_at=None,
+                duration_s=10.0,
+                score_start=None,
+                score_end=loop.evaluator.parse(artifact).score,
+                score_delta=None,
+                experiments=[ExperimentRecord(
+                    exp_id=i + 1,
+                    hypothesis=f"try {technique}",
+                    verdict="keep",
+                    score_before=0.0,
+                    score_after=loop.evaluator.parse(artifact).score,
+                    score_delta=0.0,
+                    cost_usd=0.5,
+                    duration_s=10.0,
+                    eval_artifacts=[str(artifact)],
+                )],
+            )
+            loop._history.append(record)
+
+        return loop
+
+    def test_technique_history(self, tmp_path: Path) -> None:
+        loop = self._make_loop_with_history(tmp_path)
+        history = loop.technique_history()
+
+        assert len(history) == 3
+        assert history[0]["technique"] == "pruning"
+        assert history[1]["technique"] == "quantization"
+        assert history[2]["technique"] == "distillation"
+        assert all(h["score"] is not None for h in history)
+
+    def test_best_technique(self, tmp_path: Path) -> None:
+        loop = self._make_loop_with_history(tmp_path)
+        best = loop.best_technique()
+
+        assert best is not None
+        assert best["technique"] == "distillation"
+        assert best["score"] is not None
+
+    def test_best_technique_empty(self, tmp_path: Path) -> None:
+        loop = CompressInnerLoop(project_dir=tmp_path)
+        assert loop.best_technique() is None
+
+    def test_compression_trajectory(self, tmp_path: Path) -> None:
+        loop = self._make_loop_with_history(tmp_path)
+        trajectory = loop.compression_trajectory()
+
+        assert len(trajectory) == 3
+        assert trajectory[0]["ratio"] == 2.0
+        assert trajectory[0]["quality"] == 0.9
+        assert trajectory[0]["technique"] == "pruning"
+        assert trajectory[2]["ratio"] == 6.0
+
+
+# ── CompressOuterLoop ─────────────────────────────────────────────
+
+
+class TestCompressOuterLoopDirectives:
+    def test_no_plateau(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=20)
+
+        directives = outer._analyze_and_steer(plateau_detected=False)
+        assert directives == {}
+
+    def test_first_plateau(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=20)
+
+        directives = outer._analyze_and_steer(plateau_detected=True)
+        assert directives["escalation"] == "inner"
+        assert outer._plateau_count == 1
+
+    def test_second_plateau(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=20)
+
+        outer._analyze_and_steer(plateau_detected=True)
+        directives = outer._analyze_and_steer(plateau_detected=True)
+        assert directives["escalation"] == "outer"
+        assert outer._plateau_count == 2
+
+    def test_third_plateau_converge(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=20)
+
+        outer._analyze_and_steer(plateau_detected=True)
+        outer._analyze_and_steer(plateau_detected=True)
+        directives = outer._analyze_and_steer(plateau_detected=True)
+        assert directives["escalation"] == "converge"
+        assert outer._plateau_count == 3
+
+
+class TestCompressOuterLoopConvergence:
+    def test_converged_by_plateau(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=20)
+        outer._plateau_count = 3
+
+        assert outer._converged() is True
+
+    def test_converged_by_budget(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=5)
+        outer._cycle = 5
+
+        assert outer._converged() is True
+
+    def test_not_converged(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=20)
+
+        assert outer._converged() is False
+
+    def test_run_respects_max_cycles(self, tmp_path: Path) -> None:
+        (tmp_path / ".factory").mkdir(parents=True, exist_ok=True)
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=3)
+
+        with patch.object(inner, "step", return_value=CycleRecord(
+            cycle_number=1, mode="compress", started_at=None,
+            ended_at=None, duration_s=1.0, score_start=None,
+            score_end=0.5, score_delta=None,
+        )):
+            result = outer.run()
+
+        assert isinstance(result, OuterLoopResult)
+        assert result.cycles_completed == 3
+        assert result.convergence_reason == "max_cycles"
+
+    def test_summarize_converged(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(project_dir=tmp_path)
+        outer = CompressOuterLoop(inner=inner, budget=20)
+        outer._plateau_count = 3
+        outer._cycle = 5
+
+        result = outer._summarize()
+        assert result.convergence_reason == "converged"
+        assert result.cycles_completed == 5
+        assert result.plateau_count == 3


### PR DESCRIPTION
## Summary

Adds `factory/compress/` package — the programmatic API layer for iterative model compression research. This enables automated multi-cycle compression optimization using the inner/outer loop pattern already established by `InnerLoop` and `CirclePackingEvaluator`.

### Changes

- **`factory/compress/evaluator.py`** — `CompressEvaluator` implementing the `Evaluator` protocol. Parses compression result JSON artifacts (`compression_ratio`, `quality_retention`, `inference_latency`, `technique`). Combined score formula: `compression_ratio * 0.4 + quality_retention * 0.5 - latency_penalty * 0.1` with configurable weights.

- **`factory/compress/inner_loop.py`** — `CompressInnerLoop` subclassing `InnerLoop` with `mode='compress'`, default frozen nodes for gate/finalize nodes, and compression-specific methods: `technique_history()`, `best_technique()`, `compression_trajectory()`.

- **`factory/compress/outer_loop.py`** — `CompressOuterLoop` wrapping `CompressInnerLoop` with plateau detection via `detect_research_plateau()`, directive escalation (inner → outer → converge), budget-based convergence, and `OuterLoopResult` dataclass.

- **`factory/compress/__init__.py`** — Public API exports.

- **`tests/test_compress_inner_outer.py`** — 25 tests covering all three classes: evaluator parsing (valid, missing, malformed, missing fields, parse_many, get_info, combined score, custom weights), inner loop (defaults, custom evaluator, frozen nodes, workflow validation, technique history, best technique, compression trajectory), outer loop (directive escalation, convergence, max cycles, summarize).

**Growth dimension:** capability_surface — new programmatic API for compression research mode.