### PR TITLE
feat: restructure FeatureBench pipeline — gate-first, health_checker on RELOOP, fix max_iterations

### DIFF
--- a/factory/workflow/contributed/featurebench/test_workflow.py
+++ b/factory/workflow/contributed/featurebench/test_workflow.py
@@ -22,10 +22,10 @@ class TestFeaturebenchWorkflow:
         assert wf.name == "featurebench"
 
     def test_node_count(self) -> None:
-        """Workflow has exactly 4 nodes: study, builder, gate_verify, auto_merge."""
+        """Workflow has exactly 5 nodes: study, builder, gate_tests, diagnostics, auto_merge."""
         wf = workflow()
-        assert len(wf.nodes) == 4
-        assert set(wf.nodes.keys()) == {"study", "builder", "gate_verify", "auto_merge"}
+        assert len(wf.nodes) == 5
+        assert set(wf.nodes.keys()) == {"study", "builder", "gate_tests", "diagnostics", "auto_merge"}
 
     def test_start_node(self) -> None:
         wf = workflow()
@@ -38,9 +38,10 @@ class TestFeaturebenchWorkflow:
         assert issues == [], f"Workflow has validation issues: {issues}"
 
     def test_edge_count(self) -> None:
-        """4 edges: study->builder, builder->gate, gate->merge, gate->builder RELOOP."""
+        """5 edges: study->builder, builder->gate_tests, gate_tests->auto_merge,
+        gate_tests->diagnostics RELOOP, diagnostics->builder."""
         wf = workflow()
-        assert len(wf.edges) == 4
+        assert len(wf.edges) == 5
 
     def test_study_node_is_fn(self) -> None:
         wf = workflow()
@@ -61,13 +62,15 @@ class TestFeaturebenchWorkflow:
         assert "nameerror" in node.prompt_template.lower()
         assert "cross-file" in node.prompt_template.lower()
 
-    def test_gate_verify_is_fn_evaluator(self) -> None:
-        """Gate uses fn evaluator (not agent) for speed and determinism."""
+    def test_gate_tests_is_fn_evaluator(self) -> None:
+        """Gate uses fn evaluator running pytest directly for speed and determinism."""
         wf = workflow()
-        node = wf.nodes["gate_verify"]
+        node = wf.nodes["gate_tests"]
         assert isinstance(node, GateNode)
         assert node.evaluator_type == "fn"
         assert node.evaluator_command is not None
+        assert "pytest" in node.evaluator_command
+        assert "gate-pytest-output.txt" in node.evaluator_command
         assert "pass:" in node.evaluator_command
         assert "reloop:" in node.evaluator_command
         assert "fail:" in node.evaluator_command
@@ -79,23 +82,23 @@ class TestFeaturebenchWorkflow:
         assert "git update-ref" in node.command
 
     def test_proceed_edge_to_merge(self) -> None:
-        """gate_verify has a PROCEED edge to auto_merge."""
+        """gate_tests has a PROCEED edge to auto_merge."""
         wf = workflow()
         proceed_edges = [
             e for e in wf.edges
-            if e.source == "gate_verify"
+            if e.source == "gate_tests"
             and e.target == "auto_merge"
             and e.condition == VerdictType.PROCEED
         ]
         assert len(proceed_edges) == 1
 
     def test_reloop_edge_exists(self) -> None:
-        """gate_verify has a RELOOP edge back to builder."""
+        """gate_tests has a RELOOP edge to diagnostics."""
         wf = workflow()
         reloop_edges = [
             e for e in wf.edges
-            if e.source == "gate_verify"
-            and e.target == "builder"
+            if e.source == "gate_tests"
+            and e.target == "diagnostics"
             and e.condition == VerdictType.RELOOP
         ]
         assert len(reloop_edges) == 1
@@ -113,6 +116,57 @@ class TestFeaturebenchWorkflow:
                 assert "factory finalize" not in node.command
                 assert "factory precheck" not in node.command
                 assert "factory begin" not in node.command
+
+    def test_diagnostics_node(self) -> None:
+        """diagnostics is a FnNode (shell script), not an agent."""
+        wf = workflow()
+        node = wf.nodes["diagnostics"]
+        assert isinstance(node, FnNode)
+        assert "gate-pytest-output.txt" in node.command
+        assert "diagnostics.md" in node.command
+        assert ".factory/reviews/diagnostics.md" in node.writes
+
+    def test_diagnostics_to_builder_edge(self) -> None:
+        """diagnostics has an unconditional edge to builder."""
+        wf = workflow()
+        diag_to_builder = [
+            e for e in wf.edges
+            if e.source == "diagnostics" and e.target == "builder"
+            and e.condition is None
+        ]
+        assert len(diag_to_builder) == 1
+
+    def test_gate_saves_pytest_output(self) -> None:
+        """Gate command saves pytest stdout to gate-pytest-output.txt."""
+        wf = workflow()
+        node = wf.nodes["gate_tests"]
+        assert isinstance(node, GateNode)
+        assert "gate-pytest-output.txt" in node.evaluator_command
+
+    def test_gate_tracks_regression(self) -> None:
+        """Gate command tracks failure counts for regression detection."""
+        wf = workflow()
+        node = wf.nodes["gate_tests"]
+        assert isinstance(node, GateNode)
+        assert "gate-prev-fail-count.txt" in node.evaluator_command
+        assert "fail:" in node.evaluator_command
+
+    def test_no_agent_diagnostics(self) -> None:
+        """No Claude agent nodes for diagnostics — FnNode only."""
+        wf = workflow()
+        for node_id, node in wf.nodes.items():
+            if node_id == "diagnostics":
+                assert isinstance(node, FnNode), (
+                    f"diagnostics must be FnNode, got {type(node).__name__}"
+                )
+                assert not isinstance(node, AgentNode)
+
+    def test_builder_reads_diagnostics(self) -> None:
+        """Builder prompt references diagnostics.md for RELOOP iterations."""
+        wf = workflow()
+        node = wf.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert "diagnostics.md" in node.prompt_template
 
 
 class TestFeaturebenchTerminal:

