### PR TITLE
ci: add lambdabaa to ceo-review allowed callers

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
-      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98", "lukeinglis", "nehamalepati", "abhi1092", "s-akhtar-baig"]'), github.event.comment.user.login)
+      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98", "lukeinglis", "nehamalepati", "abhi1092", "s-akhtar-baig", "lambdabaa"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 120
 


### PR DESCRIPTION
Closes #1304

## Changes
- Added GitHub username `lambdabaa` to the allowed users list for the `@ceo-review` workflow trigger in `.github/workflows/ceo-review.yml`