### PR TITLE
feat: add factory/compress/ package with clean public API and WorkflowMutator

### DIFF
--- a/factory/compress/__init__.py
+++ b/factory/compress/__init__.py
@@ -1,0 +1,13 @@
+"""Compress domain — inner/outer loop optimization for model compression research."""
+
+from factory.compress.evaluator import CompressEvaluator
+from factory.compress.inner_loop import CompressInnerLoop
+from factory.compress.mutator import WorkflowMutator
+from factory.compress.outer_loop import CompressOuterLoop
+
+__all__ = [
+    "CompressEvaluator",
+    "CompressInnerLoop",
+    "CompressOuterLoop",
+    "WorkflowMutator",
+]

--- a/factory/compress/evaluator.py
+++ b/factory/compress/evaluator.py
@@ -1,0 +1,90 @@
+"""CompressEvaluator — parses compression result artifacts into structured EvalResults."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import structlog
+
+from factory.inner_loop import EvalResult
+
+log = structlog.get_logger()
+
+
+class CompressEvaluator:
+    """Parses JSON artifacts from compression runs.
+
+    Expected artifact schema:
+        {compression_ratio, quality_retention, inference_latency, technique}
+
+    Combined score: compression_ratio * w_compression + quality_retention * w_quality
+                    - (1.0 - latency_penalty) * w_latency
+    where latency_penalty = max(0.0, 1.0 - inference_latency).
+    """
+
+    def __init__(
+        self,
+        *,
+        w_compression: float = 0.4,
+        w_quality: float = 0.5,
+        w_latency: float = 0.1,
+    ) -> None:
+        self.w_compression = w_compression
+        self.w_quality = w_quality
+        self.w_latency = w_latency
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        try:
+            data = json.loads(Path(artifact_path).read_text())
+        except (json.JSONDecodeError, OSError):
+            log.warning("compress_eval_parse_failed", path=str(artifact_path))
+            return EvalResult(score=0.0, valid=False)
+
+        compression_ratio = data.get("compression_ratio")
+        quality_retention = data.get("quality_retention")
+        if compression_ratio is None or quality_retention is None:
+            log.warning("compress_eval_missing_fields", path=str(artifact_path))
+            return EvalResult(score=0.0, valid=False)
+
+        inference_latency = float(data.get("inference_latency", 0.0))
+        latency_penalty = max(0.0, 1.0 - inference_latency)
+
+        score = (
+            float(compression_ratio) * self.w_compression
+            + float(quality_retention) * self.w_quality
+            - (1.0 - latency_penalty) * self.w_latency
+        )
+
+        metrics = {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+
+        return EvalResult(
+            score=score,
+            metrics=metrics,
+            valid=True,
+            artifacts=[str(artifact_path)],
+        )
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        best = EvalResult(score=0.0, valid=False)
+        for p in artifact_paths:
+            result = self.parse(p)
+            if result.score > best.score:
+                best = result
+        return best
+
+    def get_info(self) -> dict:
+        return {
+            "benchmark": "compression",
+            "weights": {
+                "compression": self.w_compression,
+                "quality": self.w_quality,
+                "latency": self.w_latency,
+            },
+            "metrics": [
+                "compression_ratio",
+                "quality_retention",
+                "inference_latency",
+                "technique",
+            ],
+        }

--- a/factory/compress/inner_loop.py
+++ b/factory/compress/inner_loop.py
@@ -1,0 +1,77 @@
+"""CompressInnerLoop — InnerLoop subclass with compression-specific tracking."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import structlog
+
+from factory.inner_loop import InnerLoop
+
+log = structlog.get_logger()
+
+_DEFAULT_FROZEN_NODES = frozenset({"gate_review", "gate_precheck"})
+
+
+class CompressInnerLoop(InnerLoop):
+    """InnerLoop specialized for model compression experiments.
+
+    Adds technique tracking: each cycle records the compression technique used,
+    enabling the outer loop to analyze which techniques work best.
+    """
+
+    def __init__(
+        self,
+        project_dir: Path,
+        **kwargs,
+    ) -> None:
+        kwargs.setdefault("mode", "compress")
+        kwargs.setdefault("frozen_nodes", _DEFAULT_FROZEN_NODES)
+        super().__init__(project_dir, **kwargs)
+
+    def technique_history(self) -> list[str]:
+        """Return ordered list of techniques used across all cycles."""
+        techniques: list[str] = []
+        for record in self._history:
+            technique = self._extract_technique(record)
+            if technique:
+                techniques.append(technique)
+        return techniques
+
+    def best_technique(self) -> str | None:
+        """Return the technique that achieved the highest score."""
+        best_score = -1.0
+        best_technique: str | None = None
+        for record in self._history:
+            technique = self._extract_technique(record)
+            if technique and record.score_end is not None and record.score_end > best_score:
+                best_score = record.score_end
+                best_technique = technique
+        return best_technique
+
+    def compression_trajectory(self) -> list[dict]:
+        """Return per-cycle technique + score pairs."""
+        trajectory: list[dict] = []
+        for record in self._history:
+            technique = self._extract_technique(record)
+            trajectory.append({
+                "cycle": record.cycle_number,
+                "technique": technique,
+                "score": record.score_end,
+                "delta": record.score_delta,
+            })
+        return trajectory
+
+    @staticmethod
+    def _extract_technique(record) -> str | None:
+        """Extract technique name from a CycleRecord's eval artifacts."""
+        for exp in getattr(record, "experiments", []):
+            for artifact_path in exp.eval_artifacts:
+                try:
+                    data = json.loads(Path(artifact_path).read_text())
+                    if "technique" in data:
+                        return str(data["technique"])
+                except (json.JSONDecodeError, OSError):
+                    continue
+        return None