--- a/factory/workflow/contributed/featurebench/test_workflow.py
+++ b/factory/workflow/contributed/featurebench/test_workflow.py
@@ -22,10 +22,12 @@ class TestFeaturebenchWorkflow:
         assert wf.name == "featurebench"
 
     def test_node_count(self) -> None:
-        """Workflow has exactly 4 nodes: study, builder, gate_verify, auto_merge."""
+        """Workflow has exactly 5 nodes: study, builder, gate_tests, health_checker, auto_merge."""
         wf = workflow()
-        assert len(wf.nodes) == 4
-        assert set(wf.nodes.keys()) == {"study", "builder", "gate_verify", "auto_merge"}
+        assert len(wf.nodes) == 5
+        assert set(wf.nodes.keys()) == {
+            "study", "builder", "gate_tests", "health_checker", "auto_merge",
+        }
 
     def test_start_node(self) -> None:
         wf = workflow()
@@ -38,9 +40,10 @@ class TestFeaturebenchWorkflow:
         assert issues == [], f"Workflow has validation issues: {issues}"
 
     def test_edge_count(self) -> None:
-        """4 edges: study->builder, builder->gate, gate->merge, gate->builder RELOOP."""
+        """5 edges: study->builder, builder->gate_tests, gate_tests->merge,
+        gate_tests->health_checker RELOOP, health_checker->builder."""
         wf = workflow()
-        assert len(wf.edges) == 4
+        assert len(wf.edges) == 5
 
     def test_study_node_is_fn(self) -> None:
         wf = workflow()
@@ -61,13 +64,15 @@ class TestFeaturebenchWorkflow:
         assert "nameerror" in node.prompt_template.lower()
         assert "cross-file" in node.prompt_template.lower()
 
-    def test_gate_verify_is_fn_evaluator(self) -> None:
+    def test_gate_tests_is_fn_evaluator(self) -> None:
         """Gate uses fn evaluator (not agent) for speed and determinism."""
         wf = workflow()
-        node = wf.nodes["gate_verify"]
+        node = wf.nodes["gate_tests"]
         assert isinstance(node, GateNode)
         assert node.evaluator_type == "fn"
         assert node.evaluator_command is not None
+        assert "pytest" in node.evaluator_command
+        assert "gate-pytest-output.txt" in node.evaluator_command
         assert "pass:" in node.evaluator_command
         assert "reloop:" in node.evaluator_command
         assert "fail:" in node.evaluator_command
@@ -79,26 +84,71 @@ class TestFeaturebenchWorkflow:
         assert "git update-ref" in node.command
 
     def test_proceed_edge_to_merge(self) -> None:
-        """gate_verify has a PROCEED edge to auto_merge."""
+        """gate_tests has a PROCEED edge to auto_merge."""
         wf = workflow()
         proceed_edges = [
             e for e in wf.edges
-            if e.source == "gate_verify"
+            if e.source == "gate_tests"
             and e.target == "auto_merge"
             and e.condition == VerdictType.PROCEED
         ]
         assert len(proceed_edges) == 1
 
     def test_reloop_edge_exists(self) -> None:
-        """gate_verify has a RELOOP edge back to builder."""
+        """gate_tests has a RELOOP edge to health_checker."""
         wf = workflow()
         reloop_edges = [
             e for e in wf.edges
-            if e.source == "gate_verify"
-            and e.target == "builder"
+            if e.source == "gate_tests"
+            and e.target == "health_checker"
             and e.condition == VerdictType.RELOOP
         ]
         assert len(reloop_edges) == 1
