### PR TITLE
feat: parallelize deep-QA pipeline + worktree anchoring + strategist plan reading

### DIFF
--- a/factory/agents/prompts/adversarial_tester.md
+++ b/factory/agents/prompts/adversarial_tester.md
@@ -2,13 +2,29 @@
 
 You are the adversarial tester agent. Switch your identity: you are a skeptical user who does NOT trust the Builder. You test the feature by actually running the project. No re-running pytest or lint — that was the health check's job. This step is about: "does the thing actually work when I use it?"
 
+## Working Directory Constraint
+
+Your current working directory IS the project root. Use relative paths or `$(pwd)` for all path references. Do NOT navigate to parent directories, other worktrees, or other checkouts. If you see a `.factory-worktrees/` directory or a `.git` file (rather than directory), you are inside a git worktree — this is expected. Stay here.
+
 ---
+
+## Step 0: Read the strategist plan to determine testing scope
+
+**MANDATORY:** Before designing any tests, read the strategist's plan to understand what was supposed to be built.
+
+1. Read `.factory/strategy/current.md`
+2. Find the hypothesis (H1, H2, etc.) matching this experiment
+3. Extract the **What** field — this defines exactly what feature to test
+4. Extract the **Expected impact** field — this tells you what should have improved
+5. Note the **Why** field — this gives you context for edge cases to probe
+
+Your testing scope is derived from the hypothesis deliverables. Test what was planned, not what you guess. Use the GitHub issue acceptance criteria (if available) as a supplementary source.
 
 ## Prerequisites
 
 - The health check must have passed.
 - The code review must have found no critical issues.
-- You must have the acceptance criteria (from the GitHub issue or the CEO agent).
+- You must have the acceptance criteria (from the hypothesis and/or GitHub issue).
 
 ## Core principle: evidence for every test
 

--- a/factory/agents/prompts/adversarial_tester.md
+++ b/factory/agents/prompts/adversarial_tester.md
@@ -22,8 +22,7 @@ Your testing scope is derived from the hypothesis deliverables. Test what was pl
 
 ## Prerequisites
 
-- The health check must have passed.
-- The code review must have found no critical issues.
+- You run in parallel with the health checker and code reviewer — do not wait for or depend on their results.
 - You must have the acceptance criteria (from the hypothesis and/or GitHub issue).
 
 ## Core principle: evidence for every test

--- a/factory/agents/prompts/code_reviewer.md
+++ b/factory/agents/prompts/code_reviewer.md
@@ -2,6 +2,10 @@
 
 You are the code reviewer agent. Read every changed file in the PR diff and evaluate quality against a mandatory 7-category checklist. You do NOT run eval or adversarial tests — only code review.
 
+## Working Directory Constraint
+
+Your current working directory IS the project root. Use relative paths or `$(pwd)` for all path references. Do NOT navigate to parent directories, other worktrees, or other checkouts. If you see a `.factory-worktrees/` directory or a `.git` file (rather than directory), you are inside a git worktree — this is expected. Stay here.
+
 ---
 
 ## Prerequisites

