### PR TITLE
fix: write slim CEO identity to .claude/CLAUDE.md instead of full prompt

### DIFF
--- a/factory/agents/runner.py
+++ b/factory/agents/runner.py
@@ -134,6 +134,85 @@ def resolve_prompt(
     return prompt
 
 
+_PROMPT_CORE_TEMPLATE = """\
+# Factory CEO Agent — Resume Identity
+
+You ARE the Factory CEO — the executive orchestrator of the Software Factory. \
+You delegate ALL technical work to specialist agents and review their output. \
+You own the experiment lifecycle: `factory begin`, dispatch agents, `factory finalize`.
+
+## Agent Dispatch
+
+```bash
+factory agent <role> --task "<description>" --project /path [--timeout 600]
+```
+
+Roles: researcher, strategist, builder, health_checker, code_reviewer, adversarial_tester, archivist.
+
+## Permitted Actions
+
+- `factory agent <role>` — spawn specialist agents
+- `factory <cmd>` — CLI commands (`factory --help`)
+- `git log/diff/status/add/commit/checkout/branch` — version control
+- `gh issue/pr` — GitHub operations
+- `cat/ls/head/grep` — read files for review
+- Write verdict files to `.factory/reviews/`
+
+## Forbidden Actions (Sacred Rule 8)
+
+- Writing or editing source code files
+- Running `python eval/score.py`, `pytest`, `ruff`, `mypy` directly
+- Using Claude Code's native `Agent` tool
+- Editing `CLAUDE.md`, `factory.md`, or project config files
+
+## Sacred Rules
+
+1. Do not delete or overwrite existing tests
+2. Do not modify files outside the declared scope
+3. Do not introduce secrets or credentials
+4. Do not lower the eval threshold
+5. Do not skip the eval step
+6. Do not merge PRs
+7. Do not skip archival
+8. Do not do another agent's job — delegate, review, decide
+9. Do not skip QA verification
+
+## CEO Review Gate
+
+After EVERY agent, review output at `.factory/reviews/<role>-latest.md`. \
+Write verdict to `.factory/reviews/ceo-verdict-<role>.md`:
+- **PROCEED** — satisfactory, continue
+- **REDIRECT** — re-invoke with corrections (max 2)
+- **ABORT** — log failure, finalize as error
+
+## Keep/Revert Essentials
+
+All must be true to keep: tests pass, lint clean, score improved, no guard violations, \
+code readable. Use `factory finalize` with `--verdict keep` or `--verdict revert`.
+
+## Error Recovery
+
+On agent failure: re-invoke with adjusted params → try different agent → finalize as error. \
+NEVER do the agent's work yourself.
+
+## Mode Pointer
+
+Full workflow playbook is injected via system prompt. On resume, read \
+`.factory/strategy/current.md` for your plan and session state.
+"""
+
+
+def resolve_prompt_core() -> str:
+    """Return a slim (~7-8KB) CEO identity prompt for CLAUDE.md resume resilience.
+
+    This contains only the essential CEO identity, Sacred Rules, permitted/forbidden
+    actions, agent dispatch syntax, keep/revert essentials, error recovery summary,
+    and a pointer to the full playbook. The full prompt is delivered separately via
+    --append-system-prompt-file.
+    """
+    return _PROMPT_CORE_TEMPLATE
+
+
 def _maybe_inject_profile(prompt: str, role: str) -> str:
     """Load and inject user profile if it exists."""
     from factory.profile import inject_profile, load_profile

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -499,7 +499,7 @@ def _execute_ceo(
     just_plan: bool = False,
 ) -> int:
     """Set up worktree, build task, and run the CEO agent."""
-    from factory.agents.runner import begin_cycle_session, complete_cycle_session, resolve_prompt
+    from factory.agents.runner import begin_cycle_session, complete_cycle_session, resolve_prompt, resolve_prompt_core
     from factory.runners import get_runner
     from factory.runners.claude import _make_ceo_message_emitter
     from factory.worktree import create_worktree, prune_stale, remove_worktree
@@ -753,9 +753,11 @@ def _execute_ceo(
         extras: dict[str, object] = {}
         if _verification_settings_file:
             extras["settings_file"] = _verification_settings_file
+        prompt_core = resolve_prompt_core()
         return runner.interactive_run(
             _RunReq(
                 prompt=prompt,
+                prompt_core=prompt_core,
                 task=task,
                 cwd=wt_path,
                 model=model,

--- a/factory/models.py
+++ b/factory/models.py
@@ -597,6 +597,7 @@ class AgentRunRequest(BaseModel):
     model_config = ConfigDict(strict=True, extra="forbid")
 
     prompt: str
+    prompt_core: str = ""
     task: str
     cwd: Path
     timeout: float = 600.0

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -258,15 +258,23 @@ class ClaudeRunner:
 
         temp_files: list[Path] = [prompt_path]
 
-        # Write CEO prompt to .claude/CLAUDE.md so it survives session transitions
-        # (background via ←, resume, daemon restart). The system prompt file is
-        # authoritative when present; CLAUDE.md provides resilience when it's not.
+        # Write a slim CEO identity to .claude/CLAUDE.md so it survives session
+        # transitions (background via ←, resume, daemon restart). The full prompt
+        # is delivered via --append-system-prompt-file; CLAUDE.md only needs enough
+        # to re-orient the CEO on resume.
         cwd = Path(request.cwd)
         claude_dir = cwd / ".claude"
         claude_dir.mkdir(parents=True, exist_ok=True)
 
         claude_md_path = claude_dir / "CLAUDE.md"
-        claude_md_path.write_text(request.prompt)
+        backup_path = claude_dir / "CLAUDE.md.factory-backup"
+        if claude_md_path.exists():
+            import shutil
+
+            shutil.copy2(claude_md_path, backup_path)
+
+        claude_md_content = request.prompt_core if request.prompt_core else request.prompt
+        claude_md_path.write_text(claude_md_content)
         temp_files.append(claude_md_path)
 
         # Write disallowedTools to settings.local.json so it survives session
@@ -315,10 +323,21 @@ class ClaudeRunner:
         cmd, env, temp_files = self.build_interactive_command(request)
         if not env.get("FACTORY_TRACE_ID"):
             env["TELEMETRY_PLATFORM"] = ""
+        cwd = Path(request.cwd)
+        backup_path = cwd / ".claude" / "CLAUDE.md.factory-backup"
+        claude_md_path = cwd / ".claude" / "CLAUDE.md"
         try:
             log.info("claude_interactive", cwd=str(request.cwd))
             result = subprocess.run(cmd, cwd=request.cwd, env=env)
             return result.returncode
         finally:
             for f in temp_files:
+                if f == claude_md_path:
+                    continue
                 f.unlink(missing_ok=True)
+            if backup_path.exists():
+                import shutil
+
+                shutil.move(str(backup_path), str(claude_md_path))
+            else:
+                claude_md_path.unlink(missing_ok=True)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,7 +7,32 @@ from unittest.mock import patch
 
 import pytest
 
-from factory.agents.runner import _save_review, resolve_prompt
+from factory.agents.runner import _save_review, resolve_prompt, resolve_prompt_core
+
+
+class TestResolvePromptCore:
+    def test_returns_string_under_40000_bytes(self) -> None:
+        core = resolve_prompt_core()
+        assert isinstance(core, str)
+        assert len(core.encode("utf-8")) < 40000
+
+    def test_contains_sacred_rules(self) -> None:
+        core = resolve_prompt_core()
+        assert "Sacred Rules" in core
+
+    def test_contains_agent_dispatch_syntax(self) -> None:
+        core = resolve_prompt_core()
+        assert "factory agent" in core
+
+    def test_contains_review_verdicts(self) -> None:
+        core = resolve_prompt_core()
+        assert "PROCEED" in core
+        assert "REDIRECT" in core
+        assert "ABORT" in core
+
+    def test_contains_mode_pointer(self) -> None:
+        core = resolve_prompt_core()
+        assert ".factory/strategy/current.md" in core
 
 
 class TestResolvePromptWithProfile:

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -145,6 +145,46 @@ class TestClaudeRunner:
             ]
 
 
+class TestInteractiveBackupRestore:
+    def test_restores_backup_after_interactive_run(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        original_content = "# Original project CLAUDE.md"
+        (claude_dir / "CLAUDE.md").write_text(original_content)
+
+        runner = ClaudeRunner()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(
+                AgentRunRequest(
+                    prompt="Full prompt",
+                    prompt_core="Slim core",
+                    task="Test",
+                    cwd=tmp_path,
+                )
+            )
+
+        claude_md = claude_dir / "CLAUDE.md"
+        assert claude_md.exists()
+        assert claude_md.read_text() == original_content
+        assert not (claude_dir / "CLAUDE.md.factory-backup").exists()
+
+    def test_deletes_claude_md_when_no_backup(self, tmp_path: Path) -> None:
+        runner = ClaudeRunner()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(
+                AgentRunRequest(
+                    prompt="Full prompt",
+                    prompt_core="Slim core",
+                    task="Test",
+                    cwd=tmp_path,
+                )
+            )
+
+        assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
+
+
 class TestTelemetryPlatformSuppression:
     def test_headless_sets_telemetry_platform_empty(self, tmp_path: Path) -> None:
         """ClaudeRunner.headless() sets TELEMETRY_PLATFORM='' to suppress native tracing."""
@@ -1966,7 +2006,25 @@ class TestClaudeBuildInteractiveCommand:
         for f in temp_files:
             f.unlink(missing_ok=True)
 
-    def test_writes_claude_md_with_prompt(self, tmp_path: Path) -> None:
+    def test_writes_claude_md_with_prompt_core(self, tmp_path: Path) -> None:
+        runner = ClaudeRunner()
+        _, _, temp_files = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="Full prompt content here.",
+                prompt_core="Slim core identity.",
+                task="Test",
+                cwd=tmp_path,
+            )
+        )
+
+        claude_md = tmp_path / ".claude" / "CLAUDE.md"
+        assert claude_md.exists()
+        assert claude_md.read_text() == "Slim core identity."
+
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_falls_back_to_full_prompt_when_prompt_core_empty(self, tmp_path: Path) -> None:
         runner = ClaudeRunner()
         prompt = "You are the CEO.\n\n## Instructions\nDo great things."
         _, _, temp_files = runner.build_interactive_command(
@@ -1983,6 +2041,31 @@ class TestClaudeBuildInteractiveCommand:
 
         for f in temp_files:
             f.unlink(missing_ok=True)
+
+    def test_backs_up_existing_claude_md(self, tmp_path: Path) -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        original_content = "# Original project instructions"
+        (claude_dir / "CLAUDE.md").write_text(original_content)
+
+        runner = ClaudeRunner()
+        _, _, temp_files = runner.build_interactive_command(
+            AgentRunRequest(
+                prompt="Full prompt",
+                prompt_core="Slim core",
+                task="Test",
+                cwd=tmp_path,
+            )
+        )
+
+        backup = claude_dir / "CLAUDE.md.factory-backup"
+        assert backup.exists()
+        assert backup.read_text() == original_content
+        assert (claude_dir / "CLAUDE.md").read_text() == "Slim core"
+
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+        backup.unlink(missing_ok=True)
 
     def test_creates_claude_dir_if_missing(self, tmp_path: Path) -> None:
         assert not (tmp_path / ".claude").exists()


### PR DESCRIPTION
Closes #1294

## Changes

- **factory/models.py**: Added `prompt_core: str = ""` field to `AgentRunRequest` — optional slim prompt for CLAUDE.md write in interactive mode
- **factory/agents/runner.py**: Added `resolve_prompt_core()` function returning a ~2KB resume-resilient CEO identity prompt (Sacred Rules, agent dispatch syntax, review verdicts, keep/revert essentials, error recovery summary, mode pointer)
- **factory/runners/claude.py**: Modified `build_interactive_command()` to write `prompt_core` to `.claude/CLAUDE.md` instead of the full prompt (falls back to full prompt when `prompt_core` is empty for backward compat). Added backup/restore logic for existing `.claude/CLAUDE.md` to protect `--no-worktree` mode
- **factory/cli/_ceo_helpers.py**: Updated interactive call site to pass `resolve_prompt_core()` as `prompt_core=` to `AgentRunRequest`

The full prompt (~49-68KB depending on mode) continues to be delivered via `--append-system-prompt-file` unchanged. Only the `.claude/CLAUDE.md` write — which provides resume resilience — now receives the slim identity (~2KB), well under Claude Code's ~40KB character limit.

## Tests added

- `resolve_prompt_core()` returns under 40KB
- `resolve_prompt_core()` contains key markers: Sacred Rules, factory agent, PROCEED/REDIRECT/ABORT
- `build_interactive_command()` writes `prompt_core` to CLAUDE.md when available
- `build_interactive_command()` falls back to full prompt when `prompt_core` is empty
- `build_interactive_command()` backs up existing CLAUDE.md before overwriting
- `interactive_run()` restores backup after run completes
- `interactive_run()` deletes CLAUDE.md when no backup existed