### PR TITLE
docs: plugin architecture guide

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-re:factory is a three-layer system with strict separation between tooling, orchestration, and execution.
+re:factory is a four-layer system with strict separation between tooling, orchestration, execution, and extensibility.
 
-## Three Layers
+## Four Layers
 
 ### Layer 1: Python CLI (`factory/`)
 
@@ -38,11 +38,20 @@ Nine specialist Claude Code subprocesses, each with a narrow responsibility:
 | **Refiner** | Classify and scope post-cycle refinement requests (T1/T2/T3 tiers) | `factory agent refiner --task "..."` |
 | **Failure Analyst** | Classify run failures by root cause (research mode only) | `factory agent failure_analyst --task "..."` |
 
-Agent prompts are resolved via two-tier lookup in `factory/agents/runner.py`:
+Agent prompts are resolved via three-tier lookup in `factory/agents/runner.py`:
 1. Project-specific override: `<project>/.factory/agents/<role>.md`
-2. re:factory default: `factory/agents/prompts/<role>.md`
+2. User-global override: `~/.factory/agents/prompts/<role>.md`
+3. re:factory default: `factory/agents/prompts/<role>.md`
 
 Evolved playbooks from ACE are auto-injected at runtime.
+
+### Layer 4: Plugin System
+
+re:factory is an **engine** — the built-in modes are one configuration of it. Pip-installable plugins can extend the factory with new CEO modes, CLI commands, agent roles, pre-dispatch hooks, parser extensions, and workflow search paths via standard Python entry points (`factory.plugins` group).
+
+The plugin registry (`factory/plugins.py`) loads at parser construction time with three-tier error isolation. Collision protection ensures builtins always win and first-registered plugins take priority.
+
+See [Plugins — Build Your Own Factory](plugins.md) for the full guide.
 
 ## State Machine
 
@@ -210,6 +219,7 @@ Stuck detection activates after 3+ consecutive same-category reverts, forcing ca
 | `factory/report.py` | Performance report generation and loading |
 | `factory/adversarial.py` | GAN-style adversarial eval loop state machine |
 | `factory/agents/runner.py` | Agent subprocess spawner + event emission |
+| `factory/plugins.py` | Plugin registry — entry point discovery + extension surfaces |
 
 ## `.factory/` Directory
 
@@ -259,6 +269,7 @@ Generated at runtime — not checked into version control:
 
 ## Related Docs
 
