### PR TITLE
feat: replace workflow execution with LangGraph

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,15 +40,16 @@ mypy factory/                    # Type check
 
 ## Architecture
 
-The factory is a three-layer system:
+The factory is a four-layer system:
 
 1. **Python CLI** (`factory/cli/`): Pure tools that don't make decisions. Entry point is `factory/cli/_main.py`.
-2. **CEO Agent** (`factory/agents/prompts/ceo.md`): Orchestrates the full workflow. Spawned via `factory ceo /path`.
-3. **Specialist Agents** (`factory/agents/`): Eight subprocesses spawned by the CEO via `factory agent <role>`.
+2. **LangGraph Runtime** (`factory/workflow/`): Compiles the Factory DSL, persists SQLite checkpoints, and owns routing, fanout/fanin, loops, interrupts, and resume.
+3. **CEO Agent** (`factory/agents/prompts/ceo.md`): Interactive client and gate evaluator for the graph. Spawned via `factory ceo /path`.
+4. **Specialist Agents** (`factory/agents/`): Eight subprocesses invoked by workflow nodes via `factory agent <role>`.
 
 Agent roles: Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Distiller, Failure Analyst, CEO.
 
-Key modules: `factory/adversarial.py` (GAN-style adversarial eval loops — phase transitions with hysteresis, convergence detection, state at `.factory/adversarial_state.json`).
+Key modules: `factory/workflow/langgraph.py` (DSL compiler and state), `factory/workflow/executor.py` (domain operations and persistence), and `factory/adversarial.py` (GAN-style adversarial evaluation).
 
 ## MCP Server
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,21 +61,19 @@ Pure tools that don't make decisions. Entry point is `factory/cli.py` → `facto
 
 All 10 factory modes (build, design, improve, research, meta, discover, review, refine, founder, plan) are defined as directed graphs of typed nodes in `factory/workflow/definitions.py`. Each graph is a `Workflow` Pydantic model with `AgentNode`, `FnNode`, `GateNode`, `ForkNode`, `JoinNode`, and `Study` primitives connected by `Edge` objects. See `factory/workflow/README.md` for full documentation.
 
-The same graph definition produces two execution formats:
-- **Headless:** `WorkflowExecutor` (`factory/workflow/executor.py`) walks the DAG deterministically — `factory workflow run <name> --project /path`
-- **Interactive:** `skill_export.py` converts graphs to Claude Code `SKILL.md` files under `skills/workflow-*/` — the CEO agent reads these at runtime as mode-specific playbooks
+The Factory DSL compiles directly to persisted LangGraph threads for headless and
+interactive execution: `factory workflow run <name> /path`. `skill_export.py` remains
+an optional documentation/legacy renderer for explicit `--engine skill` runs.
 
-### Layer 3: CEO Agent (`factory/agents/prompts/ceo.md` + `skills/workflow-*/SKILL.md`)
+### Layer 3: CEO Agent (`factory/agents/prompts/ceo.md`)
 
-The CEO prompt is split into two parts:
-- **`ceo.md` (501 lines)** — core identity, cross-cutting rules (Sacred Rules, FEEC, keep/revert framework, review gates, error recovery, self-learning). No mode-specific procedures.
-- **`skills/workflow-*/SKILL.md` (8 files)** — each mode's full step-by-step playbook, auto-generated from the workflow graph definitions via `factory workflow export-skills`.
-
-Spawned via `factory ceo /path` or `factory run /path`. The CEO receives `ceo.md` as its system prompt, detects project state, then reads the appropriate `SKILL.md` into its context and follows it as the mode-specific playbook.
+The CEO is the interactive client and gate evaluator for a persisted graph thread. It
+receives `ceo.md` plus the current task/interrupt protocol and advances the thread through
+`factory workflow tool` commands. Generated `SKILL.md` files are an explicit legacy fallback.
 
 ### Layer 4: Specialist Agents (`factory/agents/`)
 
-Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent <role>`. Agent prompts are resolved via `factory/agents/runner.py` with a two-tier lookup: project-specific override (`.factory/agents/<role>.md`) then factory default (`factory/agents/prompts/<role>.md`). Evolved playbooks from `~/.factory/playbooks/<role>.md` (user-local, ACE-generated) are auto-injected, falling back to factory defaults in `factory/agents/playbooks/<role>.md`.
+Eight specialist Claude Code subprocesses invoked by workflow nodes via `factory agent <role>`. Agent prompts are resolved via `factory/agents/runner.py` with a two-tier lookup: project-specific override (`.factory/agents/<role>.md`) then factory default (`factory/agents/prompts/<role>.md`). Evolved playbooks from `~/.factory/playbooks/<role>.md` (user-local, ACE-generated) are auto-injected, falling back to factory defaults in `factory/agents/playbooks/<role>.md`.
 
 **Roles:** Researcher (observe), Strategist (hypothesize and refine ideas), Builder (implement), QA (health check + code review + adversarial QA), Archivist (record), Refiner (scope refinements), Failure Analyst (research mode), CEO (orchestrate).
 
@@ -88,7 +86,7 @@ Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent 
 5. **Store** (`factory/store.py`): `ExperimentStore` manages the `.factory/` directory — config, TSV history, per-experiment dirs with hypothesis/eval/diff/verdict artifacts. Auto-registers projects in the global registry on `begin()` and updates stats on `finalize()`
 6. **Registry** (`factory/registry.py`): Global project registry at `~/.factory/registry.json` — self-registration pattern, project discovery for ACE/insights without `--projects-dir`
 7. **Report** (`factory/report.py`): Performance report generation — consolidates experiment records, CEO verdicts, and observations into `.factory/performance_report.json` for ACE consumption
-8. **Checkpoint** (`factory/checkpoint.py`): Saves and loads CEO state for crash-resilient resume
+8. **Workflow runtime** (`factory/workflow/`): Persists LangGraph checkpoints, exact workflow snapshots, and operation receipts; `factory/checkpoint.py` is legacy CEO state
 9. **Analysis** (`factory/analysis.py`): Experiment comparison (`diff`) and FEEC analysis (`explain`)
 10. **Adversarial** (`factory/adversarial.py`): GAN-style adversarial eval loop state machine — phase transitions with hysteresis, per-role streak counters, convergence detection. State persisted at `.factory/adversarial_state.json`
 11. **Contained** (`factory/contained/` + `factory/podman.py` + `factory/cli/contained.py`): `factory contained [runtime flags] -- <any factory command>` runs the factory in a podman container (`--target local`) or a cluster pod (`--target k8s`). See "Contained runtimes" below.
@@ -108,6 +106,7 @@ Eight specialist Claude Code subprocesses spawned by the CEO via `factory agent 
 │   ├── <role>-latest.md      # Auto-saved stdout from each agent invocation
 │   └── ceo-verdict-<role>.md # CEO's review verdict (PROCEED/REDIRECT/ABORT)
 ├── adversarial_state.json    # Adversarial loop state (phase, streaks, history)
+├── langgraph/                # SQLite checkpoints, exact thread snapshots, receipts
 ├── archive/                  # Long-term knowledge store (Archivist notes)
 │   ├── experiments/          # Per-experiment learnings and decision rationale
 │   ├── patterns/             # Recurring patterns and anti-patterns

--- a/devlogs.md
+++ b/devlogs.md
@@ -1,0 +1,28 @@
+# Development Log
+
+## 2026-08-14 — LangGraph workflow runtime
+
+### Completed
+
+- Replaced recursive workflow traversal with a direct Factory DSL → LangGraph compiler.
+- Added SQLite checkpoints, exact workflow thread snapshots, interrupts/resume, and operation receipts.
+- Preserved native fork/join, gate routing, reloops, HALT cleanup, and SubgraphFork worktree isolation.
+- Rebuilt `workflow tool` as a thin interactive client over graph checkpoints; removed cursor/cache state.
+- Made LangGraph the default for `factory ceo`, `factory run`, and tmux. Kept `--engine skill` as the explicit legacy fallback.
+- Added scalar and interrupt-ID-map resume CLI contracts and preserved incomplete worktrees for recovery.
+- Updated architecture, workflow, contributor, benchmark, agent, and CLI documentation.
+
+### Decisions and gotchas
+
+- `blocking=False` remains DSL metadata for legacy rendering; LangGraph executes every node durably.
+- Checkpoints live at `.factory/langgraph/checkpoints.sqlite`; manifests and receipts live below the same directory.
+- A `started` receipt without completion blocks automatic retry because the external side effect is ambiguous.
+- Interrupted and failed graph worktrees are retained; completed and terminal worktrees follow normal cleanup.
+- Subgraph branches use separate SQLite files to avoid concurrent writer contention.
+
+### Verification
+
+- `ruff check factory ...`: passed.
+- `mypy factory/`: passed across 228 source files.
+- Hermetic suite: 5,259 passed, 12 skipped, 25 deselected.
+- Unfiltered suite also exposed existing environment-only cases: LegacyBench expects GNU `timeout` on macOS, and marked slow runner tests make real authenticated agent calls.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-re:factory is a three-layer system with strict separation between tooling, orchestration, and execution.
+re:factory is a four-layer system with strict separation between tooling, graph scheduling, orchestration, and execution.
 
-## Three Layers
+## Four Layers
 
 ### Layer 1: Python CLI (`factory/`)
 
@@ -10,19 +10,27 @@ Pure tools that don't make decisions. The CLI provides measurement, storage, and
 
 Entry point: `factory/cli.py` → `factory.cli:main` (registered as `factory` in pyproject.toml). Each subcommand is a `cmd_*` function dispatched via a handler dict.
 
-### Layer 2: CEO Agent
+### Layer 2: LangGraph Runtime (`factory/workflow/`)
 
-A dedicated Claude Code agent that owns the full workflow. Spawned via `factory ceo <path>` or `factory run <path>`. The CEO:
+The typed Factory workflow DSL compiles directly to LangGraph. The runtime owns:
 
-- Detects project state and routes to the appropriate mode
-- Spawns specialist agents as subprocesses
-- Makes keep/revert decisions based on eval scores
-- Ensures mandatory archival after every cycle
-- Reads event log and `.factory/` state directly for crash-resilient resume
+- Node scheduling, conditional routing, fanout/fanin, and reloop transitions
+- SQLite checkpoints and process-independent thread resume
+- Human approval interrupts and parallel interrupt IDs
+- Durable operation receipts at external side-effect boundaries
+
+Compiler: `factory/workflow/langgraph.py`. Domain operations and persistence facade:
+`factory/workflow/executor.py`.
+
+### Layer 3: CEO Agent
+
+A dedicated agent used as the interactive graph client and gate evaluator. Spawned via
+`factory ceo <path>`, it reads the current graph task and advances the persisted thread
+through `factory workflow tool` commands. Headless execution runs the same graph directly.
 
 Prompt: `factory/agents/prompts/ceo.md`
 
-### Layer 3: Specialist Agents
+### Layer 4: Specialist Agents
 
 Nine specialist Claude Code subprocesses, each with a narrow responsibility:
 
@@ -210,6 +218,9 @@ Stuck detection activates after 3+ consecutive same-category reverts, forcing ca
 | `factory/report.py` | Performance report generation and loading |
 | `factory/adversarial.py` | GAN-style adversarial eval loop state machine |
 | `factory/agents/runner.py` | Agent subprocess spawner + event emission |
+| `factory/workflow/langgraph.py` | Factory DSL to LangGraph compiler + state |
+| `factory/workflow/executor.py` | Domain operations, SQLite persistence, resume facade |
+| `factory/workflow/tool.py` | Thin interactive adapters over graph threads |
 
 ## `.factory/` Directory
 
@@ -238,6 +249,7 @@ Generated at runtime — not checked into version control:
 │   ├── <role>-latest.md
 │   └── ceo-verdict-<role>.md
 ├── adversarial_state.json   # Adversarial loop state (phase, streaks, history)
+├── langgraph/               # Checkpoints, thread snapshots, operation receipts
 ├── archive/                 # Archivist notes (institutional memory)
 │   ├── experiments/         # Per-experiment notes
 │   ├── strategies/          # Strategy snapshots

--- a/docs/coding-playbook.md
+++ b/docs/coding-playbook.md
@@ -1,16 +1,18 @@
 # Coding Playbook — Factory Development Guide
 
-## Workflow-to-Skill Compilation Pipeline
+## Workflow Compilation Pipeline
 
-All factory modes are defined as directed graphs (Pydantic models) that compile into two execution formats. The pipeline has three layers:
+All factory modes are defined as directed graphs (Pydantic models). LangGraph is the runtime;
+skill export remains an optional documentation/legacy format:
 
 ```
 factory/workflow/definitions.py       ← Source of truth (Pydantic graph models)
        │
-       ├──► factory/workflow/executor.py    (headless: walks the DAG)
-       │       factory workflow run <name> --project /path
+       ├──► factory/workflow/langgraph.py   (DSL → StateGraph)
+       │       factory/workflow/executor.py    (domain operations + persistence)
+       │       factory workflow run <name> /path
        │
-       └──► factory/workflow/skill_export.py  (interactive: graph → SKILL.md)
+       └──► factory/workflow/skill_export.py  (optional: graph → SKILL.md)
                WORKFLOW_META dict + compiler
                └── skills/workflow-*/SKILL.md  (generated output)
 ```

--- a/docs/contributing-benchmarks.md
+++ b/docs/contributing-benchmarks.md
@@ -181,7 +181,7 @@ __all__ = ["meta", "workflow"]
 Include a brief description of what the benchmark tests, an ASCII graph diagram showing the node pipeline, and a CLI usage example:
 
 ```bash
-factory workflow run <name> --project /path/to/repo
+factory workflow run <name> /path/to/repo
 ```
 
 See `factory/workflow/contributed/legacybench/README.md` for the expected format.

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ graph LR
     style G fill:#e53935,color:#fff,stroke:#c62828
 ```
 
-A CEO agent orchestrates eight specialists — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst — each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. The Researcher searches the web and reads prior knowledge from the archive. The Strategist generates ranked hypotheses and handles design-mode ideation. The Builder implements one on an experiment branch. The Evaluator scores before and after. The CEO decides keep or revert. The Archivist records everything to `.factory/archive/` and regenerates performance reports for cross-project learning. In design mode, the Strategist synthesizes research into a buildable plan through user feedback. In research mode, the Failure Analyst classifies run failures to guide targeted hypothesis generation.
+A persisted LangGraph thread schedules eight specialists — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst — each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. The CEO acts as its interactive client and gate evaluator. SQLite checkpoints preserve routing, parallel branches, loops, and human approvals across process restarts.
 
 ---
 
@@ -246,26 +246,34 @@ graph TB
         RF["Refiner"] ~~~ FA["Failure Analyst"]
     end
     subgraph ceo ["CEO Agent"]
-        C["Detect state → Route mode → Spawn agents → Keep/Revert → Archive"]
+        C["Interactive client · Gate evaluator"]
+    end
+    subgraph runtime ["LangGraph Runtime"]
+        W["Route · Fan out/in · Loop · Checkpoint · Resume"]
     end
     subgraph cli ["Python CLI"]
         T["eval · guard · store · discover · events · strategy"]
     end
 
-    agents --> ceo --> cli
+    ceo --> runtime
+    runtime --> agents
+    runtime --> cli
 
     style agents fill:#e8eaf6,stroke:#5c6bc0
     style ceo fill:#fff3e0,stroke:#ff8f00
+    style runtime fill:#e3f2fd,stroke:#1e88e5
     style cli fill:#e8f5e9,stroke:#43a047
 ```
 
-re:factory is a three-layer system:
+re:factory is a four-layer system:
 
 **Layer 1 — Python CLI** (`factory/`): Pure tools that don't make decisions. Eval runner, strategy engine, experiment store, discovery, event logging. Entry point: `factory --help`.
 
-**Layer 2 — CEO Agent** (`factory/agents/prompts/ceo.md`): The orchestrator. Detects project state, spawns specialist agents, and makes the keep/revert decision for each experiment. Mode-specific playbooks are auto-generated from workflow graph definitions.
+**Layer 2 — LangGraph Runtime** (`factory/workflow/`): Compiles the typed Factory DSL and owns scheduling, routing, parallel joins, loops, SQLite checkpoints, and interrupts/resume.
 
-**Layer 3 — Specialist Agents** (`factory/agents/`): Eight independent Claude Code subprocesses — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst. Each has a focused prompt, receives context from the CEO, and returns structured output.
+**Layer 3 — CEO Agent** (`factory/agents/prompts/ceo.md`): Interactive graph client and gate evaluator. Headless runs execute the same graph without a separate CEO scheduler.
+
+**Layer 4 — Specialist Agents** (`factory/agents/`): Eight independent subprocesses invoked by workflow nodes. Each has a focused prompt and returns structured output at an artifact boundary.
 
 See [Architecture](architecture.md) for the full deep-dive.
 

--- a/factory/agents/prompts/refactory.md
+++ b/factory/agents/prompts/refactory.md
@@ -88,7 +88,8 @@ When the user says "work on X":
    - `factory tmux <path> --mode design` for brainstorming what to work on
    - `factory tmux <path> --mode research` for research-driven improvement
    - `factory tmux <path> --mode create --focus "mode description"` for creating new factory modes
-   - `factory tmux <path> --engine tool` for tool-based execution (CEO drives via workflow tool commands)
+   - `factory tmux <path> --engine langgraph` for persisted LangGraph execution (default)
+   - `factory tmux <path> --engine skill` for the explicit legacy SKILL.md fallback
 
    Create mode is a meta-mode: it requires the factory project path (not a target project), uses `--focus` to provide the mode description, and generates new workflow definitions, CLI wiring, and tests for a new factory mode.
 

--- a/factory/agents/skills/factory-run.md
+++ b/factory/agents/skills/factory-run.md
@@ -32,7 +32,8 @@ factory tmux <project_path> --mode design    # brainstorm what to work on first
 factory tmux <project_path> --mode research  # research-driven improvement
 factory tmux <project_path> --mode meta      # improve the factory itself + ACE evolution
 factory tmux <factory_project_path> --mode create --focus "mode description"  # create new factory mode
-factory tmux <project_path> --engine tool    # tool-based execution (CEO drives via workflow tool commands)
+factory tmux <project_path> --engine langgraph  # default; CEO drives the persisted graph thread
+factory tmux <project_path> --engine skill      # explicit legacy SKILL.md fallback
 ```
 
 ## Post-Dispatch Verification

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -10,6 +10,10 @@ import structlog
 import sys
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from factory.workflow.primitives import Workflow
 
 from factory.cli._ceo_dispatch import _start_ceo_tailer, _stop_ceo_tailer
 from factory.cli._helpers import (
@@ -51,7 +55,7 @@ log = structlog.get_logger()
 
 
 def _tool_exec_protocol(wt_path: Path) -> str:
-    """Return the tool-exec protocol section appended to the CEO prompt."""
+    """Return the LangGraph client protocol appended to the CEO prompt."""
     p = wt_path
 
     overview = ""
@@ -62,10 +66,9 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         pass
 
     protocol = (
-        "\n\n# Tool-Based Execution Protocol\n"
+        "\n\n# LangGraph Execution Protocol\n"
         "\n"
-        "You are executing the workflow using factory tool commands instead of "
-        "following a SKILL.md playbook.\n"
+        "You are a client of the persisted LangGraph workflow thread.\n"
     )
 
     if overview:
@@ -114,7 +117,7 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         "## Loop Context\n"
         "\n"
         "For any node that is a RELOOP target in the workflow graph, the tool "
-        "engine automatically injects a **## LOOP CONTEXT** section into the "
+        "runtime automatically injects a **## LOOP CONTEXT** section into the "
         "node's task description — starting from the very first invocation "
         "(iteration 0). This section shows:\n"
         "- The full loop topology (all nodes from this node through the gate) "
@@ -133,7 +136,7 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         "reloops by making the builder aware of review criteria upfront.\n"
         "\n"
         "No separate command is needed — context is injected automatically by "
-        "the tool engine.\n"
+        "the LangGraph runtime.\n"
     )
 
     return protocol
@@ -563,9 +566,9 @@ def _execute_ceo(
             feedback_text = "\n\n---\n\n".join(resolved_plan.feedback)
             (strategy_dir / "thread-feedback.md").write_text(feedback_text)
 
-    engine = getattr(args, "engine", "skill")
+    engine = getattr(args, "engine", "langgraph")
 
-    if engine != "tool":
+    if engine == "skill":
         from factory.skill_cache import ensure_skills
 
         ensure_skills(wt_path, mode=mode)
@@ -575,6 +578,7 @@ def _execute_ceo(
     if is_graphify_installed():
         extract_graph(wt_path)
 
+    session_workflow: Workflow | None = None
     overwrite = getattr(args, "overwrite", None)
     if overwrite and mode and mode != "auto":
         from factory.workflow.definitions import register_all
@@ -582,8 +586,9 @@ def _execute_ceo(
 
         workflows = register_all()
         if mode in workflows:
-            mutated = apply_overwrite(workflows[mode], overwrite, wt_path)
-            generate_session_skill(mutated, mode, wt_path)
+            session_workflow = apply_overwrite(workflows[mode], overwrite, wt_path)
+            if engine == "skill":
+                generate_session_skill(session_workflow, mode, wt_path)
         else:
             log.warning("overwrite.mode_not_found", mode=mode)
 
@@ -604,28 +609,11 @@ def _execute_ceo(
     else:
         ceo_mode = mode
 
-    headless_prompt_override: str | None = None
-    if engine == "tool" and headless:
-        base = resolve_prompt("ceo", wt_path, use_profile=use_profile, workflow_mode=None)
-        headless_prompt_override = base + _tool_exec_protocol(wt_path)
-
-    if engine == "deterministic":
-        if not headless:
-            print(
-                "WARNING: --engine deterministic runs headless (no interactive CEO). "
-                "Adding --headless implicitly.",
-                file=sys.stderr,
-            )
-            headless = True
-
-    if engine == "tool":
+    if engine == "langgraph" and not headless:
         from factory.workflow.tool import tool_init as _tool_init
 
-        try:
-            _tool_init(ceo_mode, wt_path)
-        except Exception as e:
-            log.warning("tool_exec.init_failed", error=str(e), mode=ceo_mode)
-            engine = "skill"
+        override = session_workflow if session_workflow and session_workflow.name == ceo_mode else None
+        _tool_init(ceo_mode, wt_path, workflow=override)
 
     if clean_pr_flag is not None:
         clean_pr_resolved = clean_pr_flag
@@ -728,9 +716,11 @@ def _execute_ceo(
             verification_settings_file=_verification_settings_file,
             just_plan=just_plan,
             engine=engine,
-            prompt_override=headless_prompt_override,
+            workflow_override=session_workflow,
+            auto_approve=auto_approve,
         )
 
+    preserve_langgraph_worktree = False
     try:
         if pending_ids:
             print(
@@ -740,7 +730,7 @@ def _execute_ceo(
             mark_read(project_path, pending_ids)
         from factory.models import AgentRunRequest as _RunReq
 
-        if engine == "tool":
+        if engine == "langgraph":
             base_prompt = resolve_prompt(
                 "ceo", wt_path, use_profile=use_profile, workflow_mode=None,
             )
@@ -767,22 +757,30 @@ def _execute_ceo(
             )
         )
     finally:
-        if engine == "tool":
-            try:
-                from factory.workflow.tool import tool_finalize
-                finalize_result = tool_finalize(wt_path)
-                log.info("tool_exec.finalized", result=finalize_result)
-            except Exception:
-                pass
+        if engine == "langgraph":
+            from factory.workflow.tool import tool_finalize
+
+            finalize_result = tool_finalize(wt_path)
+            log.info("langgraph.finalized", result=finalize_result)
+            preserve_langgraph_worktree = finalize_result.startswith("Pending graph tasks:")
+            if preserve_langgraph_worktree:
+                print(
+                    f"Resume: factory workflow tool next {wt_path}",
+                    file=sys.stderr,
+                )
         _stop_ceo_tailer(ceo_tailer)
         complete_cycle_session(project_path, cycle_span_id)
         from factory.ceo_completion import print_resume_hint
 
         print_resume_hint(project_path)
-        if not no_worktree:
+        if not no_worktree and not preserve_langgraph_worktree:
             assert wt_branch is not None
             remove_worktree(project_path, wt_path, wt_branch)
-        if needs_materialize and _is_scaffold_only(project_path):
+        if (
+            needs_materialize
+            and not preserve_langgraph_worktree
+            and _is_scaffold_only(project_path)
+        ):
             import shutil
 
             shutil.rmtree(project_path, ignore_errors=True)
@@ -816,8 +814,10 @@ def _run_headless(
     ceo_mode: str,
     verification_settings_file: str | None,
     just_plan: bool = False,
-    engine: str = "skill",
+    engine: str = "langgraph",
     prompt_override: str | None = None,
+    workflow_override: Workflow | None = None,
+    auto_approve: bool = False,
 ) -> int:
     """Run the CEO in headless mode with completion guard."""
     from factory.ceo_completion import run_ceo_with_completion_guard
@@ -825,30 +825,50 @@ def _run_headless(
     from factory.agents.runner import complete_cycle_session
     from factory.worktree import remove_worktree
 
-    if engine == "deterministic":
+    if engine == "langgraph":
         import asyncio
         from factory.workflow.executor import WorkflowExecutor
         from factory.workflow.registry import WorkflowRegistry
         from factory.workflow.primitives import DEFAULT_AGENT_POOL
 
-        wf = WorkflowRegistry.get_workflow(ceo_mode, wt_path)
+        wf = workflow_override or WorkflowRegistry.get_workflow(ceo_mode, wt_path)
         if not wf:
             print(f'Error: workflow "{ceo_mode}" not found', file=sys.stderr)
             _stop_ceo_tailer(ceo_tailer)
             complete_cycle_session(project_path, cycle_span_id)
             return 1
 
-        executor = WorkflowExecutor(wf, wt_path, agent_pool=DEFAULT_AGENT_POOL)
+        executor = WorkflowExecutor(
+            wf,
+            wt_path,
+            agent_pool=DEFAULT_AGENT_POOL,
+            auto_approve=auto_approve,
+            thread_id=ceo_session_id,
+        )
+        preserve_langgraph_worktree = True
         try:
             exec_result = asyncio.run(executor.execute())
+            preserve_langgraph_worktree = exec_result.interrupted or not exec_result.completed
             print(json.dumps({
                 "workflow": ceo_mode,
-                "engine": "deterministic",
+                "engine": "langgraph",
+                "project_path": str(wt_path),
+                "thread_id": exec_result.thread_id,
                 "success": exec_result.success,
+                "completed": exec_result.completed,
+                "interrupted": exec_result.interrupted,
+                "interrupts": exec_result.interrupts,
                 "nodes_executed": exec_result.nodes_executed,
                 "duration_ms": round(exec_result.duration_ms, 1),
             }, indent=2))
-            code = 0 if exec_result.success else 1
+            if exec_result.interrupted:
+                print(
+                    "Resume: "
+                    f"factory workflow resume {ceo_mode} {wt_path} "
+                    f"--thread-id {exec_result.thread_id}",
+                    file=sys.stderr,
+                )
+            code = 2 if exec_result.interrupted else 0 if exec_result.success else 1
             if code != 0:
                 return code
             return _chain_modes(
@@ -865,6 +885,7 @@ def _run_headless(
                 background=background,
                 completed_mode=mode,
                 no_worktree=no_worktree,
+                engine=engine,
             )
         finally:
             _stop_ceo_tailer(ceo_tailer)
@@ -872,9 +893,13 @@ def _run_headless(
             from factory.ceo_completion import print_resume_hint
 
             print_resume_hint(project_path)
-            if not no_worktree and wt_branch:
+            if not no_worktree and wt_branch and not preserve_langgraph_worktree:
                 remove_worktree(project_path, wt_path, wt_branch)
-            if needs_materialize and _is_scaffold_only(project_path):
+            if (
+                needs_materialize
+                and not preserve_langgraph_worktree
+                and _is_scaffold_only(project_path)
+            ):
                 import shutil
 
                 shutil.rmtree(project_path, ignore_errors=True)
@@ -918,14 +943,9 @@ def _run_headless(
             background=background,
             completed_mode=chain_mode,
             no_worktree=no_worktree,
+            engine=engine,
         )
     finally:
-        if engine == "tool":
-            try:
-                from factory.workflow.tool import tool_finalize
-                tool_finalize(wt_path)
-            except Exception:
-                pass
         _stop_ceo_tailer(ceo_tailer)
         complete_cycle_session(project_path, cycle_span_id)
         from factory.ceo_completion import print_resume_hint

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -452,10 +452,8 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     p.add_argument("--just-plan", action="store_true", default=False, dest="just_plan",
                     help="Plan-only mode: research + strategy + GitHub publishing, NO implementation. "
                          "Requires --mode design. Mutually exclusive with --from-plan and --prompt.")
-    p.add_argument("--engine", choices=["skill", "tool", "deterministic"], default="skill",
-                    help="Execution engine: skill (CEO follows SKILL.md, default), "
-                         "tool (CEO drives via factory workflow tool commands), "
-                         "deterministic (headless WorkflowExecutor, no CEO)")
+    p.add_argument("--engine", choices=["langgraph", "skill"], default="langgraph",
+                    help="Execution engine: langgraph (default) or legacy skill rendering")
 
     p = sub.add_parser("run", help="Run factory cycle (delegates to CEO agent)")
     p.add_argument("path", help="Project path, GitHub URL, idea file path, or prompt")
@@ -528,10 +526,8 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
     p.add_argument("--no-worktree", action="store_true", default=False, dest="no_worktree",
                     help="Run directly in the project directory without creating a worktree "
                          "(useful for testing in-flight branch changes)")
-    p.add_argument("--engine", choices=["skill", "tool", "deterministic"], default="skill",
-                    help="Execution engine: skill (CEO follows SKILL.md, default), "
-                         "tool (CEO drives via factory workflow tool commands), "
-                         "deterministic (headless WorkflowExecutor, no CEO)")
+    p.add_argument("--engine", choices=["langgraph", "skill"], default="langgraph",
+                    help="Execution engine: langgraph (default) or legacy skill rendering")
     p.add_argument("--overwrite", default=None, metavar="TEXT",
                     help="Natural-language directive to mutate the workflow for this session")
     p.add_argument("--auto-approve", action="store_true", default=False,
@@ -592,10 +588,8 @@ def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: i
                     help="Run agent interactively in a tmux window instead of headless (claude only)")
     p.add_argument("--use-profile", action="store_true", default=False,
                     help="Inject user profile (~/.factory/profile.md) into agent prompts")
-    p.add_argument("--engine", choices=["skill", "tool", "deterministic"], default="skill",
-                    help="Execution engine: skill (CEO follows SKILL.md, default), "
-                         "tool (CEO drives via factory workflow tool commands), "
-                         "deterministic (headless WorkflowExecutor, no CEO)")
+    p.add_argument("--engine", choices=["langgraph", "skill"], default="langgraph",
+                    help="Execution engine: langgraph (default) or legacy skill rendering")
     p.add_argument("--overwrite", default=None, metavar="TEXT",
                     help="Natural-language directive to mutate the workflow for this session")
 

--- a/factory/cli/_tmux_commands.py
+++ b/factory/cli/_tmux_commands.py
@@ -102,8 +102,8 @@ def _build_tmux_run_args(args: argparse.Namespace, project_path: Path, model: st
         parts.append("--use-profile")
     if getattr(args, "overwrite", None):
         parts.append(f"--overwrite {shlex.quote(args.overwrite)}")
-    engine = getattr(args, "engine", "skill")
-    if engine != "skill":
+    engine = getattr(args, "engine", "langgraph")
+    if engine != "langgraph":
         parts.append(f"--engine {engine}")
     return " ".join(parts)
 

--- a/factory/cli/run.py
+++ b/factory/cli/run.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import os
 import signal
@@ -77,8 +78,10 @@ def _run_single_cycle(
     run_id: str | None = None,
     no_worktree: bool = False,
     overwrite: str | None = None,
+    engine: str = "langgraph",
+    auto_approve: bool = False,
 ) -> int:
-    """Execute a single factory run cycle via the CEO agent. Returns 0 on success, 1 on error."""
+    """Execute one cycle through LangGraph or the explicit legacy skill path."""
     from factory.agents.runner import invoke_agent
     from factory.worktree import create_worktree, remove_worktree
 
@@ -99,20 +102,69 @@ def _run_single_cycle(
     else:
         wt_path, wt_branch = create_worktree(project_path, base_branch, run_id=run_id)
 
-    from factory.skill_cache import ensure_skills
+    if engine == "skill":
+        from factory.skill_cache import ensure_skills
 
-    ensure_skills(wt_path)
+        ensure_skills(wt_path)
 
+    workflow_override = None
     if overwrite and mode and mode != "auto":
         from factory.workflow.definitions import register_all
         from factory.workflow.overwrite import apply_overwrite, generate_session_skill
 
         workflows = register_all()
         if mode in workflows:
-            mutated = apply_overwrite(workflows[mode], overwrite, wt_path)
-            generate_session_skill(mutated, mode, wt_path)
+            workflow_override = apply_overwrite(workflows[mode], overwrite, wt_path)
+            if engine == "skill":
+                generate_session_skill(workflow_override, mode, wt_path)
 
+    preserve_langgraph_worktree = engine == "langgraph"
     try:
+        if engine == "langgraph":
+            from factory.workflow.executor import WorkflowExecutor
+            from factory.workflow.primitives import DEFAULT_AGENT_POOL
+            from factory.workflow.registry import WorkflowRegistry
+
+            workflow = workflow_override or WorkflowRegistry.get_workflow(mode, wt_path)
+            if not workflow:
+                print(f'Error: workflow "{mode}" not found', file=sys.stderr)
+                return 1
+
+            executor = WorkflowExecutor(
+                workflow,
+                wt_path,
+                agent_pool=DEFAULT_AGENT_POOL,
+                auto_approve=auto_approve,
+            )
+            exec_result = asyncio.run(executor.execute())
+            preserve_langgraph_worktree = exec_result.interrupted or not exec_result.completed
+            print(
+                json.dumps(
+                    {
+                        "workflow": mode,
+                        "engine": "langgraph",
+                        "project_path": str(wt_path),
+                        "thread_id": exec_result.thread_id,
+                        "success": exec_result.success,
+                        "completed": exec_result.completed,
+                        "interrupted": exec_result.interrupted,
+                        "interrupts": exec_result.interrupts,
+                        "nodes_executed": exec_result.nodes_executed,
+                        "duration_ms": round(exec_result.duration_ms, 1),
+                    },
+                    indent=2,
+                )
+            )
+            if exec_result.interrupted:
+                print(
+                    "Resume: "
+                    f"factory workflow resume {mode} {wt_path} "
+                    f"--thread-id {exec_result.thread_id}",
+                    file=sys.stderr,
+                )
+                return 2
+            return 0 if exec_result.success else 1
+
         task = _build_ceo_task(
             wt_path,
             mode,
@@ -154,7 +206,7 @@ def _run_single_cycle(
         print(result)
         return code
     finally:
-        if not no_worktree:
+        if not no_worktree and not preserve_langgraph_worktree:
             assert wt_branch is not None
             remove_worktree(project_path, wt_path, wt_branch)
 
@@ -174,6 +226,7 @@ def _chain_modes(
     background: bool = False,
     completed_mode: str | None = None,
     no_worktree: bool = False,
+    engine: str = "langgraph",
 ) -> int:
     """After a cycle completes, re-detect state and chain into the next mode.
 
@@ -225,6 +278,7 @@ def _chain_modes(
             tmux_persist=tmux_persist,
             background=background,
             no_worktree=no_worktree,
+            engine=engine,
         )
         if code != 0:
             return code
@@ -255,6 +309,8 @@ def _run_heartbeat_loop(
     max_cycles: int | None,
     no_worktree: bool = False,
     completed_mode: str | None = None,
+    engine: str = "langgraph",
+    auto_approve: bool = False,
 ) -> int:
     """Continuous heartbeat loop with signal handling."""
     shutdown_event = threading.Event()
@@ -266,6 +322,7 @@ def _run_heartbeat_loop(
     old_sigint = signal.signal(signal.SIGINT, _shutdown_handler)
 
     cycle = 0
+    exit_code = 0
     start_time = time.monotonic()
 
     try:
@@ -275,7 +332,7 @@ def _run_heartbeat_loop(
             print(f"[factory] Cycle {cycle} started at {ts}")
             _emit_cli_event(project_path, "cycle.started", {"cycle": cycle, "mode": mode})
 
-            _run_single_cycle(
+            exit_code = _run_single_cycle(
                 project_path,
                 mode,
                 context,
@@ -294,9 +351,13 @@ def _run_heartbeat_loop(
                 background=background,
                 run_id=run_id,
                 no_worktree=no_worktree,
+                engine=engine,
+                auto_approve=auto_approve,
                 **budget_kwargs,
             )
-            _chain_modes(
+            if exit_code != 0:
+                break
+            exit_code = _chain_modes(
                 project_path,
                 focus=focus,
                 already_improved=skip_improve,
@@ -310,7 +371,10 @@ def _run_heartbeat_loop(
                 background=background,
                 completed_mode=completed_mode or mode,
                 no_worktree=no_worktree,
+                engine=engine,
             )
+            if exit_code != 0:
+                break
             _emit_cli_event(project_path, "cycle.completed", {"cycle": cycle, "mode": mode})
 
             mode = _auto_detect_mode(project_path, has_prompt=bool(prompt_file or context))
@@ -336,7 +400,7 @@ def _run_heartbeat_loop(
         f"[factory] Shutting down gracefully after {cycle} cycles."
         f" Total runtime: {elapsed:.0f}s"
     )
-    return 0
+    return exit_code
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -407,6 +471,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     mode = getattr(args, "mode", "auto")
     warn_deprecated_mode(mode)
     auto_approve: bool = getattr(args, "auto_approve", False)
+    engine: str = getattr(args, "engine", "langgraph")
     if auto_approve and mode != "design":
         print("Error: --auto-approve only applies to --mode design", file=sys.stderr)
         return 1
@@ -482,6 +547,8 @@ def cmd_run(args: argparse.Namespace) -> int:
             run_id=run_id,
             no_worktree=no_worktree,
             overwrite=overwrite,
+            engine=engine,
+            auto_approve=auto_approve,
             **budget_kwargs,
         )
         if code != 0:
@@ -500,6 +567,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             background=background,
             completed_mode=mode,
             no_worktree=no_worktree,
+            engine=engine,
         )
 
     interval: int = getattr(args, "interval", 1800)
@@ -528,4 +596,6 @@ def cmd_run(args: argparse.Namespace) -> int:
         max_cycles=max_cycles,
         no_worktree=no_worktree,
         completed_mode=mode,
+        engine=engine,
+        auto_approve=auto_approve,
     )

--- a/factory/workflow/README.md
+++ b/factory/workflow/README.md
@@ -1,25 +1,29 @@
-# Workflow Graph Engine
+# Factory Workflow DSL
 
-The workflow graph engine defines all factory modes as directed graphs of typed nodes. One source of truth, two execution formats: headless automation via `WorkflowExecutor` and interactive CEO sessions via auto-generated `SKILL.md` files.
+Factory modes are directed graphs of typed domain nodes. The Factory DSL and validator remain the public API; LangGraph is the single execution runtime. `SKILL.md` export is documentation and a legacy fallback, not the authoritative scheduler.
 
 ## How it works
 
 ```
-definitions.py          (8 Python functions, each returning a Workflow)
+definitions.py          (Python functions returning Workflow objects)
        │
-       ├──► WorkflowExecutor    (headless: walks the DAG deterministically)
-       │       factory workflow run improve --project /path
+       ├──► compile_langgraph()  (direct DSL → StateGraph compiler)
+       │            │
+       │       LangGraph runtime
+       │       SQLite checkpoints
+       │            │
+       │       ┌────┴────┐
+       │       │         │
+       │    headless   interactive CEO client
        │
-       └──► skill_export.py     (interactive: converts graph → SKILL.md)
-               skills/workflow-improve/SKILL.md
-               └── CEO reads this at runtime as its mode-specific playbook
+       └──► skill_export.py     (Workflow → SKILL.md rendering)
 ```
 
-In interactive mode, `factory ceo` launches a Claude Code session with `ceo.md` as the system prompt. The CEO detects project state, then reads the appropriate `SKILL.md` into context and follows it step by step. The SKILL.md files are prose translations of the same graph the executor walks — so both paths execute the same pipeline.
+`factory workflow run` executes the compiled graph directly. Interactive `factory ceo` uses `workflow tool next/submit/status` as a thin client over the same persisted graph thread. LangGraph owns routing, loops, fork/join scheduling, checkpoints, interrupts, and resume.
 
 ## Node types
 
-Every workflow is a graph of 6 node types connected by edges:
+Every workflow is a graph of typed nodes connected by edges:
 
 | Node | Class | Purpose | Example |
 |------|-------|---------|---------|
@@ -29,6 +33,9 @@ Every workflow is a graph of 6 node types connected by edges:
 | Fork | `ForkNode` | Launch multiple targets in parallel | 3 researchers simultaneously |
 | Join | `JoinNode` | Barrier — wait for all parallel branches | Wait for all researchers |
 | Study | `Study` | Distinguished `FnNode` wrapping `factory study` | Local codebase analysis |
+| LLM | `LLMNode` | Run the in-process tool-use loop | Focused LLM transform |
+| Subgraph fork | `SubgraphForkNode` | Run N isolated worktree subgraphs | Parallel experiments |
+| Selection | `SelectionNode` | Select and merge an experiment winner | Best-score selection |
 
 Each node declares `reads` and `writes` — the set of files it consumes and produces. The graph validator (`validation.py`) uses these to verify data flow: every file a node reads must be written by a predecessor. Pre-existing project files (e.g. `CLAUDE.md`, `factory.md`) should not be declared as reads since no workflow node produces them.
 
@@ -48,7 +55,7 @@ Three verdict types:
 
 ## Workflows
 
-8 workflows are registered in `definitions.py`:
+Built-in workflows are registered in `definitions.py`; user and project workflows are discovered through `WorkflowRegistry`:
 
 | Name | Function | Trigger | Purpose |
 |------|----------|---------|---------|
@@ -163,7 +170,7 @@ nodes["join_research"] = JoinNode(
 )
 ```
 
-**Non-blocking archivist** (fire-and-forget):
+**Legacy non-blocking annotation**:
 
 ```python
 nodes["archivist"] = AgentNode(
@@ -171,6 +178,8 @@ nodes["archivist"] = AgentNode(
     model="haiku", blocking=False,
 )
 ```
+
+`blocking=False` is retained in the DSL for compatibility. LangGraph still runs the node durably; it is no longer launched as a cancellable in-process background task.
 
 ## Validation
 
@@ -186,7 +195,7 @@ The graph validator (`validation.py`) checks:
 Run validation:
 
 ```bash
-factory workflow validate              # All 8 workflows
+factory workflow validate              # All workflows
 python -c "from factory.workflow.definitions import register_all
 for name, wf in register_all().items():
     issues = wf.validate_graph()
@@ -196,9 +205,18 @@ for name, wf in register_all().items():
 ## CLI commands
 
 ```bash
-# Run a workflow (headless, deterministic graph execution)
-factory workflow run improve --project /path/to/project
-factory workflow run build --project /path/to/project --dry-run
+# Run through LangGraph + SQLite checkpointing
+factory workflow run improve /path/to/project
+factory workflow run build /path/to/project --dry-run
+
+# Resume a durable user gate
+factory workflow resume design /path/to/project \
+  --thread-id <thread-id> --value PROCEED
+
+# Resume multiple parallel interrupts by their emitted IDs
+factory workflow resume improve /path/to/project \
+  --thread-id <thread-id> \
+  --resume-json '{"<interrupt-id-a>": "done", "<interrupt-id-b>": "done"}'
 
 # List all registered workflows
 factory workflow list
@@ -215,7 +233,7 @@ factory workflow export-skills
 
 ## Launching the factory
 
-### Interactive mode (CEO + skills)
+### Interactive mode (CEO as LangGraph client)
 
 ```bash
 # Improve an existing project
@@ -245,19 +263,19 @@ What happens under the hood:
 1. `cmd_ceo()` resolves path, mode, focus directives
 2. Creates a git worktree for isolation
 3. Builds a task string describing what the CEO should do
-4. Resolves the CEO system prompt from `factory/agents/prompts/ceo.md`
-5. Launches `claude` (or another runner) with the CEO prompt + task
-6. The CEO detects project state → reads the matching `skills/workflow-*/SKILL.md` → follows it step by step, spawning specialist agents via `factory agent <role>`
-7. On exit, the worktree is cleaned up
+4. Compiles the selected Factory workflow and starts a persisted SQLite thread
+5. Launches the CEO with the current graph task/interrupt protocol
+6. CEO outputs resume the graph through `Command(resume=...)`
+7. Completed worktrees are cleaned up; interrupted worktrees are preserved for resume
 
 ### Headless mode (graph executor)
 
 ```bash
-# Direct graph execution — no CEO agent, the executor walks the DAG
-factory workflow run improve --project /path/to/project
+# Direct graph execution — no CEO agent
+factory workflow run improve /path/to/project
 
 # With dry-run (no actual agent spawns or commands)
-factory workflow run build --project /path/to/project --dry-run
+factory workflow run build /path/to/project --dry-run
 
 # Headless CEO (pipe mode — for scripting, cron, tmux)
 factory ceo /path/to/project --headless
@@ -278,14 +296,16 @@ factory tmux /path/to/project --loop
 
 ```
 factory/workflow/
-├── __init__.py          # Public API: re-exports all primitives + executor
+├── __init__.py          # Public workflow API
 ├── primitives.py        # Pydantic models: Node types, Edge, Verdict, Workflow
-├── definitions.py       # 8 workflow functions returning Workflow objects
-├── executor.py          # WorkflowExecutor — async graph walker
+├── definitions.py       # Built-in Workflow definitions
+├── langgraph.py         # Direct StateGraph compiler + serializable state
+├── executor.py          # Factory domain operations + LangGraph facade
+├── tool.py              # Thin interactive adapters over graph threads
 ├── validation.py        # NetworkX-based graph validator
 ├── events.py            # Structured event types for .factory/events.jsonl
-├── skill_export.py      # Graph → SKILL.md converter
-└── cli.py               # CLI subcommands: run, list, show, validate, export-skills
+├── skill_export.py      # Workflow → SKILL.md renderer
+└── cli.py               # CLI subcommands, including run/resume/tool
 
 skills/
 ├── workflow-build/SKILL.md       # Auto-generated from build_workflow()

--- a/factory/workflow/__init__.py
+++ b/factory/workflow/__init__.py
@@ -1,6 +1,7 @@
 """Workflow graph engine — composable primitives for factory orchestration."""
 
 from factory.workflow.executor import ExecutionResult, WorkflowExecutor
+from factory.workflow.langgraph import FactoryRunState, compile_langgraph, initial_state
 from factory.workflow.primitives import (
     AgentConfig,
     AgentNode,
@@ -26,6 +27,7 @@ __all__ = [
     "Edge",
     "ExecutionResult",
     "Factory",
+    "FactoryRunState",
     "FnNode",
     "ForkNode",
     "GateNode",
@@ -37,4 +39,6 @@ __all__ = [
     "VerdictType",
     "Workflow",
     "WorkflowExecutor",
+    "compile_langgraph",
+    "initial_state",
 ]

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import structlog
 
 from factory.workflow.registry import WorkflowRegistry
-from factory.workflow.executor import WorkflowExecutor
+from factory.workflow.executor import ExecutionResult, WorkflowExecutor
 from factory.workflow.primitives import (
     DEFAULT_AGENT_POOL,
     AgentNode,
@@ -28,11 +28,15 @@ def cmd_workflow(args: argparse.Namespace) -> int:
     """Dispatch workflow subcommands."""
     sub = getattr(args, "workflow_command", None)
     if not sub:
-        print("Usage: factory workflow {run,list,show,validate,export-skills,lint-contributed,tool}")
+        print(
+            "Usage: factory workflow "
+            "{run,resume,list,show,validate,export-skills,lint-contributed,tool}"
+        )
         return 1
 
     handlers = {
         "run": _cmd_run,
+        "resume": _cmd_resume,
         "list": _cmd_list,
         "show": _cmd_show,
         "validate": _cmd_validate,
@@ -85,6 +89,8 @@ def _cmd_run(args: argparse.Namespace) -> int:
         project_path,
         agent_pool=DEFAULT_AGENT_POOL,
         dry_run=dry_run,
+        auto_approve=getattr(args, "auto_approve", False),
+        thread_id=getattr(args, "thread_id", None),
     )
 
     from factory.agents.runner import begin_cycle_session, complete_cycle_session
@@ -93,19 +99,55 @@ def _cmd_run(args: argparse.Namespace) -> int:
     try:
         result = asyncio.run(executor.execute())
 
-        print(json.dumps({
-            "workflow": name,
-            "success": result.success,
-            "halted": result.halted,
-            "halt_reason": result.halt_reason,
-            "nodes_executed": result.nodes_executed,
-            "duration_ms": round(result.duration_ms, 1),
-            "files_produced": sorted(result.completed_files),
-        }, indent=2))
-
-        return 0 if result.success else 1
+        print(_execution_result_json(name, result))
+        return 2 if result.interrupted else 0 if result.success else 1
     finally:
         complete_cycle_session(project_path, cycle_span_id)
+
+
+def _cmd_resume(args: argparse.Namespace) -> int:
+    """Resume a persisted workflow thread with scalar or interrupt-ID values."""
+    import sys
+
+    name = args.name
+    project_path = Path(args.project_path).resolve()
+    resume_json = getattr(args, "resume_json", None)
+    if resume_json is not None:
+        value: object = json.loads(resume_json)
+        if not isinstance(value, dict):
+            raise TypeError("--resume-json must decode to an interrupt-ID mapping")
+    else:
+        value = args.value if args.value is not None else sys.stdin.read().strip()
+    executor = WorkflowExecutor.from_thread(
+        project_path,
+        agent_pool=DEFAULT_AGENT_POOL,
+        thread_id=args.thread_id,
+    )
+    if executor.workflow.name != name:
+        raise ValueError(
+            f"thread '{args.thread_id}' belongs to workflow "
+            f"'{executor.workflow.name}', not '{name}'"
+        )
+    result = asyncio.run(executor.resume(value))
+    print(_execution_result_json(name, result))
+    return 2 if result.interrupted else 0 if result.success else 1
+
+
+def _execution_result_json(name: str, result: ExecutionResult) -> str:
+    """Serialize the stable CLI result shape without exposing checkpoint internals."""
+    return json.dumps({
+        "workflow": name,
+        "thread_id": result.thread_id,
+        "success": result.success,
+        "completed": result.completed,
+        "interrupted": result.interrupted,
+        "interrupts": result.interrupts,
+        "halted": result.halted,
+        "halt_reason": result.halt_reason,
+        "nodes_executed": result.nodes_executed,
+        "duration_ms": round(result.duration_ms, 1),
+        "files_produced": sorted(result.completed_files),
+    }, indent=2)
 
 
 def _cmd_list(args: argparse.Namespace) -> int:
@@ -140,13 +182,13 @@ def _cmd_show(args: argparse.Namespace) -> int:
 
     # Nodes table
     print("Nodes:")
-    header = f"  {'ID':<25} {'Type':<12} {'Blocking':>8} {'Reads':<30} {'Writes':<30}"
+    header = f"  {'ID':<25} {'Type':<12} {'Legacy':>8} {'Reads':<30} {'Writes':<30}"
     print(header)
     print("  " + "-" * (len(header) - 2))
 
     for nid, node in wf.nodes.items():
         ntype = type(node).__name__
-        blocking = "yes" if node.blocking else "async"
+        blocking = "blocking" if node.blocking else "nonblock"
         reads = ", ".join(sorted(node.reads)) if node.reads else "-"
         writes = ", ".join(sorted(node.writes)) if node.writes else "-"
 
@@ -346,9 +388,28 @@ def add_workflow_parser(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     p.add_argument("name", help="Workflow name (build, design, improve, research, meta)")
     p.add_argument("project_path", help="Path to the project")
     p.add_argument("--dry-run", action="store_true", help="Execute without real agent calls")
+    p.add_argument("--auto-approve", action="store_true", help="Proceed through user gates")
+    p.add_argument("--thread-id", default=None, help="Explicit LangGraph thread ID")
     p.add_argument(
         "--from-yaml", default=None, metavar="PATH",
         help="Load workflow from YAML annotations file (overrides slot values on base workflow)",
+    )
+
+    # resume
+    p = wf_sub.add_parser("resume", help="Resume a paused LangGraph workflow thread")
+    p.add_argument("name", help="Workflow name")
+    p.add_argument("project_path", help="Path to the project")
+    p.add_argument("--thread-id", required=True, help="LangGraph thread ID returned by run")
+    resume_values = p.add_mutually_exclusive_group()
+    resume_values.add_argument(
+        "--value",
+        default=None,
+        help="Interrupt response (reads stdin when omitted)",
+    )
+    resume_values.add_argument(
+        "--resume-json",
+        default=None,
+        help="JSON mapping of interrupt IDs to responses for parallel interrupts",
     )
 
     # list

--- a/factory/workflow/contributed/devopsgym/README.md
+++ b/factory/workflow/contributed/devopsgym/README.md
@@ -18,7 +18,7 @@ study (FnNode) → solver (AgentNode) → gate_verify (GateNode) → auto_merge 
 ## Usage
 
 ```bash
-factory workflow run devopsgym --project /path/to/repo
+factory workflow run devopsgym /path/to/repo
 ```
 
 Typically invoked inside a Harbor container. The benchmark uses hidden verification steps — solutions must implement general fixes, not hardcode outputs.

--- a/factory/workflow/contributed/featurebench/README.md
+++ b/factory/workflow/contributed/featurebench/README.md
@@ -18,7 +18,7 @@ study (FnNode) → builder (AgentNode) → gate_verify (GateNode) → auto_merge
 ## Usage
 
 ```bash
-factory workflow run featurebench --project /path/to/repo
+factory workflow run featurebench /path/to/repo
 ```
 
 Typically invoked inside a Harbor container where the task instruction contains detailed interface definitions.

--- a/factory/workflow/contributed/legacybench/README.md
+++ b/factory/workflow/contributed/legacybench/README.md
@@ -18,7 +18,7 @@ study (FnNode) → builder (AgentNode) → gate_verify (GateNode) → auto_merge
 ## Usage
 
 ```bash
-factory workflow run legacybench --project /path/to/repo
+factory workflow run legacybench /path/to/repo
 ```
 
 Typically invoked inside a Harbor container. The benchmark uses hidden test inputs — solutions must implement general algorithms, not hardcode outputs.

--- a/factory/workflow/contributed/programbench/README.md
+++ b/factory/workflow/contributed/programbench/README.md
@@ -19,7 +19,7 @@ discover (AgentNode) → plan (FnNode) → builder (AgentNode) → gate_verify (
 ## Usage
 
 ```bash
-factory workflow run programbench --project /path/to/repo
+factory workflow run programbench /path/to/repo
 ```
 
 Typically invoked inside a Harbor container with a compiled binary at `/workspace/executable`.

--- a/factory/workflow/contributed/swebench/README.md
+++ b/factory/workflow/contributed/swebench/README.md
@@ -18,7 +18,7 @@ study (FnNode) → builder (AgentNode) → gate_verify (GateNode) → auto_merge
 ## Usage
 
 ```bash
-factory workflow run swebench --project /path/to/repo
+factory workflow run swebench /path/to/repo
 ```
 
 Typically invoked inside a Harbor container where the task instruction is pre-populated at `/tmp/task-instruction.md`.

--- a/factory/workflow/contributed/terminalbench/README.md
+++ b/factory/workflow/contributed/terminalbench/README.md
@@ -18,7 +18,7 @@ study (FnNode) → builder (AgentNode) → gate_verify (GateNode) → auto_merge
 ## Usage
 
 ```bash
-factory workflow run terminalbench --project /path/to/repo
+factory workflow run terminalbench /path/to/repo
 ```
 
 Typically invoked inside a Harbor container. Tasks span software engineering, scientific computing, system administration, security, ML, data processing, and more.

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -327,7 +327,7 @@ def build_workflow() -> Workflow:
         reads={".factory/strategy/current.md"},
     )
 
-    # Archivist (async, non-blocking)
+    # Archivist (legacy blocking=False annotation; durable in LangGraph)
     nodes["archivist_plan"] = AgentNode(
         id="archivist_plan",
         role=AgentRole.ARCHIVIST,
@@ -419,7 +419,7 @@ def build_workflow() -> Workflow:
     nodes["spec_generate"] = FnNode(
         id="spec_generate",
         command="factory workflow run spec-generate {project_path}",
-        notes="Generate the project specification via the gated spec-generate workflow. Runs non-blocking after archival.",
+        notes="Generate the project specification via the gated spec-generate workflow after archival.",
         blocking=False,
     )
 
@@ -455,7 +455,7 @@ def build_workflow() -> Workflow:
         # Precheck → archivist (proceed) or halt → archivist (error handling)
         Edge(source="gate_precheck", target="archivist_build", condition=VerdictType.PROCEED),
         Edge(source="gate_precheck", target="archivist_build", condition=VerdictType.HALT),
-        # Archivist → spec generate (non-blocking)
+        # Archivist → spec generate (durable; blocking=False is legacy metadata)
         Edge(source="archivist_build", target="spec_generate"),
     ]
 
@@ -909,7 +909,7 @@ def improve_workflow() -> Workflow:
             "sys.exit(0)"
             '"'
         ),
-        notes="Update SPEC.md via the gated spec-update workflow if it exists. Runs non-blocking after archival; skips silently if no spec file is present.",
+        notes="Update SPEC.md via the gated spec-update workflow after archival; skips silently if no spec file is present.",
         blocking=False,
     )
 
@@ -948,7 +948,7 @@ def improve_workflow() -> Workflow:
         # Precheck → finalize (proceed) or halt → archivist (error handling)
         Edge(source="gate_precheck", target="finalize", condition=VerdictType.PROCEED),
         Edge(source="gate_precheck", target="archivist", condition=VerdictType.HALT),
-        # Finalize → archivist → spec_update (non-blocking)
+        # Finalize → archivist → spec_update (durable LangGraph sequence)
         Edge(source="finalize", target="archivist"),
         Edge(source="archivist", target="spec_update"),
     ]
@@ -1097,7 +1097,7 @@ def research_workflow() -> Workflow:
         Edge(source="gate_doc_freshness", target="builder", condition=VerdictType.RELOOP),
         Edge(source="gate_precheck", target="finalize", condition=VerdictType.PROCEED),
         Edge(source="gate_precheck", target="archivist", condition=VerdictType.HALT),
-        # Finalize → archivist → spec_update (non-blocking) → plateau gate
+        # Finalize → archivist → spec_update (durable) → plateau gate
         Edge(source="finalize", target="archivist"),
         Edge(source="archivist", target="spec_update"),
         Edge(source="spec_update", target="plateau_gate"),
@@ -1125,8 +1125,8 @@ def meta_workflow() -> Workflow:
     Archivist(async) → test_collect → test_researcher → gate → test_builder →
     qa_verify → gate_qa_verify(max 3)
 
-    The archivist is non-blocking, so it fires in the background while the
-    test pruning chain proceeds immediately.
+    The archivist retains blocking=False for legacy skill rendering. LangGraph
+    executes it durably before the test-pruning chain proceeds.
     """
     nodes: dict[str, Any] = {}
     edges: list[Edge] = []
@@ -1195,7 +1195,7 @@ def meta_workflow() -> Workflow:
         writes={".factory/archive/playbooks-applied.md"},
     )
 
-    # Archivist (async, non-blocking — fires in background while test chain proceeds)
+    # Archivist (legacy blocking=False annotation; durable in LangGraph)
     nodes["archivist"] = AgentNode(
         id="archivist",
         role=AgentRole.ARCHIVIST,
@@ -1278,7 +1278,7 @@ def meta_workflow() -> Workflow:
         Edge(source="strategist", target="gate_user"),
         Edge(source="gate_user", target="apply_playbooks", condition=VerdictType.PROCEED),
         Edge(source="gate_user", target="strategist", condition=VerdictType.RELOOP),
-        # Apply → archivist (non-blocking) → test chain
+        # Apply → archivist (durable) → test chain
         Edge(source="apply_playbooks", target="archivist"),
         Edge(source="archivist", target="test_collect"),
         # Test pruning branch
@@ -1794,7 +1794,7 @@ def create_workflow() -> Workflow:
         reads={".factory/strategy/current.md"},
     )
 
-    # Archivist (async, non-blocking)
+    # Archivist (legacy blocking=False annotation; durable in LangGraph)
     nodes["archivist_plan"] = AgentNode(
         id="archivist_plan",
         role=AgentRole.ARCHIVIST,
@@ -3841,7 +3841,7 @@ def evolve_workflow() -> Workflow:
         writes={".factory/experiments/verdict.json"},
     )
 
-    # Archivist: record results (async, non-blocking)
+    # Archivist: record results (legacy blocking=False annotation; durable in LangGraph)
     nodes["archivist"] = AgentNode(
         id="archivist",
         role=AgentRole.ARCHIVIST,

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -1,31 +1,33 @@
-"""Deterministic async graph walker implementing formal execution semantics."""
+"""Factory node behavior executed by the LangGraph workflow runtime."""
 
 from __future__ import annotations
 
 import asyncio
 import json
+import re
 import shlex
-import time
+import subprocess
 import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import structlog
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from langgraph.types import Command, Interrupt
 
-from factory.workflow.events import (
-    GateVerdictEvent,
-    NodeCompleted,
-    NodeFailed,
-    NodeStarted,
-    WorkflowCompleted,
-    WorkflowHalted,
-    WorkflowStarted,
-    emit_workflow_event,
+from factory.workflow.events import WorkflowEvent, emit_workflow_event
+from factory.workflow.langgraph import (
+    FactoryRunState,
+    collect_subgraph_nodes,
+    compile_langgraph,
+    initial_state,
 )
 from factory.workflow.primitives import (
     AgentConfig,
     AgentNode,
-    Edge,
     FnNode,
     ForkNode,
     GateNode,
@@ -59,22 +61,28 @@ HALT reason="<your reason>"
 """
 
 
+@dataclass
 class ExecutionResult:
-    """Result of a workflow execution."""
+    """External result returned by a LangGraph workflow invocation."""
 
-    def __init__(self) -> None:
-        self.success: bool = False
-        self.halted: bool = False
-        self.halt_reason: str = ""
-        self.nodes_executed: int = 0
-        self.events: list[dict[str, Any]] = []
-        self.completed_files: set[str] = set()
-        self.node_outputs: dict[str, str] = {}
-        self.duration_ms: float = 0.0
+    success: bool = False
+    completed: bool = False
+    halted: bool = False
+    halt_reason: str = ""
+    interrupted: bool = False
+    thread_id: str = ""
+    interrupts: list[dict[str, Any]] = field(default_factory=list)
+    nodes_executed: int = 0
+    completed_nodes: set[str] = field(default_factory=set)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    completed_files: set[str] = field(default_factory=set)
+    node_outputs: dict[str, str] = field(default_factory=dict)
+    duration_ms: float = 0.0
+    state: dict[str, Any] = field(default_factory=dict)
 
 
 class WorkflowExecutor:
-    """Deterministic async graph walker for workflow execution."""
+    """Compatibility facade over the canonical LangGraph workflow runtime."""
 
     def __init__(
         self,
@@ -84,492 +92,377 @@ class WorkflowExecutor:
         *,
         dry_run: bool = False,
         auto_approve: bool = False,
+        interactive: bool = False,
+        thread_id: str | None = None,
+        checkpoint_path: Path | None = None,
     ) -> None:
         self.workflow = workflow
         self.project_path = project_path
         self.agent_pool = agent_pool or {}
         self.dry_run = dry_run
         self.auto_approve = auto_approve
-        self.run_id = uuid.uuid4().hex[:12]
+        self.interactive = interactive
+        self.run_id = thread_id or uuid.uuid4().hex[:12]
+        self.checkpoint_path = checkpoint_path or (
+            project_path / ".factory" / "langgraph" / "checkpoints.sqlite"
+        )
+        self.result = ExecutionResult(thread_id=self.run_id)
         self.completed_files: set[str] = set()
         self.node_context: dict[str, str] = {}
         self.iteration_counts: dict[tuple[str, str], int] = {}
-        self.background_tasks: list[asyncio.Task[Any]] = []
-        self.result = ExecutionResult()
-        self._edge_index: dict[str, list[Edge]] = {}
-        for edge in workflow.edges:
-            self._edge_index.setdefault(edge.source, []).append(edge)
+        self._edge_index = {
+            node_id: [edge for edge in workflow.edges if edge.source == node_id]
+            for node_id in workflow.nodes
+        }
+
+    @property
+    def config(self) -> RunnableConfig:
+        """LangGraph thread configuration for this workflow run."""
+        return {"configurable": {"thread_id": self.run_id}}
 
     async def execute(self) -> ExecutionResult:
-        """Run the workflow from start to completion."""
-        start_time = time.monotonic()
+        """Start the workflow and run until completion or an interrupt."""
+        self._write_thread_manifest()
+        state = initial_state(self.workflow, str(self.project_path), self.run_id)
+        result = await self._invoke(state)
+        if result.completed:
+            self._log_timing_summary(result)
+        return result
 
-        self._emit(
-            "workflow.started",
-            WorkflowStarted(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                start_node=self.workflow.start_node,
-            ),
+    async def resume(self, value: Any) -> ExecutionResult:
+        """Resume this persisted workflow thread after an interrupt."""
+        result = await self._invoke(Command(resume=value))
+        if result.completed:
+            self._log_timing_summary(result)
+        return result
+
+    async def inspect(self) -> ExecutionResult:
+        """Read the latest persisted state without advancing the graph."""
+        self.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        async with AsyncSqliteSaver.from_conn_string(str(self.checkpoint_path)) as saver:
+            await saver.setup()
+            graph = compile_langgraph(self.workflow, self, checkpointer=saver)
+            snapshot = await graph.aget_state(self.config)
+        return self._sync_result(snapshot.values, snapshot.interrupts)
+
+    @classmethod
+    def from_thread(
+        cls,
+        project_path: Path,
+        thread_id: str,
+        agent_pool: dict[str, AgentConfig] | None = None,
+        *,
+        checkpoint_path: Path | None = None,
+    ) -> WorkflowExecutor:
+        """Reconstruct the exact workflow/runtime settings recorded for a thread."""
+        resolved_checkpoint = checkpoint_path or (
+            project_path / ".factory" / "langgraph" / "checkpoints.sqlite"
+        )
+        manifest_path = resolved_checkpoint.parent / "threads" / f"{thread_id}.json"
+        manifest = json.loads(manifest_path.read_text())
+        workflow = Workflow.model_validate_json(str(manifest["workflow_json"]))
+        return cls(
+            workflow,
+            project_path,
+            agent_pool=agent_pool,
+            dry_run=bool(manifest["dry_run"]),
+            auto_approve=bool(manifest["auto_approve"]),
+            interactive=bool(manifest["interactive"]),
+            thread_id=thread_id,
+            checkpoint_path=resolved_checkpoint,
         )
 
-        try:
-            await self._execute_from(self.workflow.start_node)
-            self.result.success = not self.result.halted
-        except Exception as exc:
-            self.result.success = False
-            self.result.halted = True
-            self.result.halt_reason = str(exc)
-            log.error("workflow.exception", error=str(exc), workflow=self.workflow.name)
+    async def _invoke(self, graph_input: FactoryRunState | Command[Any]) -> ExecutionResult:
+        self.checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        async with AsyncSqliteSaver.from_conn_string(str(self.checkpoint_path)) as saver:
+            await saver.setup()
+            graph = compile_langgraph(self.workflow, self, checkpointer=saver)
+            await graph.ainvoke(graph_input, self.config)
+            snapshot = await graph.aget_state(self.config)
+        return self._sync_result(snapshot.values, snapshot.interrupts)
 
-        if self.background_tasks:
-            done, pending = await asyncio.wait(
-                self.background_tasks,
-                timeout=30.0,
-            )
-            for task in pending:
-                task.cancel()
+    def _sync_result(
+        self,
+        values: dict[str, Any] | Any,
+        interrupts: tuple[Interrupt, ...],
+    ) -> ExecutionResult:
+        state = cast(FactoryRunState, values or {})
+        events = list(state.get("events", []))
+        interrupted = bool(interrupts)
+        halted = bool(state.get("halted", False))
+        completed = any(
+            event.get("type") in {"workflow.completed", "workflow.halted"}
+            for event in events
+        )
+        duration_ms = 0.0
+        for event in reversed(events):
+            if event.get("type") == "workflow.completed":
+                duration_ms = float(event.get("duration_ms", 0.0))
+                break
 
-        elapsed = (time.monotonic() - start_time) * 1000
-        self.result.duration_ms = elapsed
-        self.result.completed_files = set(self.completed_files)
+        self.completed_files = set(state.get("completed_files", []))
+        self.node_context = {
+            key: str(value) for key, value in state.get("node_context", {}).items()
+        }
+        self.iteration_counts = {}
+        for key, value in state.get("iteration_counts", {}).items():
+            gate_id, target_id = key.split("->", 1)
+            self.iteration_counts[(gate_id, target_id)] = int(value)
+        self.result = ExecutionResult(
+            success=completed and not interrupted and not halted,
+            completed=completed,
+            halted=halted,
+            halt_reason=str(state.get("halt_reason", "")),
+            interrupted=interrupted,
+            thread_id=self.run_id,
+            interrupts=[{"id": item.id, "value": item.value} for item in interrupts],
+            nodes_executed=int(state.get("nodes_executed", 0)),
+            completed_nodes=set(state.get("completed_nodes", [])),
+            events=events,
+            completed_files=self.completed_files,
+            node_outputs={
+                key: str(value) for key, value in state.get("node_outputs", {}).items()
+            },
+            duration_ms=duration_ms,
+            state=dict(state),
+        )
+        return self.result
 
-        # Timing summary: extract per-node durations from completed events
-        node_timings: list[dict[str, Any]] = []
-        for ev in self.result.events:
-            if ev.get("type") == "node.completed" and "duration_ms" in ev:
-                node_timings.append({
-                    "id": ev.get("node_id", ""),
-                    "type": ev.get("node_type", ""),
-                    "duration_ms": round(ev["duration_ms"], 1),
-                })
-        node_timings.sort(key=lambda n: n["duration_ms"], reverse=True)
-        node_total_ms = sum(n["duration_ms"] for n in node_timings)
+    def _log_timing_summary(self, result: ExecutionResult) -> None:
+        """Log timing data projected from durable node-completion events."""
+        node_timings = [
+            {
+                "id": event.get("node_id", ""),
+                "type": event.get("node_type", ""),
+                "duration_ms": round(float(event["duration_ms"]), 1),
+            }
+            for event in result.events
+            if event.get("type") == "node.completed" and "duration_ms" in event
+        ]
+        node_timings.sort(key=lambda entry: float(entry["duration_ms"]), reverse=True)
+        node_total_ms = sum(float(entry["duration_ms"]) for entry in node_timings)
         log.info(
             "workflow.timing_summary",
             workflow=self.workflow.name,
             run_id=self.run_id,
-            total_ms=round(elapsed, 1),
+            total_ms=round(result.duration_ms, 1),
             node_count=len(node_timings),
             nodes=node_timings,
-            overhead_ms=round(elapsed - node_total_ms, 1),
+            overhead_ms=round(result.duration_ms - node_total_ms, 1),
         )
 
-        if self.result.halted:
-            self._emit(
-                "workflow.halted",
-                WorkflowHalted(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    reason=self.result.halt_reason,
-                    halted_at_node="unknown",
-                ),
-            )
-        else:
-            self._emit(
-                "workflow.completed",
-                WorkflowCompleted(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    nodes_executed=self.result.nodes_executed,
-                    duration_ms=elapsed,
-                ),
+    async def run_node(self, node: NodeType, state: FactoryRunState) -> str:
+        """Run one Factory domain node with a durable completion receipt."""
+        attempt = int(state["node_attempts"].get(node.id, 0)) + 1
+        receipt_path = self._receipt_path(node.id, attempt)
+        if receipt_path.exists():
+            receipt = json.loads(receipt_path.read_text())
+            if receipt["status"] == "completed":
+                return str(receipt["output"])
+            raise RuntimeError(
+                f"operation {receipt['operation_id']} has an ambiguous prior attempt; "
+                "inspect external effects before retrying"
             )
 
-        return self.result
+        operation_id = f"{self.run_id}:{node.id}:{attempt}"
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(json.dumps({
+            "operation_id": operation_id,
+            "node_id": node.id,
+            "attempt": attempt,
+            "status": "started",
+        }, indent=2))
+        output = await self._run_node(node, state)
+        receipt_path.write_text(json.dumps({
+            "operation_id": operation_id,
+            "node_id": node.id,
+            "attempt": attempt,
+            "status": "completed",
+            "output": output,
+        }, indent=2))
+        return output
 
-    async def _execute_from(self, node_id: str) -> None:
-        """Execute starting from the given node, following edges."""
-        if self.result.halted:
-            return
+    async def evaluate_gate(self, node: GateNode, state: FactoryRunState) -> Verdict:
+        """Evaluate one gate through the Factory-owned evaluator behavior."""
+        self.node_context = {
+            key: str(value) for key, value in state["node_context"].items()
+        }
+        return await self._evaluate_gate(node)
 
-        node = self.workflow.nodes.get(node_id)
-        if not node:
-            self.result.halted = True
-            self.result.halt_reason = f"node '{node_id}' not found"
-            return
+    def parse_gate_submission(self, node: GateNode, output: str) -> Verdict:
+        """Parse an interactive gate response into the Factory verdict algebra."""
+        return self._parse_agent_verdict(output, node.id)
 
-        await self._wait_for_reads(node)
-        if self.result.halted:
-            return
+    def accept_submission(self, node: NodeType, output: str) -> str:
+        """Persist externally executed agent output at its declared artifact boundary."""
+        if isinstance(node, AgentNode):
+            for write_path in node.writes:
+                artifact = self.project_path / write_path
+                artifact.parent.mkdir(parents=True, exist_ok=True)
+                artifact.write_text(output)
+            self._validate_agent_artifacts(node)
+        return output
 
-        if isinstance(node, SubgraphForkNode):
-            await self._execute_subgraph_fork(node)
-            return
+    def emit_event(self, event_type: str, event: WorkflowEvent) -> None:
+        """Write one graph event to the project's append-only event log."""
+        emit_workflow_event(self.project_path, event_type, event)
 
-        if isinstance(node, ForkNode):
-            await self._execute_fork(node)
-            return
+    async def _run_node(self, node: NodeType, state: FactoryRunState) -> str:
+        if self.dry_run:
+            if isinstance(node, SelectionNode):
+                return json.dumps({
+                    "strategy": node.strategy,
+                    "winner": None,
+                    "reason": "dry-run",
+                })
+            if isinstance(node, SubgraphForkNode):
+                return await self._run_subgraph_fork(node)
+            return f"[dry-run] {node.id} executed"
 
+        if isinstance(node, Study):
+            return await self._run_study(node)
+        if isinstance(node, AgentNode):
+            return await self._run_agent(node, state)
+        if isinstance(node, LLMNode):
+            return await self._run_llm(node, state)
         if isinstance(node, SelectionNode):
-            await self._execute_selection(node)
-            return
-
+            return await self._run_selection(node, state)
+        if isinstance(node, SubgraphForkNode):
+            return await self._run_subgraph_fork(node)
+        if isinstance(node, FnNode):
+            return await self._run_fn(node)
+        if isinstance(node, ForkNode):
+            return json.dumps({"targets": node.targets})
         if isinstance(node, JoinNode):
-            self.result.nodes_executed += 1
-            self.completed_files |= node.writes
-            next_id = self._next_unconditional(node_id)
-            if next_id:
-                await self._execute_from(next_id)
-            return
+            return json.dumps({"sources": node.sources})
+        raise TypeError(f"unsupported workflow node: {type(node).__name__}")
 
-        if isinstance(node, GateNode):
-            await self._execute_gate(node)
-            return
+    async def _run_study(self, node: Study) -> str:
+        cmd = node.command or f"factory study {shlex.quote(str(self.project_path))}"
+        if node.focus and "--focus" not in cmd:
+            cmd += f" --focus {shlex.quote(node.focus)}"
+        return await self._run_shell(self._resolve_command(cmd))
 
-        await self._execute_action_node(node)
+    async def _run_fn(self, node: FnNode) -> str:
+        if not node.command:
+            return ""
+        return await self._run_shell(self._resolve_command(node.command))
 
-    async def _execute_action_node(self, node: NodeType) -> None:
-        """Execute an AgentNode, FnNode, or Study node."""
-        node_id = node.id
-        node_type = type(node).__name__
+    async def _run_agent(self, node: AgentNode, state: FactoryRunState) -> str:
+        from factory.agents.runner import invoke_agent
 
-        if not node.blocking:
-            task = asyncio.create_task(self._run_node_background(node))
-            self.background_tasks.append(task)
-            next_id = self._next_unconditional(node_id)
-            if next_id:
-                await self._execute_from(next_id)
-            return
+        task = node.prompt_template
+        context = str(state["node_context"].get(node.id, ""))
+        if context:
+            task = f"{task}\n\n{context}"
 
-        self._emit(
-            "node.started",
-            NodeStarted(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                node_id=node_id,
-                node_type=node_type,
-            ),
+        pool_entry = self.agent_pool.get(node.role.value)
+        model = node.model or (pool_entry.model if pool_entry else "")
+        timeout = node.timeout or (pool_entry.timeout if pool_entry else 600)
+        stdout, code = await invoke_agent(
+            node.role.value,  # type: ignore[arg-type]
+            task,
+            self.project_path,
+            model=model or None,
+            timeout=float(timeout),
         )
+        if code != 0:
+            raise RuntimeError(f"agent {node.role.value} exited with code {code}")
+        self._validate_agent_artifacts(node)
+        return stdout
 
-        start = time.monotonic()
-        try:
-            output = await self._run_node(node)
-            elapsed = (time.monotonic() - start) * 1000
+    async def _run_llm(self, node: LLMNode, state: FactoryRunState) -> str:
+        from factory.workflow.llm_loop import run_llm_loop
 
-            self.result.node_outputs[node_id] = output
-            self.completed_files |= node.writes
-            self.result.nodes_executed += 1
-
-            self._emit(
-                "node.completed",
-                NodeCompleted(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    node_id=node_id,
-                    node_type=node_type,
-                    files_written=sorted(node.writes),
-                    duration_ms=elapsed,
-                ),
-            )
-
-        except Exception as exc:
-            self._emit(
-                "node.failed",
-                NodeFailed(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    node_id=node_id,
-                    node_type=node_type,
-                    error=str(exc),
-                ),
-            )
-            self.result.halted = True
-            self.result.halt_reason = f"node '{node_id}' failed: {exc}"
-            return
-
-        next_id = self._next_unconditional(node_id)
-        if next_id:
-            await self._execute_from(next_id)
-
-    async def _run_node_background(self, node: NodeType) -> None:
-        """Run a non-blocking node as a background task."""
-        node_id = node.id
-        node_type = type(node).__name__
-        self._emit(
-            "node.started",
-            NodeStarted(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                node_id=node_id,
-                node_type=node_type,
+        context_parts = [
+            (self.project_path / path).read_text()
+            for path in sorted(node.reads)
+            if (self.project_path / path).exists()
+        ]
+        gate_context = str(state["node_context"].get(node.id, ""))
+        if gate_context:
+            context_parts.append(gate_context)
+        output = await asyncio.wait_for(
+            run_llm_loop(
+                node,
+                self.project_path,
+                instance_context="\n\n".join(context_parts),
             ),
+            timeout=float(node.timeout),
         )
-        start = time.monotonic()
-        try:
-            output = await self._run_node(node)
-            elapsed = (time.monotonic() - start) * 1000
-            self.result.node_outputs[node_id] = output
-            self.completed_files |= node.writes
-            self.result.nodes_executed += 1
-            self._emit(
-                "node.completed",
-                NodeCompleted(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    node_id=node_id,
-                    node_type=node_type,
-                    files_written=sorted(node.writes),
-                    duration_ms=elapsed,
-                ),
-            )
-        except Exception as exc:
-            self._emit(
-                "node.failed",
-                NodeFailed(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    node_id=node_id,
-                    node_type=node_type,
-                    error=str(exc),
-                ),
-            )
-            log.warning("background_node_failed", node=node_id, error=str(exc))
+        output_path = self.project_path / ".factory" / "reviews" / "builder-latest.md"
+        if node.writes:
+            output_path = self.project_path / sorted(node.writes)[0]
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output)
+        return output
 
-    async def _execute_gate(self, node: GateNode) -> None:
-        """Execute a gate node, parse verdict, follow the matching edge."""
-        node_id = node.id
-        self._emit(
-            "node.started",
-            NodeStarted(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                node_id=node_id,
-                node_type="GateNode",
-            ),
-        )
-
-        try:
-            verdict = await self._evaluate_gate(node)
-        except Exception as exc:
-            self._emit(
-                "node.failed",
-                NodeFailed(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    node_id=node_id,
-                    node_type="GateNode",
-                    error=str(exc),
-                ),
-            )
-            self.result.halted = True
-            self.result.halt_reason = f"gate '{node_id}' failed: {exc}"
-            return
-
-        self.result.nodes_executed += 1
-
-        self._emit(
-            "gate.verdict",
-            GateVerdictEvent(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                node_id=node_id,
-                verdict_type=verdict.type,
-                target=verdict.target,
-                feedback=verdict.feedback,
-                reason=verdict.reason,
-            ),
-        )
-
-        if verdict.type == VerdictType.HALT:
-            self.result.halted = True
-            self.result.halt_reason = verdict.reason or "gate halted"
-            return
-
-        if verdict.type == VerdictType.RELOOP:
-            target = verdict.target
-            if not target:
-                self.result.halted = True
-                self.result.halt_reason = "reloop verdict missing target"
-                return
-
-            key = (node_id, target)
-            count = self.iteration_counts.get(key, 0) + 1
-            self.iteration_counts[key] = count
-
-            if count > verdict.max_iterations:
-                self.result.halted = True
-                self.result.halt_reason = (
-                    f"max iterations ({verdict.max_iterations}) exhausted "
-                    f"for gate '{node_id}' -> '{target}'"
-                )
-                return
-
-            if verdict.feedback:
-                existing = self.node_context.get(target, "")
-                self.node_context[target] = (
-                    f"{existing}\n\n[Feedback iteration {count}]: {verdict.feedback}"
-                    if existing
-                    else f"[Feedback iteration {count}]: {verdict.feedback}"
-                )
-
-            await self._execute_from(target)
-            return
-
-        target_id = self._next_conditional(node_id, VerdictType.PROCEED)
-        if target_id is None:
-            target_id = self._next_unconditional(node_id)
-
-        if target_id:
-            await self._execute_from(target_id)
-
-    async def _execute_fork(self, node: ForkNode) -> None:
-        """Execute all fork targets concurrently via asyncio.gather.
-
-        Branches are run in isolation — they do NOT follow outgoing edges.
-        After all branches complete, the fork's own unconditional edge is followed.
-        """
-        self.result.nodes_executed += 1
-
-        async def run_branch(target_id: str) -> None:
-            target = self.workflow.nodes.get(target_id)
-            if not target:
-                return
-            node_type = type(target).__name__
-            self._emit(
-                "node.started",
-                NodeStarted(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    node_id=target_id,
-                    node_type=node_type,
-                ),
-            )
-            start = time.monotonic()
-            try:
-                output = await self._run_node(target)
-                elapsed = (time.monotonic() - start) * 1000
-                self.result.node_outputs[target_id] = output
-                self.completed_files |= target.writes
-                self.result.nodes_executed += 1
-                self._emit(
-                    "node.completed",
-                    NodeCompleted(
-                        workflow_name=self.workflow.name,
-                        run_id=self.run_id,
-                        node_id=target_id,
-                        node_type=node_type,
-                        files_written=sorted(target.writes),
-                        duration_ms=elapsed,
-                    ),
-                )
-            except Exception as exc:
-                self._emit(
-                    "node.failed",
-                    NodeFailed(
-                        workflow_name=self.workflow.name,
-                        run_id=self.run_id,
-                        node_id=target_id,
-                        node_type=node_type,
-                        error=str(exc),
-                    ),
-                )
-                if not self.result.halted:
-                    self.result.halt_reason = f"fork branch '{target_id}' failed: {exc}"
-                self.result.halted = True
-
-        await asyncio.gather(*(run_branch(t) for t in node.targets))
-
-        if self.result.halted:
-            return
-
-        branch_set = set(node.targets)
-        next_id: str | None = None
-        for edge in self._edge_index.get(node.id, []):
-            if edge.condition is None and edge.target not in branch_set:
-                next_id = edge.target
-                break
-        if next_id is None and node.targets:
-            next_id = self._next_unconditional(node.targets[0])
-        if next_id:
-            await self._execute_from(next_id)
-
-    async def _execute_subgraph_fork(self, node: SubgraphForkNode) -> None:
-        """Execute N copies of a subgraph in parallel, each in an isolated worktree.
-
-        Each branch gets an independent WorkflowExecutor with its own state,
-        running against a separate git worktree branching from the same commit.
-        """
-        import subprocess as sp
-
+    async def _run_subgraph_fork(self, node: SubgraphForkNode) -> str:
         from factory.worktree import create_experiment_worktree
 
-        self.result.nodes_executed += 1
-
-        self._emit(
-            "node.started",
-            NodeStarted(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                node_id=node.id,
-                node_type="SubgraphForkNode",
-            ),
-        )
-
-        start = time.monotonic()
-
-        # Resolve base commit for all branches
         if self.dry_run:
             base_commit = "0" * 40
         else:
-            result = sp.run(
+            resolved = subprocess.run(
                 ["git", "rev-parse", "HEAD"],
                 cwd=self.project_path,
                 capture_output=True,
                 text=True,
                 check=True,
             )
-            base_commit = result.stdout.strip()
+            base_commit = resolved.stdout.strip()
 
-        # Parse hypotheses from strategist output to determine branch count
         strategy_file = self.project_path / ".factory" / "strategy" / "current.md"
         hypotheses = _parse_hypotheses(strategy_file) if strategy_file.exists() else []
         branch_count = min(len(hypotheses), node.parallelism) if hypotheses else node.parallelism
-
-        if branch_count < 1:
-            branch_count = 1
-
-        # Collect subgraph node IDs by walking edges from entry to exit
-        subgraph_ids = _collect_subgraph_nodes(
-            self.workflow, node.subgraph_entry, node.subgraph_exit,
+        branch_count = max(branch_count, 1)
+        subgraph_ids = collect_subgraph_nodes(
+            self.workflow,
+            node.subgraph_entry,
+            node.subgraph_exit,
         )
         sub_workflow = self.workflow.subgraph(
-            subgraph_ids, name=f"{self.workflow.name}__branch", start_node=node.subgraph_entry,
+            subgraph_ids,
+            name=f"{self.workflow.name}__branch",
+            start_node=node.subgraph_entry,
         )
 
-        branch_results: list[dict[str, Any]] = []
-        worktrees: list[tuple[Path, str, int]] = []
-
-        async def run_branch(idx: int) -> dict[str, Any]:
+        async def run_branch(index: int) -> dict[str, Any]:
             from factory.store import ExperimentStore
 
-            hypothesis = hypotheses[idx] if idx < len(hypotheses) else f"Hypothesis {idx + 1}"
-
+            hypothesis = (
+                hypotheses[index] if index < len(hypotheses) else f"Hypothesis {index + 1}"
+            )
             if self.dry_run:
-                wt_path = self.project_path / ".factory-worktrees" / f"exp-dry-{idx}"
-                branch_name = f"factory/exp-dry-{idx}"
-                exp_id = idx + 1
+                worktree_path = self.project_path
+                branch = f"factory/exp-dry-{index}"
+                experiment_id = index + 1
             else:
                 store = ExperimentStore(self.project_path)
-                exp_id = await store.begin(hypothesis)
-                wt_path, branch_name = create_experiment_worktree(
-                    self.project_path, exp_id, base_commit,
+                experiment_id = await store.begin(hypothesis)
+                worktree_path, branch = create_experiment_worktree(
+                    self.project_path,
+                    experiment_id,
+                    base_commit,
                 )
-                worktrees.append((wt_path, branch_name, exp_id))
 
             branch_executor = WorkflowExecutor(
                 sub_workflow.model_copy(deep=True),
-                wt_path if not self.dry_run else self.project_path,
+                worktree_path,
                 agent_pool=self.agent_pool,
                 dry_run=self.dry_run,
+                auto_approve=self.auto_approve,
+                checkpoint_path=(
+                    self.checkpoint_path.parent
+                    / f"{self.run_id}-{node.id}-{index}-checkpoints.sqlite"
+                ),
             )
             branch_result = await branch_executor.execute()
-
             return {
-                "exp_id": exp_id,
+                "exp_id": experiment_id,
                 "hypothesis": hypothesis,
-                "worktree_path": str(wt_path),
-                "branch": branch_name,
+                "worktree_path": str(worktree_path),
+                "branch": branch,
                 "success": branch_result.success,
                 "halted": branch_result.halted,
                 "halt_reason": branch_result.halt_reason,
@@ -577,180 +470,94 @@ class WorkflowExecutor:
                 "node_outputs": branch_result.node_outputs,
             }
 
-        sem = asyncio.Semaphore(node.parallelism)
+        semaphore = asyncio.Semaphore(node.parallelism)
 
-        async def throttled_branch(idx: int) -> dict[str, Any]:
-            async with sem:
-                return await run_branch(idx)
+        async def throttled_branch(index: int) -> dict[str, Any]:
+            async with semaphore:
+                return await run_branch(index)
 
-        tasks = [throttled_branch(i) for i in range(branch_count)]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        for r in results:
-            if isinstance(r, BaseException):
-                log.warning("subgraph_branch_failed", error=str(r))
-                branch_results.append({
-                    "success": False, "halted": True, "halt_reason": str(r),
-                })
-            else:
-                branch_results.append(r)  # type: ignore[arg-type]
-
-        elapsed = (time.monotonic() - start) * 1000
-        self.result.node_outputs[node.id] = json.dumps(branch_results)
-        self.completed_files |= node.writes
-
-        self._emit(
-            "node.completed",
-            NodeCompleted(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                node_id=node.id,
-                node_type="SubgraphForkNode",
-                files_written=sorted(node.writes),
-                duration_ms=elapsed,
-            ),
+        gathered = await asyncio.gather(
+            *(throttled_branch(index) for index in range(branch_count)),
+            return_exceptions=True,
         )
+        branch_results = [
+            (
+                {
+                    "success": False,
+                    "halted": True,
+                    "halt_reason": str(item),
+                }
+                if isinstance(item, BaseException)
+                else item
+            )
+            for item in gathered
+        ]
+        output = json.dumps(branch_results)
+        for write_path in node.writes:
+            target = self.project_path / write_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(output)
+        return output
 
-        next_id = self._next_unconditional(node.id)
-        if next_id:
-            await self._execute_from(next_id)
-
-    async def _execute_selection(self, node: SelectionNode) -> None:
-        """Compare parallel experiment results and select the best."""
-        import subprocess as sp
-
+    async def _run_selection(self, node: SelectionNode, state: FactoryRunState) -> str:
+        from factory.models import ExperimentRecord
+        from factory.store import ExperimentStore
         from factory.worktree import remove_worktree
 
-        self.result.nodes_executed += 1
-
-        self._emit(
-            "node.started",
-            NodeStarted(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                node_id=node.id,
-                node_type="SelectionNode",
-            ),
-        )
-
-        start = time.monotonic()
-
-        # Find the SubgraphForkNode's output (branch results)
-        fork_output = ""
-        for nid, output in self.result.node_outputs.items():
-            try:
-                parsed = json.loads(output)
-                if isinstance(parsed, list) and parsed and "exp_id" in parsed[0]:
-                    fork_output = output
-                    break
-            except (json.JSONDecodeError, TypeError, KeyError):
-                continue
-
-        if self.dry_run or not fork_output:
-            selection_result: dict[str, Any] = {"strategy": node.strategy, "winner": None, "reason": "dry-run"}
-            self.result.node_outputs[node.id] = json.dumps(selection_result)
-            self.completed_files |= node.writes
-            elapsed = (time.monotonic() - start) * 1000
-            self._emit(
-                "node.completed",
-                NodeCompleted(
-                    workflow_name=self.workflow.name,
-                    run_id=self.run_id,
-                    node_id=node.id,
-                    node_type="SelectionNode",
-                    files_written=sorted(node.writes),
-                    duration_ms=elapsed,
-                ),
-            )
-            next_id = self._next_unconditional(node.id)
-            if next_id:
-                await self._execute_from(next_id)
-            return
-
-        branches: list[dict[str, Any]] = json.loads(fork_output)
-        successful = [b for b in branches if b.get("success")]
-
+        branches = self._find_branch_results(state["node_outputs"])
+        successful = [branch for branch in branches if branch.get("success")]
         if not successful:
-            self.result.halted = True
-            self.result.halt_reason = "all parallel experiment branches failed"
-            return
-
-        # best_score: read eval results from each worktree
-        best: dict[str, Any] | None = None
-        best_score = -1.0
+            raise RuntimeError("all parallel experiment branches failed")
 
         for branch in successful:
-            wt_path = Path(branch["worktree_path"])
-            eval_file = wt_path / ".factory" / "last_eval.json"
+            eval_file = Path(str(branch["worktree_path"])) / ".factory" / "last_eval.json"
             score = 0.0
             if eval_file.exists():
-                try:
-                    data = json.loads(eval_file.read_text())
-                    score = float(data.get("total", data.get("score", 0.0)))
-                except (json.JSONDecodeError, TypeError, ValueError):
-                    pass
-
+                data = json.loads(eval_file.read_text())
+                score = float(data.get("total", data.get("score", 0.0)))
             branch["score"] = score
-            if score > best_score:
-                best_score = score
-                best = branch
 
-        if not best:
-            best = successful[0]
-
-        # Merge winner branch into baseline
-        winner_branch = best["branch"]
-        try:
-            sp.run(
-                ["git", "merge", winner_branch, "--no-edit", "-m",
-                 f"Merge parallel experiment winner (exp {best['exp_id']})"],
-                cwd=self.project_path,
-                check=True,
-                capture_output=True,
-            )
-        except sp.CalledProcessError as exc:
-            log.error("selection_merge_failed", branch=winner_branch, error=str(exc))
-            self.result.halted = True
-            self.result.halt_reason = f"failed to merge winner branch {winner_branch}"
-            return
-
-        # Finalize losers as superseded, clean up all worktrees
-        from factory.store import ExperimentStore
+        best = max(successful, key=lambda branch: float(branch.get("score", 0.0)))
+        subprocess.run(
+            [
+                "git",
+                "merge",
+                str(best["branch"]),
+                "--no-edit",
+                "-m",
+                f"Merge parallel experiment winner (exp {best['exp_id']})",
+            ],
+            cwd=self.project_path,
+            check=True,
+            capture_output=True,
+        )
 
         store = ExperimentStore(self.project_path)
         for branch in branches:
-            wt_path = Path(branch.get("worktree_path", ""))
-            branch_name = branch.get("branch", "")
-            exp_id = branch.get("exp_id")
-
-            if branch is not best and exp_id is not None:
-                from factory.models import ExperimentRecord
+            experiment_id = branch.get("exp_id")
+            if branch is not best and experiment_id is not None:
                 record = ExperimentRecord(
-                    id=exp_id,
-                    timestamp=__import__("datetime").datetime.now(tz=__import__("datetime").timezone.utc),
-                    hypothesis=branch.get("hypothesis", ""),
-                    change_summary="superseded by experiment " + str(best["exp_id"]),
+                    id=int(experiment_id),
+                    timestamp=datetime.now(tz=timezone.utc),
+                    hypothesis=str(branch.get("hypothesis", "")),
+                    change_summary=f"superseded by experiment {best['exp_id']}",
                     issue_number=None,
                     pr_number=None,
                     score_before=None,
-                    score_after=branch.get("score"),
+                    score_after=float(branch.get("score", 0.0)),
                     delta=None,
                     verdict="superseded",
                     cost_usd=None,
                     notes="",
                 )
-                try:
-                    await store.finalize(exp_id, record)
-                except Exception as exc:
-                    log.warning("finalize_superseded_failed", exp_id=exp_id, error=str(exc))
+                await store.finalize(int(experiment_id), record)
 
-            if wt_path.exists() and branch_name:
-                try:
-                    remove_worktree(self.project_path, wt_path, branch_name)
-                except Exception as exc:
-                    log.warning("worktree_cleanup_failed", path=str(wt_path), error=str(exc))
+            worktree_path = Path(str(branch.get("worktree_path", "")))
+            branch_name = str(branch.get("branch", ""))
+            if worktree_path.exists() and branch_name:
+                remove_worktree(self.project_path, worktree_path, branch_name)
 
-        selection_result = {
+        selection = {
             "strategy": node.strategy,
             "winner_exp_id": best["exp_id"],
             "winner_score": best.get("score", 0.0),
@@ -758,378 +565,224 @@ class WorkflowExecutor:
             "total_branches": len(branches),
             "successful_branches": len(successful),
         }
-        self.result.node_outputs[node.id] = json.dumps(selection_result)
-        self.completed_files |= node.writes
-
-        elapsed = (time.monotonic() - start) * 1000
-        self._emit(
-            "node.completed",
-            NodeCompleted(
-                workflow_name=self.workflow.name,
-                run_id=self.run_id,
-                node_id=node.id,
-                node_type="SelectionNode",
-                files_written=sorted(node.writes),
-                duration_ms=elapsed,
-            ),
-        )
-
-        next_id = self._next_unconditional(node.id)
-        if next_id:
-            await self._execute_from(next_id)
-
-    async def _run_node(self, node: NodeType) -> str:
-        """Execute a single node and return its output."""
-        if self.dry_run:
-            return f"[dry-run] {node.id} executed"
-
-        if isinstance(node, Study):
-            return await self._run_study(node)
-
-        if isinstance(node, FnNode):
-            return await self._run_fn(node)
-
-        if isinstance(node, AgentNode):
-            return await self._run_agent(node)
-
-        if isinstance(node, LLMNode):
-            return await self._run_llm(node)
-
-        return f"[unknown node type] {type(node).__name__}"
-
-    async def _run_study(self, node: Study) -> str:
-        """Run factory study command."""
-        cmd = f"factory study {shlex.quote(str(self.project_path))}"
-        if node.focus:
-            cmd += f' --focus "{node.focus}"'
-        return await self._run_shell(cmd)
-
-    async def _run_fn(self, node: FnNode) -> str:
-        """Run a FnNode's shell command."""
-        if not node.command:
-            return ""
-        cmd = node.command.replace("{project_path}", shlex.quote(str(self.project_path)))
-        return await self._run_shell(cmd)
-
-    async def _run_agent(self, node: AgentNode) -> str:
-        """Invoke an agent via factory/agents/runner.py."""
-        from factory.agents.runner import invoke_agent
-
-        task = node.prompt_template
-        context = self.node_context.get(node.id, "")
-        if context:
-            task = f"{task}\n\n{context}"
-
-        model = node.model
-        if not model:
-            pool_entry = self.agent_pool.get(node.role.value)
-            if pool_entry:
-                model = pool_entry.model
-
-        timeout = node.timeout
-        if timeout is None:
-            pool_entry = self.agent_pool.get(node.role.value)
-            if pool_entry:
-                timeout = pool_entry.timeout
-
-        stdout, code = await invoke_agent(
-            node.role.value,  # type: ignore[arg-type]
-            task,
-            self.project_path,
-            model=model or None,
-            timeout=float(timeout) if timeout is not None else 600.0,
-        )
-
-        if code != 0:
-            raise RuntimeError(f"agent {node.role.value} exited with code {code}")
-
-        return stdout
-
-    async def _run_llm(self, node: LLMNode) -> str:
-        """Run an LLMNode via direct API tool-use loop."""
-        from factory.workflow.llm_loop import run_llm_loop
-
-        context_parts: list[str] = []
-        for read_path in sorted(node.reads):
-            full_path = self.project_path / read_path
-            if full_path.exists():
-                context_parts.append(full_path.read_text())
-        gate_context = self.node_context.get(node.id, "")
-        if gate_context:
-            context_parts.append(gate_context)
-
-        output = await asyncio.wait_for(
-            run_llm_loop(
-                node, self.project_path,
-                instance_context="\n\n".join(context_parts),
-            ),
-            timeout=float(node.timeout),
-        )
-
-        output_path = self.project_path / ".factory" / "reviews" / "builder-latest.md"
-        if node.writes:
-            first_write = next(iter(node.writes))
-            output_path = self.project_path / first_write
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(output)
-
+        output = json.dumps(selection)
+        for write_path in node.writes:
+            target = self.project_path / write_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(output)
         return output
 
     async def _evaluate_gate(self, node: GateNode) -> Verdict:
-        """Evaluate a gate and return a verdict."""
         if self.dry_run:
             return Verdict.proceed()
-
         if node.evaluator_type == "user":
-            if self.auto_approve:
-                log.info("gate.auto_approved", gate_id=node.id, workflow=self.workflow.name)
+            log.info("gate.auto_approved", gate_id=node.id, workflow=self.workflow.name)
             return Verdict.proceed()
-
         if node.evaluator_type == "fn":
-            if node.evaluator_command:
-                cmd = node.evaluator_command.replace(
-                    "{project_path}", shlex.quote(str(self.project_path)),
-                )
-                try:
-                    output = await self._run_shell(cmd)
-                    return self._parse_fn_verdict(output, node.id)
-                except RuntimeError:
-                    return Verdict.halt(reason=f"gate command failed: {cmd}")
-            return Verdict.proceed()
+            if not node.evaluator_command:
+                return Verdict.proceed()
+            cmd = self._resolve_command(node.evaluator_command)
+            stdout, stderr, code = await self._run_shell_result(cmd)
+            if code != 0:
+                reason = stderr.strip() or stdout.strip() or f"gate command failed: {cmd}"
+                return Verdict.halt(reason=reason[:500])
+            return self._parse_fn_verdict(stdout, node.id)
 
-        prompt = self._build_gate_prompt(node)
         from factory.agents.runner import invoke_agent
 
-        model = "opus"
         pool_entry = self.agent_pool.get("ceo")
-        if pool_entry:
-            model = pool_entry.model
-
         stdout, code = await invoke_agent(
             "ceo",
-            prompt,
+            self._build_gate_prompt(node),
             self.project_path,
-            model=model,
+            model=pool_entry.model if pool_entry else "opus",
         )
-
         if code != 0:
-            return Verdict.halt(reason=f"CEO gate agent exited with code {code}")
-
+            raise RuntimeError(f"CEO gate agent exited with code {code}")
         return self._parse_agent_verdict(stdout, node.id)
 
     def _build_gate_prompt(self, node: GateNode) -> str:
-        """Build the lightweight CEO gate prompt."""
         if node.gate_prompt:
-            return node.gate_prompt.replace(
-                "{project_path}", str(self.project_path),
-            )
-
-        output_files = sorted(node.reads) if node.reads else ["(no specific file)"]
-        context = self.node_context.get(node.id, "none")
-
-        reloop_targets: list[str] = []
-        for edge in self._edge_index.get(node.id, []):
-            if edge.condition == VerdictType.RELOOP:
-                reloop_targets.append(edge.target)
-
+            return node.gate_prompt.replace("{project_path}", str(self.project_path))
+        reloop_targets = [
+            edge.target
+            for edge in self._edge_index.get(node.id, [])
+            if edge.condition == VerdictType.RELOOP
+        ]
         return CEO_GATE_PROMPT.format(
             step_name=node.id,
             workflow_name=self.workflow.name,
-            output_file=", ".join(output_files),
-            previous_context=context,
-            reloop_targets=", ".join(reloop_targets) if reloop_targets else "(use exact node IDs)",
+            output_file=", ".join(sorted(node.reads)) or "(no specific file)",
+            previous_context=self.node_context.get(node.id, "none"),
+            reloop_targets=", ".join(reloop_targets) or "(use exact node IDs)",
         )
 
     def _parse_agent_verdict(self, output: str, gate_id: str) -> Verdict:
-        """Parse agent output into a Verdict by examining the last non-empty line."""
-        import re
-
-        lines = output.strip().splitlines()
-        last_line = ""
-        for line in reversed(lines):
-            if line.strip():
-                last_line = line.strip()
-                break
-
+        last_line = next(
+            (line.strip() for line in reversed(output.strip().splitlines()) if line.strip()),
+            "",
+        )
         text = last_line.upper()
-
-        if text.startswith("HALT") or re.match(r"^HALT\b", text):
+        if text.startswith("HALT"):
             reason_match = re.search(r'REASON="([^"]+)"', last_line, re.IGNORECASE)
-            reason = reason_match.group(1) if reason_match else "gate halted"
-            return Verdict.halt(reason=reason)
-
-        if text.startswith("RELOOP") or re.match(r"^RELOOP\b", text):
-            target_match = re.search(r'TARGET="([^"]+)"', last_line, re.IGNORECASE)
+            return Verdict.halt(
+                reason=reason_match.group(1) if reason_match else "gate halted",
+            )
+        if text.startswith(("RELOOP", "RETRY")):
+            target_match = re.search(
+                r'TARGET=(?:"([^"]+)"|(\S+))',
+                last_line,
+                re.IGNORECASE,
+            )
             feedback_match = re.search(r'FEEDBACK="([^"]+)"', last_line, re.IGNORECASE)
-            target = target_match.group(1) if target_match else None
-
-            if target and target not in self.workflow.nodes:
-                matches = [nid for nid in self.workflow.nodes if target in nid]
-                if len(matches) == 1:
-                    target = matches[0]
-                else:
-                    target = self._next_conditional(gate_id, VerdictType.RELOOP)
-
-            if not target:
+            target = None
+            if target_match:
+                target = target_match.group(1) or target_match.group(2)
+            if target not in self.workflow.nodes:
                 target = self._next_conditional(gate_id, VerdictType.RELOOP)
-            if not target:
-                return Verdict.halt(reason=f"RELOOP verdict from gate '{gate_id}' missing target and no RELOOP edge defined")
+            if target is None:
+                return Verdict.halt(
+                    reason=f"RELOOP verdict from gate '{gate_id}' has no target",
+                )
             feedback = feedback_match.group(1) if feedback_match else "needs improvement"
             return Verdict.reloop(target=target, feedback=feedback)
-
         return Verdict.proceed()
 
     def _parse_fn_verdict(self, output: str, gate_id: str) -> Verdict:
-        """Parse function output into a Verdict."""
         text = output.strip()
-
-        try:
+        if text.startswith("{"):
             data = json.loads(text)
             if isinstance(data, dict) and "passed" in data:
                 if data["passed"]:
                     return Verdict.proceed()
                 return Verdict.halt(
-                    reason=f"precheck failed: {data.get('blocking_failures', [])!r}"[:200]
+                    reason=f"precheck failed: {data.get('blocking_failures', [])!r}"[:200],
                 )
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-        first_line = text.split("\n")[0].strip().lower()
+        first_line = text.split("\n", 1)[0].strip().lower()
         if first_line.startswith("pass"):
             return Verdict.proceed()
-        if first_line.startswith("fail") or first_line.startswith("revert"):
+        if first_line.startswith(("fail", "revert", "halt")):
             return Verdict.halt(reason=f"precheck failed: {text[:200]}")
-        if first_line.startswith("reloop"):
+        if first_line.startswith(("reloop", "retry")):
             target = self._next_conditional(gate_id, VerdictType.RELOOP)
-            raw_line = text.split("\n")[0].strip()
-            after_prefix = raw_line.split(":", 1)[1].strip() if ":" in raw_line else ""
-            feedback = after_prefix if after_prefix else "fn gate requested reloop"
+            feedback = first_line.split(":", 1)[1].strip() if ":" in first_line else ""
             if target:
-                return Verdict.reloop(target=target, feedback=feedback)
+                return Verdict.reloop(
+                    target=target,
+                    feedback=feedback or "fn gate requested reloop",
+                )
             return Verdict.halt(reason="fn gate returned RELOOP but no RELOOP edge defined")
         return Verdict.proceed()
 
     async def _run_shell(self, cmd: str) -> str:
-        """Run a shell command and return stdout."""
-        proc = await asyncio.create_subprocess_shell(
+        stdout, stderr, code = await self._run_shell_result(cmd)
+        if code != 0:
+            raise RuntimeError(f"command failed (exit {code}): {cmd}\n{stderr[:500]}")
+        return stdout
+
+    async def _run_shell_result(self, cmd: str) -> tuple[str, str, int]:
+        process = await asyncio.create_subprocess_shell(
             cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=self.project_path,
         )
-        stdout_bytes, stderr_bytes = await proc.communicate()
-        stdout = stdout_bytes.decode() if stdout_bytes else ""
+        stdout_bytes, stderr_bytes = await process.communicate()
+        return (
+            stdout_bytes.decode() if stdout_bytes else "",
+            stderr_bytes.decode() if stderr_bytes else "",
+            int(process.returncode or 0),
+        )
 
-        if proc.returncode != 0:
-            stderr = stderr_bytes.decode() if stderr_bytes else ""
-            raise RuntimeError(
-                f"command failed (exit {proc.returncode}): {cmd}\n{stderr[:500]}"
-            )
+    def _resolve_command(self, command: str) -> str:
+        return command.replace("{project_path}", shlex.quote(str(self.project_path)))
 
-        return stdout
+    def _validate_agent_artifacts(self, node: AgentNode) -> None:
+        from factory.workflow.primitives import ArtifactCheck
 
-    async def _wait_for_reads(self, node: NodeType) -> None:
-        """Wait until all files in node.reads are available in completed_files."""
-        if not node.reads:
-            return
-        poll_interval = 0.1
-        max_wait = 60.0
-        waited = 0.0
-        while True:
-            missing = node.reads - self.completed_files
-            if not missing:
-                return
-            if waited >= max_wait:
-                self.result.halted = True
-                self.result.halt_reason = (
-                    f"node '{node.id}' timed out waiting for reads: {sorted(missing)}"
+        checks = node.post_checks or [
+            ArtifactCheck(path=path) for path in sorted(node.writes)
+        ]
+        for check in checks:
+            artifact = self.project_path / check.path
+            if check.must_exist and not artifact.is_file():
+                raise RuntimeError(f"artifact verification failed: {check.path} missing")
+            if artifact.is_file() and artifact.stat().st_size < check.min_size:
+                raise RuntimeError(
+                    f"artifact verification failed: {check.path} smaller than {check.min_size}",
                 )
-                return
-            log.debug(
-                "node.waiting_for_reads",
-                node=node.id,
-                missing=sorted(missing),
-                waited_s=round(waited, 1),
-            )
-            await asyncio.sleep(poll_interval)
-            waited += poll_interval
-
-    def _next_unconditional(self, node_id: str) -> str | None:
-        """Find the next node via unconditional edge."""
-        for edge in self._edge_index.get(node_id, []):
-            if edge.condition is None:
-                return edge.target
-        return None
+            if artifact.is_file() and check.must_contain:
+                content = artifact.read_text()
+                if not any(sentinel in content for sentinel in check.must_contain):
+                    raise RuntimeError(
+                        f"artifact verification failed: {check.path} missing sentinel",
+                    )
 
     def _next_conditional(self, node_id: str, verdict_type: VerdictType) -> str | None:
-        """Find the next node via conditional edge matching the verdict."""
         for edge in self._edge_index.get(node_id, []):
             if edge.condition == verdict_type:
                 return edge.target
         return None
 
-    def _emit(self, event_type: str, event: Any) -> None:
-        """Emit a workflow event."""
-        self.result.events.append({"type": event_type, **event.model_dump(mode="python")})
-        try:
-            emit_workflow_event(self.project_path, event_type, event)
-        except Exception:
-            log.debug("event_emission_failed", event_type=event_type)
+    def _receipt_path(self, node_id: str, attempt: int) -> Path:
+        return (
+            self.project_path
+            / ".factory"
+            / "langgraph"
+            / "receipts"
+            / self.run_id
+            / f"{node_id}-{attempt}.json"
+        )
+
+    def _write_thread_manifest(self) -> None:
+        manifest_path = self.checkpoint_path.parent / "threads" / f"{self.run_id}.json"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps({
+            "thread_id": self.run_id,
+            "workflow_name": self.workflow.name,
+            "workflow_json": self.workflow.model_dump_json(),
+            "project_path": str(self.project_path),
+            "dry_run": self.dry_run,
+            "auto_approve": self.auto_approve,
+            "interactive": self.interactive,
+        }, indent=2))
+
+    @staticmethod
+    def _find_branch_results(outputs: dict[str, Any]) -> list[dict[str, Any]]:
+        for output in outputs.values():
+            value = json.loads(str(output))
+            if isinstance(value, list) and value and isinstance(value[0], dict):
+                if "exp_id" in value[0]:
+                    return value
+        return []
 
 
 def _parse_hypotheses(strategy_file: Path) -> list[str]:
-    """Extract individual hypotheses from the strategist's current.md output."""
+    """Parse hypothesis sections from a strategy markdown file."""
     text = strategy_file.read_text()
     hypotheses: list[str] = []
     current: list[str] = []
-
     for line in text.splitlines():
         stripped = line.strip()
-        if stripped.startswith("## Hypothesis") or stripped.startswith("### Hypothesis"):
+        if stripped.startswith(("## Hypothesis", "### Hypothesis")):
             if current:
                 hypotheses.append("\n".join(current).strip())
-                current = []
-            current.append(stripped)
+            current = [stripped]
         elif stripped.startswith("## ") and current:
             hypotheses.append("\n".join(current).strip())
             current = []
         elif current:
             current.append(line)
-
     if current:
         hypotheses.append("\n".join(current).strip())
-
     if not hypotheses:
         for line in text.splitlines():
             stripped = line.strip()
-            if stripped.startswith("- **") or stripped.startswith("1. **"):
+            if stripped.startswith("- **") or re.match(r"^\d+\. \*\*", stripped):
                 hypotheses.append(stripped.lstrip("- 0123456789.").strip())
-
     return hypotheses
 
 
-def _collect_subgraph_nodes(
-    workflow: Workflow,
-    entry: str,
-    exit_node: str,
-) -> set[str]:
-    """Collect all node IDs on paths from entry to exit_node (inclusive)."""
-    edges_by_source: dict[str, list[str]] = {}
-    for edge in workflow.edges:
-        edges_by_source.setdefault(edge.source, []).append(edge.target)
-
-    # BFS from entry, stop at exit_node
-    visited: set[str] = set()
-    queue = [entry]
-    while queue:
-        nid = queue.pop(0)
-        if nid in visited:
-            continue
-        visited.add(nid)
-        if nid == exit_node:
-            continue
-        for target in edges_by_source.get(nid, []):
-            if target not in visited:
-                queue.append(target)
-
-    return visited
+def _collect_subgraph_nodes(workflow: Workflow, entry: str, exit_node: str) -> set[str]:
+    """Backward-compatible alias for the compiler's subgraph collector."""
+    return collect_subgraph_nodes(workflow, entry, exit_node)

--- a/factory/workflow/langgraph.py
+++ b/factory/workflow/langgraph.py
@@ -1,0 +1,419 @@
+"""Compile Factory workflow definitions to the LangGraph runtime."""
+
+from __future__ import annotations
+
+import operator
+import time
+from collections.abc import Callable
+from typing import Annotated, Any, Protocol, TypedDict, cast
+
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+from langgraph.types import Command, interrupt
+
+from factory.workflow.events import (
+    GateVerdictEvent,
+    NodeCompleted,
+    NodeStarted,
+    WorkflowCompleted,
+    WorkflowEvent,
+    WorkflowHalted,
+    WorkflowStarted,
+)
+from factory.workflow.primitives import (
+    ForkNode,
+    GateNode,
+    JoinNode,
+    NodeType,
+    SelectionNode,
+    SubgraphForkNode,
+    Verdict,
+    VerdictType,
+    Workflow,
+)
+
+
+def _merge_unique(left: list[str], right: list[str]) -> list[str]:
+    return list(dict.fromkeys([*left, *right]))
+
+
+def _merge_dict(left: dict[str, Any], right: dict[str, Any]) -> dict[str, Any]:
+    return {**left, **right}
+
+
+def _prefer_right(left: str, right: str) -> str:
+    return right or left
+
+
+class FactoryRunState(TypedDict):
+    """Small, serializable execution state persisted by LangGraph."""
+
+    run_id: str
+    workflow_name: str
+    project_path: str
+    started_at: float
+    completed_nodes: Annotated[list[str], _merge_unique]
+    completed_files: Annotated[list[str], _merge_unique]
+    node_outputs: Annotated[dict[str, Any], _merge_dict]
+    node_context: Annotated[dict[str, Any], _merge_dict]
+    node_attempts: Annotated[dict[str, Any], _merge_dict]
+    iteration_counts: Annotated[dict[str, Any], _merge_dict]
+    feedback_log: Annotated[dict[str, Any], _merge_dict]
+    verdicts: Annotated[dict[str, Any], _merge_dict]
+    events: Annotated[list[dict[str, Any]], operator.add]
+    nodes_executed: Annotated[int, operator.add]
+    halted: Annotated[bool, operator.or_]
+    halt_reason: Annotated[str, _prefer_right]
+
+
+class WorkflowRuntime(Protocol):
+    """Factory-owned behavior invoked by the LangGraph compiler."""
+
+    workflow: Workflow
+    run_id: str
+    interactive: bool
+    auto_approve: bool
+
+    async def run_node(self, node: NodeType, state: FactoryRunState) -> str: ...
+
+    async def evaluate_gate(self, node: GateNode, state: FactoryRunState) -> Verdict: ...
+
+    def parse_gate_submission(self, node: GateNode, output: str) -> Verdict: ...
+
+    def accept_submission(self, node: NodeType, output: str) -> str: ...
+
+    def emit_event(self, event_type: str, event: WorkflowEvent) -> None: ...
+
+
+CompiledFactoryGraph = CompiledStateGraph[
+    FactoryRunState,
+    None,
+    FactoryRunState,
+    FactoryRunState,
+]
+
+
+def initial_state(workflow: Workflow, project_path: str, run_id: str) -> FactoryRunState:
+    """Build the complete input state for a new workflow thread."""
+    return {
+        "run_id": run_id,
+        "workflow_name": workflow.name,
+        "project_path": project_path,
+        "started_at": 0.0,
+        "completed_nodes": [],
+        "completed_files": [],
+        "node_outputs": {},
+        "node_context": {},
+        "node_attempts": {},
+        "iteration_counts": {},
+        "feedback_log": {},
+        "verdicts": {},
+        "events": [],
+        "nodes_executed": 0,
+        "halted": False,
+        "halt_reason": "",
+    }
+
+
+def compile_langgraph(
+    workflow: Workflow,
+    runtime: WorkflowRuntime,
+    *,
+    checkpointer: BaseCheckpointSaver[Any] | None = None,
+) -> CompiledFactoryGraph:
+    """Compile the Factory DSL directly to a LangGraph ``StateGraph``."""
+    builder = StateGraph(FactoryRunState)
+    start_node = "__factory_start__"
+    complete_node = "__factory_complete__"
+    subgraph_nodes = _nested_subgraph_nodes(workflow)
+    compiled_nodes = {
+        node_id: node
+        for node_id, node in workflow.nodes.items()
+        if node_id not in subgraph_nodes
+    }
+
+    for node_id, node in compiled_nodes.items():
+        if isinstance(node, GateNode):
+            destinations = tuple([*_gate_destinations(workflow, node_id), complete_node])
+            builder.add_node(
+                node_id,
+                cast(Any, _gate_callable(workflow, runtime, node)),
+                destinations=destinations,
+            )
+        else:
+            builder.add_node(node_id, cast(Any, _action_callable(runtime, node)))
+
+    builder.add_node(start_node, cast(Any, _start_callable(runtime)))
+    builder.add_node(complete_node, cast(Any, _complete_callable(runtime)))
+    builder.add_edge(START, start_node)
+    builder.add_edge(start_node, workflow.start_node)
+    wired_sources: set[str] = set()
+
+    for node in compiled_nodes.values():
+        if not isinstance(node, JoinNode):
+            continue
+        sources = [source for source in node.sources if source in compiled_nodes]
+        if not sources:
+            continue
+        builder.add_edge(sources[0] if len(sources) == 1 else sources, node.id)
+        wired_sources.update(sources)
+
+    for edge in workflow.edges:
+        if edge.source not in compiled_nodes or edge.target not in compiled_nodes:
+            continue
+        if isinstance(compiled_nodes[edge.source], GateNode):
+            continue
+        if isinstance(compiled_nodes[edge.target], JoinNode):
+            continue
+        if edge.condition is None:
+            builder.add_edge(edge.source, edge.target)
+            wired_sources.add(edge.source)
+
+    for node_id, node in compiled_nodes.items():
+        if isinstance(node, GateNode) or node_id in wired_sources:
+            continue
+        builder.add_edge(node_id, complete_node)
+
+    builder.add_edge(complete_node, END)
+
+    return builder.compile(checkpointer=checkpointer, name=workflow.name)
+
+
+def _start_callable(runtime: WorkflowRuntime) -> Callable[[FactoryRunState], Any]:
+    async def start_workflow(state: FactoryRunState) -> dict[str, Any]:
+        started = WorkflowStarted(
+            workflow_name=runtime.workflow.name,
+            run_id=runtime.run_id,
+            start_node=runtime.workflow.start_node,
+        )
+        event = _record_event(runtime, "workflow.started", started)
+        return {"started_at": time.time(), "events": [event]}
+
+    return start_workflow
+
+
+def _complete_callable(runtime: WorkflowRuntime) -> Callable[[FactoryRunState], Any]:
+    async def complete_workflow(state: FactoryRunState) -> dict[str, Any]:
+        duration_ms = (time.time() - state["started_at"]) * 1000
+        if state["halted"]:
+            completed: WorkflowEvent = WorkflowHalted(
+                workflow_name=runtime.workflow.name,
+                run_id=runtime.run_id,
+                reason=state["halt_reason"],
+                halted_at_node="unknown",
+            )
+            event_type = "workflow.halted"
+        else:
+            completed = WorkflowCompleted(
+                workflow_name=runtime.workflow.name,
+                run_id=runtime.run_id,
+                nodes_executed=state["nodes_executed"],
+                duration_ms=duration_ms,
+            )
+            event_type = "workflow.completed"
+        return {"events": [_record_event(runtime, event_type, completed)]}
+
+    return complete_workflow
+
+
+def _action_callable(
+    runtime: WorkflowRuntime,
+    node: NodeType,
+) -> Callable[[FactoryRunState], Any]:
+    async def execute_action(state: FactoryRunState) -> dict[str, Any]:
+        submitted: object | None = None
+        internal_node = isinstance(
+            node,
+            (ForkNode, JoinNode, SubgraphForkNode, SelectionNode),
+        )
+        if runtime.interactive and not internal_node:
+            submitted = interrupt({"kind": "node", "node_id": node.id})
+
+        started = NodeStarted(
+            workflow_name=runtime.workflow.name,
+            run_id=runtime.run_id,
+            node_id=node.id,
+            node_type=type(node).__name__,
+            iteration=int(state["node_attempts"].get(node.id, 0)),
+        )
+        started_event = _record_event(runtime, "node.started", started)
+        start = time.monotonic()
+        if submitted is not None:
+            output = runtime.accept_submission(node, str(submitted))
+        else:
+            output = await runtime.run_node(node, state)
+        elapsed = (time.monotonic() - start) * 1000
+        completed = NodeCompleted(
+            workflow_name=runtime.workflow.name,
+            run_id=runtime.run_id,
+            node_id=node.id,
+            node_type=type(node).__name__,
+            files_written=sorted(node.writes),
+            duration_ms=elapsed,
+        )
+        completed_event = _record_event(runtime, "node.completed", completed)
+        attempt = int(state["node_attempts"].get(node.id, 0)) + 1
+        return {
+            "completed_nodes": [node.id],
+            "completed_files": sorted(node.writes),
+            "node_outputs": {node.id: output},
+            "node_attempts": {node.id: attempt},
+            "events": [started_event, completed_event],
+            "nodes_executed": 1,
+        }
+
+    return execute_action
+
+
+def _gate_callable(
+    workflow: Workflow,
+    runtime: WorkflowRuntime,
+    node: GateNode,
+) -> Callable[[FactoryRunState], Any]:
+    async def execute_gate(state: FactoryRunState) -> Command[Any]:
+        needs_input = (
+            runtime.interactive and node.evaluator_type != "fn"
+        ) or (node.evaluator_type == "user" and not runtime.auto_approve)
+        if needs_input:
+            submitted = interrupt({"kind": "gate", "node_id": node.id})
+            verdict = runtime.parse_gate_submission(node, str(submitted))
+        else:
+            verdict = await runtime.evaluate_gate(node, state)
+
+        attempt = int(state["node_attempts"].get(node.id, 0)) + 1
+        started = NodeStarted(
+            workflow_name=workflow.name,
+            run_id=runtime.run_id,
+            node_id=node.id,
+            node_type="GateNode",
+            iteration=attempt - 1,
+        )
+        started_event = _record_event(runtime, "node.started", started)
+        gate_event = GateVerdictEvent(
+            workflow_name=workflow.name,
+            run_id=runtime.run_id,
+            node_id=node.id,
+            verdict_type=verdict.type,
+            target=verdict.target,
+            feedback=verdict.feedback,
+            reason=verdict.reason,
+            iteration=attempt - 1,
+        )
+        verdict_event = _record_event(runtime, "gate.verdict", gate_event)
+        update: dict[str, Any] = {
+            "completed_nodes": [node.id],
+            "node_attempts": {node.id: attempt},
+            "verdicts": {node.id: verdict.model_dump(mode="json")},
+            "events": [started_event, verdict_event],
+            "nodes_executed": 1,
+        }
+
+        target = _gate_target(workflow, node.id, verdict)
+        if verdict.type == VerdictType.RELOOP:
+            if target is None:
+                reason = f"reloop verdict from gate '{node.id}' has no target"
+                return Command(
+                    update={**update, "halted": True, "halt_reason": reason},
+                    goto="__factory_complete__",
+                )
+            key = f"{node.id}->{target}"
+            count = int(state["iteration_counts"].get(key, 0)) + 1
+            update["iteration_counts"] = {key: count}
+            if count > verdict.max_iterations:
+                reason = (
+                    f"max iterations ({verdict.max_iterations}) exhausted "
+                    f"for gate '{node.id}' -> '{target}'"
+                )
+                halt_target = _edge_target(workflow, node.id, VerdictType.HALT)
+                return Command(
+                    update={**update, "halted": True, "halt_reason": reason},
+                    goto=halt_target or "__factory_complete__",
+                )
+            if verdict.feedback:
+                existing = str(state["node_context"].get(target, ""))
+                feedback = f"[Feedback iteration {count}]: {verdict.feedback}"
+                update["node_context"] = {
+                    target: f"{existing}\n\n{feedback}" if existing else feedback,
+                }
+                entries = list(state["feedback_log"].get(target, []))
+                update["feedback_log"] = {
+                    target: [
+                        *entries,
+                        {
+                            "gate": node.id,
+                            "iteration": count,
+                            "feedback": verdict.feedback,
+                            "timestamp": time.time(),
+                        },
+                    ],
+                }
+
+        if verdict.type == VerdictType.HALT:
+            reason = verdict.reason or "gate halted"
+            update.update({"halted": True, "halt_reason": reason})
+
+        return Command(update=update, goto=target or "__factory_complete__")
+
+    return execute_gate
+
+
+def _record_event(
+    runtime: WorkflowRuntime,
+    event_type: str,
+    event: WorkflowEvent,
+) -> dict[str, Any]:
+    runtime.emit_event(event_type, event)
+    return {"type": event_type, **event.model_dump(mode="json")}
+
+
+def _gate_target(workflow: Workflow, gate_id: str, verdict: Verdict) -> str | None:
+    if verdict.type == VerdictType.RELOOP and verdict.target in workflow.nodes:
+        return verdict.target
+    target = _edge_target(workflow, gate_id, verdict.type)
+    if target is not None:
+        return target
+    if verdict.type == VerdictType.PROCEED:
+        return _edge_target(workflow, gate_id, None)
+    return None
+
+
+def _edge_target(
+    workflow: Workflow,
+    source: str,
+    condition: VerdictType | None,
+) -> str | None:
+    for edge in workflow.edges:
+        if edge.source == source and edge.condition == condition:
+            return edge.target
+    return None
+
+
+def _gate_destinations(workflow: Workflow, gate_id: str) -> list[str]:
+    return list(dict.fromkeys(edge.target for edge in workflow.edges if edge.source == gate_id))
+
+
+def collect_subgraph_nodes(workflow: Workflow, entry: str, exit_node: str) -> set[str]:
+    """Collect nodes reachable from ``entry`` through ``exit_node`` inclusive."""
+    edge_index: dict[str, list[str]] = {}
+    for edge in workflow.edges:
+        edge_index.setdefault(edge.source, []).append(edge.target)
+
+    collected: set[str] = set()
+    stack = [entry]
+    while stack:
+        node_id = stack.pop()
+        if node_id in collected:
+            continue
+        collected.add(node_id)
+        if node_id != exit_node:
+            stack.extend(edge_index.get(node_id, []))
+    return collected
+
+
+def _nested_subgraph_nodes(workflow: Workflow) -> set[str]:
+    nested: set[str] = set()
+    for node in workflow.nodes.values():
+        if isinstance(node, SubgraphForkNode):
+            nested.update(collect_subgraph_nodes(workflow, node.subgraph_entry, node.subgraph_exit))
+    return nested

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -181,8 +181,8 @@ class JoinNode(Node):
 class SubgraphForkNode(Node):
     """Fan-out to N copies of a subgraph, each in an isolated worktree.
 
-    The executor creates independent WorkflowExecutor instances per branch,
-    each with its own worktree branching from the same base commit.
+    Factory creates one isolated worktree and compiled child graph thread per
+    branch, all starting from the same base commit.
     """
 
     model_config = ConfigDict(strict=True, extra="forbid")

--- a/factory/workflow/tool.py
+++ b/factory/workflow/tool.py
@@ -1,15 +1,16 @@
-"""Tool-based workflow execution — step-by-step cursor over the DAG."""
+"""Thin CLI adapters over a persisted interactive LangGraph workflow thread."""
 
 from __future__ import annotations
 
+import asyncio
 import json
-import subprocess
 import time
 import uuid
 from pathlib import Path
+from typing import Any, TypedDict, cast
 
-import structlog
-
+from factory.workflow.executor import ExecutionResult, WorkflowExecutor
+from factory.workflow.langgraph import collect_subgraph_nodes
 from factory.workflow.primitives import (
     AgentConfig,
     AgentNode,
@@ -17,761 +18,526 @@ from factory.workflow.primitives import (
     FnNode,
     ForkNode,
     GateNode,
-    JoinNode,
     Study,
+    SubgraphForkNode,
     VerdictType,
     Workflow,
 )
 from factory.workflow.registry import WorkflowRegistry
 from factory.workflow.skill_export import _topological_sort
 
-log = structlog.get_logger()
+
+class ToolSession(TypedDict):
+    """Metadata and exact DSL snapshot used to reconstruct one graph thread."""
+
+    workflow_name: str
+    thread_id: str
+    original_project: str
+    started_at: float
+    workflow_json: str
+
 
 _workflow_cache: dict[str, Workflow] = {}
 
 
-def _resolve_original_project(wt_path: Path) -> Path:
-    """Resolve the original project path from a worktree path.
-
-    Worktree paths look like: /project/.factory-worktrees/run-xxx
-    or: /project/.factory/worktrees/run-xxx
-    Falls back to wt_path itself if not a worktree.
-    """
-    parts = wt_path.parts
-    for i, part in enumerate(parts):
+def _resolve_original_project(worktree_path: Path) -> Path:
+    """Resolve the original project path from a Factory worktree path."""
+    parts = worktree_path.parts
+    for index, part in enumerate(parts):
         if part == ".factory-worktrees":
-            return Path(*parts[:i])
-        if part == ".factory" and i + 1 < len(parts) and parts[i + 1] == "worktrees":
-            return Path(*parts[:i])
-    return wt_path
+            return Path(*parts[:index])
+        if part == ".factory" and parts[index + 1:index + 2] == ("worktrees",):
+            return Path(*parts[:index])
+    return worktree_path
 
 
-def _load_state(project_path: Path) -> dict:
-    state_path = project_path / ".factory" / "tool_session" / "state.json"
-    return json.loads(state_path.read_text())
+def _session_dir(project_path: Path) -> Path:
+    return project_path / ".factory" / "langgraph"
 
 
-def _save_state(project_path: Path, state: dict) -> None:
-    state_path = project_path / ".factory" / "tool_session" / "state.json"
-    state_path.write_text(json.dumps(state, indent=2))
+def _session_path(project_path: Path) -> Path:
+    return _session_dir(project_path) / "session.json"
 
 
-def _emit_event(project_path: Path, event_type: str, **data: object) -> None:
-    """Append a structured event to .factory/events.jsonl.
-
-    Resolves the original project path so events survive worktree deletion.
-    """
-    try:
-        state_path = project_path / ".factory" / "tool_session" / "state.json"
-        if state_path.exists():
-            state = json.loads(state_path.read_text())
-            orig = state.get("original_project")
-            if orig:
-                target = Path(orig)
-            else:
-                target = _resolve_original_project(project_path)
-        else:
-            target = _resolve_original_project(project_path)
-    except Exception:
-        target = project_path
-
-    event = {
-        "type": event_type,
-        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        **data,
-    }
-    events_file = target / ".factory" / "events.jsonl"
-    events_file.parent.mkdir(parents=True, exist_ok=True)
-    with open(events_file, "a") as f:
-        f.write(json.dumps(event) + "\n")
+def _load_session(project_path: Path) -> ToolSession:
+    return cast(ToolSession, json.loads(_session_path(project_path).read_text()))
 
 
-def _rebuild_workflow(cache_data: dict) -> Workflow:
-    """Rebuild a Workflow from cached JSON data."""
-    from factory.workflow.primitives import AgentRole, Edge, VerdictType
-
-    from factory.workflow.primitives import NodeType
-    nodes: dict[str, NodeType] = {}
-    for nid, info in cache_data["nodes"].items():
-        ntype = info["type"]
-        common: dict[str, object] = {
-            "id": nid,
-            "reads": set(info.get("reads", [])),
-            "writes": set(info.get("writes", [])),
-            "blocking": info.get("blocking", True),
-        }
-
-        if ntype == "AgentNode":
-            nodes[nid] = AgentNode(
-                **common,  # type: ignore[arg-type]
-                role=AgentRole(info["role"]),
-                model=info.get("model", ""),
-                prompt_template=info.get("prompt_template", ""),
-                timeout=info.get("timeout"),
-                max_iterations=info.get("max_iterations", 1),
-            )
-        elif ntype == "GateNode":
-            nodes[nid] = GateNode(
-                **common,  # type: ignore[arg-type]
-                evaluator_type=info.get("evaluator_type", "agent"),
-                evaluator_command=info.get("evaluator_command"),
-                gate_prompt=info.get("gate_prompt", ""),
-                evaluator_role=AgentRole(info["evaluator_role"]) if info.get("evaluator_role") else None,
-            )
-        elif ntype == "Study":
-            nodes[nid] = Study(
-                **common,  # type: ignore[arg-type]
-                command=info.get("command", ""),
-                focus=info.get("focus"),
-            )
-        elif ntype == "FnNode":
-            nodes[nid] = FnNode(
-                **common,  # type: ignore[arg-type]
-                command=info.get("command", ""),
-                notes=info.get("notes", ""),
-            )
-        elif ntype == "ForkNode":
-            nodes[nid] = ForkNode(
-                **common,  # type: ignore[arg-type]
-                targets=info.get("targets", []),
-            )
-        elif ntype == "JoinNode":
-            nodes[nid] = JoinNode(
-                **common,  # type: ignore[arg-type]
-                sources=info.get("sources", []),
-            )
-        else:
-            nodes[nid] = FnNode(**common, command="", notes="")  # type: ignore[arg-type]
-
-    edges = []
-    for e in cache_data.get("edges", []):
-        edges.append(Edge(
-            source=e["source"],
-            target=e["target"],
-            condition=VerdictType(e["condition"]) if e.get("condition") else None,
-        ))
-
-    return Workflow(
-        name=cache_data["name"],
-        nodes=nodes,
-        edges=edges,
-        start_node=cache_data["start_node"],
-    )
+def _save_session(project_path: Path, session: ToolSession) -> None:
+    path = _session_path(project_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(session, indent=2))
 
 
 def _get_workflow_cached(name: str, project_path: Path) -> Workflow:
+    """Load a workflow definition; graph checkpoints remain the execution authority."""
     cache_key = f"{project_path}:{name}"
     if cache_key in _workflow_cache:
         return _workflow_cache[cache_key]
 
-    cache_file = project_path / ".factory" / "tool_session" / "workflow_cache.json"
-    if cache_file.exists():
-        try:
-            cache_data = json.loads(cache_file.read_text())
-            if cache_data.get("name") == name:
-                wf = _rebuild_workflow(cache_data)
-                _workflow_cache[cache_key] = wf
-                return wf
-        except Exception:
-            pass
-
-    from factory.workflow.definitions import register_all
-
-    all_wf = register_all()
-    found: Workflow | None = all_wf.get(name)
-    if not found:
-        found = WorkflowRegistry.get_workflow(name, project_path)
-    if not found:
+    workflow = WorkflowRegistry.get_workflow(name, project_path)
+    if workflow is None:
         raise ValueError(f"Workflow not found: {name}")
-    _workflow_cache[cache_key] = found
-    return found
+    _workflow_cache[cache_key] = workflow
+    return workflow
 
 
-def tool_init(workflow_name: str, project_path: Path) -> str:
-    """Initialize a tool session. Returns session dir path."""
-    wf = WorkflowRegistry.get_workflow(workflow_name, project_path)
-    if not wf:
+def _executor(project_path: Path, session: ToolSession) -> WorkflowExecutor:
+    cache_key = f"{project_path}:{session['workflow_name']}"
+    workflow = _workflow_cache.get(cache_key)
+    if workflow is None:
+        workflow = Workflow.model_validate_json(session["workflow_json"])
+        _workflow_cache[cache_key] = workflow
+    return WorkflowExecutor(
+        workflow,
+        project_path,
+        agent_pool=DEFAULT_AGENT_POOL,
+        interactive=True,
+        thread_id=session["thread_id"],
+    )
+
+
+def _inspect(project_path: Path) -> tuple[ToolSession, Workflow, ExecutionResult]:
+    session = _load_session(project_path)
+    executor = _executor(project_path, session)
+    return session, executor.workflow, asyncio.run(executor.inspect())
+
+
+def tool_init(
+    workflow_name: str,
+    project_path: Path,
+    *,
+    workflow: Workflow | None = None,
+) -> str:
+    """Start a persisted interactive workflow and pause at its first task."""
+    workflow = workflow or WorkflowRegistry.get_workflow(workflow_name, project_path)
+    if workflow is None:
         raise ValueError(f"Unknown workflow: {workflow_name}")
 
-    session_dir = project_path / ".factory" / "tool_session"
-    session_dir.mkdir(parents=True, exist_ok=True)
-
-    order = _topological_sort(wf)
-
-    order = [nid for nid in order if not isinstance(wf.nodes.get(nid), JoinNode)]
-
-    state = {
-        "workflow_name": workflow_name,
-        "session_id": uuid.uuid4().hex[:12],
-        "original_project": str(_resolve_original_project(project_path)),
-        "started_at": int(time.time()),
-        "topo_order": order,
-        "pointer_idx": 0,
-        "completed": {},
-        "gate_results": {},
-        "iteration_counts": {},
-        "feedback_log": {},
-        "status": "active",
-    }
-
-    (session_dir / "state.json").write_text(json.dumps(state, indent=2))
-
-    cache_data: dict[str, object] = {
-        "name": wf.name,
-        "start_node": wf.start_node,
-        "nodes": {},
-        "edges": [
-            {
-                "source": e.source,
-                "target": e.target,
-                "condition": e.condition.value if e.condition else None,
-            }
-            for e in wf.edges
-        ],
-    }
-    nodes_cache: dict[str, dict[str, object]] = {}
-    for nid, node in wf.nodes.items():
-        node_info: dict[str, object] = {
-            "type": type(node).__name__,
-            "id": nid,
-            "blocking": node.blocking,
-            "reads": sorted(node.reads),
-            "writes": sorted(node.writes),
-        }
-        if isinstance(node, AgentNode):
-            node_info["role"] = node.role.value
-            node_info["model"] = node.model
-            node_info["prompt_template"] = node.prompt_template
-            node_info["timeout"] = node.timeout
-            node_info["max_iterations"] = node.max_iterations
-        elif isinstance(node, GateNode):
-            node_info["evaluator_type"] = node.evaluator_type
-            node_info["evaluator_command"] = node.evaluator_command
-            node_info["gate_prompt"] = node.gate_prompt
-            if node.evaluator_role:
-                node_info["evaluator_role"] = node.evaluator_role.value
-        elif isinstance(node, Study):
-            node_info["command"] = node.command
-            node_info["focus"] = node.focus
-        elif isinstance(node, FnNode):
-            node_info["command"] = node.command
-            node_info["notes"] = node.notes
-        elif isinstance(node, ForkNode):
-            node_info["targets"] = node.targets
-        nodes_cache[nid] = node_info
-    cache_data["nodes"] = nodes_cache
-    (session_dir / "workflow_cache.json").write_text(json.dumps(cache_data, indent=2))
-
-    _emit_event(
-        project_path, "workflow.tool.init",
-        workflow=workflow_name, session_id=state["session_id"], nodes=len(order),
+    thread_id = uuid.uuid4().hex[:12]
+    session = ToolSession(
+        workflow_name=workflow_name,
+        thread_id=thread_id,
+        original_project=str(_resolve_original_project(project_path)),
+        started_at=time.time(),
+        workflow_json=workflow.model_dump_json(),
     )
-    return str(session_dir)
+    _workflow_cache[f"{project_path}:{workflow_name}"] = workflow
+    _save_session(project_path, session)
+    asyncio.run(_executor(project_path, session).execute())
+    return str(_session_dir(project_path))
 
 
 def tool_next(project_path: Path, dry_run: bool = False) -> str:
-    """Get the next node to execute.
-
-    Auto-submits any pending node whose artifacts exist:
-    - AgentNode: .factory/reviews/<role>-latest.md or <role>-<tag>-latest.md
-    - Study: .factory/strategy/observations.md
-    - FnNode: declared writes exist
-    - ForkNode: skip (handled by sequential ordering)
-
-    The CEO never calls submit for agent/fn nodes — just next repeatedly.
-    Submit is only needed for gate verdicts.
-
-    When dry_run=True, runs the auto-submit scan but does not persist state
-    changes or emit events.
-    """
-    import copy
-
-    state = _load_state(project_path)
+    """Show pending graph tasks, auto-resuming tasks whose fresh artifacts exist."""
+    session, workflow, result = _inspect(project_path)
     if dry_run:
-        state = copy.deepcopy(state)
+        return _format_result(result, workflow, session, project_path)
 
-    if state["status"] != "active":
-        if not dry_run:
-            finalize_msg = tool_finalize(project_path)
-            return f"DONE\n{finalize_msg}"
-        return "DONE"
+    while result.interrupted:
+        resumes: dict[str, str] = {}
+        for pending in result.interrupts:
+            payload = _interrupt_payload(pending)
+            node = workflow.nodes[str(payload["node_id"])]
+            artifact = _detect_artifact(
+                node.id,
+                node,
+                project_path,
+                session_start=session["started_at"],
+            )
+            if artifact is not None:
+                resumes[str(pending["id"])] = artifact
 
-    wf = _get_workflow_cached(state["workflow_name"], project_path)
-    order = state["topo_order"]
-    idx = state["pointer_idx"]
+        if not resumes:
+            break
+        result = asyncio.run(_executor(project_path, session).resume(resumes))
 
-    while idx < len(order):
-        nid = order[idx]
-
-        if nid in state["completed"]:
-            idx += 1
-            continue
-
-        node = wf.nodes[nid]
-        artifact = _detect_artifact(
-            nid, node, project_path, session_start=state.get("started_at", 0.0),
-        )
-
-        if artifact is not None:
-            state["completed"][nid] = artifact
-            if isinstance(node, AgentNode) and node.writes:
-                for wp in node.writes:
-                    out = project_path / wp
-                    out.parent.mkdir(parents=True, exist_ok=True)
-                    if not out.exists():
-                        out.write_text(artifact)
-            log.info("tool.auto_submit", node=nid)
-            if not dry_run:
-                _emit_event(project_path, "workflow.tool.auto_submit", node=nid)
-            idx += 1
-            state["pointer_idx"] = idx
-
-            if idx < len(order):
-                next_nid = order[idx]
-                next_node = wf.nodes.get(next_nid)
-                if (
-                    isinstance(next_node, GateNode)
-                    and next_node.evaluator_type == "fn"
-                    and next_node.evaluator_command
-                ):
-                    gate_result = _auto_evaluate_fn_gate(
-                        next_node, project_path, state, wf, order, idx,
-                    )
-                    if gate_result:
-                        return gate_result
-                    idx = state["pointer_idx"]
-
-            if not dry_run:
-                _save_state(project_path, state)
-            continue
-
-        break
-
-    state["pointer_idx"] = idx
-    if not dry_run:
-        _save_state(project_path, state)
-
-    if idx >= len(order):
-        if not dry_run:
-            finalize_msg = tool_finalize(project_path)
-            return f"DONE\n{finalize_msg}"
-        return "DONE"
-
-    nid = order[idx]
-    node = wf.nodes[nid]
-
-    if not dry_run:
-        _emit_event(project_path, "workflow.tool.next", node=nid, node_type=type(node).__name__)
-
-    if isinstance(node, GateNode) and node.evaluator_type == "agent":
-        return f"GATE\n{_format_gate_task(nid, node, state, project_path)}"
-
-    if isinstance(node, GateNode) and node.evaluator_type == "user":
-        return f"APPROVAL_NEEDED\n{node.gate_prompt}"
-
-    return _format_node_task(nid, node, wf, state, project_path)
+    return _format_result(result, workflow, session, project_path)
 
 
 def tool_submit(project_path: Path, node_id: str, output: str) -> str:
-    """Submit output for a node (primarily used for gate verdicts)."""
-    state = _load_state(project_path)
-    wf = _get_workflow_cached(state["workflow_name"], project_path)
+    """Resume a pending graph interrupt for ``node_id`` with external output."""
+    session, workflow, result = _inspect(project_path)
+    matching = [
+        pending
+        for pending in result.interrupts
+        if _interrupt_payload(pending)["node_id"] == node_id
+    ]
+    if not matching:
+        pending_ids = [
+            str(_interrupt_payload(pending)["node_id"])
+            for pending in result.interrupts
+        ]
+        raise ValueError(
+            f"node '{node_id}' is not pending; pending nodes: {', '.join(pending_ids) or 'none'}"
+        )
 
-    state["completed"][node_id] = output
-    _emit_event(project_path, "workflow.tool.submit", node=node_id)
-
-    if isinstance(wf.nodes.get(node_id), GateNode) and output.strip().startswith("RETRY"):
-        import re as _re
-        target_m = _re.search(r'target=(\S+)', output)
-        feedback_m = _re.search(r'feedback="([^"]*)"', output)
-        if target_m:
-            reloop_target = target_m.group(1)
-            feedback_text = feedback_m.group(1) if feedback_m else output[:500]
-            feedback_log = state.setdefault("feedback_log", {})
-            entries = feedback_log.setdefault(reloop_target, [])
-            entries.append({
-                "gate": node_id,
-                "iteration": len([e for e in entries if e["gate"] == node_id]) + 1,
-                "feedback": feedback_text[:500],
-                "timestamp": time.time(),
-            })
-
-    node = wf.nodes.get(node_id)
-    if isinstance(node, AgentNode) and node.writes:
-        for write_path in node.writes:
-            out_file = project_path / write_path
-            out_file.parent.mkdir(parents=True, exist_ok=True)
-            out_file.write_text(output)
-
-    order = state["topo_order"]
-    idx = state["pointer_idx"]
-
-    if idx < len(order) and order[idx] == node_id:
-        idx += 1
-
-    state["pointer_idx"] = idx
-
-    if idx >= len(order):
-        state["status"] = "completed"
-        _save_state(project_path, state)
+    resumed = asyncio.run(
+        _executor(project_path, session).resume({str(matching[0]["id"]): output})
+    )
+    if resumed.halted:
+        return f"HALT\n{resumed.halt_reason}"
+    if resumed.completed:
         return "DONE"
 
-    next_nid = order[idx]
-    next_node = wf.nodes.get(next_nid)
-    if (
-        isinstance(next_node, GateNode)
-        and next_node.evaluator_type == "fn"
-        and next_node.evaluator_command
-    ):
-        gate_result = _auto_evaluate_fn_gate(
-            next_node, project_path, state, wf, order, idx,
-        )
-        if gate_result:
-            return gate_result
-
-    _save_state(project_path, state)
+    reloop_target = _find_reloop_target(workflow, node_id)
+    current_ids = {
+        str(_interrupt_payload(pending)["node_id"])
+        for pending in resumed.interrupts
+    }
+    if output.strip().startswith(("RELOOP", "RETRY")) and reloop_target in current_ids:
+        count = int(resumed.state.get("iteration_counts", {}).get(
+            f"{node_id}->{reloop_target}", 0,
+        ))
+        return f"RETRY\nRetry from: {reloop_target} (attempt {count}/3)"
     return "CONTINUE"
 
 
 def tool_status(project_path: Path, fmt: str = "linear") -> str:
-    """Get current session status."""
-    state_path = project_path / ".factory" / "tool_session" / "state.json"
-    if not state_path.exists():
-        return "No active session. Run: factory tool init <workflow> <project_path>"
+    """Show status projected from the current LangGraph checkpoint."""
+    if not _session_path(project_path).exists():
+        return "No active session. Run: factory workflow tool init <workflow> <project_path>"
 
-    state = json.loads(state_path.read_text())
-    order = state["topo_order"]
-    idx = state["pointer_idx"]
-    current = order[idx] if idx < len(order) else "DONE"
-    completed_count = len(state["completed"])
-    total = len(order)
-
-    try:
-        wf = _get_workflow_cached(state["workflow_name"], project_path)
-    except Exception:
-        wf = None
-
-    current_nid = current if current != "DONE" else None
-
+    session, workflow, result = _inspect(project_path)
+    state = _display_state(workflow, result)
+    current_ids = _current_node_ids(result)
+    current = ", ".join(current_ids) if current_ids else "DONE"
     lines = [
-        f"Workflow: {state['workflow_name']}",
-        f"Session:  {state['session_id']}",
+        f"Workflow: {session['workflow_name']}",
+        f"Thread:   {session['thread_id']}",
         f"Status:   {state['status']}",
-        f"Progress: {completed_count}/{total} nodes",
+        f"Progress: {len(result.completed_nodes)}/{len(state['topo_order'])} nodes",
         f"Current:  {current}",
+        "",
+        _format_progress(
+            state,
+            workflow,
+            project_path,
+            set(current_ids),
+            fmt=fmt,
+        ),
     ]
-
-    if state["gate_results"]:
-        lines.append(f"Gates:    {json.dumps(state['gate_results'])}")
-
-    lines.append("")
-    lines.append(_format_progress(state, wf, project_path, current_nid, fmt=fmt))
-
     return "\n".join(lines)
 
 
 def tool_finalize(project_path: Path) -> str:
-    """Finalize the tool session — mark any remaining untracked nodes as complete.
+    """Resume only pending tasks backed by fresh artifacts; never fake completion."""
+    session, workflow, before = _inspect(project_path)
+    result = before
+    while result.interrupted:
+        resumes: dict[str, str] = {}
+        for pending in result.interrupts:
+            payload = _interrupt_payload(pending)
+            node = workflow.nodes[str(payload["node_id"])]
+            artifact = _detect_artifact(
+                node.id,
+                node,
+                project_path,
+                session_start=session["started_at"],
+            )
+            if artifact is not None:
+                resumes[str(pending["id"])] = artifact
+        if not resumes:
+            break
+        result = asyncio.run(_executor(project_path, session).resume(resumes))
 
-    Scans forward from the current pointer, auto-completing any nodes whose
-    artifacts exist but weren't tracked (e.g., async agents like archivist).
-    """
-    state = _load_state(project_path)
-    wf = _get_workflow_cached(state["workflow_name"], project_path)
-    order = state["topo_order"]
-
-    finalized = []
-    for nid in order:
-        if nid in state["completed"]:
-            continue
-        node = wf.nodes[nid]
-        artifact = _detect_artifact(
-            nid, node, project_path, session_start=state.get("started_at", 0.0),
-        )
-        if artifact is not None:
-            state["completed"][nid] = artifact
-            finalized.append(nid)
-            log.info("tool.finalize", node=nid)
-
-    if len(state["completed"]) >= len(order):
-        state["status"] = "completed"
-
-    state["pointer_idx"] = len(order)
-    _save_state(project_path, state)
-
-    _emit_event(project_path, "workflow.tool.finalize", nodes=finalized)
-
-    if finalized:
-        return (
-            f"Finalized {len(finalized)} node(s): {', '.join(finalized)}\n"
-            f"Progress: {len(state['completed'])}/{len(order)}"
-        )
-    return f"No pending nodes to finalize. Progress: {len(state['completed'])}/{len(order)}"
+    advanced = len(result.completed_nodes) - len(before.completed_nodes)
+    if result.halted:
+        return f"HALT: {result.halt_reason}"
+    if result.completed:
+        return f"DONE. Finalized {advanced} node(s)."
+    pending_text = ", ".join(_current_node_ids(result)) or "unknown"
+    return f"Pending graph tasks: {pending_text}. Finalized {advanced} node(s)."
 
 
 def tool_overview(project_path: Path, fmt: str = "linear") -> str:
-    """Render the full workflow map with completion markers. Does NOT advance."""
-    state = _load_state(project_path)
-    wf = _get_workflow_cached(state["workflow_name"], project_path)
-    order = state["topo_order"]
-    idx = state["pointer_idx"]
-    current_nid = order[idx] if idx < len(order) else None
-    return _format_progress(state, wf, project_path, current_nid, fmt=fmt)
+    """Render the graph and checkpoint progress without advancing execution."""
+    _, workflow, result = _inspect(project_path)
+    return _format_progress(
+        _display_state(workflow, result),
+        workflow,
+        project_path,
+        set(_current_node_ids(result)),
+        fmt=fmt,
+    )
 
 
 def tool_curr(project_path: Path) -> str:
-    """Show current node details without advancing or auto-submitting."""
-    state = _load_state(project_path)
-    wf = _get_workflow_cached(state["workflow_name"], project_path)
-    order = state["topo_order"]
-    idx = state["pointer_idx"]
+    """Show pending graph task details without advancing execution."""
+    session, workflow, result = _inspect(project_path)
+    return _format_result(result, workflow, session, project_path)
 
-    if idx >= len(order):
+
+def _interrupt_payload(interrupt: dict[str, Any]) -> dict[str, str]:
+    value = interrupt["value"]
+    if not isinstance(value, dict):
+        raise TypeError(f"invalid workflow interrupt payload: {value!r}")
+    return {"kind": str(value["kind"]), "node_id": str(value["node_id"])}
+
+
+def _current_node_ids(result: ExecutionResult) -> list[str]:
+    return [
+        str(_interrupt_payload(pending)["node_id"])
+        for pending in result.interrupts
+    ]
+
+
+def _display_order(workflow: Workflow) -> list[str]:
+    nested: set[str] = set()
+    for node in workflow.nodes.values():
+        if isinstance(node, SubgraphForkNode):
+            nested.update(
+                collect_subgraph_nodes(
+                    workflow,
+                    node.subgraph_entry,
+                    node.subgraph_exit,
+                )
+            )
+    return [node_id for node_id in _topological_sort(workflow) if node_id not in nested]
+
+
+def _display_state(workflow: Workflow, result: ExecutionResult) -> dict[str, Any]:
+    if result.halted:
+        status = "halted"
+    elif result.completed:
+        status = "completed"
+    else:
+        status = "active"
+    return {
+        **result.state,
+        "topo_order": _display_order(workflow),
+        "completed": {node_id: result.node_outputs.get(node_id, "") for node_id in result.completed_nodes},
+        "status": status,
+    }
+
+
+def _format_result(
+    result: ExecutionResult,
+    workflow: Workflow,
+    session: ToolSession,
+    project_path: Path,
+) -> str:
+    if result.halted:
+        return f"HALT\n{result.halt_reason}"
+    if result.completed:
         return "DONE\nAll nodes completed."
+    if not result.interrupted:
+        return "PENDING\nWorkflow has no resumable task."
 
-    nid = order[idx]
-    node = wf.nodes[nid]
-    return _format_node_task(nid, node, wf, state, project_path)
+    state = _display_state(workflow, result)
+    tasks: list[str] = []
+    for pending in result.interrupts:
+        payload = _interrupt_payload(pending)
+        node_id = payload["node_id"]
+        node = workflow.nodes[node_id]
+        if payload["kind"] == "gate":
+            if not isinstance(node, GateNode):
+                raise TypeError(f"gate interrupt references {type(node).__name__}: {node_id}")
+            if node.evaluator_type == "user":
+                tasks.append(f"APPROVAL_NEEDED\n{node.gate_prompt}")
+            else:
+                tasks.append(
+                    f"GATE\n{_format_gate_task(node_id, node, state, project_path)}"
+                )
+        else:
+            tasks.append(_format_node_task(node_id, node, workflow, state, project_path))
+
+    if len(tasks) == 1:
+        return tasks[0]
+    return "PARALLEL\n" + "\n\n---\n\n".join(tasks)
 
 
-# ── helpers ─────────────────────────────────────────────────────
-
-
-def _phase_label(nid: str, node: object) -> str:
+def _phase_label(node_id: str, node: object) -> str:
     """Generate a human-readable phase label from node id and type."""
-    name = nid.replace("_", " ").title()
-
+    name = node_id.replace("_", " ").title()
     if isinstance(node, AgentNode):
         role = node.role.value.replace("_", " ").title()
         return role if role.lower() in name.lower() else f"{role} — {name}"
-    elif isinstance(node, GateNode):
-        gate_name = nid.replace("gate_", "").replace("_", " ").title()
+    if isinstance(node, GateNode):
+        gate_name = node_id.replace("gate_", "").replace("_", " ").title()
         return f"Gate — {gate_name}"
-    elif isinstance(node, Study):
-        return f"Observe ({nid})"
-    elif isinstance(node, ForkNode):
+    if isinstance(node, Study):
+        return f"Observe ({node_id})"
+    if isinstance(node, ForkNode):
         return f"Fork ({', '.join(node.targets)})"
-    elif isinstance(node, FnNode):
+    if isinstance(node, FnNode):
         return name
     return name
 
 
 def _format_progress(
-    state: dict,
-    wf: Workflow | None,
+    state: dict[str, Any],
+    workflow: Workflow | None,
     project_path: Path,
-    current_nid: str | None,
+    current_nodes: str | set[str] | None,
     fmt: str = "linear",
 ) -> str:
     """Build a progress view of the workflow with completion markers."""
+    current = {current_nodes} if isinstance(current_nodes, str) else current_nodes or set()
     order = state["topo_order"]
     completed = state["completed"]
     lines: list[str] = []
-
-    for i, nid in enumerate(order):
-        node = wf.nodes.get(nid) if wf else None
-        is_current = nid == current_nid
-        is_done = nid in completed
-
-        if is_done:
-            marker = "✓"
-        elif is_current:
-            marker = "▶"
-        else:
-            marker = "○"
-
+    for index, node_id in enumerate(order):
+        node = workflow.nodes.get(node_id) if workflow else None
+        is_current = node_id in current
+        is_done = node_id in completed
+        marker = "✓" if is_done else "▶" if is_current else "○"
         if fmt == "phased":
-            label = _phase_label(nid, node) if node else nid.replace("_", " ").title()
-            line = f"{marker} Phase {i + 1}: {label}"
+            label = _phase_label(node_id, node) if node else node_id.replace("_", " ").title()
+            line = f"{marker} Phase {index + 1}: {label}"
         else:
-            line = f"{marker} {nid}"
-
+            line = f"{marker} {node_id}"
         if is_current:
             line += "    ← CURRENT"
-
         lines.append(line)
-
-        if is_current and node is not None and wf is not None:
-            details = _format_node_task(nid, node, wf, state, project_path)
-            for detail_line in details.split("\n"):
-                if detail_line.startswith("Node:"):
-                    continue
-                lines.append(f"  {detail_line}")
-
     return "\n".join(lines)
 
 
 def _find_loop_context(
-    nid: str, wf: Workflow, state: dict, project_path: Path,
+    node_id: str,
+    workflow: Workflow,
+    state: dict[str, Any],
+    project_path: Path,
 ) -> str:
-    """Build a LOOP CONTEXT section for a node that is a RELOOP target.
-
-    Returns an empty string when nid is not a reloop target. Otherwise,
-    always returns a markdown section showing the loop topology, gate
-    criteria, and iteration count — even on the first invocation (iteration
-    0). The feedback history subsection is only included when feedback
-    entries exist (i.e. after at least one RELOOP).
-    """
+    """Build loop topology and persisted LangGraph feedback for a reloop target."""
     reloop_edges = [
-        e for e in wf.edges
-        if e.target == nid and e.condition == VerdictType.RELOOP
+        edge
+        for edge in workflow.edges
+        if edge.target == node_id and edge.condition == VerdictType.RELOOP
     ]
     if not reloop_edges:
         return ""
 
-    topo = state.get("topo_order", [])
+    order = state.get("topo_order", [])
     iteration_counts = state.get("iteration_counts", {})
     feedback_log = state.get("feedback_log", {})
-
-    from factory.workflow.primitives import Edge as _Edge
-    latest_entry: dict | None = None
-    latest_gate_edge: _Edge | None = None
-    entries_for_node = feedback_log.get(nid, [])
-    if entries_for_node:
-        latest_entry = max(entries_for_node, key=lambda e: e.get("timestamp", 0))
-        for e in reloop_edges:
-            if e.source == latest_entry.get("gate"):
-                latest_gate_edge = e
-                break
-
-    active_edge = latest_gate_edge or reloop_edges[0]
+    entries = feedback_log.get(node_id, [])
+    latest = max(entries, key=lambda entry: entry.get("timestamp", 0)) if entries else None
+    active_edge = next(
+        (edge for edge in reloop_edges if latest and edge.source == latest.get("gate")),
+        reloop_edges[0],
+    )
     gate_id = active_edge.source
-    iter_key = f"{gate_id}->{nid}"
-    count = iteration_counts.get(iter_key, 0)
-    max_iter = 3
-
-    lines: list[str] = [
-        "",
-        "## LOOP CONTEXT",
-        f"Iteration: {count}/{max_iter}",
-    ]
-    if count >= max_iter:
+    count = int(iteration_counts.get(f"{gate_id}->{node_id}", 0))
+    max_iterations = 3
+    lines = ["", "## LOOP CONTEXT", f"Iteration: {count}/{max_iterations}"]
+    if count >= max_iterations:
         lines.append("⚠ FINAL ATTEMPT — this is the last iteration before HALT")
 
-    gate_node = wf.nodes.get(gate_id)
+    gate_node = workflow.nodes.get(gate_id)
     lines.append(f"Triggered by: {gate_id}")
     if isinstance(gate_node, GateNode):
         if gate_node.gate_prompt:
-            prompt_text = gate_node.gate_prompt.replace("{project_path}", str(project_path))
-            lines.append(f"Gate criteria: {prompt_text}")
+            prompt = gate_node.gate_prompt.replace("{project_path}", str(project_path))
+            lines.append(f"Gate criteria: {prompt}")
         if gate_node.evaluator_command:
-            cmd_text = gate_node.evaluator_command.replace("{project_path}", str(project_path))
-            lines.append(f"Gate command: {cmd_text}")
+            command = gate_node.evaluator_command.replace("{project_path}", str(project_path))
+            lines.append(f"Gate command: {command}")
 
-    try:
-        nid_idx = topo.index(nid)
-        gate_idx = topo.index(gate_id)
-    except ValueError:
-        nid_idx = gate_idx = -1
+    if node_id in order and gate_id in order:
+        node_index = order.index(node_id)
+        gate_index = order.index(gate_id)
+        if node_index < gate_index:
+            lines.extend(["", "### Loop topology"])
+            for loop_id in order[node_index:gate_index + 1]:
+                loop_node = workflow.nodes.get(loop_id)
+                parts = [f"- **{loop_id}**"]
+                if isinstance(loop_node, AgentNode):
+                    parts.append(f"(agent: {loop_node.role.value})")
+                    if loop_node.reads:
+                        parts.append(f"reads: {', '.join(sorted(loop_node.reads))}")
+                    if loop_node.writes:
+                        parts.append(f"writes: {', '.join(sorted(loop_node.writes))}")
+                elif isinstance(loop_node, GateNode):
+                    parts.append(f"(gate: {loop_node.evaluator_type})")
+                elif isinstance(loop_node, FnNode):
+                    parts.append("(fn)")
+                lines.append(" ".join(parts))
 
-    if 0 <= nid_idx < gate_idx:
-        loop_path = topo[nid_idx:gate_idx + 1]
-        lines.append("")
-        lines.append("### Loop topology")
-        for loop_nid in loop_path:
-            loop_node = wf.nodes.get(loop_nid)
-            if loop_node is None:
-                continue
-            parts = [f"- **{loop_nid}**"]
-            if isinstance(loop_node, AgentNode):
-                parts.append(f"(agent: {loop_node.role.value})")
-                if loop_node.reads:
-                    parts.append(f"reads: {', '.join(sorted(loop_node.reads))}")
-                if loop_node.writes:
-                    parts.append(f"writes: {', '.join(sorted(loop_node.writes))}")
-            elif isinstance(loop_node, GateNode):
-                parts.append(f"(gate: {loop_node.evaluator_type})")
-            elif isinstance(loop_node, FnNode):
-                parts.append("(fn)")
-            lines.append(" ".join(parts))
-
-    if entries_for_node:
-        lines.append("")
-        lines.append("### Feedback history")
-        recent = sorted(entries_for_node, key=lambda e: e.get("timestamp", 0))[-2:]
-        for entry in recent:
-            fb_text = entry.get("feedback", "")[:500]
-            lines.append(f"- [{entry.get('gate', '?')} iter {entry.get('iteration', '?')}] {fb_text}")
-
+    if entries:
+        lines.extend(["", "### Feedback history"])
+        for entry in sorted(entries, key=lambda item: item.get("timestamp", 0))[-2:]:
+            feedback = str(entry.get("feedback", ""))[:500]
+            lines.append(
+                f"- [{entry.get('gate', '?')} iter {entry.get('iteration', '?')}] {feedback}"
+            )
     return "\n".join(lines)
 
 
 def _format_node_task(
-    nid: str, node: object, wf: Workflow, state: dict, project_path: Path,
+    node_id: str,
+    node: object,
+    workflow: Workflow,
+    state: dict[str, Any],
+    project_path: Path,
 ) -> str:
-    """Format a node as a human-readable task description."""
-    lines = [f"Node: {nid}"]
-
+    """Format one pending graph node as a human-readable task."""
+    lines = [f"Node: {node_id}"]
     if isinstance(node, AgentNode):
         role = node.role.value
-        pool_cfg: AgentConfig | None = DEFAULT_AGENT_POOL.get(role)
-        model = node.model or (pool_cfg.model if pool_cfg else "opus")
-        timeout = node.timeout or (pool_cfg.timeout if pool_cfg else 600)
-
-        lines.append(f"Type: Agent ({role})")
-        lines.append(f"Model: {model}")
-        lines.append(f"Timeout: {timeout}s")
-
+        pool_config: AgentConfig | None = DEFAULT_AGENT_POOL.get(role)
+        model = node.model or (pool_config.model if pool_config else "opus")
+        timeout = node.timeout or (pool_config.timeout if pool_config else 600)
+        lines.extend([
+            f"Type: Agent ({role})",
+            f"Model: {model}",
+            f"Timeout: {timeout}s",
+        ])
         if node.prompt_template:
             task = node.prompt_template.replace("{project_path}", str(project_path))
             lines.append(f"Task: {task}")
-
         if node.reads:
             lines.append(f"Reads: {', '.join(sorted(node.reads))}")
         if node.writes:
             lines.append(f"Writes: {', '.join(sorted(node.writes))}")
-
     elif isinstance(node, GateNode):
         lines.append(f"Type: Gate ({node.evaluator_type})")
         if node.gate_prompt:
             lines.append(f"Evaluate: {node.gate_prompt}")
         if node.evaluator_command:
-            cmd = node.evaluator_command.replace("{project_path}", str(project_path))
-            lines.append(f"Command: {cmd}")
+            command = node.evaluator_command.replace("{project_path}", str(project_path))
+            lines.append(f"Command: {command}")
         if node.reads:
             lines.append(f"Reads: {', '.join(sorted(node.reads))}")
-
     elif isinstance(node, Study):
-        cmd = node.command.replace("{project_path}", str(project_path))
-        lines.append("Type: Study")
-        lines.append(f"Command: {cmd}")
-
+        command = node.command.replace("{project_path}", str(project_path))
+        lines.extend(["Type: Study", f"Command: {command}"])
     elif isinstance(node, FnNode):
-        cmd = node.command.replace("{project_path}", str(project_path))
-        lines.append("Type: Function")
-        lines.append(f"Command: {cmd}")
+        command = node.command.replace("{project_path}", str(project_path))
+        lines.extend(["Type: Function", f"Command: {command}"])
         if node.notes:
             lines.append(f"Notes: {node.notes}")
-
     elif isinstance(node, ForkNode):
-        lines.append("Type: Fork")
-        lines.append(f"Targets: {', '.join(node.targets)}")
-        lines.append("Execute all targets (listed as subsequent nodes).")
+        lines.extend([
+            "Type: Fork",
+            f"Targets: {', '.join(node.targets)}",
+            "Execute all targets (listed as parallel pending nodes).",
+        ])
 
-    loop_ctx = _find_loop_context(nid, wf, state, project_path)
-    if loop_ctx:
-        lines.append(loop_ctx)
-
+    loop_context = _find_loop_context(node_id, workflow, state, project_path)
+    if loop_context:
+        lines.append(loop_context)
     return "\n".join(lines)
 
 
 def _format_gate_task(
-    nid: str, gate_node: GateNode, state: dict, project_path: Path,
+    node_id: str,
+    gate_node: GateNode,
+    state: dict[str, Any],
+    project_path: Path,
 ) -> str:
-    """Format a gate node as a review task."""
+    """Format one pending gate interrupt as a review task."""
     prompt = gate_node.gate_prompt or "Review the output of the preceding step."
     prompt = prompt.replace("{project_path}", str(project_path))
-
     reads = ", ".join(sorted(gate_node.reads)) if gate_node.reads else "none"
-
-    reloop_targets: list[str] = []
-    wf = _get_workflow_cached(state["workflow_name"], project_path)
-    for edge in wf.edges:
-        if edge.source == nid and edge.condition == VerdictType.RELOOP:
-            reloop_targets.append(edge.target)
-
-    lines = [
-        f"Gate: {nid}",
+    workflow = _get_workflow_cached(str(state["workflow_name"]), project_path)
+    reloop_targets = [
+        edge.target
+        for edge in workflow.edges
+        if edge.source == node_id and edge.condition == VerdictType.RELOOP
+    ]
+    return "\n".join([
+        f"Gate: {node_id}",
         f"Review: {prompt}",
         f"Read: {reads}",
         f"Reloop targets: {reloop_targets if reloop_targets else 'none'}",
@@ -780,143 +546,57 @@ def _format_gate_task(
         "  PROCEED",
         '  RETRY target=<node_id> feedback="<feedback>"',
         '  HALT reason="<reason>"',
-    ]
-    return "\n".join(lines)
+    ])
 
 
 def _detect_artifact(
-    nid: str, node: object, project_path: Path, session_start: float = 0.0,
+    node_id: str,
+    node: object,
+    project_path: Path,
+    session_start: float = 0.0,
 ) -> str | None:
-    """Check if a node's output artifact exists. Returns content or None.
-
-    When session_start > 0, files with mtime before that timestamp are
-    treated as stale leftovers from a prior run and ignored.
-    """
+    """Return a fresh external artifact for a pending graph node, if present."""
     reviews_dir = project_path / ".factory" / "reviews"
 
-    def _fresh(f: Path) -> bool:
-        return session_start <= 0 or f.stat().st_mtime >= session_start
+    def fresh(path: Path) -> bool:
+        return session_start <= 0 or path.stat().st_mtime >= session_start
 
     if isinstance(node, AgentNode):
         role = node.role.value
-        tag = nid.replace(f"{role}_", "").replace(role, "")
-        if tag and tag != nid:
-            tagged_file = reviews_dir / f"{role}-{tag}-latest.md"
-            if tagged_file.exists() and _fresh(tagged_file):
-                content = tagged_file.read_text().strip()
+        tag = node_id.replace(f"{role}_", "").replace(role, "")
+        candidates: list[Path] = []
+        if tag and tag != node_id:
+            candidates.append(reviews_dir / f"{role}-{tag}-latest.md")
+        candidates.append(reviews_dir / f"{role}-latest.md")
+        candidates.extend(project_path / path for path in sorted(node.writes))
+        for candidate in candidates:
+            if candidate.exists() and fresh(candidate):
+                content = candidate.read_text().strip()
                 if content:
                     return content
-        review_file = reviews_dir / f"{role}-latest.md"
-        if review_file.exists() and _fresh(review_file):
-            content = review_file.read_text().strip()
-            if content:
-                return content
-        if node.writes:
-            for wp in node.writes:
-                f = project_path / wp
-                if f.exists() and _fresh(f):
-                    content = f.read_text().strip()
-                    if content:
-                        return content
         return None
 
-    elif isinstance(node, Study):
-        obs_file = project_path / ".factory" / "strategy" / "observations.md"
-        if obs_file.exists() and _fresh(obs_file):
-            content = obs_file.read_text().strip()
-            if content and len(content) > 50:
-                return content
+    if isinstance(node, Study):
+        observation = project_path / ".factory" / "strategy" / "observations.md"
+        if observation.exists() and fresh(observation):
+            content = observation.read_text().strip()
+            return content if len(content) > 50 else None
         return None
 
-    elif isinstance(node, FnNode):
-        if node.writes:
-            all_exist = all(
-                (project_path / wp).exists() and _fresh(project_path / wp)
-                for wp in node.writes
-            )
-            if all_exist:
-                parts = []
-                for wp in node.writes:
-                    parts.append((project_path / wp).read_text().strip()[:500])
-                return "; ".join(parts) if parts else None
+    if isinstance(node, FnNode):
+        outputs = [project_path / path for path in sorted(node.writes)]
+        if outputs and all(path.exists() and fresh(path) for path in outputs):
+            return "; ".join(path.read_text().strip()[:500] for path in outputs)
         return None
 
-    elif isinstance(node, ForkNode):
-        return f"Fork targets: {', '.join(node.targets)}"
-
-    elif isinstance(node, GateNode):
-        return None
-
+    if isinstance(node, ForkNode):
+        return json.dumps({"targets": node.targets})
     return None
 
 
-def _auto_evaluate_fn_gate(
-    gate_node: GateNode,
-    project_path: Path,
-    state: dict,
-    wf: Workflow,
-    order: list[str],
-    idx: int,
-) -> str | None:
-    """Auto-evaluate a fn gate. Returns RETRY/HALT string or None if passed."""
-    nid = order[idx]
-    assert gate_node.evaluator_command is not None
-    cmd = gate_node.evaluator_command.replace("{project_path}", str(project_path))
-    try:
-        result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=60,
-        )
-        gate_output = result.stdout.strip()
-        gate_passed = result.returncode == 0 and "FAIL" not in gate_output
-    except subprocess.TimeoutExpired:
-        gate_output = "Gate command timed out"
-        gate_passed = False
-
-    state["gate_results"][nid] = "PROCEED" if gate_passed else "HALT"
-    state["completed"][nid] = gate_output
-    _emit_event(
-        project_path, "workflow.tool.gate_eval",
-        gate=nid, result="PROCEED" if gate_passed else "HALT",
-    )
-
-    if not gate_passed:
-        reloop_target = _find_reloop_target(wf, nid)
-        if reloop_target:
-            iter_key = f"{nid}->{reloop_target}"
-            count = state["iteration_counts"].get(iter_key, 0) + 1
-            state["iteration_counts"][iter_key] = count
-
-            feedback_log = state.setdefault("feedback_log", {})
-            entries = feedback_log.setdefault(reloop_target, [])
-            entries.append({
-                "gate": nid,
-                "iteration": count,
-                "feedback": gate_output[:500],
-                "timestamp": time.time(),
-            })
-
-            if count <= 3:
-                if reloop_target in order:
-                    state["pointer_idx"] = order.index(reloop_target)
-                _save_state(project_path, state)
-                return (
-                    f"RETRY\nGate {nid} failed: {gate_output}\n"
-                    f"Retry from: {reloop_target} (attempt {count}/3)"
-                )
-
-        state["status"] = "halted"
-        state["pointer_idx"] = idx + 1
-        _save_state(project_path, state)
-        return f"HALT\nGate {nid} failed: {gate_output}"
-
-    state["pointer_idx"] = idx + 1
-    _save_state(project_path, state)
-    return None
-
-
-def _find_reloop_target(wf: Workflow, gate_id: str) -> str | None:
+def _find_reloop_target(workflow: Workflow, gate_id: str) -> str | None:
     """Find the RELOOP target for a gate node."""
-    for edge in wf.edges:
+    for edge in workflow.edges:
         if edge.source == gate_id and edge.condition == VerdictType.RELOOP:
             return edge.target
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "anthropic[vertex]>=0.52",
     "mempalace>=3.6.0",
     "graphifyy>=0.9",
+    "langgraph>=1.2.11",
+    "langgraph-checkpoint-sqlite>=3.1.1",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -450,7 +450,9 @@ class TestCmdCeoDesign:
             patch("factory.cli._helpers._ensure_dashboard"),
             patch("factory.graph.is_graphify_installed", return_value=False),
         ):
-            result = main(["ceo", str(tmp_path), "--mode", "design", "--auto-approve"])
+            result = main(
+                ["ceo", str(tmp_path), "--mode", "design", "--auto-approve", "--engine", "skill"]
+            )
         assert result == 0
 
     def test_auto_approve_forces_headless(self):
@@ -543,7 +545,9 @@ class TestAutoApproveEvent:
             patch("factory.graph.is_graphify_installed", return_value=False),
             patch("factory.cli._ceo_helpers._emit_cli_event") as mock_emit,
         ):
-            result = main(["ceo", str(tmp_path), "--mode", "design", "--auto-approve"])
+            result = main(
+                ["ceo", str(tmp_path), "--mode", "design", "--auto-approve", "--engine", "skill"]
+            )
         assert result == 0
         mock_emit.assert_any_call(tmp_path, "auto_approve.enabled", {"mode": "design"})
 
@@ -745,7 +749,8 @@ class TestCmdDetect:
 
 class TestCmdDiscover:
     def test_discover_python_project(self, python_project, capsys):
-        result = main(["discover", str(python_project)])
+        with patch("factory.cli.spec._run_spec_workflow", return_value=(1, "skipped in unit test")):
+            result = main(["discover", str(python_project)])
         assert result == 0
         output = json.loads(capsys.readouterr().out)
         assert output["project"]["language"] == "python"
@@ -851,16 +856,63 @@ class TestCmdHistory:
 
 
 class TestCmdRun:
+    def test_run_defaults_to_langgraph(self, tmp_path, capsys):
+        """cmd_run starts the persisted graph runtime unless skill is explicit."""
+        from factory.workflow.executor import ExecutionResult
+
+        with (
+            patch("factory.workflow.executor.WorkflowExecutor") as executor_cls,
+            patch(
+                "factory.worktree.create_worktree",
+                return_value=(tmp_path, "factory/run-test"),
+            ),
+            patch("factory.worktree.remove_worktree"),
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("factory.cli.run._chain_modes", return_value=0),
+            patch("factory.cli.run._ensure_dashboard"),
+        ):
+            executor_cls.return_value.execute = AsyncMock(
+                return_value=ExecutionResult(
+                    success=True,
+                    completed=True,
+                    thread_id="thread-1",
+                )
+            )
+            result = main(["run", str(tmp_path), "--mode", "improve"])
+
+        assert result == 0
+        executor_cls.assert_called_once()
+        assert '"engine": "langgraph"' in capsys.readouterr().out
+
+    def test_langgraph_failure_preserves_worktree_for_resume(self, tmp_path):
+        with (
+            patch("factory.workflow.executor.WorkflowExecutor") as executor_cls,
+            patch(
+                "factory.worktree.create_worktree",
+                return_value=(tmp_path, "factory/run-test"),
+            ),
+            patch("factory.worktree.remove_worktree") as remove_worktree,
+            patch("factory.worktree.prune_stale", return_value=[]),
+            patch("factory.cli.run._ensure_dashboard"),
+        ):
+            executor_cls.return_value.execute = AsyncMock(
+                side_effect=RuntimeError("ambiguous operation")
+            )
+            result = main(["run", str(tmp_path), "--mode", "improve"])
+
+        assert result == 1
+        remove_worktree.assert_not_called()
+
     def test_run_success(self, tmp_path):
-        """cmd_run returns 0 when CEO agent succeeds."""
+        """The explicit skill fallback returns 0 when its CEO agent succeeds."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()):
-            result = main(["run", str(tmp_path)])
+            result = main(["run", str(tmp_path), "--engine", "skill"])
         assert result == 0
 
     def test_run_agent_failure(self, tmp_path):
-        """cmd_run returns 1 when CEO agent fails."""
+        """The explicit skill fallback returns 1 when its CEO agent fails."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_fail()):
-            result = main(["run", str(tmp_path)])
+            result = main(["run", str(tmp_path), "--engine", "skill"])
         assert result == 1
 
 
@@ -1069,7 +1121,7 @@ class TestRunWithGitHubUrl:
             patch("factory.cli._path_resolver.tempfile.mkdtemp", return_value="/tmp/factory-abc"),
             patch("factory.cli.run._read_target_branch", return_value="main"),
         ):
-            result = main(["run", url])
+            result = main(["run", url, "--engine", "skill"])
 
         assert result == 0
         mock_clone.assert_called_once_with(
@@ -1088,7 +1140,7 @@ class TestRunWithGitHubUrl:
             patch("factory.cli._path_resolver.tempfile.mkdtemp", return_value="/tmp/factory-xyz"),
             patch("factory.cli.run._read_target_branch", return_value="main"),
         ):
-            result = main(["run", url])
+            result = main(["run", url, "--engine", "skill"])
 
         assert result == 0
         mock_clone.assert_called_once_with(
@@ -1104,7 +1156,7 @@ class TestRunWithGitHubUrl:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli.run._chain_modes", return_value=0),
         ):
-            result = main(["run", str(tmp_path)])
+            result = main(["run", str(tmp_path), "--engine", "skill"])
 
         assert result == 0
         mock_agent.assert_called_once()
@@ -1115,7 +1167,9 @@ class TestRunWithGitHubUrl:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli.run._chain_modes", return_value=0),
         ):
-            result = main(["run", str(tmp_path), "--mode", "discover"])
+            result = main(
+                ["run", str(tmp_path), "--mode", "discover", "--engine", "skill"]
+            )
 
         assert result == 0
         call_args = mock_agent.call_args
@@ -1128,7 +1182,7 @@ class TestRunWithGitHubUrl:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli.run._chain_modes", return_value=0),
         ):
-            result = main(["run", str(tmp_path), "--mode", "meta"])
+            result = main(["run", str(tmp_path), "--mode", "meta", "--engine", "skill"])
 
         assert result == 0
         call_args = mock_agent.call_args
@@ -1184,7 +1238,7 @@ class TestHeartbeatLoop:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli.run._chain_modes", return_value=0),
         ):
-            result = main(["run", str(tmp_path)])
+            result = main(["run", str(tmp_path), "--engine", "skill"])
         assert result == 0
         mock_agent.assert_called_once()
 
@@ -1203,6 +1257,8 @@ class TestHeartbeatLoop:
                     "3",
                     "--interval",
                     "0",
+                    "--engine",
+                    "skill",
                 ]
             )
         assert result == 0
@@ -1227,6 +1283,8 @@ class TestHeartbeatLoop:
                     "--loop",
                     "--max-cycles",
                     "1",
+                    "--engine",
+                    "skill",
                 ]
             )
         assert result == 0
@@ -1257,7 +1315,9 @@ class TestHeartbeatLoop:
             ),
             patch("factory.cli.run._chain_modes", return_value=0),
         ):
-            result = main(["run", str(tmp_path), "--loop", "--interval", "30"])
+            result = main(
+                ["run", str(tmp_path), "--loop", "--interval", "30", "--engine", "skill"]
+            )
 
         assert result == 0
         out = capsys.readouterr().out
@@ -1286,7 +1346,9 @@ class TestHeartbeatLoop:
             ),
             patch("factory.cli.run._chain_modes", return_value=0),
         ):
-            result = main(["run", str(tmp_path), "--loop", "--interval", "30"])
+            result = main(
+                ["run", str(tmp_path), "--loop", "--interval", "30", "--engine", "skill"]
+            )
 
         assert result == 0
         out = capsys.readouterr().out
@@ -1307,6 +1369,8 @@ class TestHeartbeatLoop:
                     "2",
                     "--interval",
                     "0",
+                    "--engine",
+                    "skill",
                 ]
             )
         assert result == 0
@@ -1474,7 +1538,12 @@ class TestCmdCeoReview:
     def test_review_mode_headless_builds_correct_task(self, tmp_path, capsys):
         """--mode review --pr 42 --headless builds a review task and invokes CEO."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            result = main(["ceo", str(tmp_path), "--mode", "review", "--pr", "42", "--headless"])
+            result = main(
+                [
+                    "ceo", str(tmp_path), "--mode", "review", "--pr", "42",
+                    "--headless", "--engine", "skill",
+                ]
+            )
         assert result == 0
         mock_agent.assert_called_once()
         task = mock_agent.call_args[0][1]
@@ -1502,6 +1571,8 @@ class TestCmdCeoReview:
                     "--repo",
                     "owner/repo",
                     "--headless",
+                    "--engine",
+                    "skill",
                 ]
             )
         assert result == 0
@@ -1516,7 +1587,12 @@ class TestCmdCeoReview:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
             patch("factory.worktree.create_worktree") as mock_wt,
         ):
-            main(["ceo", str(tmp_path), "--mode", "review", "--pr", "42", "--headless"])
+            main(
+                [
+                    "ceo", str(tmp_path), "--mode", "review", "--pr", "42",
+                    "--headless", "--engine", "skill",
+                ]
+            )
         mock_wt.assert_not_called()
 
     def test_review_mode_foreground(self, tmp_path):
@@ -1538,7 +1614,12 @@ class TestCmdCeoReview:
     def test_review_mode_max_respawns_is_1(self, tmp_path):
         """Review mode uses max_respawns=1."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            main(["ceo", str(tmp_path), "--mode", "review", "--pr", "42", "--headless"])
+            main(
+                [
+                    "ceo", str(tmp_path), "--mode", "review", "--pr", "42",
+                    "--headless", "--engine", "skill",
+                ]
+            )
         call_kwargs = mock_agent.call_args[1]
         assert call_kwargs.get("timeout") == 7200.0
 
@@ -1557,7 +1638,12 @@ class TestCmdCeoDeepQa:
     def test_qa_mode_headless_builds_correct_task(self, tmp_path, capsys):
         """--mode deep-qa --pr 42 --headless builds a deep-qa task and invokes CEO."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            result = main(["ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42", "--headless"])
+            result = main(
+                [
+                    "ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42",
+                    "--headless", "--engine", "skill",
+                ]
+            )
         assert result == 0
         mock_agent.assert_called_once()
         task = mock_agent.call_args[0][1]
@@ -1582,6 +1668,8 @@ class TestCmdCeoDeepQa:
                     "--repo",
                     "owner/repo",
                     "--headless",
+                    "--engine",
+                    "skill",
                 ]
             )
         assert result == 0
@@ -1595,7 +1683,12 @@ class TestCmdCeoDeepQa:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()),
             patch("factory.worktree.create_worktree") as mock_wt,
         ):
-            main(["ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42", "--headless"])
+            main(
+                [
+                    "ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42",
+                    "--headless", "--engine", "skill",
+                ]
+            )
         mock_wt.assert_not_called()
 
     def test_qa_mode_foreground(self, tmp_path):
@@ -1617,7 +1710,12 @@ class TestCmdCeoDeepQa:
     def test_qa_mode_max_respawns_is_1(self, tmp_path):
         """Deep-QA mode uses max_respawns=1."""
         with patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent:
-            main(["ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42", "--headless"])
+            main(
+                [
+                    "ceo", str(tmp_path), "--mode", "deep-qa", "--pr", "42",
+                    "--headless", "--engine", "skill",
+                ]
+            )
         call_kwargs = mock_agent.call_args[1]
         assert call_kwargs.get("timeout") == 7200.0
 
@@ -1629,7 +1727,7 @@ class TestCmdCeo:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli._ceo_helpers._chain_modes", return_value=0),
         ):
-            result = main(["ceo", str(tmp_path), "--headless"])
+            result = main(["ceo", str(tmp_path), "--headless", "--engine", "skill"])
         assert result == 0
         mock_agent.assert_called_once()
         call_args = mock_agent.call_args
@@ -1642,7 +1740,9 @@ class TestCmdCeo:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli._ceo_helpers._chain_modes", return_value=0),
         ):
-            result = main(["ceo", str(tmp_path), "--mode", "meta", "--headless"])
+            result = main(
+                ["ceo", str(tmp_path), "--mode", "meta", "--headless", "--engine", "skill"]
+            )
         assert result == 0
         task = mock_agent.call_args[0][1]
         assert "Meta mode" in task
@@ -1658,7 +1758,7 @@ class TestCmdCeo:
             patch("factory.cli._ceo_helpers._read_target_branch", return_value="main"),
             patch("factory.graph.is_graphify_installed", return_value=False),
         ):
-            result = main(["ceo", url, "--headless"])
+            result = main(["ceo", url, "--headless", "--engine", "skill"])
         assert result == 0
         mock_clone.assert_called_once_with(
             ["git", "clone", url, "/tmp/factory-ceo"],
@@ -1671,7 +1771,7 @@ class TestCmdCeo:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli._ceo_helpers._chain_modes", return_value=0),
         ):
-            main(["ceo", str(tmp_path), "--headless"])
+            main(["ceo", str(tmp_path), "--headless", "--engine", "skill"])
         call_kwargs = mock_agent.call_args[1]
         assert call_kwargs["timeout"] == 7200.0
 
@@ -1899,7 +1999,7 @@ class TestResolveInput:
             patch("factory.cli._ceo_helpers._chain_modes", return_value=0),
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
         ):
-            main(["ceo", str(idea_file), "--headless"])
+            main(["ceo", str(idea_file), "--headless", "--engine", "skill"])
 
         task_arg = mock_agent.call_args[0][1]  # second positional = task
         assert "Build X that does Y" in task_arg
@@ -1981,7 +2081,12 @@ class TestResearchMode:
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli._ceo_helpers._chain_modes", return_value=0),
         ):
-            result = main(["ceo", str(tmp_path), "--mode", "research", "--headless"])
+            result = main(
+                [
+                    "ceo", str(tmp_path), "--mode", "research", "--headless",
+                    "--engine", "skill",
+                ]
+            )
         assert result == 0
         task = mock_agent.call_args[0][1]
         assert "Research mode" in task
@@ -2992,7 +3097,10 @@ class TestFromPlanFeedbackWritesFile:
             patch("factory.cli._ceo_helpers._resolve_plan_source", return_value=plan_source),
         ):
             result = main(
-                ["ceo", str(tmp_path), "--mode", "design", "--from-plan", "42", "--auto-approve"]
+                [
+                    "ceo", str(tmp_path), "--mode", "design", "--from-plan", "42",
+                    "--auto-approve", "--engine", "skill",
+                ]
             )
         assert result == 0
         feedback_file = tmp_path / ".factory" / "strategy" / "thread-feedback.md"
@@ -3034,6 +3142,8 @@ class TestFromPlanFeedbackWritesFile:
                     "--from-plan",
                     "plan.md",
                     "--auto-approve",
+                    "--engine",
+                    "skill",
                 ]
             )
         assert result == 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 """Integration tests — end-to-end workflows."""
 
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -29,7 +30,8 @@ class TestDiscoverToInit:
         compile(script, str(path), "exec")
 
     def test_discover_cli_produces_valid_json(self, python_project, capsys):
-        result = main(["discover", str(python_project)])
+        with patch("factory.cli.spec._run_spec_workflow", return_value=(1, "skipped in test")):
+            result = main(["discover", str(python_project)])
         assert result == 0
         output = json.loads(capsys.readouterr().out)
         assert "project" in output

--- a/tests/test_loop_context.py
+++ b/tests/test_loop_context.py
@@ -1,11 +1,8 @@
-"""Tests for loop context injection and feedback log in tool mode."""
+"""Loop-context rendering from persisted LangGraph state."""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-
-import pytest
 
 from factory.workflow.primitives import (
     AgentNode,
@@ -16,850 +13,116 @@ from factory.workflow.primitives import (
     VerdictType,
     Workflow,
 )
-from factory.workflow.registry import WorkflowRegistry
-from factory.workflow.tool import (
-    _find_loop_context,
-    _format_node_task,
-    _load_state,
-    _save_state,
-    _workflow_cache,
-    tool_init,
-    tool_next,
-    tool_submit,
-)
+from factory.workflow.tool import _find_loop_context, _format_node_task
 
 
-@pytest.fixture(autouse=True)
-def _reset_registry():
-    WorkflowRegistry.reset()
-    _workflow_cache.clear()
-    yield
-    WorkflowRegistry.reset()
-    _workflow_cache.clear()
-
-
-def _register_workflow(wf: Workflow) -> None:
-    from factory.workflow.registry import WorkflowEntry
-    WorkflowRegistry._entries[wf.name] = WorkflowEntry(
-        name=wf.name,
-        description="test workflow",
-        path="<test>",
-        source="builtin",
-        _workflow_fn=lambda _wf=wf: _wf,
-    )
-
-
-def _reloop_workflow() -> Workflow:
-    """builder -> gate_qa -> (RELOOP) builder | (PROCEED) archivist."""
+def reloop_workflow() -> Workflow:
     return Workflow(
-        name="test-reloop",
+        name="loop-context",
         start_node="builder",
         nodes={
             "builder": AgentNode(
                 id="builder",
                 role=AgentRole.BUILDER,
-                prompt_template="Build the project at {project_path}",
-                reads={".factory/strategy/current.md"},
-                writes={".factory/reviews/builder-latest.md"},
+                reads={"strategy.md"},
+                writes={"build.md"},
             ),
-            "gate_qa": GateNode(
-                id="gate_qa",
-                evaluator_type="fn",
-                evaluator_command="echo FAIL: tests broken",
-                gate_prompt="Run QA checks on the builder output",
-                reads={".factory/reviews/builder-latest.md"},
-            ),
-            "archivist": AgentNode(
-                id="archivist",
-                role=AgentRole.ARCHIVIST,
-                prompt_template="Archive results",
-                writes={".factory/archive/build.md"},
-                blocking=False,
-            ),
-        },
-        edges=[
-            Edge(source="builder", target="gate_qa"),
-            Edge(source="gate_qa", target="archivist", condition=VerdictType.PROCEED),
-            Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
-        ],
-    )
-
-
-def _multi_gate_workflow() -> Workflow:
-    """builder -> gate_build -> health_checker -> gate_qa -> (RELOOP) builder."""
-    return Workflow(
-        name="test-multi-gate",
-        start_node="builder",
-        nodes={
-            "builder": AgentNode(
-                id="builder",
-                role=AgentRole.BUILDER,
-                prompt_template="Build at {project_path}",
-                reads={".factory/strategy/current.md"},
-                writes={".factory/reviews/builder-latest.md"},
-            ),
-            "gate_build": GateNode(
-                id="gate_build",
+            "gate": GateNode(
+                id="gate",
                 evaluator_type="agent",
-                gate_prompt="Review build output",
-                reads={".factory/reviews/builder-latest.md"},
+                gate_prompt="Run QA checks",
             ),
-            "health_checker": AgentNode(
-                id="health_checker",
-                role=AgentRole.HEALTH_CHECKER,
-                prompt_template="Check health",
-                writes={".factory/reviews/health-check.md"},
-            ),
-            "gate_qa": GateNode(
-                id="gate_qa",
-                evaluator_type="fn",
-                evaluator_command="echo FAIL: qa issues",
-                gate_prompt="Run QA verification",
-                reads={".factory/reviews/health-check.md"},
-            ),
-            "archivist": AgentNode(
-                id="archivist",
-                role=AgentRole.ARCHIVIST,
-                prompt_template="Archive",
-                blocking=False,
-            ),
+            "archive": FnNode(id="archive", command="echo archive"),
         },
         edges=[
-            Edge(source="builder", target="gate_build"),
-            Edge(source="gate_build", target="health_checker", condition=VerdictType.PROCEED),
-            Edge(source="gate_build", target="builder", condition=VerdictType.RELOOP),
-            Edge(source="health_checker", target="gate_qa"),
-            Edge(source="gate_qa", target="archivist", condition=VerdictType.PROCEED),
-            Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
+            Edge(source="builder", target="gate"),
+            Edge(source="gate", target="archive", condition=VerdictType.PROCEED),
+            Edge(source="gate", target="builder", condition=VerdictType.RELOOP),
         ],
     )
 
 
-class TestFindLoopContext:
-    def test_not_a_reloop_target_returns_empty(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {},
-            "feedback_log": {},
-        }
-        result = _find_loop_context("archivist", wf, state, tmp_path)
-        assert result == ""
+def test_non_target_has_no_loop_context(tmp_path: Path) -> None:
+    state = {"topo_order": ["builder", "gate", "archive"]}
+    assert _find_loop_context("archive", reloop_workflow(), state, tmp_path) == ""
 
-    def test_first_invocation_returns_topology_without_feedback(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {},
-            "feedback_log": {},
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
-        assert "## LOOP CONTEXT" in result
-        assert "0/3" in result
-        assert "gate_qa" in result
-        assert "Run QA checks" in result
-        assert "Loop topology" in result
-        assert "Feedback history" not in result
 
-    def test_first_invocation_shows_zero_of_three(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 0},
-            "feedback_log": {},
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
-        assert "## LOOP CONTEXT" in result
-        assert "0/3" in result
-        assert "FINAL ATTEMPT" not in result
-        assert "Feedback history" not in result
+def test_first_attempt_shows_topology_without_feedback(tmp_path: Path) -> None:
+    state = {
+        "topo_order": ["builder", "gate", "archive"],
+        "iteration_counts": {},
+        "feedback_log": {},
+    }
 
-    def test_single_gate_reloop_at_iteration_1(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 1},
-            "feedback_log": {
-                "builder": [{
-                    "gate": "gate_qa",
+    result = _find_loop_context("builder", reloop_workflow(), state, tmp_path)
+
+    assert "## LOOP CONTEXT" in result
+    assert "Iteration: 0/3" in result
+    assert "Run QA checks" in result
+    assert "Loop topology" in result
+    assert "Feedback history" not in result
+
+
+def test_persisted_iteration_and_feedback_are_rendered(tmp_path: Path) -> None:
+    state = {
+        "topo_order": ["builder", "gate", "archive"],
+        "iteration_counts": {"gate->builder": 2},
+        "feedback_log": {
+            "builder": [
+                {
+                    "gate": "gate",
                     "iteration": 1,
-                    "feedback": "tests broken: 3 failures in test_auth.py",
-                    "timestamp": 1000.0,
-                }],
-            },
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
+                    "feedback": "first issue",
+                    "timestamp": 1.0,
+                },
+                {
+                    "gate": "gate",
+                    "iteration": 2,
+                    "feedback": "second issue",
+                    "timestamp": 2.0,
+                },
+            ]
+        },
+    }
 
-        assert "## LOOP CONTEXT" in result
-        assert "1/3" in result
-        assert "gate_qa" in result
-        assert "Run QA checks" in result
-        assert "Loop topology" in result
-        assert "builder" in result
-        assert "Feedback history" in result
-        assert "tests broken" in result
-        assert "FINAL ATTEMPT" not in result
+    result = _find_loop_context("builder", reloop_workflow(), state, tmp_path)
 
-    def test_multiple_gates_most_recent_wins(self, tmp_path: Path) -> None:
-        wf = _multi_gate_workflow()
-        state = {
-            "topo_order": ["builder", "gate_build", "health_checker", "gate_qa", "archivist"],
-            "iteration_counts": {
-                "gate_build->builder": 1,
-                "gate_qa->builder": 1,
-            },
-            "feedback_log": {
-                "builder": [
-                    {
-                        "gate": "gate_build",
-                        "iteration": 1,
-                        "feedback": "build review failed",
-                        "timestamp": 1000.0,
-                    },
-                    {
-                        "gate": "gate_qa",
-                        "iteration": 1,
-                        "feedback": "qa issues found",
-                        "timestamp": 2000.0,
-                    },
-                ],
-            },
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
-
-        assert "## LOOP CONTEXT" in result
-        assert "Triggered by: gate_qa" in result
-        assert "qa issues found" in result
-
-    def test_max_iteration_warning(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 3},
-            "feedback_log": {
-                "builder": [{
-                    "gate": "gate_qa",
-                    "iteration": 3,
-                    "feedback": "still failing",
-                    "timestamp": 1000.0,
-                }],
-            },
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
-
-        assert "FINAL ATTEMPT" in result
-        assert "3/3" in result
-
-    def test_iterations_but_no_feedback_log(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 1},
-            "feedback_log": {},
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
-
-        assert "## LOOP CONTEXT" in result
-        assert "1/3" in result
-        assert "gate_qa" in result
-        assert "Feedback history" not in result
-
-    def test_loop_topology_includes_intermediate_nodes(self, tmp_path: Path) -> None:
-        wf = _multi_gate_workflow()
-        state = {
-            "topo_order": ["builder", "gate_build", "health_checker", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 1},
-            "feedback_log": {
-                "builder": [{
-                    "gate": "gate_qa",
-                    "iteration": 1,
-                    "feedback": "qa failed",
-                    "timestamp": 1000.0,
-                }],
-            },
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
-
-        assert "Loop topology" in result
-        assert "**builder**" in result
-        assert "**gate_build**" in result
-        assert "**health_checker**" in result
-        assert "**gate_qa**" in result
-
-    def test_feedback_truncated_to_500_chars(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        long_feedback = "x" * 1000
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 1},
-            "feedback_log": {
-                "builder": [{
-                    "gate": "gate_qa",
-                    "iteration": 1,
-                    "feedback": long_feedback,
-                    "timestamp": 1000.0,
-                }],
-            },
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
-
-        feedback_section = result.split("### Feedback history")[1]
-        line_with_feedback = [line for line in feedback_section.split("\n") if line.startswith("- [")][0]
-        feedback_content = line_with_feedback.split("] ", 1)[1]
-        assert len(feedback_content) <= 500
-
-    def test_only_last_2_feedback_entries_shown(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 3},
-            "feedback_log": {
-                "builder": [
-                    {"gate": "gate_qa", "iteration": 1, "feedback": "first failure", "timestamp": 1.0},
-                    {"gate": "gate_qa", "iteration": 2, "feedback": "second failure", "timestamp": 2.0},
-                    {"gate": "gate_qa", "iteration": 3, "feedback": "third failure", "timestamp": 3.0},
-                ],
-            },
-        }
-        result = _find_loop_context("builder", wf, state, tmp_path)
-
-        assert "first failure" not in result
-        assert "second failure" in result
-        assert "third failure" in result
+    assert "Iteration: 2/3" in result
+    assert "Feedback history" in result
+    assert "first issue" in result
+    assert "second issue" in result
 
 
-class TestFeedbackLog:
-    def test_feedback_appended_on_fn_gate_reloop(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-reloop", tmp_path)
+def test_final_attempt_warning(tmp_path: Path) -> None:
+    state = {
+        "topo_order": ["builder", "gate", "archive"],
+        "iteration_counts": {"gate->builder": 3},
+        "feedback_log": {},
+    }
+    result = _find_loop_context("builder", reloop_workflow(), state, tmp_path)
+    assert "FINAL ATTEMPT" in result
 
-        result = tool_submit(tmp_path, "builder", "First attempt")
-        assert result.startswith("RETRY")
 
-        state = _load_state(tmp_path)
-        assert "builder" in state["feedback_log"]
-        entries = state["feedback_log"]["builder"]
-        assert len(entries) == 1
-        assert entries[0]["gate"] == "gate_qa"
-        assert entries[0]["iteration"] == 1
-        assert "FAIL" in entries[0]["feedback"]
-        assert isinstance(entries[0]["timestamp"], float)
-
-    def test_feedback_persists_across_save_load(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-reloop", tmp_path)
-
-        state = _load_state(tmp_path)
-        state["feedback_log"] = {
+def test_node_task_includes_loop_context(tmp_path: Path) -> None:
+    workflow = reloop_workflow()
+    state = {
+        "topo_order": ["builder", "gate", "archive"],
+        "iteration_counts": {"gate->builder": 1},
+        "feedback_log": {
             "builder": [{
-                "gate": "gate_qa",
+                "gate": "gate",
                 "iteration": 1,
-                "feedback": "test feedback",
-                "timestamp": 12345.0,
-            }],
-        }
-        _save_state(tmp_path, state)
-
-        reloaded = _load_state(tmp_path)
-        assert reloaded["feedback_log"]["builder"][0]["feedback"] == "test feedback"
-        assert reloaded["feedback_log"]["builder"][0]["timestamp"] == 12345.0
-
-    def test_feedback_truncated_on_gate_output(self, tmp_path: Path) -> None:
-        wf = Workflow(
-            name="test-long-feedback",
-            start_node="builder",
-            nodes={
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build",
-                ),
-                "gate_check": GateNode(
-                    id="gate_check",
-                    evaluator_type="fn",
-                    evaluator_command="python3 -c \"print('FAIL: ' + 'x' * 1000)\"",
-                ),
-            },
-            edges=[
-                Edge(source="builder", target="gate_check"),
-                Edge(source="gate_check", target="builder", condition=VerdictType.RELOOP),
-            ],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-long-feedback", tmp_path)
-
-        tool_submit(tmp_path, "builder", "attempt")
-
-        state = _load_state(tmp_path)
-        entries = state["feedback_log"]["builder"]
-        assert len(entries[0]["feedback"]) <= 500
-
-    def test_multiple_feedback_entries_preserved(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-reloop", tmp_path)
-
-        tool_submit(tmp_path, "builder", "First attempt")
-
-        state = _load_state(tmp_path)
-        del state["completed"]["builder"]
-        _save_state(tmp_path, state)
-
-        tool_submit(tmp_path, "builder", "Second attempt")
-
-        state = _load_state(tmp_path)
-        entries = state["feedback_log"]["builder"]
-        assert len(entries) == 2
-        assert entries[0]["iteration"] == 1
-        assert entries[1]["iteration"] == 2
-
-    def test_ceo_retry_verdict_appends_feedback(self, tmp_path: Path) -> None:
-        """When CEO submits RETRY for an agent gate, feedback is logged."""
-        wf = Workflow(
-            name="test-agent-gate",
-            start_node="builder",
-            nodes={
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build",
-                ),
-                "gate_review": GateNode(
-                    id="gate_review",
-                    evaluator_type="agent",
-                    gate_prompt="Review the build",
-                    reads={".factory/reviews/builder-latest.md"},
-                ),
-            },
-            edges=[
-                Edge(source="builder", target="gate_review"),
-                Edge(source="gate_review", target="builder", condition=VerdictType.RELOOP),
-            ],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-agent-gate", tmp_path)
-
-        state = _load_state(tmp_path)
-        state["pointer_idx"] = 1
-        state["completed"]["builder"] = "built"
-        _save_state(tmp_path, state)
-
-        tool_submit(
-            tmp_path,
-            "gate_review",
-            'RETRY target=builder feedback="Missing test coverage for auth module"',
-        )
-
-        state = _load_state(tmp_path)
-        assert "builder" in state["feedback_log"]
-        entries = state["feedback_log"]["builder"]
-        assert len(entries) == 1
-        assert entries[0]["gate"] == "gate_review"
-        assert "Missing test coverage" in entries[0]["feedback"]
-
-    def test_feedback_log_initialized_in_state(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-reloop", tmp_path)
-
-        state = _load_state(tmp_path)
-        assert "feedback_log" in state
-        assert state["feedback_log"] == {}
-
-
-class TestFormatNodeTaskLoopContext:
-    def test_loop_context_present_at_iteration_0(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {},
-            "feedback_log": {},
-        }
-        result = _format_node_task("builder", wf.nodes["builder"], wf, state, tmp_path)
-        assert "LOOP CONTEXT" in result
-        assert "0/3" in result
-        assert "gate_qa" in result
-        assert "Feedback history" not in result
-
-    def test_loop_context_appended_at_iteration_1(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 1},
-            "feedback_log": {
-                "builder": [{
-                    "gate": "gate_qa",
-                    "iteration": 1,
-                    "feedback": "tests broken",
-                    "timestamp": 1000.0,
-                }],
-            },
-        }
-        result = _format_node_task("builder", wf.nodes["builder"], wf, state, tmp_path)
-
-        assert "Node: builder" in result
-        assert "Type: Agent (builder)" in result
-        assert "## LOOP CONTEXT" in result
-        assert "1/3" in result
-        assert "gate_qa" in result
-        assert "tests broken" in result
-
-    def test_loop_context_not_injected_for_non_reloop_node(self, tmp_path: Path) -> None:
-        wf = _reloop_workflow()
-        state = {
-            "topo_order": ["builder", "gate_qa", "archivist"],
-            "iteration_counts": {"gate_qa->builder": 1},
-            "feedback_log": {},
-        }
-        result = _format_node_task("archivist", wf.nodes["archivist"], wf, state, tmp_path)
-        assert "LOOP CONTEXT" not in result
-
-    def test_integration_tool_next_includes_loop_context(self, tmp_path: Path) -> None:
-        """Full integration: fn gate RELOOP -> tool_next returns builder with loop context."""
-        wf = _reloop_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-reloop", tmp_path)
-
-        result = tool_submit(tmp_path, "builder", "First attempt")
-        assert result.startswith("RETRY")
-
-        state = _load_state(tmp_path)
-        del state["completed"]["builder"]
-        del state["completed"]["gate_qa"]
-        _save_state(tmp_path, state)
-
-        review_file = tmp_path / ".factory" / "reviews" / "builder-latest.md"
-        if review_file.exists():
-            review_file.unlink()
-
-        result = tool_next(tmp_path)
-
-        assert "Node: builder" in result
-        assert "## LOOP CONTEXT" in result
-        assert "1/3" in result
-        assert "gate_qa" in result
-
-
-class TestLoopContextE2EComparison:
-    """A/B comparison tests: verify loop context injection changes builder task prompts."""
-
-    def _make_cli_app_workflow(self, name: str) -> Workflow:
-        return Workflow(
-            name=name,
-            start_node="builder",
-            nodes={
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build the CLI app at {project_path}",
-                    reads={".factory/strategy/current.md"},
-                    writes={".factory/reviews/builder-latest.md"},
-                ),
-                "gate_qa": GateNode(
-                    id="gate_qa",
-                    evaluator_type="fn",
-                    evaluator_command="echo FAIL: lint errors",
-                    gate_prompt="Check lint and tests pass",
-                    reads={".factory/reviews/builder-latest.md"},
-                ),
-                "done": FnNode(id="done", command="echo done"),
-            },
-            edges=[
-                Edge(source="builder", target="gate_qa"),
-                Edge(source="gate_qa", target="done", condition=VerdictType.PROCEED),
-                Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
-            ],
-        )
-
-    def _make_web_app_workflow(self, name: str) -> Workflow:
-        return Workflow(
-            name=name,
-            start_node="builder",
-            nodes={
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build the web app at {project_path}",
-                    reads={".factory/strategy/current.md"},
-                    writes={".factory/reviews/builder-latest.md"},
-                ),
-                "health_checker": AgentNode(
-                    id="health_checker",
-                    role=AgentRole.HEALTH_CHECKER,
-                    prompt_template="Check health",
-                    writes={".factory/reviews/health-check.md"},
-                ),
-                "gate_qa": GateNode(
-                    id="gate_qa",
-                    evaluator_type="fn",
-                    evaluator_command="echo FAIL: api tests broken",
-                    gate_prompt="Verify API endpoints work",
-                    reads={".factory/reviews/health-check.md"},
-                ),
-                "done": FnNode(id="done", command="echo done"),
-            },
-            edges=[
-                Edge(source="builder", target="health_checker"),
-                Edge(source="health_checker", target="gate_qa"),
-                Edge(source="gate_qa", target="done", condition=VerdictType.PROCEED),
-                Edge(source="gate_qa", target="builder", condition=VerdictType.RELOOP),
-            ],
-        )
-
-    def _make_lib_workflow(self, name: str) -> Workflow:
-        return Workflow(
-            name=name,
-            start_node="builder",
-            nodes={
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build the library at {project_path}",
-                    reads={".factory/strategy/current.md"},
-                    writes={".factory/reviews/builder-latest.md"},
-                ),
-                "code_reviewer": AgentNode(
-                    id="code_reviewer",
-                    role=AgentRole.CODE_REVIEWER,
-                    prompt_template="Review code",
-                    writes={".factory/reviews/code-review.md"},
-                ),
-                "gate_review": GateNode(
-                    id="gate_review",
-                    evaluator_type="fn",
-                    evaluator_command="echo FAIL: coverage below 80%",
-                    gate_prompt="Check test coverage meets threshold",
-                    reads={".factory/reviews/code-review.md"},
-                ),
-                "done": FnNode(id="done", command="echo done"),
-            },
-            edges=[
-                Edge(source="builder", target="code_reviewer"),
-                Edge(source="code_reviewer", target="gate_review"),
-                Edge(source="gate_review", target="done", condition=VerdictType.PROCEED),
-                Edge(source="gate_review", target="builder", condition=VerdictType.RELOOP),
-            ],
-        )
-
-    def _simulate_reloop_cycle(
-        self, wf: Workflow, tmp_path: Path, *, with_loop_context: bool,
-    ) -> dict:
-        """Simulate one RELOOP cycle and collect builder task prompts.
-
-        Walks the workflow from builder through all intermediate nodes until
-        a fn gate triggers RELOOP, then simulates CEO re-invocation of builder.
-        Returns {prompts, reloop_count, has_loop_context, has_feedback}.
-        """
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir(parents=True, exist_ok=True)
-        tool_init(wf.name, tmp_path)
-
-        prompts: list[str] = []
-        reloop_count = 0
-
-        result = tool_next(tmp_path)
-        prompts.append(result)
-
-        result = tool_submit(tmp_path, "builder", "attempt 1")
-
-        if result.startswith("RETRY"):
-            reloop_count += 1
-        else:
-            state = _load_state(tmp_path)
-            order = state["topo_order"]
-            idx = state["pointer_idx"]
-
-            while idx < len(order):
-                nid = order[idx]
-                node = wf.nodes.get(nid)
-                if isinstance(node, AgentNode):
-                    reviews_dir = tmp_path / ".factory" / "reviews"
-                    reviews_dir.mkdir(parents=True, exist_ok=True)
-                    role = node.role.value
-                    (reviews_dir / f"{role}-latest.md").write_text(f"{role} output")
-                    result = tool_next(tmp_path)
-                    if result.startswith("RETRY"):
-                        reloop_count += 1
-                        break
-                    state = _load_state(tmp_path)
-                    idx = state["pointer_idx"]
-                else:
-                    break
-
-        state = _load_state(tmp_path)
-        for nid in list(state["completed"]):
-            del state["completed"][nid]
-
-        if not with_loop_context:
-            state["iteration_counts"] = {}
-            state["feedback_log"] = {}
-
-        _save_state(tmp_path, state)
-
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        if reviews_dir.exists():
-            for f in reviews_dir.iterdir():
-                if f.suffix == ".md":
-                    f.unlink()
-
-        result = tool_next(tmp_path)
-        prompts.append(result)
-
-        return {
-            "prompts": prompts,
-            "reloop_count": reloop_count,
-            "has_loop_context": "LOOP CONTEXT" in prompts[-1],
-            "has_feedback": "Feedback history" in prompts[-1],
-        }
-
-    def test_ab_comparison_cli_app(self, tmp_path: Path) -> None:
-        """CLI app: both arms have topology; only with_ctx has feedback."""
-        wf = self._make_cli_app_workflow("cli-app")
-
-        without = self._simulate_reloop_cycle(
-            wf, tmp_path / "cli-no-ctx", with_loop_context=False,
-        )
-        _workflow_cache.clear()
-        WorkflowRegistry.reset()
-
-        wf2 = self._make_cli_app_workflow("cli-app-ctx")
-        with_ctx = self._simulate_reloop_cycle(
-            wf2, tmp_path / "cli-with-ctx", with_loop_context=True,
-        )
-
-        assert without["has_loop_context"]
-        assert not without["has_feedback"]
-        assert with_ctx["has_loop_context"]
-        assert with_ctx["has_feedback"]
-        assert "lint" in with_ctx["prompts"][-1].lower()
-
-    def test_ab_comparison_web_app(self, tmp_path: Path) -> None:
-        """Web app: both arms have topology; only with_ctx has feedback."""
-        wf = self._make_web_app_workflow("web-app")
-
-        without = self._simulate_reloop_cycle(
-            wf, tmp_path / "web-no-ctx", with_loop_context=False,
-        )
-        _workflow_cache.clear()
-        WorkflowRegistry.reset()
-
-        wf2 = self._make_web_app_workflow("web-app-ctx")
-        with_ctx = self._simulate_reloop_cycle(
-            wf2, tmp_path / "web-with-ctx", with_loop_context=True,
-        )
-
-        assert without["has_loop_context"]
-        assert not without["has_feedback"]
-        assert with_ctx["has_loop_context"]
-        assert with_ctx["has_feedback"]
-        assert "api" in with_ctx["prompts"][-1].lower()
-        assert "health_checker" in with_ctx["prompts"][-1]
-
-    def test_ab_comparison_library(self, tmp_path: Path) -> None:
-        """Library: both arms have topology; only with_ctx has feedback."""
-        wf = self._make_lib_workflow("lib")
-
-        without = self._simulate_reloop_cycle(
-            wf, tmp_path / "lib-no-ctx", with_loop_context=False,
-        )
-        _workflow_cache.clear()
-        WorkflowRegistry.reset()
-
-        wf2 = self._make_lib_workflow("lib-ctx")
-        with_ctx = self._simulate_reloop_cycle(
-            wf2, tmp_path / "lib-with-ctx", with_loop_context=True,
-        )
-
-        assert without["has_loop_context"]
-        assert not without["has_feedback"]
-        assert with_ctx["has_loop_context"]
-        assert with_ctx["has_feedback"]
-        assert "coverage" in with_ctx["prompts"][-1].lower()
-        assert "code_reviewer" in with_ctx["prompts"][-1]
-
-    def test_ab_report_generation(self, tmp_path: Path) -> None:
-        """Generate a comparison report across all 3 test repos."""
-        scenarios = [
-            ("cli-app", self._make_cli_app_workflow),
-            ("web-app", self._make_web_app_workflow),
-            ("library", self._make_lib_workflow),
-        ]
-
-        report: dict[str, dict] = {}
-
-        for name, factory_fn in scenarios:
-            _workflow_cache.clear()
-            WorkflowRegistry.reset()
-
-            wf_no_ctx = factory_fn(f"{name}-no-ctx")
-            result_no_ctx = self._simulate_reloop_cycle(
-                wf_no_ctx, tmp_path / f"{name}-no-ctx", with_loop_context=False,
-            )
-
-            _workflow_cache.clear()
-            WorkflowRegistry.reset()
-
-            wf_with_ctx = factory_fn(f"{name}-with-ctx")
-            result_with_ctx = self._simulate_reloop_cycle(
-                wf_with_ctx, tmp_path / f"{name}-with-ctx", with_loop_context=True,
-            )
-
-            prompt_no_ctx = result_no_ctx["prompts"][-1]
-            prompt_with_ctx = result_with_ctx["prompts"][-1]
-
-            mentions_gate = any(
-                kw in prompt_with_ctx.lower()
-                for kw in ["gate", "qa", "check", "review", "coverage", "lint"]
-            )
-
-            report[name] = {
-                "without_feedback": {
-                    "prompt_length": len(prompt_no_ctx),
-                    "has_loop_context": result_no_ctx["has_loop_context"],
-                    "has_feedback": result_no_ctx["has_feedback"],
-                    "reloop_count": result_no_ctx["reloop_count"],
-                },
-                "with_feedback": {
-                    "prompt_length": len(prompt_with_ctx),
-                    "has_loop_context": result_with_ctx["has_loop_context"],
-                    "has_feedback": result_with_ctx["has_feedback"],
-                    "reloop_count": result_with_ctx["reloop_count"],
-                    "mentions_downstream_criteria": mentions_gate,
-                },
-            }
-
-        report_path = tmp_path / "ab_comparison_report.json"
-        report_path.write_text(json.dumps(report, indent=2))
-
-        for name, data in report.items():
-            assert data["without_feedback"]["has_loop_context"], (
-                f"{name}: prompt without feedback should still have LOOP CONTEXT topology"
-            )
-            assert not data["without_feedback"]["has_feedback"], (
-                f"{name}: prompt without feedback should lack Feedback history"
-            )
-            assert data["with_feedback"]["has_loop_context"], (
-                f"{name}: prompt WITH feedback should include LOOP CONTEXT"
-            )
-            assert data["with_feedback"]["has_feedback"], (
-                f"{name}: prompt WITH feedback should include Feedback history"
-            )
-            assert data["with_feedback"]["mentions_downstream_criteria"], (
-                f"{name}: prompt WITH feedback should mention downstream gate criteria"
-            )
-            assert data["with_feedback"]["prompt_length"] > data["without_feedback"]["prompt_length"], (
-                f"{name}: prompt with feedback should be longer than without"
-            )
-
-        assert report_path.exists()
-        loaded = json.loads(report_path.read_text())
-        assert len(loaded) == 3
+                "feedback": "fix tests",
+                "timestamp": 1.0,
+            }]
+        },
+    }
+    result = _format_node_task(
+        "builder",
+        workflow.nodes["builder"],
+        workflow,
+        state,
+        tmp_path,
+    )
+    assert "## LOOP CONTEXT" in result
+    assert "fix tests" in result

--- a/tests/test_parallel_improve.py
+++ b/tests/test_parallel_improve.py
@@ -258,6 +258,34 @@ def tmp_project(tmp_path: Path) -> Path:
     return tmp_path
 
 
+async def _run_selection_node(
+    executor: WorkflowExecutor,
+    node: SelectionNode,
+) -> str:
+    """Exercise Factory's selection operation with graph-shaped state."""
+    from factory.workflow.langgraph import initial_state
+
+    state = initial_state(
+        executor.workflow,
+        str(executor.project_path),
+        executor.run_id,
+    )
+    state["node_outputs"] = dict(executor.result.node_outputs)
+    output = await executor._run_selection(node, state)
+    executor.result.node_outputs[node.id] = output
+    return output
+
+
+async def _run_subgraph_fork_node(
+    executor: WorkflowExecutor,
+    node: SubgraphForkNode,
+) -> str:
+    """Exercise Factory's worktree fan-out operation without a second walker."""
+    output = await executor._run_subgraph_fork(node)
+    executor.result.node_outputs[node.id] = output
+    return output
+
+
 class TestSubgraphForkDryRun:
     async def test_dry_run_subgraph_fork(self, tmp_project: Path) -> None:
         wf = Workflow(
@@ -562,7 +590,7 @@ class TestSubgraphForkValidation:
 
 
 class TestSelectionAllFailed:
-    async def test_all_branches_failed_halts(self, tmp_project: Path) -> None:
+    async def test_all_branches_failed_surfaces(self, tmp_project: Path) -> None:
         wf = Workflow(
             name="test-select",
             nodes={
@@ -581,12 +609,11 @@ class TestSelectionAllFailed:
         ])
         executor.completed_files = {"pre.txt"}
 
-        await executor._execute_selection(
-            SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
-        )
-
-        assert executor.result.halted is True
-        assert "all parallel experiment branches failed" in executor.result.halt_reason
+        with pytest.raises(RuntimeError, match="all parallel experiment branches failed"):
+            await _run_selection_node(
+                executor,
+                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+            )
 
 
 class TestSelectionPicksBest:
@@ -623,7 +650,7 @@ class TestSelectionPicksBest:
              patch("factory.store.ExperimentStore.finalize", mock_finalize):
             mock_sp.return_value = MagicMock(returncode=0)
 
-            await executor._execute_selection(
+            await _run_selection_node(executor,
                 SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
             )
 
@@ -663,7 +690,7 @@ class TestSelectionPicksBest:
 
         with patch("subprocess.run") as mock_sp:
             mock_sp.return_value = MagicMock(returncode=0)
-            await executor._execute_selection(
+            await _run_selection_node(executor,
                 SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
             )
 
@@ -693,14 +720,14 @@ class TestSelectionPicksBest:
 
         with patch("subprocess.run") as mock_sp:
             mock_sp.return_value = MagicMock(returncode=0)
-            await executor._execute_selection(
+            await _run_selection_node(executor,
                 SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
             )
 
         selection = json.loads(executor.result.node_outputs["select"])
         assert selection["winner_score"] == 0.0
 
-    async def test_malformed_eval_json_defaults_to_zero(self, tmp_project: Path) -> None:
+    async def test_malformed_eval_json_surfaces(self, tmp_project: Path) -> None:
         wt1 = tmp_project / ".factory-worktrees" / "exp-1"
         wt1.mkdir(parents=True)
         (wt1 / ".factory").mkdir()
@@ -724,16 +751,15 @@ class TestSelectionPicksBest:
 
         with patch("subprocess.run") as mock_sp:
             mock_sp.return_value = MagicMock(returncode=0)
-            await executor._execute_selection(
-                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
-            )
-
-        selection = json.loads(executor.result.node_outputs["select"])
-        assert selection["winner_score"] == 0.0
+            with pytest.raises(json.JSONDecodeError):
+                await _run_selection_node(
+                    executor,
+                    SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+                )
 
 
 class TestSelectionMergeFailure:
-    async def test_merge_failure_halts(self, tmp_project: Path) -> None:
+    async def test_merge_failure_surfaces(self, tmp_project: Path) -> None:
         import subprocess as sp
 
         wt1 = tmp_project / ".factory-worktrees" / "exp-1"
@@ -757,16 +783,15 @@ class TestSelectionMergeFailure:
 
         with patch("subprocess.run") as mock_sp:
             mock_sp.side_effect = sp.CalledProcessError(1, "git merge")
-            await executor._execute_selection(
-                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
-            )
-
-        assert executor.result.halted is True
-        assert "failed to merge winner branch" in executor.result.halt_reason
+            with pytest.raises(sp.CalledProcessError):
+                await _run_selection_node(
+                    executor,
+                    SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+                )
 
 
 class TestSelectionCleanup:
-    async def test_finalize_failure_is_logged_not_fatal(self, tmp_project: Path) -> None:
+    async def test_finalize_failure_surfaces(self, tmp_project: Path) -> None:
         wt1 = tmp_project / ".factory-worktrees" / "exp-1"
         wt2 = tmp_project / ".factory-worktrees" / "exp-2"
         wt1.mkdir(parents=True)
@@ -794,14 +819,13 @@ class TestSelectionCleanup:
         with patch("subprocess.run") as mock_sp, \
              patch("factory.store.ExperimentStore.finalize", mock_finalize):
             mock_sp.return_value = MagicMock(returncode=0)
-            await executor._execute_selection(
-                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
-            )
+            with pytest.raises(RuntimeError, match="db error"):
+                await _run_selection_node(
+                    executor,
+                    SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+                )
 
-        assert not executor.result.halted
-        assert "select" in executor.result.node_outputs
-
-    async def test_worktree_cleanup_failure_not_fatal(self, tmp_project: Path) -> None:
+    async def test_worktree_cleanup_failure_surfaces(self, tmp_project: Path) -> None:
         wt1 = tmp_project / ".factory-worktrees" / "exp-1"
         wt1.mkdir(parents=True)
 
@@ -824,14 +848,14 @@ class TestSelectionCleanup:
         with patch("subprocess.run") as mock_sp, \
              patch("factory.worktree.remove_worktree", side_effect=OSError("rm fail")):
             mock_sp.return_value = MagicMock(returncode=0)
-            await executor._execute_selection(
-                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
-            )
+            with pytest.raises(OSError, match="rm fail"):
+                await _run_selection_node(
+                    executor,
+                    SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+                )
 
-        assert not executor.result.halted
-
-    async def test_fork_output_search_skips_invalid_json(self, tmp_project: Path) -> None:
-        """Non-JSON node outputs are skipped when searching for fork results."""
+    async def test_invalid_fork_output_surfaces(self, tmp_project: Path) -> None:
+        """Malformed graph output surfaces at the domain boundary."""
         wf = Workflow(
             name="test-select",
             nodes={
@@ -846,13 +870,11 @@ class TestSelectionCleanup:
         executor.result.node_outputs["plain"] = json.dumps({"some": "data"})
         executor.completed_files = {"pre.txt"}
 
-        await executor._execute_selection(
-            SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
-        )
-
-        selection = json.loads(executor.result.node_outputs["select"])
-        assert selection["winner"] is None
-        assert selection["reason"] == "dry-run"
+        with pytest.raises(json.JSONDecodeError):
+            await _run_selection_node(
+                executor,
+                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+            )
 
 
 # ── _execute_subgraph_fork non-dry-run tests (executor.py) ─────
@@ -875,7 +897,7 @@ class TestSubgraphForkNonDryRun:
         )
         executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
 
-        await executor._execute_subgraph_fork(
+        await _run_subgraph_fork_node(executor,
             SubgraphForkNode(
                 id="fork", subgraph_entry="step", subgraph_exit="step",
                 parallelism=2, writes={"fork.json"},
@@ -915,7 +937,7 @@ class TestSubgraphForkNonDryRun:
              patch("factory.store.ExperimentStore.begin", new_callable=AsyncMock, return_value=1):
             mock_sp.return_value = MagicMock(stdout="abc123\n")
 
-            await executor._execute_subgraph_fork(
+            await _run_subgraph_fork_node(executor,
                 SubgraphForkNode(
                     id="fork", subgraph_entry="step", subgraph_exit="step",
                     parallelism=2, writes={"fork.json"},
@@ -962,7 +984,7 @@ class TestSubgraphForkNonDryRun:
                  return_value=(fake_wt_path, "factory/exp-1"),
              ), \
              patch("factory.store.ExperimentStore.begin", new_callable=AsyncMock, return_value=1):
-            await executor._execute_subgraph_fork(
+            await _run_subgraph_fork_node(executor,
                 SubgraphForkNode(
                     id="fork", subgraph_entry="step", subgraph_exit="step",
                     parallelism=1, writes={"fork.json"},
@@ -1243,7 +1265,7 @@ class TestSelectionLiveExecution:
         }])
         executor.completed_files = {"pre.txt"}
 
-        await executor._execute_selection(
+        await _run_selection_node(executor,
             SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
         )
 
@@ -1305,7 +1327,7 @@ class TestSelectionLiveExecution:
         ])
         executor.completed_files = {"pre.txt"}
 
-        await executor._execute_selection(
+        await _run_selection_node(executor,
             SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
         )
 
@@ -1354,8 +1376,8 @@ class TestErrorRecoveryPaths:
         assert results[0]["success"] is False
         assert results[0]["halted"] is True
 
-    async def test_fork_subprocess_timeout_captured(self, tmp_path: Path) -> None:
-        """When git rev-parse times out, the fork halts gracefully."""
+    async def test_fork_subprocess_failure_surfaces(self, tmp_path: Path) -> None:
+        """A git failure surfaces and leaves the graph checkpoint resumable."""
         import subprocess as sp
 
         project = _git_project(tmp_path)
@@ -1384,12 +1406,11 @@ class TestErrorRecoveryPaths:
             "subprocess.run",
             side_effect=sp.CalledProcessError(128, "git rev-parse"),
         ):
-            result = await executor.execute()
+            with pytest.raises(sp.CalledProcessError):
+                await executor.execute()
 
-        assert result.halted is True
-
-    async def test_selection_merge_conflict_halts(self, tmp_path: Path) -> None:
-        """When merging the winner causes a conflict, selection halts."""
+    async def test_selection_merge_conflict_surfaces(self, tmp_path: Path) -> None:
+        """A winner merge conflict surfaces with the git failure."""
         import subprocess as sp
 
         project = _git_project(tmp_path)
@@ -1443,17 +1464,16 @@ class TestErrorRecoveryPaths:
         }])
         executor.completed_files = {"pre.txt"}
 
-        await executor._execute_selection(
-            SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
-        )
+        with pytest.raises(sp.CalledProcessError):
+            await _run_selection_node(
+                executor,
+                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+            )
 
-        assert executor.result.halted is True
-        assert "failed to merge winner branch" in executor.result.halt_reason
-
-    async def test_selection_worktree_cleanup_failure_non_fatal(
+    async def test_selection_worktree_cleanup_failure_surfaces(
         self, tmp_path: Path,
     ) -> None:
-        """When worktree removal fails, selection still succeeds."""
+        """A worktree cleanup failure surfaces at the selection node."""
         import subprocess as sp
 
         project = _git_project(tmp_path)
@@ -1498,10 +1518,8 @@ class TestErrorRecoveryPaths:
         executor.completed_files = {"pre.txt"}
 
         with patch("factory.worktree.remove_worktree", side_effect=OSError("perm denied")):
-            await executor._execute_selection(
-                SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
-            )
-
-        assert not executor.result.halted
-        selection = json.loads(executor.result.node_outputs["select"])
-        assert selection["winner_exp_id"] == 1
+            with pytest.raises(OSError, match="perm denied"):
+                await _run_selection_node(
+                    executor,
+                    SelectionNode(id="select", reads={"pre.txt"}, writes={"result.json"}),
+                )

--- a/tests/test_workflow_cli.py
+++ b/tests/test_workflow_cli.py
@@ -13,12 +13,13 @@ from factory.workflow.cli import (
     _cmd_export_skills,
     _cmd_lint_contributed,
     _cmd_list,
+    _cmd_resume,
     _cmd_run,
     _cmd_show,
     _cmd_validate,
     cmd_workflow,
 )
-from factory.workflow.executor import ExecutionResult
+from factory.workflow.executor import ExecutionResult, WorkflowExecutor
 from factory.workflow.primitives import (
     DEFAULT_AGENT_POOL,
     AgentNode,
@@ -140,6 +141,29 @@ class TestCmdRun:
             tmp_path.resolve(),
             agent_pool=DEFAULT_AGENT_POOL,
             dry_run=True,
+            auto_approve=False,
+            thread_id=None,
+        )
+
+
+class TestCmdResume:
+    def test_parallel_resume_json_is_forwarded_by_interrupt_id(self, tmp_path: Path) -> None:
+        executor = MagicMock()
+        executor.workflow.name = "build"
+        executor.resume = AsyncMock(return_value=_success_result())
+        args = argparse.Namespace(
+            name="build",
+            project_path=str(tmp_path),
+            thread_id="thread-1",
+            value=None,
+            resume_json='{"interrupt-a": "done-a", "interrupt-b": "done-b"}',
+        )
+
+        with patch.object(WorkflowExecutor, "from_thread", return_value=executor):
+            assert _cmd_resume(args) == 0
+
+        executor.resume.assert_awaited_once_with(
+            {"interrupt-a": "done-a", "interrupt-b": "done-b"}
         )
 
 

--- a/tests/test_workflow_executor.py
+++ b/tests/test_workflow_executor.py
@@ -250,8 +250,8 @@ class TestForkJoin:
 
 
 class TestNonBlocking:
-    async def test_fire_and_forget(self, tmp_project: Path) -> None:
-        """Non-blocking node fires, executor advances immediately."""
+    async def test_legacy_nonblocking_node_is_durable(self, tmp_project: Path) -> None:
+        """LangGraph completes nodes marked non-blocking before advancing."""
         wf = Workflow(
             name="nonblock_test",
             nodes={
@@ -276,6 +276,7 @@ class TestNonBlocking:
         result = await executor.execute()
 
         assert result.success
+        assert "async_node" in result.completed_nodes
         assert result.nodes_executed >= 2
 
 
@@ -335,8 +336,8 @@ class TestEventEmission:
 
 
 class TestErrorHandling:
-    async def test_node_failure_halts(self, tmp_project: Path) -> None:
-        """Node failure produces Halt with error message."""
+    async def test_node_failure_surfaces(self, tmp_project: Path) -> None:
+        """Node failures surface with the original stack rather than being swallowed."""
         wf = Workflow(
             name="error_test",
             nodes={
@@ -348,10 +349,8 @@ class TestErrorHandling:
         )
 
         executor = WorkflowExecutor(wf, tmp_project)
-        result = await executor.execute()
-
-        assert result.halted
-        assert "failed" in result.halt_reason.lower()
+        with pytest.raises(RuntimeError, match="command failed"):
+            await executor.execute()
 
 
 # ── Auto-approve ────────────────────────────────────────────────
@@ -382,8 +381,8 @@ class TestAutoApprove:
         assert len(gate_events) == 1
         assert gate_events[0]["verdict_type"] == VerdictType.PROCEED
 
-    async def test_executor_default_still_proceeds(self, tmp_project: Path) -> None:
-        """WorkflowExecutor(auto_approve=False) still proceeds through user gates."""
+    async def test_executor_default_interrupts_for_user_gate(self, tmp_project: Path) -> None:
+        """A user gate persists an interrupt until its thread is resumed."""
         wf = Workflow(
             name="default_user_gate",
             nodes={
@@ -401,8 +400,11 @@ class TestAutoApprove:
         executor = WorkflowExecutor(wf, tmp_project, dry_run=True, auto_approve=False)
         result = await executor.execute()
 
+        assert result.interrupted
+        assert result.interrupts[0]["value"]["node_id"] == "gate"
+        result = await executor.resume("PROCEED")
         assert result.success
-        gate_events = [e for e in result.events if e["type"] == "gate.verdict"]
+        gate_events = [event for event in result.events if event["type"] == "gate.verdict"]
         assert len(gate_events) == 1
         assert gate_events[0]["verdict_type"] == VerdictType.PROCEED
 
@@ -476,6 +478,6 @@ class TestAutoApprove:
         finally:
             structlog.reset_defaults()
 
-        assert result.success
+        assert result.interrupted
         auto_approved = [e for e in captured if e.get("event") == "gate.auto_approved"]
         assert len(auto_approved) == 0

--- a/tests/test_workflow_langgraph.py
+++ b/tests/test_workflow_langgraph.py
@@ -1,0 +1,178 @@
+"""Canonical LangGraph compilation, persistence, and durability tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from factory.workflow.definitions import register_all
+from factory.workflow.executor import WorkflowExecutor
+from factory.workflow.langgraph import compile_langgraph, initial_state
+from factory.workflow.primitives import (
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    VerdictType,
+    Workflow,
+)
+
+
+def test_every_builtin_workflow_compiles_directly_to_langgraph(tmp_path: Path) -> None:
+    for workflow in register_all().values():
+        runtime = WorkflowExecutor(workflow, tmp_path, dry_run=True)
+        graph = compile_langgraph(workflow, runtime)
+        assert graph.name == workflow.name
+
+
+async def test_thread_manifest_reconstructs_exact_dry_run_for_resume(
+    tmp_path: Path,
+) -> None:
+    workflow = Workflow(
+        name="manifest-resume",
+        start_node="before",
+        nodes={
+            "before": FnNode(id="before", command="exit 99"),
+            "approval": GateNode(id="approval", evaluator_type="user"),
+            "after": FnNode(id="after", command="exit 99"),
+        },
+        edges=[
+            Edge(source="before", target="approval"),
+            Edge(source="approval", target="after", condition=VerdictType.PROCEED),
+        ],
+    )
+    executor = WorkflowExecutor(workflow, tmp_path, dry_run=True, thread_id="resume-me")
+
+    paused = await executor.execute()
+
+    assert paused.interrupted
+    manifest = json.loads(
+        (tmp_path / ".factory" / "langgraph" / "threads" / "resume-me.json").read_text()
+    )
+    assert manifest["dry_run"] is True
+    restarted = WorkflowExecutor.from_thread(tmp_path, "resume-me")
+    assert restarted.workflow.model_dump_json() == workflow.model_dump_json()
+    completed = await restarted.resume("PROCEED")
+    assert completed.success
+    assert completed.completed_nodes == {"before", "approval", "after"}
+
+
+async def test_interactive_parallel_thread_resumes_after_process_restart(
+    tmp_path: Path,
+) -> None:
+    workflow = Workflow(
+        name="parallel-resume",
+        start_node="fork",
+        nodes={
+            "fork": ForkNode(id="fork", targets=["a", "b"]),
+            "a": FnNode(id="a", command="echo a"),
+            "b": FnNode(id="b", command="echo b"),
+            "join": JoinNode(id="join", sources=["a", "b"]),
+            "done": FnNode(id="done", command="echo done"),
+        },
+        edges=[
+            Edge(source="fork", target="a"),
+            Edge(source="fork", target="b"),
+            Edge(source="a", target="join"),
+            Edge(source="b", target="join"),
+            Edge(source="join", target="done"),
+        ],
+    )
+    first = WorkflowExecutor(
+        workflow,
+        tmp_path,
+        interactive=True,
+        thread_id="parallel-thread",
+    )
+    paused = await first.execute()
+    assert {item["value"]["node_id"] for item in paused.interrupts} == {"a", "b"}
+
+    restarted = WorkflowExecutor.from_thread(tmp_path, "parallel-thread")
+    branch_values = {str(item["id"]): item["value"]["node_id"] for item in paused.interrupts}
+    paused_at_done = await restarted.resume(branch_values)
+    assert paused_at_done.interrupts[0]["value"]["node_id"] == "done"
+
+    restarted_again = WorkflowExecutor.from_thread(tmp_path, "parallel-thread")
+    completed = await restarted_again.resume("finished")
+    assert completed.success
+    assert completed.completed_nodes == {"fork", "a", "b", "join", "done"}
+
+
+async def test_completion_receipt_prevents_duplicate_side_effect(tmp_path: Path) -> None:
+    node = FnNode(id="effect", command="printf x >> effect.txt")
+    workflow = Workflow(name="receipt", nodes={"effect": node}, edges=[], start_node="effect")
+    executor = WorkflowExecutor(workflow, tmp_path, thread_id="receipt-thread")
+    state = initial_state(workflow, str(tmp_path), executor.run_id)
+
+    await executor.run_node(node, state)
+    await executor.run_node(node, state)
+
+    assert (tmp_path / "effect.txt").read_text() == "x"
+    receipt = json.loads(
+        (
+            tmp_path
+            / ".factory"
+            / "langgraph"
+            / "receipts"
+            / "receipt-thread"
+            / "effect-1.json"
+        ).read_text()
+    )
+    assert receipt["status"] == "completed"
+    assert receipt["operation_id"] == "receipt-thread:effect:1"
+
+
+async def test_started_receipt_blocks_ambiguous_side_effect_retry(tmp_path: Path) -> None:
+    node = FnNode(id="effect", command="printf x >> effect.txt")
+    workflow = Workflow(name="ambiguous", nodes={"effect": node}, edges=[], start_node="effect")
+    executor = WorkflowExecutor(workflow, tmp_path, thread_id="ambiguous-thread")
+    receipt = (
+        tmp_path
+        / ".factory"
+        / "langgraph"
+        / "receipts"
+        / "ambiguous-thread"
+        / "effect-1.json"
+    )
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text(json.dumps({
+        "operation_id": "ambiguous-thread:effect:1",
+        "node_id": "effect",
+        "attempt": 1,
+        "status": "started",
+    }))
+
+    with pytest.raises(RuntimeError, match="ambiguous prior attempt"):
+        await executor.run_node(
+            node,
+            initial_state(workflow, str(tmp_path), executor.run_id),
+        )
+    assert not (tmp_path / "effect.txt").exists()
+
+
+async def test_halt_cleanup_edge_runs_but_thread_remains_halted(tmp_path: Path) -> None:
+    workflow = Workflow(
+        name="halt-cleanup",
+        start_node="approval",
+        nodes={
+            "approval": GateNode(id="approval", evaluator_type="user"),
+            "cleanup": FnNode(id="cleanup", command="echo cleanup"),
+        },
+        edges=[
+            Edge(source="approval", target="cleanup", condition=VerdictType.HALT),
+        ],
+    )
+    executor = WorkflowExecutor(workflow, tmp_path, dry_run=True)
+    paused = await executor.execute()
+    assert paused.interrupted
+
+    result = await executor.resume('HALT reason="rejected"')
+
+    assert result.completed
+    assert result.halted
+    assert not result.success
+    assert result.halt_reason == "rejected"
+    assert "cleanup" in result.completed_nodes

--- a/tests/test_workflow_tool.py
+++ b/tests/test_workflow_tool.py
@@ -1,9 +1,11 @@
-"""Tests for factory/workflow/tool.py — tool-based workflow execution."""
+"""Behavior tests for graph-backed interactive workflow tools."""
 
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
+
 import pytest
 
 from factory.workflow.primitives import (
@@ -11,12 +13,14 @@ from factory.workflow.primitives import (
     AgentRole,
     Edge,
     FnNode,
+    ForkNode,
     GateNode,
+    JoinNode,
     Study,
     VerdictType,
     Workflow,
 )
-from factory.workflow.registry import WorkflowRegistry
+from factory.workflow.registry import WorkflowEntry, WorkflowRegistry
 from factory.workflow.tool import (
     _detect_artifact,
     _find_reloop_target,
@@ -25,7 +29,6 @@ from factory.workflow.tool import (
     _format_progress,
     _get_workflow_cached,
     _phase_label,
-    _rebuild_workflow,
     _resolve_original_project,
     _workflow_cache,
     tool_curr,
@@ -39,18 +42,24 @@ from factory.workflow.tool import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_registry():
-    WorkflowRegistry.reset()
-    _workflow_cache.clear()
-    yield
+def reset_registry() -> None:
     WorkflowRegistry.reset()
     _workflow_cache.clear()
 
 
-def _simple_workflow() -> Workflow:
-    """A minimal workflow: study -> researcher -> gate -> builder."""
+def register(workflow: Workflow) -> None:
+    WorkflowRegistry._entries[workflow.name] = WorkflowEntry(
+        name=workflow.name,
+        description="test workflow",
+        path="<test>",
+        source="builtin",
+        _workflow_fn=lambda: workflow,
+    )
+
+
+def simple_workflow() -> Workflow:
     return Workflow(
-        name="test-simple",
+        name="tool-simple",
         start_node="study",
         nodes={
             "study": Study(
@@ -61,1400 +70,335 @@ def _simple_workflow() -> Workflow:
             "researcher": AgentNode(
                 id="researcher",
                 role=AgentRole.RESEARCHER,
-                prompt_template="Research the project at {project_path}",
+                prompt_template="Research {project_path}",
                 writes={".factory/reviews/researcher-latest.md"},
             ),
             "gate_research": GateNode(
                 id="gate_research",
                 evaluator_type="agent",
-                gate_prompt="Review research output",
-                reads={".factory/reviews/researcher-latest.md"},
+                gate_prompt="Review research",
             ),
-            "builder": AgentNode(
-                id="builder",
-                role=AgentRole.BUILDER,
-                prompt_template="Build the project",
-                writes={".factory/reviews/builder-latest.md"},
-            ),
-        },
-        edges=[
-            Edge(source="study", target="researcher"),
-            Edge(source="researcher", target="gate_research"),
-            Edge(source="gate_research", target="builder", condition=VerdictType.PROCEED),
-            Edge(source="gate_research", target="researcher", condition=VerdictType.RELOOP),
-        ],
-    )
-
-
-def _fn_gate_workflow() -> Workflow:
-    """Workflow with an fn-type gate for auto-evaluation."""
-    return Workflow(
-        name="test-fn-gate",
-        start_node="builder",
-        nodes={
             "builder": AgentNode(
                 id="builder",
                 role=AgentRole.BUILDER,
                 prompt_template="Build",
                 writes={".factory/reviews/builder-latest.md"},
             ),
-            "gate_review": GateNode(
-                id="gate_review",
-                evaluator_type="fn",
-                evaluator_command="echo PROCEED",
-                reads={".factory/reviews/builder-latest.md"},
-            ),
-            "archivist": AgentNode(
-                id="archivist",
-                role=AgentRole.ARCHIVIST,
-                prompt_template="Archive results",
-                writes={".factory/archive/build.md"},
-                blocking=False,
-            ),
         },
         edges=[
-            Edge(source="builder", target="gate_review"),
-            Edge(source="gate_review", target="archivist", condition=VerdictType.PROCEED),
-            Edge(source="gate_review", target="builder", condition=VerdictType.RELOOP),
+            Edge(source="study", target="researcher"),
+            Edge(source="researcher", target="gate_research"),
+            Edge(
+                source="gate_research",
+                target="builder",
+                condition=VerdictType.PROCEED,
+            ),
+            Edge(
+                source="gate_research",
+                target="researcher",
+                condition=VerdictType.RELOOP,
+            ),
         ],
     )
 
 
-def _register_workflow(wf: Workflow) -> None:
-    """Helper to register a workflow in the registry."""
-    from factory.workflow.registry import WorkflowEntry
-    WorkflowRegistry._entries[wf.name] = WorkflowEntry(
-        name=wf.name,
-        description="test workflow",
-        path="<test>",
-        source="builtin",
-        _workflow_fn=lambda _wf=wf: _wf,
+def test_init_persists_thread_metadata_dsl_snapshot_and_checkpoint(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+
+    session_dir = Path(tool_init(workflow.name, tmp_path))
+
+    session = json.loads((session_dir / "session.json").read_text())
+    assert session["workflow_name"] == workflow.name
+    assert len(session["thread_id"]) == 12
+    assert Workflow.model_validate_json(session["workflow_json"]).name == workflow.name
+    assert (session_dir / "checkpoints.sqlite").exists()
+    assert not (tmp_path / ".factory" / "tool_session" / "state.json").exists()
+    assert "pointer_idx" not in session
+    assert "completed" not in session
+
+
+def test_init_rejects_unknown_workflow(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unknown workflow"):
+        tool_init("missing", tmp_path)
+
+
+def test_curr_and_next_project_pending_interrupt(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+
+    assert "Node: study" in tool_curr(tmp_path)
+    assert "Type: Study" in tool_next(tmp_path)
+
+
+def test_submit_resumes_graph_and_writes_agent_artifact(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+
+    assert tool_submit(tmp_path, "study", "observations") == "CONTINUE"
+    assert "Node: researcher" in tool_curr(tmp_path)
+    assert tool_submit(tmp_path, "researcher", "research findings") == "CONTINUE"
+    assert (
+        tmp_path / ".factory" / "reviews" / "researcher-latest.md"
+    ).read_text() == "research findings"
+    assert tool_next(tmp_path).startswith("GATE\n")
+
+
+def test_submit_rejects_non_pending_node(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+
+    with pytest.raises(ValueError, match="not pending"):
+        tool_submit(tmp_path, "builder", "early")
+
+
+def test_gate_reloop_is_persisted_and_returns_to_target(tmp_path: Path) -> None:
+    workflow = Workflow(
+        name="tool-reloop",
+        start_node="builder",
+        nodes={
+            "builder": AgentNode(
+                id="builder",
+                role=AgentRole.BUILDER,
+                writes={".factory/reviews/builder-latest.md"},
+            ),
+            "gate": GateNode(id="gate", evaluator_type="agent", gate_prompt="Check"),
+            "done": FnNode(id="done", command="echo done"),
+        },
+        edges=[
+            Edge(source="builder", target="gate"),
+            Edge(source="gate", target="done", condition=VerdictType.PROCEED),
+            Edge(source="gate", target="builder", condition=VerdictType.RELOOP),
+        ],
+    )
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+    tool_submit(tmp_path, "builder", "first")
+
+    result = tool_submit(
+        tmp_path,
+        "gate",
+        'RETRY target=builder feedback="tests still fail"',
     )
 
-
-class TestToolInit:
-    def test_init_creates_state(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-
-        session_dir = tool_init("test-simple", tmp_path)
-
-        state_path = Path(session_dir) / "state.json"
-        assert state_path.exists()
-        state = json.loads(state_path.read_text())
-        assert state["workflow_name"] == "test-simple"
-        assert state["status"] == "active"
-        assert state["pointer_idx"] == 0
-        assert len(state["session_id"]) == 12
-        assert "study" in state["topo_order"]
-
-    def test_init_unknown_workflow(self, tmp_path: Path) -> None:
-        with pytest.raises(ValueError, match="Unknown workflow"):
-            tool_init("nonexistent", tmp_path)
-
-    def test_init_filters_join_nodes(self, tmp_path: Path) -> None:
-        """JoinNodes should be excluded from topo_order."""
-        from factory.workflow.primitives import JoinNode
-        wf = Workflow(
-            name="test-join",
-            start_node="a",
-            nodes={
-                "a": FnNode(id="a", command="echo a"),
-                "join": JoinNode(id="join", sources=["a"]),
-                "b": FnNode(id="b", command="echo b"),
-            },
-            edges=[
-                Edge(source="a", target="join"),
-                Edge(source="join", target="b"),
-            ],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-
-        tool_init("test-join", tmp_path)
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "join" not in state["topo_order"]
-        assert "a" in state["topo_order"]
-        assert "b" in state["topo_order"]
-
-
-class TestToolNext:
-    def test_next_returns_first_node(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        result = tool_next(tmp_path)
-
-        assert "Node: study" in result
-        assert "Type: Study" in result
-
-    def test_next_returns_done_when_completed(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        state["status"] = "completed"
-        (tmp_path / ".factory" / "tool_session" / "state.json").write_text(
-            json.dumps(state)
-        )
-
-        result = tool_next(tmp_path)
-        assert "DONE" in result
-
-    def test_next_completes_when_past_end(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        state["pointer_idx"] = len(state["topo_order"])
-        (tmp_path / ".factory" / "tool_session" / "state.json").write_text(
-            json.dumps(state)
-        )
-
-        result = tool_next(tmp_path)
-        assert "DONE" in result
-
-
-class TestToolSubmit:
-    def test_submit_stores_output(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        result = tool_submit(tmp_path, "study", "Observations: project looks good")
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert state["completed"]["study"] == "Observations: project looks good"
-        assert result == "CONTINUE"
-
-    def test_submit_writes_agent_output_files(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        # Advance past study first
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        state["pointer_idx"] = 1  # researcher
-        (tmp_path / ".factory" / "tool_session" / "state.json").write_text(
-            json.dumps(state)
-        )
-
-        tool_submit(tmp_path, "researcher", "Research findings here")
-
-        output_file = tmp_path / ".factory" / "reviews" / "researcher-latest.md"
-        assert output_file.exists()
-        assert output_file.read_text() == "Research findings here"
-
-    def test_submit_advances_past_submitted_node(self, tmp_path: Path) -> None:
-        """Submit advances the pointer past the submitted node."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        state["pointer_idx"] = 1  # researcher
-        (tmp_path / ".factory" / "tool_session" / "state.json").write_text(
-            json.dumps(state)
-        )
-
-        result = tool_submit(tmp_path, "researcher", "Research done")
-        assert result == "CONTINUE"
-
-        # Next call to tool_next should return the agent gate
-        next_result = tool_next(tmp_path)
-        assert "GATE" in next_result
-        assert "gate_research" in next_result
-
-    def test_submit_fn_gate_proceed(self, tmp_path: Path) -> None:
-        wf = _fn_gate_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-fn-gate", tmp_path)
-
-        result = tool_submit(tmp_path, "builder", "Built successfully")
-
-        assert result == "CONTINUE"
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert state["gate_results"]["gate_review"] == "PROCEED"
-
-    def test_submit_fn_gate_halt(self, tmp_path: Path) -> None:
-        wf = Workflow(
-            name="test-halt",
-            start_node="builder",
-            nodes={
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build",
-                ),
-                "gate_fail": GateNode(
-                    id="gate_fail",
-                    evaluator_type="fn",
-                    evaluator_command="echo FAIL: tests broken",
-                ),
-            },
-            edges=[
-                Edge(source="builder", target="gate_fail"),
-            ],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-halt", tmp_path)
-
-        result = tool_submit(tmp_path, "builder", "Built")
-        assert result.startswith("HALT")
-        assert "FAIL" in result
-
-    def test_submit_fn_gate_reloop(self, tmp_path: Path) -> None:
-        wf = Workflow(
-            name="test-reloop",
-            start_node="builder",
-            nodes={
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build",
-                ),
-                "gate_check": GateNode(
-                    id="gate_check",
-                    evaluator_type="fn",
-                    evaluator_command="echo FAIL: needs fixes",
-                ),
-            },
-            edges=[
-                Edge(source="builder", target="gate_check"),
-                Edge(source="gate_check", target="builder", condition=VerdictType.RELOOP),
-            ],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-reloop", tmp_path)
-
-        result = tool_submit(tmp_path, "builder", "First attempt")
-        assert result.startswith("RETRY")
-        assert "attempt 1/3" in result
-
-    def test_submit_fn_gate_reloop_max_iterations(self, tmp_path: Path) -> None:
-        wf = Workflow(
-            name="test-max-iter",
-            start_node="builder",
-            nodes={
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build",
-                ),
-                "gate_check": GateNode(
-                    id="gate_check",
-                    evaluator_type="fn",
-                    evaluator_command="echo FAIL: still broken",
-                ),
-            },
-            edges=[
-                Edge(source="builder", target="gate_check"),
-                Edge(source="gate_check", target="builder", condition=VerdictType.RELOOP),
-            ],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-max-iter", tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        state["iteration_counts"]["gate_check->builder"] = 3
-        (tmp_path / ".factory" / "tool_session" / "state.json").write_text(
-            json.dumps(state)
-        )
-
-        result = tool_submit(tmp_path, "builder", "Fourth attempt")
-        assert result.startswith("HALT")
-
-    def test_submit_then_next_returns_user_gate(self, tmp_path: Path) -> None:
-        """After submit, calling next returns user gate as APPROVAL_NEEDED."""
-        wf = Workflow(
-            name="test-user-gate",
-            start_node="strategist",
-            nodes={
-                "strategist": AgentNode(
-                    id="strategist",
-                    role=AgentRole.STRATEGIST,
-                    prompt_template="Strategize",
-                ),
-                "gate_approval": GateNode(
-                    id="gate_approval",
-                    evaluator_type="user",
-                    gate_prompt="Approve this strategy?",
-                ),
-                "builder": AgentNode(
-                    id="builder",
-                    role=AgentRole.BUILDER,
-                    prompt_template="Build",
-                ),
-            },
-            edges=[
-                Edge(source="strategist", target="gate_approval"),
-                Edge(source="gate_approval", target="builder", condition=VerdictType.PROCEED),
-            ],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-user-gate", tmp_path)
-
-        result = tool_submit(tmp_path, "strategist", "Strategy ready")
-        assert result == "CONTINUE"
-
-        next_result = tool_next(tmp_path)
-        assert "APPROVAL_NEEDED" in next_result
-        assert "Approve this strategy?" in next_result
-
-    def test_submit_returns_done_at_end(self, tmp_path: Path) -> None:
-        wf = Workflow(
-            name="test-single",
-            start_node="study",
-            nodes={
-                "study": Study(id="study", command="factory study {project_path}"),
-            },
-            edges=[],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-single", tmp_path)
-
-        result = tool_submit(tmp_path, "study", "Done studying")
-        assert result == "DONE"
-
-
-class TestToolStatus:
-    def test_status_no_session(self, tmp_path: Path) -> None:
-        result = tool_status(tmp_path)
-        assert "No active session" in result
-
-    def test_status_active_session(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        result = tool_status(tmp_path)
-        assert "Workflow: test-simple" in result
-        assert "Status:   active" in result
-        assert "Progress: 0/" in result
-
-    def test_status_with_completed_nodes(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-        tool_submit(tmp_path, "study", "Observations here")
-
-        result = tool_status(tmp_path)
-        assert "Progress: 1/" in result
-        assert "✓ study" in result
-
-    def test_status_with_gate_results(self, tmp_path: Path) -> None:
-        wf = _fn_gate_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-fn-gate", tmp_path)
-        tool_submit(tmp_path, "builder", "Built")
-
-        result = tool_status(tmp_path)
-        assert "Gates:" in result
-        assert "PROCEED" in result
-
-
-class TestAutoSubmit:
-    """Tests for the primary auto-submit mechanism in tool_next."""
-
-    def test_next_auto_submits_agent(self, tmp_path: Path) -> None:
-        """tool_next auto-submits an agent node when its review file exists."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        # Submit study to advance past it
-        tool_submit(tmp_path, "study", "Observations done")
-
-        # Simulate agent ran: write the review file directly (no submit)
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-latest.md").write_text("Research findings here")
-
-        # tool_next should auto-submit the researcher and return the gate
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "researcher" in state["completed"]
-        assert state["completed"]["researcher"] == "Research findings here"
-        assert "GATE" in result
-        assert "gate_research" in result
-
-    def test_next_auto_submits_study(self, tmp_path: Path) -> None:
-        """tool_next auto-submits a study node when observations.md exists."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        # Write observations file directly (no submit)
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text(
-            "Detailed observations about the project that exceed the minimum length threshold"
-        )
-
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "study" in state["completed"]
-        assert "researcher" in result
-
-    def test_next_stops_at_gate(self, tmp_path: Path) -> None:
-        """tool_next auto-submits agent, then stops at the following agent gate."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        # Write both study and researcher artifacts
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text(
-            "Detailed observations about the project that exceed the minimum length threshold"
-        )
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-latest.md").write_text("Research findings")
-
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "study" in state["completed"]
-        assert "researcher" in state["completed"]
-        assert "GATE" in result
-        assert "gate_research" in result
-
-    def test_next_auto_evaluates_fn_gate(self, tmp_path: Path) -> None:
-        """tool_next auto-submits agent and auto-evaluates following fn gate."""
-        wf = _fn_gate_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-fn-gate", tmp_path)
-
-        # Write builder review file (fn gate passes via "echo PROCEED")
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "builder-latest.md").write_text("Built successfully")
-
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "builder" in state["completed"]
-        assert "gate_review" in state["completed"]
-        assert state["gate_results"]["gate_review"] == "PROCEED"
-        # Should return the archivist node (after auto-evaluating gate)
-        assert "archivist" in result
-
-    def test_next_chain_multiple(self, tmp_path: Path) -> None:
-        """tool_next chains through multiple auto-submittable nodes in one call."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        # Write both study observations and researcher review
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text(
-            "Detailed observations about the project that exceed the minimum length threshold"
-        )
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-latest.md").write_text("Research findings")
-
-        # Single call to next should skip both and stop at gate
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "study" in state["completed"]
-        assert "researcher" in state["completed"]
-        assert "GATE" in result
-        assert "gate_research" in result
-
-    def test_next_auto_submits_fn_with_output_files(self, tmp_path: Path) -> None:
-        """tool_next auto-submits a FnNode when its declared output files exist."""
-        wf = Workflow(
-            name="test-fn-auto",
-            start_node="fn1",
-            nodes={
-                "fn1": FnNode(
-                    id="fn1",
-                    command="echo hello",
-                    writes={".factory/output.md"},
-                ),
-                "fn2": FnNode(id="fn2", command="echo done"),
-            },
-            edges=[Edge(source="fn1", target="fn2")],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-fn-auto", tmp_path)
-
-        # Write the output file directly
-        (tmp_path / ".factory" / "output.md").write_text("Generated output")
-
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "fn1" in state["completed"]
-        assert "fn2" in result
-
-    def test_next_does_not_auto_submit_empty_review(self, tmp_path: Path) -> None:
-        """Empty review files should not trigger auto-submit."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        tool_submit(tmp_path, "study", "Observations done")
-
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-latest.md").write_text("")
-
-        result = tool_next(tmp_path)
-        assert "researcher" in result
-        assert "Type: Agent" in result
-
-    def test_next_auto_submits_fork_node(self, tmp_path: Path) -> None:
-        """ForkNodes are auto-submitted immediately (structural nodes)."""
-        from factory.workflow.primitives import ForkNode
-        wf = Workflow(
-            name="test-fork-auto",
-            start_node="fork1",
-            nodes={
-                "fork1": ForkNode(id="fork1", targets=["a", "b"]),
-                "a": FnNode(id="a", command="echo a"),
-                "b": FnNode(id="b", command="echo b"),
-            },
-            edges=[
-                Edge(source="fork1", target="a"),
-                Edge(source="fork1", target="b"),
-            ],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-fork-auto", tmp_path)
-
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "fork1" in state["completed"]
-        assert "Fork targets" in state["completed"]["fork1"]
-        assert "a" in result or "b" in result
-
-
-class TestHelpers:
-    def test_find_reloop_target(self) -> None:
-        wf = _simple_workflow()
-        target = _find_reloop_target(wf, "gate_research")
-        assert target == "researcher"
-
-    def test_find_reloop_target_none(self) -> None:
-        wf = _simple_workflow()
-        target = _find_reloop_target(wf, "study")
-        assert target is None
-
-    def test_format_node_task_agent(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        node = wf.nodes["researcher"]
-        result = _format_node_task("researcher", node, wf, {}, tmp_path)
-        assert "Type: Agent (researcher)" in result
-        assert "Model:" in result
-        assert "Timeout:" in result
-
-    def test_format_node_task_study(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        node = wf.nodes["study"]
-        result = _format_node_task("study", node, wf, {}, tmp_path)
-        assert "Type: Study" in result
-        assert "Command:" in result
-
-    def test_format_node_task_gate(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        node = wf.nodes["gate_research"]
-        result = _format_node_task("gate_research", node, wf, {}, tmp_path)
-        assert "Type: Gate (agent)" in result
-
-    def test_format_node_task_fn(self, tmp_path: Path) -> None:
-        node = FnNode(id="fn1", command="echo hello", notes="test note")
-        wf = Workflow(
-            name="test", start_node="fn1",
-            nodes={"fn1": node}, edges=[],
-        )
-        result = _format_node_task("fn1", node, wf, {}, tmp_path)
-        assert "Type: Function" in result
-        assert "Notes: test note" in result
-
-    def test_format_node_task_fork(self, tmp_path: Path) -> None:
-        from factory.workflow.primitives import ForkNode
-        node = ForkNode(id="fork1", targets=["a", "b"])
-        wf = Workflow(
-            name="test", start_node="fork1",
-            nodes={"fork1": node}, edges=[],
-        )
-        result = _format_node_task("fork1", node, wf, {}, tmp_path)
-        assert "Type: Fork" in result
-        assert "a, b" in result
-
-    def test_format_gate_task(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        gate = wf.nodes["gate_research"]
-        state = {"workflow_name": "test-simple"}
-        result = _format_gate_task("gate_research", gate, state, tmp_path)
-        assert "Gate: gate_research" in result
-        assert "PROCEED" in result
-        assert "RETRY" in result
-        assert "researcher" in result
-
-    def test_detect_artifact_agent_review_file(self, tmp_path: Path) -> None:
-        node = AgentNode(id="researcher", role=AgentRole.RESEARCHER, prompt_template="r")
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-latest.md").write_text("findings")
-
-        result = _detect_artifact("researcher", node, tmp_path)
-        assert result == "findings"
-
-    def test_detect_artifact_agent_empty(self, tmp_path: Path) -> None:
-        node = AgentNode(id="researcher", role=AgentRole.RESEARCHER, prompt_template="r")
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-latest.md").write_text("")
-
-        result = _detect_artifact("researcher", node, tmp_path)
-        assert result is None
-
-    def test_detect_artifact_agent_tagged(self, tmp_path: Path) -> None:
-        node = AgentNode(id="researcher_similar", role=AgentRole.RESEARCHER, prompt_template="r")
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-similar-latest.md").write_text("similar findings")
-
-        result = _detect_artifact("researcher_similar", node, tmp_path)
-        assert result == "similar findings"
-
-    def test_detect_artifact_study(self, tmp_path: Path) -> None:
-        node = Study(id="study", command="factory study {project_path}")
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text("x" * 100)
-
-        result = _detect_artifact("study", node, tmp_path)
-        assert result is not None
-
-    def test_detect_artifact_study_too_short(self, tmp_path: Path) -> None:
-        node = Study(id="study", command="factory study {project_path}")
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text("short")
-
-        result = _detect_artifact("study", node, tmp_path)
-        assert result is None
-
-    def test_detect_artifact_fn_node(self, tmp_path: Path) -> None:
-        node = FnNode(id="fn1", command="echo hello", writes={".factory/out.md"})
-        (tmp_path / ".factory").mkdir(parents=True, exist_ok=True)
-        (tmp_path / ".factory" / "out.md").write_text("output")
-
-        result = _detect_artifact("fn1", node, tmp_path)
-        assert result == "output"
-
-    def test_detect_artifact_fn_missing_writes(self, tmp_path: Path) -> None:
-        node = FnNode(id="fn1", command="echo hello", writes={".factory/out.md"})
-        (tmp_path / ".factory").mkdir(parents=True, exist_ok=True)
-
-        result = _detect_artifact("fn1", node, tmp_path)
-        assert result is None
-
-    def test_detect_artifact_fork(self, tmp_path: Path) -> None:
-        from factory.workflow.primitives import ForkNode
-        node = ForkNode(id="fork1", targets=["a", "b"])
-        result = _detect_artifact("fork1", node, tmp_path)
-        assert result is not None
-        assert "Fork targets" in result
-
-    def test_detect_artifact_gate_returns_none(self, tmp_path: Path) -> None:
-        node = GateNode(id="g", evaluator_type="agent", gate_prompt="review")
-        result = _detect_artifact("g", node, tmp_path)
-        assert result is None
-
-
-class TestFinalize:
-    def test_finalize_marks_remaining_nodes(self, tmp_path: Path) -> None:
-        """Finalize auto-completes nodes whose artifacts exist but weren't tracked."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        # Write artifacts without calling next/submit
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text(
-            "Detailed observations about the project that exceed the minimum length threshold"
-        )
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-latest.md").write_text("Research findings")
-        (reviews_dir / "builder-latest.md").write_text("Built successfully")
-
-        result = tool_finalize(tmp_path)
-
-        assert "Finalized" in result
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "study" in state["completed"]
-        assert "researcher" in state["completed"]
-        assert "builder" in state["completed"]
-
-    def test_finalize_no_pending(self, tmp_path: Path) -> None:
-        """Finalize with all nodes already complete reports nothing to do."""
-        wf = Workflow(
-            name="test-single-fn",
-            start_node="fn1",
-            nodes={"fn1": FnNode(id="fn1", command="echo done")},
-            edges=[],
-        )
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-single-fn", tmp_path)
-        tool_submit(tmp_path, "fn1", "Done")
-
-        result = tool_finalize(tmp_path)
-
-        assert "No pending nodes" in result
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert state["status"] == "completed"
-
-
-class TestWorkflowCache:
-    def test_cache_avoids_redundant_loads(self, tmp_path: Path) -> None:
-        """Second call to _get_workflow_cached returns from cache dict."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-
-        result1 = _get_workflow_cached("test-simple", tmp_path)
-        cache_key = f"{tmp_path}:test-simple"
-        assert cache_key in _workflow_cache
-
-        result2 = _get_workflow_cached("test-simple", tmp_path)
-        assert result1 is result2
-
-
-class TestEventLogging:
-    def _read_events(self, project_path: Path) -> list[dict]:
-        events_file = project_path / ".factory" / "events.jsonl"
-        if not events_file.exists():
-            return []
-        return [json.loads(line) for line in events_file.read_text().strip().split("\n") if line]
-
-    def test_events_emitted_on_init(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-
-        tool_init("test-simple", tmp_path)
-
-        events = self._read_events(tmp_path)
-        init_events = [e for e in events if e["type"] == "workflow.tool.init"]
-        assert len(init_events) == 1
-        assert init_events[0]["workflow"] == "test-simple"
-
-    def test_events_emitted_on_next(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        tool_next(tmp_path)
-
-        events = self._read_events(tmp_path)
-        next_events = [e for e in events if e["type"] == "workflow.tool.next"]
-        assert len(next_events) == 1
-        assert next_events[0]["node"] == "study"
-
-    def test_events_emitted_on_auto_submit(self, tmp_path: Path) -> None:
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        # Write artifact so auto-submit triggers
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text(
-            "Detailed observations about the project that exceed the minimum length threshold"
-        )
-
-        tool_next(tmp_path)
-
-        events = self._read_events(tmp_path)
-        auto_events = [e for e in events if e["type"] == "workflow.tool.auto_submit"]
-        assert len(auto_events) == 1
-        assert auto_events[0]["node"] == "study"
-
-    def test_events_written_to_original_project(self, tmp_path: Path) -> None:
-        """Events should be written to the original project, not the worktree."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-
-        original = tmp_path / "my-project"
-        wt = original / ".factory-worktrees" / "run-abc123"
-        wt.mkdir(parents=True)
-        (wt / ".factory").mkdir()
-        (original / ".factory").mkdir(parents=True, exist_ok=True)
-
-        tool_init("test-simple", wt)
-
-        # Events should land in the original project, not the worktree
-        orig_events = original / ".factory" / "events.jsonl"
-        wt_events = wt / ".factory" / "events.jsonl"
-        assert orig_events.exists()
-        assert not wt_events.exists()
-
-        events = self._read_events(original)
-        init_events = [e for e in events if e["type"] == "workflow.tool.init"]
-        assert len(init_events) == 1
-
-
-class TestResolveOriginalProject:
-    def test_factory_worktrees_pattern(self) -> None:
-        p = Path("/home/user/project/.factory-worktrees/run-abc123")
-        assert _resolve_original_project(p) == Path("/home/user/project")
-
-    def test_factory_worktrees_nested(self) -> None:
-        p = Path("/home/user/project/.factory/worktrees/run-abc123")
-        assert _resolve_original_project(p) == Path("/home/user/project")
-
-    def test_no_worktree_passthrough(self) -> None:
-        p = Path("/home/user/project")
-        assert _resolve_original_project(p) == Path("/home/user/project")
-
-    def test_deep_factory_worktrees(self) -> None:
-        p = Path("/workspace/src/repo/.factory-worktrees/run-deadbeef")
-        assert _resolve_original_project(p) == Path("/workspace/src/repo")
-
-
-class TestHeadlessFinalize:
-    def test_run_headless_accepts_engine(self) -> None:
-        """Verify _run_headless has engine in its signature."""
-        import inspect
-        from factory.cli._ceo_helpers import _run_headless
-
-        sig = inspect.signature(_run_headless)
-        assert "engine" in sig.parameters
-        assert sig.parameters["engine"].default == "skill"
-
-
-class TestWorkflowDiskCache:
-    def test_cache_persisted_on_init(self, tmp_path: Path) -> None:
-        """tool_init writes workflow_cache.json to session dir."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-
-        tool_init("test-simple", tmp_path)
-
-        cache_file = tmp_path / ".factory" / "tool_session" / "workflow_cache.json"
-        assert cache_file.exists()
-        cache = json.loads(cache_file.read_text())
-        assert cache["name"] == "test-simple"
-        assert "study" in cache["nodes"]
-        assert cache["nodes"]["study"]["type"] == "Study"
-
-    def test_cache_loaded_on_next(self, tmp_path: Path) -> None:
-        """After init, clearing in-memory cache still allows next to work via disk."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-
-        tool_init("test-simple", tmp_path)
-
-        # Clear the in-memory cache
-        _workflow_cache.clear()
-        # Also clear the registry so register_all won't find it
-        WorkflowRegistry.reset()
-
-        result = tool_next(tmp_path)
-        assert "Node: study" in result
-
-    def test_rebuild_workflow_roundtrip(self, tmp_path: Path) -> None:
-        """Serialized cache can be deserialized back into a valid Workflow."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-
-        tool_init("test-simple", tmp_path)
-
-        cache_file = tmp_path / ".factory" / "tool_session" / "workflow_cache.json"
-        cache_data = json.loads(cache_file.read_text())
-        rebuilt = _rebuild_workflow(cache_data)
-
-        assert rebuilt.name == wf.name
-        assert rebuilt.start_node == wf.start_node
-        assert set(rebuilt.nodes.keys()) == set(wf.nodes.keys())
-        assert len(rebuilt.edges) == len(wf.edges)
-        assert isinstance(rebuilt.nodes["study"], Study)
-        assert isinstance(rebuilt.nodes["researcher"], AgentNode)
-        assert isinstance(rebuilt.nodes["gate_research"], GateNode)
-
-
-class TestInvokeAgentPromptOverride:
-    def test_prompt_override_skips_resolve(self) -> None:
-        """When prompt_override is set, resolve_prompt should NOT be called."""
-        import asyncio
-        from unittest.mock import AsyncMock, patch
-
-        with patch("factory.agents.runner.resolve_prompt") as mock_resolve, \
-             patch("factory.agents.runner.get_runner") as mock_get_runner:
-            mock_runner = AsyncMock()
-            mock_runner.headless.return_value = AsyncMock(
-                stdout="ok", return_code=0, usage=None, metadata={},
-            )
-            mock_get_runner.return_value = mock_runner
-
-            from factory.agents.runner import invoke_agent
-
-            asyncio.run(invoke_agent(
-                "builder",
-                "build it",
-                Path("/tmp/fake-project"),
-                prompt_override="custom prompt content",
-                _track_failures=False,
-            ))
-
-            mock_resolve.assert_not_called()
-
-    def test_no_override_calls_resolve(self) -> None:
-        """Without prompt_override, resolve_prompt IS called."""
-        import asyncio
-        from unittest.mock import AsyncMock, patch
-
-        with patch("factory.agents.runner.resolve_prompt", return_value="resolved") as mock_resolve, \
-             patch("factory.agents.runner.get_runner") as mock_get_runner:
-            mock_runner = AsyncMock()
-            mock_runner.headless.return_value = AsyncMock(
-                stdout="ok", return_code=0, usage=None, metadata={},
-            )
-            mock_get_runner.return_value = mock_runner
-
-            from factory.agents.runner import invoke_agent
-
-            asyncio.run(invoke_agent(
-                "builder",
-                "build it",
-                Path("/tmp/fake-project"),
-                _track_failures=False,
-            ))
-
-            mock_resolve.assert_called_once()
-
-
-class TestFormatProgress:
-    def test_format_progress_linear(self, tmp_path: Path) -> None:
-        """Linear format shows ✓/▶/○ markers and expands current node."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        state["completed"]["study"] = "done"
-        state["completed"]["researcher"] = "done"
-
-        result = _format_progress(state, wf, tmp_path, "gate_research", fmt="linear")
-
-        assert "✓ study" in result
-        assert "✓ researcher" in result
-        assert "▶ gate_research" in result
-        assert "← CURRENT" in result
-        assert "○ builder" in result
-        assert "Type: Gate" in result
-
-    def test_format_progress_phased(self, tmp_path: Path) -> None:
-        """Phased format shows 'Phase N:' labels with role/gate names."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        state["completed"]["study"] = "done"
-        state["completed"]["researcher"] = "done"
-
-        result = _format_progress(state, wf, tmp_path, "gate_research", fmt="phased")
-
-        assert "Phase 1:" in result
-        assert "Phase 2:" in result
-        assert "Phase 3:" in result
-        assert "Gate —" in result
-        assert "Observe" in result or "Researcher" in result
-
-    def test_overview_linear_format(self, tmp_path: Path) -> None:
-        """tool_overview with fmt='linear' includes ✓/▶/○ markers."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        # Complete study via submit so it shows as ✓
-        tool_submit(tmp_path, "study", "Observations done")
-
-        result = tool_overview(tmp_path, fmt="linear")
-
-        assert "✓ study" in result
-        assert "▶ researcher" in result
-        assert "○" in result
-
-    def test_overview_phased_format(self, tmp_path: Path) -> None:
-        """tool_overview with fmt='phased' includes 'Phase' labels."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        result = tool_overview(tmp_path, fmt="phased")
-
-        assert "Phase 1:" in result
-        assert "Phase" in result
-
-    def test_phase_label(self) -> None:
-        """_phase_label produces correct labels for each node type."""
-        agent = AgentNode(id="builder", role=AgentRole.BUILDER, prompt_template="build")
-        assert "Builder" in _phase_label("builder", agent)
-
-        gate = GateNode(id="gate_research", evaluator_type="agent", gate_prompt="review")
-        label = _phase_label("gate_research", gate)
-        assert "Gate —" in label
-        assert "Research" in label
-
-        study = Study(id="study", command="factory study")
-        label = _phase_label("study", study)
-        assert "Observe" in label
-        assert "study" in label
-
-        fn = FnNode(id="apply_spec", command="echo ok")
-        label = _phase_label("apply_spec", fn)
-        assert "Apply Spec" in label
-
-        from factory.workflow.primitives import ForkNode
-        fork = ForkNode(id="fork1", targets=["a", "b"])
-        label = _phase_label("fork1", fork)
-        assert "Fork" in label
-        assert "a" in label
-        assert "b" in label
-
-
-class TestDeterministicImpliesHeadless:
-    def test_deterministic_code_path(self) -> None:
-        """Verify _run_headless handles engine='deterministic' early return path."""
-        import inspect
-        from factory.cli._ceo_helpers import _run_headless
-
-        sig = inspect.signature(_run_headless)
-        assert "engine" in sig.parameters
-        assert "prompt_override" in sig.parameters
-
-    def test_deterministic_warning_printed(self) -> None:
-        """The deterministic engine block prints a WARNING and sets headless=True."""
-        import io
-        import sys
-
-        old_stderr = sys.stderr
-        captured = io.StringIO()
-        sys.stderr = captured
-        try:
-            # Simulate the code block from _execute_ceo
-            engine = "deterministic"
-            headless = False
-            if engine == "deterministic":
-                if not headless:
-                    print(
-                        "WARNING: --engine deterministic runs headless (no interactive CEO). "
-                        "Adding --headless implicitly.",
-                        file=sys.stderr,
-                    )
-                    headless = True
-        finally:
-            sys.stderr = old_stderr
-
-        assert headless is True
-        assert "WARNING" in captured.getvalue()
-        assert "--engine deterministic" in captured.getvalue()
-
-
-class TestStaleFileDetection:
-    def test_stale_file_ignored(self, tmp_path: Path) -> None:
-        """Review files from before the session start are ignored."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        stale_file = reviews_dir / "researcher-latest.md"
-        stale_file.write_text("Stale findings from prior run")
-        import os
-        os.utime(stale_file, (1000000, 1000000))
-
-        tool_init("test-simple", tmp_path)
-        tool_submit(tmp_path, "study", "Observations done")
-
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "researcher" not in state["completed"]
-        assert "Node: researcher" in result
-
-    def test_fresh_file_detected(self, tmp_path: Path) -> None:
-        """Review files created after session start are auto-submitted."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        tool_submit(tmp_path, "study", "Observations done")
-
-        reviews_dir = tmp_path / ".factory" / "reviews"
-        reviews_dir.mkdir(parents=True, exist_ok=True)
-        (reviews_dir / "researcher-latest.md").write_text("Fresh research findings")
-
-        result = tool_next(tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert "researcher" in state["completed"]
-        assert "GATE" in result
-
-
-class TestToolOverview:
-    def test_overview_shows_all_nodes(self, tmp_path: Path) -> None:
-        """tool_overview lists all nodes with completion markers."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        result = tool_overview(tmp_path)
-
-        assert "study" in result
-        assert "researcher" in result
-        assert "gate_research" in result
-        assert "builder" in result
-        assert "▶" in result or "○" in result
-
-
-class TestToolCurr:
-    def test_curr_shows_current(self, tmp_path: Path) -> None:
-        """tool_curr shows first node details without advancing."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        result = tool_curr(tmp_path)
-
-        assert "Node: study" in result
-        assert "Type: Study" in result
-
-    def test_curr_done(self, tmp_path: Path) -> None:
-        """tool_curr returns DONE when all nodes completed."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        state["pointer_idx"] = len(state["topo_order"])
-        (tmp_path / ".factory" / "tool_session" / "state.json").write_text(
-            json.dumps(state)
-        )
-
-        result = tool_curr(tmp_path)
-        assert "DONE" in result
-
-
-class TestNextDryRun:
-    def test_next_dry_run(self, tmp_path: Path) -> None:
-        """dry_run=True returns the node but does NOT advance the pointer."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        result = tool_next(tmp_path, dry_run=True)
-
-        assert "Node: study" in result
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert state["pointer_idx"] == 0
-
-    def test_next_dry_run_auto_submit_no_persist(self, tmp_path: Path) -> None:
-        """dry_run scans for artifacts but does not persist completions."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        strategy_dir = tmp_path / ".factory" / "strategy"
-        strategy_dir.mkdir(parents=True, exist_ok=True)
-        (strategy_dir / "observations.md").write_text(
-            "Detailed observations about the project that exceed the minimum length threshold"
-        )
-
-        result = tool_next(tmp_path, dry_run=True)
-
-        assert "researcher" in result
-
-        state = json.loads(
-            (tmp_path / ".factory" / "tool_session" / "state.json").read_text()
-        )
-        assert state["pointer_idx"] == 0
-        assert "study" not in state["completed"]
-
-    def test_dry_run_no_events_emitted(self, tmp_path: Path) -> None:
-        """dry_run=True must not emit any events to events.jsonl."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        events_file = tmp_path / ".factory" / "events.jsonl"
-        events_before = events_file.read_text() if events_file.exists() else ""
-
-        tool_next(tmp_path, dry_run=True)
-
-        events_after = events_file.read_text() if events_file.exists() else ""
-        assert events_before == events_after, "dry_run should not emit events"
-
-    def test_dry_run_completed_status_no_finalize(self, tmp_path: Path) -> None:
-        """dry_run=True with status='completed' must not call finalize."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        state_path = tmp_path / ".factory" / "tool_session" / "state.json"
-        state = json.loads(state_path.read_text())
-        state["status"] = "completed"
-        state_path.write_text(json.dumps(state))
-
-        state_before = state_path.read_text()
-        events_file = tmp_path / ".factory" / "events.jsonl"
-        events_before = events_file.read_text() if events_file.exists() else ""
-
-        result = tool_next(tmp_path, dry_run=True)
-
-        assert "DONE" in result
-        assert state_path.read_text() == state_before, "dry_run should not mutate state"
-        events_after = events_file.read_text() if events_file.exists() else ""
-        assert events_before == events_after, "dry_run should not emit events"
-
-    def test_dry_run_pointer_past_end_no_finalize(self, tmp_path: Path) -> None:
-        """dry_run=True with pointer past end must not call finalize."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        state_path = tmp_path / ".factory" / "tool_session" / "state.json"
-        state = json.loads(state_path.read_text())
-        order = state["topo_order"]
-        state["pointer_idx"] = len(order)
-        for nid in order:
-            state["completed"][nid] = "done"
-        state_path.write_text(json.dumps(state))
-
-        state_before = state_path.read_text()
-        events_file = tmp_path / ".factory" / "events.jsonl"
-        events_before = events_file.read_text() if events_file.exists() else ""
-
-        result = tool_next(tmp_path, dry_run=True)
-
-        assert "DONE" in result
-        assert state_path.read_text() == state_before, "dry_run should not mutate state"
-        events_after = events_file.read_text() if events_file.exists() else ""
-        assert events_before == events_after, "dry_run should not emit events"
-
-
-class TestNextCompactOutput:
-    def test_next_compact_output(self, tmp_path: Path) -> None:
-        """tool_next returns compact node details, not progress markers."""
-        wf = _simple_workflow()
-        _register_workflow(wf)
-        (tmp_path / ".factory").mkdir()
-        tool_init("test-simple", tmp_path)
-
-        result = tool_next(tmp_path)
-
-        assert "✓" not in result
-        assert "○" not in result
-        assert "▶" not in result
-        assert "Node: study" in result
-        assert "Type: Study" in result
+    assert result.startswith("RETRY")
+    current = tool_curr(tmp_path)
+    assert "Node: builder" in current
+    assert "Iteration: 1/3" in current
+    assert "tests still fail" in current
+
+
+def test_gate_halt_completes_thread_without_running_successor(tmp_path: Path) -> None:
+    workflow = Workflow(
+        name="tool-halt",
+        start_node="gate",
+        nodes={
+            "gate": GateNode(id="gate", evaluator_type="user"),
+            "never": FnNode(id="never", command="echo never"),
+        },
+        edges=[
+            Edge(source="gate", target="never", condition=VerdictType.PROCEED),
+        ],
+    )
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+
+    assert tool_curr(tmp_path).startswith("APPROVAL_NEEDED")
+    result = tool_submit(tmp_path, "gate", 'HALT reason="not approved"')
+    assert result == "HALT\nnot approved"
+    assert "Status:   halted" in tool_status(tmp_path)
+    assert "✓ gate" in tool_status(tmp_path)
+    assert "○ never" in tool_status(tmp_path)
+
+
+def test_fn_gate_runs_inside_graph_after_submission(tmp_path: Path) -> None:
+    workflow = Workflow(
+        name="tool-fn-gate",
+        start_node="builder",
+        nodes={
+            "builder": AgentNode(id="builder", role=AgentRole.BUILDER),
+            "gate": GateNode(
+                id="gate",
+                evaluator_type="fn",
+                evaluator_command="echo PROCEED",
+            ),
+            "archive": AgentNode(id="archive", role=AgentRole.ARCHIVIST),
+        },
+        edges=[
+            Edge(source="builder", target="gate"),
+            Edge(source="gate", target="archive", condition=VerdictType.PROCEED),
+        ],
+    )
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+
+    assert tool_submit(tmp_path, "builder", "built") == "CONTINUE"
+    assert "Node: archive" in tool_curr(tmp_path)
+    assert "gate" in tool_status(tmp_path)
+
+
+def test_next_auto_resumes_fresh_artifact(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+    observations = tmp_path / ".factory" / "strategy" / "observations.md"
+    observations.parent.mkdir(parents=True)
+    observations.write_text("fresh observations " * 5)
+
+    result = tool_next(tmp_path)
+
+    assert "Node: researcher" in result
+    assert "✓ study" in tool_overview(tmp_path)
+
+
+def test_next_ignores_stale_artifact(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+    observations = tmp_path / ".factory" / "strategy" / "observations.md"
+    observations.parent.mkdir(parents=True)
+    observations.write_text("stale observations " * 5)
+    stale = time.time() - 60
+    observations.touch()
+    observations.chmod(0o644)
+    import os
+
+    os.utime(observations, (stale, stale))
+    tool_init(workflow.name, tmp_path)
+
+    assert "Node: study" in tool_next(tmp_path)
+
+
+def test_next_dry_run_never_auto_resumes(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+    observations = tmp_path / ".factory" / "strategy" / "observations.md"
+    observations.parent.mkdir(parents=True)
+    observations.write_text("fresh observations " * 5)
+
+    assert "Node: study" in tool_next(tmp_path, dry_run=True)
+    assert "Node: study" in tool_curr(tmp_path)
+
+
+def test_finalize_does_not_fake_completion(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+
+    result = tool_finalize(tmp_path)
+
+    assert result.startswith("Pending graph tasks: study")
+    assert "Progress: 0/4" in tool_status(tmp_path)
+
+
+def test_parallel_interrupts_share_one_graph_thread(tmp_path: Path) -> None:
+    workflow = Workflow(
+        name="tool-parallel",
+        start_node="fork",
+        nodes={
+            "fork": ForkNode(id="fork", targets=["a", "b"]),
+            "a": FnNode(id="a", command="echo a"),
+            "b": FnNode(id="b", command="echo b"),
+            "join": JoinNode(id="join", sources=["a", "b"]),
+            "done": FnNode(id="done", command="echo done"),
+        },
+        edges=[
+            Edge(source="fork", target="a"),
+            Edge(source="fork", target="b"),
+            Edge(source="a", target="join"),
+            Edge(source="b", target="join"),
+            Edge(source="join", target="done"),
+        ],
+    )
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+
+    current = tool_curr(tmp_path)
+    assert current.startswith("PARALLEL")
+    assert "Node: a" in current
+    assert "Node: b" in current
+    assert tool_submit(tmp_path, "a", "A") == "CONTINUE"
+    assert tool_submit(tmp_path, "b", "B") == "CONTINUE"
+    assert "Node: done" in tool_curr(tmp_path)
+    assert tool_submit(tmp_path, "done", "done") == "DONE"
+    assert "Progress: 5/5" in tool_status(tmp_path)
+
+
+def test_status_overview_and_curr_are_read_only(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+    tool_init(workflow.name, tmp_path)
+
+    status = tool_status(tmp_path)
+    overview = tool_overview(tmp_path, fmt="phased")
+    current = tool_curr(tmp_path)
+
+    assert "Thread:" in status
+    assert "Progress: 0/4" in status
+    assert "Phase 1" in overview
+    assert "CURRENT" in overview
+    assert "Node: study" in current
+    assert "Progress: 0/4" in tool_status(tmp_path)
+
+
+def test_status_without_session(tmp_path: Path) -> None:
+    assert tool_status(tmp_path).startswith("No active session")
+
+
+def test_workflow_cache_is_process_local_only(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    register(workflow)
+
+    assert _get_workflow_cached(workflow.name, tmp_path) is workflow
+    assert not (tmp_path / ".factory" / "langgraph" / "workflow_cache.json").exists()
+
+
+def test_resolve_original_project_variants() -> None:
+    assert _resolve_original_project(
+        Path("/repo/.factory-worktrees/run-1")
+    ) == Path("/repo")
+    assert _resolve_original_project(
+        Path("/repo/.factory/worktrees/run-1")
+    ) == Path("/repo")
+    assert _resolve_original_project(Path("/repo")) == Path("/repo")
+
+
+def test_helper_formatting_and_reloop_lookup(tmp_path: Path) -> None:
+    workflow = simple_workflow()
+    _workflow_cache[f"{tmp_path}:{workflow.name}"] = workflow
+    gate = workflow.nodes["gate_research"]
+    researcher = workflow.nodes["researcher"]
+    state = {
+        "workflow_name": workflow.name,
+        "topo_order": ["study", "researcher", "gate_research", "builder"],
+        "completed": {"study": "done"},
+        "iteration_counts": {},
+        "feedback_log": {},
+    }
+
+    assert _phase_label("researcher", researcher) == "Researcher"
+    assert "Node: researcher" in _format_node_task(
+        "researcher", researcher, workflow, state, tmp_path
+    )
+    assert isinstance(gate, GateNode)
+    assert "RETRY" in _format_gate_task("gate_research", gate, state, tmp_path)
+    assert "✓ study" in _format_progress(
+        state, workflow, tmp_path, {"researcher"}
+    )
+    assert _find_reloop_target(workflow, "gate_research") == "researcher"
+
+
+def test_detect_artifact_uses_declared_agent_write(tmp_path: Path) -> None:
+    node = AgentNode(
+        id="custom",
+        role=AgentRole.BUILDER,
+        writes={"custom/output.md"},
+    )
+    output = tmp_path / "custom" / "output.md"
+    output.parent.mkdir()
+    output.write_text("result")
+
+    assert _detect_artifact("custom", node, tmp_path) == "result"

--- a/uv.lock
+++ b/uv.lock
@@ -148,6 +148,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -163,6 +172,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.122.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/23/9987d70b74e3481d5bc5d2021d3e10fd5f60c1f7b54088ea86506d9b7f2b/anthropic-0.122.0.tar.gz", hash = "sha256:ffec56ae96657c8d19fa575ec96f140f380c353a07ab7d61b92eb18ee6536601", size = 1021535, upload-time = "2026-08-13T18:36:00.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/5b/f5c87e71097a9f89f1b414d1ef7ae8439051fae57d5e4ee90946082982b8/anthropic-0.122.0-py3-none-any.whl", hash = "sha256:45ec906452ffae6b5f7f0c53d01f50bfb7e4ce878d7ae8e4309d13171e557e67", size = 1041853, upload-time = "2026-08-13T18:36:01.831Z" },
+]
+
+[package.optional-dependencies]
+vertex = [
+    { name = "google-auth", extra = ["requests"] },
 ]
 
 [[package]]
@@ -698,6 +731,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -863,6 +914,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
 ]
 
 [[package]]
@@ -1134,6 +1203,113 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1182,6 +1358,38 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-core"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpatch" },
+    { name = "langchain-protocol" },
+    { name = "langsmith" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/18/20c3eec05ccf2fff8e553866bec3bb2f92880aea3cb878603e5a854bd5c0/langchain_core-1.5.4.tar.gz", hash = "sha256:aa76104f30b6c7305f292cb2c364e67cb52c321940ae812d7969471dce32a89a", size = 980540, upload-time = "2026-08-11T18:02:52.239Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/9b/2219c2873c182765a2e966015672d725fdf5c9f625ef599e780168661d24/langchain_core-1.5.4-py3-none-any.whl", hash = "sha256:f1d45e84c4e4d6158218b7a8072ebe9b6d4b51e10cb728c0469650a648e18f1b", size = 565086, upload-time = "2026-08-11T18:02:50.16Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
+]
+
+[[package]]
 name = "langfuse"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1198,6 +1406,104 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/77/69/4c339bb7cfb4909db340c9b40852bd268fd2bfd93c526e7ac95b7dd725bb/langfuse-4.9.0.tar.gz", hash = "sha256:244d8309cd75d663f29c399f5691e3f04c4a2838e0cc947704e123bdc7233040", size = 339189, upload-time = "2026-06-16T08:44:38.744Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/f0/65735b14e792007381e1e9cf17b4dbd1355be056507c06517e75040102aa/langfuse-4.9.0-py3-none-any.whl", hash = "sha256:ac03eaf7ee6f5fb18036284445833cae92248ae240f3c6068b83d408afb57fe1", size = 599170, upload-time = "2026-06-16T08:44:37.387Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/0d/c8e7ee98896659e1b6555db0ab115a9ca899844744645d5d894032bab1d7/langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363", size = 725753, upload-time = "2026-08-11T14:00:36.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7f/c5c30e4be99ff821029c7ac872a480676bb179c9f3df85ea3f38d13f86d4/langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b", size = 248854, upload-time = "2026-08-11T14:00:35.494Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/e1/089c4c9e0a2fec7f883f82ae8e6a727138d50074cfeb6644bc2d13b1019b/langgraph_checkpoint-4.2.0.tar.gz", hash = "sha256:51a593b6bee684b0818e5d6e58e28ab340c6db7794575056ce7bd1b746a84ed7", size = 180239, upload-time = "2026-08-07T20:05:03.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/71/3b475f09bd57d3a5649792c66353312b4432afd843f301739dfcebd157f0/langgraph_checkpoint-4.2.0-py3-none-any.whl", hash = "sha256:0547fd228935a0b758865de3a3d6d7a2537c308895d0f9ab092ce9151b5da942", size = 56833, upload-time = "2026-08-07T20:05:02.655Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "langgraph-checkpoint" },
+    { name = "sqlite-vec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/b1/26fef7572c4fce0322740ef3fcee471510028355d4d4c1d800f0fd432d73/langgraph_checkpoint_sqlite-3.1.1.tar.gz", hash = "sha256:6fcb20db4c37ef7aad52f29b539eb98c38e2dad6fab7c2446a2a9db24f37a70e", size = 146805, upload-time = "2026-07-30T19:19:37.516Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/b9/e458601a1718337839bcfeec9d1b27b8b16ce135be2bd50ed0395d33a878/langgraph_checkpoint_sqlite-3.1.1-py3-none-any.whl", hash = "sha256:8505c54c94a658080525d7e6780fdd4e0c078ff2566b30d399c02cc9f9af1c63", size = 40785, upload-time = "2026-07-30T19:19:36.424Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
+    { name = "orjson" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
+]
+
+[[package]]
+name = "langsmith"
+version = "0.10.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+    { name = "websockets" },
+    { name = "xxhash" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/08/f6575fbaf22179c52c10286df5c454fc8a7c8ce64b194a18ae0f19232503/langsmith-0.10.18.tar.gz", hash = "sha256:f78402bdbe333727459831fead2c75d0c1d1119c28e4095e5a1d65a7485e2f3a", size = 4801890, upload-time = "2026-08-11T20:27:48.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/07/f83cdfef58b3627175f15345105c6ee2ac152f25a0fefb930a53d4bb216c/langsmith-0.10.18-py3-none-any.whl", hash = "sha256:388236a4f031c1fe60e1517891c276ed01b102ad4405e0e9236255f2abd24cfa", size = 735339, upload-time = "2026-08-11T20:27:46.796Z" },
 ]
 
 [[package]]
@@ -2073,6 +2379,54 @@ wheels = [
 ]
 
 [[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/08/8b68f24b18e69d92238aa8f258218e6dfeacf4381d9d07ab8df303f524a9/ormsgpack-1.12.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bd5f4bf04c37888e864f08e740c5a573c4017f6fd6e99fa944c5c935fabf2dd9", size = 378266, upload-time = "2026-01-18T20:55:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/24/29fc13044ecb7c153523ae0a1972269fcd613650d1fa1a9cec1044c6b666/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34d5b28b3570e9fed9a5a76528fc7230c3c76333bc214798958e58e9b79cc18a", size = 203035, upload-time = "2026-01-18T20:55:30.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c2/00169fb25dd8f9213f5e8a549dfb73e4d592009ebc85fbbcd3e1dcac575b/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3708693412c28f3538fb5a65da93787b6bbab3484f6bc6e935bfb77a62400ae5", size = 210539, upload-time = "2026-01-18T20:55:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/33/543627f323ff3c73091f51d6a20db28a1a33531af30873ea90c5ac95a9b5/ormsgpack-1.12.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43013a3f3e2e902e1d05e72c0f1aeb5bedbb8e09240b51e26792a3c89267e181", size = 212401, upload-time = "2026-01-18T20:56:10.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5d/f70e2c3da414f46186659d24745483757bcc9adccb481a6eb93e2b729301/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7c8b1667a72cbba74f0ae7ecf3105a5e01304620ed14528b2cb4320679d2869b", size = 387082, upload-time = "2026-01-18T20:56:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/06e8dc920c7903e051f30934d874d4afccc9bb1c09dcaf0bc03a7de4b343/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:df6961442140193e517303d0b5d7bc2e20e69a879c2d774316125350c4a76b92", size = 482346, upload-time = "2026-01-18T20:56:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c4/f337ac0905eed9c393ef990c54565cd33644918e0a8031fe48c098c71dbf/ormsgpack-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6a4c34ddef109647c769d69be65fa1de7a6022b02ad45546a69b3216573eb4a", size = 425181, upload-time = "2026-01-18T20:55:37.83Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/6d5758fabef3babdf4bbbc453738cc7de9cd3334e4c38dd5737e27b85653/ormsgpack-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:73670ed0375ecc303858e3613f407628dd1fca18fe6ac57b7b7ce66cc7bb006c", size = 117182, upload-time = "2026-01-18T20:55:31.472Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/17a15549233c37e7fd054c48fe9207492e06b026dbd872b826a0b5f833b6/ormsgpack-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:c2be829954434e33601ae5da328cccce3266b098927ca7a30246a0baec2ce7bd", size = 111464, upload-time = "2026-01-18T20:55:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2250,6 +2604,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -2845,10 +3220,13 @@ wheels = [
 name = "remote-factory"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic", extra = ["vertex"] },
     { name = "fastapi" },
     { name = "filelock" },
     { name = "graphifyy" },
     { name = "langfuse" },
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint-sqlite" },
     { name = "mcp" },
     { name = "mempalace" },
     { name = "networkx" },
@@ -2883,11 +3261,14 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", extras = ["vertex"], specifier = ">=0.52" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "filelock", specifier = ">=3.0" },
     { name = "graphifyy", specifier = ">=0.9" },
     { name = "langfuse", specifier = ">=3.0" },
     { name = "langfuse", marker = "extra == 'telemetry'", specifier = ">=3.0" },
+    { name = "langgraph", specifier = ">=1.2.11" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.1" },
     { name = "mcp", specifier = ">=1.27.0" },
     { name = "mempalace", specifier = ">=3.6.0" },
     { name = "networkx", specifier = ">=3.6.1" },
@@ -2938,6 +3319,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
 ]
 
 [[package]]
@@ -3102,6 +3495,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]
@@ -3739,6 +4153,94 @@ wheels = [
 ]
 
 [[package]]
+name = "uuid-utils"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/91/63938e0e7e7876658e5e40178e7c0735b53527886fe11797a11699c55edd/uuid_utils-0.17.0.tar.gz", hash = "sha256:abb5667a36119019b3fa320c4d10c21ebccfcc87c8a739e6a0056cee7f48dde2", size = 43220, upload-time = "2026-07-09T13:49:58.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/b2/8f03b61f0aa4afc687855c4f00db35f4d3e58c480cd885abc46f6e41308f/uuid_utils-0.17.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f9b093cb3b6c9d6233ef45a05cab064d2aa0a8cb3c5777084c9e20fcb77c2371", size = 563901, upload-time = "2026-07-09T13:48:08.961Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cb/88b909ffb9ac11f88d2e6ceabc592ccc660b5830b06dbcbd290ab8981f1f/uuid_utils-0.17.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0bc4c431ccd59c764080ceb43b126043325fe17861b87759d026a0cdd8423bb2", size = 286383, upload-time = "2026-07-09T13:48:10.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b8/bc5b64e9898867227c535cd0366c571c580a736748e81329437c1773e442/uuid_utils-0.17.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c00d182e31034250690f417b9068b78eab423c10d76766664e82d9860c340479", size = 323244, upload-time = "2026-07-09T13:48:11.477Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d9/8a17462ce066fbf89670fb737a3f0c93a77816736d2a4d134787e759d8ea/uuid_utils-0.17.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:570db214f6d8507587a8faa968a3fe65e957daeb7bc48b27dc7f69bc3ecdd6f1", size = 330466, upload-time = "2026-07-09T13:48:13.092Z" },
+    { url = "https://files.pythonhosted.org/packages/43/37/0c65d0db3bae45183419756d938f1791a82c835fd92bf234eb4f008d2e02/uuid_utils-0.17.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:351462debd866f1f25e4d4f5c7fac89525b52151f0102a1bdfe94a999b046f5f", size = 443806, upload-time = "2026-07-09T13:48:14.372Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d5/7e698466d1f5254620b5ee0d711fdd20a0e9c2acd7040740c37193a8f673/uuid_utils-0.17.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:622cdde768300591ac79bfcd7bb3468e4b191b1105d5dbfe8d87c39d8f63dd46", size = 324261, upload-time = "2026-07-09T13:48:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/48/3a5b242d7f0b8e3ca77dcd7177f3cf73e0280cee32e2349d9796ca27f183/uuid_utils-0.17.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:75d7411e8eb9259764dd60310738540649057cda4509b4af14b36b7f663bfeb0", size = 350657, upload-time = "2026-07-09T13:48:17.273Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/f32ea82a89efed2eafee2f1d925d64687a81e550a9951933fb1b75c95ca6/uuid_utils-0.17.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1019476b6bdc047216ef7414be5babe0fa5ccfde977c0cac4fd6c75ddec66ff7", size = 500613, upload-time = "2026-07-09T13:48:18.459Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5c/c7b73ec4bbe28db162a4841d352c6eda582801e0dd9fe72f6ad5cc584ee4/uuid_utils-0.17.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:04452640d8b6920c480c16e5afe91ff896d236e0c972830f9247e0898d38c803", size = 606306, upload-time = "2026-07-09T13:48:19.726Z" },
+    { url = "https://files.pythonhosted.org/packages/63/95/8a2777204e8691b4961e6aa619001c3e5175aa430ab43da3079142e8d310/uuid_utils-0.17.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:793229621e1ad6cac55f015cfa9f4eff102accbc3da25d607b91c6b0bec167fb", size = 567231, upload-time = "2026-07-09T13:48:21.024Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/6f/1d778ca3ed6d2cf35f22088e2de714675416747ab41be510f22c141043a7/uuid_utils-0.17.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03815cea572c8a693cab5475b9d750cc161470961c7defa27e9286cad62f38f5", size = 529373, upload-time = "2026-07-09T13:48:22.312Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d3/9ad1ab64b3bed0a0237d1db89dc6f5001d6116a82766753da4ac4496f979/uuid_utils-0.17.0-cp311-cp311-win32.whl", hash = "sha256:c4f845166b09acc65c5213a35551a7f81c17fa010ab467229b5813f79d17fe13", size = 169930, upload-time = "2026-07-09T13:48:23.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1a/e01417f52eae6e2cb412260bb332b4ee4b37af2982d9c38cff4b68b2e899/uuid_utils-0.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:14dc2f46abb1091260c0d203fcbdf4e045042cc07e49183fd3b255904b95eb70", size = 177242, upload-time = "2026-07-09T13:48:24.723Z" },
+    { url = "https://files.pythonhosted.org/packages/35/20/396c27f996add19f8ac31e49cc4570824e51a97719087dabf94694d25bc4/uuid_utils-0.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:29179ffb7b317239b6d6afb100d14c439c728770460718280b9c0a42d2561ec2", size = 177023, upload-time = "2026-07-09T13:48:25.834Z" },
+    { url = "https://files.pythonhosted.org/packages/20/80/a7e685968e3cec99d6fe2fb25d0f5726310e1bba356da68c13dfd8b7d140/uuid_utils-0.17.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9205068badf453d2f0821fd5d340389b4679992d7ff79d4f3e5608996dd1b287", size = 556403, upload-time = "2026-07-09T13:48:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/56/47/3102d93bcb7b0bfe6bede63ff8f221a7f91348e10a37f682773be27c56d9/uuid_utils-0.17.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0fcca4e838af9ac9243b3358d7c14afa4dca286a87781124c272d6c4cad9c968", size = 285608, upload-time = "2026-07-09T13:48:28.769Z" },
+    { url = "https://files.pythonhosted.org/packages/55/fb/d59695f0f8db065b93c63316eaafa05a22d75a0486978a33736c52c646d5/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f3729e839209f3457d0d8b6a35a376fdf65577a5aecaf4cc3587d3305759ba6", size = 319926, upload-time = "2026-07-09T13:48:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/03/62fabcd1e990e07a0e220e8d552af45bc16f107fa8e55c2014a706bb1a1e/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3dac0ad0cd9a2818d1775215365a4e8c2f8ada215529dd26f3f8cceeb67a6988", size = 327172, upload-time = "2026-07-09T13:48:31.187Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/a5081391338b459e2f8d8b12581f00f8caa6317fab510e0e85c18c59e938/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e671b2322ef09106ecb1ca0f4c398b134d5e2c1f80d7a4f3336847a3072c0e94", size = 439075, upload-time = "2026-07-09T13:48:32.295Z" },
+    { url = "https://files.pythonhosted.org/packages/59/30/91795bd01e17a13661280d4899fbf38fb05e3f38e873f9aaec106ec30aa0/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8eb3e5caca8d3a6f72ea4cce024583f989f6f2e9186f98800213fff0176e8bcc", size = 320247, upload-time = "2026-07-09T13:48:33.64Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/11/09102b78303e4eb62069d6d88ef9fd661dc523e8f429e1fd67eaa78a6f44/uuid_utils-0.17.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8b72c2002202038666bf647f9a790906214c7c11cd0d6efef77b7d07bef3034a", size = 344738, upload-time = "2026-07-09T13:48:34.786Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f9/be95bad6954b60328878c3800258f01a6accd24fd75112d13f023462d53f/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4e2ac1c0b56f2c91b6f158e29ed96b1503223fe8aa6e79b1be1dc55bd8a5131c", size = 496845, upload-time = "2026-07-09T13:48:36.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/02/8a19a34e0530d987488a068a71576a236f5c8c746630b870b57f71eb24ef/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6c142bd0cb4dba31c10babe00d59f7ef6460f0ef55eaa9c1a9da270684af996a", size = 603233, upload-time = "2026-07-09T13:48:37.512Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a8/b1abab36ff73b0248d82179816467f6d39a2e80fd64329a895ca94f3508e/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e252db239eb41c32248e096e0d170bce5896a4fd3405556362bc3dd83d912206", size = 561401, upload-time = "2026-07-09T13:48:38.977Z" },
+    { url = "https://files.pythonhosted.org/packages/61/91/70e7b528b351cc03a9ca43e6116371cdde31bb12bcead7ca2ca1367366cc/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:237722b6581bb5b4eb4cefbcbe5c6e2980a440aabe781fbe50ebf1cb71eee4cc", size = 525314, upload-time = "2026-07-09T13:48:40.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/9167e90cf9937d6558f92d022ff3024a69d938a514d9c8faa4080f73b001/uuid_utils-0.17.0-cp312-cp312-win32.whl", hash = "sha256:46a73cacdf512f473a81f65dbf84186e08cfe6e9118fa582b6c6b33a8288a30d", size = 166831, upload-time = "2026-07-09T13:48:41.862Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/7d/0b889654d9ee3413f810cf4685e241285f650d98a4103ac9f3c6bcc95f29/uuid_utils-0.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:e59b60a0a4cb7541480e02090d37dc2df3b72df4c2e776fff64ce3a4e3dd4637", size = 172944, upload-time = "2026-07-09T13:48:42.992Z" },
+    { url = "https://files.pythonhosted.org/packages/be/35/8c6e1bf65e4d400352885dadc656ad6d0af96e89231e3f04686bc2197128/uuid_utils-0.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:d561a4c5747a1e6c7fa7c49a0292e78b4e8c456332caa084fc7abad8de828652", size = 172459, upload-time = "2026-07-09T13:48:44.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/dd/614fb9912157ac0128e6050859ccf06d9f13df9a944a803e8f80f6157e38/uuid_utils-0.17.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d11a7bc1e02da8984d32e6de9e0826c6edac00eac17de270f372bf32f9a0af63", size = 557259, upload-time = "2026-07-09T13:48:45.664Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/d072711704de3d21bec08b6c2f36a215200ca1d5e01a390ea1ac434080a0/uuid_utils-0.17.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7a49f47ac26df3e431c56b825c1bae8e6d3d591fdbb7438c227cc9845a7e3d73", size = 286271, upload-time = "2026-07-09T13:48:47.018Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6d/8a63e5eb2d5a6ba69a6c2036e305075bd6f5a022e7ea25fc6ce0eb7c51d2/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32df1944808877702ceea398c103881c09a679bb672a215e01c2a84231266bf9", size = 320025, upload-time = "2026-07-09T13:48:48.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/bdc2caf9719d9090d7c46043242ae6136cba4f7a7ee384992ab905ad9aa1/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:98c88d3edd08e7245562e9815996dbc6f0bd4745e1c76462f24af5ae4e187dd1", size = 327931, upload-time = "2026-07-09T13:48:49.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/33/9219d09d51ead282b578b2a4e0a515c2cce3ec52076cada8bfb7e35727d5/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a4370089c8b2e42f1db51d76408c7fa8eaa2934bf854d17983d16179c07c098", size = 438537, upload-time = "2026-07-09T13:48:50.842Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/79/e8e0f8b3955f2081c116157119d87659937893242eb834aa170da04d660b/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09a55b7a5ae764985cb46467496a1787678d0a1400356157a080ad95b1a36869", size = 320656, upload-time = "2026-07-09T13:48:52.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/d1ceddc430ff04b6e21704b2030d4438074a2f478b265dab43da957791c1/uuid_utils-0.17.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:56aa6488b931246fae11924e4bd0e2b32677e63945eecb71c29e3c2ca0dc3131", size = 345310, upload-time = "2026-07-09T13:48:54.076Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/62/89438e12f389a843e626b7e37691319a057b3d6b80914609106891faadda/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:309a35f12d99dde19032bc2259cda6431c85eeac0879134dc777cc3087d7e1cb", size = 496771, upload-time = "2026-07-09T13:48:55.365Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d2/eedcd99f522d60e238ead03844f0d51743ba84d33044959e230b756bf212/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:21c79b61ff750abcf057163dd764ccb6196cde7a26cda1b31b45cd97769e03b3", size = 603631, upload-time = "2026-07-09T13:48:56.746Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a8/bb1b38aaddd7243b6e562c6694f499bf094800918316192fd8cb2cdc2620/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4134353bfe3026ddab8e886002dc52bc5a0ab04611aabb0eaae23c32e6e57f64", size = 562008, upload-time = "2026-07-09T13:48:58.241Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/77/5f7ed930dc105e293845c09e4d5bd84076318a12f45a46783e1af64906d7/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7c89359affecebe2e39e6a116d069b363c936511a9572b308402489a26957d89", size = 525527, upload-time = "2026-07-09T13:48:59.784Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/25/1b55697adf6811a6f92cff6340e6b03e31fd6bc51066a5c10698c29b3679/uuid_utils-0.17.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:6a019a31bc4db89a0903a3e4f6b218571f3a6ff0ad4b3d3fe1c8f91a05ff6e3e", size = 97965, upload-time = "2026-07-09T13:49:01.217Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bf/cd729343de4684230be8a966bad7bfc2cf10ce3e643b1189a8b5370dbe35/uuid_utils-0.17.0-cp313-cp313-win32.whl", hash = "sha256:b3131a82d0c7611f0aa480a6d36929e001a3f54ba0fc029a8118a5863cce513c", size = 167316, upload-time = "2026-07-09T13:49:02.354Z" },
+    { url = "https://files.pythonhosted.org/packages/76/f0/e602ae0a1b139a7826e5189b93d91902564def06d5006324fd2faf82c8fc/uuid_utils-0.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:9e311f908d2f842fca4c7dcebc4f10306b8089b204ef04cf6704b4332c9ff6ff", size = 173630, upload-time = "2026-07-09T13:49:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/52/024ebece265b387154115dc4f1d9727174ef82623069f4bec8b7ed7e73f7/uuid_utils-0.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:c351737e2e65497c7200ab4ffb8af97e9f48be6488309abdd265fe08d66ee92f", size = 173214, upload-time = "2026-07-09T13:49:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/56/44/e2fd3fdf356e1b55d2acf1b956b4f3f29ffb215a99c387eba04b1c5fba66/uuid_utils-0.17.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:673d89cc434cc9b97a0b4cf61272f6fca70a81f64eb0afbface2a0d9f77f06cd", size = 562232, upload-time = "2026-07-09T13:49:06.201Z" },
+    { url = "https://files.pythonhosted.org/packages/19/28/65e0980d668a6d44e699f59d1acf43d6b5d4893592c115ce7c680bb4dfa1/uuid_utils-0.17.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:387cf7437c94ddec08651a0f1081381299c7075bc48a6251d8922bf39973378a", size = 287858, upload-time = "2026-07-09T13:49:07.45Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/8d/5e97bcebc90fb6a10f98af3dc1ba552e04183aba59e2edc0b9cf486dd998/uuid_utils-0.17.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:220b52746d99e11964badac3c0869016e0c24bafb70a7dd5c2c072a6be3da9cc", size = 321587, upload-time = "2026-07-09T13:49:09.489Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d7/88b2a2370cc3d455ba0515fb6f5c8f7ac0c0f55a86801b6e56a432f22c17/uuid_utils-0.17.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0ab4a66e7a035ad6625cfc1fbdb34f5c2d25a80ae1ef4bfee458ea2036333c6d", size = 328964, upload-time = "2026-07-09T13:49:11.292Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/181c5da673953dfc0958cb4fb3a4984a9098673ddb05cac68e994bc8511b/uuid_utils-0.17.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5641071337eb11d61a001ea08793bf72216f3241f0a433ed2764804b2a3e3cc7", size = 442909, upload-time = "2026-07-09T13:49:12.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/38/5c5e665af542884a8fd3c61725c38453239e13940326b5b70f3ef8881a97/uuid_utils-0.17.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9082e709014946b1f6e96ae6ecd93652efca2d2a6a3ab67dbe151c8b4bf193a4", size = 323076, upload-time = "2026-07-09T13:49:13.897Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/35/7de97de18cbf226c2a4f2104ad15e56ca4491717c81c0b71795c0c585b4e/uuid_utils-0.17.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1fd6f0e8a162dc0e9255b6aebe3cd175e76c33202f1bf39da9e6294b93db0099", size = 347360, upload-time = "2026-07-09T13:49:15.237Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a1/9915d5dd59fdd1957ded5d188c0ea0b9db5a1d84d42c8d8828a7b83b366e/uuid_utils-0.17.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d63010803d7c368963bbe6f7ec379593e76dd581d7db0f29118d88713c9e0354", size = 499267, upload-time = "2026-07-09T13:49:16.774Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/05/88108405262ec850cea0f95733445d6873e5772af3292baabd9ef8457740/uuid_utils-0.17.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a46bedc273b6f58f11dee816ff74999625ef8d007890f411b7a4975bf1c89330", size = 604940, upload-time = "2026-07-09T13:49:18.147Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d5/6dbcd300de47cc443cff2656cd5327a385751213dcb2101cfee7388170b2/uuid_utils-0.17.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:405233a5f625b3d995648f4647fa6befa4567cf3f74e1f6b9837e16f7310f0e0", size = 564172, upload-time = "2026-07-09T13:49:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/94/e8057f2288a415fba8a978bca4b589f5cb6b91a028a5dc07a1775938b33f/uuid_utils-0.17.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b6c5d2d71e1f17329150ad9427d27f4a3f29a01792e7ecdc64a98ac5368fc4d5", size = 528533, upload-time = "2026-07-09T13:49:21.075Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6b/31713148c77e48e62f51aa042a98a54a8be0396912ea5130f83f52ae722d/uuid_utils-0.17.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f7e9b8728ba07a3cb2f29d5aa1a266c2664eb8ef0fd43afa34627c92f7fac8f0", size = 99197, upload-time = "2026-07-09T13:49:22.351Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f3/ca6f6ac5428312df8ed632f6dd9f9e6aba23090471fcdeae53eab027e8b3/uuid_utils-0.17.0-cp314-cp314-win32.whl", hash = "sha256:58838921e377791ef22c64cc92141bfae030f43651ff9272f0f28a208a9e6a5a", size = 169540, upload-time = "2026-07-09T13:49:23.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cd/7ede0db66411fa09817d79b680f7454ea9bee2d374e1922e4efd065760a3/uuid_utils-0.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:42275ebd0e8e74e32cdbfb8bd88fc99576567d51d54a508020611fd8f4f463a0", size = 175984, upload-time = "2026-07-09T13:49:24.703Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/81/533b5f80cd4918c0693f4e1b7b90ceb1caa45f4266ae8b528135d7ecca5d/uuid_utils-0.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:b5d11cccba076a32321ef1380dea956821f0b51794ef59df64e58fb1cd543aae", size = 174749, upload-time = "2026-07-09T13:49:25.886Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/f400ac39d06fd8be5b099c09e41bb975205926722a3e8d53348817cb7ff9/uuid_utils-0.17.0-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:fae8b282f0cb22a5de222999f7723f4e5ec04f6fcdf4aaef879b5b36625ae2b0", size = 562610, upload-time = "2026-07-09T13:49:27.374Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8c/c71c8312304c56f6d0bcba87cd402fa79bec35d18ffc8c41954196ca68e5/uuid_utils-0.17.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:967955620df45e6cffe2e9950cb9903cb455649396f896b26b04363a91a5054b", size = 289473, upload-time = "2026-07-09T13:49:28.989Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/cd/522117e2e5184ca1d4f0f85ee833e9e21bd8c6b99eff8a4d1a8e5a194e33/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:375cde148430d60a4a07c03abaa0774c4fddfdd90de99b4ba02f24088bc9d750", size = 321600, upload-time = "2026-07-09T13:49:30.4Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f4/0d81f9bd346fc717bc561c08fa6457e0328966eb76e536b938fe77d56459/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:975c17da26c5b9d46c336b03c52a057ac28378d6f9d98b58d32a038589bb3912", size = 329569, upload-time = "2026-07-09T13:49:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/41/26e1363f36a94c9e8ec2dd21d5f63088d3e7c723adbb12dcc8fdc77be417/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3150d836290c88f1d26eb59c4db280d87417dd3bfaadd2889c77416c8f0ff6fa", size = 442051, upload-time = "2026-07-09T13:49:33.024Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a7/2c1ed1b34d7df7fdcc11c28fd26d94d44843b37d9af2435ff9fd8abdbc08/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9472a8de37faf8bd216c628e0e68c8f6bef730d3ba0a5060f3b0fa460c992ac2", size = 324372, upload-time = "2026-07-09T13:49:34.554Z" },
+    { url = "https://files.pythonhosted.org/packages/78/bf/328d3c6bb22c496944a1b3b732207d71aa6964eb604e5e3b9dcb91ed0a00/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d27c531edb8d1f38ca2eddaa1fa24913a460aeb721f2efd4ef42a124ce94e354", size = 348548, upload-time = "2026-07-09T13:49:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/76/a07de5cb7b90582fdbbc830fd19be129cbbb9897cfe239fef469d7bd2d09/uuid_utils-0.17.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5670c52a438e21483ce715776144914a4e2a2a5c62d9dee15f8a3e90cf128ae6", size = 498985, upload-time = "2026-07-09T13:49:37.142Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/62/9966e46ae34fcec6b06119631fb3c09705ea78835035ce3a82d3348eb61a/uuid_utils-0.17.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:6f29689a76fe7a49cbd629a794d0ec1eab48814e323a00a146a741b0195bde68", size = 605183, upload-time = "2026-07-09T13:49:38.648Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/4e/bb962ba0fe31e903b199f22cf4c1a6cba35a8987aef526d287277ab8ca8b/uuid_utils-0.17.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4441600447d340ae103a353f01dbcd22ff680e5ee1a22988efe8d7b791d8fdb3", size = 565412, upload-time = "2026-07-09T13:49:40.115Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/122adfeeeae8a84ccfd43bce627b104d12a2180a93bffd2c0e1b54dad7a6/uuid_utils-0.17.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7b04935a79c03c41ad08d0a5f390aac968bfb561f1268897bc5b0f077971efd", size = 529885, upload-time = "2026-07-09T13:49:41.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4f/257304dded339dc35fc9bf35722ac68fd4fdb930f255b8f7bccdf74ebba9/uuid_utils-0.17.0-cp314-cp314t-win32.whl", hash = "sha256:239d8a281fe10bae33205b5d43185834d556b18434e0a113b5dc1dfb2fd97e91", size = 169472, upload-time = "2026-07-09T13:49:42.871Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c8/e78c06db7e9ce317ce7b8759ff2058333eac75caa8c22b75f0059589c9be/uuid_utils-0.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e288a06cbbbcd01b44386e767985c9e21d2ad9bf59829aa7058d9a2a494804ab", size = 176271, upload-time = "2026-07-09T13:49:44.105Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/11/bd1c70e1ad3301163cebe66c8d26de26e6814d52f642a849448bd2833626/uuid_utils-0.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:1776a80d16369999b21627028cc5dbce819be83e1e079fdd7a51b587d2916db9", size = 175004, upload-time = "2026-07-09T13:49:45.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/14/4ae708968b15cac7b68d5b854bfce724b21faa1c7a5147fb96d87f468a45/uuid_utils-0.17.0-pp311-pypy311_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7b9044ce4acbf392d4b3a503fe377641f4deff82e6c341c36ef27af0dea76cdf", size = 567823, upload-time = "2026-07-09T13:49:46.902Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e2/d3af9c3d1dc6efb9ee1cffab30f3f2aacacc3892b21b495d78d34c6696bc/uuid_utils-0.17.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9a91c4814c7150a4d798da691b7804eacd78c4b84fb392a60fa0de21341861eb", size = 288763, upload-time = "2026-07-09T13:49:48.491Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/f1b183e412387529893015a94a8447633c665f6d0392de20e245680e636a/uuid_utils-0.17.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dd4a21baaac9a88486f0dd166c5793feb101a0bb9f006f2c401657fff5a1343", size = 324919, upload-time = "2026-07-09T13:49:49.972Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3c/d32c799bdd51f3b08b6ee95f9de921b59c69075a96767f937fab55014813/uuid_utils-0.17.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32abaafc8e91928b3d9f4d82e42d2094041e38ad6bb964066faadff28e4162f1", size = 332689, upload-time = "2026-07-09T13:49:51.402Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/90/b4cd455619ff276dc3c3262a7420ead63aa1e531362f00df4cdb07d90e0a/uuid_utils-0.17.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd741c73440b328f937dc53b344ecadc46bc4f0cec0333a8f42b55f3468ce7ec", size = 445726, upload-time = "2026-07-09T13:49:52.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f1/5cc042a37932aa9a66eb8ab4a9a5b31d80261ae4565ff0193d8cc1fb9392/uuid_utils-0.17.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89a0980d49683c00539c59cd9f46b1908c538e6b5b0a48ad12187bb856d0f391", size = 325610, upload-time = "2026-07-09T13:49:54.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/72/9e800c41d766484484e97845a7a7f677ba94462df86c97183e0290229d16/uuid_utils-0.17.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:de1064663aa7c839286488a319d2b3b478ca5ab5b2091ade888ed0eeca11a98a", size = 352672, upload-time = "2026-07-09T13:49:55.748Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8e/86ce2c03a1d9674530f6649e49067f7c69929600127077731de590d12132/uuid_utils-0.17.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2db386941cfdecdd0b5a8ceeed5cf7479c83d1730dcf64a48d43cfa018cc3310", size = 178681, upload-time = "2026-07-09T13:49:57.096Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4041,6 +4543,177 @@ wheels = [
 ]
 
 [[package]]
+name = "xxhash"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/6f/4d42b20b0dc688552f568e356e7d55b8ea18092eb79c78e40a96f59e7e12/xxhash-4.0.0.tar.gz", hash = "sha256:6b4040b26c73c75e6c12273b0ae237f9235f39cce5fabb683a64e9f20d09df8b", size = 100993, upload-time = "2026-08-12T16:59:59.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/9f/3736468bf0680ede8d93a488eba7dac58ca2ff25d6bff168810f7528c300/xxhash-4.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7ce6de9166b8a8c1c29d5eab91b508f4c31ae3ff8626a3ed65bd2cbbe64a40", size = 38087, upload-time = "2026-08-12T16:53:10.683Z" },
+    { url = "https://files.pythonhosted.org/packages/23/27/a1370dc53ae4c10efe0eef02dfc57a613b4e104073a335fa88c3983e8b12/xxhash-4.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3b783b3b8a7c6cb79be6be6c32cc0f9c2dc3bbf4beb013bece39b4f8fcb2b4de", size = 35925, upload-time = "2026-08-12T16:52:51.017Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/87/f0703078a7cae7caf210d77ad6a2d91509434c1c1496233bb304e1202933/xxhash-4.0.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:601b3c3b09b44ed2ada35674bcb19c435ba9203862a4832731384269391bfed9", size = 252935, upload-time = "2026-08-12T16:52:50.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/f472a6bc86208de130b2317af1aefe08d5139bd06696e7e920cf47d8b6bb/xxhash-4.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7e38e909ed1d5a86511bf2fc57891d0fea5ef64063cf7995bf954cef2365b2b", size = 276246, upload-time = "2026-08-12T16:53:14.475Z" },
+    { url = "https://files.pythonhosted.org/packages/74/7c/4ff4ad2f16169070461460bdb99568eebd167932d8145f793d1cdba8077c/xxhash-4.0.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:492f267d1dedeef7c44310e60a08f38f34db75ed373062fafe68aa09801e4281", size = 295909, upload-time = "2026-08-12T16:53:08.962Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1d/417266187a86a340f4b8ec55d16844cbc53c20fd0503e7fb5b7a07aabd55/xxhash-4.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f2bc28050a61684f1c825ca72be56eefe1421112d1ccceb4eb99d86b52aa4c56", size = 279566, upload-time = "2026-08-12T16:53:22.923Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2a/c5e4987c4fa758bcaaa6fe320ecde667380e93ae206f36daa37c4545cc8f/xxhash-4.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:97730a254c3d11e43dffa815a9837a622d7f2a30a9d897bd29184d5589b7dc25", size = 509522, upload-time = "2026-08-12T16:54:01.123Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d7/1a3e8044c94053e8230ae746218741dcad2e67ceb4ce3d55bc85f923f406/xxhash-4.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:baa9828055ebaa00b95523aabef7504c3d1685bfab48b7c2ed15d0ba56269708", size = 260625, upload-time = "2026-08-12T16:53:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/24/07/05186cfaa8410f5f6d14a691db021d930a84bc2205e45d6bed61078b8af5/xxhash-4.0.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:23ec6388d554e523bc06bf40dbf2dd09b74af246a6f2a6a17223a16fc575f676", size = 339347, upload-time = "2026-08-12T16:52:57.801Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/17/7628c83969d68287fb174aa3b993c5147c578ae60856f72ffad488cd1684/xxhash-4.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c1d56a5c9fb9c6c6a6eaf0adbe398c57ab6e89348a83cb99d230a52668cea557", size = 272193, upload-time = "2026-08-12T16:52:58.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/18/ded75ea5a74b8538d75e825558dbc0304726509890980edf0dd9884f3a02/xxhash-4.0.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:681892a96f5727e4a082af13fb75c1cbf1ef66f2d56cadeddf31db6bbaa09945", size = 300004, upload-time = "2026-08-12T16:53:18.853Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c5/5215550ec7690a9dbc406a6e29cb77a130bdb1942fb639d6fbf2005f11e6/xxhash-4.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4395c0a03a1336915c677fc71e1693afb1317751ea80c130b23d6292d14f75fe", size = 258893, upload-time = "2026-08-12T16:53:41.076Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a0/8d7a0addb64e32762af3f5e7838e1808a6997a516a2493648d651ba795c1/xxhash-4.0.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:2987f0908d5e3908bc1949a0ca4f465583ba55befad5899581edfb6b59441f56", size = 277785, upload-time = "2026-08-12T16:59:00.01Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1c/62dd9957ed770b2ef5f8fc0527442975afd4055921ba009fef54d54f0b79/xxhash-4.0.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3de54ba80c88096fbcca29e3b255989b3bca02e47a976bf9303de2f36261c57f", size = 329548, upload-time = "2026-08-12T16:54:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/329ba182d0fdc65fce8057fa9bc0d8979e7bd31cd4cfbc4fd991d1db2db0/xxhash-4.0.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0a9d3fc725df9b0029094dbbe700a5d4633881f2afb87392ce5860388c22bebd", size = 477008, upload-time = "2026-08-12T16:53:37.32Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c9/f9041891290b403d07de8cdc66da95289e6b407bc83d16be62a6acaad5f1/xxhash-4.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:84e0b626285289e40be24eefd51ab9fef9bc6373f4025c3271b3b0e3a2ac78f3", size = 257166, upload-time = "2026-08-12T16:53:07.244Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/6f0f310ea658e83df21f171fed313f6be01fe918a2eec76c4ea549b79233/xxhash-4.0.0-cp311-cp311-win32.whl", hash = "sha256:6ec7a1b252ba32719605ecc2f9bd4230fdb3b5f0bb424c671961d21dd0acf7db", size = 34287, upload-time = "2026-08-12T16:53:09.692Z" },
+    { url = "https://files.pythonhosted.org/packages/02/cc/3702bf613a42923627bbad08b434237cef9b525b00341207496548cb10af/xxhash-4.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:50cf753d4d93797c2d32a72c305ab7017af4bae9bb6c999222fb29d9ea9961f7", size = 36653, upload-time = "2026-08-12T16:53:29.162Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5e/d0ccb316354dbf7d5868896e5d87bceb6f50710d6b386159294a4da4679e/xxhash-4.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:460146a030d3dfcd6cd08a0bb45c2fe10f04026f80ac16ae42a846e8d850f0ce", size = 32958, upload-time = "2026-08-12T16:53:46.82Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d9/493e761ee66047de5d15b7b5137972bf26d889eb58e49b1f18e2f35cea6e/xxhash-4.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d58ab471ab4442ac29ce225edf496f40d136dba552b0a718c796d14b71550b0", size = 38115, upload-time = "2026-08-12T16:59:02.316Z" },
+    { url = "https://files.pythonhosted.org/packages/87/7b/a03aca88de3fae90f619ef6acd72b90e4b06e840a66ed4574558c29a080b/xxhash-4.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3a42fa24a47961e38ace7e4675680eb3cbd024588eb0dbc9dfbd009f4dce6bd", size = 35932, upload-time = "2026-08-12T16:54:12.151Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b4/8e935dc765a3018ada3da2455eed2e878c6cb686a9c01b3db1619a7c79b5/xxhash-4.0.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4c6eca223bcd94a9a5d291512114364facc5c4738c0d468ced386e88fa9071b", size = 252775, upload-time = "2026-08-12T16:53:43.21Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/aa/7c1cbcf64d8c5e9ea23808356af91a158e891e08d8f206884ceaf0425d61/xxhash-4.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7264a1a8bc4cda273347b6fead2a15c1fc070736160fe927867279a9d991604a", size = 276218, upload-time = "2026-08-12T16:53:12.936Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a3/5ffcecc8fb1480f147a5396ae52b27a9b519092d0ba31a4c614a5a0ecc57/xxhash-4.0.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7f9a849a801557a3a2dc9226dfd11b6911c766cb3f16d36822488204788de65b", size = 297412, upload-time = "2026-08-12T16:53:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/90/c4067783a921aa055372bf2f66fccec0bb4fd06edd6ab3b752b973492d05/xxhash-4.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f9a33820c448e9fa3a720396d90ae3eff7dfa942d86af855965a095f954d0ac7", size = 279882, upload-time = "2026-08-12T16:53:38.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0c/a777dbcd2f10517a0f49cd276b9c6a2d1f30cc0bde0f67da65b56849a646/xxhash-4.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:76989952a47452f66ac213779b62961b8e489c98f45c4ea7d7dea9115a00d06f", size = 510640, upload-time = "2026-08-12T16:54:01.844Z" },
+    { url = "https://files.pythonhosted.org/packages/22/bb/4148016c68211d8cc348eabe06e40686c71c4f7b336261f4b4e72d2d46ab/xxhash-4.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c72ee49f74745e554226018e56dd93d4ff924dfa870d119a59828d29080853", size = 261458, upload-time = "2026-08-12T16:59:04.292Z" },
+    { url = "https://files.pythonhosted.org/packages/72/dc/170ee0593a11c472e32b745b6a300f2eaf531347d1053bbc411f24d3071e/xxhash-4.0.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9335b632cdec5498068372b75ab18a6c1905eb51ba76c727db46080b66ef7d4f", size = 339621, upload-time = "2026-08-12T16:54:31.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/b31e1be5d3f892eb8fa306d1bfbe7c1c5c4d6011e045351434278c2526d3/xxhash-4.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b939f78096460a1e3905cd92815d01fde6fb2c54a544daf8ea03a1fded41d74b", size = 272552, upload-time = "2026-08-12T16:53:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/1f/82830fa11afb369ae8ab0692d316e68be6128d12756e22d23d0f7a5b34aa/xxhash-4.0.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7d6fe512a9c84e5031d1b97c7b931c7694ba7f10f44bf4466c219f468f0ed749", size = 301046, upload-time = "2026-08-12T16:53:30.172Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c0/b081f9ae955d452be3b8f3c17ef8d5d4484606ea871c45f73046d9eaf438/xxhash-4.0.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5a9656d42c8e87013655a8a668a870222235ae26cbaae69c922b12c66b672f38", size = 259794, upload-time = "2026-08-12T16:53:52.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/01/b35974b9890d5d1d83c325220f9e98482c54109a4e98e3596b9464de4813/xxhash-4.0.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:14b91efc9fc7072ee22b4ce0c778d41e53dd2d45ca5b16fdfe8cf33ebad3c386", size = 277906, upload-time = "2026-08-12T16:53:50.359Z" },
+    { url = "https://files.pythonhosted.org/packages/84/95/78d8a7228a9caa65e7adcfe0a72c160b2e739930f90ae0b4267386d8510e/xxhash-4.0.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e07cba198b78fef4ea81b219058ee3e9ed8d612b055e0388b205a3f20e1b70e", size = 329997, upload-time = "2026-08-12T16:54:06.363Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/84/29f5bbbcc14a56ccfa4fe0e025ce2fa55ee4b40485a268c828c47ce52405/xxhash-4.0.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:963e5b1f0152193703997eabcdb7320c0d2e3f934a00be03a25dac4fb4af66dd", size = 478204, upload-time = "2026-08-12T16:59:07.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/13/56da2f5d5f2eb28b64aca54240e555221a8e2292644b60a73f46dfaaacb5/xxhash-4.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bc49915f326b888773979381140eb1a5e804fbc872670f6a2d36d8d421225a2a", size = 257845, upload-time = "2026-08-12T16:54:42.948Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/80/65141cc3d3e6b0cd52b4c7d9af32a6fbc3ea223995cfabf406b2f589e0c1/xxhash-4.0.0-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:89bc01208487b7f4b0b636b4e8b809ec3c41644fc38487394d9faf9570d4795b", size = 20416, upload-time = "2026-08-12T16:54:03.689Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/cb/8e261dc126968573b999908fdc091705e850337af24a3492f44b3d48de58/xxhash-4.0.0-cp312-cp312-win32.whl", hash = "sha256:453c9bff5e2c6a2b938704e41965c65d1339a2e07817e1cacaf239c330af4d5e", size = 34309, upload-time = "2026-08-12T16:54:04.695Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bb/edec8f095a24a331293fbdacbed9addc4f5a6f2e2f88c3ed539d7cbdb438/xxhash-4.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:4f8515f2e70a98382adf2c1b1e413f3bfa46a3cb1b35752928265577f958f1da", size = 36739, upload-time = "2026-08-12T16:54:02.85Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c8/42de8febea42413de52b2d1ac5bf0081aba71c37705a3565c0c021f46bc0/xxhash-4.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:63f3cac239fcdcdcbc56cbaf5b5164f056e8a2b1e06d61436c134628743eabfa", size = 32970, upload-time = "2026-08-12T16:54:28.673Z" },
+    { url = "https://files.pythonhosted.org/packages/af/34/1a6f7f86d94084ded050f6f7b3dadb6103d8cce0bc2022f7f45f003d4b97/xxhash-4.0.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:3ad3124acd9ae0c8d069cd1879e453ded1d5b72024b1f7a90cf8fb1d30f9681a", size = 43233, upload-time = "2026-08-12T16:54:14.472Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/fa/e71472c0af1c6cd710f50fdda7cd0fe2931977c40845dcf3d45ef93fd633/xxhash-4.0.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:abeae2d9e797f7bdd627df6785d4839517d1f67a0f91deb4da27ab3417e5c56c", size = 40311, upload-time = "2026-08-12T16:59:10.158Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/fe/3456e5d85a89d6421d009ca97fb77a9f5cefc5c8d465232be51aa39ac591/xxhash-4.0.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:cdf3a9494a0418d37cb1d7b490620b331b09167e5923fcde9d0bc759a87e33dc", size = 34376, upload-time = "2026-08-12T16:54:45.456Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/06/9cc19701019915c83767f78be0a16aa3ce0be01372f964c6545941bcf298/xxhash-4.0.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:af6ba29275dde4eba5fc223a7635edb88fbaf658289e1f89007e05c74204bc06", size = 35335, upload-time = "2026-08-12T16:54:07.032Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f2/871dfea505b2ed142c536046fd06b42478b50ac45bb793d3ad151dfdc9cf/xxhash-4.0.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:51288138c05f55fd1cb9c98c33e01eb573744e768ac342e3e938d03b0e0b9683", size = 37637, upload-time = "2026-08-12T16:54:07.605Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d2/0585560cd638f267c8a6e219b1acb428e8a7e1d9170d47df2e8b8af4ecbe/xxhash-4.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0ed59c8f1eabb250cb293590dd59af835e4b6c5a2c749923ae1292c3743ec82a", size = 37735, upload-time = "2026-08-12T16:54:23.115Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a3/c65f35ea36754998e4359cd4be71b3685c8847e1ff3c7217ef5d624e237c/xxhash-4.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6838e142ac44cb0838c395db285d040784404dd33f6b7d92b2338f2d849f8b97", size = 35578, upload-time = "2026-08-12T16:54:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/33/6a0d39f99177f34a85f215293fbc064a7de3c2f65eb29c3300119fd7291e/xxhash-4.0.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:070fde1355b8ba1da1ab78fe78297abb919a61aea5adbf2b8ee2a2a592ce007b", size = 259108, upload-time = "2026-08-12T16:54:17.662Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d8/b2391845e679b0bcfa915643d89492dc80b814d526a35de03d4685fd6f70/xxhash-4.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2ed50ea632e80951cedd89714505a8f85d199f2014faba4bbbc81baccc1c2081", size = 283622, upload-time = "2026-08-12T16:59:15.896Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ba/f0d8766eec1928a03ad9ff9c6a1447c73628f0b998968f92ea947ed6af92/xxhash-4.0.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:73274fe4597094bb5c19f9812b044d97d6ded8fefb04599bd2710dc5963fbb2f", size = 303437, upload-time = "2026-08-12T16:54:54.341Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c7/ad5c80fa54796328f2517899b4cfa3a94784abcd6057fb9cbedb829910fb/xxhash-4.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f0170f95d0c15c7d60cbac9b0d10dfefc01f0ecd61ce3609936495bf988189fb", size = 286862, upload-time = "2026-08-12T16:54:10.78Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e6/d0ff14bfda7b5e660aad7e6e342dbc3af6cc1e9e645ce26a46fe6f2f1efd/xxhash-4.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:45b905eb4116ae7ad280ba9f5b702fe77569403d53b90762b3d0509ddec3b9cd", size = 519477, upload-time = "2026-08-12T16:54:13.461Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/33/2e50c9a828240d76a956d2b4426f8f1e5264a60a06b84c9150b718ec8633/xxhash-4.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ae29aa4ca0d8be4c13154bea4a82f77ed62062d400ead38b599b2d7bbf5b727", size = 268202, upload-time = "2026-08-12T16:54:34.635Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ca/f8350df6ff74963e6f7dd88edf200b17ee33dc6eba1a892f70e7f1378e2d/xxhash-4.0.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b72e2a2f65dbda433f09e1de5a116366b3305d5f4a968f44e4ac1023dd053744", size = 344705, upload-time = "2026-08-12T16:59:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/70/87e0c9d65bc47a285e97024de83e237fa2309cb556a28972738dbbc9fc2d/xxhash-4.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:57ebd48125d8a469bdb167a53199213a068088a28a4e5c05bf57c15cc6eb8c7b", size = 279524, upload-time = "2026-08-12T16:54:24.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/1f37db24c05e316767f4cb5eb00c4ad6c5d06718a71faf5d34aac0afad01/xxhash-4.0.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ccbfe39040e2b4643e7e2cdef623fd45d187e430f0e6631d41101d2454cfb3e4", size = 307154, upload-time = "2026-08-12T16:59:18.85Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/34/771af917dbb390619083afa56c975b6e25b3256c3f8f8b93e688ceb6a42a/xxhash-4.0.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:edb635eb0904a04b27585a02e9030692dd0a642cdcf3f46834f598281fad246d", size = 265495, upload-time = "2026-08-12T16:55:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/72/0e3d8e0a6153d22abcca15cc13e1a9a488b855e255839713347e69deca83/xxhash-4.0.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:e9e68e32f9d7d6dacf3b7a9b7f777cbe2e2db975606e6e2af098c73ad89f09c3", size = 284019, upload-time = "2026-08-12T16:54:16.243Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2f/e4f1384a85479805f2dab9501b461ad6011e58aee9f74ec6a1919c228fba/xxhash-4.0.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1f9c48c63f707de4c9e76da46418838a8ab07ebd3608188389008fba264e433d", size = 335645, upload-time = "2026-08-12T16:54:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/27/a0b66e349a0f8a855ff62b16ef0244c231a50f7d001fb91f0fb1616b851c/xxhash-4.0.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:07958037004350048b62ac5d088c08f83f4291c36ebe7e302f6497773903dcee", size = 486666, upload-time = "2026-08-12T16:54:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/cc99d61a81d0b3d38fdbb7c7c702a3a0577f48527b768885c0a26af06722/xxhash-4.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e54e35ff1095737599338b264d092e60c770b9c319badc47d3c61f4e037ec9b9", size = 263982, upload-time = "2026-08-12T16:59:06.51Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/23/f30b4d31469b1ee79316b7970e1e2b87185af16924d62ff2a77f085c0246/xxhash-4.0.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:340d30e1030d0cfd239a96b45ce3368dac061517a4c56283e3d0ac4b5da43a10", size = 20220, upload-time = "2026-08-12T16:54:41.041Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0f/6ff9aa9f7ec323a690fa94737be54bdcf3b28ad445d9419394a5bfc60aa3/xxhash-4.0.0-cp313-cp313-win32.whl", hash = "sha256:54c09a575b8b7c9c77ece653c6267dbef7829144358403ec2aa06cfc16d2a737", size = 34096, upload-time = "2026-08-12T16:59:20.735Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/39/34472a4ee5bba5abba4f5cbe6b4e6e9636a408b9e1d1dfbb856e057b193a/xxhash-4.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:c5f7268147219bad4ffa56a06a0416d30b9a4c16dd1f2fc847bcee0a82babdb7", size = 36139, upload-time = "2026-08-12T16:55:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8e/2b85ae94a5b112512552e6bac3c81dca62bd09344bed7eed39918152bb3a/xxhash-4.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:efde4e9568509643cf149e4d9ff8dd33aaf0e933d4e75f50549072807bd2d2c6", size = 33087, upload-time = "2026-08-12T16:54:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/41/588e92b0ebee8068499619795948a010d8f95eccb5a09f9f2f9917b8aae8/xxhash-4.0.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:db84ea3b737a6739a85e83369d1580735429ce77aeaa170098cae68c53808823", size = 43322, upload-time = "2026-08-12T16:54:34.351Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9f/a7842537ae06bb81e4ef56c86c761f1679d2db23bbbdae58de26bc794ff0/xxhash-4.0.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:1cd2a1f525f6de2f12f2f082f3cb3cef42c1e312391a5c775aef29e250fbe025", size = 40391, upload-time = "2026-08-12T16:54:58.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/30/ac4bc97e28ba17c4bdc6ca7205a165aaa85d78d5b31370038217515e7364/xxhash-4.0.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:76e518792bab77567bbec2ffa79a832b4d6d6f3e381eebe5438f4edaedfe60e8", size = 34405, upload-time = "2026-08-12T16:59:12.225Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/98/d595fd2d231b6ad000c23f2d5b2d8927378b783cdc727b94906fd36fe7ac/xxhash-4.0.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8846f6f7fc91b31da17e65fa1388dc7564ab2a49705bafc7385685cb138d8c97", size = 35333, upload-time = "2026-08-12T16:54:45.926Z" },
+    { url = "https://files.pythonhosted.org/packages/31/36/004f2c793ea27b380ca288237438bc39efe3e009158de7dcd2ebaea193a8/xxhash-4.0.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:281bee1d220ef2bcd98da244645b64b63ab4529639adfae08493149b683dca7c", size = 37702, upload-time = "2026-08-12T16:59:22.503Z" },
+    { url = "https://files.pythonhosted.org/packages/36/77/a8a518eff9772f074a73fbe21b5bed8d6c2a2be9190a9e1ffd33f4565ca3/xxhash-4.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06c1d6011c7126da93a6ec1fdb587a9e672622721747287c49f0d9f8c74d8a2c", size = 37859, upload-time = "2026-08-12T16:55:31.76Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/1c/03d2ef7526bea146d10247fbb546ac5c204374825e00f333e050034da9a9/xxhash-4.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63572670b457b18404aa2bf1e4eccf15b11897cb84c1d8d37f245ac3c0398564", size = 35579, upload-time = "2026-08-12T16:54:32.47Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d4/5586b3bb8564d48bcad8db26ded6fa441adf352348f794a20d35b163782e/xxhash-4.0.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5f4ef8e1187013597c2ce1dd0f1eb03111d53b524ac4e31edbcbd44ca99c20ab", size = 259237, upload-time = "2026-08-12T16:54:38.665Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2e/de7da52bbb6efe85b609bc45fe31973f4cdc5abb3e66a20aca0d158dafb3/xxhash-4.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:945ec1b96f381c3646baf7a3a02dd9c5c2f1471f6433f3fe76f54dacdf865b4f", size = 283931, upload-time = "2026-08-12T16:55:03.414Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ca/fa6b3dfba13123a4ba48e9c024275d46e6ab84f79836d25ea59cf4b264f5/xxhash-4.0.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f0debc5d798cc976edec29e6b2b3b995144cabbcd1434a2b3a3132a3b7f72cd0", size = 303589, upload-time = "2026-08-12T16:59:14.762Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/af/834b2d3da35052307a7892b111e60d825b28ce7a5ebb400664a25f5795a6/xxhash-4.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:69b66cc631ad37f07e44ca04ec44eadcc86d0ecb9533c151e01df44c0741f2fe", size = 287097, upload-time = "2026-08-12T16:54:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b9/155d29cd9fae4fe3814cc072bfd4c2b45d1814f4c48c7b85e3850c9e7bf7/xxhash-4.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c1ad023a357ae1210f6d5fff4cca7273c08cf4adbf60cc6df243c262d3ce6a1b", size = 518895, upload-time = "2026-08-12T16:59:24.55Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/ad3a313fbaea9116cd33b1f1c454eb363012ce46933e1760ac072b1ee9f9/xxhash-4.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a2fcead5cdff26b002e8336cdec6f6eea588d350b1ec1010801878c9381779f", size = 267820, upload-time = "2026-08-12T16:55:36.44Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/dfa99ca585e2e7275f0fec3c93a2907a2e1f0a0498af1d320c425701dc15/xxhash-4.0.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:adc511931fda0114b05611b14474471b0a472ca9153fc347d30ed96fd628bbf7", size = 345169, upload-time = "2026-08-12T16:54:41.138Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b0/e6a00e115cb9c0c7a32375e23d4dc4b94e733e756766978a9c6fc7aa9cbe/xxhash-4.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:495820b8908edd87bb69924f04106dad7cb349763aacf741f820d7d0e04bb4da", size = 280231, upload-time = "2026-08-12T16:54:44.351Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/10/3855a7275d6bc04cb4ad31e5b44d91fc0f0ad2fcb6676ae56b313d4abbf6/xxhash-4.0.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:3cd39edf34945dd02f256a778eda5c9ea52e865a45f218460a5d6d12b266607f", size = 306797, upload-time = "2026-08-12T16:55:20.632Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/57/69ed901908fd34d264a5941fcccc83fb0886a6a6fefee8d40a25a3b1d59b/xxhash-4.0.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:02b998b2a3150780d596f9cf8ae90fc19e38c64971bddbe6e492de0c0c0d07e9", size = 265528, upload-time = "2026-08-12T16:59:17.822Z" },
+    { url = "https://files.pythonhosted.org/packages/52/62/cfceb242c029a3198d4fb8b804c41b08d51e661aa43891a05a5839fc8562/xxhash-4.0.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:41c810a5ad4aaf862812575f477361e8a76a368764d3c265f53511fbbf8fa5ef", size = 284161, upload-time = "2026-08-12T16:55:07.446Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ca/1ec30ab71826decd231f1231e276f6cf0f54cae709e11427be8102b1843f/xxhash-4.0.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:91aa1d5418de8aaca5a418f22657a3e4c1bc37f993aba8b010a46b39f6d37501", size = 335726, upload-time = "2026-08-12T16:59:26.785Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ea/c710d5d1279c7c7e7ad4cf9d1d2f9106223e484a9b761a353cfcc5900a24/xxhash-4.0.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ef341c82fc06696c1feb6923c900e6e00a9f049f86d6bbc275cd6c02f7091c2a", size = 486311, upload-time = "2026-08-12T16:55:44.33Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/95/777a75e55e540da1c0fa83ab4ae6d517e047ba72a299d89f850d5d57bc76/xxhash-4.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb96c1c045996975892d55118f5fe323b1c7fb56ce1a5505f065e4c66e7f341c", size = 263414, upload-time = "2026-08-12T16:54:48.469Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/a5a0c97212574ff5bd9a297e11536e6caad705f0e9a554bf6e78ce2cafef/xxhash-4.0.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:82160fc93048d66bf7872b3e3d482f833d6c586e56357c53d9a4c147871a677e", size = 20200, upload-time = "2026-08-12T16:54:54.361Z" },
+    { url = "https://files.pythonhosted.org/packages/df/da/b4de0e377f0f9bb732c9b7814492a249e668c3910b9a51df86a11ff5c4a2/xxhash-4.0.0-cp314-cp314-win32.whl", hash = "sha256:ca16817ba162e53c56e19c428f7629fbf86e0c36d6c95c1ae9f2206767a81f47", size = 34774, upload-time = "2026-08-12T16:55:37.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0a/4cebdfd9970a7859e0287621954270ca3ac63807b95e9d4dec316de13c80/xxhash-4.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:77dbca7da50340f2bddb1ab16ced523ae275f319d209362a7bdb7f306dd9cfdb", size = 36763, upload-time = "2026-08-12T16:59:19.774Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d7/d96b991a5fb945d6a6e54ae0bdda7502717a6d34640e4b00964682329f38/xxhash-4.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:e104176ad369e3d52cba2dd85832d19f9ad04393ccf738b260553e7a54a6fed6", size = 34036, upload-time = "2026-08-12T16:55:28.081Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/c1cc56e1fcbadcec54ce005e77e689a306299087320c4ddbc848af5d867b/xxhash-4.0.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:e9dccaddc24daee3c0aa0cfbaed95cdee594edf5638d941675628dc7bfbb22fc", size = 38329, upload-time = "2026-08-12T16:59:28.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/18/70afb6fc2c2e1bb4cea8387d3e4a8467678e6acb0786c88ebe704839f86c/xxhash-4.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8a00751c4b92c1f4b5785ef1729ae4ccebcffdba1ff4095a6c7285ab122e223e", size = 35958, upload-time = "2026-08-12T16:55:51.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/90/4bc82997ff15aeaedbb2c8a5e1b3908f8eba7599bf49c37ba5af71627a78/xxhash-4.0.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:06eb2bdab339f0a59a1a6ad97c2be21d4dc4c2fa095182540bef56ccf1d149b1", size = 273387, upload-time = "2026-08-12T16:54:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ad/b881718ae097adedc2d03db5c7c30dce7da7f054f4e7bb7b7c3d1bf7e631/xxhash-4.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67284df807563ca3f79cf3ee0acc76ffa873aad85a9e587441d18d0cdb1fc143", size = 300757, upload-time = "2026-08-12T16:55:00.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/32/b7afbba0750a4792e59f81bcc0e9c105dd388c7977b6d3fbaab24641380a/xxhash-4.0.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3290769c98ea77b99d24017bccd72851079b15434478e6537034a8869f9b6fc4", size = 312404, upload-time = "2026-08-12T16:55:46Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/78/619630629a7e998c4a31b3111136420f15e715b72fda4fff71afa35da653/xxhash-4.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:39046bb0cc10d7eb86805d4d2b0ea9a5d3b4fb03b9061a679e48b2c8651cd31a", size = 301087, upload-time = "2026-08-12T16:59:21.767Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a2/4269e599e9a7ab4b8f91529aee41c62a5c0cbc2624014cbc8a313ad082f9/xxhash-4.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:73774102f1cd53989d33ae340601139d6015a4ef4f9e38fd8fe47f24ab59472a", size = 534061, upload-time = "2026-08-12T16:55:46.98Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6c/4089a593bbf5c51b4d4750a0e2bdade5e3b1771f8e209d0e390f6892de79/xxhash-4.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445a802761e2d6f0ca4741464fbbb08e21e3a7885845e930bca4c8faf48fde2", size = 279278, upload-time = "2026-08-12T16:59:30.944Z" },
+    { url = "https://files.pythonhosted.org/packages/47/05/f544e0db4fffe64dd25de640152a64f341c4a9a915108d507bbc873c6c62/xxhash-4.0.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:513304b55d0f857066548492005c2edd332ca88bdfa36a53619fe09f4f582dc5", size = 358600, upload-time = "2026-08-12T16:55:56.265Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c3/ce6853d35227f16d7cee4c231e6dd79fc50725808dbdd18f74e5f5f239d9/xxhash-4.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:124d503e5ac068a0977dbfd3cbf906043bb377e223f6fda76695fe070a5e2acf", size = 295001, upload-time = "2026-08-12T16:55:06.447Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/91bb0d5be29e60284d78d5769a80247e55480015fd8be67e4c9e7c0a2496/xxhash-4.0.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:fbc07b879e9e8290a42556914234b5ae149c00c2e2c95ae1fbeedf96785c0f89", size = 319835, upload-time = "2026-08-12T16:55:10.564Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/60/5f9792b182848e7fe24acc81ff3d48f4729416361e79c1e4c30202183580/xxhash-4.0.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:310c51cbf02be5ee7fc70a40c3d8fb609ab9efc83d0371eebdb9158b9324c0a9", size = 279061, upload-time = "2026-08-12T16:55:52.714Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e0/88c48e6de56b33182fae9817d67a7f3276cc6a41afc6abfd884adb1fc803/xxhash-4.0.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:d96feacc843a42644ba5644f8119c2f0696fc3e0164b8d85dc22a3b702fdc2f1", size = 297263, upload-time = "2026-08-12T16:59:23.682Z" },
+    { url = "https://files.pythonhosted.org/packages/30/2c/dcd5f06fed249a41a785d83d8882759e0792258a40717808a7a38fe864bc/xxhash-4.0.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a43ff13f62a6c0afa04464ed1932a8fb2dcf1cd24ac01c3b90e82d3cf22d4c3d", size = 348133, upload-time = "2026-08-12T16:55:53.517Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/54/aeac468983c72d71c4299b0eabbec9264685bc82d5f78c56b5336097c1f9/xxhash-4.0.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:471a2122c59d05accf9001f1d8dabca473faf1caf01081b5226506d823468e3b", size = 498970, upload-time = "2026-08-12T16:59:33.199Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2a/707b28087bf5b196753897680c20a3ae7ab8f60226cc8a1ca2b63efbf9f8/xxhash-4.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:78b4fc6bb9bac999eb1ff141dc597aed3b0ddadf52f572211f0f17acfc2b844e", size = 274693, upload-time = "2026-08-12T16:56:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6c/80f952b5badf300b11469af73bcff7928017f27d6143ba4fa999708b96fd/xxhash-4.0.0-cp314-cp314t-win32.whl", hash = "sha256:60fdebd3eb6da7ef6b5e2b36105dc0711d1419f7c45caa0cd14244119315be65", size = 35125, upload-time = "2026-08-12T16:55:11.3Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f6/ce91b1e06c24bcb9ae24cdf0481bc0cb39e41c98d61631b09659501b6cf9/xxhash-4.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8920c21c73dadf9e5bee1e13e250a1acf63f3dd6d609ab2ba5d4abbd86394be2", size = 37103, upload-time = "2026-08-12T16:55:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/95/860bed3a0c7dede4a6a1734ab6f88998bef3e20a3d5ccf2c169073aaff9f/xxhash-4.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:55c026944fd593b4199fa299f7667aa79622d625e30f638f41f92f0c192c90d8", size = 34254, upload-time = "2026-08-12T16:55:58.587Z" },
+    { url = "https://files.pythonhosted.org/packages/98/05/4e30f443ae181d91a112d22dad9e34e60028a52cd8afd9d41c1c237b419d/xxhash-4.0.0-cp315-cp315-android_24_arm64_v8a.whl", hash = "sha256:63593a631535b205f0e5fdad0121cd57366c00b7b00846dbe9de513051c03796", size = 43328, upload-time = "2026-08-12T16:59:25.621Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5c/a6ef6ce5c3a8a3132931d0eec3cb2a711a75355611be786009867ba113f5/xxhash-4.0.0-cp315-cp315-android_24_x86_64.whl", hash = "sha256:c9515e4babe412b06e0f9e46b806b7b2b9ce946da90e9ab0130758dcdaba74a5", size = 40396, upload-time = "2026-08-12T16:56:04.305Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6f/e80ae3fd446c9f3ad9933afc24e9a49fcfacdb1097ef4eecc5bf0b7786aa/xxhash-4.0.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:fb8787ce65e0358af457353fdb261cb89382670ec87cf2c0dbddcded165388f6", size = 34443, upload-time = "2026-08-12T16:59:35.176Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5e/41a0d46d01488d362bfc5ce94b57a3422e5a74543306cc06aad968f58285/xxhash-4.0.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:c97fc349108401ca73a0b7e625fd06ed8d5ae94aa9e7285eb8c60497d448eb1a", size = 35436, upload-time = "2026-08-12T16:56:10.105Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4f/7a89b14701f53f9832b01012c3c5ff580118c89ae6a48ac68aa0444b41d5/xxhash-4.0.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:f43682b8f65b7571f90ac125feb87a1382a4d37f9dc41b2b759fc4b2a8ee20f2", size = 37711, upload-time = "2026-08-12T16:55:23.451Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/5fdaf0d29f9ac2bb0945d4c88aaa64f1abac40e788f3f2c64f8c374db80d/xxhash-4.0.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:3f71e14e5bca3ffa97c728463ccad14ee939bbf9c4224ccd4b3c422ef8aa2791", size = 37858, upload-time = "2026-08-12T16:55:42.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/64/6acc8a32f0ca5cbc581a1cf62352cd0e46f27ee090d10906fa51ba8b934f/xxhash-4.0.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:3ee15fb91280eed4f63386350e06be33589a366004cc6467a1599c36f746d078", size = 35677, upload-time = "2026-08-12T16:56:02.914Z" },
+    { url = "https://files.pythonhosted.org/packages/31/bf/9f1c3bdc4645855f44c63e87a46909ceb209ec8ff9ef9863c94846cd58bf/xxhash-4.0.0-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6d2f619722866cc583f40a756f54528749a5bce6a7a80fda7a5dff868b992967", size = 264256, upload-time = "2026-08-12T16:59:27.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/0e/6496112e775198b79dc2a8e2cf3fc095844275af2ad4b2d76ec549ada5db/xxhash-4.0.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5398ba89021d4066890c3333e2e167a038fab8570580177b9cd0c3386eb47661", size = 285579, upload-time = "2026-08-12T16:56:07.755Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/e147637f8f35572571a371c6e7631e9a3d0efcbed42ee61aba40e451613f/xxhash-4.0.0-cp315-cp315-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b5e8b65a881aaecbd25509df36629f1ab492f362424f2dad0c57e4127d1a1083", size = 306214, upload-time = "2026-08-12T16:59:37.296Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ab/4fcce21d7be3c6cf18d2ea31bd2b602ed43469fbcdba0186548f05576daf/xxhash-4.0.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:efdad32c578f66ca0845034d4f271b437eb171e97bed7bd273354f37ef4da8ae", size = 287578, upload-time = "2026-08-12T16:56:24.811Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d2/11ddb15c27d3511de94baba2855d66a7cc40e918db2c582dc8b36e0fd8bb/xxhash-4.0.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a3acc4dba6fc4b1f4f70ef5464bba460eda3058fd3a109c424ae44291dc50fe0", size = 519722, upload-time = "2026-08-12T16:55:32.81Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ff/d38c42cf1d34486cd85147c3178e04ddd01d4318b8e07316709f2d70800b/xxhash-4.0.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ac51bc651472066723721eb59508aa4f3b2611ecc0b4773ab60d2681a639cb2", size = 267907, upload-time = "2026-08-12T16:55:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/3f38a93627e6430583e3976be4344b48dc8242a50b917fd480b394e06008/xxhash-4.0.0-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f1d54c84bfb67e063636fd653cb9a2ffb7e647de8da1004a351a27dff9de9669", size = 349861, upload-time = "2026-08-12T16:56:06.996Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/46/4090deeca4004de6dfe08cbd87f55f4bf086762aa03ccf487c66b484441b/xxhash-4.0.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:407d0e39e477c414a86050c4cc2831a628d1b8948c9e2bd73c49585d6e99cddc", size = 281668, upload-time = "2026-08-12T16:59:30.107Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/37/599c6c59395a64e8068b3c00586e882017b5f732a7d6c02104cad3c735cb/xxhash-4.0.0-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:22bc76799e668c24a73f113a6621104fc1a41d85c007f755f57f5b3a43a8bb62", size = 307435, upload-time = "2026-08-12T16:56:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/35a79ff77f9d216064b8c959db7ecb5abdb411b4427cb7ca1eb9d8eead0f/xxhash-4.0.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:a7114d66fa58deb1c7bd1de3ee41b046bbf2db0ab972f87d9e627e3cbf0c1308", size = 267888, upload-time = "2026-08-12T16:59:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5d/f0cdf4312c4689075015d0e6e6d9fcc21a805c6d036e8d07166ed33d188e/xxhash-4.0.0-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:54610f8a2e506fa9c6ea5fc2b1082638ef9fd747b7aed70fe5b1cbc281e93f31", size = 284599, upload-time = "2026-08-12T16:56:31.067Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/be/b01ff7e9e05bd17380369b4f5ffa562ac12831b856416ce6233196d7b045/xxhash-4.0.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:ac951a9627034fd56864614036e9866d21d94a3ce203dafb0997ebf8e8895987", size = 337778, upload-time = "2026-08-12T16:55:45.097Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2a/062cd6954140e695ed3e04e856dbfe4e85047d52bede53adb0c9a908c757/xxhash-4.0.0-cp315-cp315-musllinux_1_2_s390x.whl", hash = "sha256:475bf58602738085a515c1279263964ddb7c3d833dad4eda07e79f56f885b970", size = 487351, upload-time = "2026-08-12T16:55:56.829Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e4/0424e7da6cdbedd1cbc82b3b8adbec379d5c4c0a5a48bd65bffa384e83f2/xxhash-4.0.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:aa6ae5421223693063c04b32456bd64c9b5ef115f7c4c9e19fd8c4a145b1df54", size = 263520, upload-time = "2026-08-12T16:56:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/92/21/d60db12cae912f10063ed24c3ce32012efd3f1e0ef747218cc4e1efed45a/xxhash-4.0.0-cp315-cp315-pyemscripten_2026_5_wasm32.whl", hash = "sha256:2b204025a20bc1d2a3e55a741ec83efbcef59d5666784a4a16568217818afa08", size = 20208, upload-time = "2026-08-12T16:59:31.941Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1e/12e94b5941559d16070a119ceacdd33e97202f048f8d1d750e1ee8db7fc2/xxhash-4.0.0-cp315-cp315-win32.whl", hash = "sha256:b15607539c9697b60052672badbd08699b691f47273c4a88f2b2c698ef28ba48", size = 34767, upload-time = "2026-08-12T16:56:23.447Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/b0/9d639d32a688e25acf27853d9e87a17a3bfb93f70a6970dc269f0b360eeb/xxhash-4.0.0-cp315-cp315-win_amd64.whl", hash = "sha256:e0e4e03bf2f53eb00e357ba351c909cb5f70f6bc92aa741a079c9663082b1f8e", size = 36755, upload-time = "2026-08-12T16:59:42.614Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7c/cc8b681c59996b4893fdecbc28f378afeb877d1404e11327fac627e771e9/xxhash-4.0.0-cp315-cp315-win_arm64.whl", hash = "sha256:5cee6e02c4f9295da82b783fdbb70b78c6417e2c9c7f33073426bf3b3f9bb046", size = 34031, upload-time = "2026-08-12T16:56:38.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7e/1274750be96bbddb5dfa1985de47dff8d5a5974207ca8e101b459bc9ea12/xxhash-4.0.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c38e2792b322a52444be509e81492ef839d1134227a0771366012a11256a026f", size = 38294, upload-time = "2026-08-12T16:55:50.571Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/88/8a10e2c0f741404a8787cbcb3a95f02591d5237fa97ff6b3d8407716fd6e/xxhash-4.0.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:3b5fa8181a65d3060ebf94712b34c6e68266c1119d245f959c3b1c2dc78800b6", size = 36029, upload-time = "2026-08-12T16:58:56.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f2/854a196948bde98e03919a711eeb34722fffcb1f5495f39ad03fff43fe04/xxhash-4.0.0-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9c099fb5a46aa9781a4f6115cfbf799da1e1309ba880237911a9ce4626c113a9", size = 273203, upload-time = "2026-08-12T16:56:25.389Z" },
+    { url = "https://files.pythonhosted.org/packages/81/52/bd810d07e8cd02457fc92c204a11363f295b313b4838bdbeb76aecf500fd/xxhash-4.0.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b262c895ed923b75ff2cb4f3137d7f4eeae3d8295ea6d86a66f6190e88a792c3", size = 298792, upload-time = "2026-08-12T16:59:34.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4e/af6d84158955780b7c3874293ca5be3e105686e68db1f63a121291715c6b/xxhash-4.0.0-cp315-cp315t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6f7b3839b8a407c666fb37f8e4235f3274abaf3c561038613b9300ddd3152667", size = 314127, upload-time = "2026-08-12T16:56:26.035Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f0/d1cb1537789715f399f529202eff4ed61a64af842943964d71f9661162fd/xxhash-4.0.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:495342265b1495c754c497a1bae03a4d081877443883a04c3163d5f34e5fdfa9", size = 298786, upload-time = "2026-08-12T16:59:44.776Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7d/3f11597cd9b28a02e5085fc68eb0c6363d3f52caa588643123c31d0c2112/xxhash-4.0.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1354501ba9cfde53fc2f64a685713fc0b457d940b911f7053eb5062733423eb6", size = 531582, upload-time = "2026-08-12T16:56:45.603Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/18/4ca9c34ea79a5f8f32858c0ee44771e4c9cc640104eba69e1582ad888d1d/xxhash-4.0.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86ba859f8c9fb5eea9f3452beb692e88eaa19fcd72dcb1a4ab4bf61d1ef7a349", size = 278440, upload-time = "2026-08-12T16:55:55.305Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/2f/53647ce0acde9f3aa053579e8ecfcd78c2db8c67cef6cff50363e1e30e43/xxhash-4.0.0-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bcad0042c4b7b4384af9758bc1b843e574cc28002fef5808b907b8a6681cfa65", size = 359572, upload-time = "2026-08-12T16:58:58.379Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/80/33d6a144e17464d244209dc8e04962420bc942ecc6e2db0e41f517c0d20a/xxhash-4.0.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:4341e6acffd0f7d407e82fa76081ce4c886282934906f7bea64f646536e0d463", size = 293285, upload-time = "2026-08-12T16:56:32.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/52/1b7c25d08b22e5d28e59119c455693152bb61a636ee8f6e9679e05eeae54/xxhash-4.0.0-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:953bffb74816c878d3df107e7bffb3b2de61069bec2bf7983712c5427739d340", size = 318408, upload-time = "2026-08-12T16:59:36.507Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a7/6bf95568247564cc08995277b1d993cb3920168044d61cbb9e3d681d34ae/xxhash-4.0.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:7e221d1ea5ec85a96c0946c22c31866a83c53dbd1a9222775e2e04254bb836aa", size = 277241, upload-time = "2026-08-12T16:56:29.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1a/b7d75c8e2b35a3a57de1468204e8e313e896039bcc98e01a2f778731a2d0/xxhash-4.0.0-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:9af2b9b10d6623e472cd671b7fc060fbb8d336c9c3504ad7b2bf690ccbb429f1", size = 294684, upload-time = "2026-08-12T16:59:47.04Z" },
+    { url = "https://files.pythonhosted.org/packages/76/73/cb83c3393cdd4d9025bfe3b3ae06979a4c0d571c6720b57a40233d8ff1cd/xxhash-4.0.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:f48f64db93c91259d8c32839ba3be1b3fa11b4cc451791e0144fcebd7aaaaf2a", size = 346706, upload-time = "2026-08-12T16:56:52.302Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/d7/6547d8efb8bf04063c9bd60dfd17e8afbadad56e7cb4e9663f862343abef/xxhash-4.0.0-cp315-cp315t-musllinux_1_2_s390x.whl", hash = "sha256:4a93db301eb87c1df0ff353f4c5a66571cb7473480cc9e32a4cdebc39f2c8b59", size = 496910, upload-time = "2026-08-12T16:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e9/04030c5f759344c63f1e796f3f756a90f02f56b73fe0008ef56dba058e83/xxhash-4.0.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:c442f105adf731ae096cbf8830079739d3f6dec2b76809e3c7c0a6a42fe78fa3", size = 273978, upload-time = "2026-08-12T16:58:59.904Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/6c6e9d182b23d6301d1543b897eca975e796cb23536bf1d70bcc82656871/xxhash-4.0.0-cp315-cp315t-win32.whl", hash = "sha256:c16d66337724cf23e753e72d967646a1236127701cf6ec5b5ccf82af3d2932c9", size = 35115, upload-time = "2026-08-12T16:56:36.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/62/b4383d7481380a8428abeb969b91324cc2b6fa8c48f747c2d4d1f8cf5cf7/xxhash-4.0.0-cp315-cp315t-win_amd64.whl", hash = "sha256:5fe3e37e5c00a265deb33e233b94e468f38d9325f1c62e05de3ff768c4237702", size = 37094, upload-time = "2026-08-12T16:59:39.284Z" },
+    { url = "https://files.pythonhosted.org/packages/52/3b/76ff969e59ce6491a9aba99b5b06a52b82684de637d0c22cdda9aba36292/xxhash-4.0.0-cp315-cp315t-win_arm64.whl", hash = "sha256:2cabef18c8353c1e28d4c3f8ba030e1892799d53bd83fa31f0ddb3e590e6aa7f", size = 34246, upload-time = "2026-08-12T16:56:35.428Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/50/525619de9e4ec98f5738ee4a0aa6177bc297bea5e53288080e5c15f377d2/xxhash-4.0.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:cc563b697d5eefc6a0a699203076687ec87db4ef8fd03330786343e309a6c009", size = 31502, upload-time = "2026-08-12T16:59:45.85Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1b/1718da1d831ce7b00b6ea69fa7f19b52a1a700ac32f8b913a799ee0bdde7/xxhash-4.0.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:9a9d55a4dd7e6693cc1e15119b0719d446495513b06ed020bec8ff77a84288f0", size = 34116, upload-time = "2026-08-12T16:56:51.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6d/7ffeb80640ecafdc51a0de3096f450891d1c3baaf77543f49a1451a844a7/xxhash-4.0.0-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07b899cf57f2573019a064b66c25b20d3e6934273fb8b921f96d74f417032d87", size = 38163, upload-time = "2026-08-12T16:59:55.311Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/88/51ff39be48d02e223942127189359397f87301c6c5f12efb9fda2d7ac8d6/xxhash-4.0.0-graalpy312-graalpy250_312_native-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:affef90b19eb63d054a1c16df70daee553dd735e9109e3ded5f390dda7e1eab4", size = 37885, upload-time = "2026-08-12T16:57:06.59Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/cd7d58dc604a395d33f5b73773caba6fdfca7e20ab54087094655c1a474b/xxhash-4.0.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:56ab134b8a5ef7a4d95c8cc0436ccab03ab20cab799e0886f4f1e728e205893e", size = 36816, upload-time = "2026-08-12T16:56:32.76Z" },
+    { url = "https://files.pythonhosted.org/packages/83/b1/49cb67d760607af93db044208df1ae51d667e74e9352bdf0a79559445ce0/xxhash-4.0.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a1c8a2ea77ad2b22ab4ad34cc673aedd291143169ce10fac5728f5d3c017b378", size = 35993, upload-time = "2026-08-12T16:56:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1a/d2855a8bb2f5a7ae10ffd55621a17bef3021646e8b1095494c678f6ace80/xxhash-4.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1969258533437c96c8a46028820e9c99741ad7d03476abcb76566e2e324d89", size = 33186, upload-time = "2026-08-12T16:59:10.926Z" },
+    { url = "https://files.pythonhosted.org/packages/75/fd/9b6cafb5bcaf99442b5ac0ed2898c830cea9d2f9d962f7f732a17677771e/xxhash-4.0.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8f3808b745a46aebdc844c603c6b9ab550451cbb499f706decd76f7d1a65ca4b", size = 47649, upload-time = "2026-08-12T16:57:00.637Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d0/0f527d9b2b5b62ae3fed9c28c870d06e3f68926fed465f0b53f2322e6985/xxhash-4.0.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:627149915a90215c694e4ac0c75bad8ae00eee1937f39f45b4ff46c01130fdee", size = 42388, upload-time = "2026-08-12T16:59:50.026Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/9c/ec4801ca684181b0f8bcea447721bc007b740a9ae5c15128e3aed481e51b/xxhash-4.0.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:65a6af70b5f5ed88f88791c5de70905c655cff0fee062604f67acfc843c2841e", size = 39184, upload-time = "2026-08-12T16:56:56.505Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/43/efbc17c2a467da34f207dcef369cc9364aa2a8172b4e056a0e875e934688/xxhash-4.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:36f59fa0d52d984a19c3026a951a183ebabfb2a847f9c5addc43e0191d44c3ab", size = 36911, upload-time = "2026-08-12T16:59:58.257Z" },
+]
+
+[[package]]
 name = "yarl"
 version = "1.24.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4137,4 +4810,78 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/37/91eb2e5ca883a529c1b390348a74cd9fc0512171727f547ce70bfe02be5c/yarl-1.24.5-cp314-cp314t-win_amd64.whl", hash = "sha256:5c88e5815a49d289e599f3513aa7fde0bc2092ff188f99c940f007f90f53d104", size = 102450, upload-time = "2026-07-20T02:07:39.578Z" },
     { url = "https://files.pythonhosted.org/packages/bf/f4/ed5c402ac8fde4403ed3366c2716bfddc8a6677ebd59f3d62772cc7fe468/yarl-1.24.5-cp314-cp314t-win_arm64.whl", hash = "sha256:cf139c02f5f23ef6532040a30ff662c00a318c952334f211046b8e60b7f17688", size = 97222, upload-time = "2026-07-20T02:07:41.55Z" },
     { url = "https://files.pythonhosted.org/packages/61/02/962c1cbfc401a30c1d034dc67ff395f64b52302c6d62de556c1fca99acc0/yarl-1.24.5-py3-none-any.whl", hash = "sha256:a33700d13d9b7d84fd10947b09ff69fb9a792e519c8cb9764a3ca70baa6c23a7", size = 58612, upload-time = "2026-07-20T02:07:43.461Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/83/c3ca27c363d104980f1c9cee1101cc8ba724ac8c28a033ede6aab89585b1/zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c", size = 795254, upload-time = "2025-09-14T22:16:26.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4d/e66465c5411a7cf4866aeadc7d108081d8ceba9bc7abe6b14aa21c671ec3/zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f", size = 640559, upload-time = "2025-09-14T22:16:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/12/56/354fe655905f290d3b147b33fe946b0f27e791e4b50a5f004c802cb3eb7b/zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431", size = 5348020, upload-time = "2025-09-14T22:16:29.523Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/13/2b7ed68bd85e69a2069bcc72141d378f22cae5a0f3b353a2c8f50ef30c1b/zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a", size = 5058126, upload-time = "2025-09-14T22:16:31.811Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/fdaf0674f4b10d92cb120ccff58bbb6626bf8368f00ebfd2a41ba4a0dc99/zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc", size = 5405390, upload-time = "2025-09-14T22:16:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/67/354d1555575bc2490435f90d67ca4dd65238ff2f119f30f72d5cde09c2ad/zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6", size = 5452914, upload-time = "2025-09-14T22:16:35.277Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/e9cfd801a3f9190bf3e759c422bbfd2247db9d7f3d54a56ecde70137791a/zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072", size = 5559635, upload-time = "2025-09-14T22:16:37.141Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/5ba550f797ca953a52d708c8e4f380959e7e3280af029e38fbf47b55916e/zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277", size = 5048277, upload-time = "2025-09-14T22:16:38.807Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c0/ca3e533b4fa03112facbe7fbe7779cb1ebec215688e5df576fe5429172e0/zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313", size = 5574377, upload-time = "2025-09-14T22:16:40.523Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9b/3fb626390113f272abd0799fd677ea33d5fc3ec185e62e6be534493c4b60/zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097", size = 4961493, upload-time = "2025-09-14T22:16:43.3Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d3/23094a6b6a4b1343b27ae68249daa17ae0651fcfec9ed4de09d14b940285/zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778", size = 5269018, upload-time = "2025-09-14T22:16:45.292Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a7/bb5a0c1c0f3f4b5e9d5b55198e39de91e04ba7c205cc46fcb0f95f0383c1/zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065", size = 5443672, upload-time = "2025-09-14T22:16:47.076Z" },
+    { url = "https://files.pythonhosted.org/packages/27/22/503347aa08d073993f25109c36c8d9f029c7d5949198050962cb568dfa5e/zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa", size = 5822753, upload-time = "2025-09-14T22:16:49.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/be/94267dc6ee64f0f8ba2b2ae7c7a2df934a816baaa7291db9e1aa77394c3c/zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7", size = 5366047, upload-time = "2025-09-14T22:16:51.328Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/732893eab0a3a7aecff8b99052fecf9f605cf0fb5fb6d0290e36beee47a4/zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4", size = 436484, upload-time = "2025-09-14T22:16:55.005Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a3/c6155f5c1cce691cb80dfd38627046e50af3ee9ddc5d0b45b9b063bfb8c9/zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2", size = 506183, upload-time = "2025-09-14T22:16:52.753Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/8945ab86a0820cc0e0cdbf38086a92868a9172020fdab8a03ac19662b0e5/zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137", size = 462533, upload-time = "2025-09-14T22:16:53.878Z" },
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]


### PR DESCRIPTION
## Summary

- Replace the recursive deterministic executor and cursor-based tool scheduler with a direct Factory DSL → LangGraph compiler.
- Persist workflow threads in SQLite with exact workflow snapshots, interrupts/resume, operation receipts, and restart-safe state.
- Let LangGraph own conditional routing, fanout/fanin, reloops, HALT cleanup, and subgraph branch scheduling.
- Make LangGraph the default for `factory ceo`, `factory run`, tmux, and workflow commands; retain `--engine skill` as the explicit legacy fallback.

## Why

The existing execution paths implement overlapping scheduling semantics and disagree on gates, joins, background work, workflow reconstruction, and completion. Recent adversarial review found the following issues on upstream `main`.

### Directly addressed by this migration

- #1243 — user gates now create durable interrupts unless `--auto-approve` is explicit.
- #1244 — finalization projects persisted graph state and cannot move a cursor past unfinished nodes.
- #1245 — interactive resume reconstructs the exact Pydantic workflow snapshot; unknown node types are no longer converted to empty `FnNode`s.
- #1247 and #1251 — `blocking=False` no longer creates cancellable in-process background tasks. Nodes execute durably and failures surface through the graph runtime.
- #1249 — native LangGraph edges execute complete branch subgraphs instead of the old immediate-target traversal.
- #1189 — joins compile to multi-source LangGraph barriers and wait for all declared sources.

### Partially addressed or retained as explicit follow-ups

- #1242 — `AgentNode` artifacts are validated, but declared outputs are not yet universally verified for every node type.
- #1246 — recursive parent traversal is removed, but subgraph membership still uses reachability collection; the reported case remains latent in registered workflows.
- #1248 — selection is checkpointed and sequentially reproducible, but branch-result discovery remains heuristic. The old issue's “nondeterministic” wording is inaccurate.
- #1250 — gate state is now durable, but unrecognized evaluator vocabulary still falls through to `PROCEED`. This remains important because builtin prompts commonly emit `REDIRECT`, `PLAN APPROVED`, or `ABORT`.
- #1188 — join barrier semantics are fixed, but materializing arbitrary declared join outputs remains domain-specific.
- #1234 — shared mutable `.factory/` state in CEO worktrees is outside this execution-runtime migration and is not claimed fixed here.

## Runtime contract

- Checkpoints: `.factory/langgraph/checkpoints.sqlite`
- Thread snapshots: `.factory/langgraph/threads/<thread-id>.json`
- Side-effect receipts: `.factory/langgraph/receipts/<thread-id>/`
- Parallel interrupts resume by emitted interrupt ID.
- A started receipt without completion blocks automatic replay because the external side effect is ambiguous.
- Interrupted or failed graph worktrees are preserved; completed and terminal runs follow normal cleanup.

## Validation

- `ruff check`: passed.
- `mypy factory/`: passed across 228 source files.
- Hermetic suite: 5,259 passed, 12 skipped, 25 deselected.
- The unfiltered suite additionally contains environment-dependent LegacyBench tests requiring GNU `timeout` and marked slow tests that invoke authenticated external agents.
