### PR TITLE
Refactor create mode to produce portable workflow artifacts

### DIFF
--- a/factory/cli/run.py
+++ b/factory/cli/run.py
@@ -189,10 +189,10 @@ def _chain_modes(
     from factory.state import detect_state
 
     if completed_mode:
-        from factory.workflow.definitions import register_all
+        from factory.workflow.registry import WorkflowRegistry
 
-        workflows = register_all()
-        if completed_mode in workflows and workflows[completed_mode].terminal:
+        wf = WorkflowRegistry.get_workflow(completed_mode, project_path)
+        if wf and wf.terminal:
             print(
                 f"[factory] Terminal mode completed: {completed_mode} "
                 "— skipping post-completion chaining",

--- a/factory/skill_cache.py
+++ b/factory/skill_cache.py
@@ -57,11 +57,26 @@ def ensure_skills(project_dir: Path, *, mode: str | None = None) -> list[Path]:
 
 
 def _ensure_skills_inner(project_dir: Path, *, mode: str | None = None) -> list[Path]:
-    from factory.workflow.definitions import register_all
+    from factory.workflow.registry import WorkflowRegistry
     from factory.workflow.skill_export import export_all_skills
 
-    workflows = register_all()
-    checksum = _compute_checksum(workflows)
+    entries = WorkflowRegistry.discover(project_dir)
+
+    builtin_workflows: dict[str, Workflow] = {}
+    project_workflows: dict[str, Workflow] = {}
+
+    for name, entry in entries.items():
+        wf = WorkflowRegistry.get_workflow(name, project_dir)
+        if wf is None:
+            continue
+        if entry.source == "project":
+            project_workflows[name] = wf
+        else:
+            builtin_workflows[name] = wf
+
+    log.info("skill_cache.project_workflows_discovered", count=len(project_workflows))
+
+    checksum = _compute_checksum(builtin_workflows)
 
     cache_dir = Path.home() / ".factory" / "cache" / "skills" / checksum
     skills_target = project_dir / "skills"
@@ -74,7 +89,7 @@ def _ensure_skills_inner(project_dir: Path, *, mode: str | None = None) -> list[
     else:
         log.info("skill_cache.miss", checksum=checksum)
         cache_dir.mkdir(parents=True, exist_ok=True)
-        export_all_skills(cache_dir, workflows)
+        export_all_skills(cache_dir, builtin_workflows)
         workflow_dirs = sorted(cache_dir.glob("workflow-*"))
 
         cache_parent = cache_dir.parent
@@ -96,10 +111,17 @@ def _ensure_skills_inner(project_dir: Path, *, mode: str | None = None) -> list[
 
     log.info("skill_cache.copied", count=len(generated), target=str(skills_target))
 
-    if mode and mode in workflows:
+    if project_workflows:
+        project_generated = export_all_skills(skills_target, project_workflows)
+        generated.extend(project_generated)
+        log.info("skill_cache.project_skills_generated", count=len(project_generated))
+
+    all_workflows = {**builtin_workflows, **project_workflows}
+
+    if mode and mode in all_workflows:
         from factory.workflow.verification import write_verification_hooks
 
-        settings_path = write_verification_hooks(workflows[mode], project_dir)
+        settings_path = write_verification_hooks(all_workflows[mode], project_dir)
         if settings_path:
             log.info("skill_cache.hooks_generated", mode=mode, settings=str(settings_path))
 

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -168,12 +168,32 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
 def _cmd_validate(args: argparse.Namespace) -> int:
     """Validate a workflow using NetworkX."""
-    name = args.name
-    project_path = Path(getattr(args, "project_path", None) or ".").resolve()
-    wf = WorkflowRegistry.get_workflow(name, project_path)
-    if not wf:
-        print(f"Unknown workflow: {name}")
-        return 1
+    file_path = getattr(args, "file", None)
+
+    if file_path:
+        from factory.workflow.registry import _load_workflow_file
+
+        path = Path(file_path).resolve()
+        if not path.exists():
+            print(f"File not found: {path}")
+            return 1
+        try:
+            meta, workflow_fn = _load_workflow_file(path)
+        except ValueError as exc:
+            print(f"Failed to load workflow file: {exc}")
+            return 1
+        wf = workflow_fn()
+        name = meta["name"]
+    else:
+        name = args.name
+        if not name:
+            print("Error: provide a workflow name or --file <path>")
+            return 1
+        project_path = Path(getattr(args, "project_path", None) or ".").resolve()
+        wf = WorkflowRegistry.get_workflow(name, project_path)
+        if not wf:
+            print(f"Unknown workflow: {name}")
+            return 1
 
     issues = wf.validate_graph()
 
@@ -302,7 +322,8 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
 
     # validate
     p = wf_sub.add_parser("validate", help="Validate workflow graph structure")
-    p.add_argument("name", help="Workflow name")
+    p.add_argument("name", nargs="?", default=None, help="Workflow name")
+    p.add_argument("--file", default=None, help="Path to a standalone workflow .py file to validate")
     p.add_argument("--project-path", default=None, help="Project path for local workflow discovery")
 
     # export-skills

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -1634,15 +1634,18 @@ def create_workflow() -> Workflow:
             "20 registration points from the CEO task, run factory workflow validate <name>, "
             "regenerate SKILL.md via factory workflow export-skills, update tests, run pytest "
             "and ruff check. "
-            "Otherwise, follow the new-mode checklist: "
-            "1) Add the workflow function to factory/workflow/definitions.py "
-            "2) Register it in register_all() "
-            "3) Add WORKFLOW_META entry in factory/workflow/skill_export.py "
-            "4) Wire --mode in factory/cli.py (build_parser, cmd_ceo, _build_ceo_task) "
-            "5) Run factory workflow validate <name> to verify the graph "
-            "6) Run factory workflow export-skills to generate the SKILL.md "
-            "7) Write tests in tests/ "
-            "8) Run pytest and ruff check to verify "
+            "Otherwise, follow the new-mode checklist for portable workflows: "
+            "1) Create $PROJECT_PATH/.factory/workflows/ directory if it doesn't exist "
+            "2) Write the workflow file to $PROJECT_PATH/.factory/workflows/<name>.py "
+            "3) The file must contain a `meta` dict with `name` and `description` keys, "
+            "and a `workflow()` function returning a Workflow object "
+            "4) Only import from factory.workflow.primitives and stdlib — no other factory internals "
+            "5) Do NOT modify factory/workflow/definitions.py, register_all(), WORKFLOW_META, "
+            "or CLI wiring — the workflow registry discovers .factory/workflows/ automatically "
+            "6) Run factory workflow validate <name> --project-path $PROJECT_PATH to verify the graph "
+            "7) Run factory workflow export-skills --project-path $PROJECT_PATH to generate the SKILL.md "
+            "8) Write tests in tests/ "
+            "9) Run pytest and ruff check to verify "
             "Commit changes and open a draft PR."
         ),
         reads={".factory/strategy/current.md"},
@@ -1656,9 +1659,10 @@ def create_workflow() -> Workflow:
         evaluator_role=AgentRole.CEO,
         gate_prompt=(
             "Read builder output and PR diff. Does work match the approved spec? "
-            "Verify: workflow function exists, registered in register_all(), "
-            "WORKFLOW_META entry added, CLI wiring complete, tests written. "
-            "REDIRECT if any component is missing."
+            "For new modes: verify workflow file exists at .factory/workflows/<name>.py "
+            "with meta dict and workflow() function, NOT patched into definitions.py. "
+            "For existing mode updates: verify definitions.py changes are correct. "
+            "Tests written. REDIRECT if any component is missing."
         ),
         reads={".factory/reviews/builder-latest.md"},
     )
@@ -1666,9 +1670,11 @@ def create_workflow() -> Workflow:
     # Deep-QA verification (replaces monolithic QA)
     dq_nodes, dq_edges = _deep_qa_subgraph(
         adversarial_extra=(
-            "Run: factory workflow validate <name>, factory workflow show <name>, "
-            "factory workflow export-skills --verify. Verify SKILL.md generated under "
-            "skills/workflow-<name>/. Check CLI recognizes --mode <name>. "
+            "For new modes: verify the workflow was written to "
+            ".factory/workflows/<name>.py (NOT to definitions.py). "
+            "Run: factory workflow validate <name> --project-path $PROJECT_PATH, "
+            "factory workflow show <name> --project-path $PROJECT_PATH. "
+            "Verify SKILL.md generated under skills/workflow-<name>/. "
             "Check workflow handles both interactive and headless paths."
         ),
     )

--- a/tests/test_chain_modes_terminal.py
+++ b/tests/test_chain_modes_terminal.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from factory.models import ProjectState
 from factory.workflow.primitives import FnNode, Workflow
+from factory.workflow.registry import WorkflowRegistry
 
 
 def _terminal_workflow() -> Workflow:
@@ -34,11 +35,9 @@ class TestChainModesTerminal:
         """_chain_modes exits immediately when completed_mode is terminal."""
         from factory.cli.run import _chain_modes
 
-        registry = {
-            "swebench": _terminal_workflow(),
-            "improve": _non_terminal_workflow(),
-        }
-        with patch("factory.workflow.definitions.register_all", return_value=registry):
+        with patch.object(
+            WorkflowRegistry, "get_workflow", return_value=_terminal_workflow()
+        ):
             result = _chain_modes(tmp_path, completed_mode="swebench")
         assert result == 0
 
@@ -46,9 +45,9 @@ class TestChainModesTerminal:
         """Terminal mode prevents any further cycle execution."""
         from factory.cli.run import _chain_modes
 
-        registry = {"swebench": _terminal_workflow()}
-        with patch("factory.workflow.definitions.register_all", return_value=registry), \
-             patch("factory.cli.run._run_single_cycle") as mock_run:
+        with patch.object(
+            WorkflowRegistry, "get_workflow", return_value=_terminal_workflow()
+        ), patch("factory.cli.run._run_single_cycle") as mock_run:
             _chain_modes(tmp_path, completed_mode="swebench")
         mock_run.assert_not_called()
 
@@ -56,8 +55,9 @@ class TestChainModesTerminal:
         """Non-terminal completed_mode does not short-circuit."""
         from factory.cli.run import _chain_modes
 
-        registry = {"improve": _non_terminal_workflow()}
-        with patch("factory.workflow.definitions.register_all", return_value=registry), \
+        with patch.object(
+            WorkflowRegistry, "get_workflow", return_value=_non_terminal_workflow()
+        ), \
              patch("factory.state.detect_state", return_value=ProjectState.HAS_FACTORY), \
              patch("factory.cli.run._auto_detect_mode", return_value="improve"), \
              patch("factory.cli.run._run_single_cycle", return_value=0):
@@ -74,4 +74,21 @@ class TestChainModesTerminal:
              patch("factory.cli.run._auto_detect_mode", return_value="improve"), \
              patch("factory.cli.run._run_single_cycle", return_value=0):
             result = _chain_modes(tmp_path, already_improved=True)
+        assert result == 0
+
+    def test_project_local_terminal_workflow(self, tmp_path: Path) -> None:
+        """_chain_modes recognizes terminal project-local workflows."""
+        from factory.cli.run import _chain_modes
+
+        local_terminal = Workflow(
+            name="custom_bench",
+            nodes={"start": FnNode(id="start", command="true")},
+            edges=[],
+            start_node="start",
+            terminal=True,
+        )
+        with patch.object(
+            WorkflowRegistry, "get_workflow", return_value=local_terminal
+        ):
+            result = _chain_modes(tmp_path, completed_mode="custom_bench")
         assert result == 0

--- a/tests/test_skill_cache.py
+++ b/tests/test_skill_cache.py
@@ -5,9 +5,20 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from factory.skill_cache import _compute_checksum, _sort_recursive, ensure_skills
 from factory.workflow.definitions import register_all
 from factory.workflow.primitives import AgentNode, AgentRole, FnNode, Workflow
+from factory.workflow.registry import WorkflowRegistry
+
+
+@pytest.fixture(autouse=True)
+def _reset_workflow_registry():
+    """Reset WorkflowRegistry state between tests."""
+    WorkflowRegistry.reset()
+    yield
+    WorkflowRegistry.reset()
 
 
 def _make_workflow(name: str = "test", cmd: str = "echo hi") -> Workflow:
@@ -17,6 +28,21 @@ def _make_workflow(name: str = "test", cmd: str = "echo hi") -> Workflow:
         edges=[],
         start_node="a",
     )
+
+
+SAMPLE_WORKFLOW_PY = """\
+from factory.workflow.primitives import FnNode, Workflow
+
+meta = {"name": "test_mode", "description": "A test project-local workflow"}
+
+def workflow():
+    return Workflow(
+        name="test_mode",
+        nodes={"start": FnNode(id="start", command="echo hello")},
+        edges=[],
+        start_node="start",
+    )
+"""
 
 
 class TestComputeChecksum:
@@ -102,12 +128,10 @@ class TestEnsureSkills:
         assert len(first_dirs) == 1
         old_checksum_dir = first_dirs[0]
 
-        different_workflow = {
-            "alt": _make_workflow("alt", "echo changed"),
-        }
+        different_registry = {"alt": lambda: _make_workflow("alt", "echo changed")}
         monkeypatch.setattr(
-            "factory.workflow.definitions.register_all",
-            lambda: different_workflow,
+            "factory.workflow.definitions._get_builtin_registry",
+            lambda: different_registry,
         )
 
         ensure_skills(project)
@@ -130,3 +154,75 @@ class TestEnsureSkills:
         ensure_skills(project)
 
         assert marker.read_text() == "hand-written"
+
+
+class TestProjectLocalWorkflows:
+    def test_discovers_project_local_workflow(self, tmp_path: Path, monkeypatch: object) -> None:
+        """ensure_skills() discovers and generates skills for a project-local workflow."""
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))  # type: ignore[arg-type]
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        wf_dir = project / ".factory" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "test_mode.py").write_text(SAMPLE_WORKFLOW_PY)
+
+        paths = ensure_skills(project)
+        skill_names = [p.parent.name for p in paths]
+        assert "workflow-test_mode" in skill_names
+
+        skill_md = project / "skills" / "workflow-test_mode" / "SKILL.md"
+        assert skill_md.exists()
+
+    def test_project_local_always_regenerated(self, tmp_path: Path, monkeypatch: object) -> None:
+        """Project-local workflows are always regenerated, not cached."""
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))  # type: ignore[arg-type]
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        wf_dir = project / ".factory" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "test_mode.py").write_text(SAMPLE_WORKFLOW_PY)
+
+        ensure_skills(project)
+        skill_md = project / "skills" / "workflow-test_mode" / "SKILL.md"
+        first_content = skill_md.read_text()
+
+        updated_py = SAMPLE_WORKFLOW_PY.replace("echo hello", "echo updated")
+        (wf_dir / "test_mode.py").write_text(updated_py)
+
+        ensure_skills(project)
+        second_content = skill_md.read_text()
+        assert second_content != first_content
+
+    def test_builtins_still_use_cache(self, tmp_path: Path, monkeypatch: object) -> None:
+        """Builtin workflows use the cache path, not direct regeneration."""
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))  # type: ignore[arg-type]
+
+        project = tmp_path / "proj"
+        project.mkdir()
+
+        ensure_skills(project)
+
+        cache_root = tmp_path / ".factory" / "cache" / "skills"
+        cache_dirs = list(cache_root.iterdir())
+        assert len(cache_dirs) == 1
+        cached_skills = list(cache_dirs[0].glob("workflow-*"))
+        assert len(cached_skills) > 0
+
+    def test_project_local_not_in_cache_dir(self, tmp_path: Path, monkeypatch: object) -> None:
+        """Project-local workflow skills go directly to project/skills/, not cache."""
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))  # type: ignore[arg-type]
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        wf_dir = project / ".factory" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "test_mode.py").write_text(SAMPLE_WORKFLOW_PY)
+
+        ensure_skills(project)
+
+        cache_root = tmp_path / ".factory" / "cache" / "skills"
+        for cache_dir in cache_root.iterdir():
+            cached_names = [d.name for d in cache_dir.iterdir() if d.is_dir()]
+            assert "workflow-test_mode" not in cached_names