--- a/factory/agents/prompts/code_reviewer.md
+++ b/factory/agents/prompts/code_reviewer.md
@@ -10,7 +10,7 @@ Your current working directory IS the project root. Use relative paths or `$(pwd
 
 ## Prerequisites
 
-- The health check must have passed.
+- You run in parallel with the health checker and adversarial tester — do not wait for or depend on their results.
 - You must have the hypothesis and acceptance criteria (from the GitHub issue or the CEO agent).
 
 ## Getting the diff

--- a/factory/agents/prompts/health_checker.md
+++ b/factory/agents/prompts/health_checker.md
@@ -2,6 +2,10 @@
 
 You are the health checker agent. Your job is to run the project eval, compare scores against the baseline, and check whether unit tests pass. This is a mechanical step — no code review, no adversarial testing.
 
+## Working Directory Constraint
+
+Your current working directory IS the project root. Use relative paths or `$(pwd)` for all path references. Do NOT navigate to parent directories, other worktrees, or other checkouts. If you see a `.factory-worktrees/` directory or a `.git` file (rather than directory), you are inside a git worktree — this is expected. Stay here.
+
 ---
 
 ## What to do

--- a/factory/agents/prompts/health_checker.md
+++ b/factory/agents/prompts/health_checker.md
@@ -43,6 +43,8 @@ Write a structured report to `.factory/reviews/health-check.md` with:
 
 ## Gate
 
-- REVERT → stop entirely, do not proceed
-- FAIL → report findings, do not proceed to code review
-- PASS → proceed to code review
+You run in parallel with the code reviewer and adversarial tester. Your result feeds into the join node, where the gate evaluates all three results together.
+
+- REVERT → eval crashed or returned no valid output
+- FAIL → tests failing or significant score regression
+- PASS → tests pass and score is at or near baseline

--- a/factory/workflow/deep_qa.py
+++ b/factory/workflow/deep_qa.py
@@ -1,7 +1,7 @@
 """Deep-QA standalone verification workflow.
 
-Runs the decomposed QA pipeline (health_checker → code_reviewer →
-adversarial_tester) with a gate after code review as a standalone mode.
+Runs the parallel QA pipeline (health_checker, code_reviewer,
+adversarial_tester via fork/join) as a standalone mode.
 Triggered via `factory workflow run deep-qa` or `factory ceo /path --mode deep-qa`.
 """
 
@@ -14,9 +14,9 @@ from factory.workflow.primitives import AgentNode, Edge, FnNode, GateNode, Verdi
 meta = {
     "name": "deep-qa",
     "description": (
-        "Standalone deep-QA verification pipeline — 3 sequential specialist "
-        "agents (health_checker, code_reviewer, adversarial_tester) with a gate "
-        "after code review to short-circuit on critical bugs."
+        "Standalone deep-QA verification pipeline — 3 parallel specialist "
+        "agents (health_checker, code_reviewer, adversarial_tester) via "
+        "fork/join."
     ),
 }
 
@@ -50,7 +50,7 @@ def workflow() -> Workflow:
 
     edges = [
         *dq_edges,
-        Edge(source="adversarial_tester", target="gate_precheck"),
+        Edge(source="join_qa", target="gate_precheck"),
         Edge(source="gate_precheck", target="post_review", condition=VerdictType.PROCEED),
         Edge(source="gate_precheck", target="post_review", condition=VerdictType.HALT),
     ]
@@ -62,6 +62,6 @@ def workflow() -> Workflow:
         name="deep-qa",
         nodes=nodes,
         edges=edges,
-        start_node="health_checker",
+        start_node="fork_qa",
         trigger=trigger,
     )

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -166,17 +166,16 @@ def _deep_qa_subgraph(
     code_reviewer_extra: str = "",
     adversarial_extra: str = "",
 ) -> tuple[dict[str, Any], list[Edge]]:
-    """Return (nodes, internal_edges) for the 4-node deep-qa verification subgraph.
+    """Return (nodes, internal_edges) for the parallel deep-qa verification subgraph.
 
-    Three specialist agents run sequentially with a single gate after
-    code_reviewer to short-circuit on critical bugs:
+    Three specialist agents run in parallel via fork/join:
 
-        health_checker → code_reviewer → gate_review → adversarial_tester
+        fork_qa → [health_checker, code_reviewer, adversarial_tester] → join_qa
 
     Agent prompts live in their role .md files; prompt_template is only set
     when a workflow passes extra context via code_reviewer_extra / adversarial_extra.
-    The caller wires the entry edge (→ health_checker) and the exit edge
-    (adversarial_tester →) into the surrounding workflow.
+    The caller wires the entry edge (→ fork_qa) and the exit edge
+    (join_qa →) into the surrounding workflow.
     """
     nodes: dict[str, Any] = {}
 
@@ -195,18 +194,6 @@ def _deep_qa_subgraph(
         writes={".factory/reviews/code-review.md"},
     )
 
-    nodes["gate_review"] = GateNode(
-        id="gate_review",
-        evaluator_type="fn",
-        evaluator_command=(
-            "if grep -q 'CRITICAL_FOUND' "
-            "{project_path}/.factory/reviews/code-review.md; "
-            "then echo 'FAIL: critical issues found'; "
-            "else echo 'PROCEED'; fi"
-        ),
-        reads={".factory/reviews/code-review.md"},
-    )
-
     nodes["adversarial_tester"] = AgentNode(
         id="adversarial_tester",
         role=AgentRole.ADVERSARIAL_TESTER,
@@ -216,10 +203,23 @@ def _deep_qa_subgraph(
         writes={".factory/reviews/adversarial-qa.md"},
     )
 
+    nodes["fork_qa"] = ForkNode(
+        id="fork_qa",
+        targets=["health_checker", "code_reviewer", "adversarial_tester"],
+    )
+
+    nodes["join_qa"] = JoinNode(
+        id="join_qa",
+        sources=["health_checker", "code_reviewer", "adversarial_tester"],
+        reads={
+            ".factory/reviews/health-check.md",
+            ".factory/reviews/code-review.md",
+            ".factory/reviews/adversarial-qa.md",
+        },
+    )
+
     internal_edges = [
-        Edge(source="health_checker", target="code_reviewer"),
-        Edge(source="code_reviewer", target="gate_review"),
-        Edge(source="gate_review", target="adversarial_tester", condition=VerdictType.PROCEED),
+        Edge(source="fork_qa", target="join_qa"),
     ]
 
     return nodes, internal_edges
@@ -528,12 +528,12 @@ def build_workflow() -> Workflow:
         # Builder → build gate
         Edge(source="builder", target="gate_build"),
         # Build gate → deep-qa (proceed) or builder (reloop)
-        Edge(source="gate_build", target="health_checker", condition=VerdictType.PROCEED),
+        Edge(source="gate_build", target="fork_qa", condition=VerdictType.PROCEED),
         Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
         # Deep-QA internal edges
         *dq_edges,
         # adversarial_tester → gate_qa
-        Edge(source="adversarial_tester", target="gate_qa"),
+        Edge(source="join_qa", target="gate_qa"),
         # gate_qa → doc freshness (proceed) or builder (reloop, max 3)
         Edge(source="gate_qa", target="gate_doc_freshness", condition=VerdictType.PROCEED),
         Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
@@ -769,10 +769,11 @@ def design_workflow(just_plan: bool = False) -> Workflow:
             "archivist_plan",
             "builder",
             "gate_build",
+            "fork_qa",
             "health_checker",
             "code_reviewer",
-            "gate_review",
             "adversarial_tester",
+            "join_qa",
             "gate_qa",
             "gate_doc_freshness",
             "gate_precheck",
@@ -1052,12 +1053,12 @@ def improve_workflow() -> Workflow:
         # Builder → build gate
         Edge(source="builder", target="gate_build"),
         # Build gate → deep-qa (proceed) or builder (reloop)
-        Edge(source="gate_build", target="health_checker", condition=VerdictType.PROCEED),
+        Edge(source="gate_build", target="fork_qa", condition=VerdictType.PROCEED),
         Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
         # Deep-QA internal edges
         *dq_edges,
         # adversarial_tester → gate_qa
-        Edge(source="adversarial_tester", target="gate_qa"),
+        Edge(source="join_qa", target="gate_qa"),
         # gate_qa → doc freshness (proceed) or builder (reloop, max 3)
         Edge(source="gate_qa", target="gate_doc_freshness", condition=VerdictType.PROCEED),
         Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
@@ -1202,12 +1203,12 @@ def research_workflow() -> Workflow:
         # Builder → build gate
         Edge(source="builder", target="gate_build"),
         # Build gate → deep-qa (proceed) or builder (reloop)
-        Edge(source="gate_build", target="health_checker", condition=VerdictType.PROCEED),
+        Edge(source="gate_build", target="fork_qa", condition=VerdictType.PROCEED),
         Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
         # Deep-QA internal edges
         *dq_edges,
         # adversarial_tester → gate_qa
-        Edge(source="adversarial_tester", target="gate_qa"),
+        Edge(source="join_qa", target="gate_qa"),
         # gate_qa → doc freshness (proceed) or builder (reloop, max 3)
         Edge(source="gate_qa", target="gate_doc_freshness", condition=VerdictType.PROCEED),
         Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
@@ -1769,11 +1770,11 @@ def refine_workflow() -> Workflow:
         Edge(source="begin", target="create_issue"),
         Edge(source="create_issue", target="builder"),
         # Builder → deep-qa directly (no gate_build in refine)
-        Edge(source="builder", target="health_checker"),
+        Edge(source="builder", target="fork_qa"),
         # Deep-QA internal edges
         *dq_edges,
         # adversarial_tester → gate_qa
-        Edge(source="adversarial_tester", target="gate_qa"),
+        Edge(source="join_qa", target="gate_qa"),
         Edge(source="gate_qa", target="gate_doc_freshness", condition=VerdictType.PROCEED),
         Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
         # Doc freshness → precheck (proceed) or builder (reloop)
@@ -2048,12 +2049,12 @@ def create_workflow() -> Workflow:
         # Builder → build gate
         Edge(source="builder", target="gate_build"),
         # Build gate → deep-qa (proceed) or builder (reloop)
-        Edge(source="gate_build", target="health_checker", condition=VerdictType.PROCEED),
+        Edge(source="gate_build", target="fork_qa", condition=VerdictType.PROCEED),
         Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
         # Deep-QA internal edges
         *dq_edges,
         # adversarial_tester → gate_qa
-        Edge(source="adversarial_tester", target="gate_qa"),
+        Edge(source="join_qa", target="gate_qa"),
         # gate_qa → doc freshness (proceed) or builder (reloop)
         Edge(source="gate_qa", target="gate_doc_freshness", condition=VerdictType.PROCEED),
         Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
@@ -4269,7 +4270,13 @@ def parallel_improve_workflow() -> Workflow:
     dq_rename = {nid: f"exp_{nid}" for nid in dq_nodes}
     for nid, node in dq_nodes.items():
         new_id = dq_rename[nid]
-        new_node = node.model_copy(update={"id": new_id})
+        update: dict[str, Any] = {"id": new_id}
+        # Rename ForkNode targets and JoinNode sources
+        if isinstance(node, ForkNode):
+            update["targets"] = [dq_rename.get(t, t) for t in node.targets]
+        if isinstance(node, JoinNode):
+            update["sources"] = [dq_rename.get(s, s) for s in node.sources]
+        new_node = node.model_copy(update=update)
         exp_dq_nodes[new_id] = new_node
     for edge in dq_edges:
         exp_dq_edges.append(
@@ -4374,11 +4381,11 @@ def parallel_improve_workflow() -> Workflow:
             Edge(source="exp_begin", target="exp_builder"),
             Edge(source="exp_builder", target="exp_gate_build"),
             Edge(
-                source="exp_gate_build", target="exp_health_checker", condition=VerdictType.PROCEED
+                source="exp_gate_build", target="exp_fork_qa", condition=VerdictType.PROCEED
             ),
             Edge(source="exp_gate_build", target="exp_builder", condition=VerdictType.RELOOP),
             *exp_dq_edges,
-            Edge(source="exp_adversarial_tester", target="exp_gate_qa"),
+            Edge(source="exp_join_qa", target="exp_gate_qa"),
             Edge(source="exp_gate_qa", target="exp_gate_precheck", condition=VerdictType.PROCEED),
             Edge(source="exp_gate_qa", target="exp_builder", condition=VerdictType.RELOOP),
             Edge(source="exp_gate_precheck", target="exp_eval", condition=VerdictType.PROCEED),

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -299,6 +299,20 @@ def _topological_sort(workflow: Workflow) -> list[str]:
         adj[edge.source].append(edge.target)
         in_degree[edge.target] = in_degree.get(edge.target, 0) + 1
 
+    # Add implicit edges for fork/join semantics so fork targets sort
+    # after the fork node and join sources sort before the join node.
+    for nid, node in workflow.nodes.items():
+        if type(node).__name__ == "ForkNode":
+            for t in node.targets:  # type: ignore[union-attr]
+                if t in workflow.nodes:
+                    adj[nid].append(t)
+                    in_degree[t] = in_degree.get(t, 0) + 1
+        if type(node).__name__ == "JoinNode":
+            for s in node.sources:  # type: ignore[union-attr]
+                if s in workflow.nodes:
+                    adj[s].append(nid)
+                    in_degree[nid] = in_degree.get(nid, 0) + 1
+
     queue: deque[str] = deque()
     for nid in workflow.nodes:
         if in_degree.get(nid, 0) == 0:

--- a/factory/workflow/validation.py
+++ b/factory/workflow/validation.py
@@ -26,6 +26,20 @@ def _validate_edges(workflow: Workflow, issues: list[str]) -> None:
 def _validate_reachability(
     g: nx.DiGraph, workflow: Workflow, issues: list[str],  # type: ignore[type-arg]
 ) -> None:
+    # Add implicit edges for fork/join semantics.
+    # ForkNode.targets are reached implicitly (not via explicit edges).
+    # JoinNode.sources flow into the join implicitly.
+    nodes = workflow.nodes
+    for nid, node in nodes.items():
+        if type(node).__name__ == "ForkNode":
+            for t in node.targets:  # type: ignore[union-attr]
+                if t in nodes:
+                    g.add_edge(nid, t)
+        if type(node).__name__ == "JoinNode":
+            for s in node.sources:  # type: ignore[union-attr]
+                if s in nodes:
+                    g.add_edge(s, nid)
+
     reachable = nx.descendants(g, workflow.start_node) | {workflow.start_node}
     unreachable = set(workflow.nodes.keys()) - reachable
     for nid in sorted(unreachable):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -237,16 +237,16 @@ class TestCeoPrompt:
         assert has_deep_qa
 
     def test_e2e_gate_before_improve(self, ceo_prompt: str) -> None:
-        """Build workflow has health_checker after builder in topological order."""
+        """Build workflow has fork_qa (QA entry) after builder in topological order."""
         from factory.workflow.skill_export import _topological_sort
         from factory.workflow.definitions import register_all
         wfs = register_all()
         build = wfs["build"]
         order = _topological_sort(build)
         builder_ids = [nid for nid in order if nid == "builder"]
-        hc_ids = [nid for nid in order if nid == "health_checker"]
-        if builder_ids and hc_ids:
-            assert order.index(builder_ids[0]) < order.index(hc_ids[0])
+        fork_ids = [nid for nid in order if nid == "fork_qa"]
+        if builder_ids and fork_ids:
+            assert order.index(builder_ids[0]) < order.index(fork_ids[0])
 
     def test_e2e_gate_asks_user_for_input(self, ceo_prompt: str) -> None:
         """CEO prompt communicates with user in foreground mode."""

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -585,11 +585,15 @@ def _workflows_with_builder() -> list[str]:
 
 
 def _is_reachable(workflow_name: str, source_id: str, target_id: str) -> bool:
-    """Check if target_id is reachable from source_id via forward edges."""
+    """Check if target_id is reachable from source_id via forward edges + fork targets."""
     wf = register_all()[workflow_name]
     adj: dict[str, list[str]] = defaultdict(list)
     for edge in wf.edges:
         adj[edge.source].append(edge.target)
+    # Include ForkNode targets as implicit edges for reachability
+    for nid, node in wf.nodes.items():
+        if isinstance(node, ForkNode):
+            adj[nid].extend(node.targets)
 
     visited: set[str] = set()
     queue: deque[str] = deque([source_id])
@@ -647,10 +651,11 @@ class TestBuilderQaReachability:
 
 
 DEEP_QA_NODE_IDS = {
+    "fork_qa",
     "health_checker",
     "code_reviewer",
-    "gate_review",
     "adversarial_tester",
+    "join_qa",
 }
 
 DEEP_QA_WORKFLOWS = ["build", "improve", "research", "refine", "create"]
@@ -667,7 +672,7 @@ def _get_workflow(name: str):
 
 
 class TestDeepQaSubgraph:
-    """Verify the deep-QA subgraph is correctly wired in all 5 core workflows."""
+    """Verify the parallel deep-QA subgraph is correctly wired in all 5 core workflows."""
 
     @pytest.mark.parametrize("wf_name", DEEP_QA_WORKFLOWS)
     def test_deep_qa_present_in_all_workflows(self, wf_name: str) -> None:
@@ -679,9 +684,7 @@ class TestDeepQaSubgraph:
     def test_deep_qa_internal_edges(self, wf_name: str) -> None:
         wf = _get_workflow(wf_name)
         expected_edges = [
-            ("health_checker", "code_reviewer", None),
-            ("code_reviewer", "gate_review", None),
-            ("gate_review", "adversarial_tester", VerdictType.PROCEED),
+            ("fork_qa", "join_qa", None),
         ]
         edge_set = {(e.source, e.target, e.condition) for e in wf.edges}
         for src, tgt, cond in expected_edges:
@@ -690,12 +693,11 @@ class TestDeepQaSubgraph:
             )
 
     @pytest.mark.parametrize("wf_name", DEEP_QA_WORKFLOWS)
-    def test_deep_qa_gate_review_is_fn(self, wf_name: str) -> None:
+    def test_deep_qa_fork_targets(self, wf_name: str) -> None:
         wf = _get_workflow(wf_name)
-        gate = wf.nodes["gate_review"]
-        assert isinstance(gate, GateNode)
-        assert gate.evaluator_type == "fn"
-        assert "CRITICAL_FOUND" in gate.evaluator_command
+        fork = wf.nodes["fork_qa"]
+        assert isinstance(fork, ForkNode)
+        assert set(fork.targets) == {"health_checker", "code_reviewer", "adversarial_tester"}
 
     @pytest.mark.parametrize("wf_name", DEEP_QA_WORKFLOWS)
     def test_deep_qa_no_redundant_nodes(self, wf_name: str) -> None:

--- a/tests/test_workflow_qa.py
+++ b/tests/test_workflow_qa.py
@@ -12,7 +12,6 @@ from factory.workflow.primitives import (
     AgentNode,
     AgentRole,
     FnNode,
-    GateNode,
     VerdictType,
 )
 
@@ -52,18 +51,18 @@ class TestSubgraph:
     def test_preserves_edge_between_included_nodes(self) -> None:
         wf = improve_workflow()
         sub = wf.subgraph(
-            {"health_checker", "code_reviewer", "gate_review"}, name="test", start_node="health_checker",
+            {"fork_qa", "join_qa", "gate_qa"}, name="test", start_node="fork_qa",
         )
         edge_pairs = {(e.source, e.target) for e in sub.edges}
-        assert ("health_checker", "code_reviewer") in edge_pairs
-        assert ("code_reviewer", "gate_review") in edge_pairs
+        assert ("fork_qa", "join_qa") in edge_pairs
+        assert ("join_qa", "gate_qa") in edge_pairs
 
     def test_excludes_edges_to_outside_nodes(self) -> None:
         wf = improve_workflow()
-        sub = wf.subgraph({"health_checker", "code_reviewer"}, name="test", start_node="health_checker")
+        sub = wf.subgraph({"fork_qa", "join_qa"}, name="test", start_node="fork_qa")
         for edge in sub.edges:
-            assert edge.target != "gate_review"
             assert edge.target != "builder"
+            assert edge.target != "gate_qa"
 
 
 # ── deep-qa workflow structure ─────────────────────────────────
@@ -85,15 +84,16 @@ class TestDeepQaWorkflow:
 
     def test_start_node(self) -> None:
         wf = self._get_wf()
-        assert wf.start_node == "health_checker"
+        assert wf.start_node == "fork_qa"
 
     def test_has_expected_nodes(self) -> None:
         wf = self._get_wf()
-        assert set(wf.nodes.keys()) == {
-            "health_checker", "code_reviewer", "gate_review",
-            "adversarial_tester",
+        expected = {
+            "fork_qa", "health_checker", "code_reviewer",
+            "adversarial_tester", "join_qa",
             "gate_precheck", "post_review",
         }
+        assert set(wf.nodes.keys()) == expected
 
     def test_specialist_roles(self) -> None:
         wf = self._get_wf()
@@ -131,12 +131,10 @@ class TestDeepQaWorkflow:
         reloop = [e for e in wf.edges if e.condition == VerdictType.RELOOP]
         assert reloop == []
 
-    def test_gate_review_is_fn(self) -> None:
+    def test_fork_join_present(self) -> None:
         wf = self._get_wf()
-        gate = wf.nodes["gate_review"]
-        assert isinstance(gate, GateNode)
-        assert gate.evaluator_type == "fn"
-        assert "CRITICAL_FOUND" in gate.evaluator_command
+        assert "fork_qa" in wf.nodes
+        assert "join_qa" in wf.nodes
 
     def test_precheck_routes_to_post_review(self) -> None:
         wf = self._get_wf()


### PR DESCRIPTION
## Summary

Fixes #1204, #1205, #1206. Supersedes #1207 (rebased cleanly on latest main).

Converts the sequential deep-QA pipeline to parallel execution via fork/join, adds worktree anchoring to all 3 QA prompts, and makes the adversarial tester explicitly read the strategist plan.

### Before (sequential)
```
health_checker → code_reviewer → gate_review → adversarial_tester
```

### After (parallel)
```
fork_qa → [health_checker, code_reviewer, adversarial_tester] → join_qa
```

### Changes

**Prompt fixes (3 files):**
- `adversarial_tester.md` — added Working Directory Constraint + Step 0 (read `.factory/strategy/current.md` for hypothesis scope)
- `health_checker.md` — added Working Directory Constraint
- `code_reviewer.md` — added Working Directory Constraint

**Workflow engine (3 files):**
- `definitions.py` — `_deep_qa_subgraph()` now returns fork/join nodes instead of sequential edges; removed `gate_review`; fixed SubgraphForkNode renaming to also rename ForkNode.targets/JoinNode.sources
- `deep_qa.py` — updated standalone deep-qa workflow for fork/join (start_node=fork_qa, exit=join_qa)
- `validation.py` — added implicit edges for ForkNode targets and JoinNode sources in reachability analysis

**Tests (2 files):**
- `test_workflow_definitions.py` — updated deep-QA subgraph tests for fork/join pattern
- `test_workflow_qa.py` — updated subgraph and deep-qa workflow tests

### Key fixes

1. **Worktree anchoring (#1204):** All 3 QA prompts include "Working Directory Constraint" preventing agents from escaping to parent directories or other worktrees.

2. **Strategist plan reading (#1205):** `adversarial_tester.md` has Step 0 that reads `.factory/strategy/current.md` to derive testing scope from hypothesis deliverables.

3. **Parallel execution (#1206):** `_deep_qa_subgraph()` returns `fork_qa`/`join_qa` nodes. All 7 workflows using the subgraph (build, improve, research, refine, create, deep-qa, parallel-improve) automatically get parallel QA.

## Test plan

- [x] All 213 workflow tests pass
- [x] Lint clean (`ruff check`)
- [x] Previously validated via E2E: `factory ceo "Build a snake game"` — 3 QA agents ran in parallel, 56% wall-clock savings