### PR TITLE
feat: FeatureBench gate/reloop restructuring — deterministic pytest/spec-compliance checks

### DIFF
--- a/factory/workflow/contributed/featurebench/test_workflow.py
+++ b/factory/workflow/contributed/featurebench/test_workflow.py
@@ -62,15 +62,17 @@ class TestFeaturebenchWorkflow:
         assert "cross-file" in node.prompt_template.lower()
 
     def test_gate_verify_is_fn_evaluator(self) -> None:
-        """Gate uses fn evaluator (not agent) for speed and determinism."""
+        """Gate uses fn evaluator with deterministic pytest execution."""
         wf = workflow()
         node = wf.nodes["gate_verify"]
         assert isinstance(node, GateNode)
         assert node.evaluator_type == "fn"
         assert node.evaluator_command is not None
-        assert "pass:" in node.evaluator_command
-        assert "reloop:" in node.evaluator_command
-        assert "fail:" in node.evaluator_command
+        assert "PROCEED" in node.evaluator_command
+        assert "RELOOP" in node.evaluator_command
+        assert "HALT" in node.evaluator_command
+        assert "pytest" in node.evaluator_command
+        assert "git diff" in node.evaluator_command
 
     def test_auto_merge_node(self) -> None:
         wf = workflow()
@@ -177,3 +179,45 @@ class TestFeaturebenchMeta:
 
     def test_meta_has_description(self) -> None:
         assert "featurebench" in meta["description"].lower() or "FeatureBench" in meta["description"]
+
+
+class TestGateVerifyDeterministic:
+    """Tests for the deterministic pytest-based gate_verify."""
+
+    def test_gate_no_resolved_grep(self) -> None:
+        """Gate does NOT grep for RESOLVED — uses pytest directly."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_command is not None
+        assert "RESOLVED" not in node.evaluator_command
+
+    def test_gate_runs_pytest_for_l1(self) -> None:
+        """Gate runs pytest when test files exist (L1 path)."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert node.evaluator_command is not None
+        assert "pytest" in node.evaluator_command
+        assert "test_*.py" in node.evaluator_command
+
+    def test_gate_accepts_commit_without_tests(self) -> None:
+        """Gate PROCEEDs when no test files found (L2 path)."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert node.evaluator_command is not None
+        assert "no test files found" in node.evaluator_command
+
+    def test_gate_halts_on_no_commits(self) -> None:
+        """Gate HALTs when builder didn't commit."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert node.evaluator_command is not None
+        assert "HALT" in node.evaluator_command
+        assert "did not commit" in node.evaluator_command
+
+    def test_gate_always_exits_zero(self) -> None:
+        """Gate command uses exit 0 (not non-zero) to avoid RuntimeError in executor."""
+        wf = workflow()
+        node = wf.nodes["gate_verify"]
+        assert node.evaluator_command is not None
+        assert "exit 0" in node.evaluator_command

--- a/factory/workflow/contributed/featurebench/workflow.py
+++ b/factory/workflow/contributed/featurebench/workflow.py
@@ -136,16 +136,15 @@ def workflow() -> Workflow:
             "cd {project_path} && "
             "CHANGES=$(git diff HEAD~1 --stat 2>/dev/null || echo 'NO_COMMITS') && "
             "if [ \"$CHANGES\" = 'NO_COMMITS' ] || [ -z \"$CHANGES\" ]; then "
-            "echo 'fail: builder did not commit any changes'; "
+            "echo 'HALT: builder did not commit any changes'; "
             "exit 0; fi && "
-            "BUILDER_OUTPUT=$(cat .factory/reviews/builder-latest.md 2>/dev/null || echo '') && "
-            "if echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(pass|succeed|ok|PASSED)'; then "
-            "echo 'pass: builder reports tests passing'; "
-            "elif echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(fail|error|FAILED)'; then "
-            "echo 'reloop: builder needs to retry — tests did not pass'; "
+            "TEST_FILES=$(find . -name 'test_*.py' -o -name '*_test.py' 2>/dev/null | head -1) && "
+            "if [ -n \"$TEST_FILES\" ]; then "
+            "conda run -n testbed pytest . -x --tb=short 2>&1 && "
+            "echo 'PROCEED' || "
+            "echo 'RELOOP: pytest failed'; "
             "else "