--- a/factory/compress/mutator.py
+++ b/factory/compress/mutator.py
@@ -1,0 +1,124 @@
+"""WorkflowMutator — GEPA-style prompt evolution for workflow AgentNode prompt_templates."""
+
+from __future__ import annotations
+
+import structlog
+
+from factory.cycle_analyzer import CycleRecord
+from factory.workflow.primitives import AgentNode, Workflow
+
+log = structlog.get_logger()
+
+
+class WorkflowMutator:
+    """Mutates workflow AgentNode prompt_templates based on technique performance history.
+
+    Respects frozen_nodes: raises ValueError if asked to mutate a frozen node.
+    Uses model_copy(deep=True) for safe workflow cloning.
+    """
+
+    def __init__(
+        self,
+        frozen_nodes: frozenset[str] = frozenset(),
+        mutation_model: str = "sonnet",
+    ) -> None:
+        self.frozen_nodes = frozenset(frozen_nodes)
+        self.mutation_model = mutation_model
+
+    def classify_techniques(self, history: list[CycleRecord]) -> dict:
+        """Categorize techniques as successful, failed, or plateau based on score deltas."""
+        successful: list[str] = []
+        failed: list[str] = []
+        plateau: list[str] = []
+
+        for record in history:
+            for exp in record.experiments:
+                technique = exp.hypothesis or "unknown"
+                if exp.score_delta is not None:
+                    if exp.score_delta > 0.01:
+                        successful.append(technique)
+                    elif exp.score_delta < -0.01:
+                        failed.append(technique)
+                    else:
+                        plateau.append(technique)
+                elif exp.verdict == "keep":
+                    successful.append(technique)
+                elif exp.verdict == "revert":
+                    failed.append(technique)
+                else:
+                    plateau.append(technique)
+
+        return {
+            "successful": successful,
+            "failed": failed,
+            "plateau": plateau,
+        }
+
+    def build_prompt_amendments(self, technique_perf: dict) -> dict[str, str]:
+        """Generate prompt amendments from technique performance classification.
+
+        Failed techniques become constraints (avoid), successful become priorities.
+        """
+        amendments: dict[str, str] = {}
+
+        failed = technique_perf.get("failed", [])
+        if failed:
+            constraint_lines = [f"- Avoid: {t}" for t in failed]
+            amendments["constraints"] = (
+                "Based on prior experiments, avoid these approaches:\n"
+                + "\n".join(constraint_lines)
+            )
+
+        successful = technique_perf.get("successful", [])
+        if successful:
+            priority_lines = [f"- Prioritize: {t}" for t in successful]
+            amendments["priorities"] = (
+                "These approaches have shown improvement:\n"
+                + "\n".join(priority_lines)
+            )
+
+        return amendments
+
+    def mutate(
+        self,
+        workflow: Workflow,
+        history: list[CycleRecord],
+        focus_nodes: list[str] | None = None,
+    ) -> Workflow:
+        """Deep-copy workflow and apply prompt amendments to mutable AgentNodes.
+
+        Raises ValueError if a focus_node is frozen.
+        """
+        target_nodes = focus_nodes or [
+            nid for nid, node in workflow.nodes.items()
+            if isinstance(node, AgentNode) and nid not in self.frozen_nodes
+        ]
+
+        for nid in target_nodes:
+            if nid in self.frozen_nodes:
+                raise ValueError(
+                    f"Cannot mutate frozen node {nid!r}. "
+                    f"Frozen nodes: {sorted(self.frozen_nodes)}"
+                )
+
+        technique_perf = self.classify_techniques(history)
+        amendments = self.build_prompt_amendments(technique_perf)
+
+        mutated = workflow.model_copy(deep=True)
+
+        for nid in target_nodes:
+            node = mutated.nodes.get(nid)
+            if not isinstance(node, AgentNode):
+                continue
+
+            amendment_text = ""
+            if "constraints" in amendments:
+                amendment_text += f"\n\n{amendments['constraints']}"
+            if "priorities" in amendments:
+                amendment_text += f"\n\n{amendments['priorities']}"
+
+            if amendment_text:
+                node.prompt_template += amendment_text
+                log.info("mutated_node", node_id=nid, amendment_length=len(amendment_text))
+
+        return mutated