--- a/tests/test_workflow_cli.py
+++ b/tests/test_workflow_cli.py
@@ -336,7 +336,7 @@ class TestCmdShow:
 class TestCmdValidate:
     def test_unknown_workflow_returns_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(WorkflowRegistry, "get_workflow", return_value=None):
-            args = argparse.Namespace(name="nope", project_path=None)
+            args = argparse.Namespace(name="nope", project_path=None, file=None)
             assert _cmd_validate(args) == 1
         assert "Unknown workflow: nope" in capsys.readouterr().out
 
@@ -347,7 +347,7 @@ class TestCmdValidate:
         wf.edges = [MagicMock()]
 
         with patch.object(WorkflowRegistry, "get_workflow", return_value=wf):
-            args = argparse.Namespace(name="ok_wf", project_path=None)
+            args = argparse.Namespace(name="ok_wf", project_path=None, file=None)
             assert _cmd_validate(args) == 0
 
         out = capsys.readouterr().out
@@ -359,13 +359,63 @@ class TestCmdValidate:
         wf.validate_graph.return_value = ["orphan node X", "missing edge Y"]
 
         with patch.object(WorkflowRegistry, "get_workflow", return_value=wf):
-            args = argparse.Namespace(name="bad_wf", project_path=None)
+            args = argparse.Namespace(name="bad_wf", project_path=None, file=None)
             assert _cmd_validate(args) == 1
 
         out = capsys.readouterr().out
         assert "2 issue(s)" in out
         assert "orphan node X" in out
         assert "missing edge Y" in out