-            "echo 'pass: changes committed, no issues detected'; "
-            "fi"
+            "echo 'PROCEED: no test files found, accepting commit'; fi"
         ),
         reads={".factory/reviews/builder-latest.md"},
     )

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -84,12 +84,14 @@ class WorkflowExecutor:
         *,
         dry_run: bool = False,
         auto_approve: bool = False,
+        context: dict[str, str] | None = None,
     ) -> None:
         self.workflow = workflow
         self.project_path = project_path
         self.agent_pool = agent_pool or {}
         self.dry_run = dry_run
         self.auto_approve = auto_approve
+        self.context: dict[str, str] = context or {}
         self.run_id = uuid.uuid4().hex[:12]
         self.completed_files: set[str] = set()
         self.node_context: dict[str, str] = {}
@@ -99,6 +101,13 @@ class WorkflowExecutor:
         self._edge_index: dict[str, list[Edge]] = {}
         for edge in workflow.edges:
             self._edge_index.setdefault(edge.source, []).append(edge)
+
+    def _expand_templates(self, text: str) -> str:
+        """Replace {project_path} and any context variables in template strings."""
+        result = text.replace("{project_path}", shlex.quote(str(self.project_path)))
+        for key, value in self.context.items():
+            result = result.replace(f"{{{key}}}", shlex.quote(value))
+        return result
 
     async def execute(self) -> ExecutionResult:
         """Run the workflow from start to completion."""
@@ -808,7 +817,7 @@ class WorkflowExecutor:
         """Run a FnNode's shell command."""
         if not node.command:
             return ""
-        cmd = node.command.replace("{project_path}", shlex.quote(str(self.project_path)))
+        cmd = self._expand_templates(node.command)
         return await self._run_shell(cmd)
 
     async def _run_agent(self, node: AgentNode) -> str:
@@ -887,9 +896,7 @@ class WorkflowExecutor:
 
         if node.evaluator_type == "fn":
             if node.evaluator_command:
-                cmd = node.evaluator_command.replace(
-                    "{project_path}", shlex.quote(str(self.project_path)),
-                )
+                cmd = self._expand_templates(node.evaluator_command)
                 try:
                     output = await self._run_shell(cmd)
                     return self._parse_fn_verdict(output, node.id)
@@ -920,9 +927,7 @@ class WorkflowExecutor:
     def _build_gate_prompt(self, node: GateNode) -> str:
         """Build the lightweight CEO gate prompt."""
         if node.gate_prompt:
-            return node.gate_prompt.replace(
-                "{project_path}", str(self.project_path),
-            )
+            return self._expand_templates(node.gate_prompt)
 
         output_files = sorted(node.reads) if node.reads else ["(no specific file)"]
         context = self.node_context.get(node.id, "none")
@@ -995,8 +1000,12 @@ class WorkflowExecutor:
             pass
 
         first_line = text.split("\n")[0].strip().lower()
-        if first_line.startswith("pass"):
+        if first_line.startswith("pass") or first_line.startswith("proceed"):
             return Verdict.proceed()
+        if first_line.startswith("halt"):
+            raw_line = text.split("\n")[0].strip()
+            after_prefix = raw_line.split(":", 1)[1].strip() if ":" in raw_line else ""
+            return Verdict.halt(reason=after_prefix if after_prefix else "gate halted")
         if first_line.startswith("fail") or first_line.startswith("revert"):
             return Verdict.halt(reason=f"precheck failed: {text[:200]}")
         if first_line.startswith("reloop"):

--- a/tests/test_executor_context.py
+++ b/tests/test_executor_context.py
@@ -204,6 +204,34 @@ class TestHostGateIntegration:
         content = fb_path.read_text()
         assert "SPEC_COMPLIANCE: PASS" in content
 
