### PR TITLE
fix: widen CycleState.mode from Literal to str for plugin modes

### DIFF
--- a/factory/models.py
+++ b/factory/models.py
@@ -491,24 +491,7 @@ class CycleState(BaseModel):
 
     cycle_id: str
     started_at: datetime
-    mode: Literal[
-        "build",
-        "create",
-        "deep-qa",
-        "deep-research",
-        "design",
-        "discover",
-        "founder",
-        "improve",
-        "meta",
-        "parallel-improve",
-        "qa",
-        "refine",
-        "research",
-        "review",
-        "study",
-        "swebench",
-    ]
+    mode: str
     initial_prompt: str = ""
     respawns: int = 0
     runner_name: str | None = None


### PR DESCRIPTION
Closes #1262

## Changes

- Changed `CycleState.mode` field from `Literal["build", "create", ...]` (16 hardcoded mode names) to `str`
- Plugin modes registered via `add_modes()` now pass Pydantic validation when headless mode creates a `CycleState`
- Model remains `strict=True` with `extra="forbid"` — only the `mode` field type is widened
- All 156 relevant tests pass, ruff and mypy clean