### PR TITLE
feat: FeatureBench direct-workflow benchmarking script

### DIFF
--- a/benchmarks/featurebench-bench/README.md
+++ b/benchmarks/featurebench-bench/README.md
@@ -1,0 +1,67 @@
+# FeatureBench Direct-Workflow Benchmark
+
+Benchmarks the factory's `featurebench` workflow against the standard FeatureBench baseline agent (`claude_code`).
+
+## Prerequisites
+
+- Docker running (for extracting task repos from FeatureBench images)
+- `factory` CLI installed and on PATH
+- `fb` CLI installed (for baseline runs and evaluation)
+- `datasets` Python package (`pip install datasets`)
+
+## Usage
+
+### Run specific tasks (factory workflow only)
+
+```bash
+python bench.py --task-id "astropy__astropy.b0db0daa.test_tilde_path.383d7c0c.lv1" --factory-only
+```
+
+### Run a split file
+
+```bash
+python bench.py --split ../featurebench-splits/val.jsonl --factory-only --timeout 1800
+```
+
+### Run both factory and baseline, then compare
+
+```bash
+python bench.py --task-id "astropy__astropy.b0db0daa.test_tilde_path.383d7c0c.lv1" --timeout 1800
+```
+
+### Baseline only
+
+```bash
+python bench.py --task-id "astropy__astropy.b0db0daa.test_tilde_path.383d7c0c.lv1" \
+    --baseline-only --model claude-sonnet-4-20250514
+```
+
+### Custom results directory
+
+```bash
+python bench.py --split val.jsonl --factory-only --results-dir /tmp/fb-results
+```
+
+### Skip evaluation (just produce patches)
+
+```bash
+python bench.py --task-id "task1" "task2" --factory-only --skip-eval
+```
+
+## Output
+
+Results are written to `--results-dir` (default: `benchmarks/featurebench-bench/results/`):
+
+```
+results/
+├── factory/
+│   └── output.jsonl          # One JSON entry per task
+├── baseline/
+│   └── output.jsonl          # Baseline agent output
+└── comparison_report.json    # Side-by-side comparison
+```
+
+Each `output.jsonl` entry:
+```json
+{"instance_id": "...", "model_patch": "<diff>", "agent": "factory_workflow", "model": "...", "success": true}
+```

--- a/benchmarks/featurebench-bench/bench.py
+++ b/benchmarks/featurebench-bench/bench.py
@@ -28,11 +28,6 @@ DEFAULT_MODEL = "claude-sonnet-4-20250514"
 DEFAULT_RESULTS_DIR = Path(__file__).parent / "results"
 
 
-# ---------------------------------------------------------------------------
-# 1. Task Setup
-# ---------------------------------------------------------------------------
-
-
 def load_task_metadata(task_id: str) -> dict:
     """Load task metadata from HuggingFace dataset."""
     try:
@@ -143,11 +138,6 @@ def _git_init(task_dir: Path) -> str:
     return result.stdout.strip()
 
 