+    def test_host_gate_no_broken_pytest_rc_capture(self) -> None:
+        """gate_tests L1 path must not use $(cmd) && PYTEST_RC=$? pattern.
+
+        That pattern short-circuits on pytest failure: the $() returns
+        non-zero, && skips PYTEST_RC=$?, RELOOP never fires, and the
+        overall command exits non-zero causing _run_shell to raise.
+        """
+        fb_path = Path(__file__).parents[3] / ".factory" / "workflows" / "featurebench.py"
+        if not fb_path.exists():
+            pytest.skip("Host featurebench workflow not found")
+        content = fb_path.read_text()
+        # Extract the gate_tests evaluator_command block
+        lines = content.split("\n")
+        in_gate = False
+        gate_lines = []
+        for line in lines:
+            if "gate_tests" in line and "GateNode" in line:
+                in_gate = True
+            elif in_gate:
+                gate_lines.append(line)
+                if line.strip().startswith(")") and not line.strip().startswith("'"):
+                    break
+        gate_text = "\n".join(gate_lines)
+        assert "PYTEST_RC" not in gate_text, (
+            "gate_tests must not capture PYTEST_RC with && — "
+            "use 'cmd && echo PROCEED || echo RELOOP' pattern instead"
+        )
+
     def test_host_health_checker_no_resolved(self) -> None:
         """Health checker prompt does NOT instruct writing RESOLVED."""
         fb_path = Path(__file__).parents[3] / ".factory" / "workflows" / "featurebench.py"

