### PR TITLE
feat: add study mode workflow with graph exploration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,10 @@ factory ceo /path/to/project --mode founder                       # One fast hyp
 factory ceo /path/to/project --mode founder --focus "auth flow"   # Targeted prototype
 factory run /path/to/project --mode founder --loop --interval 300 # Rapid iteration
 
+# Study — graph-powered codebase analysis
+factory ceo /path/to/project --mode study                    # Graph-powered codebase study
+factory ceo /path/to/project --mode study --focus "auth flow" # Focused study with graph context
+
 # Meta — improve the factory's own agents
 factory ceo /path/to/project --mode meta        # Improve + ACE playbook evolution
 

--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -285,6 +285,13 @@ At the start of every cycle, create a task list using `TaskCreate` **before spaw
 | 2 | Hypothesize — Strategist | Picking hypothesis |
 | 3 | Prototype — Builder + health check | Prototyping |
 
+**Study mode:**
+
+| # | Subject | activeForm |
+|---|---------|------------|
+| 1 | Graph update + study | Scanning project |
+| 2 | Graph exploration | Exploring code structure |
+
 ### Status Transition Rules
 
 - Mark each task `in_progress` when starting the corresponding phase
@@ -325,6 +332,7 @@ Each mode's full instructions live in a workflow skill under `skills/workflow-<n
 - `--refine "<request>"` → read `skills/workflow-refine/SKILL.md`
 - `--mode create` or `## Create Mode` → read `skills/workflow-create/SKILL.md`
 - `--mode founder` → read `skills/workflow-founder/SKILL.md`
+- `--mode study` → read `skills/workflow-study/SKILL.md`
 
 **Invocation:** Read the selected SKILL.md file, then follow its instructions as your mode-specific playbook. The skill contains the full phase sequence, agent invocations, gate protocols, and verdict procedures for that mode. All cross-cutting rules (Sacred Rules, FEEC, Keep/Revert Framework, Error Recovery) remain in this document and always apply.
 

--- a/factory/agents/prompts/researcher.md
+++ b/factory/agents/prompts/researcher.md
@@ -53,7 +53,7 @@ You are invoked during the Improve phase. The project is already configured with
 
 ### Task
 
-1. **Run local study**: `factory study "$PROJECT_PATH"` for interaction logs + shallow search
+1. **Read study context**: Read `.factory/strategy/study-combined.md` for project observations and structural graph analysis. If it does not exist, run `factory study "$PROJECT_PATH"` as a fallback.
 2. **Read the backlog**: Read `.factory/strategy/backlog.md` and assess which items are achievable, which are blocked, and which may be already done or obsolete. Note this in your report so the Strategist can prioritize.
 3. **Read project context**: README, pyproject.toml, experiment history, current strategy
 4. **Search externally**: Use WebSearch for similar projects, best practices, relevant techniques
@@ -63,7 +63,7 @@ You are invoked during the Improve phase. The project is already configured with
 
 ### Constraints
 
-- Always run local study first — it's fast baseline context
+- Always read study context first — it's fast baseline context
 - Limit WebSearch to 5-8 queries (3-5 in targeted mode)
 - Limit WebFetch to 3-5 pages
 - Focus on actionable insights, not academic summaries

--- a/factory/cli/__init__.py
+++ b/factory/cli/__init__.py
@@ -50,7 +50,10 @@ from factory.cli.run import (
     cmd_run as cmd_run,
 )
 from factory.cli.graph import (
+    cmd_graph_explain as cmd_graph_explain,
     cmd_graph_extract as cmd_graph_extract,
+    cmd_graph_path as cmd_graph_path,
+    cmd_graph_query as cmd_graph_query,
     cmd_graph_status as cmd_graph_status,
     cmd_graph_update as cmd_graph_update,
 )

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -454,9 +454,9 @@ def _validate_late_flags(
         )
         return 1
 
-    if focus and mode not in ("improve", "research", "create", "evolve", "frontend-design", "frontend-design-discover") and not design_existing and not just_plan:
+    if focus and mode not in ("improve", "research", "create", "evolve", "study", "frontend-design", "frontend-design-discover") and not design_existing and not just_plan:
         print(
-            f"Error: --focus (targeted mode) only works in improve, research, create, evolve, frontend-design, "
+            f"Error: --focus (targeted mode) only works in improve, research, create, evolve, study, frontend-design, "
             f"frontend-design-discover, or design (with --just-plan) mode, "
             f"got '{mode}'. The project must already be built before targeting specific items.",
             file=sys.stderr,

--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -1,4 +1,5 @@
 """CLI _helpers commands."""
+
 from __future__ import annotations
 
 import argparse
@@ -16,10 +17,45 @@ log = structlog.get_logger()
 _WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
 
 
-CEO_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "design", "interactive", "parallel-improve", "research", "review", "deep-qa", "create", "swebench", "frontend-design", "frontend-design-discover", "frontend-design-scan", "evolve", "deep-research"]
+CEO_MODES = [
+    "auto",
+    "auto-fresh",
+    "build",
+    "discover",
+    "founder",
+    "improve",
+    "meta",
+    "design",
+    "interactive",
+    "parallel-improve",
+    "research",
+    "review",
+    "deep-qa",
+    "create",
+    "study",
+    "swebench",
+    "frontend-design",
+    "frontend-design-discover",
+    "frontend-design-scan",
+    "evolve",
+    "deep-research",
+]
 
 
-RUN_MODES = ["auto", "auto-fresh", "build", "discover", "founder", "improve", "meta", "parallel-improve", "research", "swebench", "frontend-design-scan"]
+RUN_MODES = [
+    "auto",
+    "auto-fresh",
+    "build",
+    "discover",
+    "founder",
+    "improve",
+    "meta",
+    "parallel-improve",
+    "research",
+    "study",
+    "swebench",
+    "frontend-design-scan",
+]
 
 
 def get_all_ceo_modes() -> list[str]:
@@ -30,10 +66,19 @@ def get_all_ceo_modes() -> list[str]:
     return CEO_MODES + [m for m in registry.modes if m not in CEO_MODES]
 
 
-DEPRECATED_MODES: frozenset[str] = frozenset({
-    "build", "improve", "research", "meta", "discover",
-    "review", "refine", "parallel-improve", "interactive",
-})
+DEPRECATED_MODES: frozenset[str] = frozenset(
+    {
+        "build",
+        "improve",
+        "research",
+        "meta",
+        "discover",
+        "review",
+        "refine",
+        "parallel-improve",
+        "interactive",
+    }
+)
 
 
 def warn_deprecated_mode(mode: str) -> None:
@@ -120,10 +165,16 @@ def _ensure_dashboard(project_path: Path, port: int = _DASHBOARD_PORT) -> None:
 
     # Start dashboard as a detached background process
     cmd = [
-        sys.executable, "-m", "factory", "dashboard",
-        "--projects-dir", str(projects_dir),
-        "--port", str(port),
-        "--host", "0.0.0.0",
+        sys.executable,
+        "-m",
+        "factory",
+        "dashboard",
+        "--projects-dir",
+        str(projects_dir),
+        "--port",
+        str(port),
+        "--host",
+        "0.0.0.0",
     ]
     subprocess.Popen(
         cmd,
@@ -142,19 +193,25 @@ def _print_banner(mode: str = "improve") -> None:
         else:
             print(f"Factory v2 — mode: {mode}", file=sys.stderr)
         if mode == "founder":
-            print("WARNING: Founder mode — prototype only, not for production use.", file=sys.stderr)
+            print(
+                "WARNING: Founder mode — prototype only, not for production use.", file=sys.stderr
+            )
         return
 
     c = "\033[1;36m"  # bold cyan
-    d = "\033[2m"      # dim
-    r = "\033[0m"      # reset
+    d = "\033[2m"  # dim
+    r = "\033[0m"  # reset
 
     mode_line = "" if mode == "welcome" else f"{d}  Mode: {mode}{r}\n"
     y = "\033[1;33m"  # bold yellow
     founder_warn = (
-        f"{y}  ⚠  PROTOTYPE ONLY — not for production use.{r}\n"
-        f"{y}  ⚠  Run --mode improve afterward to harden.{r}\n"
-    ) if mode == "founder" else ""
+        (
+            f"{y}  ⚠  PROTOTYPE ONLY — not for production use.{r}\n"
+            f"{y}  ⚠  Run --mode improve afterward to harden.{r}\n"
+        )
+        if mode == "founder"
+        else ""
+    )
     banner = (
         f"\n{c}  ┏━╸┏━┓┏━╸╺┳╸┏━┓┏━┓╻ ╻{r}\n"
         f"{c}  ┣╸ ┣━┫┃   ┃ ┃ ┃┣┳┛┗┳┛{r}\n"
@@ -249,4 +306,3 @@ def _load_env_local() -> None:
                     key, _, value = line.partition("=")
                     os.environ.setdefault(key.strip(), value.strip())
             break
-

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -302,6 +302,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_graph_update.add_argument("path", help="Path to the project")
     p_graph_status = graph_sub.add_parser("status", help="Show graph freshness and stats")
     p_graph_status.add_argument("path", help="Path to the project")
+    p_graph_query = graph_sub.add_parser("query", help="BFS traversal of the knowledge graph")
+    p_graph_query.add_argument("path", help="Path to the project")
+    p_graph_query.add_argument("question", help="Natural-language query for graph traversal")
+    p_graph_query.add_argument("--depth", type=int, default=2, help="BFS depth (default: 2)")
+    p_graph_explain = graph_sub.add_parser("explain", help="Explain a node and its neighbors")
+    p_graph_explain.add_argument("path", help="Path to the project")
+    p_graph_explain.add_argument("node", help="Node name or label to explain")
+    p_graph_path = graph_sub.add_parser("path", help="Shortest path between two nodes")
+    p_graph_path.add_argument("path", help="Path to the project")
+    p_graph_path.add_argument("source", help="Source node name")
+    p_graph_path.add_argument("target", help="Target node name")
 
     # mempalace — MemPalace operations (read, write, browse)
     mp = sub.add_parser("mempalace", help="MemPalace operations (read, write, browse)")
@@ -424,9 +435,12 @@ def main(argv: list[str] | None = None) -> int:
             "extract": _cli.cmd_graph_extract,
             "update": _cli.cmd_graph_update,
             "status": _cli.cmd_graph_status,
+            "query": _cli.cmd_graph_query,
+            "explain": _cli.cmd_graph_explain,
+            "path": _cli.cmd_graph_path,
         }.get(
             str(getattr(a, "graph_command", "")),
-            lambda args: print("Usage: factory graph {extract,update,status}") or 1,
+            lambda args: print("Usage: factory graph {extract,update,status,query,explain,path}") or 1,
         )(a),
     }
 

