### PR TITLE
feat: automated weekly doc-drift detection

### DIFF
--- a/factory/cli/__init__.py
+++ b/factory/cli/__init__.py
@@ -44,6 +44,9 @@ from factory.cli.backlog import (
     cmd_backlog_list as cmd_backlog_list,
     cmd_backlog_remove as cmd_backlog_remove,
 )
+from factory.cli.doc import (
+    cmd_doc_drift as cmd_doc_drift,
+)
 from factory.cli.ceo import (
     _auto_detect_mode as _auto_detect_mode,
     _build_ceo_task as _build_ceo_task,

--- a/factory/cli/_main.py
+++ b/factory/cli/_main.py
@@ -79,6 +79,7 @@ _COMMAND_GROUPS: list[tuple[str, list[str]]] = [
             "clean-pr",
             "spec",
             "adversarial-state",
+            "doc-drift",
         ],
     ),
     (
@@ -334,6 +335,24 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("path", help="Path to the project")
     p.add_argument(
         "--reset", action="store_true", default=False, help="Reset adversarial state to defaults"
+    )
+
+    # doc-drift
+    p = sub.add_parser(
+        "doc-drift", help="Detect documentation drift from recently merged PRs"
+    )
+    p.add_argument("path", help="Path to the project")
+    p.add_argument(
+        "--days",
+        type=int,
+        default=7,
+        help="Number of days to look back for merged PRs (default: 7)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Classify drift only — do not open a PR",
     )
 
     # backfill-citations
@@ -1186,6 +1205,7 @@ def main(argv: list[str] | None = None) -> int:
         "leakage-check": _cli.cmd_leakage_check,
         "validate-research": _cli.cmd_validate_research,
         "adversarial-state": _cli.cmd_adversarial_state,
+        "doc-drift": _cli.cmd_doc_drift,
         "refine-status": _cli.cmd_refine_status,
         "refine-begin": _cli.cmd_refine_begin,
         "refine-complete": _cli.cmd_refine_complete,

--- a/factory/cli/doc.py
+++ b/factory/cli/doc.py
@@ -1,0 +1,45 @@
+"""CLI doc-drift command — detect documentation drift from recently merged PRs."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def cmd_doc_drift(args: argparse.Namespace) -> int:
+    """Run the doc-drift workflow to detect stale documentation."""
+    from factory.workflow.executor import WorkflowExecutor
+    from factory.workflow.definitions import register_all
+
+    project_path = Path(args.path).resolve()
+    if not project_path.is_dir():
+        print(f"Error: {project_path} is not a directory", file=sys.stderr)
+        return 1
+
+    workflows = register_all()
+    wf = workflows.get("doc-drift")
+    if wf is None:
+        print("Error: doc-drift workflow not found", file=sys.stderr)
+        return 1
+
+    log.info("doc_drift.start", project=str(project_path), days=args.days, dry_run=args.dry_run)
+
+    executor = WorkflowExecutor(
+        workflow=wf,
+        project_path=project_path,
+        dry_run=args.dry_run,
+    )
+
+    result = asyncio.run(executor.execute())
+    if result.success:
+        log.info("doc_drift.complete", nodes_run=result.nodes_executed)
+    else:
+        log.warning("doc_drift.halted", reason=result.halt_reason)
+
+    return 0 if result.success else 1

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -53,6 +53,7 @@ __all__ = [
     "refine_workflow",
     "create_workflow",
     "skill_refine_workflow",
+    "doc_drift_workflow",
     "doc_generate_workflow",
     "doc_update_workflow",
     "spec_generate_workflow",
@@ -1868,6 +1869,154 @@ def skill_refine_workflow() -> Workflow:
 # ── W₁₁: Doc Generate ───────────────────────────────────────────
 
 
+def doc_drift_workflow() -> Workflow:
+    """W₁₅: Doc Drift — detect documentation drift from recently merged PRs.
+
+    scan_prs (FnNode) → classify (AgentNode/researcher) → gate_drift (GateNode) →
+    builder (AgentNode) → gate_review (GateNode) → archivist (AgentNode, non-blocking)
+    """
+    nodes: dict[str, Any] = {}
+    edges: list[Edge] = []
+
+    nodes["scan_prs"] = FnNode(
+        id="scan_prs",
+        command=(
+            'python3 -c "'
+            "import subprocess, json, sys; "
+            "from pathlib import Path; "
+            "from datetime import datetime, timedelta, timezone; "
+            "project = Path('{project_path}'); "
+            "out_dir = project / '.factory' / 'doc_drift'; "
+            "out_dir.mkdir(parents=True, exist_ok=True); "
+            "open_check = subprocess.run("
+            "['gh', 'pr', 'list', '--state', 'open', '--label', 'doc-drift', "
+            "'--json', 'number'], capture_output=True, text=True); "
+            "open_prs = json.loads(open_check.stdout) if open_check.returncode == 0 else []; "
+            "has_open = len(open_prs) > 0; "
+            "result = subprocess.run("
+            "['gh', 'pr', 'list', '--state', 'merged', '--base', 'main', "
+            "'--json', 'number,title,files,author,mergedAt,url', '--limit', '100'], "
+            "capture_output=True, text=True); "
+            "prs = json.loads(result.stdout) if result.returncode == 0 else []; "
+            "days = int('{days}') if '{days}' else 7; "
+            "cutoff = datetime.now(timezone.utc) - timedelta(days=days); "
+            "recent = [p for p in prs "
+            "if datetime.fromisoformat(p['mergedAt'].replace('Z', '+00:00')) > cutoff]; "
+            "(project / '.factory' / 'doc_drift' / 'merged_prs.json').write_text("
+            "json.dumps(recent, indent=2)); "
+            "msg = 'HALT: open doc-drift PR exists' if has_open "
+            "else ('HALT: no PRs merged in window' if not recent "
+            "else f'PROCEED: {{len(recent)}} PRs found'); "
+            "print(msg)"
+            '"'
+        ),
+        notes=(
+            "Scan merged PRs from the last N days via gh CLI. "
+            "Checks for existing open doc-drift PRs first — halts if one exists. "
+            "Writes .factory/doc_drift/merged_prs.json."
+        ),
+        writes={".factory/doc_drift/merged_prs.json"},
+    )
+
+    nodes["classify"] = AgentNode(
+        id="classify",
+        role=AgentRole.RESEARCHER,
+        model="haiku",
+        prompt_template=(
+            "Read the merged PR list at .factory/doc_drift/merged_prs.json. "
+            "Also read README.md and any website/ content files. "
+            "Classify each PR as doc-worthy or internal-only. "
+            "Doc-worthy signals: new CLI commands, new modes/features, changed behavior, "
+            "new config options, breaking changes, new runner support, "
+            "files touching CLI parsers (argparse, cmd_*), config changes. "
+            "Internal-only signals: test-only changes, refactors, plumbing, "
+            "CI fixes, dependency updates, internal architecture changes. "
+            "Write a drift report to .factory/doc_drift/drift_report.md listing: "
+            "each doc-worthy PR with title, number, URL, and which doc sections are stale."
+        ),
+        reads={".factory/doc_drift/merged_prs.json"},
+        writes={".factory/doc_drift/drift_report.md"},
+    )
+
+    nodes["gate_drift"] = GateNode(
+        id="gate_drift",
+        evaluator_type="fn",
+        evaluator_command=(
+            'python3 -c "'
+            "from pathlib import Path; "
+            "report = Path('{project_path}/.factory/doc_drift/drift_report.md'); "
+            "text = report.read_text() if report.exists() else ''; "
+            "has_drift = bool(text.strip()) and 'no doc-worthy' not in text.lower(); "
+            "print('PROCEED' if has_drift else 'HALT: no drift detected')"
+            '"'
+        ),
+        gate_prompt="",
+        reads={".factory/doc_drift/drift_report.md"},
+    )
+
+    nodes["builder"] = AgentNode(
+        id="builder",
+        role=AgentRole.BUILDER,
+        prompt_template=(
+            "Read the drift report at .factory/doc_drift/drift_report.md. "
+            "Only modify sections that directly correspond to code changes listed in the report. "
+            "Do not invent features, flags, or behaviors not present in the current codebase. "
+            "When unsure, flag the section for human review rather than guessing. "
+            "Create a feature branch, update the specific doc sections flagged as stale "
+            "in README.md and website/ content. "
+            "Commit changes and open a draft PR labeled 'doc-drift' and 'documentation'. "
+            "PR body must include: which PRs triggered the update, which doc sections changed, "
+            "and an 'AI-generated — review carefully' notice."
+        ),
+        reads={".factory/doc_drift/drift_report.md"},
+        writes={"README.md", "website/"},
+    )
+
+    nodes["gate_review"] = GateNode(
+        id="gate_review",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Review the builder's PR diff against the drift report. "
+            "Check: no hallucinated content, changes match flagged sections, "
+            "no scope creep, AI-generated notice present. "
+            "PROCEED to archive. RELOOP to builder if issues found."
+        ),
+        reads={".factory/doc_drift/drift_report.md"},
+    )
+
+    nodes["archivist"] = AgentNode(
+        id="archivist",
+        role=AgentRole.ARCHIVIST,
+        model="haiku",
+        blocking=False,
+        prompt_template=(
+            "Record drift patterns to .factory/archive/doc-drift/. "
+            "Note which PRs triggered doc updates, what types of changes "
+            "cause drift most often, and any recurring patterns."
+        ),
+        reads={".factory/doc_drift/drift_report.md"},
+        writes={".factory/archive/doc-drift/"},
+    )
+
+    edges = [
+        Edge(source="scan_prs", target="classify"),
+        Edge(source="classify", target="gate_drift"),
+        Edge(source="gate_drift", target="builder", condition=VerdictType.PROCEED),
+        Edge(source="builder", target="gate_review"),
+        Edge(source="gate_review", target="archivist", condition=VerdictType.PROCEED),
+        Edge(source="gate_review", target="builder", condition=VerdictType.RELOOP),
+    ]
+
+    return Workflow(
+        name="doc-drift",
+        nodes=nodes,
+        edges=edges,
+        start_node="scan_prs",
+        trigger=None,
+    )
+
+
 def doc_generate_workflow() -> Workflow:
     """W₁₁: Doc Generate — scan codebase and generate documentation from scratch.
 
@@ -2598,6 +2747,7 @@ def register_all() -> dict[str, Workflow]:
         "refine": refine_workflow(),
         "create": create_workflow(),
         "skill-refine": skill_refine_workflow(),
+        "doc-drift": doc_drift_workflow(),
         "doc-generate": doc_generate_workflow(),
         "doc-update": doc_update_workflow(),
         "spec-generate": spec_generate_workflow(),

--- a/tests/test_doc_drift.py
+++ b/tests/test_doc_drift.py
@@ -1,0 +1,203 @@
+"""Tests for the doc-drift workflow and CLI subcommand."""
+
+from __future__ import annotations
+
+from factory.workflow.definitions import doc_drift_workflow, register_all
+from factory.workflow.primitives import AgentNode, AgentRole, FnNode, GateNode
+
+
+# ── Workflow graph validation ─────────────────────────────────────
+
+
+class TestDocDriftWorkflow:
+    def test_graph_validates(self) -> None:
+        wf = doc_drift_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Graph validation issues: {issues}"
+
+    def test_workflow_name(self) -> None:
+        wf = doc_drift_workflow()
+        assert wf.name == "doc-drift"
+
+    def test_start_node(self) -> None:
+        wf = doc_drift_workflow()
+        assert wf.start_node == "scan_prs"
+
+    def test_node_count(self) -> None:
+        wf = doc_drift_workflow()
+        assert len(wf.nodes) == 6
+
+    def test_node_types(self) -> None:
+        wf = doc_drift_workflow()
+        assert isinstance(wf.nodes["scan_prs"], FnNode)
+        assert isinstance(wf.nodes["classify"], AgentNode)
+        assert isinstance(wf.nodes["gate_drift"], GateNode)
+        assert isinstance(wf.nodes["builder"], AgentNode)
+        assert isinstance(wf.nodes["gate_review"], GateNode)
+        assert isinstance(wf.nodes["archivist"], AgentNode)
+
+    def test_classify_uses_haiku(self) -> None:
+        wf = doc_drift_workflow()
+        classify = wf.nodes["classify"]
+        assert isinstance(classify, AgentNode)
+        assert classify.model == "haiku"
+
+    def test_classify_role_is_researcher(self) -> None:
+        wf = doc_drift_workflow()
+        classify = wf.nodes["classify"]
+        assert isinstance(classify, AgentNode)
+        assert classify.role == AgentRole.RESEARCHER
+
+    def test_builder_role(self) -> None:
+        wf = doc_drift_workflow()
+        builder = wf.nodes["builder"]
+        assert isinstance(builder, AgentNode)
+        assert builder.role == AgentRole.BUILDER
+
+    def test_archivist_non_blocking(self) -> None:
+        wf = doc_drift_workflow()
+        archivist = wf.nodes["archivist"]
+        assert isinstance(archivist, AgentNode)
+        assert archivist.blocking is False
+
+    def test_archivist_uses_haiku(self) -> None:
+        wf = doc_drift_workflow()
+        archivist = wf.nodes["archivist"]
+        assert isinstance(archivist, AgentNode)
+        assert archivist.model == "haiku"
+
+    def test_gate_drift_is_fn_evaluator(self) -> None:
+        wf = doc_drift_workflow()
+        gate = wf.nodes["gate_drift"]
+        assert isinstance(gate, GateNode)
+        assert gate.evaluator_type == "fn"
+
+    def test_gate_review_is_agent_evaluator(self) -> None:
+        wf = doc_drift_workflow()
+        gate = wf.nodes["gate_review"]
+        assert isinstance(gate, GateNode)
+        assert gate.evaluator_type == "agent"
+        assert gate.evaluator_role == AgentRole.CEO
+
+    def test_edge_count(self) -> None:
+        wf = doc_drift_workflow()
+        assert len(wf.edges) == 6
+
+    def test_scan_to_classify_edge(self) -> None:
+        wf = doc_drift_workflow()
+        edge = wf.edges[0]
+        assert edge.source == "scan_prs"
+        assert edge.target == "classify"
+        assert edge.condition is None
+
+    def test_classify_prompt_references_website(self) -> None:
+        wf = doc_drift_workflow()
+        classify = wf.nodes["classify"]
+        assert isinstance(classify, AgentNode)
+        assert "website/" in classify.prompt_template
+
+    def test_builder_writes_website(self) -> None:
+        wf = doc_drift_workflow()
+        builder = wf.nodes["builder"]
+        assert isinstance(builder, AgentNode)
+        assert "website/" in builder.writes
+
+
+# ── register_all integration ──────────────────────────────────────
+
+
+class TestDocDriftRegistration:
+    def test_register_all_includes_doc_drift(self) -> None:
+        all_wf = register_all()
+        assert "doc-drift" in all_wf
+
+    def test_register_all_count(self) -> None:
+        all_wf = register_all()
+        assert len(all_wf) == 24
+
+
+# ── CLI arg parsing ───────────────────────────────────────────────
+
+
+class TestDocDriftCLI:
+    def test_parser_accepts_doc_drift(self) -> None:
+        from factory.cli._main import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["doc-drift", "/tmp/project"])
+        assert args.command == "doc-drift"
+        assert args.path == "/tmp/project"
+        assert args.days == 7
+        assert args.dry_run is False
+
+    def test_parser_custom_days(self) -> None:
+        from factory.cli._main import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["doc-drift", "/tmp/project", "--days", "14"])
+        assert args.days == 14
+
+    def test_parser_dry_run(self) -> None:
+        from factory.cli._main import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["doc-drift", "/tmp/project", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_doc_drift_in_command_groups(self) -> None:
+        from factory.cli._main import _COMMAND_GROUPS
+
+        intel_group = next(g for name, g in _COMMAND_GROUPS if name == "Project Intelligence")
+        assert "doc-drift" in intel_group
+
+
+# ── scan_prs FnNode command logic ─────────────────────────────────
+
+
+class TestScanPrsDuplicateDetection:
+    def test_scan_command_contains_duplicate_check(self) -> None:
+        wf = doc_drift_workflow()
+        scan = wf.nodes["scan_prs"]
+        assert isinstance(scan, FnNode)
+        assert "doc-drift" in scan.command
+        assert "open" in scan.command
+
+    def test_scan_command_filters_by_days(self) -> None:
+        wf = doc_drift_workflow()
+        scan = wf.nodes["scan_prs"]
+        assert isinstance(scan, FnNode)
+        assert "{days}" in scan.command
+
+
+# ── Drift classification ──────────────────────────────────────────
+
+
+class TestDriftClassification:
+    def test_classify_prompt_mentions_doc_worthy_signals(self) -> None:
+        wf = doc_drift_workflow()
+        classify = wf.nodes["classify"]
+        assert isinstance(classify, AgentNode)
+        prompt = classify.prompt_template
+        assert "CLI commands" in prompt
+        assert "breaking changes" in prompt
+        assert "config options" in prompt
+
+    def test_classify_prompt_mentions_internal_signals(self) -> None:
+        wf = doc_drift_workflow()
+        classify = wf.nodes["classify"]
+        assert isinstance(classify, AgentNode)
+        prompt = classify.prompt_template
+        assert "test-only" in prompt
+        assert "refactor" in prompt
+
+    def test_builder_prompt_has_hallucination_guard(self) -> None:
+        wf = doc_drift_workflow()
+        builder = wf.nodes["builder"]
+        assert isinstance(builder, AgentNode)
+        assert "Do not invent" in builder.prompt_template
+
+    def test_builder_prompt_requires_ai_notice(self) -> None:
+        wf = doc_drift_workflow()
+        builder = wf.nodes["builder"]
+        assert isinstance(builder, AgentNode)
+        assert "AI-generated" in builder.prompt_template

--- a/tests/test_spec_generate.py
+++ b/tests/test_spec_generate.py
@@ -237,7 +237,7 @@ class TestRegistryIncludesSpec:
 
     def test_register_all_count(self) -> None:
         all_wf = register_all()
-        assert len(all_wf) == 23
+        assert len(all_wf) == 24
 
     def test_all_workflows_validate(self) -> None:
         all_wf = register_all()


### PR DESCRIPTION
Closes #1292

## Changes

- **New workflow DAG** (`doc_drift_workflow()`) in `factory/workflow/definitions.py` — 6-node pipeline: `scan_prs` (FnNode) → `classify` (AgentNode/researcher, haiku) → `gate_drift` (GateNode/fn) → `builder` (AgentNode) → `gate_review` (GateNode/CEO) → `archivist` (AgentNode, non-blocking, haiku). Registered as `"doc-drift"` in `register_all()`.
- **New CLI subcommand** `factory doc-drift` in `factory/cli/doc.py` — args: `path`, `--days` (default 7), `--dry-run`. Registered in `_main.py` under Project Intelligence group.
- **Duplicate PR prevention** — `scan_prs` checks `gh pr list --state open --label doc-drift` before scanning; halts if an open doc-drift PR exists.
- **Hallucination guards** — builder prompt constrains against inventing features, requires AI-generated notice in PR body.
- **Website content included** — classify and builder both reference `website/` content per plan amendment (not deferred).
- **Tests** (`tests/test_doc_drift.py`) — 28 tests: graph validation, node types/roles/models, edge structure, CLI arg parsing, command group membership, duplicate detection, classification signals, hallucination guards. Updated `register_all` count assertion from 23 → 24 in `test_spec_generate.py`.