--- a/factory/compress/outer_loop.py
+++ b/factory/compress/outer_loop.py
@@ -1,0 +1,172 @@
+"""CompressOuterLoop — multi-cycle optimizer wrapping CompressInnerLoop."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from factory.compress.inner_loop import CompressInnerLoop
+from factory.compress.mutator import WorkflowMutator
+from factory.cycle_analyzer import CycleRecord
+from factory.models import OuterLoopConfig
+from factory.strategy import detect_research_plateau
+
+log = structlog.get_logger()
+
+
+class CompressOuterLoop:
+    """Outer loop that drives CompressInnerLoop cycles with plateau detection and mutation.
+
+    Public API:
+        converged()           — check if optimization has converged
+        generate_directives() — produce steering directives for the inner loop
+        step()                — run one outer-loop iteration
+        best_overall_technique() — best technique across all cycles
+        run()                 — run the full outer loop until convergence
+    """
+
+    def __init__(
+        self,
+        inner: CompressInnerLoop,
+        config: OuterLoopConfig,
+        *,
+        target_score: float = 0.9,
+        plateau_threshold: int = 3,
+        mutator: WorkflowMutator | None = None,
+    ) -> None:
+        self.inner = inner
+        self.config = config
+        self.target_score = target_score
+        self.plateau_threshold = plateau_threshold
+        self.mutator = mutator
+        self._cycle_count = 0
+        self._plateau_count = 0
+        self.reason: str | None = None
+
+    def converged(self) -> bool:
+        """Check if the outer loop should stop."""
+        max_cycles = self.config.max_outer_cycles
+        if max_cycles is not None and self._cycle_count >= max_cycles:
+            self.reason = "max_cycles_reached"
+            return True
+
+        history = self.inner.history()
+        if not history:
+            return False
+
+        latest = history[-1]
+        if latest.score_end is not None and latest.score_end >= self.target_score:
+            self.reason = "target_reached"
+            return True
+
+        summaries = [
+            {"metric_value": r.score_end}
+            for r in history
+            if r.score_end is not None
+        ]
+        if detect_research_plateau(summaries, threshold=self.plateau_threshold):
+            self._plateau_count += 1
+            if self.mutator and self._plateau_count < 3:
+                log.info(
+                    "plateau_detected_will_mutate",
+                    plateau_count=self._plateau_count,
+                )
+                return False
+            self.reason = "plateau"
+            return True
+
+        return False
+
+    def generate_directives(self, plateau_detected: bool = False) -> dict[str, Any]:
+        """Produce steering directives for the next inner-loop cycle."""
+        directives: dict[str, Any] = {
+            "outer_cycle": self._cycle_count + 1,
+            "target_score": self.target_score,
+        }
+
+        history = self.inner.history()
+        if history:
+            latest = history[-1]
+            if latest.score_end is not None:
+                directives["current_score"] = latest.score_end
+                directives["gap"] = self.target_score - latest.score_end
+
+        best = self.inner.best_technique()
+        if best:
+            directives["best_technique"] = best
+
+        trajectory = self.inner.compression_trajectory()
+        if trajectory:
+            directives["trajectory_summary"] = trajectory[-3:]
+
+        if plateau_detected:
+            directives["plateau_detected"] = True
+            directives["guidance"] = "Try a fundamentally different compression approach"
+
+        return directives
+
+    def step(self) -> CycleRecord:
+        """Run one outer-loop iteration: generate directives, run inner loop, check plateau."""
+        summaries = [
+            {"metric_value": r.score_end}
+            for r in self.inner.history()
+            if r.score_end is not None
+        ]
+        plateau_detected = detect_research_plateau(
+            summaries, threshold=self.plateau_threshold
+        )
+
+        if plateau_detected:
+            self._plateau_count += 1
+            if self.mutator and self._plateau_count >= 2 and self.inner.workflow:
+                log.info("triggering_workflow_mutation", plateau_count=self._plateau_count)
+                self.inner.workflow = self.mutator.mutate(
+                    self.inner.workflow,
+                    self.inner.history(),
+                )
+                self._plateau_count = 0
+
+        directives = self.generate_directives(plateau_detected=plateau_detected)
+        record = self.inner.step(directives=directives)
+        self._cycle_count += 1
+
+        log.info(
+            "outer_loop_step",
+            cycle=self._cycle_count,
+            score=record.score_end,
+            delta=record.score_delta,
+        )
+        return record
+
+    def best_overall_technique(self) -> str | None:
+        """Return the best technique across all inner-loop cycles."""
+        return self.inner.best_technique()
+
+    def run(self) -> list[CycleRecord]:
+        """Run the full outer loop until convergence."""
+        records: list[CycleRecord] = []
+
+        while not self.converged():
+            record = self.step()
+            records.append(record)
+
+        log.info(
+            "outer_loop_finished",
+            total_cycles=self._cycle_count,
+            reason=self.reason,
+        )
+
+        return records
+
+    def _summarize(self) -> dict[str, Any]:
+        """Summarize the outer loop run."""
+        history = self.inner.history()
+        return {
+            "total_cycles": self._cycle_count,
+            "reason": self.reason,
+            "best_technique": self.best_overall_technique(),
+            "final_score": history[-1].score_end if history else None,
+            "total_cost": self.inner.total_cost(),
+            "trajectory": self.inner.score_trajectory(),
+        }

--- a/factory/compress/outer_loop.py
+++ b/factory/compress/outer_loop.py
@@ -42,6 +42,7 @@ class CompressOuterLoop:
         self.mutator = mutator
         self._cycle_count = 0
         self._plateau_count = 0
+        self._plateau_detected = False
         self.reason: str | None = None
 
     def converged(self) -> bool:
@@ -65,7 +66,10 @@ class CompressOuterLoop:
             for r in history
             if r.score_end is not None
         ]
-        if detect_research_plateau(summaries, threshold=self.plateau_threshold):
+        self._plateau_detected = detect_research_plateau(
+            summaries, threshold=self.plateau_threshold
+        )
+        if self._plateau_detected:
             self._plateau_count += 1
             if self.mutator and self._plateau_count < 3:
                 log.info(
@@ -108,24 +112,15 @@ class CompressOuterLoop:
 
     def step(self) -> CycleRecord:
         """Run one outer-loop iteration: generate directives, run inner loop, check plateau."""
-        summaries = [
-            {"metric_value": r.score_end}
-            for r in self.inner.history()
-            if r.score_end is not None
-        ]
-        plateau_detected = detect_research_plateau(
-            summaries, threshold=self.plateau_threshold
-        )
+        plateau_detected = self._plateau_detected
 
-        if plateau_detected:
-            self._plateau_count += 1
-            if self.mutator and self._plateau_count >= 2 and self.inner.workflow:
-                log.info("triggering_workflow_mutation", plateau_count=self._plateau_count)
-                self.inner.workflow = self.mutator.mutate(
-                    self.inner.workflow,
-                    self.inner.history(),
-                )
-                self._plateau_count = 0
+        if plateau_detected and self.mutator and self._plateau_count >= 2 and self.inner.workflow:
+            log.info("triggering_workflow_mutation", plateau_count=self._plateau_count)
+            self.inner.workflow = self.mutator.mutate(
+                self.inner.workflow,
+                self.inner.history(),
+            )
+            self._plateau_count = 0
 
         directives = self.generate_directives(plateau_detected=plateau_detected)
         record = self.inner.step(directives=directives)

--- a/tests/test_compress_inner_outer.py
+++ b/tests/test_compress_inner_outer.py
@@ -333,6 +333,49 @@ class TestCompressOuterLoop:
             assert record.score_end == 0.6
             assert outer._cycle_count == 1
 
+    def test_run_plateau_counting_with_mutator(self, tmp_path: Path) -> None:
+        """Verify _plateau_count increments once per iteration in run(), not twice."""
+        workflow = _make_workflow()
+        inner = CompressInnerLoop(tmp_path, workflow=workflow, frozen_nodes=frozenset())
+        mutator = WorkflowMutator(frozen_nodes=frozenset({"gate_review"}))
+        config = OuterLoopConfig(max_outer_cycles=10)
+        outer = CompressOuterLoop(
+            inner, config, mutator=mutator, plateau_threshold=2, target_score=0.99,
+        )
+
+        inner._history.extend([
+            _make_cycle_record(cycle_number=1, score_end=0.5, score_delta=0.1, hypothesis="good"),
+            _make_cycle_record(cycle_number=2, score_end=0.5, score_delta=-0.1, hypothesis="bad"),
+            _make_cycle_record(cycle_number=3, score_end=0.5, score_delta=0.0),
+        ])
+
+        step_call_count = 0
+        original_prompt = inner.workflow.nodes["researcher"].prompt_template
+
+        def fake_step(*, directives: dict | None = None) -> CycleRecord:
+            nonlocal step_call_count
+            step_call_count += 1
+            rec = _make_cycle_record(
+                cycle_number=3 + step_call_count, score_end=0.5, score_delta=0.0,
+            )
+            inner._history.append(rec)
+            return rec
+
+        with patch.object(inner, "step", side_effect=fake_step):
+            # First iteration: plateau detected → _plateau_count goes to 1 (not 2).
+            # Mutator should NOT fire (count < 2).
+            assert not outer.converged()
+            outer.step()
+            assert outer._plateau_count == 1
+            assert inner.workflow.nodes["researcher"].prompt_template == original_prompt
+
+            # Second iteration: plateau again → _plateau_count goes to 2.
+            # Mutator SHOULD fire (count >= 2), then reset to 0.
+            assert not outer.converged()
+            outer.step()
+            assert outer._plateau_count == 0
+            assert inner.workflow.nodes["researcher"].prompt_template != original_prompt
+
     def test_best_overall_technique_delegates(self, tmp_path: Path) -> None:
         inner = CompressInnerLoop(tmp_path)
         config = OuterLoopConfig(max_outer_cycles=5)
@@ -441,6 +484,7 @@ class TestWorkflowMutator:
             score_delta=0.05,
         )
         with patch.object(inner, "step", return_value=mock_record):
+            assert not outer.converged()
             outer.step()
 
         assert inner.workflow.nodes["researcher"].prompt_template != original_prompt

--- a/tests/test_compress_inner_outer.py
+++ b/tests/test_compress_inner_outer.py
@@ -1,0 +1,446 @@
+"""Tests for factory/compress/ — evaluator, inner loop, outer loop, and mutator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from factory.compress.evaluator import CompressEvaluator
+from factory.compress.inner_loop import CompressInnerLoop
+from factory.compress.mutator import WorkflowMutator
+from factory.compress.outer_loop import CompressOuterLoop
+from factory.cycle_analyzer import CycleRecord, ExperimentRecord
+from factory.inner_loop import Evaluator, InnerLoop
+from factory.models import OuterLoopConfig
+from factory.workflow.primitives import AgentNode, AgentRole, Edge, GateNode, Workflow
+
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def artifact_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def _write_artifact(directory: Path, name: str, data: dict) -> Path:
+    p = directory / name
+    p.write_text(json.dumps(data))
+    return p
+
+
+def _make_workflow() -> Workflow:
+    return Workflow(
+        name="test-compress",
+        nodes={
+            "researcher": AgentNode(
+                id="researcher",
+                role=AgentRole.RESEARCHER,
+                prompt_template="Research compression techniques",
+            ),
+            "builder": AgentNode(
+                id="builder",
+                role=AgentRole.BUILDER,
+                prompt_template="Build the solution",
+            ),
+            "gate_review": GateNode(
+                id="gate_review",
+                evaluator_type="fn",
+            ),
+        },
+        edges=[
+            Edge(source="researcher", target="builder"),
+            Edge(source="builder", target="gate_review"),
+        ],
+        start_node="researcher",
+    )
+
+
+def _make_cycle_record(
+    *,
+    cycle_number: int = 1,
+    score_end: float | None = 0.5,
+    score_delta: float | None = 0.1,
+    hypothesis: str = "test technique",
+    verdict: str = "keep",
+) -> CycleRecord:
+    return CycleRecord(
+        cycle_number=cycle_number,
+        mode="compress",
+        started_at=None,
+        ended_at=None,
+        duration_s=10.0,
+        score_start=None,
+        score_end=score_end,
+        score_delta=score_delta,
+        experiments=[
+            ExperimentRecord(
+                exp_id=cycle_number,
+                hypothesis=hypothesis,
+                verdict=verdict,
+                score_before=None,
+                score_after=score_end,
+                score_delta=score_delta,
+                cost_usd=1.0,
+                duration_s=10.0,
+            )
+        ],
+    )
+
+
+# ── CompressEvaluator tests ───────────────────────────────────
+
+
+class TestCompressEvaluator:
+    def test_parse_valid_artifact(self, artifact_dir: Path) -> None:
+        path = _write_artifact(artifact_dir, "result.json", {
+            "compression_ratio": 0.8,
+            "quality_retention": 0.95,
+            "inference_latency": 0.1,
+            "technique": "pruning",
+        })
+        evaluator = CompressEvaluator()
+        result = evaluator.parse(path)
+        assert result.valid
+        assert result.score > 0
+        expected = 0.8 * 0.4 + 0.95 * 0.5 - (1.0 - max(0.0, 1.0 - 0.1)) * 0.1
+        assert abs(result.score - expected) < 1e-9
+
+    def test_parse_missing_file(self, artifact_dir: Path) -> None:
+        result = CompressEvaluator().parse(artifact_dir / "nonexistent.json")
+        assert not result.valid
+        assert result.score == 0.0
+
+    def test_parse_malformed_json(self, artifact_dir: Path) -> None:
+        path = artifact_dir / "bad.json"
+        path.write_text("{not valid json")
+        result = CompressEvaluator().parse(path)
+        assert not result.valid
+        assert result.score == 0.0
+
+    def test_parse_missing_required_fields(self, artifact_dir: Path) -> None:
+        path = _write_artifact(artifact_dir, "partial.json", {
+            "compression_ratio": 0.8,
+        })
+        result = CompressEvaluator().parse(path)
+        assert not result.valid
+        assert result.score == 0.0
+
+    def test_parse_many_selects_best(self, artifact_dir: Path) -> None:
+        p1 = _write_artifact(artifact_dir, "r1.json", {
+            "compression_ratio": 0.5,
+            "quality_retention": 0.5,
+            "inference_latency": 0.1,
+        })
+        p2 = _write_artifact(artifact_dir, "r2.json", {
+            "compression_ratio": 0.9,
+            "quality_retention": 0.95,
+            "inference_latency": 0.05,
+        })
+        evaluator = CompressEvaluator()
+        result = evaluator.parse_many([p1, p2])
+        assert result.valid
+        assert result.score == evaluator.parse(p2).score
+
+    def test_get_info(self) -> None:
+        info = CompressEvaluator().get_info()
+        assert info["benchmark"] == "compression"
+        assert "compression_ratio" in info["metrics"]
+        assert "weights" in info
+
+    def test_combined_score_formula(self, artifact_dir: Path) -> None:
+        path = _write_artifact(artifact_dir, "score.json", {
+            "compression_ratio": 1.0,
+            "quality_retention": 1.0,
+            "inference_latency": 0.0,
+        })
+        evaluator = CompressEvaluator(w_compression=0.4, w_quality=0.5, w_latency=0.1)
+        result = evaluator.parse(path)
+        expected = 1.0 * 0.4 + 1.0 * 0.5 - (1.0 - 1.0) * 0.1
+        assert abs(result.score - expected) < 1e-9
+        assert result.score == 0.9
+
+    def test_implements_evaluator_protocol(self) -> None:
+        assert isinstance(CompressEvaluator(), Evaluator)
+
+
+# ── CompressInnerLoop tests ───────────────────────────────────
+
+
+class TestCompressInnerLoop:
+    def test_initialization_defaults(self, tmp_path: Path) -> None:
+        loop = CompressInnerLoop(tmp_path)
+        assert loop.mode == "compress"
+        assert "gate_review" in loop.frozen_nodes
+        assert "gate_precheck" in loop.frozen_nodes
+
+    def test_subclasses_inner_loop(self, tmp_path: Path) -> None:
+        loop = CompressInnerLoop(tmp_path)
+        assert isinstance(loop, InnerLoop)
+
+    def test_technique_history_empty(self, tmp_path: Path) -> None:
+        loop = CompressInnerLoop(tmp_path)
+        assert loop.technique_history() == []
+
+    def test_best_technique_from_history(self, tmp_path: Path) -> None:
+        loop = CompressInnerLoop(tmp_path)
+        eval_dir = tmp_path / ".factory" / "experiments" / "001"
+        eval_dir.mkdir(parents=True)
+        artifact = eval_dir / "eval_result.json"
+        artifact.write_text(json.dumps({
+            "compression_ratio": 0.9,
+            "quality_retention": 0.95,
+            "technique": "quantization",
+        }))
+
+        record = CycleRecord(
+            cycle_number=1,
+            mode="compress",
+            started_at=None,
+            ended_at=None,
+            duration_s=10.0,
+            score_start=None,
+            score_end=0.85,
+            score_delta=0.1,
+            experiments=[
+                ExperimentRecord(
+                    exp_id=1,
+                    hypothesis="quantize model",
+                    verdict="keep",
+                    score_before=0.75,
+                    score_after=0.85,
+                    score_delta=0.1,
+                    cost_usd=1.0,
+                    duration_s=10.0,
+                    eval_artifacts=[str(artifact)],
+                )
+            ],
+        )
+        loop._history.append(record)
+        assert loop.best_technique() == "quantization"
+
+    def test_compression_trajectory(self, tmp_path: Path) -> None:
+        loop = CompressInnerLoop(tmp_path)
+        loop._history.append(CycleRecord(
+            cycle_number=1,
+            mode="compress",
+            started_at=None,
+            ended_at=None,
+            duration_s=5.0,
+            score_start=None,
+            score_end=0.5,
+            score_delta=None,
+        ))
+        traj = loop.compression_trajectory()
+        assert len(traj) == 1
+        assert traj[0]["cycle"] == 1
+        assert traj[0]["score"] == 0.5
+
+
+# ── CompressOuterLoop tests ───────────────────────────────────
+
+
+class TestCompressOuterLoop:
+    def test_directive_generation_no_plateau(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(tmp_path)
+        config = OuterLoopConfig(max_outer_cycles=10)
+        outer = CompressOuterLoop(inner, config)
+        directives = outer.generate_directives(plateau_detected=False)
+        assert "outer_cycle" in directives
+        assert "target_score" in directives
+        assert "plateau_detected" not in directives
+
+    def test_directive_generation_with_plateau(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(tmp_path)
+        config = OuterLoopConfig(max_outer_cycles=10)
+        outer = CompressOuterLoop(inner, config)
+        directives = outer.generate_directives(plateau_detected=True)
+        assert directives["plateau_detected"] is True
+        assert "guidance" in directives
+
+    def test_directive_generation_includes_history(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(tmp_path)
+        inner._history.append(CycleRecord(
+            cycle_number=1,
+            mode="compress",
+            started_at=None,
+            ended_at=None,
+            duration_s=10.0,
+            score_start=None,
+            score_end=0.7,
+            score_delta=None,
+        ))
+        config = OuterLoopConfig(max_outer_cycles=10)
+        outer = CompressOuterLoop(inner, config, target_score=0.9)
+        directives = outer.generate_directives()
+        assert directives["current_score"] == 0.7
+        assert abs(directives["gap"] - 0.2) < 1e-9
+
+    def test_convergence_on_target_reached(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(tmp_path)
+        inner._history.append(CycleRecord(
+            cycle_number=1,
+            mode="compress",
+            started_at=None,
+            ended_at=None,
+            duration_s=10.0,
+            score_start=None,
+            score_end=0.95,
+            score_delta=None,
+        ))
+        config = OuterLoopConfig(max_outer_cycles=10)
+        outer = CompressOuterLoop(inner, config, target_score=0.9)
+        assert outer.converged()
+        assert outer.reason == "target_reached"
+
+    def test_convergence_on_max_cycles(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(tmp_path)
+        config = OuterLoopConfig(max_outer_cycles=2)
+        outer = CompressOuterLoop(inner, config)
+        outer._cycle_count = 2
+        assert outer.converged()
+        assert outer.reason == "max_cycles_reached"
+
+    def test_public_api_names(self) -> None:
+        """Verify public API methods have no underscore prefix."""
+        assert not CompressOuterLoop.converged.__name__.startswith("_")
+        assert not CompressOuterLoop.generate_directives.__name__.startswith("_")
+        assert not CompressOuterLoop.step.__name__.startswith("_")
+        assert not CompressOuterLoop.best_overall_technique.__name__.startswith("_")
+
+    def test_step_runs_one_cycle(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(tmp_path)
+        config = OuterLoopConfig(max_outer_cycles=5)
+        outer = CompressOuterLoop(inner, config)
+
+        mock_record = CycleRecord(
+            cycle_number=1,
+            mode="compress",
+            started_at=None,
+            ended_at=None,
+            duration_s=10.0,
+            score_start=None,
+            score_end=0.6,
+            score_delta=None,
+        )
+
+        with patch.object(inner, "step", return_value=mock_record) as mock_step:
+            record = outer.step()
+            mock_step.assert_called_once()
+            assert record.score_end == 0.6
+            assert outer._cycle_count == 1
+
+    def test_best_overall_technique_delegates(self, tmp_path: Path) -> None:
+        inner = CompressInnerLoop(tmp_path)
+        config = OuterLoopConfig(max_outer_cycles=5)
+        outer = CompressOuterLoop(inner, config)
+
+        with patch.object(inner, "best_technique", return_value="pruning") as mock_bt:
+            assert outer.best_overall_technique() == "pruning"
+            mock_bt.assert_called_once()
+
+
+# ── WorkflowMutator tests ────────────────────────────────────
+
+
+class TestWorkflowMutator:
+    def test_classify_techniques_with_history(self) -> None:
+        history = [
+            _make_cycle_record(cycle_number=1, score_delta=0.15, hypothesis="pruning"),
+            _make_cycle_record(cycle_number=2, score_delta=-0.05, hypothesis="distillation"),
+            _make_cycle_record(cycle_number=3, score_delta=0.005, hypothesis="quantization"),
+        ]
+        mutator = WorkflowMutator()
+        perf = mutator.classify_techniques(history)
+        assert "pruning" in perf["successful"]
+        assert "distillation" in perf["failed"]
+        assert "quantization" in perf["plateau"]
+
+    def test_build_prompt_amendments(self) -> None:
+        mutator = WorkflowMutator()
+        perf = {
+            "successful": ["pruning"],
+            "failed": ["distillation"],
+            "plateau": [],
+        }
+        amendments = mutator.build_prompt_amendments(perf)
+        assert "constraints" in amendments
+        assert "distillation" in amendments["constraints"]
+        assert "priorities" in amendments
+        assert "pruning" in amendments["priorities"]
+
+    def test_build_prompt_amendments_empty(self) -> None:
+        mutator = WorkflowMutator()
+        amendments = mutator.build_prompt_amendments({"successful": [], "failed": [], "plateau": []})
+        assert amendments == {}
+
+    def test_mutate_produces_modified_copy(self) -> None:
+        workflow = _make_workflow()
+        original_prompt = workflow.nodes["researcher"].prompt_template
+        history = [
+            _make_cycle_record(score_delta=0.2, hypothesis="pruning"),
+            _make_cycle_record(score_delta=-0.1, hypothesis="bad approach"),
+        ]
+        mutator = WorkflowMutator(frozen_nodes=frozenset({"gate_review"}))
+        mutated = mutator.mutate(workflow, history)
+
+        assert mutated is not workflow
+        assert mutated.nodes["researcher"].prompt_template != original_prompt
+        assert workflow.nodes["researcher"].prompt_template == original_prompt
+
+    def test_frozen_node_raises_valueerror(self) -> None:
+        workflow = _make_workflow()
+        mutator = WorkflowMutator(frozen_nodes=frozenset({"gate_review"}))
+        history = [_make_cycle_record()]
+
+        with pytest.raises(ValueError, match="Cannot mutate frozen node"):
+            mutator.mutate(workflow, history, focus_nodes=["gate_review"])
+
+    def test_mutate_skips_non_agent_nodes(self) -> None:
+        workflow = _make_workflow()
+        history = [_make_cycle_record(score_delta=0.2, hypothesis="good")]
+        mutator = WorkflowMutator()
+        mutated = mutator.mutate(workflow, history)
+        gate_node = mutated.nodes["gate_review"]
+        assert not hasattr(gate_node, "prompt_template")
+
+    def test_outer_loop_integration_with_mutator(self, tmp_path: Path) -> None:
+        workflow = _make_workflow()
+        inner = CompressInnerLoop(tmp_path, workflow=workflow, frozen_nodes=frozenset())
+        mutator = WorkflowMutator(frozen_nodes=frozenset({"gate_review"}))
+        config = OuterLoopConfig(max_outer_cycles=5)
+        outer = CompressOuterLoop(inner, config, mutator=mutator, plateau_threshold=1)
+        outer._plateau_count = 1
+
+        inner._history.append(_make_cycle_record(
+            cycle_number=1, score_end=0.5, score_delta=0.1, hypothesis="good_technique",
+        ))
+        inner._history.append(_make_cycle_record(
+            cycle_number=2, score_end=0.5, score_delta=-0.05, hypothesis="bad_technique",
+        ))
+        inner._history.append(_make_cycle_record(
+            cycle_number=3, score_end=0.5, score_delta=0.0, hypothesis="neutral_technique",
+        ))
+        inner._history.append(_make_cycle_record(
+            cycle_number=4, score_end=0.5, score_delta=0.0, hypothesis="stale_technique",
+        ))
+
+        original_prompt = inner.workflow.nodes["researcher"].prompt_template
+
+        mock_record = CycleRecord(
+            cycle_number=5,
+            mode="compress",
+            started_at=None,
+            ended_at=None,
+            duration_s=10.0,
+            score_start=None,
+            score_end=0.55,
+            score_delta=0.05,
+        )
+        with patch.object(inner, "step", return_value=mock_record):
+            outer.step()
+
+        assert inner.workflow.nodes["researcher"].prompt_template != original_prompt


### PR DESCRIPTION
Closes the compress package backlog item (rebuild with code review fixes + WorkflowMutator).

## Changes

- **factory/compress/evaluator.py** — `CompressEvaluator` implementing the `Evaluator` protocol. Parses compression result JSON (`compression_ratio`, `quality_retention`, `inference_latency`, `technique`). Combined score with configurable weights. `import json` at module level.
- **factory/compress/inner_loop.py** — `CompressInnerLoop` subclassing `InnerLoop`. Sets `mode='compress'`, default `frozen_nodes`. Adds `technique_history()`, `best_technique()`, `compression_trajectory()`.
- **factory/compress/outer_loop.py** — `CompressOuterLoop` with public API: `converged()`, `generate_directives()`, `step()`, `best_overall_technique()`. No underscore prefixes. No `budget_exhausted` default — uses `self.reason` directly. Accepts optional `mutator` parameter.
- **factory/compress/mutator.py** — `WorkflowMutator` for GEPA-style prompt evolution: `classify_techniques()`, `build_prompt_amendments()`, `mutate()`. Uses `model_copy(deep=True)` for Workflow cloning. Raises `ValueError` for frozen node mutations.
- **factory/compress/__init__.py** — Public re-exports of all four classes.
- **tests/test_compress_inner_outer.py** — 28 tests covering all modules and integration.

All prior code review issues (private API names, import placement, dead code, missing mutator) addressed from the start.