### PR TITLE
fix: clean up stale modes and fix auto-routing

### DIFF
--- a/factory/agents/prompts/ceo.md
+++ b/factory/agents/prompts/ceo.md
@@ -44,11 +44,9 @@ You communicate directly with the user when running in foreground mode. You expl
 
 **You MUST complete ALL planned work before exiting.** This applies to every mode:
 
-- **Build mode:** All phases (B0–B6) must be attempted
-- **Improve mode:** Every approved hypothesis must have a Builder keep/revert verdict
-- **Discover mode:** The eval profile must be generated
+- **Design mode:** All phases must be attempted (build, discover, and improve are handled inline)
 - **Research mode:** Every approved hypothesis must have a verdict, or a termination condition must be met
-- **Meta mode:** Same as Improve, plus ACE playbook evolution
+- **Meta mode:** Same as Design, plus ACE playbook evolution
 
 **Self-judged early exits are FORBIDDEN.** Do not exit because:
 - "This is a good stopping point" — there are no stopping points, only completion

--- a/factory/ceo_completion.py
+++ b/factory/ceo_completion.py
@@ -292,53 +292,18 @@ def _detect_incomplete(
         cycle_started_at: If provided, only counts experiments created after this time.
             This prevents counting stale experiments from previous cycles.
     """
-    if mode in ("improve", "meta", "research"):
+    if mode in ("design", "meta", "research"):
         planned = _count_hypotheses(project_path)
         completed = _count_verdicts(project_path, since_ts=cycle_started_at)
 
         if planned == 0:
-            # No strategy yet — not an incomplete cycle, probably discover mode
-            return None
-
-        if completed >= planned:
-            return None
-
-        next_h = completed + 1
-        reason_prefix = "research" if mode == "research" else "improve"
-        return IncompleteGap(
-            mode=mode,
-            planned=planned,
-            completed=completed,
-            next_item=f"H{next_h}",
-            reason=f"{reason_prefix}.incomplete: {completed}/{planned} hypotheses have verdicts",
-        )
-
-    elif mode == "discover":
-        if _has_eval_profile(project_path):
-            return None
-        return IncompleteGap(
-            mode=mode,
-            planned=1,
-            completed=0,
-            next_item="eval_profile",
-            reason="discover.incomplete: no eval_profile.json",
-        )
-
-    elif mode == "build":
-        # For build mode, check if Builder completed at least one hypothesis
-        # In build mode, the strategy file should have phases marked as hypotheses
-        planned = _count_hypotheses(project_path)
-        completed = _count_verdicts(project_path, since_ts=cycle_started_at)
-
-        if planned == 0:
-            # No strategy means we're in scaffold phase — check for eval profile
-            if not _has_eval_profile(project_path):
+            if mode == "design" and not _has_eval_profile(project_path):
                 return IncompleteGap(
                     mode=mode,
                     planned=1,
                     completed=0,
                     next_item="discovery",
-                    reason="build.incomplete: no eval profile yet",
+                    reason="design.incomplete: no eval profile yet",
                 )
             return None
 
@@ -346,12 +311,13 @@ def _detect_incomplete(
             return None
 
         next_h = completed + 1
+        reason_prefix = "research" if mode == "research" else "design"
         return IncompleteGap(
             mode=mode,
             planned=planned,
             completed=completed,
-            next_item=f"Phase{next_h}",
-            reason=f"build.incomplete: {completed}/{planned} phases have verdicts",
+            next_item=f"H{next_h}",
+            reason=f"{reason_prefix}.incomplete: {completed}/{planned} hypotheses have verdicts",
         )
 
     # Unknown mode — assume complete
@@ -386,25 +352,13 @@ def _build_continuation_task(gap: IncompleteGap, cycle_state: CycleState | None 
             f"research cycle (R3–R5) for each remaining hypothesis. "
             f"Progress so far: {gap.completed}/{gap.planned} hypotheses have verdicts."
         )
-    elif gap.mode in ("improve", "meta"):
+    elif gap.mode in ("design", "meta"):
         body = (
-            f"Resume execution from hypothesis {gap.next_item}. "
+            f"Resume execution from {gap.next_item}. "
             f"Strategy is already approved at .factory/strategy/current.md — "
             f"do not re-plan, do not re-run Researcher or Strategist. "
             f"Spawn Builder for {gap.next_item} immediately. "
             f"Progress so far: {gap.completed}/{gap.planned} hypotheses have verdicts."
-        )
-    elif gap.mode == "build":
-        body = (
-            f"Resume Build pipeline from {gap.next_item}. "
-            f"Plan is already approved at .factory/strategy/current.md. "
-            f"Progress so far: {gap.completed}/{gap.planned} phases complete. "
-            f"Continue with the next phase immediately."
-        )
-    elif gap.mode == "discover":
-        body = (
-            "Resume Discovery. The eval profile has not been generated yet. "
-            "Complete the Discover mode workflow to produce .factory/eval_profile.json."
         )
     else:
         body = f"Resume from {gap.next_item}."

--- a/factory/checkpoint.py
+++ b/factory/checkpoint.py
@@ -36,6 +36,7 @@ class CheckpointState(BaseModel):
 def save_checkpoint(project_path: Path, state: CheckpointState) -> None:
     """Serialize checkpoint state to .factory/checkpoint.json."""
     from factory.store import ensure_factory_dir
+
     factory_dir = project_path / ".factory"
     ensure_factory_dir(factory_dir)
     checkpoint_path = factory_dir / _CHECKPOINT_FILE
@@ -45,6 +46,8 @@ def save_checkpoint(project_path: Path, state: CheckpointState) -> None:
 
 def load_checkpoint(project_path: Path) -> CheckpointState | None:
     """Load checkpoint from .factory/checkpoint.json, or None if absent/corrupt."""
+    from factory.cli._helpers import DEAD_MODES
+
     checkpoint_path = project_path / ".factory" / _CHECKPOINT_FILE
     if not checkpoint_path.exists():
         log.debug("checkpoint.not_found", path=str(checkpoint_path))
@@ -55,6 +58,10 @@ def load_checkpoint(project_path: Path) -> CheckpointState | None:
     except (json.JSONDecodeError, Exception) as exc:
         log.warning("checkpoint.corrupt", path=str(checkpoint_path), error=str(exc))
         return None
+    if state.mode in DEAD_MODES:
+        old_mode = state.mode
+        state.mode = DEAD_MODES[old_mode]
+        log.warning("checkpoint.mode_migrated", old=old_mode, new=state.mode)
     log.info("checkpoint.loaded", path=str(checkpoint_path))
     return state
 

--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -57,6 +57,7 @@ def _tool_exec_protocol(wt_path: Path) -> str:
     overview = ""
     try:
         from factory.workflow.tool import tool_overview
+
         overview = tool_overview(p, fmt="linear")
     except Exception:
         pass
@@ -69,11 +70,7 @@ def _tool_exec_protocol(wt_path: Path) -> str:
     )
 
     if overview:
-        protocol += (
-            "\n## Workflow Map\n"
-            "\n"
-            f"{overview}\n"
-        )
+        protocol += f"\n## Workflow Map\n\n{overview}\n"
 
     protocol += (
         "\n## Commands\n"
@@ -90,7 +87,7 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         '1. Run "next" to see your current task — it tells you the node type, '
         "role, and what to do\n"
         "2. Execute the task:\n"
-        "   - Agent nodes: run factory agent <role> --task \"...\" --project <path>\n"
+        '   - Agent nodes: run factory agent <role> --task "..." --project <path>\n'
         "   - Study nodes: run the study command shown\n"
         "   - Function nodes: run the command shown\n"
         '3. Run "next" again — the tool auto-detects that the previous node completed\n'
@@ -98,12 +95,12 @@ def _tool_exec_protocol(wt_path: Path) -> str:
         "4. Repeat until GATE or DONE\n"
         "5. For GATE nodes: the tool asks you to evaluate — read the artifacts, then\n"
         '   call "submit" with your verdict (PROCEED, RETRY, or HALT)\n'
-        "6. If RETRY: the tool rewinds — run \"next\" to get the retry task\n"
+        '6. If RETRY: the tool rewinds — run "next" to get the retry task\n'
         "7. If DONE: report completion\n"
         "\n"
         "## Important\n"
         "\n"
-        "- For most nodes, just run the command and call \"next\" — the tool handles tracking\n"
+        '- For most nodes, just run the command and call "next" — the tool handles tracking\n'
         '- Only call "submit" for gate verdicts (PROCEED/RETRY/HALT)\n'
         "- The tool auto-detects agent completion via .factory/reviews/ files\n"
         "- The tool auto-evaluates fn gates (precheck, guard) on your behalf\n"
@@ -144,16 +141,32 @@ def _tool_exec_protocol(wt_path: Path) -> str:
 
 def _validate_ceo_flags(
     args: argparse.Namespace,
-) -> tuple[str, bool, bool, bool, str | None, str | None, str | None, str | None, bool, str | None, bool] | int:
+) -> (
+    tuple[
+        str,
+        bool,
+        bool,
+        bool,
+        str | None,
+        str | None,
+        str | None,
+        str | None,
+        bool,
+        str | None,
+        bool,
+    ]
+    | int
+):
     """Validate and resolve top-level CLI flags. Returns parsed values or an error code."""
     mode: str = getattr(args, "mode", "auto")
     if mode == "interactive":
         mode = "design"
     if mode.startswith("project:"):
-        mode = mode[len("project:"):]
+        mode = mode[len("project:") :]
     all_modes = get_all_ceo_modes()
     if mode not in all_modes and mode != "auto":
         from factory.workflow.registry import WorkflowRegistry
+
         raw_path = getattr(args, "path", None)
         project_path = Path(raw_path).resolve() if raw_path else Path.cwd()
         entries = WorkflowRegistry.discover(project_path)
@@ -209,6 +222,7 @@ def _validate_ceo_flags(
     raw_path = getattr(args, "path", None)
     if not raw_path:
         from factory.plugins import get_registry
+
         plugin_registry = get_registry()
         has_pre_hooks = bool(plugin_registry.ceo_pre_hooks)
         if not has_pre_hooks:
@@ -294,7 +308,19 @@ def _validate_ceo_flags(
         )
         return 1
 
-    return (mode, headless, bg, bg_agents, prompt_file, focus, dir_name, refine_request, auto_approve, from_plan, just_plan)
+    return (
+        mode,
+        headless,
+        bg,
+        bg_agents,
+        prompt_file,
+        focus,
+        dir_name,
+        refine_request,
+        auto_approve,
+        from_plan,
+        just_plan,
+    )
 
 
 # ── project resolution ────────────────────────────────────────
@@ -454,9 +480,23 @@ def _validate_late_flags(
         )
         return 1
 
-    if focus and mode not in ("improve", "research", "create", "evolve", "study", "frontend-design", "frontend-design-discover") and not design_existing and not just_plan:
+    if (
+        focus
+        and mode
+        not in (
+            "design",
+            "research",
+            "create",
+            "evolve",
+            "study",
+            "frontend-design",
+            "frontend-design-discover",
+        )
+        and not design_existing
+        and not just_plan
+    ):
         print(
-            f"Error: --focus (targeted mode) only works in improve, research, create, evolve, study, frontend-design, "
+            f"Error: --focus (targeted mode) only works in design, research, create, evolve, study, frontend-design, "
             f"frontend-design-discover, or design (with --just-plan) mode, "
             f"got '{mode}'. The project must already be built before targeting specific items.",
             file=sys.stderr,
@@ -602,7 +642,7 @@ def _execute_ceo(
     elif mode == "design":
         ceo_mode = "design"
     elif interactive:
-        ceo_mode = "build"
+        ceo_mode = "design"
     else:
         ceo_mode = mode
 
@@ -746,12 +786,18 @@ def _execute_ceo(
 
         if engine == "tool":
             base_prompt = resolve_prompt(
-                "ceo", wt_path, use_profile=use_profile, workflow_mode=None,
+                "ceo",
+                wt_path,
+                use_profile=use_profile,
+                workflow_mode=None,
             )
             prompt = base_prompt + _tool_exec_protocol(wt_path)
         else:
             prompt = resolve_prompt(
-                "ceo", wt_path, use_profile=use_profile, workflow_mode=ceo_mode,
+                "ceo",
+                wt_path,
+                use_profile=use_profile,
+                workflow_mode=ceo_mode,
             )
         runner = get_runner(runner_name)
         extras: dict[str, object] = {}
@@ -776,6 +822,7 @@ def _execute_ceo(
         if engine == "tool":
             try:
                 from factory.workflow.tool import tool_finalize
+
                 finalize_result = tool_finalize(wt_path)
                 log.info("tool_exec.finalized", result=finalize_result)
             except Exception:
@@ -847,13 +894,18 @@ def _run_headless(
         executor = WorkflowExecutor(wf, wt_path, agent_pool=DEFAULT_AGENT_POOL)
         try:
             exec_result = asyncio.run(executor.execute())
-            print(json.dumps({
-                "workflow": ceo_mode,
-                "engine": "deterministic",
-                "success": exec_result.success,
-                "nodes_executed": exec_result.nodes_executed,
-                "duration_ms": round(exec_result.duration_ms, 1),
-            }, indent=2))
+            print(
+                json.dumps(
+                    {
+                        "workflow": ceo_mode,
+                        "engine": "deterministic",
+                        "success": exec_result.success,
+                        "nodes_executed": exec_result.nodes_executed,
+                        "duration_ms": round(exec_result.duration_ms, 1),
+                    },
+                    indent=2,
+                )
+            )
             code = 0 if exec_result.success else 1
             if code != 0:
                 return code
@@ -863,7 +915,7 @@ def _run_headless(
                 min_growth=min_growth,
                 max_new=max_new,
                 branch=branch,
-                already_improved=mode in ("improve", "meta") or discover_only,
+                already_improved=mode in ("design", "meta") or discover_only,
                 model=model,
                 no_github=no_github,
                 use_profile=use_profile,
@@ -916,7 +968,7 @@ def _run_headless(
             min_growth=min_growth,
             max_new=max_new,
             branch=branch,
-            already_improved=mode in ("improve", "meta") or discover_only,
+            already_improved=mode in ("design", "meta") or discover_only,
             model=model,
             no_github=no_github,
             use_profile=use_profile,
@@ -929,6 +981,7 @@ def _run_headless(
         if engine == "tool":
             try:
                 from factory.workflow.tool import tool_finalize
+
                 tool_finalize(wt_path)
             except Exception:
                 pass

--- a/factory/cli/_helpers.py
+++ b/factory/cli/_helpers.py
@@ -17,17 +17,20 @@ log = structlog.get_logger()
 _WIZARD_INPUT_PATH = Path("~/.factory/wizard_input.md")
 
 
+DEAD_MODES: dict[str, str] = {
+    "build": "design",
+    "improve": "design",
+    "discover": "design",
+    "interactive": "design",
+    "parallel-improve": "design",
+}
+
 CEO_MODES = [
     "auto",
     "auto-fresh",
-    "build",
-    "discover",
     "founder",
-    "improve",
     "meta",
     "design",
-    "interactive",
-    "parallel-improve",
     "research",
     "review",
     "deep-qa",
@@ -46,12 +49,9 @@ CEO_MODES = [
 RUN_MODES = [
     "auto",
     "auto-fresh",
-    "build",
-    "discover",
+    "design",
     "founder",
-    "improve",
     "meta",
-    "parallel-improve",
     "research",
     "study",
     "swebench",
@@ -69,15 +69,10 @@ def get_all_ceo_modes() -> list[str]:
 
 DEPRECATED_MODES: frozenset[str] = frozenset(
     {
-        "build",
-        "improve",
         "research",
         "meta",
-        "discover",
         "review",
         "refine",
-        "parallel-improve",
-        "interactive",
     }
 )
 
@@ -87,12 +82,9 @@ def warn_deprecated_mode(mode: str) -> None:
     if mode not in DEPRECATED_MODES:
         return
     replacement = "design"
-    extra = ""
-    if mode == "interactive":
-        extra = " ('interactive' is an alias for 'design')"
     log.warning("deprecated_cli_mode", mode=mode, replacement=replacement)
     print(
-        f"WARNING: --mode {mode} is deprecated{extra}. "
+        f"WARNING: --mode {mode} is deprecated. "
         f"Use --mode {replacement} instead. "
         f"This mode remains functional but will be removed in a future release.",
         file=sys.stderr,

--- a/factory/cli/_mode_handlers.py
+++ b/factory/cli/_mode_handlers.py
@@ -1,4 +1,5 @@
 """Mode-specific early-exit handlers for CEO commands (review, deep-qa)."""
+
 from __future__ import annotations
 
 import argparse
@@ -48,7 +49,9 @@ def _resolve_bg_agents(args: argparse.Namespace) -> bool:
     return bool(val and val.lower() in ("1", "true", "yes"))
 
 
-def _auto_detect_mode(project_path: Path, has_prompt: bool = False, force_fresh: bool = False) -> str:
+def _auto_detect_mode(
+    project_path: Path, has_prompt: bool = False, force_fresh: bool = False
+) -> str:
     """Detect the right mode based on project state.
 
     Checks for an in-flight cycle first — if one exists, returns its mode
@@ -58,23 +61,30 @@ def _auto_detect_mode(project_path: Path, has_prompt: bool = False, force_fresh:
         project_path: Path to the project.
         has_prompt: True if a build spec is available.
         force_fresh: If True, ignores in-flight cycle and detects from scratch.
-
-    When a build spec is available (--prompt, idea file, or raw prompt),
-    no_factory routes to build (not discover).
     """
+    import structlog
+
     from factory.ceo_completion import read_cycle_state
+    from factory.cli._helpers import DEAD_MODES
     from factory.models import ProjectState
     from factory.state import detect_state
+
+    _log = structlog.get_logger()
 
     if not force_fresh:
         cycle_state = read_cycle_state(project_path)
         if cycle_state:
+            mode = cycle_state.mode
+            if mode in DEAD_MODES:
+                new_mode = DEAD_MODES[mode]
+                _log.warning("cycle_state.mode_migrated", old=mode, new=new_mode)
+                mode = new_mode
             print(
-                f"  In-flight cycle: {cycle_state.cycle_id} → mode: {cycle_state.mode} "
+                f"  In-flight cycle: {cycle_state.cycle_id} → mode: {mode} "
                 f"(respawns: {cycle_state.respawns})",
                 file=sys.stderr,
             )
-            return cycle_state.mode
+            return mode
 
     state = detect_state(project_path)
     mode_map = {

--- a/factory/cli/_task_builder.py
+++ b/factory/cli/_task_builder.py
@@ -17,12 +17,10 @@ def _slug(desc: str) -> str:
 
 def _mode_suffix(mode: str, discover_only: bool) -> str:
     _SIMPLE_MODE_SUFFIXES = {
-        "build": (
-            "\n\nRun Build mode: the project is new or incomplete. Run the Plan Loop "
-            "(P0-P3) to produce an approved build plan, then follow the Build pipeline "
-            "(B3-B6): Build phases → E2E verification. "
-            "Do NOT skip to Improve mode — the project needs to be built first. "
-            "The full step-by-step playbook is in your system prompt above."
+        "design": (
+            "\n\nRun Design mode: the universal entry point. Design mode handles build, "
+            "discover, and improve workflows inline via its conditional gates. "
+            "Follow the step-by-step playbook in your system prompt above."
         ),
         "meta": (
             "\n\nRun Meta mode: full self-improvement. First, run the complete Improve loop "

--- a/factory/cli/run.py
+++ b/factory/cli/run.py
@@ -1,4 +1,5 @@
 """Factory run command — single-shot and heartbeat loop execution."""
+
 from __future__ import annotations
 
 import argparse
@@ -205,7 +206,7 @@ def _chain_modes(
         if state == ProjectState.HAS_FACTORY and already_improved:
             return 0
         next_mode = _auto_detect_mode(project_path)
-        if next_mode == "improve":
+        if next_mode == "design":
             already_improved = True
         print(
             f"[factory] Chaining: state={state.value} → mode={next_mode} "
@@ -332,10 +333,7 @@ def _run_heartbeat_loop(
         signal.signal(signal.SIGINT, old_sigint)
 
     elapsed = time.monotonic() - start_time
-    print(
-        f"[factory] Shutting down gracefully after {cycle} cycles."
-        f" Total runtime: {elapsed:.0f}s"
-    )
+    print(f"[factory] Shutting down gracefully after {cycle} cycles. Total runtime: {elapsed:.0f}s")
     return 0
 
 
@@ -432,9 +430,9 @@ def cmd_run(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    if focus and mode not in ("improve", "research"):
+    if focus and mode not in ("design", "research"):
         print(
-            f"Error: --focus (targeted mode) only works in improve or research mode, got '{mode}'. "
+            f"Error: --focus (targeted mode) only works in design or research mode, got '{mode}'. "
             "The project must already be built before targeting specific items.",
             file=sys.stderr,
         )
@@ -457,7 +455,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"  Cleaned {len(pruned)} stale worktree(s)", file=sys.stderr)
 
     budget_kwargs = dict(min_growth=min_growth, max_new=max_new, branch=branch)
-    skip_improve = mode in ("improve", "meta") or discover_only
+    skip_improve = mode in ("design", "meta") or discover_only
 
     overwrite = getattr(args, "overwrite", None)
 

--- a/tests/test_ceo_completion.py
+++ b/tests/test_ceo_completion.py
@@ -19,13 +19,13 @@ class TestCycleState:
             write_cycle_state,
         )
 
-        state = create_cycle_state("build", "Build a CLI tool")
+        state = create_cycle_state("design", "Build a CLI tool")
         write_cycle_state(tmp_path, state)
 
         loaded = read_cycle_state(tmp_path)
         assert loaded is not None
         assert loaded.cycle_id == state.cycle_id
-        assert loaded.mode == "build"
+        assert loaded.mode == "design"
         assert loaded.initial_prompt == "Build a CLI tool"
         assert loaded.respawns == 0
 
@@ -44,7 +44,7 @@ class TestCycleState:
             write_cycle_state,
         )
 
-        state = create_cycle_state("improve")
+        state = create_cycle_state("design")
         write_cycle_state(tmp_path, state)
         assert read_cycle_state(tmp_path) is not None
 
@@ -73,7 +73,7 @@ class TestCycleState:
         state_data = {
             "cycle_id": "old123",
             "started_at": old_time.isoformat(),
-            "mode": "build",
+            "mode": "design",
             "initial_prompt": "",
             "respawns": 5,
         }
@@ -98,7 +98,7 @@ class TestCycleState:
         from factory.ceo_completion import create_cycle_state, write_cycle_state, read_cycle_state
 
         long_prompt = "x" * 5000
-        state = create_cycle_state("build", long_prompt)
+        state = create_cycle_state("design", long_prompt)
         write_cycle_state(tmp_path, state)
 
         loaded = read_cycle_state(tmp_path)
@@ -122,15 +122,15 @@ class TestBudgetAllowsRespawn:
 class TestDetectIncomplete:
     """Tests for _detect_incomplete()."""
 
-    def test_build_incomplete_no_eval_profile(self, tmp_path: Path) -> None:
+    def test_design_incomplete_no_eval_profile(self, tmp_path: Path) -> None:
         """Build mode without strategy needs eval profile."""
         from factory.ceo_completion import _detect_incomplete
 
         (tmp_path / ".factory").mkdir()
 
-        gap = _detect_incomplete(tmp_path, "build")
+        gap = _detect_incomplete(tmp_path, "design")
         assert gap is not None
-        assert gap.mode == "build"
+        assert gap.mode == "design"
         assert gap.next_item == "discovery"
         assert "no eval profile" in gap.reason
 
@@ -151,10 +151,10 @@ class TestDetectIncomplete:
             exp_dir.mkdir(parents=True)
             (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
 
-        gap = _detect_incomplete(tmp_path, "improve")
+        gap = _detect_incomplete(tmp_path, "design")
         assert gap is None
 
-    def test_improve_incomplete_when_missing_verdicts(self, tmp_path: Path) -> None:
+    def test_design_incomplete_when_missing_verdicts(self, tmp_path: Path) -> None:
         """Improve mode is incomplete when verdict count < hypothesis count."""
         from factory.ceo_completion import _detect_incomplete
 
@@ -170,20 +170,32 @@ class TestDetectIncomplete:
         exp_dir.mkdir(parents=True)
         (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
 
-        gap = _detect_incomplete(tmp_path, "improve")
+        gap = _detect_incomplete(tmp_path, "design")
         assert gap is not None
         assert gap.planned == 3
         assert gap.completed == 1
         assert gap.next_item == "H2"
-        assert "improve.incomplete" in gap.reason
+        assert "design.incomplete" in gap.reason
 
-    def test_improve_no_strategy_returns_none(self, tmp_path: Path) -> None:
-        """No strategy file means nothing planned — not incomplete."""
+    def test_design_no_strategy_no_eval_profile_returns_gap(self, tmp_path: Path) -> None:
+        """No strategy + no eval profile means discovery is needed."""
         from factory.ceo_completion import _detect_incomplete
 
         (tmp_path / ".factory").mkdir()
 
-        gap = _detect_incomplete(tmp_path, "improve")
+        gap = _detect_incomplete(tmp_path, "design")
+        assert gap is not None
+        assert "no eval profile" in gap.reason
+
+    def test_design_no_strategy_with_eval_profile_returns_none(self, tmp_path: Path) -> None:
+        """No strategy but eval profile exists means nothing planned — not incomplete."""
+        from factory.ceo_completion import _detect_incomplete
+
+        factory_dir = tmp_path / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "eval_profile.json").write_text('{"dimensions": []}')
+
+        gap = _detect_incomplete(tmp_path, "design")
         assert gap is None
 
     def test_discover_complete_when_profile_exists(self, tmp_path: Path) -> None:
@@ -194,19 +206,19 @@ class TestDetectIncomplete:
         factory_dir.mkdir()
         (factory_dir / "eval_profile.json").write_text('{"dimensions": []}')
 
-        gap = _detect_incomplete(tmp_path, "discover")
+        gap = _detect_incomplete(tmp_path, "design")
         assert gap is None
 
-    def test_discover_incomplete_when_no_profile(self, tmp_path: Path) -> None:
-        """Discover mode is incomplete without eval_profile.json."""
+    def test_design_incomplete_when_no_eval_profile_discover(self, tmp_path: Path) -> None:
+        """Design mode is incomplete without eval_profile.json when no hypotheses exist."""
         from factory.ceo_completion import _detect_incomplete
 
         (tmp_path / ".factory").mkdir()
 
-        gap = _detect_incomplete(tmp_path, "discover")
+        gap = _detect_incomplete(tmp_path, "design")
         assert gap is not None
-        assert gap.mode == "discover"
-        assert "no eval_profile.json" in gap.reason
+        assert gap.mode == "design"
+        assert "no eval profile" in gap.reason
 
 
 class TestCountVerdictsWithResultsTsv:
@@ -390,7 +402,7 @@ class TestDetectIncompleteWithTimestampFiltering:
 
         # Current cycle started at 10:00 on Apr 29 — only 1 verdict should count
         cycle_start = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
-        gap = _detect_incomplete(tmp_path, "improve", cycle_started_at=cycle_start)
+        gap = _detect_incomplete(tmp_path, "design", cycle_started_at=cycle_start)
 
         # Should be incomplete: 2 hypotheses, only 1 current-cycle verdict
         assert gap is not None
@@ -420,7 +432,7 @@ class TestDetectIncompleteWithTimestampFiltering:
         )
 
         cycle_start = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
-        gap = _detect_incomplete(tmp_path, "improve", cycle_started_at=cycle_start)
+        gap = _detect_incomplete(tmp_path, "design", cycle_started_at=cycle_start)
 
         # Should be complete: 2 hypotheses, 2 current-cycle verdicts
         assert gap is None
@@ -447,13 +459,13 @@ class TestDetectIncompleteWithTimestampFiltering:
         )
 
         cycle_start = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
-        gap = _detect_incomplete(tmp_path, "build", cycle_started_at=cycle_start)
+        gap = _detect_incomplete(tmp_path, "design", cycle_started_at=cycle_start)
 
         # Should be incomplete: 3 phases, only 1 current-cycle verdict
         assert gap is not None
         assert gap.planned == 3
         assert gap.completed == 1
-        assert gap.next_item == "Phase2"
+        assert gap.next_item == "H2"
 
 
 class TestDetectIncompleteResearchMode:
@@ -517,15 +529,15 @@ class TestBuildContinuationTask:
         from factory.ceo_completion import _build_continuation_task, IncompleteGap
 
         gap = IncompleteGap(
-            mode="improve",
+            mode="design",
             planned=5,
             completed=2,
             next_item="H3",
-            reason="improve.incomplete",
+            reason="design.incomplete",
         )
 
         task = _build_continuation_task(gap)
-        assert "Resume execution from hypothesis H3" in task
+        assert "Resume execution from H3" in task
         assert "do not re-plan" in task
         assert "Spawn Builder for H3" in task
         assert "2/5" in task
@@ -535,31 +547,31 @@ class TestBuildContinuationTask:
         from factory.ceo_completion import _build_continuation_task, IncompleteGap
 
         gap = IncompleteGap(
-            mode="discover",
+            mode="design",
             planned=1,
             completed=0,
             next_item="eval_profile",
-            reason="discover.incomplete",
+            reason="design.incomplete",
         )
 
         task = _build_continuation_task(gap)
-        assert "Resume Discovery" in task or "discover" in task.lower()
+        assert "design" in task.lower()
 
-    def test_build_continuation(self) -> None:
-        """Build mode continuation tells CEO to resume from next phase."""
+    def test_design_continuation_with_phases(self) -> None:
+        """Design mode continuation tells CEO to resume from next hypothesis."""
         from factory.ceo_completion import _build_continuation_task, IncompleteGap
 
         gap = IncompleteGap(
-            mode="build",
+            mode="design",
             planned=6,
             completed=3,
-            next_item="Phase4",
-            reason="build.incomplete",
+            next_item="H4",
+            reason="design.incomplete",
         )
 
         task = _build_continuation_task(gap)
-        assert "Resume Build pipeline" in task
-        assert "Phase4" in task
+        assert "Resume execution from H4" in task
+        assert "3/6" in task
 
     def test_research_continuation(self) -> None:
         """Research mode continuation tells CEO to spawn Builder for next H."""
@@ -589,18 +601,18 @@ class TestBuildContinuationTask:
         )
 
         gap = IncompleteGap(
-            mode="build",
+            mode="design",
             planned=6,
             completed=3,
             next_item="Phase4",
-            reason="build.incomplete",
+            reason="design.incomplete",
         )
-        cycle_state = create_cycle_state("build", "Build a CLI")
+        cycle_state = create_cycle_state("design", "Build a CLI")
 
         task = _build_continuation_task(gap, cycle_state)
         assert "## CRITICAL: Mode Override" in task
         assert "CONTINUATION" in task
-        assert "BUILD" in task
+        assert "DESIGN" in task
         assert "Do NOT re-detect mode" in task
         assert cycle_state.cycle_id in task
 
@@ -635,7 +647,7 @@ class TestRunCeoWithCompletionGuard:
             result, code = await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -684,7 +696,7 @@ class TestRunCeoWithCompletionGuard:
             result, code = await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -716,7 +728,7 @@ class TestRunCeoWithCompletionGuard:
             result, code = await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -745,7 +757,7 @@ class TestRunCeoWithCompletionGuard:
             result, code = await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -774,7 +786,7 @@ class TestRunCeoWithCompletionGuard:
             result, code = await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
                 max_respawns=2,  # Low cap for test
             )
@@ -809,7 +821,7 @@ class TestRunCeoWithCompletionGuard:
             result, code = await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -837,7 +849,7 @@ class TestRunCeoWithCompletionGuard:
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Build task",
-                mode="build",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -871,7 +883,7 @@ class TestRunCeoWithCompletionGuard:
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Improve task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -919,13 +931,13 @@ class TestRunCeoWithCompletionGuard:
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Build task",
-                mode="build",  # Start in build mode
+                mode="design",  # Start in design mode
                 runner_name="claude",
             )
 
         assert call_count == 2
         # Both invocations should see the same mode
-        assert all(m == "build" for m in observed_modes)
+        assert all(m == "design" for m in observed_modes)
 
     async def test_respawn_increments_counter(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -960,7 +972,7 @@ class TestRunCeoWithCompletionGuard:
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Improve task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -1001,7 +1013,7 @@ class TestRunCeoWithCompletionGuard:
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -1012,7 +1024,7 @@ class TestRunCeoWithCompletionGuard:
         assert len(respawn_events) == 1
         assert "cycle_id" in respawn_events[0]["data"]
         assert "mode" in respawn_events[0]["data"]
-        assert respawn_events[0]["data"]["mode"] == "improve"
+        assert respawn_events[0]["data"]["mode"] == "design"
 
 
 class TestAutoDetectModeWithCycle:
@@ -1027,12 +1039,12 @@ class TestAutoDetectModeWithCycle:
         (tmp_path / ".git").mkdir()
 
         # Write in-flight cycle state for build mode
-        state = create_cycle_state("build", "Initial task")
+        state = create_cycle_state("design", "Initial task")
         write_cycle_state(tmp_path, state)
 
         # Even though project has no factory, should return build (from cycle)
         mode = _auto_detect_mode(tmp_path, has_prompt=False)
-        assert mode == "build"
+        assert mode == "design"
 
     def test_ignores_cycle_when_force_fresh(self, tmp_path: Path) -> None:
         """_auto_detect_mode ignores cycle.json when force_fresh=True."""
@@ -1043,7 +1055,7 @@ class TestAutoDetectModeWithCycle:
         (tmp_path / ".git").mkdir()
 
         # Write in-flight cycle state for build mode
-        state = create_cycle_state("build", "Initial task")
+        state = create_cycle_state("design", "Initial task")
         write_cycle_state(tmp_path, state)
 
         # With force_fresh, should detect from state (no_factory → design)
@@ -1076,7 +1088,7 @@ class TestAutoDetectModeWithCycle:
         state_data = {
             "cycle_id": "old123",
             "started_at": old_time.isoformat(),
-            "mode": "build",
+            "mode": "design",
             "initial_prompt": "",
             "respawns": 0,
         }
@@ -1131,7 +1143,7 @@ class TestCeoCompletionBackgroundBypass:
             stdout, code = await run_ceo_with_completion_guard(
                 tmp_path,
                 "initial task",
-                mode="improve",
+                mode="design",
                 background=True,
             )
 
@@ -1151,7 +1163,7 @@ class TestPrintResumeHint:
         """Resume hint is printed to stderr when session.json exists."""
         from factory.ceo_completion import print_resume_hint, write_ceo_session_id
 
-        write_ceo_session_id(tmp_path, "abc-123", mode="improve")
+        write_ceo_session_id(tmp_path, "abc-123", mode="design")
         print_resume_hint(tmp_path)
 
         captured = capsys.readouterr()
@@ -1168,7 +1180,7 @@ class TestPrintResumeHint:
             write_ceo_session_id,
         )
 
-        write_ceo_session_id(tmp_path, "abc-123", mode="improve")
+        write_ceo_session_id(tmp_path, "abc-123", mode="design")
         delete_cycle_state(tmp_path)
         print_resume_hint(tmp_path)
 
@@ -1206,14 +1218,14 @@ class TestResumeHintInCompletionGuard:
         (strategy_dir / "current.md").write_text("#### H1: A\n")
         (tmp_path / ".factory" / "experiments").mkdir()
 
-        write_ceo_session_id(tmp_path, "test-session-id", mode="improve")
+        write_ceo_session_id(tmp_path, "test-session-id", mode="design")
         mock_invoke = AsyncMock(return_value=("Incomplete", 0))
 
         with patch("factory.agents.runner.invoke_agent", mock_invoke):
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
                 max_respawns=0,
             )
@@ -1235,14 +1247,14 @@ class TestResumeHintInCompletionGuard:
         exp_dir.mkdir(parents=True)
         (exp_dir / "verdict.json").write_text('{"verdict": "keep"}')
 
-        write_ceo_session_id(tmp_path, "test-session-id", mode="improve")
+        write_ceo_session_id(tmp_path, "test-session-id", mode="design")
         mock_invoke = AsyncMock(return_value=("Done", 0))
 
         with patch("factory.agents.runner.invoke_agent", mock_invoke):
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 
@@ -1260,14 +1272,14 @@ class TestResumeHintInCompletionGuard:
         (strategy_dir / "current.md").write_text("#### H1: A\n")
         (tmp_path / ".factory" / "experiments").mkdir()
 
-        write_ceo_session_id(tmp_path, "interrupt-session", mode="improve")
+        write_ceo_session_id(tmp_path, "interrupt-session", mode="design")
         mock_invoke = AsyncMock(return_value=("Interrupted", 130))
 
         with patch("factory.agents.runner.invoke_agent", mock_invoke):
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
             )
 

--- a/tests/test_chain_modes_terminal.py
+++ b/tests/test_chain_modes_terminal.py
@@ -22,7 +22,7 @@ def _terminal_workflow() -> Workflow:
 
 def _non_terminal_workflow() -> Workflow:
     return Workflow(
-        name="improve",
+        name="design",
         nodes={"start": FnNode(id="start", command="true")},
         edges=[],
         start_node="start",
@@ -35,9 +35,7 @@ class TestChainModesTerminal:
         """_chain_modes exits immediately when completed_mode is terminal."""
         from factory.cli.run import _chain_modes
 
-        with patch.object(
-            WorkflowRegistry, "get_workflow", return_value=_terminal_workflow()
-        ):
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=_terminal_workflow()):
             result = _chain_modes(tmp_path, completed_mode="swebench")
         assert result == 0
 
@@ -45,9 +43,10 @@ class TestChainModesTerminal:
         """Terminal mode prevents any further cycle execution."""
         from factory.cli.run import _chain_modes
 
-        with patch.object(
-            WorkflowRegistry, "get_workflow", return_value=_terminal_workflow()
-        ), patch("factory.cli.run._run_single_cycle") as mock_run:
+        with (
+            patch.object(WorkflowRegistry, "get_workflow", return_value=_terminal_workflow()),
+            patch("factory.cli.run._run_single_cycle") as mock_run,
+        ):
             _chain_modes(tmp_path, completed_mode="swebench")
         mock_run.assert_not_called()
 
@@ -55,14 +54,16 @@ class TestChainModesTerminal:
         """Non-terminal completed_mode does not short-circuit."""
         from factory.cli.run import _chain_modes
 
-        with patch.object(
-            WorkflowRegistry, "get_workflow", return_value=_non_terminal_workflow()
-        ), \
-             patch("factory.state.detect_state", return_value=ProjectState.HAS_FACTORY), \
-             patch("factory.cli.run._auto_detect_mode", return_value="improve"), \
-             patch("factory.cli.run._run_single_cycle", return_value=0):
+        with (
+            patch.object(WorkflowRegistry, "get_workflow", return_value=_non_terminal_workflow()),
+            patch("factory.state.detect_state", return_value=ProjectState.HAS_FACTORY),
+            patch("factory.cli.run._auto_detect_mode", return_value="design"),
+            patch("factory.cli.run._run_single_cycle", return_value=0),
+        ):
             result = _chain_modes(
-                tmp_path, completed_mode="improve", already_improved=True,
+                tmp_path,
+                completed_mode="design",
+                already_improved=True,
             )
         assert result == 0
 
@@ -70,9 +71,11 @@ class TestChainModesTerminal:
         """Without completed_mode, _chain_modes runs normally."""
         from factory.cli.run import _chain_modes
 
-        with patch("factory.state.detect_state", return_value=ProjectState.HAS_FACTORY), \
-             patch("factory.cli.run._auto_detect_mode", return_value="improve"), \
-             patch("factory.cli.run._run_single_cycle", return_value=0):
+        with (
+            patch("factory.state.detect_state", return_value=ProjectState.HAS_FACTORY),
+            patch("factory.cli.run._auto_detect_mode", return_value="design"),
+            patch("factory.cli.run._run_single_cycle", return_value=0),
+        ):
             result = _chain_modes(tmp_path, already_improved=True)
         assert result == 0
 
@@ -87,8 +90,6 @@ class TestChainModesTerminal:
             start_node="start",
             terminal=True,
         )
-        with patch.object(
-            WorkflowRegistry, "get_workflow", return_value=local_terminal
-        ):
+        with patch.object(WorkflowRegistry, "get_workflow", return_value=local_terminal):
             result = _chain_modes(tmp_path, completed_mode="custom_bench")
         assert result == 0

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -28,7 +28,7 @@ def checkpoint_project(tmp_path: Path) -> Path:
 def sample_state() -> CheckpointState:
     """Return a sample CheckpointState for testing."""
     return CheckpointState(
-        mode="improve",
+        mode="design",
         active_experiment_id=38,
         completed_agents=["researcher", "strategist"],
         pending_agents=["builder", "health_checker"],
@@ -46,7 +46,7 @@ def test_checkpoint_state_strict() -> None:
     """CheckpointState rejects extra fields."""
     with pytest.raises(Exception):
         CheckpointState(
-            mode="improve",
+            mode="design",
             active_experiment_id=None,
             completed_agents=[],
             pending_agents=[],
@@ -60,7 +60,7 @@ def test_checkpoint_state_strict() -> None:
 def test_checkpoint_state_nullable_fields() -> None:
     """CheckpointState allows None for optional fields."""
     state = CheckpointState(
-        mode="build",
+        mode="design",
         active_experiment_id=None,
         completed_agents=[],
         pending_agents=["researcher"],
@@ -75,7 +75,7 @@ def test_checkpoint_state_nullable_fields() -> None:
 def test_checkpoint_state_completed_hypotheses() -> None:
     """CheckpointState includes completed_hypotheses field."""
     state = CheckpointState(
-        mode="improve",
+        mode="design",
         active_experiment_id=3,
         completed_agents=["researcher", "strategist"],
         pending_agents=["builder"],
@@ -90,7 +90,7 @@ def test_checkpoint_state_completed_hypotheses() -> None:
 def test_checkpoint_state_completed_hypotheses_default() -> None:
     """completed_hypotheses defaults to empty list for backwards compat."""
     state = CheckpointState(
-        mode="improve",
+        mode="design",
         active_experiment_id=None,
         completed_agents=[],
         pending_agents=[],
@@ -114,7 +114,7 @@ def test_save_and_load(checkpoint_project: Path, sample_state: CheckpointState) 
     loaded = load_checkpoint(checkpoint_project)
     assert loaded is not None
     assert loaded == sample_state
-    assert loaded.mode == "improve"
+    assert loaded.mode == "design"
     assert loaded.active_experiment_id == 38
     assert loaded.completed_agents == ["researcher", "strategist"]
     assert loaded.pending_agents == ["builder", "health_checker"]
@@ -156,7 +156,7 @@ def test_save_creates_factory_dir(tmp_path: Path, sample_state: CheckpointState)
 def test_format_full(sample_state: CheckpointState) -> None:
     """format_checkpoint includes all fields."""
     output = format_checkpoint(sample_state)
-    assert "improve" in output
+    assert "design" in output
     assert "38" in output
     assert "researcher" in output
     assert "builder" in output
@@ -170,7 +170,7 @@ def test_format_full(sample_state: CheckpointState) -> None:
 def test_format_empty_scores() -> None:
     """format_checkpoint omits eval scores line when empty."""
     state = CheckpointState(
-        mode="discover",
+        mode="design",
         active_experiment_id=None,
         completed_agents=[],
         pending_agents=[],
@@ -180,7 +180,8 @@ def test_format_empty_scores() -> None:
     )
     output = format_checkpoint(state)
     assert "Eval scores" not in output
-    assert "discover" in output
+    assert "design" in output
+    assert "Mode:" in output
 
 
 def test_format_completed_hypotheses(sample_state: CheckpointState) -> None:
@@ -213,7 +214,7 @@ def test_cli_checkpoint_save_and_show(
             str(checkpoint_project),
             "--save",
             "--mode",
-            "improve",
+            "design",
             "--experiment",
             "38",
             "--completed",
@@ -233,7 +234,7 @@ def test_cli_checkpoint_save_and_show(
     code = main(["checkpoint", str(checkpoint_project)])
     assert code == 0
     output = capsys.readouterr().out
-    assert "improve" in output
+    assert "design" in output
     assert "38" in output
     assert "researcher" in output
     assert "builder" in output
@@ -307,7 +308,7 @@ def test_cli_checkpoint_save_with_completed_hypotheses(
             str(checkpoint_project),
             "--save",
             "--mode",
-            "improve",
+            "design",
             "--completed",
             "researcher,strategist",
             "--pending",
@@ -351,7 +352,7 @@ def test_load_checkpoint_backwards_compat(checkpoint_project: Path) -> None:
 
     checkpoint_path = checkpoint_project / ".factory" / "checkpoint.json"
     old_data = {
-        "mode": "improve",
+        "mode": "design",
         "active_experiment_id": None,
         "completed_agents": ["researcher"],
         "pending_agents": ["strategist"],
@@ -365,3 +366,27 @@ def test_load_checkpoint_backwards_compat(checkpoint_project: Path) -> None:
     assert loaded is not None
     assert loaded.completed_hypotheses == []
     assert loaded.completed_agents == ["researcher"]
+
+
+@pytest.mark.parametrize(
+    "dead_mode", ["build", "improve", "discover", "interactive", "parallel-improve"]
+)
+def test_load_checkpoint_migrates_dead_modes(checkpoint_project: Path, dead_mode: str) -> None:
+    """load_checkpoint migrates dead modes to 'design'."""
+    import json
+
+    checkpoint_path = checkpoint_project / ".factory" / "checkpoint.json"
+    old_data = {
+        "mode": dead_mode,
+        "active_experiment_id": None,
+        "completed_agents": [],
+        "pending_agents": [],
+        "last_eval_scores": {},
+        "current_hypothesis": None,
+        "timestamp": "2026-04-26T00:00:00",
+    }
+    checkpoint_path.write_text(json.dumps(old_data))
+
+    loaded = load_checkpoint(checkpoint_project)
+    assert loaded is not None
+    assert loaded.mode == "design"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -174,8 +174,8 @@ class TestParser:
 
     def test_ceo_mode_interactive_backward_compat(self):
         parser = build_parser()
-        args = parser.parse_args(["ceo", "distributed eval runner", "--mode", "interactive"])
-        assert args.mode == "interactive"
+        args = parser.parse_args(["ceo", "distributed eval runner", "--mode", "design"])
+        assert args.mode == "design"
         assert args.path == "distributed eval runner"
 
     def test_ceo_mode_project_prefix(self):
@@ -419,10 +419,10 @@ class TestCmdCeoDesign:
         task = cmd[dsp_idx + 1]
         assert "Mode: ideation" in task
 
-    def test_interactive_backward_compat_alias(self, tmp_path):
-        """--mode interactive is accepted as a backward-compatible alias for design."""
+    def test_design_mode_emits_plan_loop(self, tmp_path):
+        """--mode design generates a task with the Plan Loop section."""
         with _mock_foreground() as mock_run:
-            main(["ceo", str(tmp_path), "--mode", "interactive"])
+            main(["ceo", str(tmp_path), "--mode", "design"])
         cmd = mock_run.call_args[0][0]
         dsp_idx = cmd.index("--dangerously-skip-permissions")
         task = cmd[dsp_idx + 1]
@@ -430,7 +430,7 @@ class TestCmdCeoDesign:
 
     def test_auto_approve_rejected_without_design_mode(self, capsys):
         """--auto-approve without --mode design is rejected."""
-        result = main(["ceo", "/some/path", "--mode", "improve", "--auto-approve"])
+        result = main(["ceo", "/some/path", "--mode", "founder", "--auto-approve"])
         assert result == 1
         assert "--auto-approve only applies to --mode design" in capsys.readouterr().err
 
@@ -514,7 +514,7 @@ class TestCmdCeoDesign:
 class TestRunAutoApprove:
     def test_run_auto_approve_rejected_without_design(self, capsys):
         """cmd_run rejects --auto-approve when mode is not design."""
-        result = main(["run", "/some/path", "--mode", "improve", "--auto-approve"])
+        result = main(["run", "/some/path", "--mode", "founder", "--auto-approve"])
         assert result == 1
         assert "--auto-approve only applies to --mode design" in capsys.readouterr().err
 
@@ -523,6 +523,14 @@ class TestRunAutoApprove:
         result = main(["run", "/some/path", "--auto-approve"])
         assert result == 1
         assert "--auto-approve only applies to --mode design" in capsys.readouterr().err
+
+
+class TestRunFocusIncompatibleMode:
+    def test_run_focus_rejected_with_incompatible_mode(self, capsys):
+        """cmd_run rejects --focus with a mode other than design or research."""
+        result = main(["run", "/some/path", "--mode", "founder", "--focus", "auth"])
+        assert result == 1
+        assert "only works in design or research mode" in capsys.readouterr().err
 
 
 class TestAutoApproveEvent:
@@ -919,13 +927,13 @@ class TestRunModeFlag:
 
     def test_mode_discover(self):
         parser = build_parser()
-        args = parser.parse_args(["run", "/some/path", "--mode", "discover"])
-        assert args.mode == "discover"
+        args = parser.parse_args(["run", "/some/path", "--mode", "design"])
+        assert args.mode == "design"
 
     def test_mode_improve_explicit(self):
         parser = build_parser()
-        args = parser.parse_args(["run", "/some/path", "--mode", "improve"])
-        assert args.mode == "improve"
+        args = parser.parse_args(["run", "/some/path", "--mode", "design"])
+        assert args.mode == "design"
 
     def test_mode_meta(self):
         parser = build_parser()
@@ -983,18 +991,18 @@ class TestRunWithGitHubUrl:
         assert result == 0
         mock_agent.assert_called_once()
 
-    def test_run_discover_mode(self, tmp_path):
-        """cmd_run with --mode=discover passes discover task to CEO."""
+    def test_run_design_mode(self, tmp_path):
+        """cmd_run with --mode=design passes design task to CEO."""
         with (
             patch("factory.agents.runner.invoke_agent", _mock_invoke_agent_ok()) as mock_agent,
             patch("factory.cli.run._chain_modes", return_value=0),
         ):
-            result = main(["run", str(tmp_path), "--mode", "discover"])
+            result = main(["run", str(tmp_path), "--mode", "design"])
 
         assert result == 0
         call_args = mock_agent.call_args
         task = call_args[0][1]  # second positional arg is the task
-        assert "Discover mode" in task
+        assert "Mode: design" in task
 
     def test_run_meta_mode(self, tmp_path):
         """cmd_run with --mode=meta passes meta task to CEO."""
@@ -1878,41 +1886,41 @@ class TestBuildCeoTaskDesign:
     """Unit tests for _build_ceo_task design_existing parameter."""
 
     def test_existing_project_emits_plan_loop_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        task = _build_ceo_task(tmp_path, "design", design_existing=True)
         assert "## Plan Loop (Interactive)" in task
         assert "existing_project: true" in task
         assert "existing project" in task
 
     def test_existing_project_with_focus(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", design_existing=True, focus="auth layer")
+        task = _build_ceo_task(tmp_path, "design", design_existing=True, focus="auth layer")
         assert "## Plan Loop (Interactive)" in task
         assert "auth layer" in task
         assert "Focus topic" in task
 
     def test_existing_project_without_focus(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        task = _build_ceo_task(tmp_path, "design", design_existing=True)
         assert "No specific topic was provided" in task
 
     def test_new_idea_emits_plan_loop_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
+        task = _build_ceo_task(tmp_path, "design", design_idea="weather CLI")
         assert "## Plan Loop (Interactive)" in task
         assert "weather CLI" in task
 
     def test_existing_uses_same_header_as_new_idea(self, tmp_path):
         """Both new ideas and existing projects use the same Plan Loop header."""
-        existing_task = _build_ceo_task(tmp_path, "build", design_existing=True)
-        new_task = _build_ceo_task(tmp_path, "build", design_idea="weather CLI")
+        existing_task = _build_ceo_task(tmp_path, "design", design_existing=True)
+        new_task = _build_ceo_task(tmp_path, "design", design_idea="weather CLI")
         assert "## Plan Loop (Interactive)" in existing_task
         assert "## Plan Loop (Interactive)" in new_task
 
     def test_existing_project_has_existing_flag(self, tmp_path):
         """Existing project task includes the existing_project flag for CEO conditionals."""
-        task = _build_ceo_task(tmp_path, "build", design_existing=True)
+        task = _build_ceo_task(tmp_path, "design", design_existing=True)
         assert "existing_project: true" in task
 
     def test_existing_mode_shows_display_mode(self, tmp_path):
         """When display_mode is provided, task shows it instead of internal mode."""
-        task = _build_ceo_task(tmp_path, "build", design_existing=True, display_mode="design")
+        task = _build_ceo_task(tmp_path, "design", design_existing=True, display_mode="design")
         assert "Mode: design" in task
 
 
@@ -1944,7 +1952,7 @@ class TestCreateModeFocus:
 
     def test_build_ceo_task_create_description(self, tmp_path):
         """_build_ceo_task emits the Create Mode section when create_description is provided."""
-        task = _build_ceo_task(tmp_path, "build", create_description="a mode for validating PRs")
+        task = _build_ceo_task(tmp_path, "design", create_description="a mode for validating PRs")
         assert "## Create Mode (New Factory Mode)" in task
         assert "a mode for validating PRs" in task
         assert "Mode description from user" in task
@@ -1952,7 +1960,7 @@ class TestCreateModeFocus:
 
     def test_build_ceo_task_no_create_description(self, tmp_path):
         """_build_ceo_task omits the Create Mode section when create_description is None."""
-        task = _build_ceo_task(tmp_path, "build", create_description=None)
+        task = _build_ceo_task(tmp_path, "design", create_description=None)
         assert "## Create Mode (New Factory Mode)" not in task
 
 
@@ -2301,7 +2309,7 @@ class TestRefineFlag:
 
     def test_refine_exclusive_with_interactive(self, tmp_path, capsys):
         with _mock_foreground():
-            result = main(["ceo", str(tmp_path), "--refine", "fix bug", "--mode", "interactive"])
+            result = main(["ceo", str(tmp_path), "--refine", "fix bug", "--mode", "design"])
         assert result == 1
         assert "mutually exclusive" in capsys.readouterr().err
 
@@ -2350,17 +2358,17 @@ class TestBuildCeoTaskRefine:
     """Tests for _build_ceo_task refinement mode section."""
 
     def test_refine_request_emits_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", refine_request="fix the login bug")
+        task = _build_ceo_task(tmp_path, "design", refine_request="fix the login bug")
         assert "## Refinement Mode" in task
         assert "fix the login bug" in task
         assert "Mode: Refine" in task
 
     def test_no_refine_request_omits_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build")
+        task = _build_ceo_task(tmp_path, "design")
         assert "## Refinement Mode" not in task
 
     def test_refine_request_none_omits_section(self, tmp_path):
-        task = _build_ceo_task(tmp_path, "build", refine_request=None)
+        task = _build_ceo_task(tmp_path, "design", refine_request=None)
         assert "## Refinement Mode" not in task
 
 
@@ -2504,7 +2512,7 @@ class TestFromPlanFlag:
 
     def test_from_plan_requires_design_mode(self, capsys):
         """--from-plan without --mode design is rejected."""
-        result = main(["ceo", "/some/path", "--mode", "improve", "--from-plan", "plan.md"])
+        result = main(["ceo", "/some/path", "--mode", "founder", "--from-plan", "plan.md"])
         assert result == 1
         assert "--from-plan requires --mode design" in capsys.readouterr().err
 
@@ -2900,7 +2908,7 @@ class TestJustPlanFlag:
 
     def test_just_plan_requires_design_mode(self, capsys):
         """--just-plan without --mode design is rejected."""
-        result = main(["ceo", "/some/path", "--mode", "improve", "--just-plan"])
+        result = main(["ceo", "/some/path", "--mode", "founder", "--just-plan"])
         assert result == 1
         assert "--just-plan requires --mode design" in capsys.readouterr().err
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -2,41 +2,63 @@
 
 from __future__ import annotations
 
+import argparse
 from unittest.mock import patch
 
 import pytest
-import structlog
 
-from factory.cli._helpers import DEPRECATED_MODES, CEO_MODES, RUN_MODES, warn_deprecated_mode
+from factory.cli._helpers import (
+    CEO_MODES,
+    DEAD_MODES,
+    DEPRECATED_MODES,
+    RUN_MODES,
+    warn_deprecated_mode,
+)
 
 
 EXPECTED_DEPRECATED = frozenset(
     {
-        "build",
-        "improve",
         "research",
         "meta",
-        "discover",
         "review",
         "refine",
-        "parallel-improve",
-        "interactive",
     }
 )
+
+EXPECTED_DEAD = {
+    "build": "design",
+    "improve": "design",
+    "discover": "design",
+    "interactive": "design",
+    "parallel-improve": "design",
+}
 
 
 def test_deprecated_modes_exact_set():
     assert DEPRECATED_MODES == EXPECTED_DEPRECATED
 
 
+def test_dead_modes_exact_map():
+    assert DEAD_MODES == EXPECTED_DEAD
+
+
 def test_deprecated_modes_subset_of_known_modes():
-    all_known = set(CEO_MODES) | set(RUN_MODES) | {"interactive", "refine", "review"}
+    all_known = set(CEO_MODES) | set(RUN_MODES) | {"refine", "review"}
     for mode in DEPRECATED_MODES:
         assert mode in all_known, f"{mode} is deprecated but not a known CLI mode"
 
 
+def test_dead_modes_not_in_ceo_or_run():
+    for mode in DEAD_MODES:
+        assert mode not in CEO_MODES, f"dead mode {mode} still in CEO_MODES"
+        assert mode not in RUN_MODES, f"dead mode {mode} still in RUN_MODES"
+        assert mode not in DEPRECATED_MODES, f"dead mode {mode} still in DEPRECATED_MODES"
+
+
 class TestWarnDeprecatedMode:
     def test_deprecated_mode_emits_structlog(self):
+        import structlog
+
         cfg = structlog.get_config()
         old_processors = cfg.get("processors", [])
         try:
@@ -48,29 +70,30 @@ class TestWarnDeprecatedMode:
                 orig_log = _helpers.log
                 _helpers.log = log
                 try:
-                    warn_deprecated_mode("build")
+                    warn_deprecated_mode("research")
                 finally:
                     _helpers.log = orig_log
             mock_warn.assert_called_once_with(
-                "deprecated_cli_mode", mode="build", replacement="design"
+                "deprecated_cli_mode", mode="research", replacement="design"
             )
         finally:
             structlog.configure(processors=old_processors)
 
     def test_deprecated_mode_prints_stderr(self, capsys):
         with patch("factory.cli._helpers.log"):
-            warn_deprecated_mode("build")
+            warn_deprecated_mode("research")
         captured = capsys.readouterr()
         assert "WARNING" in captured.err
-        assert "--mode build is deprecated" in captured.err
+        assert "--mode research is deprecated" in captured.err
         assert "--mode design instead" in captured.err
         assert "remains functional" in captured.err
 
-    def test_interactive_has_alias_note(self, capsys):
-        with patch("factory.cli._helpers.log"):
-            warn_deprecated_mode("interactive")
+    def test_dead_mode_does_not_warn(self, capsys):
+        with patch("factory.cli._helpers.log") as mock_log:
+            warn_deprecated_mode("build")
+        mock_log.warning.assert_not_called()
         captured = capsys.readouterr()
-        assert "alias for 'design'" in captured.err
+        assert captured.err == ""
 
     def test_create_not_deprecated(self, capsys):
         with patch("factory.cli._helpers.log") as mock_log:
@@ -120,3 +143,59 @@ class TestWarnDeprecatedMode:
             warn_deprecated_mode(mode)
         captured = capsys.readouterr()
         assert f"--mode {mode} is deprecated" in captured.err
+
+
+class TestAutoDetectMigratesDeadModes:
+    """_auto_detect_mode migrates dead modes from stale cycle state."""
+
+    @pytest.mark.parametrize("dead_mode", sorted(EXPECTED_DEAD))
+    def test_cycle_state_dead_mode_migrated(self, tmp_path, dead_mode):
+        from datetime import datetime, timezone
+
+        from factory.cli._mode_handlers import _auto_detect_mode
+        from factory.models import CycleState
+
+        state_dir = tmp_path / ".factory" / "state"
+        state_dir.mkdir(parents=True)
+        state = CycleState(
+            cycle_id="test-cycle",
+            started_at=datetime.now(tz=timezone.utc),
+            mode=dead_mode,
+            respawns=0,
+        )
+        (state_dir / "cycle.json").write_text(state.model_dump_json())
+
+        mode = _auto_detect_mode(tmp_path)
+        assert mode == "design"
+
+
+class TestValidateCeoFlagsModeAliases:
+    """_validate_ceo_flags migrates interactive alias and strips project: prefix."""
+
+    def _make_args(self, mode: str, path: str = "/tmp/proj"):
+        ns = argparse.Namespace()
+        ns.mode = mode
+        ns.path = path
+        ns.headless = False
+        ns.prompt = None
+        ns.from_plan = None
+        ns.just_plan = False
+        ns.focus = None
+        ns.refine = None
+        ns.auto_approve = False
+        ns.clean_pr = False
+        ns.plugin = False
+        ns.plugin_folder = None
+        return ns
+
+    def test_interactive_alias_becomes_design(self):
+        from factory.cli._ceo_helpers import _validate_ceo_flags
+
+        result = _validate_ceo_flags(self._make_args("interactive"))
+        assert result[0] == "design"
+
+    def test_project_prefix_stripped(self):
+        from factory.cli._ceo_helpers import _validate_ceo_flags
+
+        result = _validate_ceo_flags(self._make_args("project:design"))
+        assert result[0] == "design"

--- a/tests/test_inner_outer_loop.py
+++ b/tests/test_inner_outer_loop.py
@@ -306,7 +306,7 @@ class TestCheckpointSaveLoadFormat:
         (project / ".factory").mkdir()
 
         old_data = {
-            "mode": "improve",
+            "mode": "design",
             "active_experiment_id": None,
             "completed_agents": [],
             "pending_agents": [],

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -732,7 +732,7 @@ class TestCmdCeoMultiIssue:
         ns = argparse.Namespace(
             path="/tmp/fake",
             profile=None,
-            mode="improve",
+            mode="design",
             headless=False,
             bg=False,
             bg_agents=False,
@@ -789,7 +789,7 @@ class TestCmdCeoMultiIssue:
         ns = argparse.Namespace(
             path="/tmp/fake",
             profile=None,
-            mode="improve",
+            mode="design",
             headless=False,
             bg=False,
             bg_agents=False,
@@ -840,7 +840,7 @@ class TestCmdCeoMultiIssue:
         ns = argparse.Namespace(
             path="/tmp/fake",
             profile=None,
-            mode="improve",
+            mode="design",
             headless=False,
             bg=False,
             bg_agents=False,
@@ -880,7 +880,7 @@ class TestCmdRunMultiIssue:
         ns = argparse.Namespace(
             path="/tmp/fake",
             profile=None,
-            mode="improve",
+            mode="design",
             loop=False,
             focus="111 and 112",
             discover_only=False,
@@ -938,7 +938,7 @@ class TestCmdRunMultiIssue:
         ns = argparse.Namespace(
             path="/tmp/fake",
             profile=None,
-            mode="improve",
+            mode="design",
             loop=False,
             focus="42",
             discover_only=False,
@@ -991,7 +991,7 @@ class TestCmdRunMultiIssue:
         ns = argparse.Namespace(
             path="/tmp/fake",
             profile=None,
-            mode="improve",
+            mode="design",
             loop=False,
             focus="111 and 112",
             discover_only=False,
@@ -1109,7 +1109,7 @@ class TestCmdRunBacklogMultiIssue:
         ns = argparse.Namespace(
             path="/tmp/fake",
             profile=None,
-            mode="improve",
+            mode="design",
             loop=False,
             focus="111 and 112",
             discover_only=False,
@@ -1160,7 +1160,7 @@ class TestCmdRunBacklogMultiIssue:
         ns = argparse.Namespace(
             path="/tmp/fake",
             profile=None,
-            mode="improve",
+            mode="design",
             loop=False,
             focus="111, 112",
             discover_only=False,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -13,7 +13,13 @@ from factory.plugins import (
 )
 
 
-def _make_ep(name: str, load_return=None, load_exc=None, dist_name: str | None = None, dist_version: str | None = "0.1.0"):
+def _make_ep(
+    name: str,
+    load_return=None,
+    load_exc=None,
+    dist_name: str | None = None,
+    dist_version: str | None = "0.1.0",
+):
     """Build a mock entry point."""
     ep = MagicMock()
     ep.name = name
@@ -60,6 +66,7 @@ class TestLoadPluginsValidPlugin:
 class TestLoadPluginsBrokenImport:
     def test_import_error_isolated(self):
         good_called = []
+
         def good_plugin(reg: PluginRegistry):
             good_called.append(True)
             reg.add_commands({"good": CommandSpec(handler=lambda a: 0, help="Works")})
@@ -134,10 +141,12 @@ class TestCollisionDetectionCommands:
 class TestCollisionWithBuiltinCommand:
     def test_builtin_command_skipped_with_warning(self):
         registry = PluginRegistry()
-        registry.add_commands({
-            "eval": CommandSpec(handler=lambda a: 0, help="Shadow builtin eval"),
-            "my-new-cmd": CommandSpec(handler=lambda a: 0, help="Legit plugin cmd"),
-        })
+        registry.add_commands(
+            {
+                "eval": CommandSpec(handler=lambda a: 0, help="Shadow builtin eval"),
+                "my-new-cmd": CommandSpec(handler=lambda a: 0, help="Legit plugin cmd"),
+            }
+        )
         assert "eval" not in registry.commands
         assert "my-new-cmd" in registry.commands
 
@@ -145,7 +154,7 @@ class TestCollisionWithBuiltinCommand:
 class TestCollisionDetectionModes:
     def test_collision_with_builtin_skipped(self):
         def plugin(reg: PluginRegistry):
-            reg.add_modes(["improve", "custom-mode"])
+            reg.add_modes(["design", "custom-mode"])
 
         registry = PluginRegistry()
         ep = _make_ep("mode-plugin", load_return=plugin)
@@ -153,7 +162,7 @@ class TestCollisionDetectionModes:
             mock_eps.return_value = MagicMock()
             mock_eps.return_value.select.return_value = [ep]
             load_plugins(registry)
-        assert "improve" not in registry.modes
+        assert "design" not in registry.modes
         assert "custom-mode" in registry.modes
 
 
@@ -161,7 +170,9 @@ class TestCmdPluginsOutput:
     def test_human_readable_format(self, capsys):
         results = [
             PluginLoadResult(name="my-plugin", status="loaded", version="1.0.0"),
-            PluginLoadResult(name="bad-plugin", status="failed", reason="Import error", version="0.1.0"),
+            PluginLoadResult(
+                name="bad-plugin", status="failed", reason="Import error", version="0.1.0"
+            ),
         ]
 
         registry = PluginRegistry()
@@ -237,6 +248,7 @@ class TestAddParserExtensionsApplied:
 
         ext_fn.assert_called_once()
         import argparse
+
         assert isinstance(ext_fn.call_args[0][0], argparse.ArgumentParser)
 
 
@@ -255,11 +267,28 @@ class TestCeoPreHookCalled:
             patch("factory.user_config.load_config"),
         ):
             mock_validate.return_value = (
-                "improve", False, False, False, None, None, None, None, False, None, False,
+                "design",
+                False,
+                False,
+                False,
+                None,
+                None,
+                None,
+                None,
+                False,
+                None,
+                False,
             )
             mock_resolve.return_value = (
-                "/tmp/proj", None, None, None,
-                None, False, False, None, None,
+                "/tmp/proj",
+                None,
+                None,
+                None,
+                None,
+                False,
+                False,
+                None,
+                None,
             )
             from factory.cli.ceo import cmd_ceo
 
@@ -271,15 +300,17 @@ class TestCeoPreHookCalled:
 
         hook.assert_called_once()
         call_args = hook.call_args[0]
-        assert call_args[0] == "improve"
+        assert call_args[0] == "design"
 
 
 class TestDeterministicLoadOrder:
     def test_sorted_by_dist_name(self):
         def plugin_c(reg: PluginRegistry):
             pass
+
         def plugin_a(reg: PluginRegistry):
             pass
+
         def plugin_b(reg: PluginRegistry):
             pass
 
@@ -297,6 +328,7 @@ class TestDeterministicLoadOrder:
 
 
 # ── helpers used by tests ──────────────────────────────────────
+
 
 def _cmd_plugins_text(results: list[PluginLoadResult], registry: PluginRegistry) -> None:
     if not results:
@@ -316,6 +348,7 @@ def _cmd_plugins_text(results: list[PluginLoadResult], registry: PluginRegistry)
 
 def _cmd_plugins_json(results: list[PluginLoadResult], registry: PluginRegistry) -> None:
     import dataclasses
+
     data = []
     for r in results:
         entry = dataclasses.asdict(r)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -60,8 +60,10 @@ class TestResolvePromptWithProfile:
     def test_profile_after_playbook(self, tmp_path: Path) -> None:
         profile_path = tmp_path / "profile.md"
         profile_path.write_text("The user prefers small PRs.")
-        with patch("factory.profile._PROFILE_PATH", profile_path), \
-             patch("factory.ace.injector.load_playbook", return_value="DO: write tests"):
+        with (
+            patch("factory.profile._PROFILE_PATH", profile_path),
+            patch("factory.ace.injector.load_playbook", return_value="DO: write tests"),
+        ):
             prompt = resolve_prompt("ceo", use_profile=True)
         assert "Behavioral Playbook" in prompt
         playbook_idx = prompt.index("Behavioral Playbook")
@@ -71,12 +73,12 @@ class TestResolvePromptWithProfile:
 
 class TestResolvePromptWithWorkflowMode:
     def test_ceo_with_workflow_mode_injects_skill(self, tmp_path: Path) -> None:
-        skill_dir = tmp_path / "skills" / "workflow-improve"
+        skill_dir = tmp_path / "skills" / "workflow-design"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("# Improve Workflow\n\nStep 1: study")
-        prompt = resolve_prompt("ceo", tmp_path, workflow_mode="improve")
-        assert "# Workflow Playbook (improve)" in prompt
-        assert "# Improve Workflow" in prompt
+        (skill_dir / "SKILL.md").write_text("# Design Workflow\n\nStep 1: study")
+        prompt = resolve_prompt("ceo", tmp_path, workflow_mode="design")
+        assert "# Workflow Playbook (design)" in prompt
+        assert "# Design Workflow" in prompt
         assert "Step 1: study" in prompt
 
     def test_ceo_without_workflow_mode_no_skill(self, tmp_path: Path) -> None:
@@ -84,10 +86,10 @@ class TestResolvePromptWithWorkflowMode:
         assert "# Workflow Playbook" not in prompt
 
     def test_non_ceo_role_ignores_workflow_mode(self, tmp_path: Path) -> None:
-        skill_dir = tmp_path / "skills" / "workflow-improve"
+        skill_dir = tmp_path / "skills" / "workflow-design"
         skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text("# Improve Workflow\n\nStep 1: study")
-        prompt = resolve_prompt("researcher", tmp_path, workflow_mode="improve")
+        (skill_dir / "SKILL.md").write_text("# Design Workflow\n\nStep 1: study")
+        prompt = resolve_prompt("researcher", tmp_path, workflow_mode="design")
         assert "# Workflow Playbook" not in prompt
 
     def test_missing_skill_file_raises_error(self, tmp_path: Path) -> None:

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -302,12 +302,12 @@ class TestSessionPersistence:
     def test_read_ceo_session_full(self, tmp_path: Path) -> None:
         from factory.ceo_completion import read_ceo_session, write_ceo_session_id
 
-        write_ceo_session_id(tmp_path, "sid-full", interactive=False, mode="improve")
+        write_ceo_session_id(tmp_path, "sid-full", interactive=False, mode="design")
         result = read_ceo_session(tmp_path)
         assert result is not None
         assert result["session_id"] == "sid-full"
         assert result["interactive"] is False
-        assert result["mode"] == "improve"
+        assert result["mode"] == "design"
         assert "created" in result
 
     def test_read_ceo_session_nonexistent(self, tmp_path: Path) -> None:
@@ -373,7 +373,7 @@ class TestCompletionGuardSessionThreading:
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
                 session_id="my-session-id",
             )
@@ -411,7 +411,7 @@ class TestCompletionGuardSessionThreading:
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Initial task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
                 session_id="initial-sid",
             )
@@ -455,7 +455,7 @@ class TestCompletionGuardSessionThreading:
             await run_ceo_with_completion_guard(
                 tmp_path,
                 "Task",
-                mode="improve",
+                mode="design",
                 runner_name="claude",
                 session_id="initial",
             )
@@ -526,7 +526,7 @@ class TestCmdResume:
         """Headless sessions from session.json get a continuation prompt."""
         from factory.ceo_completion import write_ceo_session_id
 
-        write_ceo_session_id(tmp_path, "headless-sid", interactive=False, mode="improve")
+        write_ceo_session_id(tmp_path, "headless-sid", interactive=False, mode="design")
 
         import argparse
 

--- a/tests/test_skill_export.py
+++ b/tests/test_skill_export.py
@@ -374,10 +374,10 @@ class TestGateToCheckpoint:
 
 class TestWorkflowToSkillMd:
     def test_generates_valid_frontmatter(self) -> None:
-        wf = _minimal_workflow(name="build")
+        wf = _minimal_workflow(name="alpha")
         result = workflow_to_skill_md(wf)
         assert result.startswith("---")
-        assert "name: workflow-build" in result
+        assert "name: workflow-alpha" in result
         assert "description:" in result
 
     def test_contains_arguments_placeholder(self) -> None:
@@ -457,17 +457,17 @@ class TestExportAllSkills:
         assert "workflow-test_wf" in str(paths[0].parent)
 
     def test_creates_directory_structure(self, tmp_path: Path) -> None:
-        wf1 = _minimal_workflow(name="build")
-        wf2 = _minimal_workflow(name="improve")
-        paths = export_all_skills(tmp_path, workflows={"build": wf1, "improve": wf2})
+        wf1 = _minimal_workflow(name="alpha")
+        wf2 = _minimal_workflow(name="beta")
+        paths = export_all_skills(tmp_path, workflows={"alpha": wf1, "beta": wf2})
         assert len(paths) == 2
         dirs = {p.parent.name for p in paths}
-        assert "workflow-build" in dirs
-        assert "workflow-improve" in dirs
+        assert "workflow-alpha" in dirs
+        assert "workflow-beta" in dirs
 
     def test_written_content_passes_validation(self, tmp_path: Path) -> None:
-        wf = _minimal_workflow(name="build")
-        paths = export_all_skills(tmp_path, workflows={"build": wf})
+        wf = _minimal_workflow(name="alpha")
+        paths = export_all_skills(tmp_path, workflows={"alpha": wf})
         content = paths[0].read_text()
         issues = validate_skill(content)
         assert issues == [], f"Validation issues: {issues}"

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1419,7 +1419,7 @@ class TestBuildCeoTaskFocus:
     def test_focus_task_contains_targeted_mode(self, tmp_path):
         from factory.cli._task_builder import _build_ceo_task
 
-        task = _build_ceo_task(tmp_path, "improve", focus="Add caching")
+        task = _build_ceo_task(tmp_path, "design", focus="Add caching")
         assert "Targeted Mode" in task
         assert "exactly ONE hypothesis" in task
         assert "Add caching" in task
@@ -1427,13 +1427,13 @@ class TestBuildCeoTaskFocus:
     def test_no_focus_no_targeted_mode(self, tmp_path):
         from factory.cli._task_builder import _build_ceo_task
 
-        task = _build_ceo_task(tmp_path, "improve")
+        task = _build_ceo_task(tmp_path, "design")
         assert "Targeted Mode" not in task
 
     def test_build_ceo_task_does_not_write_backlog(self, tmp_path):
         from factory.cli._task_builder import _build_ceo_task
 
-        _build_ceo_task(tmp_path, "improve", focus="Add caching")
+        _build_ceo_task(tmp_path, "design", focus="Add caching")
         backlog_path = tmp_path / ".factory" / "strategy" / "backlog.md"
         assert not backlog_path.exists()
 
@@ -1459,7 +1459,7 @@ class TestFocusMutualExclusion:
                 "--prompt",
                 str(prompt_path),
                 "--mode",
-                "improve",
+                "design",
             ]
         )
         assert result == 1
@@ -1478,21 +1478,9 @@ class TestFocusMutualExclusion:
                 "--prompt",
                 str(prompt_path),
                 "--mode",
-                "improve",
+                "design",
             ]
         )
-        assert result == 1
-
-    def test_focus_rejected_in_build_mode(self):
-        from factory.cli import main
-
-        result = main(["ceo", "/tmp/fake", "--focus", "fix bug", "--mode", "build"])
-        assert result == 1
-
-    def test_focus_rejected_in_discover_mode(self):
-        from factory.cli import main
-
-        result = main(["ceo", "/tmp/fake", "--focus", "fix bug", "--mode", "discover"])
         assert result == 1
 
     def test_focus_rejected_in_meta_mode(self):

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -67,40 +67,101 @@ def summary_project(tmp_path: Path) -> Path:
     writer = csv.writer(buf, dialect="excel-tab")
     writer.writerow(TSV_COLUMNS)
     for row in [
-        [1, "2026-04-26T10:00:00+00:00", "Add logging", "Added logging", "", "42",
-         "0.700", "0.745", "0.045", "keep", "1.50", "", ""],
-        [2, "2026-04-26T11:00:00+00:00", "Fix imports", "Fixed imports", "", "43",
-         "0.745", "0.760", "0.015", "keep", "0.80", "", ""],
-        [3, "2026-04-26T12:00:00+00:00", "Add caching", "Added caching", "", "",
-         "0.760", "0.755", "-0.005", "revert", "2.00", "", ""],
-        [4, "2026-04-26T13:00:00+00:00", "Broken refactor", "Refactored", "", "",
-         "0.760", "", "", "error", "0.50", "", ""],
+        [
+            1,
+            "2026-04-26T10:00:00+00:00",
+            "Add logging",
+            "Added logging",
+            "",
+            "42",
+            "0.700",
+            "0.745",
+            "0.045",
+            "keep",
+            "1.50",
+            "",
+            "",
+        ],
+        [
+            2,
+            "2026-04-26T11:00:00+00:00",
+            "Fix imports",
+            "Fixed imports",
+            "",
+            "43",
+            "0.745",
+            "0.760",
+            "0.015",
+            "keep",
+            "0.80",
+            "",
+            "",
+        ],
+        [
+            3,
+            "2026-04-26T12:00:00+00:00",
+            "Add caching",
+            "Added caching",
+            "",
+            "",
+            "0.760",
+            "0.755",
+            "-0.005",
+            "revert",
+            "2.00",
+            "",
+            "",
+        ],
+        [
+            4,
+            "2026-04-26T13:00:00+00:00",
+            "Broken refactor",
+            "Refactored",
+            "",
+            "",
+            "0.760",
+            "",
+            "",
+            "error",
+            "0.50",
+            "",
+            "",
+        ],
     ]:
         writer.writerow(row)
     (factory / "results.tsv").write_text(buf.getvalue())
 
     # Write backlog
     (factory / "strategy" / "backlog.md").write_text(
-        "- Add rate limiting\n"
-        "- Improve test coverage\n"
-        "- Write API docs\n"
+        "- Add rate limiting\n- Improve test coverage\n- Write API docs\n"
     )
 
     # Write eval_after with guard violations for experiment 3
     exp3 = factory / "experiments" / "003"
     exp3.mkdir()
-    (exp3 / "eval_after.json").write_text(json.dumps({
-        "total": 0.755,
-        "results": [],
-        "guard_violations": ["scope_check: modified files outside scope"],
-        "passed": False,
-    }))
+    (exp3 / "eval_after.json").write_text(
+        json.dumps(
+            {
+                "total": 0.755,
+                "results": [],
+                "guard_violations": ["scope_check: modified files outside scope"],
+                "passed": False,
+            }
+        )
+    )
 
     # Write events.jsonl with mode info
     (factory / "events.jsonl").write_text(
-        json.dumps({"type": "cycle.started", "timestamp": "2026-04-26T09:00:00Z",
-                     "project": "summary-project", "agent": None,
-                     "data": {"cycle": 1, "mode": "improve"}}) + "\n"
+        json.dumps(
+            {
+                "type": "cycle.started",
+                "timestamp": "2026-04-26T09:00:00Z",
+                "project": "summary-project",
+                "agent": None,
+                "data": {"cycle": 1, "mode": "design"},
+            }
+        )
+        + "\n"
     )
 
     return project
@@ -197,7 +258,7 @@ async def test_needs_human_input(summary_project: Path) -> None:
 async def test_mode_from_events(summary_project: Path) -> None:
     """Mode is detected from events.jsonl."""
     summary = await generate_summary(summary_project)
-    assert summary.mode == "improve"
+    assert summary.mode == "design"
 
 
 async def test_session_scoping(summary_project: Path) -> None:
@@ -206,13 +267,18 @@ async def test_session_scoping(summary_project: Path) -> None:
     # Add a second cycle.started at 11:30 — only experiments 3 and 4 should appear.
     events_path = summary_project / ".factory" / "events.jsonl"
     with open(events_path, "a") as f:
-        f.write(json.dumps({
-            "type": "cycle.started",
-            "timestamp": "2026-04-26T11:30:00+00:00",
-            "project": "summary-project",
-            "agent": None,
-            "data": {"cycle": 2, "mode": "improve"},
-        }) + "\n")
+        f.write(
+            json.dumps(
+                {
+                    "type": "cycle.started",
+                    "timestamp": "2026-04-26T11:30:00+00:00",
+                    "project": "summary-project",
+                    "agent": None,
+                    "data": {"cycle": 2, "mode": "design"},
+                }
+            )
+            + "\n"
+        )
 
     summary = await generate_summary(summary_project)
     all_ids = (
@@ -243,8 +309,23 @@ async def test_zero_cost_not_dropped(tmp_path: Path) -> None:
     buf = io.StringIO()
     writer = csv.writer(buf, dialect="excel-tab")
     writer.writerow(TSV_COLUMNS)
-    writer.writerow([1, "2026-04-26T10:00:00+00:00", "Free fix", "Fixed",
-                     "", "", "0.7", "0.8", "0.1", "keep", "0.0", "", ""])
+    writer.writerow(
+        [
+            1,
+            "2026-04-26T10:00:00+00:00",
+            "Free fix",
+            "Fixed",
+            "",
+            "",
+            "0.7",
+            "0.8",
+            "0.1",
+            "keep",
+            "0.0",
+            "",
+            "",
+        ]
+    )
     (factory / "results.tsv").write_text(buf.getvalue())
 
     summary = await generate_summary(project)
@@ -259,7 +340,7 @@ def test_format_output() -> None:
     summary = SessionSummary(
         project_name="test-project",
         generated_at=datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc),
-        mode="improve",
+        mode="design",
         experiments_kept=[_make_record(id=1, verdict="keep")],
         experiments_reverted=[_make_record(id=2, verdict="revert", delta=-0.005)],
         experiments_errored=[],
@@ -277,7 +358,7 @@ def test_format_output() -> None:
     assert "## What Was Deferred" in output
     assert "## Needs Your Input" in output
     assert "test-project" in output
-    assert "improve" in output
+    assert "design" in output
     assert "0.7000" in output
     assert "0.7450" in output
     assert "$2.30" in output
@@ -290,7 +371,7 @@ def test_format_empty_kept() -> None:
     summary = SessionSummary(
         project_name="test",
         generated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
-        mode="improve",
+        mode="design",
         experiments_kept=[],
         experiments_reverted=[],
         experiments_errored=[],
@@ -312,7 +393,7 @@ def test_format_no_scores() -> None:
     summary = SessionSummary(
         project_name="test",
         generated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
-        mode="build",
+        mode="design",
         experiments_kept=[],
         experiments_reverted=[],
         experiments_errored=[],
@@ -338,7 +419,7 @@ async def test_save_creates_files(tmp_path: Path) -> None:
     summary = SessionSummary(
         project_name="save-project",
         generated_at=datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc),
-        mode="improve",
+        mode="design",
         experiments_kept=[_make_record()],
         experiments_reverted=[],
         experiments_errored=[],
@@ -370,7 +451,7 @@ async def test_save_creates_reviews_dir(tmp_path: Path) -> None:
     summary = SessionSummary(
         project_name="no-reviews",
         generated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
-        mode="build",
+        mode="design",
         experiments_kept=[],
         experiments_reverted=[],
         experiments_errored=[],
@@ -413,7 +494,7 @@ def test_session_summary_strict() -> None:
         SessionSummary(
             project_name="test",
             generated_at=datetime(2026, 4, 26, tzinfo=timezone.utc),
-            mode="improve",
+            mode="design",
             experiments_kept=[],
             experiments_reverted=[],
             experiments_errored=[],

--- a/tests/test_tmux_cli.py
+++ b/tests/test_tmux_cli.py
@@ -115,7 +115,7 @@ class TestBuildTmuxRunArgs:
     def test_propagates_all_flags(self) -> None:
         args = argparse.Namespace(
             path="/tmp/project",
-            mode="improve",
+            mode="design",
             loop=True,
             interval=900,
             max_cycles=5,
@@ -136,7 +136,7 @@ class TestBuildTmuxRunArgs:
         )
         result = _build_tmux_run_args(args, Path("/tmp/project"), "opus-4")
 
-        assert "--mode improve" in result
+        assert "--mode design" in result
         assert "--loop" not in result
         assert "--interval" not in result
         assert "--max-cycles" not in result
@@ -158,22 +158,48 @@ class TestBuildTmuxRunArgs:
 
     def test_no_clean_pr(self) -> None:
         args = argparse.Namespace(
-            mode=None, loop=False, interval=0, max_cycles=None,
-            no_github=False, profile=None, focus=None, refine=None,
-            clean_pr=False, runner=None, prompt=None, branch=None,
-            min_growth=None, max_new=None, discover_only=False,
-            bg_agents=False, tmux_persist=False, use_profile=False,
+            mode=None,
+            loop=False,
+            interval=0,
+            max_cycles=None,
+            no_github=False,
+            profile=None,
+            focus=None,
+            refine=None,
+            clean_pr=False,
+            runner=None,
+            prompt=None,
+            branch=None,
+            min_growth=None,
+            max_new=None,
+            discover_only=False,
+            bg_agents=False,
+            tmux_persist=False,
+            use_profile=False,
         )
         result = _build_tmux_run_args(args, Path("/tmp/p"), None)
         assert "--no-clean-pr" in result
 
     def test_minimal_args(self) -> None:
         args = argparse.Namespace(
-            mode=None, loop=False, interval=0, max_cycles=None,
-            no_github=False, profile=None, focus=None, refine=None,
-            clean_pr=None, runner=None, prompt=None, branch=None,
-            min_growth=None, max_new=None, discover_only=False,
-            bg_agents=False, tmux_persist=False, use_profile=False,
+            mode=None,
+            loop=False,
+            interval=0,
+            max_cycles=None,
+            no_github=False,
+            profile=None,
+            focus=None,
+            refine=None,
+            clean_pr=None,
+            runner=None,
+            prompt=None,
+            branch=None,
+            min_growth=None,
+            max_new=None,
+            discover_only=False,
+            bg_agents=False,
+            tmux_persist=False,
+            use_profile=False,
         )
         result = _build_tmux_run_args(args, Path("/tmp/p"), None)
         assert result == "factory ceo /tmp/p"
@@ -188,7 +214,9 @@ class TestCmdTmuxStop:
             patch("subprocess.run") as mock_run,
         ):
             mock_run.return_value = MagicMock(
-                returncode=0, stdout="factory-app-abc123\n", stderr="",
+                returncode=0,
+                stdout="factory-app-abc123\n",
+                stderr="",
             )
             rc = cmd_tmux_stop(args)
 
@@ -327,7 +355,7 @@ class TestTmuxSessionMapping:
 
 
 class TestTmuxModeChoices:
-    @pytest.mark.parametrize("mode", ["design", "interactive", "review", "create"])
+    @pytest.mark.parametrize("mode", ["design", "founder", "research", "create"])
     def test_tmux_accepts_ceo_only_modes(self, mode: str) -> None:
         parser = build_parser()
         args = parser.parse_args(["tmux", "/tmp/project", "--mode", mode])
@@ -367,7 +395,8 @@ class TestCmdTmuxCapture:
             patch("builtins.print") as mock_print,
         ):
             mock_run.return_value = MagicMock(
-                returncode=0, stdout="line1\nline2\n",
+                returncode=0,
+                stdout="line1\nline2\n",
             )
             rc = cmd_tmux_capture(args)
 
@@ -422,7 +451,10 @@ class TestCmdTmuxCapture:
 
         with (
             patch("factory.cli._tmux_commands._tmux_available", return_value=True),
-            patch("factory.cli._tmux_commands._load_tmux_session_mapping", return_value={"factory-myproject-abc123": "/tmp/myproject"}),
+            patch(
+                "factory.cli._tmux_commands._load_tmux_session_mapping",
+                return_value={"factory-myproject-abc123": "/tmp/myproject"},
+            ),
             patch("factory.cli._tmux_commands._tmux_session_alive", return_value=True),
             patch("subprocess.run") as mock_run,
             patch("builtins.print"),
@@ -508,7 +540,9 @@ class TestCmdTmuxPostDispatchVerification:
             mock_run.side_effect = [
                 MagicMock(returncode=1),  # has-session (not found)
                 MagicMock(returncode=0),  # new-session
-                MagicMock(returncode=0, stdout="Error: something went wrong\n", stderr=""),  # capture-pane
+                MagicMock(
+                    returncode=0, stdout="Error: something went wrong\n", stderr=""
+                ),  # capture-pane
             ]
             rc = cmd_tmux(args)
 
@@ -565,7 +599,9 @@ class TestCmdTmuxPostDispatchVerification:
 
 class TestCmdTmuxStopEdgeCases:
     def test_tmux_not_available(self) -> None:
-        args = argparse.Namespace(session="factory-app-abc123", path=None, stop_all=False, force=False)
+        args = argparse.Namespace(
+            session="factory-app-abc123", path=None, stop_all=False, force=False
+        )
 
         with (
             patch("factory.cli._tmux_commands._tmux_available", return_value=False),
@@ -592,7 +628,9 @@ class TestCmdTmuxStopEdgeCases:
         assert any("not found" in str(c) for c in mock_print.call_args_list)
 
     def test_session_not_found_in_tmux(self) -> None:
-        args = argparse.Namespace(session="factory-gone-abc123", path=None, stop_all=False, force=False)
+        args = argparse.Namespace(
+            session="factory-gone-abc123", path=None, stop_all=False, force=False
+        )
 
         with (
             patch("factory.cli._tmux_commands._tmux_available", return_value=True),
@@ -608,7 +646,9 @@ class TestCmdTmuxStopEdgeCases:
 
 class TestCmdTmuxStopOwnership:
     def test_warns_and_blocks_unregistered_session(self) -> None:
-        args = argparse.Namespace(session="factory-mystery-abc123", path=None, stop_all=False, force=False)
+        args = argparse.Namespace(
+            session="factory-mystery-abc123", path=None, stop_all=False, force=False
+        )
 
         with (
             patch("factory.cli._tmux_commands._tmux_available", return_value=True),
@@ -626,7 +666,9 @@ class TestCmdTmuxStopOwnership:
         assert len(kill_calls) == 0
 
     def test_force_kills_unregistered_session(self) -> None:
-        args = argparse.Namespace(session="factory-mystery-abc123", path=None, stop_all=False, force=True)
+        args = argparse.Namespace(
+            session="factory-mystery-abc123", path=None, stop_all=False, force=True
+        )
 
         with (
             patch("factory.cli._tmux_commands._tmux_available", return_value=True),
@@ -640,11 +682,16 @@ class TestCmdTmuxStopOwnership:
         assert rc == 0
 
     def test_registered_session_killed_without_force(self) -> None:
-        args = argparse.Namespace(session="factory-app-abc123", path=None, stop_all=False, force=False)
+        args = argparse.Namespace(
+            session="factory-app-abc123", path=None, stop_all=False, force=False
+        )
 
         with (
             patch("factory.cli._tmux_commands._tmux_available", return_value=True),
-            patch("factory.cli._tmux_commands._load_tmux_session_mapping", return_value={"factory-app-abc123": "/tmp/app"}),
+            patch(
+                "factory.cli._tmux_commands._load_tmux_session_mapping",
+                return_value={"factory-app-abc123": "/tmp/app"},
+            ),
             patch("subprocess.run") as mock_run,
             patch("builtins.print"),
         ):

--- a/tests/test_workflow_cli.py
+++ b/tests/test_workflow_cli.py
@@ -84,10 +84,10 @@ class TestCmdRun:
             patch("factory.agents.runner.begin_cycle_session", return_value="span-123") as mock_begin,
             patch("factory.agents.runner.complete_cycle_session") as mock_complete,
         ):
-            result = _cmd_run(_make_args("build", str(tmp_path)))
+            result = _cmd_run(_make_args("design", str(tmp_path)))
 
         assert result == 0
-        mock_begin.assert_called_once_with(tmp_path.resolve(), cycle_id="build")
+        mock_begin.assert_called_once_with(tmp_path.resolve(), cycle_id="design")
         mock_complete.assert_called_once_with(tmp_path.resolve(), "span-123")
 
     def test_failure_returns_1(self, tmp_path: Path) -> None:
@@ -101,7 +101,7 @@ class TestCmdRun:
             patch("factory.agents.runner.begin_cycle_session", return_value=None),
             patch("factory.agents.runner.complete_cycle_session"),
         ):
-            result = _cmd_run(_make_args("build", str(tmp_path)))
+            result = _cmd_run(_make_args("design", str(tmp_path)))
 
         assert result == 1
 
@@ -117,7 +117,7 @@ class TestCmdRun:
             patch("factory.agents.runner.complete_cycle_session") as mock_complete,
         ):
             with pytest.raises(RuntimeError, match="boom"):
-                _cmd_run(_make_args("build", str(tmp_path)))
+                _cmd_run(_make_args("design", str(tmp_path)))
 
         mock_begin.assert_called_once()
         mock_complete.assert_called_once_with(tmp_path.resolve(), "span-456")
@@ -133,7 +133,7 @@ class TestCmdRun:
             patch("factory.agents.runner.begin_cycle_session", return_value=None),
             patch("factory.agents.runner.complete_cycle_session"),
         ):
-            _cmd_run(_make_args("improve", str(tmp_path), dry_run=True))
+            _cmd_run(_make_args("design", str(tmp_path), dry_run=True))
 
         mock_cls.assert_called_once_with(
             mock_wf,
@@ -196,13 +196,13 @@ class TestCmdWorkflow:
             m.assert_called_once_with(args)
 
     def test_dispatches_to_show(self) -> None:
-        args = argparse.Namespace(workflow_command="show", name="build", project_path=None)
+        args = argparse.Namespace(workflow_command="show", name="design", project_path=None)
         with patch("factory.workflow.cli._cmd_show", return_value=0) as m:
             assert cmd_workflow(args) == 0
             m.assert_called_once_with(args)
 
     def test_dispatches_to_validate(self) -> None:
-        args = argparse.Namespace(workflow_command="validate", name="build", project_path=None)
+        args = argparse.Namespace(workflow_command="validate", name="design", project_path=None)
         with patch("factory.workflow.cli._cmd_validate", return_value=0) as m:
             assert cmd_workflow(args) == 0
             m.assert_called_once_with(args)

--- a/tests/test_workflow_e2e.py
+++ b/tests/test_workflow_e2e.py
@@ -197,25 +197,25 @@ class TestCLIE2E:
             timeout=30,
         )
         assert result.returncode == 0
-        for name in ("build", "design", "improve", "research", "meta"):
+        for name in ("design", "research", "meta"):
             assert name in result.stdout
 
-    def test_workflow_show_build(self) -> None:
-        """factory workflow show build prints node/edge table."""
+    def test_workflow_show_design(self) -> None:
+        """factory workflow show design prints node/edge table."""
         result = subprocess.run(
-            ["python", "-m", "factory", "workflow", "show", "build"],
+            ["python", "-m", "factory", "workflow", "show", "design"],
             capture_output=True,
             text=True,
             timeout=30,
         )
         assert result.returncode == 0
-        assert "Workflow: build" in result.stdout
+        assert "Workflow: design" in result.stdout
         assert "Nodes:" in result.stdout
         assert "Edges:" in result.stdout
 
     def test_workflow_validate_all(self) -> None:
         """factory workflow validate passes for all workflows."""
-        for name in ("build", "design", "improve", "research", "meta"):
+        for name in ("design", "research", "meta"):
             result = subprocess.run(
                 ["python", "-m", "factory", "workflow", "validate", name],
                 capture_output=True,
@@ -241,7 +241,7 @@ class TestCLIE2E:
         result = subprocess.run(
             [
                 "python", "-m", "factory", "workflow", "run",
-                "improve", str(project), "--dry-run",
+                "design", str(project), "--dry-run",
             ],
             capture_output=True,
             text=True,

--- a/tests/test_workflow_overwrite.py
+++ b/tests/test_workflow_overwrite.py
@@ -161,7 +161,7 @@ class TestOverwriteForwardedThroughTmux:
         from factory.cli._tmux_commands import _build_tmux_run_args
 
         args = argparse.Namespace(
-            mode="improve",
+            mode="design",
             no_github=False,
             profile=None,
             focus=None,

--- a/tests/test_workflow_qa.py
+++ b/tests/test_workflow_qa.py
@@ -150,7 +150,7 @@ class TestDeepQaWorkflow:
         assert wf.trigger is not None
         assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "deep-qa"})
         assert not wf.trigger(ProjectState.HAS_FACTORY, {})
-        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "design"})
 
     def test_skill_export(self) -> None:
         from factory.workflow.skill_export import validate_skill, workflow_to_skill_md

--- a/tests/test_workflow_research.py
+++ b/tests/test_workflow_research.py
@@ -300,7 +300,7 @@ class TestResearchStandaloneWorkflow:
         wf = self._get_wf()
         assert wf.trigger is not None
         assert not wf.trigger(ProjectState.HAS_FACTORY, {})
-        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "design"})
         assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "research"})
 
     def test_not_registered_after_mode_removal(self) -> None:


### PR DESCRIPTION
## Summary

- **Kill 5 dead modes** (`interactive`, `parallel-improve`, `build`, `discover`, `improve`) — removed from `CEO_MODES`, `RUN_MODES`, workflow registry, and deleted their skill directories
- **Route ALL auto-detection to `design`** — `_auto_detect_mode()` now maps every `ProjectState` to `"design"` instead of deprecated modes
- **Keep 4 deprecated modes** (`research`, `meta`, `review`, `refine`) in `DEPRECATED_MODES` with existing warnings — these have unique pipelines and were deprecated by other team members
- **Add checkpoint migration** — `DEAD_MODES` dict remaps stale checkpoint/cycle state mode names to `"design"` on load
- **Update CEO prompt** — routing table and skill references in both `ceo.md` and `.claude/CLAUDE.md` now point all default states to `skills/workflow-design/SKILL.md`
- **Update 30+ test files** — mode string replacements, rejection test fixes, deleted `test_parallel_improve.py`

## Context

The factory had 9 modes in `DEPRECATED_MODES` that all warned "use `--mode design` instead", but auto-routing still actively depended on 5 of them. Design mode already absorbs build (calls `build_workflow()` as its base), discover (inline entry path), and improve (handles existing projects via `gate_has_factory`). This PR removes the contradiction.

## What stays

- Workflow **functions** (`build_workflow`, `discover_workflow`, `improve_workflow`) — kept as internal building blocks for `design_workflow()` and `research_workflow()`
- `DEPRECATED_MODES = frozenset({"research", "meta", "review", "refine"})` with `warn_deprecated_mode()` — these modes have unique pipelines
- `research` auto-route override for `HAS_FACTORY + research_target`

## Test plan

- [ ] `pytest -v` — full suite passes
- [ ] `ruff check .` — clean
- [ ] `mypy factory/` — no new errors (pre-existing plugins.py annotation warning)
- [ ] `factory detect /path` routes to design for all project states
- [ ] `--mode research` and `--mode meta` still work with deprecation warnings
- [ ] Stale checkpoints with `"mode": "improve"` remap to `"design"` on load