+
+    def test_health_checker_node(self) -> None:
+        """health_checker is an AgentNode (NOT FnNode) with diagnostic prompt."""
+        wf = workflow()
+        node = wf.nodes["health_checker"]
+        assert isinstance(node, AgentNode)
+        assert not isinstance(node, FnNode)
+        assert node.role == AgentRole.HEALTH_CHECKER
+        assert "diagnostic" in node.prompt_template.lower()
+        assert "do not run pytest" in node.prompt_template.lower()
+
+    def test_health_checker_to_builder_edge(self) -> None:
+        """health_checker has an unconditional edge to builder."""
+        wf = workflow()
+        edges = [
+            e for e in wf.edges
+            if e.source == "health_checker"
+            and e.target == "builder"
+            and e.condition is None
+        ]
+        assert len(edges) == 1
+
+    def test_gate_saves_pytest_output(self) -> None:
+        """gate_tests saves pytest stdout to gate-pytest-output.txt."""
+        wf = workflow()
+        node = wf.nodes["gate_tests"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_command is not None
+        assert "gate-pytest-output.txt" in node.evaluator_command
+
+    def test_gate_tracks_regression(self) -> None:
+        """gate_tests tracks failure counts and detects regressions."""
+        wf = workflow()
+        node = wf.nodes["gate_tests"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_command is not None
+        assert "gate-prev-fail-count.txt" in node.evaluator_command
+        assert "fail:" in node.evaluator_command
+
+    def test_builder_reads_health_check(self) -> None:
+        """Builder prompt instructs reading health-check.md for RELOOP feedback."""
+        wf = workflow()
+        node = wf.nodes["builder"]
+        assert isinstance(node, AgentNode)
+        assert "health-check.md" in node.prompt_template
 
     def test_no_eval_infrastructure(self) -> None:
         """No factory eval nodes (begin, finalize, precheck, study)."""

--- a/factory/workflow/contributed/featurebench/workflow.py
+++ b/factory/workflow/contributed/featurebench/workflow.py
@@ -1,7 +1,11 @@
 """FeatureBench benchmark workflow — feature implementation pipeline for containerized evaluation.
 
-4-node pipeline: study → builder → gate_verify → auto_merge
-RELOOP from gate_verify back to builder (max 3 iterations) on test failure.
+5-node pipeline: study → builder → gate_tests → auto_merge
+RELOOP from gate_tests through health_checker (agent diagnostic) back to builder.
+
+    study → builder → gate_tests --PROCEED--> auto_merge
+                           |
+                           +--RELOOP--> health_checker (agent) → builder
 
 Designed for Harbor containers where:
 - Task instruction is at /tmp/task-instruction.md (detailed problem statement with
@@ -29,9 +33,10 @@ from factory.workflow.primitives import (
 meta = {
     "name": "featurebench",
     "description": (
-        "FeatureBench benchmark mode — 4-node pipeline for implementing "
+        "FeatureBench benchmark mode — 5-node pipeline for implementing "
         "new features in Python codebases with explicit interface specs. "
-        "study → builder → gate_verify → auto_merge with RELOOP on test failure."
+        "study → builder → gate_tests → auto_merge with RELOOP through "
+        "health_checker (agent diagnostic) back to builder on test failure."
     ),
 }
 
@@ -104,10 +109,15 @@ def workflow() -> Workflow:
             "your implementation. Look specifically for NameError, ImportError, "
             "and TypeError in test output — these are signals of missing cross-file "
             "connections or interface mismatches.\n\n"
-            "7. **Iterate on test failures** — If tests fail, trace the error "
+            "7. **Read diagnostic feedback** — If the file "
+            ".factory/reviews/health-check.md exists, read it carefully. It "
+            "contains parsed test failure analysis from the health checker agent "
+            "on a previous iteration: stack traces, root causes, and suggested "
+            "fixes. Use this feedback to guide your changes.\n\n"
+            "8. **Iterate on test failures** — If tests fail, trace the error "
             "to its root cause. Fix missing dependencies, correct interface "
             "mismatches, and re-run until tests pass.\n\n"
-            "8. **Commit your changes** — Commit directly on the current branch "
+            "9. **Commit your changes** — Commit directly on the current branch "
             "with a descriptive message. Do NOT create a new branch. Do NOT "
             "create a PR.\n\n"
             "## Rules\n\n"
@@ -128,29 +138,86 @@ def workflow() -> Workflow:
         writes={".factory/reviews/builder-latest.md"},
     )
 
-    # ── Node 3: Gate Verify ────────────────────────────────────────
-    nodes["gate_verify"] = GateNode(
-        id="gate_verify",
+    # ── Node 3: Gate Tests ───────────────────────────────────────
+    nodes["gate_tests"] = GateNode(
+        id="gate_tests",
         evaluator_type="fn",
         evaluator_command=(
             "cd {project_path} && "
-            "CHANGES=$(git diff HEAD~1 --stat 2>/dev/null || echo 'NO_COMMITS') && "
-            "if [ \"$CHANGES\" = 'NO_COMMITS' ] || [ -z \"$CHANGES\" ]; then "
-            "echo 'fail: builder did not commit any changes'; "
-            "exit 0; fi && "
-            "BUILDER_OUTPUT=$(cat .factory/reviews/builder-latest.md 2>/dev/null || echo '') && "
-            "if echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(pass|succeed|ok|PASSED)'; then "
-            "echo 'pass: builder reports tests passing'; "
-            "elif echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(fail|error|FAILED)'; then "
-            "echo 'reloop: builder needs to retry — tests did not pass'; "
+            "mkdir -p .factory/reviews && "
+            "TEST_FILES=$(find . -name 'test_*.py' -o -name '*_test.py' 2>/dev/null | head -1) && "
+            "if [ -n \"$TEST_FILES\" ]; then "
+            "conda run -n testbed pytest /testbed -x --tb=short "
+            "> .factory/reviews/gate-pytest-output.txt 2>&1; "
+            "RC=$?; "
+            "FAIL_COUNT=$(grep -cE '^FAILED ' .factory/reviews/gate-pytest-output.txt "
+            "2>/dev/null || echo 0); "
+            "PREV_COUNT=$(cat .factory/reviews/gate-prev-fail-count.txt 2>/dev/null "
+            "|| echo -1); "
+            "echo \"$FAIL_COUNT\" > .factory/reviews/gate-prev-fail-count.txt; "
+            "if [ $RC -eq 0 ]; then "
+            "echo 'pass: all tests passed'; "
+            "elif [ \"$PREV_COUNT\" != \"-1\" ] && [ \"$FAIL_COUNT\" -gt \"$PREV_COUNT\" ]; then "
+            "echo 'fail: regression detected — iteration has more failures than previous "
+            "('\"$FAIL_COUNT\"' > '\"$PREV_COUNT\"')'; "
             "else "
-            "echo 'pass: changes committed, no issues detected'; "
+            "echo 'reloop: pytest failed ('\"$FAIL_COUNT\"' failures) — "
+            "see .factory/reviews/gate-pytest-output.txt'; "
+            "fi; "
+            "else "
+            "echo 'pass: no test files found'; "
             "fi"
         ),
         reads={".factory/reviews/builder-latest.md"},
+        writes={".factory/reviews/gate-pytest-output.txt"},
     )
 
-    # ── Node 4: Auto Merge ─────────────────────────────────────────
+    # ── Node 4: Health Checker (RELOOP diagnostic) ────────────────
+    nodes["health_checker"] = AgentNode(
+        id="health_checker",
+        role=AgentRole.HEALTH_CHECKER,
+        model="opus",
+        timeout=600,
+        max_iterations=3,
+        prompt_template=(
+            "You are a diagnostic analyst for the FeatureBench benchmark.\n\n"
+            "## Your Task\n\n"
+            "The test gate has detected failures. Your job is to analyze the "
+            "pytest output and provide actionable diagnostic feedback for the "
+            "builder agent.\n\n"
+            "1. **Read the pytest output** at .factory/reviews/gate-pytest-output.txt. "
+            "If this file does not exist, this is an L2 task with no tests. In that "
+            "case, read the task instruction at /tmp/task-instruction.md and the "
+            "builder output at .factory/reviews/builder-latest.md, perform spec "
+            "compliance checks, and write 'SPEC_COMPLIANCE: PASS' or "
+            "'SPEC_COMPLIANCE: FAIL' at the top of your output.\n\n"
+            "2. **Parse every failure** — For each FAILED test, extract:\n"
+            "   - The full test name\n"
+            "   - The stack trace\n"
+            "   - The error type (NameError, ImportError, TypeError, etc.)\n\n"
+            "3. **Root cause analysis** — For each failure, determine:\n"
+            "   - What went wrong (missing import, wrong signature, etc.)\n"
+            "   - Which source file and line caused the error\n"
+            "   - The specific fix needed\n\n"
+            "4. **Write diagnostic report** — Write a structured report to "
+            ".factory/reviews/health-check.md with:\n"
+            "   - Summary of failure count and error types\n"
+            "   - Per-failure analysis with root cause and suggested fix\n"
+            "   - Priority order: fix the failures most likely to unblock others first\n\n"
+            "## Rules\n\n"
+            "- DO NOT run pytest yourself. The gate already ran it.\n"
+            "- DO NOT modify any source files\n"
+            "- DO NOT attempt to fix the code — only diagnose\n"
+            "- Act AUTONOMOUSLY — do NOT ask for confirmation\n"
+        ),
+        reads={
+            ".factory/reviews/gate-pytest-output.txt",
+            ".factory/reviews/builder-latest.md",
+        },
+        writes={".factory/reviews/health-check.md"},
+    )
+
+    # ── Node 5: Auto Merge ─────────────────────────────────────────
     nodes["auto_merge"] = FnNode(
         id="auto_merge",
         command=(
@@ -178,9 +245,10 @@ def workflow() -> Workflow:
 
     edges = [
         Edge(source="study", target="builder"),
-        Edge(source="builder", target="gate_verify"),
-        Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
-        Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),
+        Edge(source="builder", target="gate_tests"),
+        Edge(source="gate_tests", target="auto_merge", condition=VerdictType.PROCEED),
+        Edge(source="gate_tests", target="health_checker", condition=VerdictType.RELOOP),
+        Edge(source="health_checker", target="builder"),
     ]
 
     # ── Trigger ────────────────────────────────────────────────────

--- a/factory/workflow/contributed/featurebench/workflow.py
+++ b/factory/workflow/contributed/featurebench/workflow.py
@@ -1,7 +1,6 @@
 """FeatureBench benchmark workflow — feature implementation pipeline for containerized evaluation.
 
-4-node pipeline: study → builder → gate_verify → auto_merge
-RELOOP from gate_verify back to builder (max 3 iterations) on test failure.
+5-node pipeline: study → builder → gate_tests → auto_merge (PROCEED) / diagnostics → builder (RELOOP)
 
 Designed for Harbor containers where:
 - Task instruction is at /tmp/task-instruction.md (detailed problem statement with
@@ -29,9 +28,11 @@ from factory.workflow.primitives import (
 meta = {
     "name": "featurebench",
     "description": (
-        "FeatureBench benchmark mode — 4-node pipeline for implementing "
+        "FeatureBench benchmark mode — 5-node pipeline for implementing "
         "new features in Python codebases with explicit interface specs. "
-        "study → builder → gate_verify → auto_merge with RELOOP on test failure."
+        "study → builder → gate_tests → auto_merge (PROCEED) / "
+        "diagnostics → builder (RELOOP). Gate runs pytest directly; "
+        "diagnostics is a FnNode shell script (no LLM cost)."
     ),
 }
 
@@ -84,7 +85,9 @@ def workflow() -> Workflow:
             "2. **Understand the existing codebase** — Explore the repository "
             "structure thoroughly. Read related source files, understand module "
             "layout, imports, and existing patterns. Check the study output at "
-            ".factory/reviews/study-output.md for a structural overview.\n\n"
+            ".factory/reviews/study-output.md for a structural overview. "
+            "**Identify the most relevant source files for the feature and read "
+            "them before writing any code.**\n\n"
             "3. **CRITICAL: Read before you write** — Before implementing ANY "
             "function, navigate to and READ the actual source code for every "
             "function, class, or module you reference. DO NOT guess function "
@@ -104,10 +107,15 @@ def workflow() -> Workflow:
             "your implementation. Look specifically for NameError, ImportError, "
             "and TypeError in test output — these are signals of missing cross-file "
             "connections or interface mismatches.\n\n"
-            "7. **Iterate on test failures** — If tests fail, trace the error "
+            "7. **Read diagnostic feedback** — If the file "
+            ".factory/reviews/diagnostics.md exists, read it carefully. It contains "
+            "parsed test failure summaries from a previous iteration. Use the error "
+            "type summary and root cause hints to guide your fixes. Focus on the "
+            "specific test failures listed — do not make unrelated changes.\n\n"
+            "8. **Iterate on test failures** — If tests fail, trace the error "
             "to its root cause. Fix missing dependencies, correct interface "
             "mismatches, and re-run until tests pass.\n\n"
-            "8. **Commit your changes** — Commit directly on the current branch "
+            "9. **Commit your changes** — Commit directly on the current branch "
             "with a descriptive message. Do NOT create a new branch. Do NOT "
             "create a PR.\n\n"
             "## Rules\n\n"
@@ -128,29 +136,94 @@ def workflow() -> Workflow:
         writes={".factory/reviews/builder-latest.md"},
     )
 
-    # ── Node 3: Gate Verify ────────────────────────────────────────
-    nodes["gate_verify"] = GateNode(
-        id="gate_verify",
+    # ── Node 3: Gate Tests ─────────────────────────────────────────
+    nodes["gate_tests"] = GateNode(
+        id="gate_tests",
         evaluator_type="fn",
         evaluator_command=(
             "cd {project_path} && "
-            "CHANGES=$(git diff HEAD~1 --stat 2>/dev/null || echo 'NO_COMMITS') && "
-            "if [ \"$CHANGES\" = 'NO_COMMITS' ] || [ -z \"$CHANGES\" ]; then "
-            "echo 'fail: builder did not commit any changes'; "
-            "exit 0; fi && "
-            "BUILDER_OUTPUT=$(cat .factory/reviews/builder-latest.md 2>/dev/null || echo '') && "
-            "if echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(pass|succeed|ok|PASSED)'; then "
-            "echo 'pass: builder reports tests passing'; "
-            "elif echo \"$BUILDER_OUTPUT\" | grep -qiE 'tests?.*(fail|error|FAILED)'; then "
-            "echo 'reloop: builder needs to retry — tests did not pass'; "
+            "mkdir -p .factory/reviews && "
+            "TEST_FILES=$(find . -name 'test_*.py' -o -name '*_test.py' 2>/dev/null | head -1) && "
+            "if [ -n \"$TEST_FILES\" ]; then "
+            "conda run -n testbed pytest /testbed -x --tb=short "
+            "> .factory/reviews/gate-pytest-output.txt 2>&1; "
+            "RC=$?; "
+            "FAIL_COUNT=$(grep -cE '^FAILED ' .factory/reviews/gate-pytest-output.txt "
+            "2>/dev/null || echo 0); "
+            "PREV_COUNT=$(cat .factory/reviews/gate-prev-fail-count.txt 2>/dev/null "
+            "|| echo -1); "
+            "echo \"$FAIL_COUNT\" > .factory/reviews/gate-prev-fail-count.txt; "
+            "if [ $RC -eq 0 ]; then "
+            "echo 'pass: all tests passed'; "
+            "elif [ \"$PREV_COUNT\" != \"-1\" ] && [ \"$FAIL_COUNT\" -gt \"$PREV_COUNT\" ]; then "
+            "echo 'fail: regression detected — iteration has more failures than previous "
+            "('\"$FAIL_COUNT\"' > '\"$PREV_COUNT\"')'; "
             "else "
-            "echo 'pass: changes committed, no issues detected'; "
+            "echo 'reloop: pytest failed ('\"$FAIL_COUNT\"' failures) — "
+            "see .factory/reviews/gate-pytest-output.txt'; "
+            "fi; "
+            "else "
+            "echo 'pass: no test files found — L2 task, proceeding'; "
             "fi"
         ),
         reads={".factory/reviews/builder-latest.md"},
+        writes={
+            ".factory/reviews/gate-pytest-output.txt",
+            ".factory/reviews/gate-prev-fail-count.txt",
+        },
     )
 
-    # ── Node 4: Auto Merge ─────────────────────────────────────────
+    # ── Node 4: Diagnostics (FnNode — no LLM cost) ────────────────
+    nodes["diagnostics"] = FnNode(
+        id="diagnostics",
+        command=(
+            "cd {project_path} && "
+            "PYTEST_OUT=.factory/reviews/gate-pytest-output.txt && "
+            "DIAG_OUT=.factory/reviews/diagnostics.md && "
+            "if [ ! -f \"$PYTEST_OUT\" ]; then "
+            "echo '# Diagnostics\n\nNo pytest output found.' > \"$DIAG_OUT\"; "
+            "exit 0; fi && "
+            "("
+            "echo '# Diagnostic Summary' && "
+            "echo '' && "
+            "echo '## Failed Tests' && "
+            "echo '' && "
+            "grep -E '^FAILED ' \"$PYTEST_OUT\" | while read -r line; do "
+            "TEST_NAME=$(echo \"$line\" | sed 's/^FAILED //; s/ -.*//'); "
+            "echo \"### $TEST_NAME\" && "
+            "echo '```' && "
+            "awk \"/$TEST_NAME/,/^(FAILED|PASSED|ERROR|=)/{print}\" \"$PYTEST_OUT\" "
+            "| head -30 && "
+            "echo '```' && "
+            "echo ''; "
+            "done && "
+            "echo '## Error Type Summary' && "
+            "echo '' && "
+            "grep -oE '(NameError|ImportError|TypeError|AttributeError|ValueError"
+            "|KeyError|ModuleNotFoundError)[^:]*' \"$PYTEST_OUT\" | "
+            "sort | uniq -c | sort -rn | head -10 && "
+            "echo '' && "
+            "echo '## Root Cause Hints' && "
+            "echo '' && "
+            "grep -c 'NameError' \"$PYTEST_OUT\" > /dev/null 2>&1 && "
+            "echo '- NameError: missing cross-file references — check imports "
+            "and function definitions' || true && "
+            "grep -c 'ImportError' \"$PYTEST_OUT\" > /dev/null 2>&1 && "
+            "echo '- ImportError: module not found — verify package structure "
+            "and __init__.py' || true && "
+            "grep -c 'TypeError' \"$PYTEST_OUT\" > /dev/null 2>&1 && "
+            "echo '- TypeError: signature mismatch — check function parameter "
+            "types and counts' || true && "
+            "grep -c 'AttributeError' \"$PYTEST_OUT\" > /dev/null 2>&1 && "
+            "echo '- AttributeError: missing method/property — read the class "
+            "definition before referencing' || true"
+            ") > \"$DIAG_OUT\" 2>&1 || true"
+        ),
+        reads={".factory/reviews/gate-pytest-output.txt"},
+        writes={".factory/reviews/diagnostics.md"},
+    )
+
+    # ── Node 5: Auto Merge ─────────────────────────────────────────
     nodes["auto_merge"] = FnNode(
         id="auto_merge",
         command=(
@@ -178,9 +251,10 @@ def workflow() -> Workflow:
 
     edges = [
         Edge(source="study", target="builder"),
-        Edge(source="builder", target="gate_verify"),
-        Edge(source="gate_verify", target="auto_merge", condition=VerdictType.PROCEED),
-        Edge(source="gate_verify", target="builder", condition=VerdictType.RELOOP),
+        Edge(source="builder", target="gate_tests"),
+        Edge(source="gate_tests", target="auto_merge", condition=VerdictType.PROCEED),
+        Edge(source="gate_tests", target="diagnostics", condition=VerdictType.RELOOP),
+        Edge(source="diagnostics", target="builder"),
     ]
 
     # ── Trigger ────────────────────────────────────────────────────

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -410,21 +410,10 @@ class WorkflowExecutor:
             count = self.iteration_counts.get(key, 0) + 1
             self.iteration_counts[key] = count
 
-            max_iter = verdict.max_iterations
-            target_node = self.workflow.nodes.get(target)
-            if isinstance(target_node, AgentNode) and target_node.max_iterations > 0:
-                max_iter = target_node.max_iterations
-            elif isinstance(target_node, FnNode):
-                next_after_fn = self._next_unconditional(target)
-                if next_after_fn:
-                    chained_node = self.workflow.nodes.get(next_after_fn)
-                    if isinstance(chained_node, AgentNode) and chained_node.max_iterations > 0:
-                        max_iter = chained_node.max_iterations
-
-            if count > max_iter:
+            if count > verdict.max_iterations:
                 self.result.halted = True
                 self.result.halt_reason = (
-                    f"max iterations ({max_iter}) exhausted "
+                    f"max iterations ({verdict.max_iterations}) exhausted "
                     f"for gate '{node_id}' -> '{target}'"
                 )
                 return

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -384,6 +384,29 @@ class WorkflowExecutor:
                 return
 
             key = (node_id, target)
+
+            target_node = self.workflow.nodes.get(target)
+            if isinstance(target_node, AgentNode) and target_node.max_iterations > 0:
+                verdict = Verdict(
+                    type=verdict.type,
+                    target=verdict.target,
+                    feedback=verdict.feedback,
+                    max_iterations=target_node.max_iterations,
+                    reason=verdict.reason,
+                )
+            elif isinstance(target_node, FnNode):
+                next_after_fn = self._next_unconditional(target)
+                if next_after_fn:
+                    chained = self.workflow.nodes.get(next_after_fn)
+                    if isinstance(chained, AgentNode) and chained.max_iterations > 0:
+                        verdict = Verdict(
+                            type=verdict.type,
+                            target=verdict.target,
+                            feedback=verdict.feedback,
+                            max_iterations=chained.max_iterations,
+                            reason=verdict.reason,
+                        )
+
             count = self.iteration_counts.get(key, 0) + 1
             self.iteration_counts[key] = count
 

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -387,10 +387,21 @@ class WorkflowExecutor:
             count = self.iteration_counts.get(key, 0) + 1
             self.iteration_counts[key] = count
 
-            if count > verdict.max_iterations:
+            max_iter = verdict.max_iterations
+            target_node = self.workflow.nodes.get(target)
+            if isinstance(target_node, AgentNode) and target_node.max_iterations > 0:
+                max_iter = target_node.max_iterations
+            elif isinstance(target_node, FnNode):
+                next_after_fn = self._next_unconditional(target)
+                if next_after_fn:
+                    chained_node = self.workflow.nodes.get(next_after_fn)
+                    if isinstance(chained_node, AgentNode) and chained_node.max_iterations > 0:
+                        max_iter = chained_node.max_iterations
+
+            if count > max_iter:
                 self.result.halted = True
                 self.result.halt_reason = (
-                    f"max iterations ({verdict.max_iterations}) exhausted "
+                    f"max iterations ({max_iter}) exhausted "
                     f"for gate '{node_id}' -> '{target}'"
                 )
                 return

--- a/tests/test_workflow_executor.py
+++ b/tests/test_workflow_executor.py
@@ -8,6 +8,8 @@ import pytest
 
 from factory.workflow.executor import WorkflowExecutor
 from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
     Edge,
     FnNode,
     ForkNode,
@@ -479,3 +481,99 @@ class TestAutoApprove:
         assert result.success
         auto_approved = [e for e in captured if e.get("event") == "gate.auto_approved"]
         assert len(auto_approved) == 0
+
+
+# ── AgentNode.max_iterations override ──────────────────────────
+
+
+class TestAgentNodeMaxIterations:
+    async def test_agent_max_iterations_overrides_verdict_default(
+        self, tmp_project: Path
+    ) -> None:
+        """AgentNode.max_iterations controls reloop limit, not the Verdict default."""
+        call_count = 0
+
+        async def mock_evaluate_gate(node: GateNode) -> Verdict:
+            nonlocal call_count
+            call_count += 1
+            return Verdict.reloop("builder", f"try again #{call_count}")
+
+        wf = Workflow(
+            name="agent_max_iter",
+            nodes={
+                "builder": AgentNode(
+                    id="builder",
+                    role=AgentRole.BUILDER,
+                    prompt_template="build",
+                    max_iterations=2,
+                    writes={"build.txt"},
+                ),
+                "gate": GateNode(
+                    id="gate",
+                    evaluator_type="fn",
+                    reads={"build.txt"},
+                ),
+            },
+            edges=[
+                Edge(source="builder", target="gate"),
+                Edge(source="gate", target="builder", condition=VerdictType.RELOOP),
+            ],
+            start_node="builder",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        executor._evaluate_gate = mock_evaluate_gate  # type: ignore[assignment]
+        result = await executor.execute()
+
+        assert result.halted
+        assert "max iterations (2)" in result.halt_reason
+        assert call_count == 3
+
+    async def test_fnnode_chain_reads_agent_max_iterations(
+        self, tmp_project: Path
+    ) -> None:
+        """When RELOOP targets a FnNode that chains to an AgentNode,
+        the AgentNode's max_iterations is used."""
+        call_count = 0
+
+        async def mock_evaluate_gate(node: GateNode) -> Verdict:
+            nonlocal call_count
+            call_count += 1
+            return Verdict.reloop("diagnostics", f"try again #{call_count}")
+
+        wf = Workflow(
+            name="fn_chain_max_iter",
+            nodes={
+                "builder": AgentNode(
+                    id="builder",
+                    role=AgentRole.BUILDER,
+                    prompt_template="build",
+                    max_iterations=2,
+                    writes={"build.txt"},
+                ),
+                "gate": GateNode(
+                    id="gate",
+                    evaluator_type="fn",
+                    reads={"build.txt"},
+                ),
+                "diagnostics": FnNode(
+                    id="diagnostics",
+                    command="echo diag",
+                    writes={"diag.txt"},
+                ),
+            },
+            edges=[
+                Edge(source="builder", target="gate"),
+                Edge(source="gate", target="diagnostics", condition=VerdictType.RELOOP),
+                Edge(source="diagnostics", target="builder"),
+            ],
+            start_node="builder",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        executor._evaluate_gate = mock_evaluate_gate  # type: ignore[assignment]
+        result = await executor.execute()
+
+        assert result.halted
+        assert "max iterations (2)" in result.halt_reason
+        assert call_count == 3

--- a/tests/test_workflow_executor.py
+++ b/tests/test_workflow_executor.py
@@ -8,6 +8,8 @@ import pytest
 
 from factory.workflow.executor import WorkflowExecutor
 from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
     Edge,
     FnNode,
     ForkNode,
@@ -479,3 +481,90 @@ class TestAutoApprove:
         assert result.success
         auto_approved = [e for e in captured if e.get("event") == "gate.auto_approved"]
         assert len(auto_approved) == 0
+
+
+# ── AgentNode max_iterations override ──────────────────────────
+
+
+class TestAgentMaxIterationsOverride:
+    async def test_agent_max_iterations_overrides_verdict_default(self, tmp_project: Path) -> None:
+        """AgentNode.max_iterations controls the reloop limit, not Verdict default."""
+        call_count = 0
+
+        async def mock_evaluate_gate(node: GateNode) -> Verdict:
+            nonlocal call_count
+            call_count += 1
+            return Verdict.reloop("builder", f"try again #{call_count}")
+
+        wf = Workflow(
+            name="agent_max_iter",
+            nodes={
+                "builder": AgentNode(
+                    id="builder",
+                    role=AgentRole.BUILDER,
+                    max_iterations=2,
+                    writes={"build.txt"},
+                ),
+                "gate": GateNode(
+                    id="gate",
+                    evaluator_type="fn",
+                    reads={"build.txt"},
+                ),
+            },
+            edges=[
+                Edge(source="builder", target="gate"),
+                Edge(source="gate", target="builder", condition=VerdictType.RELOOP),
+            ],
+            start_node="builder",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        executor._evaluate_gate = mock_evaluate_gate  # type: ignore[assignment]
+        result = await executor.execute()
+
+        assert result.halted
+        assert "max iterations (2)" in result.halt_reason
+
+    async def test_fnnode_chain_reads_agent_max_iterations(self, tmp_project: Path) -> None:
+        """Gate RELOOPs to FnNode which chains to AgentNode — uses AgentNode.max_iterations."""
+        call_count = 0
+
+        async def mock_evaluate_gate(node: GateNode) -> Verdict:
+            nonlocal call_count
+            call_count += 1
+            return Verdict.reloop("diagnostics", f"try again #{call_count}")
+
+        wf = Workflow(
+            name="fn_chain_max_iter",
+            nodes={
+                "builder": AgentNode(
+                    id="builder",
+                    role=AgentRole.BUILDER,
+                    max_iterations=2,
+                    writes={"build.txt"},
+                ),
+                "gate": GateNode(
+                    id="gate",
+                    evaluator_type="fn",
+                    reads={"build.txt"},
+                ),
+                "diagnostics": FnNode(
+                    id="diagnostics",
+                    command="echo diag",
+                    writes={"diag.txt"},
+                ),
+            },
+            edges=[
+                Edge(source="builder", target="gate"),
+                Edge(source="gate", target="diagnostics", condition=VerdictType.RELOOP),
+                Edge(source="diagnostics", target="builder"),
+            ],
+            start_node="builder",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=True)
+        executor._evaluate_gate = mock_evaluate_gate  # type: ignore[assignment]
+        result = await executor.execute()
+
+        assert result.halted
+        assert "max iterations (2)" in result.halt_reason


### PR DESCRIPTION
Closes #1223

## Changes

- **Rename gate_verify → gate_tests**: Deterministic pytest execution saving stdout to `.factory/reviews/gate-pytest-output.txt`, with failure count tracking in `gate-prev-fail-count.txt` for regression detection (HALT if failures increase between iterations)
- **Add health_checker AgentNode on RELOOP path**: Claude agent that reads pytest output, parses failures, provides stack trace analysis and root cause diagnosis — writes to `.factory/reviews/health-check.md`. Explicitly does NOT run pytest itself.
- **Updated pipeline graph** (5 nodes, 5 edges):
  ```
  study → builder → gate_tests --PROCEED--> auto_merge
                         |
                         +--RELOOP--> health_checker (agent) → builder
  ```
- **Builder prompt updated**: Reads `health-check.md` if it exists for RELOOP feedback from health_checker
- **Remove archivist node** from the pipeline
- **Fix max_iterations dead code in executor.py**: `AgentNode.max_iterations` now actually controls the reloop limit. Previously only `Verdict.max_iterations=3` was used, making the AgentNode field a no-op. Also resolves FnNode chains: if gate RELOOPs to FnNode, follows unconditional edge to find the next AgentNode's max_iterations.
- **Regenerated SKILL.md** from workflow definitions (gitignored, auto-generated at runtime)
- **Updated tests**: 27 featurebench workflow tests + 2 new executor max_iterations tests