### PR TITLE
ci: parallelize test suite with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups
       - name: Run tests with coverage
-        run: uv run pytest -v --tb=short --cov=factory --cov-report=xml
+        run: uv run pytest -n auto -v --tb=short --cov=factory --cov-report=xml
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
     "ruff>=0.8",
     "mypy>=1.10",
     "pytest-cov>=5.0",
+    "pytest-xdist>=3.5",
     "httpx>=0.27",
     "types-pyyaml>=6.0",
     "types-networkx>=3.6.1.20260612",

--- a/uv.lock
+++ b/uv.lock
@@ -749,6 +749,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2800,6 +2809,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3041,6 +3063,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-networkx" },
     { name = "types-pyyaml" },
@@ -3075,6 +3098,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "ruff", specifier = ">=0.8" },
     { name = "types-networkx", specifier = ">=3.6.1.20260612" },
     { name = "types-pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
## Summary

- Add `pytest-xdist>=3.5` to dev dependencies
- Enable `-n auto` in CI test step for parallel test execution

## Why this is safe

Audited the full test suite (5,487 tests) for parallelism blockers:

| Check | Result |
|-------|--------|
| Bare `os.chdir` | None — all uses go through monkeypatch |
| Session/module-scoped fixtures | None — everything is function-scoped |
| Shared file paths | None — every test uses `tmp_path` |
| Port/socket binds | None |
| Direct `os.environ` mutation | 6 sites, but process-isolated under xdist |
| Global mutable state | Conftest resets are process-isolated |

## Results

Local run with `-n auto`: **5,470 passed in 5:10** (vs 10+ min sequential).
5 pre-existing failures unrelated to parallelism. On CI's 4-vCPU runners, expect 3-4x speedup.

## Test plan

- [x] Full suite passes with `-n auto` locally (5,470 passed, 5 pre-existing failures, 12 skipped)
- [x] Smoke test on subset (174 passed in 3.11s)
- [x] Pre-existing failures confirmed to reproduce without xdist

🤖 Generated with [Claude Code](https://claude.com/claude-code)