### PR TITLE
fix: restore docs/index.md to canonical old README.md content

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,13 +16,39 @@
 
 **Describe what you want — re:factory designs and builds it.** Brainstorm an idea from scratch, refine a plan for an existing project, or create entirely new factory modes.
 
+```bash
+# Design — brainstorm an idea, refine it, then build
+factory ceo "distributed eval runner" --mode design
+
+# Create — build new factory modes and pipelines
+factory ceo /path/to/factory --mode create --focus "PR validation pipeline"
+
+# Build — have a fleshed-out idea? Pass the file.
+factory ceo ~/ideas/weather-dashboard.md
+
+# Improve — point it at any codebase
+factory ceo ~/my-project
+
+# Focus — build exactly one thing
+factory ceo ~/my-project --focus "add WebSocket support"
+```
+
 All state is local — per-project in `.factory/` (add to `.gitignore`), global in `~/.factory/`. See [Architecture](architecture.md) for the full deep-dive.
 
 ---
 
 ## How It Works
 
-A CEO agent orchestrates specialists agents like Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst, each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. The Researcher searches the web and reads prior knowledge from the archive. The Strategist generates ranked hypotheses and handles design-mode ideation. The Builder implements one on an experiment branch. The Evaluator scores before and after. The CEO decides keep or revert. The Archivist records everything to `.factory/archive/` and regenerates performance reports for cross-project learning.
+re:factory orchestrates a **graph workflow of agents** — a directed acyclic graph (DAG) where each node is either an agent, a shell command, a gate check, or a fork/join for parallelism. Each workflow defines which agents run, in what order, with what conditions, and the engine walks the graph deterministically. Workflows can be created for different tasks and optimized through the outer loop's evolutionary search.
+
+For example, an **email summarizer agent** might be a simple 3-node workflow: a Researcher reads the inbox → a Strategist prioritizes by urgency → a Builder drafts the summary. A **custom research agent** might fork three parallel researchers (domain, competitors, prior art) → join their findings → pass through a coverage gate → synthesize a final report. The graph structure is the same — what changes is the nodes, their prompts, and the edges between them.
+
+A **CEO agent** sits at the top. It detects project state, selects the appropriate workflow graph, and orchestrates specialist agents — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst — each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. The CEO walks the graph step by step: the Researcher investigates, the Strategist generates ranked hypotheses, the Builder implements on an experiment branch, the Evaluator scores before and after, and the CEO decides keep or revert. The Archivist records everything for cross-project learning.
+
+The two primary modes:
+
+- **Design mode** (`--mode design`): The entry point for new ideas and existing projects alike. Researches the space, drafts a structured plan via the Strategist, iterates with you until it's right, then builds. Use this when you want to think before you code.
+- **Create mode** (`--mode create`): Builds new workflow graphs themselves — new factory modes, new pipelines, new agent topologies. Point it at the factory repo and describe what mode you want. It researches existing patterns, synthesizes a workflow spec, gets your approval, then implements the full graph definition, skill export, CLI wiring, and tests.
 
 ---
 
@@ -87,6 +113,39 @@ Point it at the factory repo itself to extend re:factory with custom pipelines.
 
 ---
 