--- a/tests/test_executor_context.py
+++ b/tests/test_executor_context.py
@@ -1,0 +1,215 @@
+"""Tests for WorkflowExecutor context template expansion and gate verdict parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from factory.workflow.executor import WorkflowExecutor
+from factory.workflow.primitives import (
+    Edge,
+    FnNode,
+    GateNode,
+    VerdictType,
+    Workflow,
+)
+
+
+def _make_executor(
+    tmp_path: Path,
+    nodes: dict | None = None,
+    edges: list | None = None,
+    context: dict[str, str] | None = None,
+) -> WorkflowExecutor:
+    """Build a minimal WorkflowExecutor for testing."""
+    if nodes is None:
+        nodes = {
+            "start": FnNode(id="start", command="echo hello"),
+        }
+    if edges is None:
+        edges = []
+    wf = Workflow(
+        name="test",
+        nodes=nodes,
+        edges=edges,
+        start_node="start",
+    )
+    return WorkflowExecutor(wf, tmp_path, dry_run=True, context=context)
+
+
+class TestExpandTemplates:
+    """Tests for _expand_templates method."""
+
+    def test_replaces_project_path(self, tmp_path: Path) -> None:
+        ex = _make_executor(tmp_path)
+        result = ex._expand_templates("cd {project_path}")
+        assert str(tmp_path) in result
+        assert "{project_path}" not in result
+
+    def test_replaces_context_variables(self, tmp_path: Path) -> None:
+        ex = _make_executor(tmp_path, context={"container_name": "fb-test-123"})
+        result = ex._expand_templates("docker exec {container_name} bash")
+        assert "fb-test-123" in result
+        assert "{container_name}" not in result
+
+    def test_replaces_multiple_context_variables(self, tmp_path: Path) -> None:
+        ex = _make_executor(
+            tmp_path, context={"container_name": "ctr", "image": "img:latest"}
+        )
+        result = ex._expand_templates("{container_name} and {image}")
+        assert "ctr" in result
+        assert "img:latest" in result
+
+    def test_no_context_leaves_unknown_placeholders(self, tmp_path: Path) -> None:
+        ex = _make_executor(tmp_path)
+        result = ex._expand_templates("{unknown_var}")
+        assert "{unknown_var}" in result
+
+    def test_empty_context(self, tmp_path: Path) -> None:
+        ex = _make_executor(tmp_path, context={})
+        result = ex._expand_templates("{project_path}/foo")
+        assert str(tmp_path) in result
+
+    def test_quotes_values_with_spaces(self, tmp_path: Path) -> None:
+        ex = _make_executor(tmp_path, context={"name": "has space"})
+        result = ex._expand_templates("{name}")
+        assert "has space" in result
+
+
+class TestParseFnVerdictReloop:
+    """Tests for _parse_fn_verdict handling RELOOP outputs."""
+
+    def test_reloop_on_pytest_failed(self, tmp_path: Path) -> None:
+        """Gate outputs 'RELOOP: pytest failed' → Verdict is RELOOP."""
+        gate = GateNode(id="gate", evaluator_type="fn")
+        nodes = {
+            "start": FnNode(id="start", command="echo hello"),
+            "builder": FnNode(id="builder", command="echo build"),
+            "gate": gate,
+        }
+        edges = [
+            Edge(source="start", target="builder"),
+            Edge(source="builder", target="gate"),
+            Edge(source="gate", target="builder", condition=VerdictType.RELOOP),
+        ]
+        ex = _make_executor(tmp_path, nodes=nodes, edges=edges)
+
+        output = "RELOOP: pytest failed\n===== 3 failed, 2 passed =====\n"
+        verdict = ex._parse_fn_verdict(output, "gate")
+        assert verdict.type == VerdictType.RELOOP
+        assert verdict.target == "builder"
+        assert "pytest failed" in (verdict.feedback or "")
+
+    def test_reloop_on_spec_compliance_fail(self, tmp_path: Path) -> None:
+        """Gate outputs 'RELOOP: spec compliance check failed' → RELOOP."""
+        gate = GateNode(id="gate", evaluator_type="fn")
+        nodes = {
+            "start": FnNode(id="start", command="echo hello"),
+            "builder": FnNode(id="builder", command="echo build"),
+            "gate": gate,
+        }
+        edges = [
+            Edge(source="start", target="builder"),
+            Edge(source="builder", target="gate"),
+            Edge(source="gate", target="builder", condition=VerdictType.RELOOP),
+        ]
+        ex = _make_executor(tmp_path, nodes=nodes, edges=edges)
+
+        output = "RELOOP: spec compliance check failed\n"
+        verdict = ex._parse_fn_verdict(output, "gate")
+        assert verdict.type == VerdictType.RELOOP
+        assert verdict.target == "builder"
+
+    def test_proceed_on_tests_pass(self, tmp_path: Path) -> None:
+        """Gate outputs 'PROCEED' → Verdict is PROCEED."""
+        ex = _make_executor(tmp_path)
+        output = "PROCEED\n"
+        verdict = ex._parse_fn_verdict(output, "gate")
+        assert verdict.type == VerdictType.PROCEED
+
+    def test_proceed_on_spec_compliance_pass(self, tmp_path: Path) -> None:
+        """Multi-line output starting with PROCEED → PROCEED."""
+        ex = _make_executor(tmp_path)
+        output = "PROCEED\nall checks passed\n"
+        verdict = ex._parse_fn_verdict(output, "gate")
+        assert verdict.type == VerdictType.PROCEED
+
+    def test_halt_on_no_commits(self, tmp_path: Path) -> None:
+        """Gate outputs 'HALT: ...' → Verdict is HALT."""
+        ex = _make_executor(tmp_path)
+        output = "HALT: builder did not commit any changes\n"
+        verdict = ex._parse_fn_verdict(output, "gate")
+        assert verdict.type == VerdictType.HALT
+
+
+class TestExecutorContextInit:
+    """Tests for context parameter initialization."""
+
+    def test_default_context_is_empty(self, tmp_path: Path) -> None:
+        ex = _make_executor(tmp_path)
+        assert ex.context == {}
+
+    def test_context_stored(self, tmp_path: Path) -> None:
+        ctx = {"container_name": "test-ctr", "foo": "bar"}
+        ex = _make_executor(tmp_path, context=ctx)
+        assert ex.context == ctx
+
+    def test_none_context_becomes_empty_dict(self, tmp_path: Path) -> None:
+        ex = _make_executor(tmp_path, context=None)
+        assert ex.context == {}
+
+
+class TestHostGateIntegration:
+    """Integration tests for the host-side featurebench gate (gate_tests)."""
+
+    def test_host_gate_has_container_name_placeholder(self) -> None:
+        """gate_tests evaluator_command uses {container_name}."""
+        import sys
+        sys.path.insert(0, str(Path(__file__).parents[3]))
+        # Read the featurebench.py workflow file to check its structure
+        fb_path = Path(__file__).parents[3] / ".factory" / "workflows" / "featurebench.py"
+        if not fb_path.exists():
+            pytest.skip("Host featurebench workflow not found")
+        content = fb_path.read_text()
+        assert "{container_name}" in content
+        assert "docker exec" in content
+
+    def test_host_gate_no_resolved_grep(self) -> None:
+        """Host gate does NOT grep for RESOLVED."""
+        fb_path = Path(__file__).parents[3] / ".factory" / "workflows" / "featurebench.py"
+        if not fb_path.exists():
+            pytest.skip("Host featurebench workflow not found")
+        content = fb_path.read_text()
+        # The gate_tests evaluator_command should not contain 'RESOLVED'
+        # (only the L2 fallback greps for SPEC_COMPLIANCE)
+        lines = content.split("\n")
+        in_gate = False
+        gate_lines = []
+        for line in lines:
+            if "gate_tests" in line and "GateNode" in line:
+                in_gate = True
+            elif in_gate:
+                gate_lines.append(line)
+                if line.strip().startswith(")") and not line.strip().startswith("'"):
+                    break
+        gate_text = "\n".join(gate_lines)
+        assert "RESOLVED" not in gate_text
+
+    def test_host_gate_spec_compliance_l2_path(self) -> None:
+        """Host gate checks SPEC_COMPLIANCE for L2 (no test files)."""
+        fb_path = Path(__file__).parents[3] / ".factory" / "workflows" / "featurebench.py"
+        if not fb_path.exists():
+            pytest.skip("Host featurebench workflow not found")
+        content = fb_path.read_text()
+        assert "SPEC_COMPLIANCE: PASS" in content
+
+    def test_host_health_checker_no_resolved(self) -> None:
+        """Health checker prompt does NOT instruct writing RESOLVED."""
+        fb_path = Path(__file__).parents[3] / ".factory" / "workflows" / "featurebench.py"
+        if not fb_path.exists():
+            pytest.skip("Host featurebench workflow not found")
+        content = fb_path.read_text()
+        # Find the health_checker prompt_template
+        # It should contain "DO NOT write RESOLVED"
+        assert "DO NOT write RESOLVED" in content


### PR DESCRIPTION
## Changes

- **Executor context expansion**: Added `context: dict[str, str]` parameter to `WorkflowExecutor.__init__()` and `_expand_templates()` helper that replaces `{project_path}` and any context variables (e.g. `{container_name}`) in gate evaluator commands, FnNode commands, and gate prompts. Replaces the inline `.replace('{project_path}', ...)` calls with the centralized helper.

- **Host gate_tests (`.factory/workflows/featurebench.py`)**: Replaced broken `grep 'RESOLVED: true'` gate with a two-path evaluator:
  - **L1** (test files exist): runs `docker exec {container_name} bash -c 'conda run -n testbed pytest /testbed -x --tb=short'` — pytest exit code is the sole authority
  - **L2** (no test files): checks health_checker's `SPEC_COMPLIANCE: PASS` marker

- **Health checker prompt**: Removed all RESOLVED verdict responsibility. Now provides diagnostic feedback only — failed test names, stack traces, root cause analysis for L1; programmatic spec-compliance validation for L2.

- **Contributed workflow gate_verify**: Replaced fragile grep-on-builder-output with deterministic pytest execution (runs inside container, no docker exec needed).

- **`_parse_fn_verdict` enhancement**: Added `halt`/`proceed` keyword recognition so gates can use `HALT:` and `PROCEED` consistently.

- **Tests**: 18 new tests covering context expansion, verdict parsing (RELOOP/PROCEED/HALT), and gate structure validation.

## Why

The health_checker LLM writes wrong RESOLVED verdicts — for L2 tasks (no test files) the agent runs its own smoke tests and writes RESOLVED:true; for L1 tasks the agent dismisses failures as "pre-existing" and writes RESOLVED:true. This makes the RELOOP iteration loop completely dead. The fix removes the LLM from the verdict path entirely.