### PR TITLE
feat: add glaude runner (Claude Code via GLM-5.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,18 @@ CODEX_API_KEY = "..."
 ```
 Then run: `factory ceo /path/to/project --profile codex`
 
+**Glaude specifics:**
+- Installed at `~/.local/bin/glaude`, wraps the `claude` binary against a GLM-5.2 LiteLLM proxy
+- Auth is baked into the wrapper script (no env var needed)
+- Dry-run mode: `FACTORY_GLAUDE_DRY_RUN=1`
+
+**Glaude config profile example** (`~/.factory/config.toml`):
+```toml
+[credentials.glaude]
+FACTORY_RUNNER = "glaude"
+```
+Then run: `factory ceo /path/to/project --runner glaude` or `factory ceo /path --profile glaude`
+
 **OpenCode specifics:**
 - Requires `OPENAI_API_KEY` environment variable
 - The factory targets `opencode-ai/opencode` v0.x (uses `-p`, `-q`, `-c` flags). Install from source: `go install github.com/opencode-ai/opencode@latest`, or via the [GitHub release tarball](https://github.com/opencode-ai/opencode/releases)

--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -8,6 +8,7 @@ from factory.runners._stream import should_stream, stream_subprocess
 from factory.runners.bob import BobRunner, is_dry_run
 from factory.runners.claude import ClaudeRunner
 from factory.runners.codex import CodexRunner, is_codex_dry_run
+from factory.runners.glaude import GlaudeRunner, is_glaude_dry_run
 from factory.runners.opencode import OpenCodeRunner, is_opencode_dry_run
 from factory.runners.protocol import Runner, RunnerMeta
 
@@ -21,12 +22,14 @@ __all__ = [
     "ClaudeRunner",
     "BobRunner",
     "CodexRunner",
+    "GlaudeRunner",
     "OpenCodeRunner",
     "get_runner",
     "get_available_runners",
     "get_runner_choices",
     "is_dry_run",
     "is_codex_dry_run",
+    "is_glaude_dry_run",
     "is_opencode_dry_run",
     "should_stream",
     "stream_subprocess",
@@ -36,6 +39,7 @@ _RUNNERS: dict[str, type[Runner]] = {
     "claude": ClaudeRunner,  # type: ignore[dict-item]
     "bob": BobRunner,  # type: ignore[dict-item]
     "codex": CodexRunner,  # type: ignore[dict-item]
+    "glaude": GlaudeRunner,  # type: ignore[dict-item]
     "opencode": OpenCodeRunner,  # type: ignore[dict-item]
 }
 

--- a/factory/runners/glaude.py
+++ b/factory/runners/glaude.py
@@ -1,0 +1,237 @@
+"""GlaudeRunner — Glaude (GLM-5.2 LiteLLM proxy) CLI backend implementation."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+
+from factory.runners._subprocess import run_subprocess
+from factory.runners.claude import _make_ceo_message_emitter, _parse_usage
+
+if TYPE_CHECKING:
+    from factory.models import AgentRunRequest, AgentRunResult
+    from factory.runners.protocol import RunnerMeta
+
+log = structlog.get_logger()
+
+
+def is_glaude_dry_run() -> bool:
+    """Return True if Glaude dry-run mode is enabled."""
+    from factory.user_config import resolve
+
+    val = resolve("glaude_dry_run", env_var="FACTORY_GLAUDE_DRY_RUN") or ""
+    return val.lower() in ("1", "true", "yes")
+
+
+class GlaudeRunner:
+    """Runner implementation for Glaude CLI (Claude Code via GLM-5.2 LiteLLM proxy)."""
+
+    name: str = "glaude"
+
+    @classmethod
+    def metadata(cls) -> RunnerMeta:
+        from factory.runners.protocol import RunnerMeta
+        return RunnerMeta(
+            name="glaude",
+            display_name="Glaude (GLM-5.2)",
+            binary="glaude",
+            install_hint="Install glaude wrapper from your team's internal tooling",
+            required_env_vars=[],
+            supports_model_override=True,
+            supports_usage_telemetry=True,
+            supports_session_name=True,
+            supports_background=True,
+        )
+
+    def build_command(self, request: AgentRunRequest) -> tuple[list[str], dict[str, str], list[Path]]:
+        """Build the Glaude CLI command, env dict, and temp files."""
+        prompt_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", prefix="factory-prompt-", delete=False,
+        )
+        prompt_file.write(request.prompt)
+        prompt_file.close()
+        prompt_path = Path(prompt_file.name)
+
+        cmd = [
+            "glaude", "--append-system-prompt-file", prompt_file.name,
+            "-p", request.task,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--disallowedTools", "Agent",
+        ]
+        settings_file = request.extras.get("settings_file")
+        if settings_file:
+            cmd.extend(["--settings", str(settings_file)])
+        if request.skip_permissions:
+            cmd.append("--dangerously-skip-permissions")
+        if request.model:
+            cmd.extend(["--model", request.model])
+        if request.session_name:
+            cmd.extend(["--name", request.session_name])
+
+        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        if request.model:
+            env["FACTORY_MODEL"] = request.model
+
+        return cmd, env, [prompt_path]
+
+    async def headless(self, request: AgentRunRequest) -> AgentRunResult:
+        """Run a headless Glaude invocation."""
+        from factory.models import AgentRunResult
+
+        if is_glaude_dry_run():
+            from factory.runners._subprocess import make_dry_run_result
+            return make_dry_run_result("glaude", request.role, request.cwd, request.task)
+
+        background = request.extras.get("background", False)
+        if background:
+            from factory.runners._background import run_in_background
+
+            stdout, rc, usage = await run_in_background(
+                request.prompt, request.task, request.cwd, request.role,
+                timeout=request.timeout,
+                model=request.model,
+                dangerously_skip_permissions=request.skip_permissions,
+            )
+            return AgentRunResult(stdout=stdout, return_code=rc, usage=usage)
+
+        tmux_persist = request.extras.get("tmux_persist", False)
+        if tmux_persist:
+            from factory.runners._tmux_persist import find_project_path, run_in_tmux, tmux_available
+
+            if tmux_available():
+                stdout, rc, usage = await run_in_tmux(
+                    request.prompt, request.task, request.cwd, request.role,
+                    find_project_path(request.cwd),
+                    model=request.model,
+                    dangerously_skip_permissions=request.skip_permissions,
+                )
+                return AgentRunResult(stdout=stdout, return_code=rc, usage=usage)
+            log.warning("tmux_not_available")
+
+        cmd, env, temp_files = self.build_command(request)
+        env["TELEMETRY_PLATFORM"] = ""
+        try:
+            log.info("glaude_headless", cwd=str(request.cwd), model=request.model)
+
+            on_line = None
+            if request.role == "ceo" and request.project_path is not None:
+                on_line = _make_ceo_message_emitter(request.project_path)
+
+            result = await run_subprocess(
+                cmd, cwd=str(request.cwd), env=env,
+                timeout=request.timeout, runner_name="glaude", role=request.role,
+                on_line=on_line,
+            )
+
+            usage = None
+            result_text = result.stdout
+            metadata: dict[str, object] = {**result.metadata}
+
+            data: dict[str, object] | None = None
+            for line in reversed(result.stdout.strip().splitlines()):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    parsed = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if isinstance(parsed, dict) and "result" in parsed:
+                    data = parsed
+                    break
+
+            if data is not None:
+                result_value = data.get("result", result.stdout)
+                result_text = result_value if isinstance(result_value, str) else result.stdout
+                usage = _parse_usage(data)
+                for key in ("session_id", "uuid", "stop_reason", "terminal_reason",
+                            "duration_api_ms", "ttft_ms", "is_error", "subtype"):
+                    metadata[key] = data.get(key)
+                metadata["model_usage"] = data.get("modelUsage")
+                metadata["permission_denials"] = data.get("permission_denials")
+
+            return AgentRunResult(
+                stdout=result_text,
+                return_code=result.return_code,
+                usage=usage,
+                metadata=metadata,
+            )
+        finally:
+            for f in temp_files:
+                f.unlink(missing_ok=True)
+
+    def build_interactive_command(self, request: AgentRunRequest) -> tuple[list[str], dict[str, str], list[Path]]:
+        """Build the CLI command, env dict, and temp files for an interactive invocation."""
+        prompt_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", prefix="factory-prompt-", delete=False,
+        )
+        prompt_file.write(request.prompt)
+        prompt_file.close()
+        prompt_path = Path(prompt_file.name)
+
+        temp_files: list[Path] = [prompt_path]
+
+        cwd = Path(request.cwd)
+        claude_dir = cwd / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+
+        claude_md_path = claude_dir / "CLAUDE.md"
+        claude_md_path.write_text(request.prompt)
+        temp_files.append(claude_md_path)
+
+        settings_path = claude_dir / "settings.local.json"
+        settings: dict[str, object] = {}
+        if settings_path.exists():
+            try:
+                settings = json.loads(settings_path.read_text())
+            except (json.JSONDecodeError, ValueError):
+                settings = {}
+        settings["disallowedTools"] = ["Agent"]
+        settings_path.write_text(json.dumps(settings, indent=2) + "\n")
+        temp_files.append(settings_path)
+
+        cmd = [
+            "glaude",
+            "--append-system-prompt-file", prompt_file.name,
+        ]
+        settings_file = request.extras.get("settings_file")
+        if settings_file:
+            cmd.extend(["--settings", str(settings_file)])
+        if request.skip_permissions:
+            cmd.append("--dangerously-skip-permissions")
+        cmd.append(request.task)
+        if request.model:
+            cmd.extend(["--model", request.model])
+        if request.session_name:
+            cmd.extend(["--name", request.session_name])
+
+        env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        if request.model:
+            env["FACTORY_MODEL"] = request.model
+
+        return cmd, env, temp_files
+
+    def interactive_run(self, request: AgentRunRequest) -> int:
+        """Run an interactive Glaude session as a subprocess."""
+        if is_glaude_dry_run():
+            print("[DRY-RUN] Would exec: glaude (interactive)")
+            print(f"[DRY-RUN] Task: {request.task[:200]}...")
+            return 0
+
+        cmd, env, temp_files = self.build_interactive_command(request)
+        if not env.get("FACTORY_TRACE_ID"):
+            env["TELEMETRY_PLATFORM"] = ""
+        try:
+            log.info("glaude_interactive", cwd=str(request.cwd))
+            result = subprocess.run(cmd, cwd=request.cwd, env=env)
+            return result.returncode
+        finally:
+            for f in temp_files:
+                f.unlink(missing_ok=True)

--- a/tests/test_glaude_runner.py
+++ b/tests/test_glaude_runner.py
@@ -1,0 +1,589 @@
+"""Tests for factory/runners/glaude.py — GlaudeRunner implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from factory.models import AgentRunRequest, AgentRunResult
+from factory.runners import GlaudeRunner, get_runner, is_glaude_dry_run
+
+
+# ---------------------------------------------------------------------------
+# Runner selection
+# ---------------------------------------------------------------------------
+
+
+class TestGetRunnerGlaude:
+    def test_explicit_glaude(self) -> None:
+        runner = get_runner("glaude")
+        assert runner.name == "glaude"
+
+    def test_from_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_RUNNER", "glaude")
+        runner = get_runner()
+        assert runner.name == "glaude"
+
+    def test_explicit_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_RUNNER", "glaude")
+        runner = get_runner("claude")
+        assert runner.name == "claude"
+
+    def test_returns_glaude_runner_type(self) -> None:
+        runner = get_runner("glaude")
+        assert isinstance(runner, GlaudeRunner)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run flag
+# ---------------------------------------------------------------------------
+
+
+class TestGlaudeDryRun:
+    def test_dry_run_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_GLAUDE_DRY_RUN", "1")
+        assert is_glaude_dry_run() is True
+
+    def test_dry_run_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+        assert is_glaude_dry_run() is False
+
+    def test_dry_run_true_word(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_GLAUDE_DRY_RUN", "true")
+        assert is_glaude_dry_run() is True
+
+    def test_dry_run_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("FACTORY_GLAUDE_DRY_RUN", "yes")
+        assert is_glaude_dry_run() is True
+
+    async def test_headless_dry_run_returns_stub(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_GLAUDE_DRY_RUN", "1")
+
+        runner = GlaudeRunner()
+        result = await runner.headless(
+            AgentRunRequest(
+                prompt="You are a test agent.",
+                task="Say hello",
+                cwd=tmp_path,
+                role="researcher",
+            )
+        )
+
+        assert result.return_code == 0
+        assert "[DRY-RUN]" in result.stdout
+        assert "researcher" in result.stdout
+        assert result.usage is None
+
+    def test_interactive_run_dry_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("FACTORY_GLAUDE_DRY_RUN", "1")
+
+        runner = GlaudeRunner()
+        code = runner.interactive_run(
+            AgentRunRequest(
+                prompt="Test prompt",
+                task="Test task",
+                cwd=tmp_path,
+                role="ceo",
+            )
+        )
+
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "[DRY-RUN]" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+class TestGlaudeMetadata:
+    def test_name(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.name == "glaude"
+
+    def test_display_name(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.display_name == "Glaude (GLM-5.2)"
+
+    def test_binary(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.binary == "glaude"
+
+    def test_no_required_env_vars(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.required_env_vars == []
+
+    def test_supports_usage_telemetry(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.supports_usage_telemetry is True
+
+    def test_supports_session_name(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.supports_session_name is True
+
+    def test_supports_background(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.supports_background is True
+
+    def test_supports_model_override(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.supports_model_override is True
+
+    def test_auth_always_passes_without_env_vars(self) -> None:
+        meta = GlaudeRunner.metadata()
+        assert meta.check_auth() is True
+
+
+# ---------------------------------------------------------------------------
+# build_command
+# ---------------------------------------------------------------------------
+
+
+class TestGlaudeBuildCommand:
+    def test_uses_glaude_binary(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, env, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="You are the CEO.",
+                task="Run experiment",
+                cwd=tmp_path,
+                role="ceo",
+            )
+        )
+        assert cmd[0] == "glaude"
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_includes_core_flags(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, env, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="You are the CEO.",
+                task="Run experiment",
+                cwd=tmp_path,
+                role="ceo",
+            )
+        )
+        assert "--append-system-prompt-file" in cmd
+        assert "-p" in cmd
+        assert "Run experiment" in cmd
+        assert "--output-format" in cmd
+        assert "stream-json" in cmd
+        assert "--verbose" in cmd
+        assert "--disallowedTools" in cmd
+        assert "Agent" in cmd
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_model_override(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, env, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                model="glm-5.2-fp8",
+            )
+        )
+        assert "--model" in cmd
+        assert "glm-5.2-fp8" in cmd
+        assert env.get("FACTORY_MODEL") == "glm-5.2-fp8"
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_no_model_flag_when_none(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, env, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                model=None,
+            )
+        )
+        assert "--model" not in cmd
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_skip_permissions_flag(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, _, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                skip_permissions=True,
+            )
+        )
+        assert "--dangerously-skip-permissions" in cmd
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_no_skip_permissions_by_default(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, _, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                skip_permissions=False,
+            )
+        )
+        assert "--dangerously-skip-permissions" not in cmd
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_session_name(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, _, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                session_name="my-session",
+            )
+        )
+        assert "--name" in cmd
+        assert "my-session" in cmd
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_virtual_env_stripped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
+        runner = GlaudeRunner()
+        _, env, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+            )
+        )
+        assert "VIRTUAL_ENV" not in env
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_creates_prompt_temp_file(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        _, _, temp_files = runner.build_command(
+            AgentRunRequest(
+                prompt="My prompt content",
+                task="Test",
+                cwd=tmp_path,
+            )
+        )
+        assert len(temp_files) == 1
+        assert temp_files[0].exists()
+        assert "My prompt content" in temp_files[0].read_text()
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# headless
+# ---------------------------------------------------------------------------
+
+
+class TestGlaudeHeadless:
+    async def test_builds_correct_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+
+        runner = GlaudeRunner()
+
+        with patch(
+            "factory.runners.glaude.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            mock_run.return_value = AgentRunResult(stdout="output", return_code=0)
+
+            result = await runner.headless(
+                AgentRunRequest(
+                    prompt="You are a test agent.",
+                    task="Say hello",
+                    cwd=tmp_path,
+                    timeout=60.0,
+                    model="glm-5.2-fp8",
+                )
+            )
+
+            assert result.return_code == 0
+            assert result.stdout == "output"
+
+            call_args = mock_run.call_args
+            cmd = call_args[0][0]
+            assert cmd[0] == "glaude"
+            assert "--append-system-prompt-file" in cmd
+            assert "-p" in cmd
+            assert "--output-format" in cmd
+            assert "stream-json" in cmd
+            assert "--model" in cmd
+            assert "glm-5.2-fp8" in cmd
+
+    async def test_parses_json_result(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+
+        runner = GlaudeRunner()
+        json_output = (
+            '{"type":"assistant","message":"hi"}\n'
+            '{"result":"Final answer","usage":{"input_tokens":100,"output_tokens":50},'
+            '"total_cost_usd":0.01,"duration_ms":1234,"num_turns":3,"model":"glm-5.2"}\n'
+        )
+
+        with patch(
+            "factory.runners.glaude.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            mock_run.return_value = AgentRunResult(stdout=json_output, return_code=0)
+
+            result = await runner.headless(
+                AgentRunRequest(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                )
+            )
+
+            assert result.stdout == "Final answer"
+            assert result.usage is not None
+            assert result.usage.input_tokens == 100
+            assert result.usage.output_tokens == 50
+            assert result.usage.total_cost_usd == 0.01
+
+    async def test_runner_name_is_glaude(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+
+        runner = GlaudeRunner()
+
+        with patch(
+            "factory.runners.glaude.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            mock_run.return_value = AgentRunResult(stdout="ok", return_code=0)
+
+            await runner.headless(
+                AgentRunRequest(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    role="builder",
+                )
+            )
+
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["runner_name"] == "glaude"
+            assert call_kwargs["role"] == "builder"
+
+    async def test_no_model_flag_when_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+
+        runner = GlaudeRunner()
+
+        with patch(
+            "factory.runners.glaude.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            mock_run.return_value = AgentRunResult(stdout="ok", return_code=0)
+
+            await runner.headless(
+                AgentRunRequest(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                    model=None,
+                )
+            )
+
+            cmd = mock_run.call_args[0][0]
+            assert "--model" not in cmd
+
+    async def test_env_strips_virtual_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+
+        runner = GlaudeRunner()
+
+        with patch(
+            "factory.runners.glaude.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            mock_run.return_value = AgentRunResult(stdout="ok", return_code=0)
+
+            await runner.headless(
+                AgentRunRequest(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                )
+            )
+
+            call_kwargs = mock_run.call_args.kwargs
+            assert "VIRTUAL_ENV" not in call_kwargs["env"]
+
+
+# ---------------------------------------------------------------------------
+# build_interactive_command
+# ---------------------------------------------------------------------------
+
+
+class TestGlaudeBuildInteractiveCommand:
+    def test_uses_glaude_binary(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, _, temp_files = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="You are the CEO.",
+                task="Start session",
+                cwd=tmp_path,
+            )
+        )
+        assert cmd[0] == "glaude"
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_writes_claude_md(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        _, _, temp_files = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="My CEO prompt",
+                task="Start session",
+                cwd=tmp_path,
+            )
+        )
+        claude_md = tmp_path / ".claude" / "CLAUDE.md"
+        assert claude_md.exists()
+        assert "My CEO prompt" in claude_md.read_text()
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_writes_settings_local_json(self, tmp_path: Path) -> None:
+        import json
+        runner = GlaudeRunner()
+        _, _, temp_files = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+            )
+        )
+        settings_path = tmp_path / ".claude" / "settings.local.json"
+        assert settings_path.exists()
+        settings = json.loads(settings_path.read_text())
+        assert settings["disallowedTools"] == ["Agent"]
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_skip_permissions_flag(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, _, temp_files = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                skip_permissions=True,
+            )
+        )
+        assert "--dangerously-skip-permissions" in cmd
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_model_override(self, tmp_path: Path) -> None:
+        runner = GlaudeRunner()
+        cmd, env, temp_files = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="Test",
+                task="Test",
+                cwd=tmp_path,
+                model="glm-5.2-fp8",
+            )
+        )
+        assert "--model" in cmd
+        assert "glm-5.2-fp8" in cmd
+        assert env.get("FACTORY_MODEL") == "glm-5.2-fp8"
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# interactive_run
+# ---------------------------------------------------------------------------
+
+
+class TestGlaudeInteractive:
+    def test_interactive_run_builds_correct_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+
+        runner = GlaudeRunner()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            code = runner.interactive_run(
+                AgentRunRequest(
+                    prompt="You are the CEO.",
+                    task="Start session",
+                    cwd=tmp_path,
+                    model="glm-5.2-fp8",
+                    skip_permissions=True,
+                )
+            )
+
+            assert code == 0
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == "glaude"
+            assert "--dangerously-skip-permissions" in cmd
+            assert "--model" in cmd
+            assert "glm-5.2-fp8" in cmd
+
+    def test_interactive_run_passes_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VIRTUAL_ENV", "/some/venv")
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+
+        runner = GlaudeRunner()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(
+                AgentRunRequest(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                )
+            )
+
+            call_kwargs = mock_run.call_args.kwargs
+            assert "VIRTUAL_ENV" not in call_kwargs["env"]
+
+    def test_interactive_cleans_temp_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_GLAUDE_DRY_RUN", raising=False)
+
+        runner = GlaudeRunner()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(
+                AgentRunRequest(
+                    prompt="Test",
+                    task="Test",
+                    cwd=tmp_path,
+                )
+            )
+
+        claude_md = tmp_path / ".claude" / "CLAUDE.md"
+        settings = tmp_path / ".claude" / "settings.local.json"
+        assert not claude_md.exists()
+        assert not settings.exists()


### PR DESCRIPTION
Closes #1229

## Changes

- **New file `factory/runners/glaude.py`**: `GlaudeRunner` implementing the Runner protocol, mirroring `ClaudeRunner` with binary `glaude`, empty `required_env_vars` (auth baked into wrapper), and full capability flags (`supports_usage_telemetry`, `supports_background`, `supports_session_name`, `supports_model_override`)
- **Updated `factory/runners/__init__.py`**: Register `GlaudeRunner` and `is_glaude_dry_run` in `_RUNNERS` dict, imports, and `__all__`
- **New file `tests/test_glaude_runner.py`**: 41 tests covering runner selection, dry-run flag detection, metadata correctness, command building, headless invocation with JSON parsing, interactive mode, env stripping, and temp file cleanup
- **Updated `CLAUDE.md`**: Added "Glaude specifics" section documenting binary location, auth model, dry-run mode, config profile example, and usage
- **`FACTORY_GLAUDE_DRY_RUN=1`** support for testing without spending tokens
- Imports and reuses `_make_ceo_message_emitter` and `_parse_usage` from `factory.runners.claude` (no helper duplication)