### PR TITLE
fix: restore detect_research_plateau removed by dead-code cleanup

### DIFF
--- a/factory/strategy.py
+++ b/factory/strategy.py
@@ -145,6 +145,42 @@ def find_anti_patterns(
     return matches
 
 
+# ── plateau detection ────────────────────────────────────────────
+
+
+def detect_research_plateau(
+    run_summaries: list[dict],
+    threshold: int = 3,
+) -> bool:
+    """Return ``True`` when the last *threshold* cycles showed no metric improvement.
+
+    *run_summaries* should be ordered oldest-first.  Each dict must contain a
+    ``metric_value`` key.  Requires at least ``threshold + 1`` entries (one
+    baseline plus *threshold* cycles).
+    """
+    if threshold <= 0:
+        return False
+
+    if len(run_summaries) < threshold + 1:
+        return False
+
+    pre_window = run_summaries[:-threshold]
+    best_before = max(s["metric_value"] for s in pre_window)
+
+    window = run_summaries[-threshold:]
+    best_in_window = max(s["metric_value"] for s in window)
+
+    plateaued = best_in_window <= best_before
+    if plateaued:
+        log.warning(
+            "plateau_detected",
+            threshold=threshold,
+            best_before=best_before,
+            best_in_window=best_in_window,
+        )
+    return plateaued
+
+
 # ── 3-tier experiment history ───────────────────────────────────
 
 

--- a/tests/test_inner_outer_loop.py
+++ b/tests/test_inner_outer_loop.py
@@ -568,3 +568,65 @@ class TestSpecFormatRoundTrip:
         assert restored.outer_loop.max_outer_cycles == 4
         assert restored.outer_loop.inner_surfaces == ["prompts/*.md", "config/*.yaml"]
         assert restored.outer_loop.outer_surfaces == ["src/**/*.py"]
+
+
+# ── detect_research_plateau tests ────────────────────────────────
+
+
+class TestDetectResearchPlateau:
+    """Tests for detect_research_plateau in factory.strategy."""
+
+    def test_not_enough_data(self) -> None:
+        from factory.strategy import detect_research_plateau
+
+        summaries = [{"metric_value": 0.5}, {"metric_value": 0.6}]
+        assert detect_research_plateau(summaries, threshold=3) is False
+
+    def test_plateau_detected(self) -> None:
+        from factory.strategy import detect_research_plateau
+
+        summaries = [
+            {"metric_value": 0.8},
+            {"metric_value": 0.7},
+            {"metric_value": 0.6},
+            {"metric_value": 0.75},
+        ]
+        assert detect_research_plateau(summaries, threshold=3) is True
+
+    def test_no_plateau_with_improvement(self) -> None:
+        from factory.strategy import detect_research_plateau
+
+        summaries = [
+            {"metric_value": 0.5},
+            {"metric_value": 0.6},
+            {"metric_value": 0.7},
+            {"metric_value": 0.9},
+        ]
+        assert detect_research_plateau(summaries, threshold=3) is False
+
+    def test_custom_threshold(self) -> None:
+        from factory.strategy import detect_research_plateau
+
+        summaries = [
+            {"metric_value": 0.8},
+            {"metric_value": 0.7},
+            {"metric_value": 0.75},
+        ]
+        assert detect_research_plateau(summaries, threshold=2) is True
+
+    def test_improvement_in_window_breaks_plateau(self) -> None:
+        from factory.strategy import detect_research_plateau
+
+        summaries = [
+            {"metric_value": 0.5},
+            {"metric_value": 0.4},
+            {"metric_value": 0.3},
+            {"metric_value": 0.6},
+        ]
+        assert detect_research_plateau(summaries, threshold=3) is False
+
+    def test_zero_threshold_returns_false(self) -> None:
+        from factory.strategy import detect_research_plateau
+
+        summaries = [{"metric_value": 0.5}]
+        assert detect_research_plateau(summaries, threshold=0) is False


### PR DESCRIPTION
Fixes #1219

## Changes

- Restored `detect_research_plateau` to `factory/strategy.py` — PR #1210 removed it as dead code, but `factory/compress/outer_loop.py` imports it, breaking CI
- Added 6 tests for `detect_research_plateau` in `tests/test_inner_outer_loop.py` covering: not enough data, plateau detected, no plateau with improvement, custom threshold, improvement in window breaks plateau, zero threshold