+- [Plugins — Build Your Own Factory](plugins.md) — How to extend re:factory with custom modes, agents, and commands
 - [Self-Improvement Loop](self-improvement.md) — How the CEO tracks agents, cross-project learning, and autonomous playbook evolution
 - [ACE Playbook Evolution](ace.md) — The Reflect → Curate → Inject playbook evolution mechanics
 - [Eval System](eval.md) — Three-tier scoring, guards, and precheck gates

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,114 @@
+# Plugins — Build Your Own Factory
+
+re:factory is an **engine**. The built-in modes (improve, design, research, build, etc.) are one configuration of it — but the plugin system lets anyone build their own factory on top of the same infrastructure.
+
+A plugin is a pip-installable Python package that registers new capabilities with the engine. The factory discovers plugins at startup via standard Python [entry points](https://packaging.python.org/en/latest/specifications/entry-points/), the same mechanism pip and pytest use. Everything the engine provides — [eval scoring](eval.md), [keep/revert decisions](architecture.md#experiment-loop-improve-mode), [archival](self-improvement.md#archive-and-performance-reports), [crash recovery](architecture.md) — works automatically for plugin modes.
+
+## Extension Surfaces
+
+A plugin's `register()` function receives a `PluginRegistry` and can extend six surfaces:
+
+| Surface | What it does | Example |
+|---------|-------------|---------|
+| **CEO modes** | New modes for `factory ceo --mode <name>` | An `ml` mode that runs paper-survey → hypothesize → train → eval |
+| **Agent roles** | New specialist agents for `factory agent <role>` | A `paper-reader` that extracts techniques from arxiv papers |
+| **CLI commands** | New top-level `factory` subcommands | `factory ml-report` to summarize experiment results |
+| **CEO pre-hooks** | Logic that runs before CEO dispatch | Scaffold a `.factory/ml/` config directory on first run |
+| **Parser extensions** | Inject flags into existing subcommands | Add `--metric` and `--gpu` to `factory ceo` |
+| **Workflow search paths** | Additional directories for [workflow definitions](architecture.md) | Point the engine at the plugin's workflow graphs |
+
+## How a Plugin Mode Runs
+
+When you run `factory ceo /path --mode ml`:
+
+```
+                    ┌─────────────────────┐
+                    │   factory ceo       │
+                    │   --mode ml         │
+                    └────────┬────────────┘
+                             │
+                    ┌────────▼────────────┐
+                    │  1. Pre-hooks       │  Plugin's pre-hook runs
+                    │                     │  before CEO dispatch
+                    └────────┬────────────┘
+                             │
+                    ┌────────▼────────────┐
+                    │  2. Mode playbook   │  CEO reads workflow skill file
+                    │                     │  (skills/workflow-ml/SKILL.md)
+                    └────────┬────────────┘
+                             │
+              ┌──────────────▼──────────────┐
+              │  3. Agent dispatch           │
+              │                              │
+              │  paper-reader ──► strategist │  Plugin + built-in agents
+              │       ──► experiment-runner  │  composed freely
+              │       ──► run_eval          │
+              └──────────────┬──────────────┘
+                             │
+                    ┌────────▼────────────┐
+                    │  4. Engine takes     │  Standard experiment
+                    │     over             │  lifecycle from here
+                    └─────────────────────┘
+```
+
+Plugin workflows can mix plugin-defined agents (`paper-reader`) with built-in agents (`strategist`, `builder`). The engine resolves each role via the [three-tier prompt lookup](architecture.md#layer-3-specialist-agents) — plugin roles ship their own prompt files, typically installed to `~/.factory/agents/prompts/` on first load.
+
+If no workflow exists for a plugin mode, the CEO falls back to its default improve loop using whatever agents are available.
+
+## Collision Protection
+
+- **Builtins always win.** A plugin cannot override a built-in command, mode, or agent role.
+- **First registration wins.** If two plugins register the same name, the first one (sorted by distribution name) keeps it.
+- **Three-tier error isolation.** Failures at any stage (import, validation, registration) are caught, logged, and skipped — a broken plugin never crashes the factory.
+
+## Discovery and Debugging
+
+```bash
+factory plugins          # list loaded plugins, versions, and status
+pip install factory-ml   # install a plugin
+pip uninstall factory-ml # remove — discovery is dynamic, no config to clean up
+```
+
+## Integration Points
+
+The `PluginRegistry` singleton (`factory/plugins.py`) is consumed at six points in the codebase:
+
+| File | What it reads |
+|------|--------------|
+| `factory/cli/_main.py` | Plugin commands → subparsers; parser extensions → existing subcommands |
+| `factory/cli/_main.py` | Plugin command handlers dispatched via `_plugin_handler` |
+| `factory/cli/ceo.py` | Pre-hooks invoked before CEO dispatch |
+| `factory/cli/_helpers.py` | `get_all_ceo_modes()` merges builtins + plugin modes |
+| `factory/cli/agents.py` | Agent role validation unions builtins + plugin roles |
+| `factory/worktree.py` | Plugin-created `.factory/` subdirs propagated into CEO worktrees |
+
+## Writing a Plugin
+
+A minimal plugin needs three things:
+
+1. A Python package with a `register(registry: PluginRegistry)` function
+2. An entry point declaration in `pyproject.toml` under `factory.plugins`
+3. Agent prompt files for any custom roles
+
+The `register()` function calls `add_modes()`, `add_agent_roles()`, `add_commands()`, `add_ceo_pre_hook()`, `add_parser_extensions()`, and `add_workflow_search_path()` on the registry. See `factory/plugins.py` for the full API — `PluginRegistry` and `CommandSpec` are the only imports needed.
+
+```toml
+# pyproject.toml — the entry point is all the factory needs to find your plugin
+[project.entry-points."factory.plugins"]
+ml = "factory_ml:register"
+```
+
+```mermaid
+graph TD
+    A["pip install factory-ml"] --> B["importlib.metadata.entry_points()"]
+    B --> C["load_plugins()"]
+    C --> D["register(registry)"]
+    D --> E["PluginRegistry singleton"]
+    E --> F["CLI parser"]
+    E --> G["CEO dispatch"]
+    E --> H["Agent runner"]
+    E --> I["Mode validation"]
+    E --> J["Worktree propagation"]
+
+    style E fill:#5c6bc0,color:#fff
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Configuration: configuration.md
   - Concepts:
       - Architecture: architecture.md
+      - Plugins — Build Your Own Factory: plugins.md
       - Eval System: eval.md
       - Self-Improvement Loop: self-improvement.md
       - ACE Playbook Evolution: ace.md


### PR DESCRIPTION
## Summary

- Adds `docs/plugins.md` — architecture-level guide for the engine + plugin system introduced in #1227–#1278
- Updates `docs/architecture.md` from three-layer to four-layer system, adds Layer 4 (Plugin System), corrects agent prompt resolution to three-tier lookup
- Wires the new page into mkdocs nav under Concepts

## What the doc covers

- The six extension surfaces (modes, agent roles, CLI commands, pre-hooks, parser extensions, workflow search paths)
- How a plugin mode executes end-to-end (flow diagram)
- Collision protection rules
- Integration points table mapping `PluginRegistry` consumers to source files
- How to write a plugin (minimal requirements + entry point contract)
- No overlap with architecture.md, eval.md, or self-improvement.md — links to them instead

## Test plan

- [ ] Verify cross-doc links resolve (anchors in architecture.md and self-improvement.md)
- [ ] Verify mkdocs build passes with new nav entry
- [ ] Read through for accuracy against `factory/plugins.py` API

🤖 Generated with [Claude Code](https://claude.com/claude-code)