### PR TITLE
fix: add timeout guidance for parallel researchers in workflow skills

### DIFF
--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -597,6 +597,20 @@ def _fork_to_instruction(node: ForkNode, workflow: Workflow) -> str:
         if isinstance(workflow.nodes.get(tid), AgentNode)
     ]
     if agent_nodes:
+        # Calculate the maximum timeout among all parallel agents
+        max_timeout = max(
+            (node.timeout or 600 for node in agent_nodes),
+            default=600
+        )
+
+        # Add timeout guidance if max_timeout exceeds Bash tool's default (120s)
+        if max_timeout > 120:
+            lines.append("")
+            lines.append(
+                f"\n**Important:** Run ALL commands above in a **single** Bash tool call "
+                f"with timeout set to at least {max_timeout} seconds.\n"
+            )
+
         from factory.workflow.verification import compile_fork_verification
 
         verify_script = compile_fork_verification(agent_nodes)

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -39,6 +39,7 @@ def _make_agent(
     prompt: str = "",
     reads: set[str] | None = None,
     writes: set[str] | None = None,
+    timeout: int | None = None,
 ) -> AgentNode:
     return AgentNode(
         id=id,
@@ -47,6 +48,7 @@ def _make_agent(
         prompt_template=prompt,
         reads=reads or set(),
         writes=writes or set(),
+        timeout=timeout,
     )
 
 
@@ -238,6 +240,34 @@ class TestForkToInstruction:
         result = _fork_to_instruction(fork, wf)
         assert "factory agent" not in result
         assert "wait" in result
+
+    def test_fork_includes_timeout_guidance_when_needed(self) -> None:
+        """When parallel agents have timeout > 120s, emit timeout guidance for Bash tool."""
+        r1 = _make_agent("researcher_a", AgentRole.RESEARCHER, timeout=600)
+        r2 = _make_agent("researcher_b", AgentRole.RESEARCHER, timeout=600)
+        fork = ForkNode(id="fork_research", targets=["researcher_a", "researcher_b"])
+        wf = _minimal_workflow(
+            nodes={"fork_research": fork, "researcher_a": r1, "researcher_b": r2},
+            start="fork_research",
+        )
+        result = _fork_to_instruction(fork, wf)
+        assert "Important:" in result
+        assert "single" in result.lower()
+        assert "Bash tool" in result
+        assert "600 seconds" in result
+
+    def test_fork_omits_timeout_guidance_when_not_needed(self) -> None:
+        """When all parallel agents have timeout <= 120s, no timeout guidance needed."""
+        r1 = _make_agent("researcher_a", AgentRole.RESEARCHER, timeout=100)
+        r2 = _make_agent("researcher_b", AgentRole.RESEARCHER, timeout=120)
+        fork = ForkNode(id="fork_research", targets=["researcher_a", "researcher_b"])
+        wf = _minimal_workflow(
+            nodes={"fork_research": fork, "researcher_a": r1, "researcher_b": r2},
+            start="fork_research",
+        )
+        result = _fork_to_instruction(fork, wf)
+        assert "Important:" not in result
+        assert "Bash tool" not in result
 
 
 # ── _gate_to_checkpoint ─────────────────────────────────────────


### PR DESCRIPTION
Closes #1201

## Changes

- **factory/workflow/skill_export.py** — Modified `_fork_to_instruction()` to emit timeout guidance when parallel agents have timeout > 120s. Calculates max timeout among fork targets and adds a guidance block instructing the CEO to set Bash tool timeout appropriately.
- **tests/test_skill_export.py** — Added `timeout` parameter to `_make_agent()` test helper. Added two new tests: `test_fork_includes_timeout_guidance_when_needed` (verifies guidance appears when max timeout > 120s) and `test_fork_omits_timeout_guidance_when_not_needed` (verifies no guidance when timeout <= 120s).

## Problem

When design mode spawns 3 parallel researcher agents (via ForkNode), they frequently timeout because:
- Each researcher needs 5-10 minutes to complete web research
- The Bash tool has a default 120-second timeout
- Even though each `factory agent researcher --timeout 600` sets 10 minutes, the Bash tool kills the entire shell process after 2 minutes

## Solution

Emit timeout guidance in generated SKILL.md files when parallel agents exceed Bash tool's default timeout. The guidance instructs the CEO agent to set an appropriate timeout parameter when invoking the Bash tool.

Example generated guidance:
```markdown
**Important:** Run ALL commands above in a **single** Bash tool call 
with timeout set to at least 600 seconds.
```

This fix is minimal and surgical — it adds guidance text only when needed (max timeout > 120s) and lets the CEO agent handle the timeout parameter naturally.

## Test plan

- [x] All 54 tests in `tests/test_skill_export.py` pass
- [x] `ruff check` passes clean
- [x] `mypy` type check passes
- [x] New tests verify guidance appears when needed and is omitted when not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)