### PR TITLE
feat: support project-local workflow modes via project: prefix

### DIFF
--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from factory.cli._ceo_dispatch import _start_ceo_tailer, _stop_ceo_tailer
 from factory.cli._helpers import (
+    CEO_MODES,
     _emit_cli_event,
     _ensure_dashboard,
     _print_banner,
@@ -148,6 +149,21 @@ def _validate_ceo_flags(
     mode: str = getattr(args, "mode", "auto")
     if mode == "interactive":
         mode = "design"
+    if mode.startswith("project:"):
+        mode = mode[len("project:"):]
+    if mode not in CEO_MODES and mode != "auto":
+        from factory.workflow.registry import WorkflowRegistry
+        raw_path = getattr(args, "path", None)
+        project_path = Path(raw_path).resolve() if raw_path else Path.cwd()
+        entries = WorkflowRegistry.discover(project_path)
+        if mode not in entries:
+            print(
+                f"Error: unknown mode '{mode}'. "
+                f"Not a built-in mode and not found in project workflows at "
+                f"{project_path / '.factory' / 'workflows'}.",
+                file=sys.stderr,
+            )
+            return 1
     warn_deprecated_mode(getattr(args, "mode", "auto"))
     bg: bool = getattr(args, "bg", False)
     bg_agents = _resolve_bg_agents(args)

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -156,7 +156,8 @@ def _validate_ceo_flags(
         raw_path = getattr(args, "path", None)
         project_path = Path(raw_path).resolve() if raw_path else Path.cwd()
         entries = WorkflowRegistry.discover(project_path)
-        if mode not in entries:
+        project_entries = {n for n, e in entries.items() if e.source == "project"}
+        if mode not in project_entries:
             print(
                 f"Error: unknown mode '{mode}'. "
                 f"Not a built-in mode and not found in project workflows at "

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 
-from factory.cli._helpers import CEO_MODES, RUN_MODES
 
 
 def add_project_setup_parsers(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -372,7 +372,7 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     )
     p.add_argument(
         "--mode",
-        choices=CEO_MODES,
+        choices=None,
         default="auto",
         help="Operating mode. Only 'create' and 'design' are actively supported; "
              "other modes (build, improve, research, meta, discover, review, refine, "
@@ -544,7 +544,7 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     p.add_argument("--session", default=None, help="Custom tmux session name")
     p.add_argument(
         "--mode",
-        choices=CEO_MODES,
+        choices=None,
         default="auto",
         help="Run mode (default: auto, respects in-flight cycle)",
     )

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -372,11 +372,11 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     )
     p.add_argument(
         "--mode",
-        choices=None,
+        metavar="MODE",
         default="auto",
-        help="Operating mode. Only 'create' and 'design' are actively supported; "
-             "other modes (build, improve, research, meta, discover, review, refine, "
-             "parallel-improve, interactive) are deprecated — use --mode design instead",
+        help="Operating mode. Built-in: auto, design, create, improve, research, "
+             "build, discover, founder, meta, plan, evolve. "
+             "Project-local: project:<name> (loads from .factory/workflows/<name>.py)",
     )
     p.add_argument(
         "--focus", default=None,
@@ -467,11 +467,10 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     )
     p.add_argument(
         "--mode",
-        choices=RUN_MODES,
+        metavar="MODE",
         default="auto",
-        help="Operating mode. Only 'create' and 'design' are actively supported; "
-             "other modes (build, improve, research, meta, discover, parallel-improve) "
-             "are deprecated — use --mode design instead",
+        help="Operating mode. Built-in: auto, improve, research, build, discover, "
+             "founder, meta. Project-local: project:<name>",
     )
     p.add_argument(
         "--focus", default=None,
@@ -544,7 +543,7 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     p.add_argument("--session", default=None, help="Custom tmux session name")
     p.add_argument(
         "--mode",
-        choices=None,
+        metavar="MODE",
         default="auto",
         help="Run mode (default: auto, respects in-flight cycle)",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3150,9 +3150,11 @@ class TestJustPlanFlag:
         assert just_plan is True
 
     def test_mode_plan_no_longer_valid(self, capsys):
-        """--mode plan is no longer a valid mode choice."""
-        with pytest.raises(SystemExit):
-            main(["ceo", "/some/path", "--mode", "plan"])
+        """--mode plan is rejected at runtime (not a valid built-in or project mode)."""
+        result = main(["ceo", "/some/path", "--mode", "plan"])
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "unknown mode" in captured.err
 
     def test_just_plan_default_is_false(self):
         """just_plan defaults to False when flag is omitted."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -179,6 +179,16 @@ class TestParser:
         assert args.mode == "interactive"
         assert args.path == "distributed eval runner"
 
+    def test_ceo_mode_project_prefix(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/tmp/proj", "--mode", "project:greet"])
+        assert args.mode == "project:greet"
+
+    def test_ceo_mode_unknown_accepted_by_parser(self):
+        parser = build_parser()
+        args = parser.parse_args(["ceo", "/tmp/proj", "--mode", "my-custom-mode"])
+        assert args.mode == "my-custom-mode"
+
     def test_ceo_path_optional(self):
         parser = build_parser()
         args = parser.parse_args(["ceo", "--mode", "design"])


### PR DESCRIPTION
## Summary

- Remove hardcoded `choices=CEO_MODES` from argparse `--mode` so any mode string is accepted
- Unknown modes are validated against `WorkflowRegistry.discover()` — if found in `.factory/workflows/`, they're accepted
- `--mode project:greet` strips the `project:` prefix and looks up `greet` in the project's local workflows
- Clear error message when a mode isn't found in either built-in or project-local workflows

This completes the create-mode-artifacts work (PR #1155) — project-local workflows written to `.factory/workflows/` can now be executed via `factory ceo --mode project:name`.

## Test plan

- [x] `factory ceo /tmp/test-create-mode --mode project:greet` resolves the project-local workflow
- [x] `factory ceo /tmp/test-create-mode --mode nonexistent` produces clear error
- [x] Built-in modes (`improve`, `design`, etc.) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)