### PR TITLE
fix: slow update writes to prompt slots, not just SKILL.md

### DIFF
--- a/factory/skillopt/trainer.py
+++ b/factory/skillopt/trainer.py
@@ -129,6 +129,10 @@ class SkillOptTrainer:
         (ckpt_dir / f"{label}_skill.md").write_text(self.current_skill)
         if self.best_skill:
             (ckpt_dir / f"{label}_best_skill.md").write_text(self.best_skill)
+        if self.prompt_slots:
+            (ckpt_dir / f"{label}_slots.json").write_text(
+                json.dumps(self.prompt_slots, indent=2)
+            )
         state = {
             "global_step": self.global_step,
             "current_score": self.current_score,
@@ -299,11 +303,24 @@ class SkillOptTrainer:
             total_steps=self.global_step,
         )
 
+    def _get_primary_prompt_slot(self) -> str | None:
+        """Return the name of the largest prompt slot (the main optimization target)."""
+        if not self.prompt_slots:
+            return None
+        return max(self.prompt_slots, key=lambda k: len(self.prompt_slots[k]))
+
     def _run_slow_update_epoch(self, epoch: int) -> None:
         if not self.use_slow_update:
             return
 
+        primary_slot = self._get_primary_prompt_slot()
+
         if epoch == 0:
+            if self.yaml_surface and primary_slot:
+                self.prompt_slots[primary_slot] = inject_empty_slow_update_field(
+                    self.prompt_slots[primary_slot],
+                )
+                self._write_yaml_annotations()
             self.current_skill = inject_empty_slow_update_field(self.current_skill)
             self._save_skill(self.current_skill)
             log.info("slow update placeholder injected", epoch=epoch + 1)
@@ -316,6 +333,11 @@ class SkillOptTrainer:
             return
         prev_skill = prev_ckpt.read_text()
 
+        prev_slots_path = self.out_dir / "checkpoints" / f"{prev_label}_slots.json"
+        prev_slots: dict[str, str] | None = None
+        if prev_slots_path.exists():
+            prev_slots = json.loads(prev_slots_path.read_text())
+
         env = self.adapter.build_train_env(self.slow_update_samples, seed=1000 + epoch)
 
         slow_dir = self.out_dir / "slow_update" / f"epoch{epoch + 1}"
@@ -326,13 +348,22 @@ class SkillOptTrainer:
             log.info("slow update: resuming from cached result", epoch=epoch + 1)
             return
 
-        results_prev = self.adapter.rollout(env, prev_skill, str(slow_dir / "rollout_prev"))
-        results_curr = self.adapter.rollout(env, self.current_skill, str(slow_dir / "rollout_curr"))
+        rollout_content = self._serialize_yaml() if self.yaml_surface else self.current_skill
+        if self.yaml_surface and prev_slots:
+            prev_rollout = self._serialize_yaml(prev_slots)
+        else:
+            prev_rollout = prev_skill
+        results_prev = self.adapter.rollout(env, prev_rollout, str(slow_dir / "rollout_prev"))
+        results_curr = self.adapter.rollout(env, rollout_content, str(slow_dir / "rollout_curr"))
 
         prev_hard, _ = self._compute_score(results_prev)
         curr_hard, _ = self._compute_score(results_curr)
 
-        prev_guidance = extract_slow_update_field(self.current_skill)
+        prev_guidance = ""
+        if self.yaml_surface and primary_slot:
+            prev_guidance = extract_slow_update_field(self.prompt_slots[primary_slot])
+        else:
+            prev_guidance = extract_slow_update_field(self.current_skill)
 
         slow_result = run_slow_update(
             skill_content=self.current_skill,
@@ -343,9 +374,13 @@ class SkillOptTrainer:
         )
 
         if slow_result and slow_result.get("slow_update_content"):
