### PR TITLE
fix: plugin integration — 4 bugs blocking plugin modes and agents

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -5,27 +5,13 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Literal
 
 from factory.ace.injector import inject_playbook, load_playbook
 from factory.runners import get_runner
 
 logger = logging.getLogger(__name__)
 
-AgentRole = Literal[
-    "researcher",
-    "strategist",
-    "builder",
-    "health_checker",
-    "code_reviewer",
-    "adversarial_tester",
-    "archivist",
-    "ceo",
-    "failure_analyst",
-    "refiner",
-    "profiler",
-    "refactory",
-]
+AgentRole = str
 
 # Consecutive failure tracking
 _consecutive_failures: int = 0
@@ -62,6 +48,7 @@ IDENTITY_REANCHOR = """\
 
 # Directory containing base agent prompts (shipped with the factory)
 _PROMPTS_DIR = Path(__file__).parent / "prompts"
+_USER_PROMPTS_DIR = Path.home() / ".factory" / "agents" / "prompts"
 
 
 def resolve_prompt(
@@ -75,7 +62,8 @@ def resolve_prompt(
 
     Resolution order:
     1. Project-specific override: <project>/.factory/agents/<role>.md
-    2. Factory default: factory/agents/prompts/<role>.md
+    2. User-global: ~/.factory/agents/prompts/<role>.md
+    3. Factory default: factory/agents/prompts/<role>.md
 
     When *use_profile* is True, loads ~/.factory/profile.md and appends it
     after the ACE playbook injection.
@@ -103,6 +91,21 @@ def resolve_prompt(
                 prompt = _maybe_inject_skill(prompt, project_path, workflow_mode)
             return prompt
 
+    # Check user-global prompts (~/.factory/agents/prompts/)
+    user_path = _USER_PROMPTS_DIR / f"{role}.md"
+    if user_path.exists():
+        logger.info("Using user-global prompt for %s: %s", role, user_path)
+        prompt = user_path.read_text()
+        playbook = load_playbook(role)
+        if playbook:
+            prompt = inject_playbook(prompt, playbook)
+            logger.info("Injected playbook for %s (user-global)", role)
+        if use_profile:
+            prompt = _maybe_inject_profile(prompt, role)
+        if role == "ceo" and workflow_mode and project_path is not None:
+            prompt = _maybe_inject_skill(prompt, project_path, workflow_mode)
+        return prompt
+
     # Fall back to factory default
     default_path = _PROMPTS_DIR / f"{role}.md"
     if not default_path.exists():
@@ -110,7 +113,8 @@ def resolve_prompt(
             f" or {project_path / '.factory' / 'agents' / f'{role}.md'}" if project_path else ""
         )
         raise FileNotFoundError(
-            f"No prompt found for agent role '{role}'. Expected at {default_path}{override_hint}"
+            f"No prompt found for agent role '{role}'. "
+            f"Expected at {default_path}, {_USER_PROMPTS_DIR / f'{role}.md'}{override_hint}"
         )
 
     prompt = default_path.read_text()

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -213,6 +213,8 @@ def _cmd_plugins(args: argparse.Namespace) -> int:
         print(f"\nRegistered commands: {', '.join(sorted(registry.commands))}")
     if registry.modes:
         print(f"Registered modes: {', '.join(registry.modes)}")
+    if registry.agent_roles:
+        print(f"Registered agent roles: {', '.join(registry.agent_roles)}")
 
     return 0
 

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 
 import argparse
 
+BUILTIN_AGENT_ROLES: frozenset[str] = frozenset({
+    "researcher", "strategist", "builder",
+    "health_checker", "code_reviewer", "adversarial_tester",
+    "archivist", "ceo", "failure_analyst", "refiner",
+})
 
 
 def add_project_setup_parsers(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -334,11 +339,8 @@ def add_validation_recovery_parsers(sub: argparse._SubParsersAction) -> None:  #
 
 def add_entry_point_parsers(sub: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = sub.add_parser("agent", help="Invoke a specialist agent with a task")
-    p.add_argument("role", choices=["researcher", "strategist", "builder",
-                                     "health_checker", "code_reviewer", "adversarial_tester",
-                                     "archivist", "ceo",
-                                     "failure_analyst", "refiner"],
-                    help="Agent role to invoke")
+    p.add_argument("role",
+                    help="Agent role to invoke (built-in or plugin-registered)")
     p.add_argument("--task", required=True, help="Task description for the agent")
     p.add_argument("--project", required=True, help="Path to the project")
     p.add_argument("--timeout", type=float, default=600.0,

--- a/factory/cli/agents.py
+++ b/factory/cli/agents.py
@@ -158,12 +158,24 @@ def cmd_agent(args: argparse.Namespace) -> int:
     """Invoke a specialist agent with the given task."""
     from factory.agents.plugin import load_agent_config
     from factory.agents.runner import invoke_agent
+    from factory.cli._parser_groups import BUILTIN_AGENT_ROLES
+    from factory.plugins import get_registry
     from factory.user_config import load_config
 
     profile = getattr(args, "profile", None)
     load_config(profile=profile)
 
     role = args.role
+    plugin_roles = set(get_registry().agent_roles)
+    valid_roles = BUILTIN_AGENT_ROLES | plugin_roles
+    if role not in valid_roles:
+        print(
+            f"Error: unknown agent role '{role}'. "
+            f"Valid roles: {', '.join(sorted(valid_roles))}",
+            file=sys.stderr,
+        )
+        return 1
+
     task = args.task
     project_path = Path(args.project).resolve()
     timeout = getattr(args, "timeout", 600.0)

--- a/factory/models.py
+++ b/factory/models.py
@@ -491,24 +491,7 @@ class CycleState(BaseModel):
 
     cycle_id: str
     started_at: datetime
-    mode: Literal[
-        "build",
-        "create",
-        "deep-qa",
-        "deep-research",
-        "design",
-        "discover",
-        "founder",
-        "improve",
-        "meta",
-        "parallel-improve",
-        "qa",
-        "refine",
-        "research",
-        "review",
-        "study",
-        "swebench",
-    ]
+    mode: str
     initial_prompt: str = ""
     respawns: int = 0
     runner_name: str | None = None

--- a/factory/plugins.py
+++ b/factory/plugins.py
@@ -49,6 +49,7 @@ class PluginLoadResult:
 class PluginRegistry:
     commands: dict[str, CommandSpec] = field(default_factory=dict)
     modes: list[str] = field(default_factory=list)
+    agent_roles: list[str] = field(default_factory=list)
     ceo_pre_hooks: list[Callable[..., Any]] = field(default_factory=list)
     workflow_search_paths: list[str] = field(default_factory=list)
     parser_extensions: dict[str, list[Callable[[argparse.ArgumentParser], None]]] = field(
@@ -76,6 +77,18 @@ class PluginRegistry:
                 log.warning("plugin_mode_collision", mode=mode, action="keeping_first")
                 continue
             self.modes.append(mode)
+
+    def add_agent_roles(self, roles: list[str]) -> None:
+        from factory.cli._parser_groups import BUILTIN_AGENT_ROLES
+
+        for role in roles:
+            if role in BUILTIN_AGENT_ROLES:
+                log.warning("plugin_agent_role_collision_builtin", role=role, action="skipped")
+                continue
+            if role in self.agent_roles:
+                log.warning("plugin_agent_role_collision", role=role, action="keeping_first")
+                continue
+            self.agent_roles.append(role)
 
     def add_ceo_pre_hook(self, hook: Callable[..., Any]) -> None:
         self.ceo_pre_hooks.append(hook)

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -140,6 +140,16 @@ def create_worktree(
     if backlog_src.exists():
         shutil.copy2(backlog_src, wt_factory / "strategy" / "backlog.md")
 
+    # Copy remaining plugin-created subdirectories not already handled.
+    _handled = set(_SHARED_SYMLINK_ENTRIES) | set(_COPY_ENTRIES)
+    if factory_dir.is_dir():
+        for child in factory_dir.iterdir():
+            if child.name in _handled or not child.is_dir():
+                continue
+            dst = wt_factory / child.name
+            if not dst.exists():
+                shutil.copytree(child, dst)
+
     log.info("worktree_created", branch=branch, path=str(wt_dir))
 
     try:

--- a/tests/test_refactory.py
+++ b/tests/test_refactory.py
@@ -6,7 +6,6 @@ import json
 import os
 import stat
 from pathlib import Path
-from typing import get_args
 from unittest.mock import patch
 
 import pytest
@@ -138,10 +137,10 @@ class TestSessionId:
 
 
 class TestAgentRegistration:
-    def test_refactory_role_in_agent_role(self) -> None:
+    def test_agent_role_accepts_any_string(self) -> None:
         from factory.agents.runner import AgentRole
 
-        assert "refactory" in get_args(AgentRole)
+        assert AgentRole is str
 
     def test_refactory_in_agents_yml(self) -> None:
         import yaml


### PR DESCRIPTION
## Summary

Four bugs that collectively prevent plugin modes and plugin agent roles from working end-to-end. Each fix is an independent commit, stacked in dependency order.

### Commits (stacked)

1. **fix: widen CycleState.mode from Literal to str** (closes #1262)
   - `factory/models.py` — `CycleState.mode` was a strict `Literal` with hardcoded mode names. Plugin modes crashed Pydantic validation in `--headless` mode.

2. **fix: allow plugin-registered agent roles in factory agent CLI** (closes #1260)
   - `factory/cli/_parser_groups.py` — removed hardcoded `choices` from argparse; moved to dynamic validation in `cmd_agent`
   - `factory/plugins.py` — added `add_agent_roles()` API to `PluginRegistry`
   - `factory/cli/agents.py` — validates role against builtin + plugin-registered roles at runtime
   - `factory/cli/_main.py` — `factory plugins` now shows registered agent roles

3. **fix: carry plugin-created .factory/ subdirs into worktrees** (closes #1263)
   - `factory/worktree.py` — after handling `_SHARED_SYMLINK_ENTRIES` and `_COPY_ENTRIES`, iterates remaining `.factory/` subdirectories and copies them to the worktree

4. **fix: add user-global tier to agent prompt resolution** (closes #1264)
   - `factory/agents/runner.py` — added `~/.factory/agents/prompts/<role>.md` as tier 2 (between project-local and factory default). Widened `AgentRole` from `Literal` to `str`

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `mypy` passes on all changed files
- [x] All 4 commits cherry-pick cleanly onto main
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)