### PR TITLE
fix: add user-global tier to agent prompt resolution

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -5,27 +5,13 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Literal
 
 from factory.ace.injector import inject_playbook, load_playbook
 from factory.runners import get_runner
 
 logger = logging.getLogger(__name__)
 
-AgentRole = Literal[
-    "researcher",
-    "strategist",
-    "builder",
-    "health_checker",
-    "code_reviewer",
-    "adversarial_tester",
-    "archivist",
-    "ceo",
-    "failure_analyst",
-    "refiner",
-    "profiler",
-    "refactory",
-]
+AgentRole = str
 
 # Consecutive failure tracking
 _consecutive_failures: int = 0
@@ -62,6 +48,7 @@ IDENTITY_REANCHOR = """\
 
 # Directory containing base agent prompts (shipped with the factory)
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
+_USER_PROMPTS_DIR = Path.home() / ".factory" / "agents" / "prompts"
 
 
 def resolve_prompt(
@@ -75,7 +62,8 @@ def resolve_prompt(
 
     Resolution order:
     1. Project-specific override: <project>/.factory/agents/<role>.md
-    2. Factory default: factory/agents/prompts/<role>.md
+    2. User-global: ~/.factory/agents/prompts/<role>.md
+    3. Factory default: factory/agents/prompts/<role>.md
 
     When *use_profile* is True, loads ~/.factory/profile.md and appends it
     after the ACE playbook injection.
@@ -103,6 +91,21 @@ def resolve_prompt(
                 prompt = _maybe_inject_skill(prompt, project_path, workflow_mode)
             return prompt
 
+    # Check user-global prompts (~/.factory/agents/prompts/)
+    user_path = _USER_PROMPTS_DIR / f"{role}.md"
+    if user_path.exists():
+        logger.info("Using user-global prompt for %s: %s", role, user_path)
+        prompt = user_path.read_text()
+        playbook = load_playbook(role)
+        if playbook:
+            prompt = inject_playbook(prompt, playbook)
+            logger.info("Injected playbook for %s (user-global)", role)
+        if use_profile:
+            prompt = _maybe_inject_profile(prompt, role)
+        if role == "ceo" and workflow_mode and project_path is not None:
+            prompt = _maybe_inject_skill(prompt, project_path, workflow_mode)
+        return prompt
+
     # Fall back to factory default
     default_path = _PROMPTS_DIR / f"{role}.md"
     if not default_path.exists():
@@ -110,7 +113,8 @@ def resolve_prompt(
             f" or {project_path / '.factory' / 'agents' / f'{role}.md'}" if project_path else ""
         )
         raise FileNotFoundError(
-            f"No prompt found for agent role '{role}'. Expected at {default_path}{override_hint}"
+            f"No prompt found for agent role '{role}'. "
+            f"Expected at {default_path}, {_USER_PROMPTS_DIR / f'{role}.md'}{override_hint}"
         )
 
     prompt = default_path.read_text()

--- a/tests/test_refactory.py
+++ b/tests/test_refactory.py
@@ -6,7 +6,6 @@ import json
 import os
 import stat
 from pathlib import Path
-from typing import get_args
 from unittest.mock import patch
 
 import pytest
@@ -138,10 +137,10 @@ class TestSessionId:
 
 
 class TestAgentRegistration:
-    def test_refactory_role_in_agent_role(self) -> None:
+    def test_agent_role_accepts_any_string(self) -> None:
         from factory.agents.runner import AgentRole
 
-        assert "refactory" in get_args(AgentRole)
+        assert AgentRole is str
 
     def test_refactory_in_agents_yml(self) -> None:
         import yaml


### PR DESCRIPTION
Closes #1264

## Changes

- **Widen `AgentRole` from `Literal[...]` to `str`** so plugin-defined roles are accepted without hardcoding every possible value
- **Add user-global prompt tier** (`~/.factory/agents/prompts/<role>.md`) between project-local and factory default in `resolve_prompt()` — plugins that install agent prompts to this directory are now discoverable
- **Update error message** to mention the user-global path when no prompt is found
- **Update test** that asserted `AgentRole` was a `Literal` to verify it's now `str`