-            self.current_skill = replace_slow_update_field(
-                self.current_skill, slow_result["slow_update_content"],
-            )
+            guidance = slow_result["slow_update_content"]
+            if self.yaml_surface and primary_slot:
+                self.prompt_slots[primary_slot] = replace_slow_update_field(
+                    self.prompt_slots[primary_slot], guidance,
+                )
+                self._write_yaml_annotations()
+            self.current_skill = replace_slow_update_field(self.current_skill, guidance)
             self._save_skill(self.current_skill)
             slow_result["prev_hard"] = round(prev_hard, 4)
             slow_result["curr_hard"] = round(curr_hard, 4)
@@ -353,7 +388,7 @@ class SkillOptTrainer:
             log.info(
                 "slow update applied",
                 epoch=epoch + 1,
-                guidance_len=len(slow_result["slow_update_content"]),
+                guidance_len=len(guidance),
                 prev_hard=round(prev_hard, 4),
                 curr_hard=round(curr_hard, 4),
             )

--- a/tests/test_skillopt_integration.py
+++ b/tests/test_skillopt_integration.py
@@ -1103,3 +1103,197 @@ class TestMainEntryPoint:
                 main()
                 call_kwargs = mock_trainer.call_args[1]
                 assert call_kwargs["use_slow_update"] is True