+## Available Workflows
+
+Beyond the core Design and Create modes, re:factory ships with a growing set of workflows — both built-in and community-contributed. Each is a complete graph definition with its own agent topology, gates, and iteration strategy.
+
+### Built-in Workflows
+
+| Workflow | What it does |
+|----------|-------------|
+| **frontend-design** | Feature-to-UI pipeline — forks 5 design researchers in parallel, joins findings, then runs design audit → spec → build → render → deep QA |
+| **parallel-improve** | Forks N hypotheses into isolated git worktrees, runs experiments concurrently, and selects the best result |
+| **deep-research** | Decomposes a topic into research directions, executes each with internal iteration, and checks coverage |
+| **deep-qa** | Multi-stage quality assurance — health check, code review, and adversarial testing in parallel |
+| **study** | Graph-powered codebase analysis — builds a dependency graph, explores it, and produces a combined study report |
+
+### Community-Contributed Benchmarks
+
+These benchmark workflows live in `factory/workflow/contributed/` and follow a standard 4-node pipeline pattern (study → solver → gate → merge). See [Contributing Benchmarks](contributing-benchmarks.md) for how to add your own.
+
+| Workflow | What it solves |
+|----------|---------------|
+| **swebench** | GitHub issues from the SWE-bench dataset in containerized evaluation |
+| **featurebench** | New feature implementations in Python codebases with explicit interface specs |
+| **legacybench** | Bugs in legacy code — COBOL, Fortran, C, Java 7, Assembly |
+| **devopsgym** | Build/configuration tasks — Maven, Gradle, Go modules, Make, Docker, CI/CD |
+| **terminalbench** | Real-world terminal engineering tasks — compiling legacy software, scientific computing, system configuration |
+| **programbench** | Adversarial discovery verification with builder → reviewer loops |
+| **tomswe** | Preference-aware coding tasks with embedded user profiles (Theory of Mind) |
+| **salitrap** | Commonsense reasoning — identifying salience traps in scenarios with numerical distractors |
+
+Run any workflow with `factory ceo /path --mode <name>` or use Create mode to build your own.
+
+---
+
 ## Quick Start
 
 **Prerequisites:** Python 3.11+, [uv](https://docs.astral.sh/uv/#installation), and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (installed and authenticated).
@@ -139,20 +198,6 @@ See [ACE Playbook Evolution](ace.md) for the playbook mechanics.
 
 ---
 
-## Architecture
-
-re:factory is a three-layer system:
-
-**Layer 1 — Python CLI** (`factory/`): Pure tools that don't make decisions. Eval runner, strategy engine, experiment store, discovery, event logging. Entry point: `factory --help`.
-
-**Layer 2 — CEO Agent** (`factory/agents/prompts/ceo.md`): The orchestrator. Detects project state, spawns specialist agents, and makes the keep/revert decision for each experiment. Mode-specific playbooks are auto-generated from workflow graph definitions.
-
-**Layer 3 — Specialist Agents** (`factory/agents/`): Eight independent Claude Code subprocesses — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst. Each has a focused prompt, receives context from the CEO, and returns structured output. Agent prompts support per-project overrides via `.factory/agents/<role>.md`.
-
-Data flows down: the CEO calls the CLI for eval, store, and guard operations. Agents call nothing — they produce text that the CEO interprets.
-
----
-
 ## Eval System
 
 Every change is measured by a composite score across three tiers:
@@ -185,17 +230,14 @@ The outer loop evolves the factory's own workflow DAGs against benchmarks. Start
 
 ## Built with re:factory
 
-re:factory has shipped something every day for the last 30 days — products, research experiments, production features, papers. Here are a few examples:
-
 | Project | What it does |
 |---------|-------------|
 | **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis |
 | **HMMT math solver** | Multi-agent team (Explorer, Theorist, Computationalist, Critic, Synthesizer) that solved HMMT Feb 2025 Combinatorics Problem 7 |
 | **Text/Sketch → CAD** | Converts natural language and hand-drawn sketches into executable CadQuery code for 3D model generation |
-| **HLS design space explorer** | Per-function AI agents explore HLS pragma/code variants in parallel, an ILP solver finds the optimal combination, then global expert agents apply cross-function optimizations — achieving up to 92% execution time reduction on cryptographic benchmarks |
+| **HLS design space explorer** | Per-function AI agents explore HLS pragma/code variants in parallel, an ILP solver finds the optimal combination, then global expert agents apply cross-function optimizations |
 | **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI |
 | **Group chat digest** | Turns iMessage group chats into weekly family newsletters with AI-curated highlights and photo selection |
-| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase |
 | **re:factory itself** | re:factory runs on itself — its own agent playbooks are evolved from its own experiment outcomes |
 
 Built something with re:factory? [Open a PR](https://github.com/akashgit/remote-factory/pulls) to add it here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,46 +18,11 @@
 
 All state is local — per-project in `.factory/` (add to `.gitignore`), global in `~/.factory/`. See [Architecture](architecture.md) for the full deep-dive.
 
-```bash
-# Design — brainstorm an idea, refine it, then build
-factory ceo "distributed eval runner" --mode design
-
-# Create — build new factory modes and pipelines
-factory ceo /path/to/factory --mode create --focus "PR validation pipeline"
-
-# Build — have a fleshed-out idea? Pass the file.
-factory ceo ~/ideas/weather-dashboard.md
-
-# Improve — point it at any codebase
-factory ceo ~/my-project
-
-# Focus — build exactly one thing
-factory ceo ~/my-project --focus "add WebSocket support"
-```
-
 ---
 
 ## How It Works
 
-```mermaid
-graph LR
-    A["Researcher<br><i>observe</i>"] --> B["Strategist<br><i>hypothesize</i>"]
-    B --> C["Builder<br><i>implement</i>"]
-    C --> RV["Reviewer<br><i>guard</i>"]
-    RV --> D["Evaluator<br><i>measure</i>"]
-    D --> E{"CEO<br><i>decide</i>"}
-    E -- "score up" --> F["KEEP"]
-    E -- "score down" --> G["REVERT"]
-    F --> H["Archivist<br><i>record</i>"]
-    G --> H
-    H -.-> A
-
-    style E fill:#5c6bc0,color:#fff,stroke:#3949ab
-    style F fill:#43a047,color:#fff,stroke:#2e7d32
-    style G fill:#e53935,color:#fff,stroke:#c62828
-```
-
-A CEO agent orchestrates eight specialists — Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst — each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. The Researcher searches the web and reads prior knowledge from the archive. The Strategist generates ranked hypotheses and handles design-mode ideation. The Builder implements one on an experiment branch. The Evaluator scores before and after. The CEO decides keep or revert. The Archivist records everything to `.factory/archive/` and regenerates performance reports for cross-project learning. In design mode, the Strategist synthesizes research into a buildable plan through user feedback. In research mode, the Failure Analyst classifies run failures to guide targeted hypothesis generation.
+A CEO agent orchestrates specialists agents like Researcher, Strategist, Builder, Reviewer, Evaluator, Archivist, Refiner, and Failure Analyst, each running as an independent [Claude Code](https://docs.anthropic.com/en/docs/claude-code) subprocess. The Researcher searches the web and reads prior knowledge from the archive. The Strategist generates ranked hypotheses and handles design-mode ideation. The Builder implements one on an experiment branch. The Evaluator scores before and after. The CEO decides keep or revert. The Archivist records everything to `.factory/archive/` and regenerates performance reports for cross-project learning.
 
 ---
 
@@ -95,8 +60,6 @@ factory ceo ~/factory-projects/my-app --mode design
 factory ceo ~/factory-projects/my-app --mode design --focus "auth layer"
 factory ceo ~/my-app --mode design --focus 42                       # GitHub issue
 factory ceo ~/my-app --mode design --focus "owner/repo#42"          # Issue shorthand
-factory ceo ~/my-app --mode design --focus '111 and 112'            # Multiple issues
-factory ceo ~/my-app --mode design --focus 'issue 42, issue 43'    # With 'issue' keyword
 ```
 
 ---
@@ -121,70 +84,6 @@ Without a colon, `--focus` always creates a new mode.
 The pipeline: **3 parallel researchers** (existing patterns, intent analysis, best practices) → **Strategist** synthesizes a workflow spec → **you approve** (like design mode) → **Builder** implements → **QA** verifies end-to-end → **PR**.
 
 Point it at the factory repo itself to extend re:factory with custom pipelines.
-
----
-
-## Other Workflows
-
-### Build — start from an idea
-
-```bash
-factory ceo "Build a REST API for bookmark management"
-factory ceo ~/ideas/weather-dashboard.md
-factory ceo https://github.com/user/repo
-```
-
-Give re:factory an idea (raw string, spec file, or GitHub URL) and it builds a complete project: scaffolding, tests, eval, and iterative improvement.
-
-### Improve — make an existing codebase better
-
-```bash
-factory ceo ~/my-project
-factory run ~/my-project --loop
-```
-
-Point it at any codebase. Each cycle observes the project, hypothesizes changes, implements one, and keeps it only if the score goes up.
-
-### Focus — build exactly one thing
-
-```bash
-factory ceo ~/my-project --focus "add authentication middleware"
-factory ceo ~/my-project --focus 42              # Target GitHub issue #42
-factory ceo ~/my-project --focus '111 and 112'   # Multiple issues
-```
-
-When you know exactly what you want, `--focus` pins a single backlog item, generates one hypothesis, runs one experiment, and exits.
-
-### Research — optimize a metric iteratively
-
-```bash
-factory ceo "SWE-bench solver agent" --mode research
-factory ceo ~/my-research-project --mode research
-```
-
-For projects with a measurable target metric (benchmark accuracy, solve rate, query precision). Research mode replaces the standard Improve loop with a specialized cycle: Baseline → Failure Analyst → Researcher → Strategist → Builder → Run → Verdict. See [Getting Started](getting-started.md#research-mode-in-detail) for the full picture.
-
-### Outer Loop — evolve workflow topologies
-
-```bash
-factory outer-loop calibrate ~/my-factory \
-  --benchmark featurebench \
-  --population-size 3 \
-  --project-dir /path/to/benchmark-instance \
-  --test-command "pytest tests/ -v"
-
-factory ceo ~/my-factory --mode outer-loop --headless
-```
-
-The outer loop evolves the factory's own workflow DAGs against benchmarks. Starting from a simple seed (e.g. builder-only), it mutates workflow structure (adding nodes, changing edges, tweaking prompts), evaluates each candidate on a real benchmark instance, and selects for higher test pass rates. See the [Outer Loop guide](outer-loop.md) for full architecture and CLI reference.
-
-### Headless & continuous loop
-
-```bash
-factory ceo ~/my-project --headless            # No interaction
-factory run ~/my-project --loop                 # Continuous improvement
-factory tmux ~/my-project --loop                # Detached tmux session
-```
 
 ---
 
@@ -227,7 +126,6 @@ See the [full setup guide](setup.md) for authentication, environment variables, 
 |---|---|
 | **Start from a raw idea** | `factory ceo "my idea" --mode design` |
 | **Improve an existing project** | `factory ceo /path/to/project --mode design --focus "issue # or area to improve"` |
-| **Target multiple issues** | `factory ceo /path/to/project --focus '111 and 112'` |
 | **Create a new factory mode** | `factory ceo /path/to/factory --mode create --focus "mode description"` |
 | **Update an existing mode** | `factory ceo /path/to/factory --mode create --focus "improve: add plateau detection"` |
 
@@ -235,50 +133,13 @@ re:factory doesn't just improve your project — it improves *itself*. Every kee
 
 This is powered by **ACE (Autonomous Context Engineering)** — inspired by Anthropic's work on [context engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) — a Reflect → Curate → Inject loop that evolves agent playbooks from real experiment outcomes.
 
-```mermaid
-graph LR
-    A["Experiment Outcomes<br><i>kept or reverted</i>"] -->|Reflect| B["Generate<br>candidate bullets"]
-    B -->|Curate| C["Merge & prune<br>playbooks"]
-    C -->|Inject| D["Agent Prompts<br><i>auto-appended</i>"]
-    D -.->|"next cycle"| A
-
-    style A fill:#fff3e0,stroke:#ff8f00
-    style D fill:#e8eaf6,stroke:#5c6bc0
-```
-
 Each agent accumulates behavioral rules — DOs and DON'Ts — with evidence counters. Rules that correlate with kept experiments get reinforced. Rules that correlate with reverts get pruned.
 
-```bash
-# Run a full improvement cycle, then evolve all agent playbooks
-factory ceo ~/my-project --mode meta
-```
-
-See [Self-Improvement Loop](self-improvement.md) for the full picture. See [ACE Playbook Evolution](ace.md) for the playbook mechanics.
+See [ACE Playbook Evolution](ace.md) for the playbook mechanics.
 
 ---
 
 ## Architecture
-
-```mermaid
-graph TB
-    subgraph agents ["Specialist Agents"]
-        R["Researcher"] ~~~ S["Strategist"] ~~~ BU["Builder"]
-        RE["Reviewer"] ~~~ EV["Evaluator"] ~~~ AR["Archivist"]
-        RF["Refiner"] ~~~ FA["Failure Analyst"]
-    end
-    subgraph ceo ["CEO Agent"]
-        C["Detect state → Route mode → Spawn agents → Keep/Revert → Archive"]
-    end
-    subgraph cli ["Python CLI"]
-        T["eval · guard · store · discover · events · strategy"]
-    end
-
-    agents --> ceo --> cli
-
-    style agents fill:#e8eaf6,stroke:#5c6bc0
-    style ceo fill:#fff3e0,stroke:#ff8f00
-    style cli fill:#e8f5e9,stroke:#43a047
-```
 
 re:factory is a three-layer system:
 
@@ -290,37 +151,9 @@ re:factory is a three-layer system:
 
 Data flows down: the CEO calls the CLI for eval, store, and guard operations. Agents call nothing — they produce text that the CEO interprets.
 
-See [Architecture](architecture.md) for the full deep-dive.
-
 ---
 
 ## Eval System
-
-```mermaid
-graph LR
-    subgraph hygiene ["Hygiene · 6 dims"]
-        H1["tests · lint · types<br>coverage · guards · config"]
-    end
-    subgraph growth ["Growth · 5 dims"]
-        G1["capability · diversity<br>observability · research<br>effectiveness"]
-    end
-    subgraph project ["Project · N dims"]
-        P1["your custom metrics<br>benchmarks · latency<br>accuracy · win rate"]
-    end
-
-    hygiene --> M["Weighted<br>Composite"]
-    growth --> M
-    project --> M
-    M --> S{"score >=<br>threshold?"}
-    S -- "yes" --> K["Keep"]
-    S -- "no" --> R["Revert"]
-
-    style hygiene fill:#e8eaf6,stroke:#5c6bc0
-    style growth fill:#fff3e0,stroke:#ff8f00
-    style project fill:#e8f5e9,stroke:#43a047
-    style K fill:#43a047,color:#fff
-    style R fill:#e53935,color:#fff
-```
 
 Every change is measured by a composite score across three tiers:
 
@@ -334,20 +167,36 @@ On first run, `factory discover` auto-detects your project's language and framew
 
 ---
 
+## Outer Loop — Evolve Workflow Topologies
+
+```bash
+factory outer-loop calibrate ~/my-factory \
+  --benchmark featurebench \
+  --population-size 3 \
+  --project-dir /path/to/benchmark-instance \
+  --test-command "pytest tests/ -v"
+
+factory ceo ~/my-factory --mode outer-loop --headless
+```
+
+The outer loop evolves the factory's own workflow DAGs against benchmarks. Starting from a simple seed (e.g. builder-only), it mutates workflow structure (adding nodes, changing edges, tweaking prompts), evaluates each candidate on a real benchmark instance, and selects for higher test pass rates. See the [Outer Loop guide](outer-loop.md) for full architecture and CLI reference.
+
+---
+
 ## Built with re:factory
 
 re:factory has shipped something every day for the last 30 days — products, research experiments, production features, papers. Here are a few examples:
 
-| Project | What it does | Mode |
-|---------|-------------|------|
-| **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis | Research |
-| **HMMT math solver** | Multi-agent team (Explorer, Theorist, Computationalist, Critic, Synthesizer) that solved HMMT Feb 2025 Combinatorics Problem 7 | Research |
-| **Text/Sketch → CAD** | Converts natural language and hand-drawn sketches into executable CadQuery code for 3D model generation | Research |
-| **HLS design space explorer** | Per-function AI agents explore HLS pragma/code variants in parallel, an ILP solver finds the optimal combination, then global expert agents apply cross-function optimizations — achieving up to 92% execution time reduction on cryptographic benchmarks | Build |
-| **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI | Build + Improve |
-| **Group chat digest** | Turns iMessage group chats into weekly family newsletters with AI-curated highlights and photo selection | Build + Improve |
-| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase | Focus + Improve |
-| **re:factory itself** | re:factory runs on itself in meta mode — its own agent playbooks are evolved from its own experiment outcomes | Meta |
+| Project | What it does |
+|---------|-------------|
+| **SWE-bench solver** | Autonomous agent that resolves GitHub issues from the SWE-bench dataset, iteratively improved via failure analysis |
+| **HMMT math solver** | Multi-agent team (Explorer, Theorist, Computationalist, Critic, Synthesizer) that solved HMMT Feb 2025 Combinatorics Problem 7 |
+| **Text/Sketch → CAD** | Converts natural language and hand-drawn sketches into executable CadQuery code for 3D model generation |
+| **HLS design space explorer** | Per-function AI agents explore HLS pragma/code variants in parallel, an ILP solver finds the optimal combination, then global expert agents apply cross-function optimizations — achieving up to 92% execution time reduction on cryptographic benchmarks |
+| **Pluck** | iOS app that extracts structured data from screenshots, links, and shared content using on-device AI |
+| **Group chat digest** | Turns iMessage group chats into weekly family newsletters with AI-curated highlights and photo selection |
+| **Production enterprise features** | Complete UI components and backend features shipped into a large-scale production codebase |
+| **re:factory itself** | re:factory runs on itself — its own agent playbooks are evolved from its own experiment outcomes |
 
 Built something with re:factory? [Open a PR](https://github.com/akashgit/remote-factory/pulls) to add it here.
 
@@ -495,7 +344,7 @@ Workflow graphs (Pydantic definitions) are converted to SKILL.md prose files tha
 
 ```
 Workflow (Pydantic) → templatize → review agent → guard → split
-                         |              |           |        |
+                         │              │           │        │
                     {{slot::default}}   opus    structural   SKILL.md +
                     + annotations     refines    diff check  annotations.yaml
 ```


### PR DESCRIPTION
Closes the content regression from PR #1303.

## Summary

- Restored `docs/index.md` to strictly the old `README.md` content (from `2e629009^`) with symlink-relative link transformations
- Removed content that came from the old `docs/index.md` but was never in `README.md`: intro code block, mermaid diagrams, "Other Workflows" section, multi-issue focus examples, `# re:factory` H1 heading
- Preserved Akash's outer-loop section (added after PR #1100) as a standalone `## Outer Loop` section after Eval System
- Applied required link fixes: absolute logo URL, full GitHub LICENSE link, `docs/foo.md` → `foo.md`, `infra/langfuse/README.md` → full GitHub URL, `uv run factory` → `factory`

## Test plan

- [x] `README.md` symlink still resolves correctly
- [x] `mkdocs build` succeeds
- [x] `ruff check .` — no new errors (pre-existing only)
- [x] `mypy factory/` — no new errors (pre-existing only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)