### PR TITLE
fix: thread --focus through study subgraph and skill export (#1291)

### DIFF
--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -45,6 +45,7 @@ __all__ = [
     "DOC_FRESHNESS_GATE_PROMPT",
     "ResearcherConfig",
     "_GRAPH_EXPLORER_PROMPT",
+    "_graph_explorer_prompt",
     "_research_subgraph",
     "_study_subgraph",
     "build_workflow",
@@ -115,7 +116,34 @@ _GRAPH_EXPLORER_PROMPT = (
 )
 
 
-def _study_subgraph() -> tuple[dict[str, Any], list[Edge]]:
+def _graph_explorer_prompt(focus: str | None = None) -> str:
+    """Return the graph_explorer prompt, optionally scoped to *focus*."""
+    if not focus:
+        return _GRAPH_EXPLORER_PROMPT
+    return (
+        f"Focus your exploration on: {focus}\n\n"
+        "Explore the project's code knowledge graph targeting the area above. "
+        "Read .factory/strategy/observations.md for additional context.\n\n"
+        "If graphify is installed and graph.json exists:\n"
+        f'1. Run `factory graph query "{focus}" --depth 2` to find relevant nodes\n'
+        '2. Run `factory graph explain "<key node>"` on the most important nodes to understand '
+        "their connections and dependencies\n"
+        '3. Run `factory graph path "<A>" "<B>"` to trace dependency paths between key components\n'
+        "4. Write structured findings to .factory/strategy/graph-context.md covering: "
+        "key modules and their relationships, dependency paths, architectural layers, "
+        "entry points and hotspots\n\n"
+        "If graphify is NOT installed or graph.json is missing, fall back to direct file exploration:\n"
+        "1. Use `find . -name '*.py' | head -50` to discover source files\n"
+        "2. Use `grep -rn 'class \\|def ' --include='*.py' | head -100` to map functions and classes\n"
+        "3. Use `grep -rn 'import ' --include='*.py' | head -100` to trace dependencies\n"
+        "4. Write the same structured findings to .factory/strategy/graph-context.md"
+    )
+
+
+def _study_subgraph(
+    *,
+    focus: str | None = None,
+) -> tuple[dict[str, Any], list[Edge]]:
     """Return (nodes, internal_edges) for the graph-powered study chain.
 
     Four nodes run sequentially:
@@ -138,12 +166,13 @@ def _study_subgraph() -> tuple[dict[str, Any], list[Edge]]:
         id="study",
         command="factory study {project_path}",
         writes={".factory/strategy/observations.md"},
+        focus=focus,
     )
 
     nodes["graph_explorer"] = AgentNode(
         id="graph_explorer",
         role=AgentRole.RESEARCHER,
-        prompt_template=_GRAPH_EXPLORER_PROMPT,
+        prompt_template=_graph_explorer_prompt(focus),
         reads={".factory/strategy/observations.md"},
         writes={".factory/strategy/graph-context.md"},
     )
@@ -4393,9 +4422,7 @@ def parallel_improve_workflow() -> Workflow:
         [
             Edge(source="exp_begin", target="exp_builder"),
             Edge(source="exp_builder", target="exp_gate_build"),
-            Edge(
-                source="exp_gate_build", target="exp_fork_qa", condition=VerdictType.PROCEED
-            ),
+            Edge(source="exp_gate_build", target="exp_fork_qa", condition=VerdictType.PROCEED),
             Edge(source="exp_gate_build", target="exp_builder", condition=VerdictType.RELOOP),
             *exp_dq_edges,
             Edge(source="exp_join_qa", target="exp_gate_qa"),

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -538,11 +538,20 @@ def _study_to_instruction(node: Study, workflow: Workflow) -> str:
         f"<!-- edges: {edges_str} -->",
     ]
 
+    focus_hint = ""
+    if not node.focus:
+        focus_hint = (
+            "\n\nIf your task includes a focus directive or focus topic, "
+            "pass it to the study command:\n"
+            '`factory study $PROJECT_PATH --focus "<your focus topic>"`'
+        )
+
     return (
         "\n".join(annotations) + "\n\n"
         f"Run local study to gather observations:\n\n"
         f"```bash\n{cmd}{focus}\n```\n\n"
         f"Writes observations to `.factory/strategy/observations.md`."
+        f"{focus_hint}"
     )
 
 

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -22,6 +22,7 @@ from factory.workflow.skill_export import (
     _fn_to_instruction,
     _fork_to_instruction,
     _gate_to_checkpoint,
+    _study_to_instruction,  # noqa: F401
     export_all_skills,
     validate_skill,
     workflow_to_skill_md,
@@ -151,7 +152,9 @@ class TestFnToInstruction:
         assert "<!-- node: FnNode id=fn_eval" in result
 
     def test_template_placeholder_gets_slot(self) -> None:
-        fn = FnNode(id="fn_finalize", command="factory review --verdict $VERDICT --project {project_path}")
+        fn = FnNode(
+            id="fn_finalize", command="factory review --verdict $VERDICT --project {project_path}"
+        )
         wf = _minimal_workflow(nodes={"fn_finalize": fn}, start="fn_finalize")
         result = _fn_to_instruction(fn, wf)
         assert "{{finalize_command_fn_finalize::" in result
@@ -175,7 +178,8 @@ class TestFnToInstruction:
         result = _fn_to_instruction(fn, wf)
         lines_before_bash = result.split("```bash")[0]
         non_annotation_lines = [
-            line for line in lines_before_bash.strip().split("\n")
+            line
+            for line in lines_before_bash.strip().split("\n")
             if line.strip() and not line.strip().startswith("<!--")
         ]
         assert non_annotation_lines == [], "Empty notes should produce no prose before bash block"
@@ -420,8 +424,12 @@ class TestWorkflowToSkillMd:
         lines = result.split("\n")
         phase_lines = [line for line in lines if line.startswith("## Phase")]
         phase_titles = [line.lower() for line in phase_lines]
-        researcher_standalone = [t for t in phase_titles if "researcher" in t and "parallel" not in t]
-        assert len(researcher_standalone) == 0, "Fork targets should not appear as standalone phases"
+        researcher_standalone = [
+            t for t in phase_titles if "researcher" in t and "parallel" not in t
+        ]
+        assert len(researcher_standalone) == 0, (
+            "Fork targets should not appear as standalone phases"
+        )
 
     def test_study_node_generates_observe_phase(self) -> None:
         study = Study(
@@ -471,10 +479,10 @@ class TestExportAllSkills:
 class TestValidateSkill:
     def test_valid_skill_no_issues(self) -> None:
         content = (
-            '---\nname: workflow-build\n'
+            "---\nname: workflow-build\n"
             'description: "Build things."\n'
-            'disable-model-invocation: true\n'
-            '---\n\n# Build\nDo stuff.\n'
+            "disable-model-invocation: true\n"
+            "---\n\n# Build\nDo stuff.\n"
         )
         assert validate_skill(content) == []
 
@@ -575,13 +583,9 @@ def _workflows_with_builder() -> list[str]:
         if wf.terminal:
             continue
         has_builder = any(
-            isinstance(n, AgentNode) and n.role == AgentRole.BUILDER
-            for n in wf.nodes.values()
+            isinstance(n, AgentNode) and n.role == AgentRole.BUILDER for n in wf.nodes.values()
         )
-        has_subgraph_fork = any(
-            isinstance(n, SubgraphForkNode)
-            for n in wf.nodes.values()
-        )
+        has_subgraph_fork = any(isinstance(n, SubgraphForkNode) for n in wf.nodes.values())
         if has_builder and not has_subgraph_fork:
             names.append(name)
     return sorted(names)
@@ -602,3 +606,29 @@ class TestSkillQaEnforcement:
             f"workflow-{workflow_name} SKILL.md is missing any QA agent invocation "
             f"(health_checker, code_reviewer, or adversarial_tester)"
         )
+
+
+# ── _study_to_instruction focus threading ──────────────────────
+
+
+class TestStudyToInstructionFocus:
+    def test_with_focus(self) -> None:
+        study = Study(
+            id="study",
+            command="factory study {project_path}",
+            focus="auth",
+        )
+        wf = _minimal_workflow(nodes={"study": study}, start="study")
+        result = _study_to_instruction(study, wf)
+        assert '--focus "auth"' in result
+
+    def test_without_focus_has_ceo_hint(self) -> None:
+        study = Study(
+            id="study",
+            command="factory study {project_path}",
+        )
+        wf = _minimal_workflow(nodes={"study": study}, start="study")
+        result = _study_to_instruction(study, wf)
+        assert '--focus "auth"' not in result
+        assert "focus directive" in result
+        assert '--focus "<your focus topic>"' in result

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -9,6 +9,9 @@ import pytest
 from factory.models import ProjectState
 from factory.workflow.definitions import (
     DOC_FRESHNESS_GATE_PROMPT,
+    _GRAPH_EXPLORER_PROMPT,  # noqa: F401
+    _graph_explorer_prompt,  # noqa: F401
+    _study_subgraph,  # noqa: F401
     build_workflow,
     create_workflow,
     design_workflow,
@@ -1070,3 +1073,30 @@ class TestFounderWorkflow:
         issues = validate_skill(skill_md)
         assert issues == [], f"founder skill has issues: {issues}"
         assert "workflow-founder" in skill_md
+
+
+# ── _study_subgraph focus threading ─────────────────────────────
+
+
+class TestStudySubgraphFocus:
+    def test_focus_sets_study_node(self) -> None:
+        nodes, _ = _study_subgraph(focus="auth")
+        assert nodes["study"].focus == "auth"
+
+    def test_focus_sets_graph_explorer_prompt(self) -> None:
+        nodes, _ = _study_subgraph(focus="auth")
+        assert "auth" in nodes["graph_explorer"].prompt_template
+
+    def test_no_focus_backward_compatible(self) -> None:
+        nodes, _ = _study_subgraph()
+        assert nodes["study"].focus is None
+        assert nodes["graph_explorer"].prompt_template == _GRAPH_EXPLORER_PROMPT
+
+    def test_graph_explorer_prompt_with_focus(self) -> None:
+        prompt = _graph_explorer_prompt("auth flow")
+        assert "Focus your exploration on: auth flow" in prompt
+        assert 'factory graph query "auth flow"' in prompt
+
+    def test_graph_explorer_prompt_without_focus(self) -> None:
+        assert _graph_explorer_prompt() == _GRAPH_EXPLORER_PROMPT
+        assert _graph_explorer_prompt(None) == _GRAPH_EXPLORER_PROMPT


### PR DESCRIPTION
Closes #1291

## Changes

- Add `_graph_explorer_prompt(focus)` helper that returns a focused prompt with the user's topic baked into graph query commands, falling back to `_GRAPH_EXPLORER_PROMPT` when focus is None
- Add `focus` keyword arg to `_study_subgraph()` — passes it to the `Study` node and uses the focused prompt for `graph_explorer`
- Update `_study_to_instruction()` to emit a CEO hint about `--focus` when `node.focus` is None (interactive path where the CEO reads the SKILL.md)
- Existing callers (`design_workflow`, `study_standalone_workflow`) unchanged — `focus=None` default preserves backward compatibility
- 7 new tests covering both the subgraph wiring and the skill export output