-# ---------------------------------------------------------------------------
-# 2. Factory Workflow Execution
-# ---------------------------------------------------------------------------
-
-
 def run_factory(
     task_id: str,
     task_dir: Path,
@@ -201,11 +191,6 @@ def extract_patch(task_dir: Path, initial_sha: str) -> str:
     return result.stdout
 
 
-# ---------------------------------------------------------------------------
-# 3. Baseline Execution
-# ---------------------------------------------------------------------------
-
-
 def run_baseline(
     task_ids: list[str],
     model: str = DEFAULT_MODEL,
@@ -230,11 +215,6 @@ def run_baseline(
     log.info("Running baseline: %s", " ".join(cmd))
     subprocess.run(cmd, check=True)
     return baseline_dir
-
-
-# ---------------------------------------------------------------------------
-# 4. Evaluation
-# ---------------------------------------------------------------------------
 
 
 def evaluate(results_dir: Path) -> dict | None:
@@ -270,11 +250,6 @@ def evaluate(results_dir: Path) -> dict | None:
 
     log.warning("Could not parse fb eval output")
     return None
-
-
-# ---------------------------------------------------------------------------
-# 5. Comparison
-# ---------------------------------------------------------------------------
 
 
 def compare(factory_results: dict, baseline_results: dict) -> dict:
@@ -380,11 +355,6 @@ def _print_summary(report: dict) -> None:
     print("=" * 80)
 
 
-# ---------------------------------------------------------------------------
-# 6. CLI Interface
-# ---------------------------------------------------------------------------
-
-
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="FeatureBench direct-workflow benchmarking script",
@@ -458,6 +428,7 @@ def main(argv: list[str] | None = None) -> None:
 
         for tid in task_ids:
             log.info("=== Factory: %s ===", tid)
+            task_dir = None
             try:
                 task_dir, initial_sha = setup_task(tid)
                 entry = run_factory(tid, task_dir, initial_sha, timeout=args.timeout)
@@ -476,8 +447,7 @@ def main(argv: list[str] | None = None) -> None:
                     "success": False,
                 })
             finally:
-                # Clean up temp dirs
-                if "task_dir" in dir() and task_dir.exists():
+                if task_dir is not None and task_dir.exists():
                     shutil.rmtree(task_dir.parent, ignore_errors=True)
 
         output_jsonl = factory_dir / "output.jsonl"

--- a/benchmarks/featurebench-bench/bench.py
+++ b/benchmarks/featurebench-bench/bench.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""FeatureBench direct-workflow benchmarking script.
+
+Runs factory's featurebench workflow directly on extracted task repos
+and compares results against the standard FeatureBench baseline agent.
+
+Usage:
+    python bench.py --task-id <id1> <id2> --timeout 1800
+    python bench.py --split val.jsonl --factory-only
+    python bench.py --task-id <id> --baseline-only --model claude-sonnet-4-20250514
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+DATASET_NAME = "LiberCoders/FeatureBench"
+DATASET_SPLIT = "full"
+DEFAULT_TIMEOUT = 1800
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_RESULTS_DIR = Path(__file__).parent / "results"
+
+
+# ---------------------------------------------------------------------------
+# 1. Task Setup
+# ---------------------------------------------------------------------------
+
+
+def load_task_metadata(task_id: str) -> dict:
+    """Load task metadata from HuggingFace dataset."""
+    try:
+        from datasets import load_dataset
+
+        ds = load_dataset(DATASET_NAME, split=DATASET_SPLIT)
+        for row in ds:
+            if row["instance_id"] == task_id:
+                return dict(row)
+        raise ValueError(f"Task {task_id!r} not found in {DATASET_NAME}")
+    except ImportError:
+        raise RuntimeError(
+            "The 'datasets' library is required. Install with: pip install datasets"
+        )
+
+
+def load_task_ids_from_split(split_path: str | Path) -> list[str]:
+    """Load task IDs from a JSONL split file."""
+    split_path = Path(split_path)
+    if not split_path.exists():
+        # Try relative to featurebench-splits
+        alt = Path(__file__).parent.parent / "featurebench-splits" / split_path
+        if alt.exists():
+            split_path = alt
+        else:
+            raise FileNotFoundError(f"Split file not found: {split_path}")
+
+    ids = []
+    for line in split_path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            ids.append(json.loads(line)["instance_id"])
+    return ids
+
+
+def setup_task(task_id: str, work_dir: Path | None = None) -> tuple[Path, str]:
+    """Extract a task repo from its Docker image to a local directory.
+
+    Returns (task_dir, initial_commit_sha).
+    """
+    metadata = load_task_metadata(task_id)
+    docker_image = metadata.get("docker_image", "")
+    if not docker_image:
+        raise ValueError(f"No docker_image found for task {task_id!r}")
+
+    if work_dir is None:
+        work_dir = Path(tempfile.mkdtemp(prefix=f"fb-{task_id[:20]}-"))
+    else:
+        work_dir.mkdir(parents=True, exist_ok=True)
+
+    task_dir = work_dir / "testbed"
+    task_dir.mkdir(parents=True, exist_ok=True)
+
+    container_id = _docker_create(docker_image)
+    try:
+        _docker_cp(container_id, "/testbed/.", str(task_dir))
+        problem_stmt = task_dir / "problem_statement.md"
+        if not problem_stmt.exists():
+            _docker_cp(container_id, "/tmp/task-instruction.md", str(problem_stmt))
+    finally:
+        _docker_rm(container_id)
+
+    initial_sha = _git_init(task_dir)
+    log.info("Task %s extracted to %s (initial commit: %s)", task_id, task_dir, initial_sha)
+    return task_dir, initial_sha
+
+
+def _docker_create(image: str) -> str:
+    result = subprocess.run(
+        ["docker", "create", image],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def _docker_cp(container_id: str, src: str, dst: str) -> None:
+    subprocess.run(
+        ["docker", "cp", f"{container_id}:{src}", dst],
+        capture_output=True, text=True, check=True,
+    )
+
+
+def _docker_rm(container_id: str) -> None:
+    subprocess.run(
+        ["docker", "rm", container_id],
+        capture_output=True, text=True, check=False,
+    )
+
+
+def _git_init(task_dir: Path) -> str:
+    subprocess.run(
+        ["git", "init"], cwd=task_dir,
+        capture_output=True, text=True, check=True,
+    )
+    subprocess.run(
+        ["git", "add", "-A"], cwd=task_dir,
+        capture_output=True, text=True, check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=bench@factory", "-c", "user.name=bench",
+         "commit", "-m", "initial"],
+        cwd=task_dir, capture_output=True, text=True, check=True,
+    )
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=task_dir,
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# 2. Factory Workflow Execution
+# ---------------------------------------------------------------------------
+
+
+def run_factory(
+    task_id: str,
+    task_dir: Path,
+    initial_sha: str,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> dict:
+    """Run the factory featurebench workflow on a task directory.
+
+    Returns an output entry in FeatureBench-compatible format.
+    """
+    log.info("Running factory workflow on %s (timeout=%ds)", task_id, timeout)
+    success = True
+    try:
+        subprocess.run(
+            ["factory", "workflow", "run", "featurebench", str(task_dir)],
+            timeout=timeout,
+            capture_output=True, text=True, check=False,
+        )
+    except subprocess.TimeoutExpired:
+        log.warning("Factory workflow timed out for %s after %ds", task_id, timeout)
+        success = False
+
+    # Commit any remaining changes
+    subprocess.run(
+        ["git", "add", "-A"], cwd=task_dir,
+        capture_output=True, text=True, check=False,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=bench@factory", "-c", "user.name=bench",
+         "commit", "-m", "solution", "--allow-empty"],
+        cwd=task_dir, capture_output=True, text=True, check=False,
+    )
+
+    patch = extract_patch(task_dir, initial_sha)
+
+    return {
+        "instance_id": task_id,
+        "model_patch": patch,
+        "agent": "factory_workflow",
+        "model": "factory-featurebench",
+        "success": success and bool(patch.strip()),
+    }
+
+
+def extract_patch(task_dir: Path, initial_sha: str) -> str:
+    """Extract the git diff between initial commit and HEAD."""
+    result = subprocess.run(
+        ["git", "diff", initial_sha, "HEAD"],
+        cwd=task_dir, capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# 3. Baseline Execution
+# ---------------------------------------------------------------------------
+
+
+def run_baseline(
+    task_ids: list[str],
+    model: str = DEFAULT_MODEL,
+    results_dir: Path = DEFAULT_RESULTS_DIR,
+) -> Path:
+    """Run the standard FeatureBench baseline agent via fb CLI.
+
+    Returns the baseline output directory.
+    """
+    baseline_dir = results_dir / "baseline"
+    baseline_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "fb", "infer",
+        "--agent", "claude_code",
+        "--model", model,
+        "--output-dir", str(baseline_dir),
+    ]
+    for tid in task_ids:
+        cmd.extend(["--task-id", tid])
+
+    log.info("Running baseline: %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+    return baseline_dir
+
+
+# ---------------------------------------------------------------------------
+# 4. Evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate(results_dir: Path) -> dict | None:
+    """Run fb eval on output.jsonl in results_dir. Returns parsed results or None."""
+    output_jsonl = results_dir / "output.jsonl"
+    if not output_jsonl.exists():
+        log.warning("No output.jsonl found in %s — skipping eval", results_dir)
+        return None
+
+    log.info("Running fb eval on %s", output_jsonl)
+    result = subprocess.run(
+        ["fb", "eval", "-p", str(output_jsonl)],
+        capture_output=True, text=True, check=False,
+    )
+
+    if result.returncode != 0:
+        log.error("fb eval failed: %s", result.stderr)
+        return None
+
+    # Try to find eval output — fb eval writes JSON to the same directory
+    eval_files = sorted(results_dir.glob("*-featurebench-full.json"))
+    if eval_files:
+        return json.loads(eval_files[-1].read_text())
+
+    # Fall back to parsing stdout
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+    log.warning("Could not parse fb eval output")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 5. Comparison
+# ---------------------------------------------------------------------------
+
+
+def compare(factory_results: dict, baseline_results: dict) -> dict:
+    """Produce a side-by-side comparison report.
+
+    Both inputs are dicts with "tasks" lists from fb eval output, or per-task
+    entries from our output.jsonl keyed by instance_id.
+    """
+    f_tasks = _index_tasks(factory_results)
+    b_tasks = _index_tasks(baseline_results)
+
+    all_ids = sorted(set(f_tasks) | set(b_tasks))
+    if not all_ids:
+        return {"error": "no tasks found", "total_tasks": 0}
+
+    per_task = []
+    factory_resolved = 0
+    baseline_resolved = 0
+    only_factory = []
+    only_baseline = []
+
+    for iid in all_ids:
+        f = f_tasks.get(iid, {})
+        b = b_tasks.get(iid, {})
+        f_res = f.get("resolved", f.get("success", False))
+        b_res = b.get("resolved", b.get("success", False))
+
+        row = {
+            "instance_id": iid,
+            "factory_resolved": f_res,
+            "baseline_resolved": b_res,
+            "factory_score": f.get("score", 0.0),
+            "baseline_score": b.get("score", 0.0),
+        }
+        per_task.append(row)
+
+        if f_res:
+            factory_resolved += 1
+        if b_res:
+            baseline_resolved += 1
+        if f_res and not b_res:
+            only_factory.append(iid)
+        if b_res and not f_res:
+            only_baseline.append(iid)
+
+    total = len(all_ids)
+    report = {
+        "total_tasks": total,
+        "factory_resolved": factory_resolved,
+        "baseline_resolved": baseline_resolved,
+        "factory_resolve_rate": factory_resolved / total if total else 0,
+        "baseline_resolve_rate": baseline_resolved / total if total else 0,
+        "only_factory_solved": only_factory,
+        "only_baseline_solved": only_baseline,
+        "per_task": per_task,
+    }
+
+    _print_summary(report)
+    return report
+
+
+def _index_tasks(results: dict) -> dict[str, dict]:
+    """Normalize results into {instance_id: task_data}."""
+    if "tasks" in results:
+        return {t["instance_id"]: t for t in results["tasks"] if "instance_id" in t}
+    if "per_task" in results:
+        return {t["instance_id"]: t for t in results["per_task"] if "instance_id" in t}
+    if all(isinstance(v, dict) for v in results.values()):
+        return results
+    return {}
+
+
+def _print_summary(report: dict) -> None:
+    total = report["total_tasks"]
+    print("=" * 80)
+    print("FeatureBench Comparison: Factory Workflow vs Baseline")
+    print("=" * 80)
+
+    header = f"{'Instance ID':<55} {'Factory':>8} {'Baseline':>8}"
+    print(header)
+    print("-" * 80)
+
+    for row in report["per_task"]:
+        f_mark = "PASS" if row["factory_resolved"] else "FAIL"
+        b_mark = "PASS" if row["baseline_resolved"] else "FAIL"
+        print(f"{row['instance_id']:<55} {f_mark:>8} {b_mark:>8}")
+
+    print("-" * 80)
+    print(f"  Factory:  {report['factory_resolved']}/{total}"
+          f" ({report['factory_resolve_rate']:.1%})")
+    print(f"  Baseline: {report['baseline_resolved']}/{total}"
+          f" ({report['baseline_resolve_rate']:.1%})")
+
+    if report["only_factory_solved"]:
+        print(f"\n  Only factory solved ({len(report['only_factory_solved'])}):")
+        for iid in report["only_factory_solved"]:
+            print(f"    + {iid}")
+    if report["only_baseline_solved"]:
+        print(f"\n  Only baseline solved ({len(report['only_baseline_solved'])}):")
+        for iid in report["only_baseline_solved"]:
+            print(f"    - {iid}")
+
+    print("=" * 80)
+
+
+# ---------------------------------------------------------------------------
+# 6. CLI Interface
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="FeatureBench direct-workflow benchmarking script",
+    )
+    parser.add_argument(
+        "--task-id", nargs="+", dest="task_ids",
+        help="One or more FeatureBench task IDs to run",
+    )
+    parser.add_argument(
+        "--split", type=str,
+        help="Path to a JSONL split file to load task IDs from",
+    )
+    parser.add_argument(
+        "--factory-only", action="store_true",
+        help="Skip baseline, only run factory workflow",
+    )
+    parser.add_argument(
+        "--baseline-only", action="store_true",
+        help="Skip factory workflow, only run baseline",
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=DEFAULT_TIMEOUT,
+        help=f"Per-task timeout in seconds (default: {DEFAULT_TIMEOUT})",
+    )
+    parser.add_argument(
+        "--model", type=str, default=DEFAULT_MODEL,
+        help=f"Model for baseline agent (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--results-dir", type=Path, default=DEFAULT_RESULTS_DIR,
+        help="Output directory for results",
+    )
+    parser.add_argument(
+        "--skip-eval", action="store_true",
+        help="Skip the fb eval step",
+    )
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    task_ids = _resolve_task_ids(args)
+    if not task_ids:
+        parser.error("Provide --task-id or --split")
+
+    if args.factory_only and args.baseline_only:
+        parser.error("Cannot use --factory-only and --baseline-only together")
+
+    results_dir = args.results_dir
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    factory_results = None
+    baseline_results = None
+
+    # --- Factory workflow ---
+    if not args.baseline_only:
+        factory_dir = results_dir / "factory"
+        factory_dir.mkdir(parents=True, exist_ok=True)
+        factory_entries = []
+
+        for tid in task_ids:
+            log.info("=== Factory: %s ===", tid)
+            try:
+                task_dir, initial_sha = setup_task(tid)
+                entry = run_factory(tid, task_dir, initial_sha, timeout=args.timeout)
+                factory_entries.append(entry)
+                log.info(
+                    "Task %s: success=%s, patch_size=%d bytes",
+                    tid, entry["success"], len(entry["model_patch"]),
+                )
+            except Exception:
+                log.exception("Failed to run factory on task %s", tid)
+                factory_entries.append({
+                    "instance_id": tid,
+                    "model_patch": "",
+                    "agent": "factory_workflow",
+                    "model": "factory-featurebench",
+                    "success": False,
+                })
+            finally:
+                # Clean up temp dirs
+                if "task_dir" in dir() and task_dir.exists():
+                    shutil.rmtree(task_dir.parent, ignore_errors=True)
+
+        output_jsonl = factory_dir / "output.jsonl"
+        with output_jsonl.open("w") as f:
+            for entry in factory_entries:
+                f.write(json.dumps(entry) + "\n")
+        log.info("Factory output written to %s", output_jsonl)
+
+        if not args.skip_eval:
+            factory_results = evaluate(factory_dir)
+        if factory_results is None:
+            factory_results = {"tasks": factory_entries}
+
+    # --- Baseline ---
+    if not args.factory_only:
+        log.info("=== Running baseline ===")
+        try:
+            baseline_dir = run_baseline(task_ids, model=args.model, results_dir=results_dir)
+            if not args.skip_eval:
+                baseline_results = evaluate(baseline_dir)
+        except Exception:
+            log.exception("Baseline run failed")
+
+    # --- Comparison ---
+    if factory_results and baseline_results:
+        report = compare(factory_results, baseline_results)
+        report_path = results_dir / "comparison_report.json"
+        report_path.write_text(json.dumps(report, indent=2) + "\n")
+        log.info("Comparison report written to %s", report_path)
+    elif factory_results:
+        log.info("Factory-only run complete. %d tasks processed.", len(task_ids))
+    elif baseline_results:
+        log.info("Baseline-only run complete. %d tasks processed.", len(task_ids))
+
+
+def _resolve_task_ids(args: argparse.Namespace) -> list[str]:
+    if args.task_ids:
+        return args.task_ids
+    if args.split:
+        return load_task_ids_from_split(args.split)
+    return []
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bench_featurebench.py
+++ b/tests/test_bench_featurebench.py
@@ -226,41 +226,20 @@ class TestSetupTask:
 
 
 class TestRunFactory:
+    @patch("bench.extract_patch", return_value="diff --git a/f.py b/f.py\n-old\n+new")
     @patch("subprocess.run")
-    def test_returns_entry_on_success(self, mock_run: MagicMock, tmp_path: Path) -> None:
+    def test_returns_entry_on_success(self, mock_run: MagicMock, mock_patch: MagicMock, tmp_path: Path) -> None:
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
         repo = tmp_path / "testbed"
         repo.mkdir()
-        (repo / "file.py").write_text("# code\n")
-        subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
-        subprocess.run(["git", "add", "-A"], cwd=repo, capture_output=True, check=True)
-        subprocess.run(
-            ["git", "-c", "user.email=t@t", "-c", "user.name=t",
-             "commit", "-m", "init"],
-            cwd=repo, capture_output=True, check=True,
-        )
-        initial = subprocess.run(
-            ["git", "rev-parse", "HEAD"], cwd=repo,
-            capture_output=True, text=True, check=True,
-        ).stdout.strip()
 
-        # Reset mock so it doesn't interfere with our real git setup
-        mock_run.reset_mock()
-
-        # Make factory workflow a no-op, but let git commands pass through
-        def side_effect(*args, **kwargs):
-            cmd = args[0] if args else kwargs.get("args", [])
-            if cmd and cmd[0] == "factory":
-                return subprocess.CompletedProcess(cmd, 0, "", "")
-            return subprocess.run.__wrapped__(*args, **kwargs)  # type: ignore[attr-defined]
-
-        # Use a simpler approach — just mock the factory call
-        with patch("subprocess.run") as m:
-            m.return_value = subprocess.CompletedProcess([], 0, "", "")
-            entry = bench.run_factory("task_x", repo, initial, timeout=60)
+        entry = bench.run_factory("task_x", repo, "a" * 40, timeout=60)
 
         assert entry["instance_id"] == "task_x"
         assert entry["agent"] == "factory_workflow"
-        assert isinstance(entry["model_patch"], str)
+        assert entry["model"] == "factory-featurebench"
+        assert entry["model_patch"] == "diff --git a/f.py b/f.py\n-old\n+new"
+        assert entry["success"] is True
 
     @patch("subprocess.run")
     def test_handles_timeout(self, mock_run: MagicMock) -> None:
@@ -277,6 +256,28 @@ class TestRunFactory:
 
         assert entry["success"] is False
         assert entry["instance_id"] == "task_timeout"
+
+
+class TestRunBaseline:
+    @patch("subprocess.run")
+    def test_constructs_correct_fb_command(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+
+        result = bench.run_baseline(
+            ["task_a", "task_b"],
+            model="claude-sonnet-4-20250514",
+            results_dir=tmp_path,
+        )
+
+        assert result == tmp_path / "baseline"
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:2] == ["fb", "infer"]
+        assert cmd[cmd.index("--agent") + 1] == "claude_code"
+        assert cmd[cmd.index("--model") + 1] == "claude-sonnet-4-20250514"
+        assert "--output-dir" in cmd
+        assert "task_a" in cmd
+        assert "task_b" in cmd
 
 
 class TestBuildParser:

--- a/tests/test_bench_featurebench.py
+++ b/tests/test_bench_featurebench.py
@@ -1,0 +1,368 @@
+"""Tests for benchmarks/featurebench-bench/bench.py.
+
+Uses mocks — does NOT require Docker, HuggingFace, or real FeatureBench.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add benchmarks dir to path so we can import bench
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "benchmarks" / "featurebench-bench"))
+
+import bench
+
+
+class TestLoadTaskIdsFromSplit:
+    def test_loads_from_jsonl(self, tmp_path: Path) -> None:
+        split_file = tmp_path / "val.jsonl"
+        split_file.write_text(
+            '{"instance_id": "task_a", "repo": "foo", "level": 1}\n'
+            '{"instance_id": "task_b", "repo": "bar", "level": 2}\n'
+        )
+        ids = bench.load_task_ids_from_split(split_file)
+        assert ids == ["task_a", "task_b"]
+
+    def test_skips_blank_lines(self, tmp_path: Path) -> None:
+        split_file = tmp_path / "test.jsonl"
+        split_file.write_text(
+            '{"instance_id": "x"}\n'
+            "\n"
+            '{"instance_id": "y"}\n'
+        )
+        ids = bench.load_task_ids_from_split(split_file)
+        assert ids == ["x", "y"]
+
+    def test_raises_on_missing_file(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            bench.load_task_ids_from_split("/nonexistent/path.jsonl")
+
+    def test_fallback_to_featurebench_splits_dir(self) -> None:
+        splits_dir = Path(__file__).parent.parent / "benchmarks" / "featurebench-splits"
+        if (splits_dir / "val.jsonl").exists():
+            ids = bench.load_task_ids_from_split("val.jsonl")
+            assert len(ids) > 0
+            assert all(isinstance(i, str) for i in ids)
+
+
+class TestExtractPatch:
+    def test_extracts_diff(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "file.py").write_text("# original\n")
+        subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+             "commit", "-m", "init"],
+            cwd=repo, capture_output=True, check=True,
+        )
+        initial = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        (repo / "file.py").write_text("# modified\n")
+        subprocess.run(["git", "add", "-A"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+             "commit", "-m", "change"],
+            cwd=repo, capture_output=True, check=True,
+        )
+
+        patch = bench.extract_patch(repo, initial)
+        assert "# original" in patch
+        assert "# modified" in patch
+        assert patch.startswith("diff --git")
+
+    def test_empty_patch_when_no_changes(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "file.py").write_text("# same\n")
+        subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+             "commit", "-m", "init"],
+            cwd=repo, capture_output=True, check=True,
+        )
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        patch = bench.extract_patch(repo, sha)
+        assert patch.strip() == ""
+
+
+class TestCompare:
+    def test_both_resolved(self) -> None:
+        factory = {"tasks": [
+            {"instance_id": "t1", "resolved": True, "score": 1.0},
+        ]}
+        baseline = {"tasks": [
+            {"instance_id": "t1", "resolved": True, "score": 0.8},
+        ]}
+        report = bench.compare(factory, baseline)
+        assert report["total_tasks"] == 1
+        assert report["factory_resolved"] == 1
+        assert report["baseline_resolved"] == 1
+        assert report["only_factory_solved"] == []
+        assert report["only_baseline_solved"] == []
+
+    def test_only_factory_solved(self) -> None:
+        factory = {"tasks": [
+            {"instance_id": "t1", "resolved": True, "score": 1.0},
+            {"instance_id": "t2", "resolved": False, "score": 0.0},
+        ]}
+        baseline = {"tasks": [
+            {"instance_id": "t1", "resolved": False, "score": 0.0},
+            {"instance_id": "t2", "resolved": False, "score": 0.0},
+        ]}
+        report = bench.compare(factory, baseline)
+        assert report["factory_resolved"] == 1
+        assert report["baseline_resolved"] == 0
+        assert report["only_factory_solved"] == ["t1"]
+
+    def test_disjoint_tasks(self) -> None:
+        factory = {"tasks": [{"instance_id": "f1", "resolved": True}]}
+        baseline = {"tasks": [{"instance_id": "b1", "resolved": True}]}
+        report = bench.compare(factory, baseline)
+        assert report["total_tasks"] == 2
+        assert set(report["only_factory_solved"]) == {"f1"}
+        assert set(report["only_baseline_solved"]) == {"b1"}
+
+    def test_empty_results(self) -> None:
+        report = bench.compare({"tasks": []}, {"tasks": []})
+        assert report["total_tasks"] == 0
+
+    def test_resolve_rate_calculation(self) -> None:
+        factory = {"tasks": [
+            {"instance_id": f"t{i}", "resolved": i < 3} for i in range(10)
+        ]}
+        baseline = {"tasks": [
+            {"instance_id": f"t{i}", "resolved": i < 5} for i in range(10)
+        ]}
+        report = bench.compare(factory, baseline)
+        assert report["factory_resolve_rate"] == pytest.approx(0.3)
+        assert report["baseline_resolve_rate"] == pytest.approx(0.5)
+
+    def test_uses_success_field_as_fallback(self) -> None:
+        factory = {"tasks": [
+            {"instance_id": "t1", "success": True},
+        ]}
+        baseline = {"tasks": [
+            {"instance_id": "t1", "success": False},
+        ]}
+        report = bench.compare(factory, baseline)
+        assert report["factory_resolved"] == 1
+        assert report["baseline_resolved"] == 0
+
+
+class TestIndexTasks:
+    def test_from_tasks_list(self) -> None:
+        result = bench._index_tasks({"tasks": [
+            {"instance_id": "a", "resolved": True},
+            {"instance_id": "b", "resolved": False},
+        ]})
+        assert set(result.keys()) == {"a", "b"}
+
+    def test_from_per_task_list(self) -> None:
+        result = bench._index_tasks({"per_task": [
+            {"instance_id": "x", "factory_resolved": True},
+        ]})
+        assert "x" in result
+
+    def test_empty_dict(self) -> None:
+        assert bench._index_tasks({}) == {}
+
+
+class TestSetupTask:
+    @patch("bench.load_task_metadata")
+    @patch("bench._docker_create", return_value="container123")
+    @patch("bench._docker_cp")
+    @patch("bench._docker_rm")
+    def test_setup_creates_git_repo(
+        self,
+        mock_rm: MagicMock,
+        mock_cp: MagicMock,
+        mock_create: MagicMock,
+        mock_meta: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_meta.return_value = {"docker_image": "test-image:latest", "instance_id": "t1"}
+
+        def fake_cp(container_id: str, src: str, dst: str) -> None:
+            dst_path = Path(dst)
+            if dst_path.suffix == ".md":
+                dst_path.write_text("# Problem\nDo something.")
+            else:
+                dst_path.mkdir(parents=True, exist_ok=True)
+                (dst_path / "setup.py").write_text("# setup\n")
+
+        mock_cp.side_effect = fake_cp
+
+        task_dir, sha = bench.setup_task("t1", work_dir=tmp_path)
+        assert task_dir.exists()
+        assert len(sha) == 40
+        assert (task_dir / ".git").is_dir()
+        mock_create.assert_called_once_with("test-image:latest")
+        mock_rm.assert_called_once_with("container123")
+
+    @patch("bench.load_task_metadata")
+    def test_raises_on_missing_docker_image(
+        self, mock_meta: MagicMock,
+    ) -> None:
+        mock_meta.return_value = {"instance_id": "t1"}
+        with pytest.raises(ValueError, match="No docker_image"):
+            bench.setup_task("t1")
+
+
+class TestRunFactory:
+    @patch("subprocess.run")
+    def test_returns_entry_on_success(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        repo = tmp_path / "testbed"
+        repo.mkdir()
+        (repo / "file.py").write_text("# code\n")
+        subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=repo, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+             "commit", "-m", "init"],
+            cwd=repo, capture_output=True, check=True,
+        )
+        initial = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        # Reset mock so it doesn't interfere with our real git setup
+        mock_run.reset_mock()
+
+        # Make factory workflow a no-op, but let git commands pass through
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if cmd and cmd[0] == "factory":
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            return subprocess.run.__wrapped__(*args, **kwargs)  # type: ignore[attr-defined]
+
+        # Use a simpler approach — just mock the factory call
+        with patch("subprocess.run") as m:
+            m.return_value = subprocess.CompletedProcess([], 0, "", "")
+            entry = bench.run_factory("task_x", repo, initial, timeout=60)
+
+        assert entry["instance_id"] == "task_x"
+        assert entry["agent"] == "factory_workflow"
+        assert isinstance(entry["model_patch"], str)
+
+    @patch("subprocess.run")
+    def test_handles_timeout(self, mock_run: MagicMock) -> None:
+        def side_effect(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if cmd and cmd[0] == "factory":
+                raise subprocess.TimeoutExpired(cmd=cmd, timeout=10)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        mock_run.side_effect = side_effect
+
+        with patch("bench.extract_patch", return_value=""):
+            entry = bench.run_factory("task_timeout", Path("/tmp/fake"), "abc123", timeout=10)
+
+        assert entry["success"] is False
+        assert entry["instance_id"] == "task_timeout"
+
+
+class TestBuildParser:
+    def test_defaults(self) -> None:
+        parser = bench.build_parser()
+        args = parser.parse_args(["--task-id", "abc"])
+        assert args.task_ids == ["abc"]
+        assert args.timeout == 1800
+        assert args.model == "claude-sonnet-4-20250514"
+        assert args.factory_only is False
+        assert args.baseline_only is False
+        assert args.skip_eval is False
+
+    def test_multiple_task_ids(self) -> None:
+        parser = bench.build_parser()
+        args = parser.parse_args(["--task-id", "a", "b", "c"])
+        assert args.task_ids == ["a", "b", "c"]
+
+    def test_split_flag(self) -> None:
+        parser = bench.build_parser()
+        args = parser.parse_args(["--split", "val.jsonl"])
+        assert args.split == "val.jsonl"
+
+    def test_factory_only_flag(self) -> None:
+        parser = bench.build_parser()
+        args = parser.parse_args(["--task-id", "x", "--factory-only"])
+        assert args.factory_only is True
+
+    def test_custom_results_dir(self) -> None:
+        parser = bench.build_parser()
+        args = parser.parse_args(["--task-id", "x", "--results-dir", "/tmp/out"])
+        assert args.results_dir == Path("/tmp/out")
+
+
+class TestResolveTaskIds:
+    def test_from_task_id_args(self) -> None:
+        args = argparse.Namespace(task_ids=["a", "b"], split=None)
+        assert bench._resolve_task_ids(args) == ["a", "b"]
+
+    def test_from_split(self, tmp_path: Path) -> None:
+        split_file = tmp_path / "s.jsonl"
+        split_file.write_text('{"instance_id": "z"}\n')
+        args = argparse.Namespace(task_ids=None, split=str(split_file))
+        assert bench._resolve_task_ids(args) == ["z"]
+
+    def test_empty_when_neither(self) -> None:
+        args = argparse.Namespace(task_ids=None, split=None)
+        assert bench._resolve_task_ids(args) == []
+
+
+class TestEvaluate:
+    def test_skips_when_no_output_jsonl(self, tmp_path: Path) -> None:
+        result = bench.evaluate(tmp_path)
+        assert result is None
+
+    @patch("subprocess.run")
+    def test_parses_eval_json_file(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        (tmp_path / "output.jsonl").write_text('{"instance_id": "t1"}\n')
+        eval_result = {"tasks": [{"instance_id": "t1", "resolved": True}]}
+        (tmp_path / "run-featurebench-full.json").write_text(json.dumps(eval_result))
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        result = bench.evaluate(tmp_path)
+        assert result is not None
+        assert result["tasks"][0]["resolved"] is True
+
+    @patch("subprocess.run")
+    def test_returns_none_on_eval_failure(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        (tmp_path / "output.jsonl").write_text('{"instance_id": "t1"}\n')
+        mock_run.return_value = subprocess.CompletedProcess([], 1, "", "eval error")
+        result = bench.evaluate(tmp_path)
+        assert result is None
+
+
+class TestGitInit:
+    def test_creates_repo_with_initial_commit(self, tmp_path: Path) -> None:
+        repo = tmp_path / "project"
+        repo.mkdir()
+        (repo / "main.py").write_text("print('hello')\n")
+
+        sha = bench._git_init(repo)
+        assert len(sha) == 40
+        assert (repo / ".git").is_dir()
+
+        log = subprocess.run(
+            ["git", "log", "--oneline"], cwd=repo,
+            capture_output=True, text=True, check=True,
+        )
+        assert "initial" in log.stdout


### PR DESCRIPTION
## Changes

- **`benchmarks/featurebench-bench/bench.py`** — Complete benchmarking script with 6 components:
  - `setup_task()` — Loads task metadata from HuggingFace, extracts repo from Docker image, initializes git
  - `run_factory()` — Runs `factory workflow run featurebench` with configurable timeout, extracts patch via git diff
  - `run_baseline()` — Runs `fb infer --agent claude_code` via standard FeatureBench harness
  - `evaluate()` — Runs `fb eval` and parses structured JSON results
  - `compare()` — Side-by-side report with per-task resolved/not-resolved, aggregate resolve rates
  - CLI with `--task-id`, `--split`, `--factory-only`, `--baseline-only`, `--timeout`, `--model`, `--results-dir`, `--skip-eval`

- **`benchmarks/featurebench-bench/README.md`** — Usage examples for all CLI modes

- **`tests/test_bench_featurebench.py`** — 31 tests covering all core logic (split loading, patch extraction, comparison, task setup, factory execution, CLI parsing, evaluation) using mocks — no Docker or real FeatureBench required