+
+
+class TestSlowUpdateWithSlots:
+    def test_slow_update_injects_into_prompt_slot(self, tmp_path):
+        """Verify epoch 0 injects placeholder into the prompt slot, not just SKILL.md."""
+        import yaml
+
+        skill_path = tmp_path / "SKILL.md"
+        skill_path.write_text("# Skill\nContent")
+        ann_path = tmp_path / "SKILL.annotations.yaml"
+        ann = {"b": {"slots": {"task_prompt_b": "original prompt text"}}}
+        ann_path.write_text(yaml.dump(ann))
+
+        adapter = MagicMock()
+        trainer = SkillOptTrainer(
+            adapter=adapter, skill_path=str(skill_path),
+            out_dir=str(tmp_path / "out"), epochs=1, steps_per_epoch=1,
+            batch_size=2, learning_rate=3, use_slow_update=True,
+        )
+
+        results = [RolloutResult(id="e1", hard=0.5, soft=0.5)]
+        adapter.rollout.side_effect = [results, results]
+        adapter.reflect.return_value = []
+
+        trainer.train()
+
+        # Verify placeholder is in the prompt slot
+        assert "SLOW_UPDATE_START" in trainer.prompt_slots["task_prompt_b"]
+        # Verify it was written to YAML
+        reloaded = yaml.safe_load(ann_path.read_text())
+        assert "SLOW_UPDATE_START" in reloaded["b"]["slots"]["task_prompt_b"]
+
+    def test_slow_update_guidance_in_prompt_slot(self, tmp_path):
+        """Verify epoch 2 writes guidance into the prompt slot."""
+        import yaml
+
+        skill_path = tmp_path / "SKILL.md"
+        skill_path.write_text("# Skill\n<!-- SLOW_UPDATE_START -->\n<!-- SLOW_UPDATE_END -->")
+        ann_path = tmp_path / "SKILL.annotations.yaml"
+        prompt_with_markers = "prompt\n\n<!-- SLOW_UPDATE_START -->\n<!-- SLOW_UPDATE_END -->"
+        ann = {"b": {"slots": {"task_prompt_b": prompt_with_markers}}}
+        ann_path.write_text(yaml.dump(ann))
+
+        adapter = MagicMock()
+        trainer = SkillOptTrainer(
+            adapter=adapter, skill_path=str(skill_path),
+            out_dir=str(tmp_path / "out"), epochs=2, steps_per_epoch=1,
+            batch_size=2, learning_rate=3, use_slow_update=True,
+        )
+
+        results = [RolloutResult(id="e1", hard=0.5, soft=0.5)]
+        adapter.rollout.side_effect = [results] * 10
+        adapter.reflect.return_value = []
+
+        # Mock run_slow_update to return guidance
+        with patch("factory.skillopt.trainer.run_slow_update") as mock_slow:
+            mock_slow.return_value = {
+                "slow_update_content": "Focus on test-first debugging.",
+                "reasoning": "Tests help.",
+            }
+            trainer.train()
+
+        # Verify guidance is in the prompt slot
+        assert "Focus on test-first debugging" in trainer.prompt_slots["task_prompt_b"]
+        # Verify YAML was updated
+        reloaded = yaml.safe_load(ann_path.read_text())
+        assert "Focus on test-first debugging" in reloaded["b"]["slots"]["task_prompt_b"]
+
+
+class TestSlowUpdateNoYaml:
+    def test_slow_update_without_yaml_surface(self, tmp_path):
+        """Verify slow update works without YAML surface (legacy SKILL.md mode)."""
+        skill_path = tmp_path / "SKILL.md"
+        skill_path.write_text("# Skill\nContent here")
+        # No annotations file — trainer uses legacy mode
+
+        adapter = MagicMock()
+        trainer = SkillOptTrainer(
+            adapter=adapter, skill_path=str(skill_path),
+            out_dir=str(tmp_path / "out"), epochs=2, steps_per_epoch=1,
+            batch_size=2, learning_rate=3, use_slow_update=True,
+        )
+        assert trainer.yaml_surface is None
+
+        results = [RolloutResult(id="e1", hard=0.5, soft=0.5)]
+        adapter.rollout.side_effect = [results] * 10
+        adapter.reflect.return_value = []
+
+        with patch("factory.skillopt.trainer.run_slow_update") as mock_slow:
+            mock_slow.return_value = {
+                "slow_update_content": "Use test-first approach.",
+                "reasoning": "Tests help.",
+            }
+            trainer.train()
+
+        # Verify slow update applied to current_skill
+        assert "SLOW_UPDATE_START" in trainer.current_skill
+
+    def test_get_primary_prompt_slot_empty(self, tmp_path):
+        skill_path = tmp_path / "SKILL.md"
+        skill_path.write_text("# Skill")
+
+        adapter = MagicMock()
+        trainer = SkillOptTrainer(
+            adapter=adapter, skill_path=str(skill_path),
+            out_dir=str(tmp_path / "out"),
+        )
+        assert trainer._get_primary_prompt_slot() is None
+
+    def test_get_primary_prompt_slot_picks_largest(self, tmp_path):
+        import yaml
+        skill_path = tmp_path / "SKILL.md"
+        skill_path.write_text("# Skill")
+        ann_path = tmp_path / "SKILL.annotations.yaml"
+        ann = {"a": {"slots": {"system_prompt_a": "short"}},
+               "b": {"slots": {"instance_prompt_b": "this is a much longer prompt text"}}}
+        ann_path.write_text(yaml.dump(ann))
+
+        adapter = MagicMock()
+        trainer = SkillOptTrainer(
+            adapter=adapter, skill_path=str(skill_path),
+            out_dir=str(tmp_path / "out"),
+        )
+        assert trainer._get_primary_prompt_slot() == "instance_prompt_b"
+
+
+class TestSlowUpdatePrevVsCurr:
+    def test_prev_rollout_uses_previous_slots(self, tmp_path):
+        """Verify prev rollout uses the checkpointed slots, not current ones."""
+        import yaml
+
+        skill_path = tmp_path / "SKILL.md"
+        skill_path.write_text("# Skill\n<!-- SLOW_UPDATE_START -->\n<!-- SLOW_UPDATE_END -->")
+        ann_path = tmp_path / "SKILL.annotations.yaml"
+        prompt = "prompt\n\n<!-- SLOW_UPDATE_START -->\n<!-- SLOW_UPDATE_END -->"
+        ann = {"b": {"slots": {"task_prompt_b": prompt}}}
+        ann_path.write_text(yaml.dump(ann))
+
+        adapter = MagicMock()
+        trainer = SkillOptTrainer(
+            adapter=adapter, skill_path=str(skill_path),
+            out_dir=str(tmp_path / "out"), epochs=2, steps_per_epoch=1,
+            batch_size=2, learning_rate=3, use_slow_update=True,
+        )
+
+        results = [RolloutResult(id="e1", hard=0.5, soft=0.5)]
+        adapter.rollout.side_effect = [results] * 10
+        adapter.reflect.return_value = []
+
+        # Modify prompt_slots between epochs to simulate optimization
+
+        def patched_train():
+            # Run epoch 1
+            trainer.rejected_edits = []
+            trainer.prompt_slots["task_prompt_b"] = "epoch1 prompt\n\n<!-- SLOW_UPDATE_START -->\n<!-- SLOW_UPDATE_END -->"
+            trainer._checkpoint("epoch1_step1")
+
+            # Now manually trigger epoch 2 slow update
+            trainer.prompt_slots["task_prompt_b"] = "epoch2 improved prompt\n\n<!-- SLOW_UPDATE_START -->\n<!-- SLOW_UPDATE_END -->"
+
+            with patch("factory.skillopt.trainer.run_slow_update", return_value=None):
+                trainer._run_slow_update_epoch(1)  # epoch index 1 = epoch 2
+
+            # Check what rollout received for prev vs curr
+            if adapter.rollout.call_count >= 2:
+                prev_yaml = adapter.rollout.call_args_list[-2][0][1]
+                curr_yaml = adapter.rollout.call_args_list[-1][0][1]
+                prev_parsed = yaml.safe_load(prev_yaml)
+                curr_parsed = yaml.safe_load(curr_yaml)
+                assert "epoch1" in prev_parsed["b"]["slots"]["task_prompt_b"]
+                assert "epoch2" in curr_parsed["b"]["slots"]["task_prompt_b"]
+
+        patched_train()
+
+    def test_checkpoint_saves_slots(self, tmp_path):
+        import yaml
+
+        skill_path = tmp_path / "SKILL.md"
+        skill_path.write_text("# Skill")
+        ann_path = tmp_path / "SKILL.annotations.yaml"
+        ann = {"b": {"slots": {"task_prompt_b": "prompt"}}}
+        ann_path.write_text(yaml.dump(ann))
+
+        adapter = MagicMock()
+        trainer = SkillOptTrainer(
+            adapter=adapter, skill_path=str(skill_path),
+            out_dir=str(tmp_path / "out"),
+        )
+
+        trainer._checkpoint("test_label")
+        slots_path = tmp_path / "out" / "checkpoints" / "test_label_slots.json"
+        assert slots_path.exists()
+        saved = json.loads(slots_path.read_text())
+        assert saved["task_prompt_b"] == "prompt"


### PR DESCRIPTION
## Summary

The slow update mechanism was injecting guidance into `self.current_skill` (rendered SKILL.md text) but never into the YAML annotation prompt slots. Since the adapter serializes YAML for Harbor via `FACTORY_WORKFLOW_YAML_B64`, the guidance never reached the agent inside the container.

## Changes

- `_run_slow_update_epoch` now injects slow update markers and guidance into `self.prompt_slots[primary_slot]` (the largest prompt slot)
- Writes YAML annotations after each slow update (`_write_yaml_annotations()`)
- Uses `_serialize_yaml()` for rollout content so the comparison runs use the correct mechanism
- Adds `_get_primary_prompt_slot()` helper to find the main optimization target

## Test plan

- [x] `TestSlowUpdateWithSlots::test_slow_update_injects_into_prompt_slot` — verifies epoch 0 placeholder in slot + YAML
- [x] `TestSlowUpdateWithSlots::test_slow_update_guidance_in_prompt_slot` — verifies epoch 2 guidance in slot + YAML

Closes #1240

🤖 Generated with [Claude Code](https://claude.com/claude-code)