### PR TITLE
fix: plugin modes rejected and pre-hooks crash on missing path

### DIFF
--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -233,7 +233,7 @@ def _validate_ceo_flags(
         if focus:
             print("Error: --refine and --focus are mutually exclusive.", file=sys.stderr)
             return 1
-        if not Path(raw_path).expanduser().resolve().is_dir():
+        if not raw_path or not Path(raw_path).expanduser().resolve().is_dir():
             print(
                 "Error: --refine requires an existing project directory, not a URL or idea.",
                 file=sys.stderr,

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -13,9 +13,9 @@ from pathlib import Path
 
 from factory.cli._ceo_dispatch import _start_ceo_tailer, _stop_ceo_tailer
 from factory.cli._helpers import (
-    CEO_MODES,
     _emit_cli_event,
     _ensure_dashboard,
+    get_all_ceo_modes,
     _print_banner,
     _read_target_branch,
     _resolve_runner,
@@ -151,7 +151,8 @@ def _validate_ceo_flags(
         mode = "design"
     if mode.startswith("project:"):
         mode = mode[len("project:"):]
-    if mode not in CEO_MODES and mode != "auto":
+    all_modes = get_all_ceo_modes()
+    if mode not in all_modes and mode != "auto":
         from factory.workflow.registry import WorkflowRegistry
         raw_path = getattr(args, "path", None)
         project_path = Path(raw_path).resolve() if raw_path else Path.cwd()
@@ -207,11 +208,15 @@ def _validate_ceo_flags(
 
     raw_path = getattr(args, "path", None)
     if not raw_path:
-        print(
-            "Error: provide a project path, GitHub URL, idea file, or prompt",
-            file=sys.stderr,
-        )
-        return 1
+        from factory.plugins import get_registry
+        plugin_registry = get_registry()
+        has_pre_hooks = bool(plugin_registry.ceo_pre_hooks)
+        if not has_pre_hooks:
+            print(
+                "Error: provide a project path, GitHub URL, idea file, or prompt",
+                file=sys.stderr,
+            )
+            return 1
 
     no_github = getattr(args, "no_github", False)
     if no_github:

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -40,7 +40,25 @@ def cmd_ceo(args: argparse.Namespace) -> int:
         return validated
     mode, headless, bg, bg_agents, prompt_file, focus, dir_name, refine_request, auto_approve, from_plan, just_plan = validated
 
-    assert raw_path is not None
+    from factory.plugins import get_registry
+
+    _log = structlog.get_logger()
+    registry = get_registry()
+    for hook in registry.ceo_pre_hooks:
+        try:
+            override = hook(mode, args)
+            if override is not None:
+                raw_path = str(override)
+                args.path = raw_path
+        except Exception as exc:
+            _log.warning("plugin_pre_hook_failed", error=str(exc))
+
+    if raw_path is None:
+        print(
+            "Error: no project path provided and no plugin pre-hook supplied one.",
+            file=sys.stderr,
+        )
+        return 1
 
     if mode == "review":
         return handle_review_mode(args, raw_path, headless)
@@ -98,18 +116,6 @@ def cmd_ceo(args: argparse.Namespace) -> int:
     )
     if err is not None:
         return err
-
-    from factory.plugins import get_registry
-
-    _log = structlog.get_logger()
-    registry = get_registry()
-    for hook in registry.ceo_pre_hooks:
-        try:
-            override = hook(mode, args)
-            if override is not None:
-                project_path = Path(override).resolve()
-        except Exception as exc:
-            _log.warning("plugin_pre_hook_failed", error=str(exc))
 
     if design_existing:
         banner_mode = "design"


### PR DESCRIPTION
## Summary

- **Bug 1**: `_validate_ceo_flags` checked `--mode` against the static `CEO_MODES` list instead of `get_all_ceo_modes()`, which includes plugin-registered modes. Plugin modes like `attack` or `buildroot` were rejected as "unknown mode" even though they were properly registered via `add_modes()`.

- **Bug 2**: `cmd_ceo` ran `assert raw_path is not None` (line 43) before invoking pre-hooks (line 106). Plugin modes that create their own work directory via `add_ceo_pre_hook` — the whole point of the pre-hook API — crashed on the assert because no positional path argument was provided. The pre-hook that would supply the path never got to run.

## Changes

- `_ceo_helpers.py`: Use `get_all_ceo_modes()` instead of `CEO_MODES` for mode validation. Defer the "no path provided" error when pre-hooks are registered (they may supply the path).
- `ceo.py`: Move pre-hook invocation before the path-is-None check. Replace the `assert` with a proper error message that only fires after hooks have had their chance to supply a path.

## Test plan

- [x] Verified plugin-registered modes pass validation (`get_all_ceo_modes()` includes them)
- [x] Verified pre-hooks can supply `raw_path` when none provided on CLI — flow reaches `_execute_ceo`
- [x] Verified no-path + no-hooks case still produces the original error message
- [x] Lint passes (`ruff check`)
- [x] Imports clean (`python -c "import factory.cli.ceo; import factory.cli._ceo_helpers"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)