--- a/factory/cli/_task_builder.py
+++ b/factory/cli/_task_builder.py
@@ -59,6 +59,12 @@ def _mode_suffix(mode: str, discover_only: bool) -> str:
             "project's domain broadly. Terminal mode — does not chain to build or improve. "
             "The full step-by-step playbook is in your system prompt above."
         ),
+        "study": (
+            "\n\nRun Study mode: analyze the codebase structure and dependency graph. "
+            "Update the code knowledge graph, then run factory study for observations "
+            "with structural graph context included. "
+            "Terminal mode — does not chain to other modes."
+        ),
     }
     if mode == "discover":
         if discover_only:
@@ -358,8 +364,13 @@ def _build_ceo_task(
         task = _append_deep_research_topic(task, focus)
 
     task += _append_focus_directive(
-        focus, mode, create_description,
-        issue_numbers, issue_urls, issue_number, issue_url,
+        focus,
+        mode,
+        create_description,
+        issue_numbers,
+        issue_urls,
+        issue_number,
+        issue_url,
     )
 
     if branch:

--- a/factory/cli/graph.py
+++ b/factory/cli/graph.py
@@ -1,12 +1,19 @@
-"""Graph subcommands — extract, update, status."""
+"""Graph subcommands — extract, update, status, query, explain, path."""
 
 from __future__ import annotations
 
 import argparse
+import subprocess
 import sys
 from pathlib import Path
 
+import structlog
+
 from factory.cli._helpers import _emit_cli_event
+
+log = structlog.get_logger()
+
+_GRAPHIFY_TIMEOUT = 60
 
 
 def cmd_graph_extract(args: argparse.Namespace) -> int:
@@ -102,3 +109,106 @@ def cmd_graph_status(args: argparse.Namespace) -> int:
         print("Freshness: unknown (could not compare timestamps)")
 
     return 0
+
+
+def _run_graphify(cmd: list[str], project_path: Path, event_prefix: str) -> int:
+    """Run a graphify CLI command with timeout, logging, and event emission."""
+    _emit_cli_event(project_path, f"{event_prefix}.started", {"cmd": cmd})
+    log.info("graphify.run", cmd=cmd)
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_GRAPHIFY_TIMEOUT,
+            cwd=project_path,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"Error: graphify timed out after {_GRAPHIFY_TIMEOUT}s", file=sys.stderr)
+        _emit_cli_event(project_path, f"{event_prefix}.timeout", {})
+        return 1
+
+    if result.returncode != 0:
+        print(result.stderr or "graphify command failed", file=sys.stderr)
+        _emit_cli_event(project_path, f"{event_prefix}.failed", {"rc": result.returncode})
+        return 1
+
+    if result.stdout:
+        print(result.stdout, end="")
+    _emit_cli_event(project_path, f"{event_prefix}.completed", {})
+    return 0
+
+
+def cmd_graph_query(args: argparse.Namespace) -> int:
+    """BFS traversal of the knowledge graph."""
+    from factory.graph import is_graph_available, is_graphify_installed
+
+    project_path = Path(args.path).resolve()
+    if not project_path.is_dir():
+        print(f"Error: not a directory: {project_path}", file=sys.stderr)
+        return 1
+
+    if not is_graphify_installed():
+        print(
+            "Error: graphify CLI not found on PATH. Install with: uv tool install graphifyy",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not is_graph_available(project_path):
+        print("Error: no graph.json found (run 'factory graph extract' first)", file=sys.stderr)
+        return 1
+
+    graph_file = str(project_path / "graph.json")
+    cmd = ["graphify", "query", args.question, "--graph", graph_file, "--depth", str(args.depth)]
+    return _run_graphify(cmd, project_path, "graph.query")
+
+
+def cmd_graph_explain(args: argparse.Namespace) -> int:
+    """Explain a node and its neighbors in the knowledge graph."""
+    from factory.graph import is_graph_available, is_graphify_installed
+
+    project_path = Path(args.path).resolve()
+    if not project_path.is_dir():
+        print(f"Error: not a directory: {project_path}", file=sys.stderr)
+        return 1
+
+    if not is_graphify_installed():
+        print(
+            "Error: graphify CLI not found on PATH. Install with: uv tool install graphifyy",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not is_graph_available(project_path):
+        print("Error: no graph.json found (run 'factory graph extract' first)", file=sys.stderr)
+        return 1
+
+    graph_file = str(project_path / "graph.json")
+    cmd = ["graphify", "explain", args.node, "--graph", graph_file]
+    return _run_graphify(cmd, project_path, "graph.explain")
+
+
+def cmd_graph_path(args: argparse.Namespace) -> int:
+    """Shortest path between two nodes in the knowledge graph."""
+    from factory.graph import is_graph_available, is_graphify_installed
+
+    project_path = Path(args.path).resolve()
+    if not project_path.is_dir():
+        print(f"Error: not a directory: {project_path}", file=sys.stderr)
+        return 1
+
+    if not is_graphify_installed():
+        print(
+            "Error: graphify CLI not found on PATH. Install with: uv tool install graphifyy",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not is_graph_available(project_path):
+        print("Error: no graph.json found (run 'factory graph extract' first)", file=sys.stderr)
+        return 1
+
+    graph_file = str(project_path / "graph.json")
+    cmd = ["graphify", "path", args.source, args.target, "--graph", graph_file]
+    return _run_graphify(cmd, project_path, "graph.path")

--- a/factory/models.py
+++ b/factory/models.py
@@ -506,6 +506,7 @@ class CycleState(BaseModel):
         "refine",
         "research",
         "review",
+        "study",
         "swebench",
     ]
     initial_prompt: str = ""

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -44,11 +44,12 @@ from factory.workflow.primitives import (
 __all__ = [
     "DOC_FRESHNESS_GATE_PROMPT",
     "ResearcherConfig",
+    "_GRAPH_EXPLORER_PROMPT",
     "_research_subgraph",
+    "_study_subgraph",
     "build_workflow",
     "design_workflow",
     "improve_workflow",
-
     "research_workflow",
     "meta_workflow",
     "discover_workflow",
@@ -66,6 +67,7 @@ __all__ = [
     "frontend_design_discover_workflow",
     "frontend_design_scan_workflow",
     "evolve_workflow",
+    "study_standalone_workflow",
     "register_all",
     "_get_builtin_registry",
 ]
@@ -79,6 +81,81 @@ DOC_FRESHNESS_GATE_PROMPT = (
     "exist. RELOOP to builder if documentation is stale — specify exactly "
     "which changes need doc updates."
 )
+
+
+# ── Study subgraph helper ───────────────────────────────────────
+
+
+_GRAPH_EXPLORER_PROMPT = (
+    "Explore the project's code knowledge graph to build structural understanding. "
+    "Read .factory/strategy/observations.md for focus context.\n\n"
+    "If graphify is installed and graph.json exists:\n"
+    '1. Run `factory graph query "<focus from observations>" --depth 2` to find relevant nodes\n'
+    '2. Run `factory graph explain "<key node>"` on the most important nodes to understand '
+    "their connections and dependencies\n"
+    '3. Run `factory graph path "<A>" "<B>"` to trace dependency paths between key components\n'
+    "4. Write structured findings to .factory/strategy/graph-context.md covering: "
+    "key modules and their relationships, dependency paths, architectural layers, "
+    "entry points and hotspots\n\n"
+    "If graphify is NOT installed or graph.json is missing, fall back to direct file exploration:\n"
+    "1. Use `find . -name '*.py' | head -50` to discover source files\n"
+    "2. Use `grep -rn 'class \\|def ' --include='*.py' | head -100` to map functions and classes\n"
+    "3. Use `grep -rn 'import ' --include='*.py' | head -100` to trace dependencies\n"
+    "4. Write the same structured findings to .factory/strategy/graph-context.md"
+)
+
+
+def _study_subgraph() -> tuple[dict[str, Any], list[Edge]]:
+    """Return (nodes, internal_edges) for the graph-powered study chain.
+
+    Four nodes run sequentially:
+
+        graph_update → study → graph_explorer → concat_study
+
+    The caller wires the entry edge (→ graph_update) and exit edge
+    (concat_study →) into the surrounding workflow.
+    """
+    nodes: dict[str, Any] = {}
+
+    nodes["graph_update"] = FnNode(
+        id="graph_update",
+        command="factory graph update {project_path}",
+        notes="Extract or incrementally update the code knowledge graph before study.",
+        writes={"graph.json"},
+    )
+
+    nodes["study"] = Study(
+        id="study",
+        command="factory study {project_path}",
+        writes={".factory/strategy/observations.md"},
+    )
+
+    nodes["graph_explorer"] = AgentNode(
+        id="graph_explorer",
+        role=AgentRole.RESEARCHER,
+        prompt_template=_GRAPH_EXPLORER_PROMPT,
+        reads={".factory/strategy/observations.md"},
+        writes={".factory/strategy/graph-context.md"},
+    )
+
+    nodes["concat_study"] = FnNode(
+        id="concat_study",
+        command=(
+            "cat {project_path}/.factory/strategy/observations.md"
+            " {project_path}/.factory/strategy/graph-context.md"
+            " > {project_path}/.factory/strategy/study-combined.md"
+        ),
+        reads={".factory/strategy/observations.md", ".factory/strategy/graph-context.md"},
+        writes={".factory/strategy/study-combined.md"},
+    )
+
+    internal_edges = [
+        Edge(source="graph_update", target="study"),
+        Edge(source="study", target="graph_explorer"),
+        Edge(source="graph_explorer", target="concat_study"),
+    ]
+
+    return nodes, internal_edges
 
 
 # ── Deep-QA subgraph helper ─────────────────────────────────────
@@ -201,8 +278,6 @@ def _research_subgraph(
     nodes["join_research"] = JoinNode(
         id="join_research",
         sources=researcher_ids,
-        reads={f".factory/strategy/research-{r.id}.md" for r in researchers},
-        writes={".factory/strategy/research-combined.md"},
     )
 
     nodes["gate_research"] = GateNode(
@@ -210,7 +285,7 @@ def _research_subgraph(
         evaluator_type="agent",
         evaluator_role=AgentRole.CEO,
         gate_prompt=gate_prompt,
-        reads={".factory/strategy/research-combined.md"},
+        reads={f".factory/strategy/research-{r.id}.md" for r in researchers},
     )
 
     internal_edges = [
@@ -241,6 +316,8 @@ def build_workflow() -> Workflow:
             id="similar",
             prompt_template=(
                 "Similar projects research. "
+                "Read .factory/strategy/study-combined.md for project context "
+                "(observations + structural graph analysis). "
                 "Search the web for similar projects, existing solutions, and prior art. "
                 "Analyze their strengths, weaknesses, and market positioning. "
                 "Check .factory/archive/ for prior knowledge on similar builds. "
@@ -254,6 +331,8 @@ def build_workflow() -> Workflow:
             id="techstack",
             prompt_template=(
                 "Tech stack research. "
+                "Read .factory/strategy/study-combined.md for project context "
+                "(observations + structural graph analysis). "
                 "Identify the best technology stack for this type of project. "
                 "Find architecture patterns and best practices. "
                 "Evaluate framework/library options with trade-offs. "
@@ -267,6 +346,8 @@ def build_workflow() -> Workflow:
             id="pitfalls",
             prompt_template=(
                 "Pitfalls and scope research. "
+                "Read .factory/strategy/study-combined.md for project context "
+                "(observations + structural graph analysis). "
                 "Identify potential pitfalls and common mistakes for this type of project. "
                 "Research MVP scope best practices. "
                 "Check .factory/archive/ for lessons from past builds. "
@@ -291,14 +372,21 @@ def build_workflow() -> Workflow:
         id="strategist",
         role=AgentRole.STRATEGIST,
         prompt_template=(
-            "Synthesize a project specification from research. "
-            "Read ALL tagged research files at .factory/strategy/research-*.md. "
+            "Synthesize a project specification from study and research. "
+            "If .factory/strategy/study-combined.md exists, read it for project observations "
+            "and structural graph analysis. "
+            "Read ALL research files at .factory/strategy/research-similar.md, "
+            "research-techstack.md, and research-pitfalls.md. "
             "Produce a complete phased build plan. Phase 1 must be project scaffold + eval harness. "
             "Every Phase must have substantive What/Why/Expected impact fields. "
             "Build EVERYTHING in this pass. Only defer items requiring human intervention. "
             "Write the plan to .factory/strategy/current.md."
         ),
-        reads={".factory/strategy/research-combined.md"},
+        reads={
+            ".factory/strategy/research-similar.md",
+            ".factory/strategy/research-techstack.md",
+            ".factory/strategy/research-pitfalls.md",
+        },
         writes={".factory/strategy/current.md"},
         post_checks=[
             ArtifactCheck(
@@ -471,7 +559,6 @@ def build_workflow() -> Workflow:
     )
 
 
-
 # ── W₂: Design Mode ─────────────────────────────────────────────
 
 
@@ -495,9 +582,9 @@ def design_workflow(just_plan: bool = False) -> Workflow:
         evaluator_type="fn",
         evaluator_command=(
             'python3 -c "'
-            'from pathlib import Path; '
-            'exists = Path(\"{project_path}/.factory/config.json\").exists(); '
-            'print(\"PROCEED\" if exists else \"HALT\")'
+            "from pathlib import Path; "
+            'exists = Path("{project_path}/.factory/config.json").exists(); '
+            'print("PROCEED" if exists else "HALT")'
             '"'
         ),
         reads={".factory/config.json"},
@@ -509,18 +596,26 @@ def design_workflow(just_plan: bool = False) -> Workflow:
         writes={".factory/eval_profile.json"},
     )
 
-    wf.nodes["study"] = Study(
-        id="study",
-        command="factory study {project_path}",
-        writes={".factory/strategy/observations.md"},
-    )
+    # Study subgraph: graph_update → study
+    s_nodes, s_edges = _study_subgraph()
+    wf.nodes.update(s_nodes)
 
-    wf.edges.extend([
-        Edge(source="gate_has_factory", target="study", condition=VerdictType.PROCEED),
-        Edge(source="gate_has_factory", target="discover", condition=VerdictType.HALT),
-        Edge(source="discover", target="study"),
-        Edge(source="study", target="fork_research"),
-    ])
+    # Researchers and strategist read study-combined.md produced by study
+    for nid in ("researcher_similar", "researcher_techstack", "researcher_pitfalls", "strategist"):
+        node = wf.nodes[nid]
+        wf.nodes[nid] = node.model_copy(
+            update={"reads": (node.reads or set()) | {".factory/strategy/study-combined.md"}},
+        )
+
+    wf.edges.extend(
+        [
+            *s_edges,
+            Edge(source="gate_has_factory", target="graph_update", condition=VerdictType.PROCEED),
+            Edge(source="gate_has_factory", target="discover", condition=VerdictType.HALT),
+            Edge(source="discover", target="graph_update"),
+            Edge(source="concat_study", target="fork_research"),
+        ]
+    )
 
     wf.start_node = "gate_has_factory"
 
@@ -541,16 +636,16 @@ def design_workflow(just_plan: bool = False) -> Workflow:
             evaluator_command=(
                 ': > "{project_path}/.factory/strategy/prior-plans.md"; '
                 'if [ -n "$FOCUS" ]; then '
-                '  if gh auth status >/dev/null 2>&1 && git remote -v 2>/dev/null | grep -q .; then '
+                "  if gh auth status >/dev/null 2>&1 && git remote -v 2>/dev/null | grep -q .; then "
                 '    gh issue list --label plan --search "$FOCUS" --json number,title,url '
                 '      --jq ".[] | \\"#\\(.number) \\(.title) — \\(.url)\\"" '
                 '      > "{project_path}/.factory/strategy/prior-plans.md" 2>/dev/null || true; '
-                '  fi; '
+                "  fi; "
                 '  if [ ! -s "{project_path}/.factory/strategy/prior-plans.md" ]; then '
                 '    grep -Frl "$FOCUS" "{project_path}/.factory/archive/" --include="plan-*.md" '
                 '      >> "{project_path}/.factory/strategy/prior-plans.md" 2>/dev/null || true; '
-                '  fi; '
-                'fi; '
+                "  fi; "
+                "fi; "
                 '[ -s "{project_path}/.factory/strategy/prior-plans.md" ]'
             ),
             gate_prompt=(
@@ -580,16 +675,16 @@ def design_workflow(just_plan: bool = False) -> Workflow:
         wf.nodes["publish_github"] = FnNode(
             id="publish_github",
             command=(
-                'bash -c \''
-                'set -e; '
+                "bash -c '"
+                "set -e; "
                 'echo "none" > "{project_path}/.factory/strategy/github-issue-ref.txt"; '
-                'if ! gh auth status >/dev/null 2>&1; then '
+                "if ! gh auth status >/dev/null 2>&1; then "
                 '  echo "SKIP: gh not authenticated — plan saved locally only"; exit 0; '
-                'fi; '
-                'if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then '
+                "fi; "
+                "if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then "
                 '  echo "SKIP: not inside a git repository"; exit 0; '
-                'fi; '
-                'if ! git remote -v 2>/dev/null | grep -q .; then '
+                "fi; "
+                "if ! git remote -v 2>/dev/null | grep -q .; then "
                 '  SLUG=$(basename "{project_path}"); '
                 '  echo "Creating GitHub repository: $SLUG..."; '
                 '  if gh repo create "$SLUG" --public --source=. --remote=origin --push 2>&1; then '
@@ -600,11 +695,11 @@ def design_workflow(just_plan: bool = False) -> Workflow:
                 '    REMOTE_URL=$(gh repo view "$SLUG" --json sshUrl -q .sshUrl 2>/dev/null || '
                 '      gh repo view "$SLUG" --json url -q .url); '
                 '    git remote add origin "$REMOTE_URL" 2>/dev/null || true; '
-                '    git push -u origin HEAD 2>/dev/null || true; '
-                '  else '
+                "    git push -u origin HEAD 2>/dev/null || true; "
+                "  else "
                 '    echo "SKIP: could not create GitHub repo — plan saved locally only"; exit 0; '
-                '  fi; '
-                'fi; '
+                "  fi; "
+                "fi; "
                 'gh label create plan --description "Approved plan" --color 0366d6 --force 2>/dev/null || true; '
                 'FOCUS="${FOCUS:-}"; '
                 'ISSUE_NUM=""; '
@@ -612,20 +707,20 @@ def design_workflow(just_plan: bool = False) -> Workflow:
                 '  ISSUE_NUM="$FOCUS"; '
                 'elif echo "$FOCUS" | grep -qoE "#([0-9]+)"; then '
                 '  ISSUE_NUM=$(echo "$FOCUS" | grep -oE "[0-9]+" | tail -1); '
-                'fi; '
+                "fi; "
                 'if [ -n "$ISSUE_NUM" ]; then '
                 '  gh issue comment "$ISSUE_NUM" --body-file "{project_path}/.factory/strategy/current.md"; '
                 '  gh issue edit "$ISSUE_NUM" --add-label plan; '
                 '  echo "$ISSUE_NUM" > "{project_path}/.factory/strategy/github-issue-ref.txt"; '
                 '  echo "Plan posted to issue #$ISSUE_NUM"; '
-                'else '
+                "else "
                 '  TITLE="Plan: ${FOCUS:-project}"; '
                 '  ISSUE_URL=$(gh issue create --title "$TITLE" --body-file "{project_path}/.factory/strategy/current.md" --label plan); '
                 '  ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE "[0-9]+$"); '
                 '  echo "$ISSUE_NUM" > "{project_path}/.factory/strategy/github-issue-ref.txt"; '
                 '  echo "Created plan issue: $ISSUE_URL"; '
-                'fi'
-                '\''
+                "fi"
+                "'"
             ),
             reads={".factory/strategy/current.md"},
             writes={".factory/strategy/github-issue-ref.txt"},
@@ -671,10 +766,18 @@ def design_workflow(just_plan: bool = False) -> Workflow:
 
         # ── Remove build-phase nodes that are unreachable in plan mode ──
         build_phase_nodes = {
-            "archivist_plan", "builder", "gate_build",
-            "health_checker", "code_reviewer", "gate_review",
-            "adversarial_tester", "gate_qa", "gate_doc_freshness",
-            "gate_precheck", "archivist_build", "spec_generate",
+            "archivist_plan",
+            "builder",
+            "gate_build",
+            "health_checker",
+            "code_reviewer",
+            "gate_review",
+            "adversarial_tester",
+            "gate_qa",
+            "gate_doc_freshness",
+            "gate_precheck",
+            "archivist_build",
+            "spec_generate",
         }
         for node_id in build_phase_nodes:
             wf.nodes.pop(node_id, None)
@@ -683,18 +786,32 @@ def design_workflow(just_plan: bool = False) -> Workflow:
         removed = build_phase_nodes
         wf.edges = [e for e in wf.edges if e.source not in removed and e.target not in removed]
 
-        # Replace study → fork_research with study → check_prior_plans
-        wf.edges = [e for e in wf.edges if not (e.source == "study" and e.target == "fork_research")]
+        # Replace concat_study → fork_research with concat_study → check_prior_plans
+        wf.edges = [
+            e for e in wf.edges if not (e.source == "concat_study" and e.target == "fork_research")
+        ]
 
         # Add plan-specific edges
-        wf.edges.extend([
-            Edge(source="study", target="check_prior_plans"),
-            Edge(source="check_prior_plans", target="gate_prior_plans", condition=VerdictType.PROCEED),
-            Edge(source="check_prior_plans", target="fork_research", condition=VerdictType.HALT),
-            Edge(source="gate_prior_plans", target="fork_research", condition=VerdictType.PROCEED),
-            Edge(source="gate_strategy", target="publish_github", condition=VerdictType.PROCEED),
-            Edge(source="publish_github", target="seed_backlog"),
-        ])
+        wf.edges.extend(
+            [
+                Edge(source="concat_study", target="check_prior_plans"),
+                Edge(
+                    source="check_prior_plans",
+                    target="gate_prior_plans",
+                    condition=VerdictType.PROCEED,
+                ),
+                Edge(
+                    source="check_prior_plans", target="fork_research", condition=VerdictType.HALT
+                ),
+                Edge(
+                    source="gate_prior_plans", target="fork_research", condition=VerdictType.PROCEED
+                ),
+                Edge(
+                    source="gate_strategy", target="publish_github", condition=VerdictType.PROCEED
+                ),
+                Edge(source="publish_github", target="seed_backlog"),
+            ]
+        )
 
         wf.name = "plan"
         wf.start_node = "gate_has_factory"
@@ -709,9 +826,11 @@ def design_workflow(just_plan: bool = False) -> Workflow:
     wf.terminal = True
 
     def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
-        return state in {ProjectState.NO_REPO, ProjectState.REPO_INCOMPLETE, ProjectState.HAS_FACTORY} and ctx.get(
-            "interactive", False
-        )
+        return state in {
+            ProjectState.NO_REPO,
+            ProjectState.REPO_INCOMPLETE,
+            ProjectState.HAS_FACTORY,
+        } and ctx.get("interactive", False)
 
     wf.trigger = trigger
     return wf
@@ -1783,7 +1902,11 @@ def create_workflow() -> Workflow:
             "builder→gate→QA→gate loops, archivist placement, and research forks. "
             "Write the specification to .factory/strategy/current.md."
         ),
-        reads={".factory/strategy/research-combined.md"},
+        reads={
+            ".factory/strategy/research-existing.md",
+            ".factory/strategy/research-intent.md",
+            ".factory/strategy/research-practices.md",
+        },
         writes={".factory/strategy/current.md"},
     )
 
@@ -2643,8 +2766,11 @@ def frontend_design_workflow() -> Workflow:
     nodes["join_design_research"] = JoinNode(
         id="join_design_research",
         sources=[
-            "researcher_tokens", "researcher_components", "researcher_patterns",
-            "researcher_ux", "researcher_infra",
+            "researcher_tokens",
+            "researcher_components",
+            "researcher_patterns",
+            "researcher_ux",
+            "researcher_infra",
         ],
         reads={
             ".factory/design-system/token-audit.md",
@@ -2849,15 +2975,15 @@ def frontend_design_workflow() -> Workflow:
             "'package.json','utf8')).scripts?.dev?0:1)\" 2>/dev/null; then "
             "ROOT='.'; "
             "else for d in studio web app frontend client; do "
-            "if [ -f \"$d/package.json\" ] && node -e "
+            'if [ -f "$d/package.json" ] && node -e '
             "\"process.exit(JSON.parse(require('fs').readFileSync("
             "'$d/package.json','utf8')).scripts?.dev?0:1)\" 2>/dev/null; then "
-            "ROOT=\"$d\"; break; fi; done; fi; "
+            'ROOT="$d"; break; fi; done; fi; '
             "if [ \"$ROOT\" = '.' ] && ! node -e "
             "\"process.exit(JSON.parse(require('fs').readFileSync("
             "'package.json','utf8')).scripts?.dev?0:1)\" 2>/dev/null; then "
             "echo 'pass: no dev server script found'; exit 0; fi; "
-            "cd \"$ROOT\" && npm run dev </dev/null >/dev/null 2>&1 & "
+            'cd "$ROOT" && npm run dev </dev/null >/dev/null 2>&1 & '
             "DEV_PID=$!; FOUND=0; "
             "for i in $(seq 1 30); do "
             "for port in 5173 3000 4200 8080; do "
@@ -2868,7 +2994,7 @@ def frontend_design_workflow() -> Workflow:
             "echo 'reloop: dev server crashed on startup'; exit 0; fi; "
             "sleep 2; done; "
             "kill $DEV_PID 2>/dev/null; wait $DEV_PID 2>/dev/null; "
-            "if [ \"$FOUND\" -eq 1 ]; then "
+            'if [ "$FOUND" -eq 1 ]; then '
             "echo 'pass: dev server started and responded'; "
             "else echo 'reloop: dev server did not respond within 60s'; fi "
             ")"
@@ -2886,15 +3012,15 @@ def frontend_design_workflow() -> Workflow:
             "PR=$(gh pr view --json number -q .number 2>/dev/null) || true; "
             "if [ -z \"$PR\" ]; then echo 'pass: no PR found'; exit 0; fi; "
             "for i in $(seq 1 20); do "
-            "BUCKETS=$(gh pr checks \"$PR\" --json bucket "
+            'BUCKETS=$(gh pr checks "$PR" --json bucket '
             "--jq '.[].bucket' 2>/dev/null) || true; "
-            "if [ -z \"$BUCKETS\" ]; then "
+            'if [ -z "$BUCKETS" ]; then '
             "echo 'pass: no CI checks configured'; exit 0; fi; "
             "if echo \"$BUCKETS\" | grep -qE '^(fail|cancel)$'; then "
-            "NAMES=$(gh pr checks \"$PR\" --json name,bucket "
-            "--jq '[.[] | select(.bucket==\"fail\" or .bucket==\"cancel\") "
-            "| .name] | join(\", \")' 2>/dev/null); "
-            "echo \"reloop: CI failed for PR #$PR - $NAMES\"; exit 0; fi; "
+            'NAMES=$(gh pr checks "$PR" --json name,bucket '
+            '--jq \'[.[] | select(.bucket=="fail" or .bucket=="cancel") '
+            '| .name] | join(", ")\' 2>/dev/null); '
+            'echo "reloop: CI failed for PR #$PR - $NAMES"; exit 0; fi; '
             "if ! echo \"$BUCKETS\" | grep -qE '^pending$'; then "
             "echo 'pass: all CI checks passed'; exit 0; fi; "
             "sleep 30; done; "
@@ -3076,9 +3202,7 @@ def frontend_design_workflow() -> Workflow:
         # Deep-QA: health_checker → code_reviewer → gate_review → consistency_tester
         Edge(source="health_checker", target="code_reviewer"),
         Edge(source="code_reviewer", target="gate_review"),
-        Edge(
-            source="gate_review", target="consistency_tester", condition=VerdictType.PROCEED
-        ),
+        Edge(source="gate_review", target="consistency_tester", condition=VerdictType.PROCEED),
         Edge(source="gate_review", target="builder", condition=VerdictType.RELOOP),
         # Consistency tester → consistency gate
         Edge(source="consistency_tester", target="gate_consistency"),
@@ -3144,7 +3268,12 @@ def frontend_design_scan_workflow() -> Workflow:
 
     nodes["join_scan_research"] = JoinNode(
         id="join_scan_research",
-        sources=["researcher_tokens", "researcher_components", "researcher_patterns", "researcher_ux"],
+        sources=[
+            "researcher_tokens",
+            "researcher_components",
+            "researcher_patterns",
+            "researcher_ux",
+        ],
         reads={
             ".factory/design-system/token-audit.md",
             ".factory/design-system/component-inventory.md",
@@ -3334,8 +3463,11 @@ def frontend_design_discover_workflow() -> Workflow:
     nodes["join_discover_research"] = JoinNode(
         id="join_discover_research",
         sources=[
-            "researcher_tokens", "researcher_components", "researcher_patterns",
-            "researcher_ux", "researcher_infra",
+            "researcher_tokens",
+            "researcher_components",
+            "researcher_patterns",
+            "researcher_ux",
+            "researcher_infra",
         ],
         reads={
             ".factory/design-system/token-audit.md",
@@ -3500,7 +3632,6 @@ def frontend_design_discover_workflow() -> Workflow:
         start_node="fork_discover_research",
         trigger=trigger,
     )
-
 
 
 # ── W₁₅: Evolve Mode ──────────────────────────────────────────────
@@ -3691,7 +3822,7 @@ def evolve_workflow() -> Workflow:
             "- ONLY modify code between EVOLVE-BLOCK-START and EVOLVE-BLOCK-END markers\n"
             "- Preserve ALL code outside evolution markers (imports, helpers, return format)\n"
             "- Maintain function signatures and return types expected by the evaluator\n"
-            "- No external dependencies beyond what\'s in the initial program\n"
+            "- No external dependencies beyond what's in the initial program\n"
             "- Validate Python syntax (AST parse check)\n"
             "Write the complete modified program to .factory/experiments/$EXP_ID/candidate.py. "
             "Also copy it to .factory/evolve/candidate.py for the evaluator."
@@ -3811,7 +3942,7 @@ def evolve_workflow() -> Workflow:
         evaluator_role=AgentRole.CEO,
         gate_prompt=(
             "Review the evaluation verdict at .factory/reviews/health-check.md.\n"
-            "Read the Health Checker\'s KEEP/REVERT recommendation and rationale.\n"
+            "Read the Health Checker's KEEP/REVERT recommendation and rationale.\n"
             "If KEEP:\n"
             "  - Update .factory/evolve/current_best.py with the candidate code\n"
             "  - Update .factory/evolve/current_score.json with the new score\n"
@@ -3905,12 +4036,10 @@ def evolve_workflow() -> Workflow:
         Edge(source="researcher", target="gate_research"),
         Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
         Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
-
         # Strategist → strategy gate
         Edge(source="strategist", target="gate_strategy"),
         Edge(source="gate_strategy", target="begin", condition=VerdictType.PROCEED),
         Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
-
         # Begin → pre_eval → builder (pre_eval copies current_score.json → eval_before.json)
         Edge(source="begin", target="pre_eval"),
         Edge(source="pre_eval", target="builder"),
@@ -3918,18 +4047,14 @@ def evolve_workflow() -> Workflow:
         Edge(source="builder", target="gate_build"),
         Edge(source="gate_build", target="health_checker", condition=VerdictType.PROCEED),
         Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
-
         # Health checker → post_eval → eval gate (post_eval emits eval.completed event)
         Edge(source="health_checker", target="post_eval"),
         Edge(source="post_eval", target="gate_eval"),
         Edge(source="gate_eval", target="finalize", condition=VerdictType.PROCEED),
-
         # Finalize → archivist (async)
         Edge(source="finalize", target="archivist"),
-
         # Archivist → convergence gate
         Edge(source="archivist", target="gate_convergence"),
-
         # Convergence: RELOOP to strategist for next cycle, PROCEED to final archivist
         Edge(source="gate_convergence", target="strategist", condition=VerdictType.RELOOP),
         Edge(source="gate_convergence", target="archivist_final", condition=VerdictType.PROCEED),
@@ -3982,9 +4107,8 @@ def _get_builtin_registry() -> dict[str, Any]:
         "deep-research": lambda: __import__(
             "factory.workflow.deep_research", fromlist=["workflow"]
         ).workflow(),
-        "deep-qa": lambda: __import__(
-            "factory.workflow.deep_qa", fromlist=["workflow"]
-        ).workflow(),
+        "study": study_standalone_workflow,
+        "deep-qa": lambda: __import__("factory.workflow.deep_qa", fromlist=["workflow"]).workflow(),
         "research-standalone": lambda: __import__(
             "factory.workflow.research", fromlist=["workflow"]
         ).workflow(),
@@ -4393,3 +4517,29 @@ def register_all() -> dict[str, Workflow]:
     """
     registry = _get_builtin_registry()
     return {name: fn() for name, fn in registry.items()}
+
+
+# ── Study Mode ────────────────────────────────────────────────────
+
+
+def study_standalone_workflow() -> Workflow:
+    """Study Mode — graph-powered codebase analysis.
+
+    graph_update → study → graph_explorer → concat_study
+
+    Terminal mode — does not chain to other modes. Produces study-combined.md
+    combining observations with graph-derived structural context.
+    """
+    s_nodes, s_edges = _study_subgraph()
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return state == ProjectState.HAS_FACTORY and ctx.get("mode") == "study"
+
+    return Workflow(
+        name="study",
+        nodes=s_nodes,
+        edges=s_edges,
+        start_node="graph_update",
+        trigger=trigger,
+        terminal=True,
+    )

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -139,8 +139,8 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
         "description": (
             "Create mode — meta-mode for creating new factory modes or updating existing ones. "
             "For new modes: takes a description and produces a fully working workflow definition, "
-            "SKILL.md, CLI wiring, and tests. For updates: use --focus \"mode_name: change description\" "
-            "to modify an existing registered mode (e.g. --focus \"improve: add plateau detection\"). "
+            'SKILL.md, CLI wiring, and tests. For updates: use --focus "mode_name: change description" '
+            'to modify an existing registered mode (e.g. --focus "improve: add plateau detection"). '
             "Use when the user says 'create a mode for X', 'update the improve mode', "
             "'add a new workflow', or wants to extend/modify factory pipelines."
         ),
@@ -263,6 +263,17 @@ WORKFLOW_META: dict[str, dict[str, str | list[str]]] = {
             "Terminal mode — does not chain to build or improve."
         ),
         "argument_hint": "<project_path> [--focus <research topic>]",
+    },
+    "study": {
+        "description": (
+            "Codebase structure and dependency graph analysis. "
+            "Updates the code knowledge graph, runs factory study for observations, "
+            "then explores the graph for structural insights via an agent. "
+            "Terminal mode — does not chain to other modes. "
+            "Use when the user says 'study', 'analyze codebase', or wants a structural "
+            "understanding of the project before planning work."
+        ),
+        "argument_hint": "<project_path>",
     },
 }
 
@@ -471,8 +482,15 @@ def _fn_to_instruction(node: FnNode, workflow: Workflow) -> str:
 
 def _has_template_placeholders(text: str) -> bool:
     """Check if a command has $VARIABLE placeholders that need CEO substitution."""
-    placeholders = {"$EXP_ID", "$VERDICT", "$HYPOTHESIS", "$REQUEST",
-                     "$PR_NUMBER", "$SCORE_BEFORE", "$SCORE_AFTER"}
+    placeholders = {
+        "$EXP_ID",
+        "$VERDICT",
+        "$HYPOTHESIS",
+        "$REQUEST",
+        "$PR_NUMBER",
+        "$SCORE_BEFORE",
+        "$SCORE_AFTER",
+    }
     return any(p in text for p in placeholders)
 
 
@@ -529,15 +547,27 @@ def _gate_to_checkpoint(
         lines.append("")
         lines.append(f"### Steering Point — {gate_name} (User Approval)")
         lines.append("")
-        lines.append("**This is a USER approval gate, NOT a CEO review gate. Do NOT self-approve.**")
+        lines.append(
+            "**This is a USER approval gate, NOT a CEO review gate. Do NOT self-approve.**"
+        )
         lines.append("")
-        lines.append("Present the strategy/findings to the user by summarizing key points in your output.")
-        lines.append('Then explicitly ask the user: "Do you approve this plan, or do you have feedback?"')
+        lines.append(
+            "Present the strategy/findings to the user by summarizing key points in your output."
+        )
+        lines.append(
+            'Then explicitly ask the user: "Do you approve this plan, or do you have feedback?"'
+        )
         lines.append("")
         lines.append("**You MUST wait for the user's response before proceeding.**")
-        lines.append("- The user says \"approve\", \"yes\", \"looks good\", or similar → proceed to next step")
-        lines.append("- The user provides feedback or corrections → re-run the previous step incorporating their feedback")
-        lines.append("- Do NOT write a verdict file and auto-proceed — this gate requires human input")
+        lines.append(
+            '- The user says "approve", "yes", "looks good", or similar → proceed to next step'
+        )
+        lines.append(
+            "- The user provides feedback or corrections → re-run the previous step incorporating their feedback"
+        )
+        lines.append(
+            "- Do NOT write a verdict file and auto-proceed — this gate requires human input"
+        )
     elif node.evaluator_type == "fn":
         evaluator_cmd = ""
         if node.evaluator_command:
@@ -564,7 +594,9 @@ def _gate_to_checkpoint(
 
         if proceed_edges:
             proceed_target = proceed_edges[0].target
-            lines.append(f"\n- **PROCEED** (exit 0 / no FAIL in output) → continue to `{proceed_target}`")
+            lines.append(
+                f"\n- **PROCEED** (exit 0 / no FAIL in output) → continue to `{proceed_target}`"
+            )
             if halt_edges:
                 halt_target = halt_edges[0].target
                 lines.append(
@@ -652,10 +684,7 @@ def _fork_to_instruction(node: ForkNode, workflow: Workflow) -> str:
     ]
     if agent_nodes:
         # Calculate the maximum timeout among all parallel agents
-        max_timeout = max(
-            (node.timeout or 600 for node in agent_nodes),
-            default=600
-        )
+        max_timeout = max((node.timeout or 600 for node in agent_nodes), default=600)
 
         # Add timeout guidance if max_timeout exceeds Bash tool's default (120s)
         if max_timeout > 120:
@@ -813,7 +842,10 @@ def workflow_to_skill_md(workflow: Workflow) -> str:
             fork_targets.update(node.targets)
         elif isinstance(node, SubgraphForkNode):
             from factory.workflow.executor import _collect_subgraph_nodes
-            subgraph_nodes |= _collect_subgraph_nodes(workflow, node.subgraph_entry, node.subgraph_exit)
+
+            subgraph_nodes |= _collect_subgraph_nodes(
+                workflow, node.subgraph_entry, node.subgraph_exit
+            )
 
     sections: list[str] = []
     phase_num = 1
@@ -847,9 +879,7 @@ def workflow_to_skill_md(workflow: Workflow) -> str:
             sections.append(_join_to_instruction(node, workflow))
 
         elif isinstance(node, GateNode):
-            sections.append(
-                _gate_to_checkpoint(node, reloop_map.get(nid, []), workflow)
-            )
+            sections.append(_gate_to_checkpoint(node, reloop_map.get(nid, []), workflow))
 
         elif isinstance(node, Study):
             node_title = "Observe"
@@ -912,6 +942,7 @@ def export_all_skills(
 
     if workflows is None:
         from factory.workflow.definitions import register_all
+
         workflows = register_all()
 
     generated: list[Path] = []

--- a/skills/study/SKILL.md
+++ b/skills/study/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: study
-description: "Analyze the current codebase using Factory's observation engine. Generates a report covering code quality, eval scores, open issues, backlog items, observability coverage, and improvement opportunities. Use when the user wants to understand the state of their project before making changes."
+description: "Analyze the current codebase using Factory's observation engine and code graph. Generates a report covering code quality, eval scores, structural analysis, open issues, backlog items, observability coverage, and improvement opportunities. Use when the user wants to understand the state of their project before making changes."
 disable-model-invocation: true
 ---
 
 # /factory:study
 
-Analyze the current codebase and generate an observation report.
+Analyze the current codebase and generate an observation report with structural graph analysis.
 
 ## Prerequisites
 
@@ -17,10 +17,26 @@ command -v factory >/dev/null 2>&1 || uv tool install "${CLAUDE_PLUGIN_ROOT}"
 ## Execution
 
 ```bash
+factory graph update "$(pwd)"
 factory study "$(pwd)"
 ```
 
-This produces a report at `.factory/strategy/observations.md` covering:
+If graphify is installed and `graph.json` exists, explore the code graph:
+
+```bash
+factory graph query "<focus from observations>" --depth 2
+factory graph explain "<key node>"
+factory graph path "<A>" "<B>"
+```
+
+Write graph findings to `.factory/strategy/graph-context.md`, then combine:
+
+```bash
+cat .factory/strategy/observations.md .factory/strategy/graph-context.md \
+  > .factory/strategy/study-combined.md
+```
+
+The combined report at `.factory/strategy/study-combined.md` covers:
 
 - **Eval scores** — current composite and per-dimension breakdown
 - **Open issues** — from GitHub, if available
@@ -28,6 +44,7 @@ This produces a report at `.factory/strategy/observations.md` covering:
 - **Observability coverage** — logging density and uninstrumented files
 - **Hypothesis budget** — how many improvements to target this cycle
 - **Cross-project insights** — patterns from sibling projects (if any)
+- **Structural analysis** — key modules, dependency paths, architectural layers, entry points
 
 For cross-project insights, pass `--projects-dir`:
 

--- a/tests/test_graph_cli.py
+++ b/tests/test_graph_cli.py
@@ -1,0 +1,127 @@
+"""Tests for graph CLI wrapper commands (query, explain, path)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def _mock_graphify_installed():
+    with patch("factory.graph.is_graphify_installed", return_value=True):
+        yield
+
+
+@pytest.fixture()
+def _mock_graphify_not_installed():
+    with patch("factory.graph.is_graphify_installed", return_value=False):
+        yield
+
+
+@pytest.fixture()
+def _mock_graph_available():
+    with patch("factory.graph.is_graph_available", return_value=True):
+        yield
+
+
+@pytest.fixture()
+def _mock_graph_not_available():
+    with patch("factory.graph.is_graph_available", return_value=False):
+        yield
+
+
+class TestCmdGraphQuery:
+    @pytest.mark.usefixtures("_mock_graphify_installed", "_mock_graph_available")
+    def test_success(self, tmp_path):
+        from factory.cli.graph import cmd_graph_query
+
+        args = argparse.Namespace(path=str(tmp_path), question="auth flow", depth=2)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="Found 3 nodes\n", stderr=""
+            )
+            result = cmd_graph_query(args)
+        assert result == 0
+        mock_run.assert_called_once()
+        call_cmd = mock_run.call_args[0][0]
+        assert call_cmd[0] == "graphify"
+        assert call_cmd[1] == "query"
+        assert "auth flow" in call_cmd
+
+    @pytest.mark.usefixtures("_mock_graphify_not_installed")
+    def test_not_installed(self, tmp_path):
+        from factory.cli.graph import cmd_graph_query
+
+        args = argparse.Namespace(path=str(tmp_path), question="test", depth=2)
+        result = cmd_graph_query(args)
+        assert result == 1
+
+    @pytest.mark.usefixtures("_mock_graphify_installed", "_mock_graph_not_available")
+    def test_no_graph(self, tmp_path):
+        from factory.cli.graph import cmd_graph_query
+
+        args = argparse.Namespace(path=str(tmp_path), question="test", depth=2)
+        result = cmd_graph_query(args)
+        assert result == 1
+
+
+class TestCmdGraphExplain:
+    @pytest.mark.usefixtures("_mock_graphify_installed", "_mock_graph_available")
+    def test_success(self, tmp_path):
+        from factory.cli.graph import cmd_graph_explain
+
+        args = argparse.Namespace(path=str(tmp_path), node="Study")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="Study node: ...\n", stderr=""
+            )
+            result = cmd_graph_explain(args)
+        assert result == 0
+        call_cmd = mock_run.call_args[0][0]
+        assert call_cmd[1] == "explain"
+
+    @pytest.mark.usefixtures("_mock_graphify_not_installed")
+    def test_not_installed(self, tmp_path):
+        from factory.cli.graph import cmd_graph_explain
+
+        args = argparse.Namespace(path=str(tmp_path), node="Study")
+        result = cmd_graph_explain(args)
+        assert result == 1
+
+
+class TestCmdGraphPath:
+    @pytest.mark.usefixtures("_mock_graphify_installed", "_mock_graph_available")
+    def test_success(self, tmp_path):
+        from factory.cli.graph import cmd_graph_path
+
+        args = argparse.Namespace(path=str(tmp_path), source="Study", target="invoke_agent")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="Path: Study -> invoke_agent\n", stderr=""
+            )
+            result = cmd_graph_path(args)
+        assert result == 0
+        call_cmd = mock_run.call_args[0][0]
+        assert call_cmd[1] == "path"
+        assert "Study" in call_cmd
+        assert "invoke_agent" in call_cmd
+
+    @pytest.mark.usefixtures("_mock_graphify_not_installed")
+    def test_not_installed(self, tmp_path):
+        from factory.cli.graph import cmd_graph_path
+
+        args = argparse.Namespace(path=str(tmp_path), source="A", target="B")
+        result = cmd_graph_path(args)
+        assert result == 1
+
+    @pytest.mark.usefixtures("_mock_graphify_installed", "_mock_graph_available")
+    def test_timeout(self, tmp_path):
+        from factory.cli.graph import cmd_graph_path
+
+        args = argparse.Namespace(path=str(tmp_path), source="A", target="B")
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("graphify", 60)):
+            result = cmd_graph_path(args)
+        assert result == 1

--- a/tests/test_plan_workflow.py
+++ b/tests/test_plan_workflow.py
@@ -25,8 +25,8 @@ def wf():
 
 def test_plan_workflow_structure(wf):
     """Verify node and edge counts match the expected topology."""
-    assert len(wf.nodes) == 15
-    assert len(wf.edges) == 20
+    assert len(wf.nodes) == 18
+    assert len(wf.edges) == 23
     assert wf.name == "plan"
     assert wf.start_node == "gate_has_factory"
     assert wf.terminal is True
@@ -58,10 +58,13 @@ def test_plan_workflow_edge_coverage(wf):
         ("gate_research", "fork_research", VerdictType.RELOOP),
         ("strategist", "gate_strategy", None),
         ("gate_strategy", "strategist", VerdictType.RELOOP),
-        ("gate_has_factory", "study", VerdictType.PROCEED),
+        ("graph_update", "study", None),
+        ("study", "graph_explorer", None),
+        ("graph_explorer", "concat_study", None),
+        ("gate_has_factory", "graph_update", VerdictType.PROCEED),
         ("gate_has_factory", "discover", VerdictType.HALT),
-        ("discover", "study", None),
-        ("study", "check_prior_plans", None),
+        ("discover", "graph_update", None),
+        ("concat_study", "check_prior_plans", None),
         ("check_prior_plans", "gate_prior_plans", VerdictType.PROCEED),
         ("check_prior_plans", "fork_research", VerdictType.HALT),
         ("gate_prior_plans", "fork_research", VerdictType.PROCEED),

--- a/tests/test_spec_generate.py
+++ b/tests/test_spec_generate.py
@@ -92,7 +92,7 @@ class TestRegistryIncludesSpec:
 
     def test_register_all_count(self) -> None:
         all_wf = register_all()
-        assert len(all_wf) == 34
+        assert len(all_wf) == 35
 
     def test_all_workflows_validate(self) -> None:
         all_wf = register_all()

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -17,10 +17,10 @@ from factory.workflow.definitions import (
     founder_workflow,
     improve_workflow,
     meta_workflow,
-
     refine_workflow,
     register_all,
     research_workflow,
+    study_standalone_workflow,  # noqa: F401
 )
 from factory.workflow.primitives import (
     AgentNode,
@@ -123,15 +123,22 @@ class TestDesignIsBuiltWithUserGate:
         assert gate_w2.evaluator_type == "user"
 
     def test_design_shares_other_nodes(self) -> None:
-        """W₂ shares all build node IDs with W₁, plus gate_has_factory and study."""
+        """W₂ shares all build node IDs with W₁, plus gate_has_factory, discover, and study subgraph."""
         w1 = build_workflow()
         w2 = design_workflow()
 
         w1_ids = set(w1.nodes.keys())
         w2_ids = set(w2.nodes.keys())
 
-        # Design has 3 extra nodes: gate_has_factory, discover, and study
-        assert w2_ids == w1_ids | {"gate_has_factory", "discover", "study"}
+        # Design has extra nodes: gate_has_factory, discover, and study subgraph
+        assert w2_ids == w1_ids | {
+            "gate_has_factory",
+            "discover",
+            "graph_update",
+            "study",
+            "graph_explorer",
+            "concat_study",
+        }
 
     def test_design_name(self) -> None:
         wf = design_workflow()
@@ -164,19 +171,20 @@ class TestDesignStudyNode:
         study = wf.nodes["study"]
         assert ".factory/strategy/observations.md" in study.writes
 
-    def test_design_study_to_fork_research_edge(self) -> None:
-        """There must be an unconditional edge from study to fork_research."""
+    def test_design_concat_study_to_fork_research_edge(self) -> None:
+        """There must be an unconditional edge from concat_study to fork_research."""
         wf = design_workflow()
         assert any(
-            e.source == "study" and e.target == "fork_research" and e.condition is None
+            e.source == "concat_study" and e.target == "fork_research" and e.condition is None
             for e in wf.edges
         )
 
-    def test_design_gate_routes_to_study(self) -> None:
-        """gate_has_factory PROCEED must route to study."""
+    def test_design_gate_routes_to_graph_update(self) -> None:
+        """gate_has_factory PROCEED must route to graph_update."""
         wf = design_workflow()
         assert any(
-            e.source == "gate_has_factory" and e.target == "study"
+            e.source == "gate_has_factory"
+            and e.target == "graph_update"
             and e.condition == VerdictType.PROCEED
             for e in wf.edges
         )
@@ -185,7 +193,8 @@ class TestDesignStudyNode:
         """gate_has_factory HALT must route to discover (not fork_research)."""
         wf = design_workflow()
         assert any(
-            e.source == "gate_has_factory" and e.target == "discover"
+            e.source == "gate_has_factory"
+            and e.target == "discover"
             and e.condition == VerdictType.HALT
             for e in wf.edges
         )
@@ -199,11 +208,11 @@ class TestDesignStudyNode:
         assert node.command == "factory discover {project_path}"
         assert ".factory/eval_profile.json" in node.writes
 
-    def test_design_discover_to_study_edge(self) -> None:
-        """There must be an unconditional edge from discover to study."""
+    def test_design_discover_to_graph_update_edge(self) -> None:
+        """There must be an unconditional edge from discover to graph_update."""
         wf = design_workflow()
         assert any(
-            e.source == "discover" and e.target == "study" and e.condition is None
+            e.source == "discover" and e.target == "graph_update" and e.condition is None
             for e in wf.edges
         )
 
@@ -326,6 +335,7 @@ class TestRegisterAll:
             "spec-generate",
             "spec-update",
             "founder",
+            "study",
         }
         assert required.issubset(set(all_wf.keys())), f"Missing: {required - set(all_wf.keys())}"
 
@@ -334,6 +344,88 @@ class TestRegisterAll:
         for name, wf in all_wf.items():
             issues = wf.validate_graph()
             assert issues == [], f"{name} has validation issues: {issues}"
+
+
+# ── Study Mode structure ────────────────────────────────────────
+
+
+class TestStudyWorkflow:
+    def test_node_ids(self) -> None:
+        wf = study_standalone_workflow()
+        assert set(wf.nodes.keys()) == {
+            "graph_update",
+            "study",
+            "graph_explorer",
+            "concat_study",
+        }
+
+    def test_start_node(self) -> None:
+        wf = study_standalone_workflow()
+        assert wf.start_node == "graph_update"
+
+    def test_trigger(self) -> None:
+        wf = study_standalone_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "study"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.NO_REPO, {"mode": "study"})
+
+    def test_terminal(self) -> None:
+        wf = study_standalone_workflow()
+        assert wf.terminal is True
+
+    def test_valid(self) -> None:
+        wf = study_standalone_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"study workflow has issues: {issues}"
+
+    def test_study_writes_observations(self) -> None:
+        wf = study_standalone_workflow()
+        node = wf.nodes["study"]
+        assert ".factory/strategy/observations.md" in node.writes
+
+    def test_graph_explorer_is_researcher(self) -> None:
+        wf = study_standalone_workflow()
+        node = wf.nodes["graph_explorer"]
+        assert isinstance(node, AgentNode)
+        assert node.role == AgentRole.RESEARCHER
+
+    def test_concat_study_writes_combined(self) -> None:
+        wf = study_standalone_workflow()
+        node = wf.nodes["concat_study"]
+        assert ".factory/strategy/study-combined.md" in node.writes
+
+
+class TestDesignStudySubgraph:
+    def test_graph_nodes_exist(self) -> None:
+        wf = design_workflow()
+        assert "graph_update" in wf.nodes
+        assert "study" in wf.nodes
+        assert "graph_explorer" in wf.nodes
+        assert "concat_study" in wf.nodes
+
+    def test_edge_wiring(self) -> None:
+        wf = design_workflow()
+        assert any(e.source == "graph_update" and e.target == "study" for e in wf.edges)
+        assert any(e.source == "study" and e.target == "graph_explorer" for e in wf.edges)
+        assert any(e.source == "graph_explorer" and e.target == "concat_study" for e in wf.edges)
+        assert any(e.source == "concat_study" and e.target == "fork_research" for e in wf.edges)
+
+    def test_graph_update_is_fn_node(self) -> None:
+        wf = design_workflow()
+        node = wf.nodes["graph_update"]
+        assert isinstance(node, FnNode)
+        assert "factory graph update" in node.command
+
+    def test_graph_explorer_writes_context(self) -> None:
+        wf = design_workflow()
+        node = wf.nodes["graph_explorer"]
+        assert ".factory/strategy/graph-context.md" in node.writes
+
+    def test_concat_study_writes_combined(self) -> None:
+        wf = design_workflow()
+        node = wf.nodes["concat_study"]
+        assert ".factory/strategy/study-combined.md" in node.writes
 
 
 # ── W₉ Create structure ────────────────────────────────────────
@@ -456,21 +548,23 @@ class TestDocFreshnessGate:
         wf = workflow_fn()
         edges = wf.edges
         assert any(
-            e.source == "gate_qa" and e.target == "gate_doc_freshness"
+            e.source == "gate_qa"
+            and e.target == "gate_doc_freshness"
             and e.condition == VerdictType.PROCEED
             for e in edges
         ), "missing gate_qa -> gate_doc_freshness PROCEED edge"
         assert any(
-            e.source == "gate_doc_freshness" and e.target == "gate_precheck"
+            e.source == "gate_doc_freshness"
+            and e.target == "gate_precheck"
             and e.condition == VerdictType.PROCEED
             for e in edges
         ), "missing gate_doc_freshness -> gate_precheck PROCEED edge"
         assert any(
-            e.source == "gate_doc_freshness" and e.target == "builder"
+            e.source == "gate_doc_freshness"
+            and e.target == "builder"
             and e.condition == VerdictType.RELOOP
             for e in edges
         ), "missing gate_doc_freshness -> builder RELOOP edge"
-
 
 
 # ── Builder → QA reachability audit ────────────────────────────
@@ -708,6 +802,7 @@ class TestFounderStructure:
 
     def test_founder_skill_export(self) -> None:
         from factory.workflow.skill_export import validate_skill, workflow_to_skill_md
+
         wf = founder_workflow()
         skill_md = workflow_to_skill_md(wf)
         issues = validate_skill(skill_md)
@@ -936,8 +1031,10 @@ class TestFounderWorkflow:
     def test_founder_reloop_to_builder(self) -> None:
         wf = founder_workflow()
         reloop_edges = [
-            e for e in wf.edges
-            if e.source == "gate_tests" and e.target == "builder"
+            e
+            for e in wf.edges
+            if e.source == "gate_tests"
+            and e.target == "builder"
             and e.condition == VerdictType.RELOOP
         ]
         assert len(reloop_edges) == 1


### PR DESCRIPTION
## Summary

Add a standalone Study Mode workflow and integrate graph-powered code exploration into the design workflow's study subgraph.

### Study subgraph (shared by design and study workflows)

```
graph_update → study → graph_explorer → concat_study
```

- **graph_update**: runs `factory graph update` to build/refresh graph.json
- **study**: runs `factory study` producing observations.md
- **graph_explorer**: researcher agent that reads observations, queries the code graph via `factory graph query/explain/path`, writes graph-context.md
- **concat_study**: merges observations.md + graph-context.md into study-combined.md

### Design workflow integration

- Existing projects route through the study subgraph before research
- Researchers and strategist read study-combined.md for project context
- join_research is now a pure sync barrier (no concatenation)
- gate_research and strategist read individual research files directly

### CLI additions

- `factory graph query/explain/path` — agent-accessible graph exploration tools
- `factory ceo --mode study` / `factory run --mode study`
- Study mode registered across all 9 integration points

### Other changes

- Researcher agent prompt reads study-combined.md instead of re-running factory study
- Plan workflow inherits the study subgraph from design_workflow
- skill_export WORKFLOW_META entry for study mode

## Test plan

- [x] `test_workflow_definitions.py` — study workflow structure, design subgraph wiring, node types, edge coverage
- [x] `test_graph_cli.py` — query/explain/path CLI wrappers (success, not-installed, no-graph, timeout)
- [x] `test_plan_workflow.py` — updated node/edge counts for inherited subgraph
- [x] `test_spec_generate.py` — updated registry count (34 → 35)
- [x] End-to-end: `factory ceo --mode design --focus "..."` ran full pipeline (study → graph_explorer → concat → researchers → strategist)