### PR TITLE
fix: conflict detector fails on branch checkout

### DIFF
--- a/.github/workflows/conflict-detector.yml
+++ b/.github/workflows/conflict-detector.yml
@@ -179,6 +179,7 @@ jobs:
           cp conflicts.jsonl /tmp/conflicts.jsonl.updated
 
           # Checkout or create conflict-data branch
+          rm -f conflicts.jsonl
           git fetch origin conflict-data || true
           if git show-ref --verify --quiet refs/remotes/origin/conflict-data; then
             git checkout -b conflict-data origin/conflict-data


### PR DESCRIPTION
## Summary

The PR Conflict Detector workflow fails at the "Commit conflicts.jsonl to conflict-data branch" step:

```
error: The following untracked working tree files would be overwritten by checkout:
    conflicts.jsonl
```

**Root cause:** `git show origin/conflict-data:conflicts.jsonl > conflicts.jsonl` creates the file early in the workflow, then `git checkout -b conflict-data origin/conflict-data` fails because git won't overwrite the untracked file.

**Fix:** `rm -f conflicts.jsonl` before the checkout. The file is already saved to `/tmp/conflicts.jsonl.updated`.

## Test plan

- [x] Verified the failure in [run 32162496911](https://github.com/akashgit/remote-factory/actions/runs/32162496911/job/95794395057)
- [x] Confirmed the fix: file is saved to /tmp before removal, restored after checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)