### PR TITLE
Draft PR lifecycle — create as draft, mark ready on KEEP verdict

### DIFF
--- a/factory/agents/prompts/builder.md
+++ b/factory/agents/prompts/builder.md
@@ -23,7 +23,7 @@ You will be given:
 4. **Implement**: Make the changes described in the issue — only modify files within the declared scope
 5. **Test**: Run tests, lint, and type checks to verify your changes work
 6. **Commit**: `git add <changed files> && git commit -m "<descriptive message>"`
-7. **Open a PR**: `gh pr create --base $TARGET_BRANCH --title "<issue title>" --body "Closes #$ISSUE_NUM\n\n## Changes\n<summary>"`
+7. **Open a PR**: `gh pr create --draft --base $TARGET_BRANCH --title "<issue title>" --body "Closes #$ISSUE_NUM\n\n## Changes\n<summary>"`
 
 ## Constraints
 

--- a/factory/review.py
+++ b/factory/review.py
@@ -158,6 +158,8 @@ def post_review(
 
     if result.returncode == 0:
         log.info("post_review_success", pr=pr_number)
+        if verdict == "KEEP":
+            mark_pr_ready(pr_number, repo=repo)
         return True
 
     log.warning(
@@ -167,7 +169,37 @@ def post_review(
     )
     if _post_comment(pr_number, review_body, repo=repo):
         log.info("post_review_comment_success", pr=pr_number)
+        if verdict == "KEEP":
+            mark_pr_ready(pr_number, repo=repo)
         return True
 
     log.error("post_review_comment_failed", pr=pr_number)
+    return False
+
+
+def mark_pr_ready(pr_number: int, repo: str | None = None) -> bool:
+    """Mark a draft PR as ready for review using gh CLI.
+
+    Idempotent — calling on an already-ready PR is a no-op (gh returns 0).
+    """
+    cmd = ["gh", "pr", "ready", str(pr_number)]
+    if repo:
+        cmd.extend(["--repo", repo])
+
+    log.info("mark_pr_ready", pr=pr_number, repo=repo)
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        log.warning("mark_pr_ready_timeout", pr=pr_number)
+        return False
+    except FileNotFoundError:
+        log.warning("mark_pr_ready_gh_not_found")
+        return False
+
+    if result.returncode == 0:
+        log.info("mark_pr_ready_success", pr=pr_number)
+        return True
+
+    log.warning("mark_pr_ready_failed", pr=pr_number, stderr=result.stderr[:200])
     return False

--- a/tests/test_precheck.py
+++ b/tests/test_precheck.py
@@ -572,7 +572,7 @@ class TestPostReview:
     def test_success(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0)
         assert post_review(42, "body", "KEEP") is True
-        call_args = mock_run.call_args[0][0]
+        call_args = mock_run.call_args_list[0][0][0]
         assert "--approve" in call_args
         assert "42" in call_args
 
@@ -596,9 +596,10 @@ class TestPostReview:
         mock_run.side_effect = [
             MagicMock(returncode=1, stderr="auth error"),
             MagicMock(returncode=0),
+            MagicMock(returncode=0),
         ]
         assert post_review(42, "body", "KEEP") is True
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 3
         fallback_cmd = mock_run.call_args_list[1][0][0]
         assert fallback_cmd[:3] == ["gh", "pr", "comment"]
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,106 @@
+"""Tests for factory/review.py — review posting and draft PR lifecycle."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from factory.review import mark_pr_ready, post_review
+
+
+class TestMarkPrReady:
+    def test_success(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            assert mark_pr_ready(42) is True
+            mock_run.assert_called_once_with(
+                ["gh", "pr", "ready", "42"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+    def test_success_with_repo(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            assert mark_pr_ready(7, repo="owner/repo") is True
+            mock_run.assert_called_once_with(
+                ["gh", "pr", "ready", "7", "--repo", "owner/repo"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+    def test_failure_returns_false(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stderr="not a draft"
+            )
+            assert mark_pr_ready(42) is False
+
+    def test_idempotent_already_ready(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            assert mark_pr_ready(42) is True
+
+    def test_timeout_returns_false(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd=[], timeout=30)
+            assert mark_pr_ready(42) is False
+
+    def test_gh_not_found_returns_false(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+            assert mark_pr_ready(42) is False
+
+
+class TestPostReviewDraftLifecycle:
+    def test_keep_calls_mark_pr_ready(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            post_review(10, "body", "KEEP")
+            calls = mock_run.call_args_list
+            assert len(calls) == 2
+            assert calls[0].args[0] == ["gh", "pr", "review", "10", "--approve", "--body", "body"]
+            assert calls[1].args[0] == ["gh", "pr", "ready", "10"]
+
+    def test_keep_with_repo_passes_repo(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            post_review(10, "body", "KEEP", repo="owner/repo")
+            calls = mock_run.call_args_list
+            assert len(calls) == 2
+            assert calls[1].args[0] == ["gh", "pr", "ready", "10", "--repo", "owner/repo"]
+
+    def test_revert_does_not_call_mark_pr_ready(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            post_review(10, "body", "REVERT")
+            calls = mock_run.call_args_list
+            assert len(calls) == 1
+            assert "review" in calls[0].args[0]
+
+    def test_review_failure_skips_mark_pr_ready(self) -> None:
+        with patch("factory.review.subprocess.run") as mock_run, \
+             patch("factory.review._post_comment", return_value=False):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stderr="error"
+            )
+            post_review(10, "body", "KEEP")
+            ready_calls = [c for c in mock_run.call_args_list if "ready" in c.args[0]]
+            assert len(ready_calls) == 0
+
+    def test_keep_fallback_comment_still_marks_ready(self) -> None:
+        def side_effect(*args, **kwargs):
+            cmd = args[0]
+            if "review" in cmd:
+                return subprocess.CompletedProcess(args=[], returncode=1, stderr="no perms")
+            return subprocess.CompletedProcess(args=[], returncode=0)
+
+        with patch("factory.review.subprocess.run", side_effect=side_effect) as mock_run, \
+             patch("factory.review._post_comment", return_value=True):
+            result = post_review(10, "body", "KEEP")
+            assert result is True
+            ready_calls = [c for c in mock_run.call_args_list if "ready" in c.args[0]]
+            assert len(ready_calls) == 1
+            assert ready_calls[0].args[0] == ["gh", "pr", "ready", "10"]


### PR DESCRIPTION
Closes #1192

## Changes

- **builder.md**: Added `--draft` flag to the `gh pr create` command in the Builder agent prompt, so all PRs are created as drafts while the factory is working
- **factory/review.py**: Added `mark_pr_ready()` function that calls `gh pr ready` with the same graceful fallback pattern (timeout/not-found handling, warning-level logging on failure)
- **factory/review.py**: `post_review()` now calls `mark_pr_ready()` on KEEP verdict — both in the direct review path and the comment-fallback path — so PRs are marked ready only when the factory approves them
- **tests/test_review.py**: 11 unit tests covering `mark_pr_ready()` (success, failure, idempotency, timeout, gh-not-found) and `post_review()` integration (KEEP triggers ready, REVERT skips it, fallback path still marks ready)