### PR TITLE
fix: broken GitHub README links via mkdocs build hook

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,5 +25,7 @@ jobs:
           python-version: "3.12"
       - name: Install MkDocs Material
         run: pip install mkdocs-material
+      - name: Validate docs build
+        run: mkdocs build --strict
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/docs/contributing-benchmarks.md
+++ b/docs/contributing-benchmarks.md
@@ -2,7 +2,7 @@
 
 This guide walks you through adding a new benchmark to re:factory. By the end, you will have a workflow definition that the factory can execute, a Harbor agent that runs it in an isolated container, and a CI matrix entry that runs it on every push.
 
-If you are looking for the technical spec (DSL primitives, node types, edge conditions), see [`factory/workflow/contributed/README.md`](../factory/workflow/contributed/README.md). This guide focuses on the practical, end to end process.
+If you are looking for the technical spec (DSL primitives, node types, edge conditions), see [`factory/workflow/contributed/README.md`](https://github.com/akashgit/remote-factory/blob/main/factory/workflow/contributed/README.md). This guide focuses on the practical, end to end process.
 
 
 ## What a Benchmark Contribution Consists Of
@@ -368,8 +368,8 @@ When in doubt, read the source. The legacybench workflow is the simplest (4 node
 
 ## Further Reading
 
-- [`factory/workflow/contributed/README.md`](../factory/workflow/contributed/README.md) for the technical spec (DSL primitives, directory layout, linting details)
-- [`factory/workflow/README.md`](../factory/workflow/README.md) for full workflow engine documentation
-- [`benchmarks/factory_harbor_agent.py`](../benchmarks/factory_harbor_agent.py) for the base Harbor agent implementation
-- [`benchmarks/config.sh`](../benchmarks/config.sh) for benchmark configuration examples
-- [`.github/workflows/benchmark.yml`](../.github/workflows/benchmark.yml) for CI integration patterns
+- [`factory/workflow/contributed/README.md`](https://github.com/akashgit/remote-factory/blob/main/factory/workflow/contributed/README.md) for the technical spec (DSL primitives, directory layout, linting details)
+- [`factory/workflow/README.md`](https://github.com/akashgit/remote-factory/blob/main/factory/workflow/README.md) for full workflow engine documentation
+- [`benchmarks/factory_harbor_agent.py`](https://github.com/akashgit/remote-factory/blob/main/benchmarks/factory_harbor_agent.py) for the base Harbor agent implementation
+- [`benchmarks/config.sh`](https://github.com/akashgit/remote-factory/blob/main/benchmarks/config.sh) for benchmark configuration examples
+- [`.github/workflows/benchmark.yml`](https://github.com/akashgit/remote-factory/blob/main/.github/workflows/benchmark.yml) for CI integration patterns

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ factory ceo ~/my-project
 factory ceo ~/my-project --focus "add WebSocket support"
 ```
 
-All state is local — per-project in `.factory/` (add to `.gitignore`), global in `~/.factory/`. See [Architecture](architecture.md) for the full deep-dive.
+All state is local — per-project in `.factory/` (add to `.gitignore`), global in `~/.factory/`. See [Architecture](docs/architecture.md) for the full deep-dive.
 
 ---
 
@@ -141,7 +141,7 @@ Beyond the core Design and Create modes, re:factory ships with a growing set of 
 
 ### Community-Contributed Benchmarks
 
-These benchmark workflows live in `factory/workflow/contributed/` and follow a standard 4-node pipeline pattern (study → solver → gate → merge). See [Contributing Benchmarks](contributing-benchmarks.md) for how to add your own.
+These benchmark workflows live in `factory/workflow/contributed/` and follow a standard 4-node pipeline pattern (study → solver → gate → merge). See [Contributing Benchmarks](docs/contributing-benchmarks.md) for how to add your own.
 
 | Workflow | What it solves |
 |----------|---------------|
@@ -187,7 +187,7 @@ factory ceo "my idea" --mode design
 factory ceo /path/to/project --mode design --focus "issue # or area to improve"
 ```
 
-See the [full setup guide](setup.md) for authentication, environment variables, and justification for why we install globally.
+See the [full setup guide](docs/setup.md) for authentication, environment variables, and justification for why we install globally.
 
 ---
 
@@ -206,7 +206,7 @@ This is powered by **ACE (Autonomous Context Engineering)** — inspired by Anth
 
 Each agent accumulates behavioral rules — DOs and DON'Ts — with evidence counters. Rules that correlate with kept experiments get reinforced. Rules that correlate with reverts get pruned.
 
-See [ACE Playbook Evolution](ace.md) for the playbook mechanics.
+See [ACE Playbook Evolution](docs/ace.md) for the playbook mechanics.
 
 ---
 
@@ -220,7 +220,7 @@ Every change is measured by a composite score across three tiers:
 | **Growth** (5 dimensions) | Capability evolution | API surface area, experiment diversity, observability, research effectiveness |
 | **Project** (user-defined) | Domain-specific metrics | Benchmark accuracy, latency, win rate |
 
-On first run, `factory discover` auto-detects your project's language and framework to generate the eval profile. The weighted composite of all dimensions determines whether each experiment is kept or reverted. See [Eval System](eval.md) for scoring details, weights, and guards.
+On first run, `factory discover` auto-detects your project's language and framework to generate the eval profile. The weighted composite of all dimensions determines whether each experiment is kept or reverted. See [Eval System](docs/eval.md) for scoring details, weights, and guards.
 
 ---
 
@@ -236,7 +236,7 @@ factory outer-loop calibrate ~/my-factory \
 factory ceo ~/my-factory --mode outer-loop --headless
 ```
 
-The outer loop evolves the factory's own workflow DAGs against benchmarks. Starting from a simple seed (e.g. builder-only), it mutates workflow structure (adding nodes, changing edges, tweaking prompts), evaluates each candidate on a real benchmark instance, and selects for higher test pass rates. See the [Outer Loop guide](outer-loop.md) for full architecture and CLI reference.
+The outer loop evolves the factory's own workflow DAGs against benchmarks. Starting from a simple seed (e.g. builder-only), it mutates workflow structure (adding nodes, changing edges, tweaking prompts), evaluates each candidate on a real benchmark instance, and selects for higher test pass rates. See the [Outer Loop guide](docs/outer-loop.md) for full architecture and CLI reference.
 
 ---
 
@@ -299,7 +299,7 @@ FACTORY_RUNNER = "bob"
 BOBSHELL_API_KEY = "..."
 ```
 
-Run `factory config show` to see resolved config, or `factory config edit` to open the file. See [Setup Guide](setup.md) for full details.
+Run `factory config show` to see resolved config, or `factory config edit` to open the file. See [Setup Guide](docs/setup.md) for full details.
 
 ---
 
@@ -421,14 +421,14 @@ A regression test (`test_annotations_match_source`) runs in CI to catch drift be
 
 | Doc | What's in it |
 |-----|-------------|
-| [Setup Guide](setup.md) | Installation, authentication, environment variables |
-| [Getting Started](getting-started.md) | Lifecycle walkthrough, research mode details, factory.md config |
-| [Architecture](architecture.md) | Three-layer system, agent roles, state machine, data flow |
-| [Eval System](eval.md) | Hygiene/growth/project tiers, scoring, guards, precheck |
-| [Configuration](configuration.md) | `factory.md` reference — all sections and options |
-| [ACE Self-Improvement](ace.md) | How re:factory evolves its own agent playbooks |
-| [Contributing](contributing.md) | Dev setup, code style, testing, PR workflow |
-| [Contributing Benchmarks](contributing-benchmarks.md) | How to add new benchmarks: workflow structure, Harbor setup, CI integration |
+| [Setup Guide](docs/setup.md) | Installation, authentication, environment variables |
+| [Getting Started](docs/getting-started.md) | Lifecycle walkthrough, research mode details, factory.md config |
+| [Architecture](docs/architecture.md) | Three-layer system, agent roles, state machine, data flow |
+| [Eval System](docs/eval.md) | Hygiene/growth/project tiers, scoring, guards, precheck |
+| [Configuration](docs/configuration.md) | `factory.md` reference — all sections and options |
+| [ACE Self-Improvement](docs/ace.md) | How re:factory evolves its own agent playbooks |
+| [Contributing](docs/contributing.md) | Dev setup, code style, testing, PR workflow |
+| [Contributing Benchmarks](docs/contributing-benchmarks.md) | How to add new benchmarks: workflow structure, Harbor setup, CI integration |
 
 ## Development
 

--- a/hooks/link_rewrite.py
+++ b/hooks/link_rewrite.py
@@ -1,0 +1,31 @@
+"""MkDocs hook: rewrite docs/-prefixed links for index.md.
+
+README.md is a symlink to docs/index.md. Links in that file use
+docs/foo.md so GitHub resolves them correctly from the repo root.
+This hook strips the docs/ prefix at build time so MkDocs resolves
+them relative to the docs directory.
+"""
+
+import re
+
+
+def on_page_markdown(markdown: str, page, config, files, **kwargs) -> str:
+    if page.file.src_path != "index.md":
+        return markdown
+
+    # Inline links: [text](docs/foo.md) or [text](docs/foo.md#anchor)
+    markdown = re.sub(
+        r'\]\(docs/([^)]+)\)',
+        r'](\1)',
+        markdown,
+    )
+
+    # Reference-style links: [text]: docs/foo.md
+    markdown = re.sub(
+        r'^(\[[^\]]+\]:\s+)docs/(.+)$',
+        r'\1\2',
+        markdown,
+        flags=re.MULTILINE,
+    )
+
+    return markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,9 @@ theme:
   icon:
     repo: fontawesome/brands/github
 
+hooks:
+  - hooks/link_rewrite.py
+
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
Closes the README broken-links issue.

## Changes

- **Reverted 16 internal doc links** in `docs/index.md` from docs-relative form (`architecture.md`) back to root-relative form (`docs/architecture.md`) so GitHub resolves them correctly through the `README.md → docs/index.md` symlink
- **Created `hooks/link_rewrite.py`** — an `on_page_markdown` mkdocs hook that strips the `docs/` prefix when building `index.md`, so mkdocs still resolves links correctly within the docs directory
- **Added `hooks:` entry to `mkdocs.yml`** to register the link rewrite hook (native mkdocs feature, no new dependency)
- **Added `mkdocs build --strict` validation step** to `.github/workflows/docs.yml` before the deploy step, catching broken links in CI
- **Fixed 6 pre-existing broken links** in `docs/contributing-benchmarks.md` that pointed to source files outside the docs directory (converted to absolute GitHub URLs)

## Verification

- `mkdocs build --strict` passes with zero warnings
- Links in `docs/index.md` use `docs/` prefix (correct for GitHub rendering via symlink)
- Generated HTML has no `docs/` prefix in links (hook correctly strips them for mkdocs)