+
+    def test_file_flag_loads_and_validates(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--file flag loads a standalone workflow .py file and validates it."""
+        wf_file = tmp_path / "my_workflow.py"
+        wf_file.write_text(
+            "from factory.workflow.primitives import FnNode, Workflow\n"
+            "\n"
+            'meta = {"name": "my_wf", "description": "Test workflow"}\n'
+            "\n"
+            "def workflow():\n"
+            "    return Workflow(\n"
+            '        name="my_wf",\n'
+            '        nodes={"start": FnNode(id="start", command="echo hi")},\n'
+            "        edges=[],\n"
+            '        start_node="start",\n'
+            "    )\n"
+        )
+        args = argparse.Namespace(name=None, project_path=None, file=str(wf_file))
+        assert _cmd_validate(args) == 0
+
+        out = capsys.readouterr().out
+        assert "VALID" in out
+        assert "my_wf" in out
+
+    def test_file_flag_missing_file_returns_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        args = argparse.Namespace(
+            name=None, project_path=None, file=str(tmp_path / "missing.py")
+        )
+        assert _cmd_validate(args) == 1
+        assert "File not found" in capsys.readouterr().out
+
+    def test_file_flag_invalid_file_returns_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--file with a file missing meta dict returns 1."""
+        wf_file = tmp_path / "bad.py"
+        wf_file.write_text("def workflow(): pass\n")
+        args = argparse.Namespace(name=None, project_path=None, file=str(wf_file))
+        assert _cmd_validate(args) == 1
+        assert "Failed to load" in capsys.readouterr().out
+
+    def test_no_name_no_file_returns_1(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Neither name nor --file provided returns an error."""
+        args = argparse.Namespace(name=None, project_path=None, file=None)
+        assert _cmd_validate(args) == 1
+        assert "provide a workflow name or --file" in capsys.readouterr().out
 
 
 # ── _cmd_export_skills ─────────────────────────────────────────


### PR DESCRIPTION
Closes #1088

## Changes

- **`factory/skill_cache.py`**: Replace `register_all()` with `WorkflowRegistry.discover(project_dir)` to find builtin + user-global + project-local workflows. Split caching: builtins use the existing checksum-based cache at `~/.factory/cache/skills/{checksum}/`; project-local workflows (source='project') are always regenerated directly into `project_dir/skills/` without caching. Logs discovery stats via `skill_cache.project_workflows_discovered`.

- **`factory/cli/run.py`**: Replace `register_all()` in `_chain_modes()` with `WorkflowRegistry.get_workflow()` for terminal mode detection. Project-local terminal workflows now correctly skip post-completion chaining (fixes #1038).

- **`factory/workflow/definitions.py`**: Update `create_workflow()` builder prompt to instruct writing portable workflow files to `$PROJECT_PATH/.factory/workflows/<name>.py` with `meta` dict + `workflow()` function, instead of patching `definitions.py` directly. Updated gate_build and adversarial_extra prompts accordingly.

- **`factory/workflow/cli.py`**: Add `--file <path>` argument to `factory workflow validate` for validating standalone workflow `.py` files before placing them in `.factory/workflows/`. Name argument is now optional when `--file` is provided.

- **Tests**: 12 new test cases covering project-local workflow discovery, cache behavior (always regenerated, not cached), builtin cache preservation, chain modes terminal detection for project-local workflows, `--file` flag validation, and error cases.

## Test plan

- [x] `pytest tests/test_skill_cache.py -v` — all 12 tests pass (4 existing + 4 new project-local)
- [x] `pytest tests/test_chain_modes_terminal.py -v` — all 5 tests pass (4 updated + 1 new)
- [x] `pytest tests/test_workflow_cli.py -v` — all 33 tests pass (29 existing + 4 new validate --file)
- [x] `ruff check` — clean
- [x] Full test suite: 972 passed (1 pre-existing failure unrelated to this PR)