### PR TITLE
fix: override strategist post_checks in design_workflow() with dual-format sentinels

### DIFF
--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -646,6 +646,18 @@ def design_workflow(just_plan: bool = False) -> Workflow:
             update={"reads": (node.reads or set()) | {".factory/strategy/study-combined.md"}},
         )
 
+    _strat = wf.nodes["strategist"]
+    wf.nodes["strategist"] = _strat.model_copy(
+        update={"post_checks": [
+            ArtifactCheck(
+                path=".factory/strategy/current.md",
+                must_exist=True,
+                min_size=200,
+                must_contain=["### Phase 1", "### Hypotheses"],
+            )
+        ]},
+    )
+
     wf.edges.extend(
         [
             *s_edges,

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -521,16 +521,16 @@ class TestDesignWorkflowAnnotations:
         assert "code_reviewer" in wf.nodes
         assert "adversarial_tester" in wf.nodes
 
-    def test_design_workflow_inherits_post_checks(self) -> None:
+    def test_design_workflow_overrides_post_checks(self) -> None:
         from factory.workflow.definitions import design_workflow
 
         wf = design_workflow()
-        # Design inherits from build — verify inherited sentinel values
+        # Design overrides build's strategist post_checks with dual-format sentinels
         strat = wf.nodes["strategist"]
         assert isinstance(strat, AgentNode)
         assert len(strat.post_checks) > 0
         assert "### Phase 1" in strat.post_checks[0].must_contain
-        assert "### Architecture" in strat.post_checks[0].must_contain
+        assert "### Hypotheses" in strat.post_checks[0].must_contain
 
         builder = wf.nodes["builder"]
         assert isinstance(builder, AgentNode)


### PR DESCRIPTION
Closes #1323

## Changes

- Override the strategist node's `post_checks` in `design_workflow()` to use `must_contain=["### Phase 1", "### Hypotheses"]`, accepting either phased plans (new projects) or improvement hypotheses (existing projects) via `grep -qE` OR semantics
- Placement after the reads loop (L643-647) preserves the `study-combined.md` reads update via `model_copy`
- Rename and update test `test_design_workflow_inherits_post_checks` → `test_design_workflow_overrides_post_checks` to reflect the override behavior and assert `### Hypotheses` instead of `### Architecture`