### PR TITLE
feat: multi-benchmark support for outer loop

### DIFF
--- a/benchmarks/configs/aime.toml
+++ b/benchmarks/configs/aime.toml
@@ -1,0 +1,18 @@
+[meta]
+name = "aime"
+description = "AIME math competition — exact match scoring with LaTeX answer extraction"
+
+[test]
+format = "exact_match"
+command = ""
+timeout = 300
+answer_extraction = "\\\\boxed\\{(\\d+)\\}"
+
+[instances]
+format = "question-answer"
+
+[seed_workflow]
+name = ""
+
+[scoring]
+method = "exact_match"

--- a/benchmarks/configs/featurebench.toml
+++ b/benchmarks/configs/featurebench.toml
@@ -1,0 +1,17 @@
+[meta]
+name = "featurebench"
+description = "Feature implementation benchmark — pytest partial credit scoring"
+
+[test]
+format = "pytest"
+command = "pytest -xvs"
+timeout = 600
+
+[instances]
+format = "directory"
+
+[seed_workflow]
+name = "improve"
+
+[scoring]
+method = "partial_credit"

--- a/benchmarks/configs/forecastbench.toml
+++ b/benchmarks/configs/forecastbench.toml
@@ -1,0 +1,18 @@
+[meta]
+name = "forecastbench"
+description = "ForecastBench — dynamic AI forecasting benchmark with Brier score evaluation"
+
+[test]
+format = "json"
+command = "python eval_forecast.py"
+timeout = 900
+metric_path = "brier_index"
+
+[instances]
+format = "question-answer"
+
+[seed_workflow]
+name = ""
+
+[scoring]
+method = "metric_extraction"

--- a/benchmarks/configs/swebench.toml
+++ b/benchmarks/configs/swebench.toml
@@ -1,0 +1,18 @@
+[meta]
+name = "swebench"
+description = "SWE-bench — software engineering bug fix benchmark"
+
+[test]
+format = "exit_code"
+command = "pytest -xvs"
+timeout = 1800
+
+[instances]
+format = "git-repo"
+prep_command = "git clone {repo_url} {instance_dir} && cd {instance_dir} && git checkout {commit}"
+
+[seed_workflow]
+name = "improve"
+
+[scoring]
+method = "binary"

--- a/benchmarks/configs/swebench.toml
+++ b/benchmarks/configs/swebench.toml
@@ -9,7 +9,7 @@ timeout = 1800
 
 [instances]
 format = "git-repo"
-prep_command = "git clone {repo_url} {instance_dir} && cd {instance_dir} && git checkout {commit}"
+prep_command = "python -m swebench.harness.prepare --instance_id {instance_id} --testbed {instance_dir}"
 
 [seed_workflow]
 name = "improve"

--- a/docs/outer-loop.md
+++ b/docs/outer-loop.md
@@ -215,6 +215,7 @@ The outer loop supports multiple benchmark types beyond FeatureBench. Each bench
 | `featurebench` | `pytest` | `directory` | Feature implementation — partial credit scoring |
 | `swebench` | `exit_code` | `git-repo` | SWE-bench bug fix — binary pass/fail |
 | `aime` | `exact_match` | `question-answer` | AIME math competition — exact answer match |
+| `forecastbench` | `json` | `question-answer` | ForecastBench — dynamic forecasting with Brier score |
 
 ### Test Output Formats
 
@@ -265,6 +266,47 @@ method = "metric_extraction"        # partial_credit | binary | metric_extractio
    ```
 
 3. The outer loop auto-resolves `test_format`, `test_command`, and `instance_format` from your TOML. You can override any field via CLI flags.
+
+### Working with Your Benchmark
+
+Once registered, your benchmark integrates with the full outer loop pipeline:
+
+**List available benchmarks:**
+```bash
+factory outer-loop list-benchmarks
+```
+
+**Calibrate with your benchmark:**
+```bash
+factory outer-loop calibrate /path/to/factory \
+  --benchmark my_bench \
+  --project-dir /path/to/instances \
+  --population-size 4
+```
+
+**Override config settings via CLI:**
+```bash
+factory outer-loop calibrate /path/to/factory \
+  --benchmark my_bench \
+  --test-format json \
+  --test-command 'python custom_eval.py' \
+  --population-size 4
+```
+
+**Prepare instances from config:**
+```bash
+factory outer-loop prep-instances my_bench \
+  --instances inst_001 inst_002 inst_003 \
+  --output-dir /tmp/my-instances
+```
+
+The outer loop auto-resolves test_format, test_command, metric_path, instance_format, seed_workflow, and prep_command from your TOML config. CLI flags override any config value.
+
+**Scoring formats:**
+- `pytest`: Partial credit — passed/(passed+failed)
+- `exit_code`: Binary — exit 0 = 1.0, non-zero = 0.0
+- `json`: Extract any metric via dotted path (e.g. `stats.accuracy`, `brier_index`)
+- `exact_match`: Compare stdout to expected_answer.txt (supports regex extraction)
 
 ### Instance Preparation
 

--- a/docs/outer-loop.md
+++ b/docs/outer-loop.md
@@ -94,7 +94,7 @@ The cycle_summary.json for each evaluation includes:
 }
 ```
 
-The `test_command` is benchmark-agnostic — any command that produces pytest-style output works. Set it during calibration with `--test-command`.
+The `test_command` is benchmark-agnostic. The `--test-format` flag controls how output is parsed. Set both during calibration, or let them auto-resolve from a benchmark TOML config.
 
 ### Isolation
 
@@ -138,7 +138,10 @@ Modes are registered via `EphemeralModeRegistry` which:
 | `mode_registry.py` | `EphemeralModeRegistry` — lifecycle management for candidate modes |
 | `designer.py` | `DesignerAgent` — from-scratch workflow design |
 | `models.py` | `SwarmConfig`, `Individual`, `EvalResult`, `OuterLoopState` |
-| `featurebench_evaluator.py` | pytest output parser for partial credit scoring |
+| `evaluators/` | Pluggable test output parsers: `pytest`, `exit_code`, `json`, `exact_match` |
+| `benchmark_config.py` | TOML-based benchmark config registry |
+| `instance_prep.py` | Instance preparation and validation |
+| `featurebench_evaluator.py` | pytest output parser for partial credit scoring (backward compat) |
 | `featurebench_inner_loop.py` | Bridges outer loop evaluation to InnerLoop.step() |
 | `filesystem.py` | Directory initialization, config/checkpoint persistence |
 | `overfit.py` | Training vs holdout score comparison |
@@ -199,4 +202,93 @@ From running the outer loop on FeatureBench instances (cancel-async-tasks, fix-c
 ├── events.jsonl          # Per-generation metrics
 ├── costs.jsonl           # Per-candidate cost tracking
 └── trajectory.jsonl      # Score trajectory over generations
+```
+
+## Multi-Benchmark Support
+
+The outer loop supports multiple benchmark types beyond FeatureBench. Each benchmark is defined as a TOML config file specifying the test format, test command, instance format, and seed workflow.
+
+### Built-in Benchmarks
+
+| Benchmark | Test Format | Instance Format | Description |
+|-----------|-------------|-----------------|-------------|
+| `featurebench` | `pytest` | `directory` | Feature implementation — partial credit scoring |
+| `swebench` | `exit_code` | `git-repo` | SWE-bench bug fix — binary pass/fail |
+| `aime` | `exact_match` | `question-answer` | AIME math competition — exact answer match |
+
+### Test Output Formats
+
+| Format | Parsing Method | Score Range |
+|--------|---------------|-------------|
+| `pytest` | Parse pytest stdout for pass/fail counts | 0.0–1.0 (fraction) |
+| `exit_code` | Binary from subprocess returncode (0 = pass) | 0.0 or 1.0 |
+| `json` | Extract metric via configurable JSON path | float |
+| `exact_match` | Compare output to expected answer (optional regex) | 0.0 or 1.0 |
+
+### Benchmark Config TOML Schema
+
+```toml
+[meta]
+name = "my_benchmark"
+description = "What this benchmark evaluates"
+
+[test]
+format = "json"                     # pytest | exit_code | json | exact_match
+command = "python run_eval.py"      # shell command to run
+timeout = 600                       # seconds
+metric_path = "accuracy"            # for json format: dotted path to metric
+answer_extraction = ""              # for exact_match: regex to extract answer
+
+[instances]
+format = "directory"                # directory | git-repo | question-answer
+prep_command = "mkdir -p {instance_dir}/data"  # template variables: {instance_id}, {instance_dir}
+
+[seed_workflow]
+name = "improve"                    # workflow to use as seed
+
+[scoring]
+method = "metric_extraction"        # partial_credit | binary | metric_extraction | exact_match
+```
+
+### Adding a Custom Benchmark
+
+1. Create a TOML file in one of these locations (searched in order):
+   - Project-local: `.factory/benchmarks/my_bench.toml`
+   - User-local: `~/.factory/benchmarks/my_bench.toml`
+   - Built-in: `benchmarks/configs/my_bench.toml`
+
+2. Run calibration with your benchmark:
+   ```bash
+   factory outer-loop calibrate /path/to/factory \
+     --benchmark my_bench \
+     --project-dir /path/to/instance
+   ```
+
+3. The outer loop auto-resolves `test_format`, `test_command`, and `instance_format` from your TOML. You can override any field via CLI flags.
+
+### Instance Preparation
+
+```bash
+# List available benchmarks
+factory outer-loop list-benchmarks
+
+# Prepare instances from config
+factory outer-loop prep-instances swebench \
+  --instances django__django-12345 flask__flask-67890 \
+  --output-dir /tmp/instances
+```
+
+The `prep_command` template supports `{instance_id}` and `{instance_dir}` variables. Validation runs after preparation:
+- `directory`: checks directory exists
+- `git-repo`: checks `.git/` exists and runs `git fsck --quick`
+- `question-answer`: checks for `question.txt`/`question.md` and `answer.txt`/`expected.txt`
+
+### CLI Flags
+
+```bash
+factory outer-loop calibrate <project> \
+  --benchmark swebench \
+  --test-format exit_code \         # override test format from TOML
+  --test-command "pytest -xvs" \    # override test command
+  --population-size 4
 ```

--- a/factory/cli/outer_loop.py
+++ b/factory/cli/outer_loop.py
@@ -98,6 +98,8 @@ def cmd_outer_loop(args: argparse.Namespace) -> int:
         "evolve": _cmd_evolve,
         "status": _cmd_status,
         "promote": _cmd_promote,
+        "prep-instances": _cmd_prep_instances,
+        "list-benchmarks": _cmd_list_benchmarks,
     }
     handler = handlers.get(sub)
     if handler is None:
@@ -129,6 +131,22 @@ def _cmd_calibrate(args: argparse.Namespace) -> int:
         designer_count = 0 if benchmark == "featurebench" else 2
         target_proj = getattr(args, "project_dir", None)
         test_cmd = getattr(args, "test_command", "")
+        test_fmt = getattr(args, "test_format", "")
+
+        bench_config = None
+        try:
+            from factory.outer_loop.benchmark_config import load_benchmark_config
+            bench_config = load_benchmark_config(benchmark, project_path)
+            _log.info("benchmark_config_loaded", benchmark=benchmark)
+        except FileNotFoundError:
+            _log.info("benchmark_config_not_found", benchmark=benchmark)
+
+        resolved_test_format = test_fmt or (bench_config.test_format if bench_config else "pytest")
+        resolved_test_command = test_cmd or (bench_config.test_command if bench_config else "")
+        resolved_seed_workflow = bench_config.seed_workflow if bench_config else ""
+        resolved_instance_format = bench_config.instance_format if bench_config else "directory"
+        resolved_prep_command = bench_config.prep_command if bench_config else ""
+
         config = SwarmConfig(
             benchmark=benchmark,
             budget=budget,
@@ -137,7 +155,11 @@ def _cmd_calibrate(args: argparse.Namespace) -> int:
             training_instances=getattr(args, "training_instances", []),
             holdout_instances=getattr(args, "holdout_instances", []),
             target_project=str(Path(target_proj).resolve()) if target_proj else "",
-            test_command=test_cmd or "",
+            test_command=resolved_test_command,
+            test_format=resolved_test_format,
+            seed_workflow=resolved_seed_workflow,
+            instance_format=resolved_instance_format,
+            prep_command=resolved_prep_command,
         )
 
     root = init_filesystem(project_path, config)
@@ -511,6 +533,55 @@ def _cmd_promote(args: argparse.Namespace) -> int:
         return 1
 
 
+def _cmd_prep_instances(args: argparse.Namespace) -> int:
+    """Prepare benchmark instances from config."""
+    benchmark = getattr(args, "benchmark", "featurebench")
+    instances = getattr(args, "instances", [])
+    output_dir = Path(getattr(args, "output_dir", ".")).resolve()
+    project_path = Path(getattr(args, "project_path", ".")).resolve()
+
+    if not instances:
+        print("Error: --instances required", file=sys.stderr)
+        return 1
+
+    from factory.outer_loop.benchmark_config import load_benchmark_config
+    from factory.outer_loop.instance_prep import prepare_instances
+
+    try:
+        config = load_benchmark_config(benchmark, project_path)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    prepared = prepare_instances(config, instances, output_dir)
+    print(f"Prepared {len(prepared)}/{len(instances)} instances:")
+    for p in prepared:
+        print(f"  ✓ {p.name}")
+    failed = set(instances) - {p.name for p in prepared}
+    for name in sorted(failed):
+        print(f"  ✗ {name}")
+    return 0 if len(prepared) == len(instances) else 1
+
+
+def _cmd_list_benchmarks(args: argparse.Namespace) -> int:
+    """List all available benchmark configurations."""
+    project_path = Path(getattr(args, "project_path", ".")).resolve()
+
+    from factory.outer_loop.benchmark_config import list_benchmarks
+
+    configs = list_benchmarks(project_path)
+    if not configs:
+        print("No benchmark configurations found.")
+        return 0
+
+    print(f"Available benchmarks ({len(configs)}):")
+    for cfg in configs:
+        print(f"  {cfg.name:20s}  format={cfg.test_format:12s}  instances={cfg.instance_format}")
+        if cfg.description:
+            print(f"    {cfg.description}")
+    return 0
+
+
 def add_outer_loop_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     """Add the outer-loop subcommand group to the CLI parser."""
     outer = subparsers.add_parser(
@@ -536,6 +607,11 @@ def add_outer_loop_parser(subparsers: argparse._SubParsersAction) -> None:  # ty
         "--test-command",
         default="",
         help="Test command for scoring (e.g. 'pytest tests/test_outputs.py -v')",
+    )
+    cal.add_argument(
+        "--test-format",
+        default="",
+        help="Test output format: pytest, exit_code, json, exact_match (auto-detected from benchmark config if omitted)",
     )
 
     ev = outer_sub.add_parser("evaluate", help="Evaluate current generation")
@@ -563,3 +639,12 @@ def add_outer_loop_parser(subparsers: argparse._SubParsersAction) -> None:  # ty
     pr.add_argument("project_path", nargs="?", default=".")
     pr.add_argument("--mode-name", required=True)
     pr.add_argument("--permanent-name", default="evolved")
+
+    prep = outer_sub.add_parser("prep-instances", help="Prepare benchmark instances")
+    prep.add_argument("benchmark", help="Benchmark name (e.g. featurebench, swebench)")
+    prep.add_argument("--instances", nargs="+", required=True, help="Instance IDs to prepare")
+    prep.add_argument("--output-dir", default=".", help="Output directory for prepared instances")
+    prep.add_argument("--project-path", default=".", help="Project path for config lookup")
+
+    lb = outer_sub.add_parser("list-benchmarks", help="List available benchmarks")
+    lb.add_argument("project_path", nargs="?", default=".")

--- a/factory/inner_loop.py
+++ b/factory/inner_loop.py
@@ -117,6 +117,7 @@ class InnerLoop:
         workflow: Workflow | None = None,
         frozen_nodes: frozenset[str] = frozenset(),
         test_command: str = "",
+        test_format: str = "pytest",
     ) -> None:
         self.project_dir = Path(project_dir).resolve()
         self.factory_dir = self.project_dir / ".factory"
@@ -125,6 +126,7 @@ class InnerLoop:
         self.workflow = workflow
         self.frozen_nodes = frozenset(frozen_nodes)
         self.test_command = test_command
+        self.test_format = test_format
         self._step_count = 0
         self._history: list[CycleRecord] = []
         self._validate_frozen_nodes()
@@ -317,9 +319,14 @@ class InnerLoop:
             return None
 
     def _run_test_command(self) -> tuple[float | None, dict[str, Any] | None]:
-        """Run the configured test command and return (pass_rate, details)."""
-        from factory.outer_loop.featurebench_evaluator import parse_pytest_stdout
+        """Run the configured test command and return (score, details).
 
+        Dispatches output parsing based on self.test_format:
+        - pytest: parse stdout for pass/fail counts
+        - exit_code: binary pass/fail from returncode
+        - json: parse stdout as JSON, extract metric
+        - exact_match: compare output to expected answer
+        """
         try:
             result = subprocess.run(
                 shlex.split(self.test_command),
@@ -328,18 +335,57 @@ class InnerLoop:
                 text=True,
                 timeout=600,
             )
-            metrics = parse_pytest_stdout(result.stdout)
-            pass_rate = metrics.get("pass_rate", 0.0)
-            return pass_rate, {
-                "tests_passed": metrics.get("tests_passed", 0.0),
-                "tests_total": metrics.get("tests_total", 0.0),
-                "pass_rate": pass_rate,
-                "test_returncode": result.returncode,
-            }
+            return self._parse_test_output(result)
         except subprocess.TimeoutExpired:
             return 0.0, {"error": "test_command_timeout"}
         except Exception as exc:
             return None, {"error": str(exc)}
+
+    def _parse_test_output(
+        self, result: subprocess.CompletedProcess[str],
+    ) -> tuple[float, dict[str, Any]]:
+        """Parse test command output based on test_format."""
+        if self.test_format == "exit_code":
+            score = 1.0 if result.returncode == 0 else 0.0
+            return score, {
+                "returncode": result.returncode,
+                "passed": score,
+                "test_format": "exit_code",
+            }
+
+        if self.test_format == "json":
+            try:
+                data = json.loads(result.stdout)
+                score = float(data.get("score", data.get("pass_rate", 0.0)))
+                return score, {
+                    "score": score,
+                    "test_format": "json",
+                    "test_returncode": result.returncode,
+                    **{k: v for k, v in data.items() if isinstance(v, (int, float))},
+                }
+            except (json.JSONDecodeError, TypeError, ValueError):
+                return 0.0, {"error": "json_parse_failed", "test_format": "json"}
+
+        if self.test_format == "exact_match":
+            output = result.stdout.strip()
+            expected = result.stderr.strip()
+            score = 1.0 if output == expected else 0.0
+            return score, {
+                "match": score,
+                "test_format": "exact_match",
+                "test_returncode": result.returncode,
+            }
+
+        from factory.outer_loop.featurebench_evaluator import parse_pytest_stdout
+        metrics = parse_pytest_stdout(result.stdout)
+        pass_rate = metrics.get("pass_rate", 0.0)
+        return pass_rate, {
+            "tests_passed": metrics.get("tests_passed", 0.0),
+            "tests_total": metrics.get("tests_total", 0.0),
+            "pass_rate": pass_rate,
+            "test_returncode": result.returncode,
+            "test_format": "pytest",
+        }
 
     def _write_cycle_summary(
         self,

--- a/factory/inner_loop.py
+++ b/factory/inner_loop.py
@@ -118,6 +118,7 @@ class InnerLoop:
         frozen_nodes: frozenset[str] = frozenset(),
         test_command: str = "",
         test_format: str = "pytest",
+        metric_path: str = "score",
     ) -> None:
         self.project_dir = Path(project_dir).resolve()
         self.factory_dir = self.project_dir / ".factory"
@@ -127,6 +128,7 @@ class InnerLoop:
         self.frozen_nodes = frozenset(frozen_nodes)
         self.test_command = test_command
         self.test_format = test_format
+        self.metric_path = metric_path
         self._step_count = 0
         self._history: list[CycleRecord] = []
         self._validate_frozen_nodes()
@@ -356,19 +358,27 @@ class InnerLoop:
         if self.test_format == "json":
             try:
                 data = json.loads(result.stdout)
-                score = float(data.get("score", data.get("pass_rate", 0.0)))
+                obj: Any = data
+                for key in self.metric_path.split("."):
+                    obj = obj[key]
+                score = float(obj)
                 return score, {
                     "score": score,
                     "test_format": "json",
                     "test_returncode": result.returncode,
                     **{k: v for k, v in data.items() if isinstance(v, (int, float))},
                 }
-            except (json.JSONDecodeError, TypeError, ValueError):
+            except (json.JSONDecodeError, TypeError, ValueError, KeyError):
                 return 0.0, {"error": "json_parse_failed", "test_format": "json"}
 
         if self.test_format == "exact_match":
             output = result.stdout.strip()
-            expected = result.stderr.strip()
+            expected_path = self.project_dir / "expected_answer.txt"
+            if not expected_path.exists():
+                expected_path = self.project_dir / "expected.txt"
+            if not expected_path.exists():
+                return 0.0, {"error": "expected_answer_file_missing", "test_format": "exact_match"}
+            expected = expected_path.read_text(errors="replace").strip()
             score = 1.0 if output == expected else 0.0
             return score, {
                 "match": score,

--- a/factory/outer_loop/__init__.py
+++ b/factory/outer_loop/__init__.py
@@ -1,7 +1,13 @@
 """Outer loop — evolutionary swarm search for workflow optimization."""
 
+from factory.outer_loop.benchmark_config import (
+    BenchmarkConfig,
+    list_benchmarks,
+    load_benchmark_config,
+)
 from factory.outer_loop.designer import DesignerAgent, extract_telemetry
 from factory.outer_loop.engine import BudgetTracker, SwarmEngine
+from factory.outer_loop.evaluators import get_evaluator
 from factory.outer_loop.filesystem import (
     export_best_workflow,
     init_filesystem,
@@ -12,6 +18,7 @@ from factory.outer_loop.filesystem import (
     save_generation,
     save_map_elites,
 )
+from factory.outer_loop.instance_prep import prepare_instances
 from factory.outer_loop.direct_evaluator import DirectFeatureBenchEvaluator
 from factory.outer_loop.models import (
     AuditResult,
@@ -28,6 +35,7 @@ from factory.outer_loop.models import (
 
 __all__ = [
     "AuditResult",
+    "BenchmarkConfig",
     "BudgetTracker",
     "DirectFeatureBenchEvaluator",
     "DesignerAgent",
@@ -43,9 +51,13 @@ __all__ = [
     "SwarmEngine",
     "export_best_workflow",
     "extract_telemetry",
+    "get_evaluator",
     "init_filesystem",
+    "list_benchmarks",
+    "load_benchmark_config",
     "load_checkpoint",
     "load_config",
+    "prepare_instances",
     "save_best",
     "save_checkpoint",
     "save_generation",

--- a/factory/outer_loop/benchmark_config.py
+++ b/factory/outer_loop/benchmark_config.py
@@ -1,0 +1,121 @@
+"""Benchmark configuration — TOML-based registry for multi-benchmark support.
+
+Each benchmark is a .toml file with metadata, test format, instance format,
+and seed workflow. The registry discovers configs from:
+  1. Project-local: .factory/benchmarks/
+  2. User-local: ~/.factory/benchmarks/
+  3. Built-in: benchmarks/configs/ (in the factory repo)
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+import structlog
+
+log = structlog.get_logger()
+
+_BUILTIN_DIR = Path(__file__).resolve().parent.parent.parent / "benchmarks" / "configs"
+
+
+class BenchmarkConfig(BaseModel):
+    """Configuration for a single benchmark."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    name: str
+    description: str = ""
+    test_format: str = "pytest"
+    test_command: str = ""
+    test_timeout: int = 600
+    instance_format: str = "directory"
+    prep_command: str = ""
+    seed_workflow: str = ""
+    answer_extraction: str = ""
+    metric_path: str = "score"
+    scoring_method: str = "partial_credit"
+    scoring_weights: dict[str, float] = Field(default_factory=dict)
+
+
+def load_benchmark_config(name: str, project_dir: Path | None = None) -> BenchmarkConfig:
+    """Load a benchmark config by name from the search path.
+
+    Search order: project .factory/benchmarks/ → ~/.factory/benchmarks/ → built-in.
+    Raises FileNotFoundError if no config found.
+    """
+    search_paths: list[Path] = []
+
+    if project_dir is not None:
+        search_paths.append(Path(project_dir) / ".factory" / "benchmarks")
+
+    user_dir = Path.home() / ".factory" / "benchmarks"
+    search_paths.append(user_dir)
+    search_paths.append(_BUILTIN_DIR)
+
+    for base in search_paths:
+        config_path = base / f"{name}.toml"
+        if config_path.exists():
+            return _parse_toml(config_path, name)
+
+    raise FileNotFoundError(
+        f"No benchmark config found for {name!r}. "
+        f"Searched: {[str(p) for p in search_paths]}"
+    )
+
+
+def list_benchmarks(project_dir: Path | None = None) -> list[BenchmarkConfig]:
+    """List all available benchmark configs from the search path."""
+    seen: set[str] = set()
+    configs: list[BenchmarkConfig] = []
+
+    search_paths: list[Path] = []
+    if project_dir is not None:
+        search_paths.append(Path(project_dir) / ".factory" / "benchmarks")
+    search_paths.append(Path.home() / ".factory" / "benchmarks")
+    search_paths.append(_BUILTIN_DIR)
+
+    for base in search_paths:
+        if not base.exists():
+            continue
+        for f in sorted(base.glob("*.toml")):
+            name = f.stem
+            if name in seen:
+                continue
+            seen.add(name)
+            try:
+                configs.append(_parse_toml(f, name))
+            except Exception:
+                log.warning("benchmark_config_parse_error", path=str(f), exc_info=True)
+
+    return configs
+
+
+def _parse_toml(path: Path, name: str) -> BenchmarkConfig:
+    """Parse a TOML benchmark config file."""
+    raw = tomllib.loads(path.read_text())
+
+    meta = raw.get("meta", {})
+    test = raw.get("test", {})
+    instances = raw.get("instances", {})
+    seed = raw.get("seed_workflow", {})
+    scoring = raw.get("scoring", {})
+
+    return BenchmarkConfig(
+        name=meta.get("name", name),
+        description=meta.get("description", ""),
+        test_format=test.get("format", "pytest"),
+        test_command=test.get("command", ""),
+        test_timeout=test.get("timeout", 600),
+        instance_format=instances.get("format", "directory"),
+        prep_command=instances.get("prep_command", ""),
+        seed_workflow=seed.get("name", ""),
+        answer_extraction=test.get("answer_extraction", ""),
+        metric_path=test.get("metric_path", "score"),
+        scoring_method=scoring.get("method", "partial_credit"),
+        scoring_weights={
+            str(k): float(v) for k, v in scoring.get("weights", {}).items()
+        },
+    )

--- a/factory/outer_loop/engine.py
+++ b/factory/outer_loop/engine.py
@@ -29,6 +29,7 @@ from factory.outer_loop.population import MAPElitesArchive, Population
 from factory.outer_loop.similarity import NoveltyFilter
 from factory.outer_loop.subset import FixedSubsetSelector, SubsetSelector
 from factory.workflow.primitives import Workflow
+from factory.workflow.registry import WorkflowRegistry
 
 if TYPE_CHECKING:
     pass
@@ -132,12 +133,24 @@ class SwarmEngine:
     ) -> Population:
         """Create the initial population from a base workflow.
 
+        If config.seed_workflow is set, looks up the workflow from
+        WorkflowRegistry and uses it instead of the passed-in base_workflow.
+        Falls back to base_workflow when seed_workflow is empty or not found.
+
         Slot 0: unmodified seed.
         Slots 1..N-designer_count: random mutations of seed.
         Last designer_count slots: from-scratch designs via DesignerAgent.
         """
         cfg = config or self._config
         pop = Population()
+
+        if cfg.seed_workflow:
+            registry_wf = WorkflowRegistry.get_workflow(cfg.seed_workflow)
+            if registry_wf is not None:
+                log.info("seed_workflow_from_registry", name=cfg.seed_workflow)
+                base_workflow = registry_wf
+            else:
+                log.warning("seed_workflow_not_found", name=cfg.seed_workflow)
 
         seed_ind = Population.make_individual(base_workflow, generation=0)
         pop.add(seed_ind)

--- a/factory/outer_loop/evaluator.py
+++ b/factory/outer_loop/evaluator.py
@@ -325,6 +325,7 @@ class SwarmEvaluator:
                 workflow=workflow,
                 frozen_nodes=frozenset(self._config.frozen_node_ids),
                 test_command=self._config.test_command,
+                test_format=self._config.test_format,
             )
             record = loop.step()
 

--- a/factory/outer_loop/evaluator.py
+++ b/factory/outer_loop/evaluator.py
@@ -326,6 +326,7 @@ class SwarmEvaluator:
                 frozen_nodes=frozenset(self._config.frozen_node_ids),
                 test_command=self._config.test_command,
                 test_format=self._config.test_format,
+                metric_path=self._config.metric_path,
             )
             record = loop.step()
 

--- a/factory/outer_loop/evaluators/__init__.py
+++ b/factory/outer_loop/evaluators/__init__.py
@@ -1,0 +1,49 @@
+"""Pluggable test output parsers for multi-benchmark support.
+
+Each evaluator implements the Evaluator protocol from factory.inner_loop,
+parsing output artifacts produced by test_command subprocess execution.
+"""
+
+from __future__ import annotations
+
+from factory.inner_loop import Evaluator
+from factory.outer_loop.evaluators.pytest_evaluator import PytestEvaluator
+from factory.outer_loop.evaluators.exit_code import ExitCodeEvaluator
+from factory.outer_loop.evaluators.json_evaluator import JSONEvaluator
+from factory.outer_loop.evaluators.exact_match import ExactMatchEvaluator
+
+_REGISTRY: dict[str, type[Evaluator]] = {
+    "pytest": PytestEvaluator,
+    "exit_code": ExitCodeEvaluator,
+    "json": JSONEvaluator,
+    "exact_match": ExactMatchEvaluator,
+}
+
+
+def get_evaluator(test_format: str, **kwargs: object) -> Evaluator:
+    """Create an evaluator for the given test output format.
+
+    Raises ValueError for unknown formats.
+    """
+    cls = _REGISTRY.get(test_format)
+    if cls is None:
+        raise ValueError(
+            f"Unknown test_format {test_format!r}. "
+            f"Available: {sorted(_REGISTRY.keys())}"
+        )
+    return cls(**kwargs)  # type: ignore[arg-type]
+
+
+def list_formats() -> list[str]:
+    """Return all registered test format names."""
+    return sorted(_REGISTRY.keys())
+
+
+__all__ = [
+    "ExactMatchEvaluator",
+    "ExitCodeEvaluator",
+    "JSONEvaluator",
+    "PytestEvaluator",
+    "get_evaluator",
+    "list_formats",
+]

--- a/factory/outer_loop/evaluators/exact_match.py
+++ b/factory/outer_loop/evaluators/exact_match.py
@@ -1,0 +1,95 @@
+"""Exact match evaluator — compare output to expected answer.
+
+Used by math benchmarks like AIME where the answer is a single value
+that must match exactly (after optional regex extraction).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from factory.inner_loop import EvalResult
+
+
+class ExactMatchEvaluator:
+    """Compares extracted output to expected answer.
+
+    If answer_extraction regex is provided, applies it to extract the
+    answer from the output (e.g. r"\\boxed{(\\d+)}" for LaTeX math).
+    Score 1.0 on match, 0.0 otherwise.
+    """
+
+    def __init__(
+        self,
+        answer_extraction: str = "",
+        **kwargs: object,
+    ) -> None:
+        self.answer_extraction = answer_extraction
+        self._pattern: re.Pattern[str] | None = None
+        if answer_extraction:
+            try:
+                self._pattern = re.compile(answer_extraction)
+            except re.error:
+                self._pattern = None
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        try:
+            data = json.loads(Path(artifact_path).read_text(errors="replace"))
+        except (json.JSONDecodeError, OSError):
+            return EvalResult(score=0.0, valid=False)
+
+        output = str(data.get("output", ""))
+        expected = str(data.get("expected", ""))
+
+        if not expected:
+            return EvalResult(score=0.0, valid=False)
+
+        extracted = self._extract_answer(output)
+        match = extracted.strip() == expected.strip()
+        score = 1.0 if match else 0.0
+
+        return EvalResult(
+            score=score,
+            metrics={"match": score, "extracted": 1.0 if extracted != output else 0.0},
+            valid=True,
+            artifacts=[str(artifact_path)],
+        )
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        if not artifact_paths:
+            return EvalResult(score=0.0, valid=False)
+        total = 0
+        correct = 0
+        for p in artifact_paths:
+            result = self.parse(p)
+            if result.valid:
+                total += 1
+                if result.score > 0:
+                    correct += 1
+        if total == 0:
+            return EvalResult(score=0.0, valid=False)
+        score = correct / total
+        return EvalResult(
+            score=score,
+            metrics={"correct": float(correct), "total": float(total), "accuracy": score},
+            valid=True,
+        )
+
+    def get_info(self) -> dict:
+        return {
+            "test_format": "exact_match",
+            "scoring": "exact_match",
+            "answer_extraction": self.answer_extraction,
+        }
+
+    def _extract_answer(self, text: str) -> str:
+        if self._pattern is None:
+            return text
+        match = self._pattern.search(text)
+        if match and match.groups():
+            return match.group(1)
+        if match:
+            return match.group(0)
+        return text

--- a/factory/outer_loop/evaluators/exit_code.py
+++ b/factory/outer_loop/evaluators/exit_code.py
@@ -1,0 +1,68 @@
+"""Exit code evaluator — binary pass/fail from subprocess return code.
+
+Used by benchmarks like SWE-bench where success is determined by
+whether the test command exits with code 0.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from factory.inner_loop import EvalResult
+
+
+class ExitCodeEvaluator:
+    """Binary pass/fail scoring from subprocess exit code.
+
+    Reads an artifact JSON with {"returncode": N, ...}.
+    Score 1.0 if returncode is 0, else 0.0.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        try:
+            data = json.loads(Path(artifact_path).read_text(errors="replace"))
+        except (json.JSONDecodeError, OSError):
+            return EvalResult(score=0.0, valid=False)
+
+        returncode = data.get("returncode")
+        if returncode is None:
+            return EvalResult(score=0.0, valid=False)
+
+        score = 1.0 if returncode == 0 else 0.0
+        return EvalResult(
+            score=score,
+            metrics={"returncode": float(returncode), "passed": score},
+            valid=True,
+            artifacts=[str(artifact_path)],
+        )
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        if not artifact_paths:
+            return EvalResult(score=0.0, valid=False)
+        total = 0
+        passed = 0
+        for p in artifact_paths:
+            result = self.parse(p)
+            if result.valid:
+                total += 1
+                if result.score > 0:
+                    passed += 1
+        if total == 0:
+            return EvalResult(score=0.0, valid=False)
+        score = passed / total
+        return EvalResult(
+            score=score,
+            metrics={"passed": float(passed), "total": float(total), "pass_rate": score},
+            valid=True,
+        )
+
+    def get_info(self) -> dict:
+        return {
+            "test_format": "exit_code",
+            "scoring": "binary",
+            "metrics": ["returncode", "passed"],
+        }

--- a/factory/outer_loop/evaluators/json_evaluator.py
+++ b/factory/outer_loop/evaluators/json_evaluator.py
@@ -1,0 +1,76 @@
+"""JSON evaluator — extract a metric from JSON output.
+
+Used by benchmarks that produce structured JSON results with a
+configurable metric path (e.g. "pass_rate" or "stats.resolve_rate").
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from factory.inner_loop import EvalResult
+
+
+class JSONEvaluator:
+    """Extracts a numeric metric from JSON output via a dotted path.
+
+    The metric_path supports dotted notation for nested fields:
+    e.g. "stats.resolve_rate" reads data["stats"]["resolve_rate"].
+    """
+
+    def __init__(self, metric_path: str = "score", **kwargs: object) -> None:
+        self.metric_path = metric_path
+
+    def parse(self, artifact_path: Path) -> EvalResult:
+        try:
+            data = json.loads(Path(artifact_path).read_text(errors="replace"))
+        except (json.JSONDecodeError, OSError):
+            return EvalResult(score=0.0, valid=False)
+
+        value = self._extract(data, self.metric_path)
+        if value is None:
+            return EvalResult(score=0.0, valid=False)
+
+        try:
+            score = float(value)
+        except (TypeError, ValueError):
+            return EvalResult(score=0.0, valid=False)
+
+        metrics: dict[str, float] = {self.metric_path: score}
+        for k, v in data.items():
+            if isinstance(v, (int, float)) and k != self.metric_path:
+                metrics[k] = float(v)
+
+        return EvalResult(
+            score=score,
+            metrics=metrics,
+            valid=True,
+            artifacts=[str(artifact_path)],
+        )
+
+    def parse_many(self, artifact_paths: list[Path]) -> EvalResult:
+        best = EvalResult(score=0.0, valid=False)
+        for p in artifact_paths:
+            result = self.parse(p)
+            if result.valid and result.score > best.score:
+                best = result
+        return best
+
+    def get_info(self) -> dict:
+        return {
+            "test_format": "json",
+            "scoring": "metric_extraction",
+            "metric_path": self.metric_path,
+        }
+
+    @staticmethod
+    def _extract(data: dict, path: str) -> object:
+        parts = path.split(".")
+        current: object = data
+        for part in parts:
+            if isinstance(current, dict):
+                current = current.get(part)
+            else:
+                return None
+        return current

--- a/factory/outer_loop/evaluators/pytest_evaluator.py
+++ b/factory/outer_loop/evaluators/pytest_evaluator.py
@@ -1,12 +1,7 @@
-"""FeatureBench evaluator — implements the Evaluator protocol with partial credit scoring.
+"""Pytest output evaluator — partial credit scoring from pytest results.
 
-Parses pytest-json-report output for per-test pass/fail to produce a fraction
-score (e.g. 5/8 = 0.625) instead of binary 0/1. This is the gradient signal
-that enables evolutionary search to optimize incrementally.
-
-The canonical implementation now lives in factory.outer_loop.evaluators.pytest_evaluator.
-This module keeps FeatureBenchEvaluator as a backward-compatible class and
-parse_pytest_stdout() as a standalone utility.
+Moved from featurebench_evaluator.py. Parses pytest-json-report output
+or factory eval artifacts for per-test pass/fail fraction scoring.
 """
 
 from __future__ import annotations
@@ -14,26 +9,22 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import structlog
-
 from factory.inner_loop import EvalResult
 
-log = structlog.get_logger()
 
-
-class FeatureBenchEvaluator:
-    """Parses FeatureBench pytest output for partial credit scoring.
+class PytestEvaluator:
+    """Parses pytest output for partial credit scoring.
 
     Looks for pytest-json-report output files (report.json) or factory
     eval artifacts. Computes score as fraction of tests passing.
     """
 
-    def __init__(self, benchmark: str = "featurebench") -> None:
+    def __init__(self, benchmark: str = "featurebench", **kwargs: object) -> None:
         self.benchmark = benchmark
 
     def parse(self, artifact_path: Path) -> EvalResult:
         try:
-            data = json.loads(Path(artifact_path).read_text())
+            data = json.loads(Path(artifact_path).read_text(errors="replace"))
         except (json.JSONDecodeError, OSError):
             return EvalResult(score=0.0, valid=False)
 
@@ -57,17 +48,15 @@ class FeatureBenchEvaluator:
         return {
             "benchmark": self.benchmark,
             "scoring": "partial_credit",
+            "test_format": "pytest",
             "metrics": ["tests_passed", "tests_total", "pass_rate"],
         }
 
     def _extract_partial_credit(self, data: dict) -> tuple[float, dict[str, float]]:
-        """Extract partial credit from pytest-json-report or factory eval output."""
         if "tests" in data:
             return self._parse_pytest_json_report(data)
-
         if "results" in data:
             return self._parse_factory_eval(data)
-
         if "summary" in data:
             summary = data["summary"]
             passed = summary.get("passed", 0)
@@ -79,20 +68,16 @@ class FeatureBenchEvaluator:
                     "tests_total": float(total),
                     "pass_rate": score,
                 }
-
         score = float(data.get("score", data.get("combined_score", 0.0)))
         return score, {"raw_score": score}
 
     def _parse_pytest_json_report(self, data: dict) -> tuple[float, dict[str, float]]:
-        """Parse pytest-json-report format: {"tests": [{"outcome": "passed"}, ...]}"""
         tests = data.get("tests", [])
         if not tests:
             return 0.0, {"tests_passed": 0.0, "tests_total": 0.0, "pass_rate": 0.0}
-
         passed = sum(1 for t in tests if t.get("outcome") == "passed")
         total = len(tests)
         score = passed / total if total > 0 else 0.0
-
         return score, {
             "tests_passed": float(passed),
             "tests_total": float(total),
@@ -100,15 +85,12 @@ class FeatureBenchEvaluator:
         }
 
     def _parse_factory_eval(self, data: dict) -> tuple[float, dict[str, float]]:
-        """Parse factory eval format: {"results": [{"score": 0.8, ...}]}"""
         results = data.get("results", [])
         if not results:
             return 0.0, {}
-
         scores = [float(r.get("score", 0.0)) for r in results if "score" in r]
         if not scores:
             return 0.0, {}
-
         avg = sum(scores) / len(scores)
         return avg, {
             "avg_score": avg,
@@ -116,39 +98,3 @@ class FeatureBenchEvaluator:
             "min_score": min(scores),
             "num_results": float(len(scores)),
         }
-
-
-def parse_pytest_stdout(stdout: str) -> dict[str, float]:
-    """Parse pytest stdout for pass/fail counts when no JSON report is available.
-
-    Looks for the summary line: "X passed, Y failed, Z errors" or similar.
-    Returns metrics dict with tests_passed, tests_total, pass_rate.
-    """
-    import re
-
-    metrics: dict[str, float] = {"tests_passed": 0.0, "tests_total": 0.0, "pass_rate": 0.0}
-
-    patterns = [
-        (r"(\d+)\s+passed", "passed"),
-        (r"(\d+)\s+failed", "failed"),
-        (r"(\d+)\s+error", "errors"),
-        (r"(\d+)\s+skipped", "skipped"),
-    ]
-
-    counts: dict[str, int] = {}
-    for pattern, key in patterns:
-        match = re.search(pattern, stdout)
-        if match:
-            counts[key] = int(match.group(1))
-
-    passed = counts.get("passed", 0)
-    failed = counts.get("failed", 0)
-    errors = counts.get("errors", 0)
-    total = passed + failed + errors
-
-    if total > 0:
-        metrics["tests_passed"] = float(passed)
-        metrics["tests_total"] = float(total)
-        metrics["pass_rate"] = passed / total
-
-    return metrics

--- a/factory/outer_loop/featurebench_inner_loop.py
+++ b/factory/outer_loop/featurebench_inner_loop.py
@@ -35,12 +35,13 @@ class FeatureBenchInnerLoop:
         frozen_nodes: frozenset[str] = frozenset(),
         test_command: str = "",
         test_format: str = "pytest",
+        metric_path: str = "score",
     ) -> None:
         if test_format == "pytest":
             self._evaluator = FeatureBenchEvaluator()
         else:
             from factory.outer_loop.evaluators import get_evaluator
-            self._evaluator = get_evaluator(test_format)
+            self._evaluator = get_evaluator(test_format, metric_path=metric_path)
         self._inner_loop = InnerLoop(
             project_dir=project_dir,
             mode=mode,
@@ -49,6 +50,7 @@ class FeatureBenchInnerLoop:
             frozen_nodes=frozen_nodes,
             test_command=test_command,
             test_format=test_format,
+            metric_path=metric_path,
         )
 
     @property

--- a/factory/outer_loop/featurebench_inner_loop.py
+++ b/factory/outer_loop/featurebench_inner_loop.py
@@ -34,8 +34,13 @@ class FeatureBenchInnerLoop:
         workflow: Workflow | None = None,
         frozen_nodes: frozenset[str] = frozenset(),
         test_command: str = "",
+        test_format: str = "pytest",
     ) -> None:
-        self._evaluator = FeatureBenchEvaluator()
+        if test_format == "pytest":
+            self._evaluator = FeatureBenchEvaluator()
+        else:
+            from factory.outer_loop.evaluators import get_evaluator
+            self._evaluator = get_evaluator(test_format)
         self._inner_loop = InnerLoop(
             project_dir=project_dir,
             mode=mode,
@@ -43,6 +48,7 @@ class FeatureBenchInnerLoop:
             workflow=workflow,
             frozen_nodes=frozen_nodes,
             test_command=test_command,
+            test_format=test_format,
         )
 
     @property

--- a/factory/outer_loop/instance_prep.py
+++ b/factory/outer_loop/instance_prep.py
@@ -6,6 +6,7 @@ instance directories ready for the outer loop.
 
 from __future__ import annotations
 
+import re
 import shlex
 import subprocess
 from pathlib import Path
@@ -15,6 +16,13 @@ import structlog
 from factory.outer_loop.benchmark_config import BenchmarkConfig
 
 log = structlog.get_logger()
+
+_SHELL_OPERATORS_RE = re.compile(r"&&|\|\||[;|]")
+
+
+def _needs_shell(cmd: str) -> bool:
+    """Return True if cmd contains shell operators that require shell=True."""
+    return bool(_SHELL_OPERATORS_RE.search(cmd))
 
 
 def prepare_instances(
@@ -26,6 +34,7 @@ def prepare_instances(
 
     Expands template variables ({instance_id}, {instance_dir}) in prep_command,
     runs via subprocess, validates required files exist based on instance_format.
+    Uses shell=True when the command contains shell operators (&&, ||, ;, |).
 
     Returns list of successfully prepared instance directories.
     """
@@ -45,14 +54,16 @@ def prepare_instances(
                 "{instance_dir}", str(instance_dir)
             )
 
-            log.info("prep_instance", instance_id=instance_id, command=cmd)
+            use_shell = _needs_shell(cmd)
+            log.info("prep_instance", instance_id=instance_id, command=cmd, shell=use_shell)
             try:
                 result = subprocess.run(
-                    shlex.split(cmd),
+                    cmd if use_shell else shlex.split(cmd),
                     cwd=str(output_dir),
                     capture_output=True,
                     text=True,
                     timeout=300,
+                    shell=use_shell,
                 )
                 if result.returncode != 0:
                     log.error(

--- a/factory/outer_loop/instance_prep.py
+++ b/factory/outer_loop/instance_prep.py
@@ -1,0 +1,111 @@
+"""Instance preparation — prepare benchmark instances from config.
+
+Runs prep_command from benchmark config, validates results, and creates
+instance directories ready for the outer loop.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+import structlog
+
+from factory.outer_loop.benchmark_config import BenchmarkConfig
+
+log = structlog.get_logger()
+
+
+def prepare_instances(
+    config: BenchmarkConfig,
+    instance_ids: list[str],
+    output_dir: Path,
+) -> list[Path]:
+    """Prepare benchmark instances using the config's prep_command.
+
+    Expands template variables ({instance_id}, {instance_dir}) in prep_command,
+    runs via subprocess, validates required files exist based on instance_format.
+
+    Returns list of successfully prepared instance directories.
+    """
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    prepared: list[Path] = []
+
+    for instance_id in instance_ids:
+        instance_dir = output_dir / instance_id
+        instance_dir.mkdir(parents=True, exist_ok=True)
+
+        if config.prep_command:
+            cmd = config.prep_command.replace(
+                "{instance_id}", instance_id
+            ).replace(
+                "{instance_dir}", str(instance_dir)
+            )
+
+            log.info("prep_instance", instance_id=instance_id, command=cmd)
+            try:
+                result = subprocess.run(
+                    shlex.split(cmd),
+                    cwd=str(output_dir),
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                )
+                if result.returncode != 0:
+                    log.error(
+                        "prep_instance_failed",
+                        instance_id=instance_id,
+                        returncode=result.returncode,
+                        stderr=result.stderr[:500],
+                    )
+                    continue
+            except subprocess.TimeoutExpired:
+                log.error("prep_instance_timeout", instance_id=instance_id)
+                continue
+            except Exception as exc:
+                log.error("prep_instance_error", instance_id=instance_id, error=str(exc))
+                continue
+
+        if validate_instance(instance_dir, config.instance_format):
+            prepared.append(instance_dir)
+            log.info("prep_instance_ok", instance_id=instance_id)
+        else:
+            log.warning("prep_instance_invalid", instance_id=instance_id, format=config.instance_format)
+
+    return prepared
+
+
+def validate_instance(instance_dir: Path, instance_format: str) -> bool:
+    """Validate that an instance directory matches the expected format."""
+    if not instance_dir.exists():
+        return False
+
+    if instance_format == "git-repo":
+        git_dir = instance_dir / ".git"
+        if not git_dir.exists():
+            return False
+        try:
+            result = subprocess.run(
+                ["git", "fsck", "--quick"],
+                cwd=str(instance_dir),
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    if instance_format == "question-answer":
+        has_question = (instance_dir / "question.txt").exists() or (
+            instance_dir / "question.md"
+        ).exists()
+        has_answer = (instance_dir / "answer.txt").exists() or (
+            instance_dir / "expected.txt"
+        ).exists()
+        return has_question and has_answer
+
+    return instance_dir.exists() and instance_dir.is_dir()

--- a/factory/outer_loop/models.py
+++ b/factory/outer_loop/models.py
@@ -102,6 +102,10 @@ class SwarmConfig(BaseModel):
     diversity_floor: float = 0.2
     target_project: str = ""
     test_command: str = ""
+    test_format: str = "pytest"
+    seed_workflow: str = ""
+    instance_format: str = "directory"
+    prep_command: str = ""
     early_stop_unchanged: int = 3
 
     @field_validator("holdout_instances")

--- a/factory/outer_loop/models.py
+++ b/factory/outer_loop/models.py
@@ -103,6 +103,7 @@ class SwarmConfig(BaseModel):
     target_project: str = ""
     test_command: str = ""
     test_format: str = "pytest"
+    metric_path: str = "score"
     seed_workflow: str = ""
     instance_format: str = "directory"
     prep_command: str = ""

--- a/tests/test_outer_loop/test_engine.py
+++ b/tests/test_outer_loop/test_engine.py
@@ -152,6 +152,77 @@ class TestSwarmEngineSeed:
         ids = {i.id for i in pop.individuals}
         assert len(ids) == pop.size
 
+    def test_seed_uses_registry_workflow_when_seed_workflow_set(self) -> None:
+        """When config.seed_workflow names a registered workflow, seed() uses it."""
+        from unittest.mock import patch
+
+        registry_wf = Workflow(
+            name="registry-seed",
+            nodes={
+                "builder": AgentNode(
+                    id="builder", role=AgentRole.BUILDER,
+                    writes={".factory/reviews/builder-latest.md"},
+                ),
+            },
+            edges=[],
+            start_node="builder",
+            terminal=True,
+        )
+
+        config = _make_config(population_size=2, designer_count=0, seed_workflow="improve")
+        evaluator = _make_deterministic_evaluator()
+        engine = SwarmEngine(config, evaluator)
+
+        with patch(
+            "factory.outer_loop.engine.WorkflowRegistry.get_workflow",
+            return_value=registry_wf,
+        ) as mock_get:
+            fallback_wf = _make_workflow()
+            pop = engine.seed(fallback_wf, config)
+            mock_get.assert_called_once_with("improve")
+
+        seed_ind = [i for i in pop.individuals if i.parent_id is None][0]
+        seed_data = Workflow.from_dict(seed_ind.workflow_data)  # type: ignore[arg-type]
+        assert seed_data.name == "registry-seed"
+
+    def test_seed_falls_back_when_seed_workflow_not_found(self) -> None:
+        """When seed_workflow is set but not found in registry, falls back to base_workflow."""
+        from unittest.mock import patch
+
+        config = _make_config(population_size=2, designer_count=0, seed_workflow="nonexistent")
+        evaluator = _make_deterministic_evaluator()
+        engine = SwarmEngine(config, evaluator)
+
+        with patch(
+            "factory.outer_loop.engine.WorkflowRegistry.get_workflow",
+            return_value=None,
+        ):
+            fallback_wf = _make_workflow()
+            pop = engine.seed(fallback_wf, config)
+
+        seed_ind = [i for i in pop.individuals if i.parent_id is None][0]
+        seed_data = Workflow.from_dict(seed_ind.workflow_data)  # type: ignore[arg-type]
+        assert seed_data.name == "test_evo"
+
+    def test_seed_ignores_empty_seed_workflow(self) -> None:
+        """When seed_workflow is empty, uses the passed-in base_workflow."""
+        from unittest.mock import patch
+
+        config = _make_config(population_size=2, designer_count=0, seed_workflow="")
+        evaluator = _make_deterministic_evaluator()
+        engine = SwarmEngine(config, evaluator)
+
+        with patch(
+            "factory.outer_loop.engine.WorkflowRegistry.get_workflow",
+        ) as mock_get:
+            fallback_wf = _make_workflow()
+            pop = engine.seed(fallback_wf, config)
+            mock_get.assert_not_called()
+
+        seed_ind = [i for i in pop.individuals if i.parent_id is None][0]
+        seed_data = Workflow.from_dict(seed_ind.workflow_data)  # type: ignore[arg-type]
+        assert seed_data.name == "test_evo"
+
 
 class TestSwarmEngineEvolve:
     def test_evolve_generation_returns_summary(self) -> None:

--- a/tests/test_outer_loop/test_multi_benchmark_e2e.py
+++ b/tests/test_outer_loop/test_multi_benchmark_e2e.py
@@ -492,6 +492,47 @@ class TestE2ESWEBench:
         assert score == 0.0
 
 
+class TestInnerLoopExactMatch:
+    """Tests for InnerLoop._parse_test_output with exact_match format."""
+
+    def test_exact_match_reads_expected_answer_file(self, tmp_path: Path):
+        (tmp_path / "expected_answer.txt").write_text("42\n")
+        loop = InnerLoop(project_dir=tmp_path, test_command="echo 42", test_format="exact_match")
+        mock_result = subprocess.CompletedProcess(
+            args=["echo", "42"], returncode=0, stdout="42\n", stderr=""
+        )
+        score, details = loop._parse_test_output(mock_result)
+        assert score == 1.0
+        assert details["test_format"] == "exact_match"
+
+    def test_exact_match_falls_back_to_expected_txt(self, tmp_path: Path):
+        (tmp_path / "expected.txt").write_text("hello\n")
+        loop = InnerLoop(project_dir=tmp_path, test_command="echo hello", test_format="exact_match")
+        mock_result = subprocess.CompletedProcess(
+            args=["echo", "hello"], returncode=0, stdout="hello\n", stderr=""
+        )
+        score, details = loop._parse_test_output(mock_result)
+        assert score == 1.0
+
+    def test_exact_match_mismatch(self, tmp_path: Path):
+        (tmp_path / "expected_answer.txt").write_text("42\n")
+        loop = InnerLoop(project_dir=tmp_path, test_command="echo wrong", test_format="exact_match")
+        mock_result = subprocess.CompletedProcess(
+            args=["echo", "wrong"], returncode=0, stdout="wrong\n", stderr=""
+        )
+        score, details = loop._parse_test_output(mock_result)
+        assert score == 0.0
+
+    def test_exact_match_missing_file(self, tmp_path: Path):
+        loop = InnerLoop(project_dir=tmp_path, test_command="echo 42", test_format="exact_match")
+        mock_result = subprocess.CompletedProcess(
+            args=["echo", "42"], returncode=0, stdout="42\n", stderr=""
+        )
+        score, details = loop._parse_test_output(mock_result)
+        assert score == 0.0
+        assert details["error"] == "expected_answer_file_missing"
+
+
 class TestE2ECustomBenchmark:
     """E2E test 3: Custom user-defined benchmark with JSON format.
 
@@ -590,11 +631,12 @@ class TestE2ECustomBenchmark:
         assert swarm.instance_format == "directory"
 
     def test_custom_inner_loop_json_parsing(self, custom_benchmark_project: Path):
-        """InnerLoop._parse_test_output with json format and custom metric."""
+        """InnerLoop._parse_test_output with json format and custom metric_path."""
         loop = InnerLoop(
             project_dir=custom_benchmark_project,
             test_command="python eval_runner.py",
             test_format="json",
+            metric_path="accuracy",
         )
         mock_result = subprocess.CompletedProcess(
             args=["python", "eval_runner.py"],
@@ -603,7 +645,7 @@ class TestE2ECustomBenchmark:
             stderr="",
         )
         score, details = loop._parse_test_output(mock_result)
-        assert score == 0.0  # default extracts "score" key, not "accuracy"
+        assert score == 0.92
         assert details["test_format"] == "json"
 
     def test_custom_inner_loop_json_with_score_key(self, custom_benchmark_project: Path):

--- a/tests/test_outer_loop/test_multi_benchmark_e2e.py
+++ b/tests/test_outer_loop/test_multi_benchmark_e2e.py
@@ -25,7 +25,7 @@ from factory.outer_loop.evaluators.exact_match import ExactMatchEvaluator
 from factory.outer_loop.evaluators.exit_code import ExitCodeEvaluator
 from factory.outer_loop.evaluators.json_evaluator import JSONEvaluator
 from factory.outer_loop.evaluators.pytest_evaluator import PytestEvaluator
-from factory.outer_loop.instance_prep import prepare_instances, validate_instance
+from factory.outer_loop.instance_prep import _needs_shell, prepare_instances, validate_instance
 from factory.outer_loop.models import SwarmConfig
 
 
@@ -370,6 +370,31 @@ class TestInstancePrep:
         assert len(prepared) == 2
         assert (prepared[0] / "src").is_dir()
 
+    def test_prepare_with_shell_operators(self, tmp_path: Path):
+        config = BenchmarkConfig(
+            name="test_shell",
+            instance_format="directory",
+            prep_command="mkdir -p {instance_dir}/src && touch {instance_dir}/src/ready.txt",
+        )
+        prepared = prepare_instances(config, ["s1"], tmp_path / "output")
+        assert len(prepared) == 1
+        assert (prepared[0] / "src" / "ready.txt").exists()
+
+    def test_needs_shell_detection(self) -> None:
+        assert _needs_shell("cmd1 && cmd2") is True
+        assert _needs_shell("cmd1 || cmd2") is True
+        assert _needs_shell("cmd1 ; cmd2") is True
+        assert _needs_shell("cmd1 | cmd2") is True
+        assert _needs_shell("simple-command --flag value") is False
+        assert _needs_shell("mkdir -p /some/path") is False
+
+    def test_swebench_prep_command_uses_supported_vars(self) -> None:
+        config = load_benchmark_config("swebench")
+        assert "{instance_id}" in config.prep_command
+        assert "{instance_dir}" in config.prep_command
+        assert "{repo_url}" not in config.prep_command
+        assert "{commit}" not in config.prep_command
+
     def test_prepare_question_answer_instances(self, tmp_path: Path):
         script = tmp_path / "setup.sh"
         script.write_text(
@@ -443,7 +468,8 @@ class TestE2ESWEBench:
         config = load_benchmark_config("swebench")
         assert config.test_format == "exit_code"
         assert config.instance_format == "git-repo"
-        assert "{repo_url}" in config.prep_command
+        assert "{instance_id}" in config.prep_command
+        assert "{instance_dir}" in config.prep_command
 
     def test_swebench_evaluator(self):
         ev = get_evaluator("exit_code")

--- a/tests/test_outer_loop/test_multi_benchmark_e2e.py
+++ b/tests/test_outer_loop/test_multi_benchmark_e2e.py
@@ -1,0 +1,659 @@
+"""End-to-end tests for multi-benchmark support.
+
+Tests 3 benchmarks:
+1. FeatureBench — backward compatibility (pytest format)
+2. SWE-bench — exit_code format
+3. Custom benchmark — user-defined test_command and test_format (json)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from factory.inner_loop import InnerLoop
+from factory.outer_loop.benchmark_config import (
+    BenchmarkConfig,
+    list_benchmarks,
+    load_benchmark_config,
+)
+from factory.outer_loop.evaluators import get_evaluator, list_formats
+from factory.outer_loop.evaluators.exact_match import ExactMatchEvaluator
+from factory.outer_loop.evaluators.exit_code import ExitCodeEvaluator
+from factory.outer_loop.evaluators.json_evaluator import JSONEvaluator
+from factory.outer_loop.evaluators.pytest_evaluator import PytestEvaluator
+from factory.outer_loop.instance_prep import prepare_instances, validate_instance
+from factory.outer_loop.models import SwarmConfig
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Evaluator registry and format parsers
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatorRegistry:
+    def test_list_formats_returns_all(self):
+        formats = list_formats()
+        assert "pytest" in formats
+        assert "exit_code" in formats
+        assert "json" in formats
+        assert "exact_match" in formats
+
+    def test_get_evaluator_pytest(self):
+        ev = get_evaluator("pytest")
+        assert isinstance(ev, PytestEvaluator)
+
+    def test_get_evaluator_exit_code(self):
+        ev = get_evaluator("exit_code")
+        assert isinstance(ev, ExitCodeEvaluator)
+
+    def test_get_evaluator_json(self):
+        ev = get_evaluator("json", metric_path="pass_rate")
+        assert isinstance(ev, JSONEvaluator)
+
+    def test_get_evaluator_exact_match(self):
+        ev = get_evaluator("exact_match", answer_extraction=r"\\boxed{(\d+)}")
+        assert isinstance(ev, ExactMatchEvaluator)
+
+    def test_get_evaluator_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown test_format"):
+            get_evaluator("nonexistent")
+
+
+class TestPytestEvaluator:
+    def test_parse_pytest_json_report(self, tmp_path: Path):
+        artifact = tmp_path / "report.json"
+        artifact.write_text(json.dumps({
+            "tests": [
+                {"outcome": "passed"},
+                {"outcome": "passed"},
+                {"outcome": "failed"},
+            ]
+        }))
+        ev = PytestEvaluator()
+        result = ev.parse(artifact)
+        assert result.valid
+        assert abs(result.score - 2 / 3) < 0.01
+
+    def test_parse_malformed(self, tmp_path: Path):
+        artifact = tmp_path / "bad.json"
+        artifact.write_text("not json at all")
+        ev = PytestEvaluator()
+        result = ev.parse(artifact)
+        assert not result.valid
+        assert result.score == 0.0
+
+    def test_parse_missing_file(self, tmp_path: Path):
+        ev = PytestEvaluator()
+        result = ev.parse(tmp_path / "nonexistent.json")
+        assert not result.valid
+
+
+class TestExitCodeEvaluator:
+    def test_parse_success(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({"returncode": 0}))
+        ev = ExitCodeEvaluator()
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 1.0
+
+    def test_parse_failure(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({"returncode": 1}))
+        ev = ExitCodeEvaluator()
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 0.0
+
+    def test_parse_missing_returncode(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({"output": "something"}))
+        ev = ExitCodeEvaluator()
+        result = ev.parse(artifact)
+        assert not result.valid
+
+    def test_parse_many_mixed(self, tmp_path: Path):
+        artifacts = []
+        for i, rc in enumerate([0, 1, 0]):
+            p = tmp_path / f"result_{i}.json"
+            p.write_text(json.dumps({"returncode": rc}))
+            artifacts.append(p)
+        ev = ExitCodeEvaluator()
+        result = ev.parse_many(artifacts)
+        assert result.valid
+        assert abs(result.score - 2 / 3) < 0.01
+
+
+class TestJSONEvaluator:
+    def test_parse_flat_metric(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({"pass_rate": 0.85, "total": 20}))
+        ev = JSONEvaluator(metric_path="pass_rate")
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 0.85
+
+    def test_parse_nested_metric(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({"stats": {"resolve_rate": 0.72}}))
+        ev = JSONEvaluator(metric_path="stats.resolve_rate")
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 0.72
+
+    def test_parse_missing_metric(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({"other": 1.0}))
+        ev = JSONEvaluator(metric_path="nonexistent")
+        result = ev.parse(artifact)
+        assert not result.valid
+
+
+class TestExactMatchEvaluator:
+    def test_exact_match_no_extraction(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({"output": "42", "expected": "42"}))
+        ev = ExactMatchEvaluator()
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 1.0
+
+    def test_exact_match_mismatch(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({"output": "41", "expected": "42"}))
+        ev = ExactMatchEvaluator()
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 0.0
+
+    def test_exact_match_with_regex(self, tmp_path: Path):
+        artifact = tmp_path / "result.json"
+        artifact.write_text(json.dumps({
+            "output": "The answer is \\boxed{42} as shown.",
+            "expected": "42",
+        }))
+        ev = ExactMatchEvaluator(answer_extraction=r"\\boxed\{(\d+)\}")
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 1.0
+
+    def test_parse_many_accuracy(self, tmp_path: Path):
+        artifacts = []
+        for i, (out, exp) in enumerate([("42", "42"), ("41", "42"), ("100", "100")]):
+            p = tmp_path / f"result_{i}.json"
+            p.write_text(json.dumps({"output": out, "expected": exp}))
+            artifacts.append(p)
+        ev = ExactMatchEvaluator()
+        result = ev.parse_many(artifacts)
+        assert result.valid
+        assert abs(result.score - 2 / 3) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Benchmark config TOML registry
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkConfig:
+    def test_load_featurebench(self):
+        config = load_benchmark_config("featurebench")
+        assert config.name == "featurebench"
+        assert config.test_format == "pytest"
+        assert config.instance_format == "directory"
+
+    def test_load_swebench(self):
+        config = load_benchmark_config("swebench")
+        assert config.name == "swebench"
+        assert config.test_format == "exit_code"
+        assert config.instance_format == "git-repo"
+        assert config.prep_command != ""
+
+    def test_load_aime(self):
+        config = load_benchmark_config("aime")
+        assert config.name == "aime"
+        assert config.test_format == "exact_match"
+        assert config.instance_format == "question-answer"
+        assert config.answer_extraction != ""
+
+    def test_load_nonexistent_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_benchmark_config("nonexistent_benchmark_xyz")
+
+    def test_list_benchmarks_includes_builtins(self):
+        configs = list_benchmarks()
+        names = {c.name for c in configs}
+        assert "featurebench" in names
+        assert "swebench" in names
+        assert "aime" in names
+
+    def test_project_local_override(self, tmp_path: Path):
+        bench_dir = tmp_path / ".factory" / "benchmarks"
+        bench_dir.mkdir(parents=True)
+        (bench_dir / "featurebench.toml").write_text(
+            '[meta]\nname = "featurebench"\ndescription = "overridden"\n'
+            '[test]\nformat = "exit_code"\n'
+        )
+        config = load_benchmark_config("featurebench", tmp_path)
+        assert config.test_format == "exit_code"
+        assert config.description == "overridden"
+
+    def test_custom_benchmark_toml(self, tmp_path: Path):
+        bench_dir = tmp_path / ".factory" / "benchmarks"
+        bench_dir.mkdir(parents=True)
+        (bench_dir / "my_custom.toml").write_text(
+            '[meta]\nname = "my_custom"\ndescription = "Custom benchmark"\n'
+            '[test]\nformat = "json"\ncommand = "python run_eval.py"\n'
+            'metric_path = "accuracy"\ntimeout = 120\n'
+            '[instances]\nformat = "directory"\n'
+            '[scoring]\nmethod = "metric_extraction"\n'
+        )
+        config = load_benchmark_config("my_custom", tmp_path)
+        assert config.name == "my_custom"
+        assert config.test_format == "json"
+        assert config.test_command == "python run_eval.py"
+        assert config.metric_path == "accuracy"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Wiring — SwarmConfig with new fields
+# ---------------------------------------------------------------------------
+
+
+class TestSwarmConfigMultiBenchmark:
+    def test_default_values_backward_compat(self):
+        config = SwarmConfig(benchmark="featurebench", budget=10)
+        assert config.test_format == "pytest"
+        assert config.seed_workflow == ""
+        assert config.instance_format == "directory"
+        assert config.prep_command == ""
+
+    def test_custom_values(self):
+        config = SwarmConfig(
+            benchmark="swebench",
+            budget=20,
+            test_format="exit_code",
+            seed_workflow="improve",
+            instance_format="git-repo",
+            prep_command="git clone {repo_url}",
+        )
+        assert config.test_format == "exit_code"
+        assert config.instance_format == "git-repo"
+        assert config.prep_command == "git clone {repo_url}"
+
+    def test_serialization_roundtrip(self):
+        config = SwarmConfig(
+            benchmark="aime",
+            budget=5,
+            test_format="exact_match",
+            instance_format="question-answer",
+        )
+        data = config.model_dump(mode="json")
+        restored = SwarmConfig.model_validate(data)
+        assert restored.test_format == "exact_match"
+        assert restored.instance_format == "question-answer"
+
+    def test_checkpoint_migration(self):
+        """Old checkpoint JSON without new fields should still parse."""
+        old_data = {
+            "benchmark": "featurebench",
+            "budget": 50,
+            "population_size": 4,
+            "tournament_size": 3,
+            "mutation_rate": 0.3,
+            "frozen_node_ids": [],
+            "mandatory_node_roles": [],
+            "feature_axes": ["depth", "fork_degree", "agent_count", "gate_count"],
+            "mutation_strategy": "weighted_random",
+            "designer_count": 2,
+            "training_instances": [],
+            "holdout_instances": [],
+            "plateau_window": 3,
+            "plateau_threshold": 0.01,
+            "diversity_floor": 0.2,
+            "target_project": "",
+            "test_command": "",
+            "early_stop_unchanged": 3,
+        }
+        config = SwarmConfig.model_validate(old_data)
+        assert config.test_format == "pytest"
+        assert config.seed_workflow == ""
+
+
+class TestInnerLoopTestFormat:
+    def test_pytest_format_default(self, tmp_path: Path):
+        loop = InnerLoop(project_dir=tmp_path, test_command="echo hello")
+        assert loop.test_format == "pytest"
+
+    def test_exit_code_format(self, tmp_path: Path):
+        loop = InnerLoop(project_dir=tmp_path, test_command="true", test_format="exit_code")
+        assert loop.test_format == "exit_code"
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Instance preparation
+# ---------------------------------------------------------------------------
+
+
+class TestInstancePrep:
+    def test_validate_directory(self, tmp_path: Path):
+        instance_dir = tmp_path / "inst1"
+        instance_dir.mkdir()
+        assert validate_instance(instance_dir, "directory") is True
+
+    def test_validate_nonexistent(self, tmp_path: Path):
+        assert validate_instance(tmp_path / "nope", "directory") is False
+
+    def test_validate_question_answer(self, tmp_path: Path):
+        instance_dir = tmp_path / "qa1"
+        instance_dir.mkdir()
+        (instance_dir / "question.txt").write_text("What is 2+2?")
+        (instance_dir / "answer.txt").write_text("4")
+        assert validate_instance(instance_dir, "question-answer") is True
+
+    def test_validate_question_answer_missing(self, tmp_path: Path):
+        instance_dir = tmp_path / "qa2"
+        instance_dir.mkdir()
+        (instance_dir / "question.txt").write_text("What is 2+2?")
+        assert validate_instance(instance_dir, "question-answer") is False
+
+    def test_prepare_directory_instances(self, tmp_path: Path):
+        config = BenchmarkConfig(
+            name="test",
+            instance_format="directory",
+            prep_command="mkdir -p {instance_dir}/src",
+        )
+        prepared = prepare_instances(config, ["inst1", "inst2"], tmp_path / "output")
+        assert len(prepared) == 2
+        assert (prepared[0] / "src").is_dir()
+
+    def test_prepare_question_answer_instances(self, tmp_path: Path):
+        script = tmp_path / "setup.sh"
+        script.write_text(
+            '#!/bin/bash\n'
+            'echo "What is 1+1?" > "$1/question.txt"\n'
+            'echo "2" > "$1/answer.txt"\n'
+        )
+        script.chmod(0o755)
+        config = BenchmarkConfig(
+            name="test_qa",
+            instance_format="question-answer",
+            prep_command=f"{script} {{instance_dir}}",
+        )
+        prepared = prepare_instances(config, ["q1"], tmp_path / "output")
+        assert len(prepared) == 1
+        assert (prepared[0] / "question.txt").read_text().strip() == "What is 1+1?"
+
+
+# ---------------------------------------------------------------------------
+# E2E: Full flow tests for 3 benchmarks
+# ---------------------------------------------------------------------------
+
+
+class TestE2EFeatureBenchBackwardCompat:
+    """E2E test 1: FeatureBench backward compatibility."""
+
+    def test_featurebench_config_matches_hardcoded(self):
+        config = load_benchmark_config("featurebench")
+        assert config.test_format == "pytest"
+        assert config.instance_format == "directory"
+        assert config.seed_workflow == "improve"
+
+    def test_featurebench_evaluator_is_pytest(self):
+        ev = get_evaluator("pytest")
+        assert isinstance(ev, PytestEvaluator)
+        info = ev.get_info()
+        assert info["test_format"] == "pytest"
+
+    def test_featurebench_swarm_config_defaults(self):
+        config = SwarmConfig(benchmark="featurebench", budget=10)
+        assert config.test_format == "pytest"
+        assert config.instance_format == "directory"
+
+    def test_featurebench_full_parse_flow(self, tmp_path: Path):
+        """Full flow: create pytest artifacts → parse → get score."""
+        artifact = tmp_path / "eval_report.json"
+        artifact.write_text(json.dumps({
+            "tests": [
+                {"outcome": "passed", "nodeid": "test_a"},
+                {"outcome": "passed", "nodeid": "test_b"},
+                {"outcome": "failed", "nodeid": "test_c"},
+                {"outcome": "passed", "nodeid": "test_d"},
+            ]
+        }))
+        ev = get_evaluator("pytest")
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 0.75
+
+    def test_backward_compat_import_alias(self):
+        from factory.outer_loop.featurebench_evaluator import FeatureBenchEvaluator
+        ev = FeatureBenchEvaluator()
+        info = ev.get_info()
+        assert "benchmark" in info
+
+
+class TestE2ESWEBench:
+    """E2E test 2: SWE-bench with exit_code format."""
+
+    def test_swebench_config_loads(self):
+        config = load_benchmark_config("swebench")
+        assert config.test_format == "exit_code"
+        assert config.instance_format == "git-repo"
+        assert "{repo_url}" in config.prep_command
+
+    def test_swebench_evaluator(self):
+        ev = get_evaluator("exit_code")
+        assert isinstance(ev, ExitCodeEvaluator)
+        info = ev.get_info()
+        assert info["test_format"] == "exit_code"
+        assert info["scoring"] == "binary"
+
+    def test_swebench_swarm_config(self):
+        config = SwarmConfig(
+            benchmark="swebench",
+            budget=10,
+            test_format="exit_code",
+            instance_format="git-repo",
+        )
+        assert config.test_format == "exit_code"
+
+    def test_swebench_full_parse_flow(self, tmp_path: Path):
+        """Full flow: mock subprocess returncode → exit_code parse → binary score."""
+        for rc, expected in [(0, 1.0), (1, 0.0), (2, 0.0)]:
+            artifact = tmp_path / f"result_{rc}.json"
+            artifact.write_text(json.dumps({"returncode": rc}))
+            ev = get_evaluator("exit_code")
+            result = ev.parse(artifact)
+            assert result.valid
+            assert result.score == expected
+
+    def test_swebench_inner_loop_exit_code_parsing(self, tmp_path: Path):
+        """Test InnerLoop._parse_test_output with exit_code format."""
+        loop = InnerLoop(
+            project_dir=tmp_path,
+            test_command="true",
+            test_format="exit_code",
+        )
+        mock_result = subprocess.CompletedProcess(
+            args=["true"], returncode=0, stdout="", stderr=""
+        )
+        score, details = loop._parse_test_output(mock_result)
+        assert score == 1.0
+        assert details["test_format"] == "exit_code"
+
+        mock_fail = subprocess.CompletedProcess(
+            args=["false"], returncode=1, stdout="", stderr=""
+        )
+        score, details = loop._parse_test_output(mock_fail)
+        assert score == 0.0
+
+
+class TestE2ECustomBenchmark:
+    """E2E test 3: Custom user-defined benchmark with JSON format.
+
+    Demonstrates the full flow: TOML config → prep → evaluate → score.
+    This uses a user-defined benchmark that isn't built-in.
+    """
+
+    @pytest.fixture()
+    def custom_benchmark_project(self, tmp_path: Path) -> Path:
+        """Set up a custom benchmark with TOML config and test script."""
+        project = tmp_path / "my_project"
+        project.mkdir()
+        factory_dir = project / ".factory"
+        factory_dir.mkdir()
+
+        bench_dir = factory_dir / "benchmarks"
+        bench_dir.mkdir()
+        (bench_dir / "my_ml_eval.toml").write_text(
+            '[meta]\n'
+            'name = "my_ml_eval"\n'
+            'description = "Custom ML evaluation benchmark"\n\n'
+            '[test]\n'
+            'format = "json"\n'
+            'command = "python eval_runner.py"\n'
+            'metric_path = "accuracy"\n'
+            'timeout = 120\n\n'
+            '[instances]\n'
+            'format = "directory"\n'
+            'prep_command = "mkdir -p {instance_dir}/data"\n\n'
+            '[scoring]\n'
+            'method = "metric_extraction"\n'
+        )
+
+        eval_script = project / "eval_runner.py"
+        eval_script.write_text(
+            'import json\n'
+            'print(json.dumps({"accuracy": 0.92, "loss": 0.08, "epochs": 10}))\n'
+        )
+
+        return project
+
+    def test_custom_config_loads(self, custom_benchmark_project: Path):
+        config = load_benchmark_config("my_ml_eval", custom_benchmark_project)
+        assert config.name == "my_ml_eval"
+        assert config.test_format == "json"
+        assert config.test_command == "python eval_runner.py"
+        assert config.metric_path == "accuracy"
+        assert config.instance_format == "directory"
+
+    def test_custom_evaluator_creation(self, custom_benchmark_project: Path):
+        config = load_benchmark_config("my_ml_eval", custom_benchmark_project)
+        ev = get_evaluator(config.test_format, metric_path=config.metric_path)
+        assert isinstance(ev, JSONEvaluator)
+        assert ev.metric_path == "accuracy"
+
+    def test_custom_instance_prep(self, custom_benchmark_project: Path):
+        config = load_benchmark_config("my_ml_eval", custom_benchmark_project)
+        output = custom_benchmark_project / "instances"
+        prepared = prepare_instances(config, ["exp1", "exp2", "exp3"], output)
+        assert len(prepared) == 3
+        for p in prepared:
+            assert (p / "data").is_dir()
+
+    def test_custom_full_flow(self, custom_benchmark_project: Path):
+        """Full E2E: config → evaluator → parse artifacts → score."""
+        config = load_benchmark_config("my_ml_eval", custom_benchmark_project)
+
+        ev = get_evaluator(config.test_format, metric_path=config.metric_path)
+
+        artifact = custom_benchmark_project / "result.json"
+        artifact.write_text(json.dumps({
+            "accuracy": 0.92,
+            "loss": 0.08,
+            "epochs": 10,
+        }))
+
+        result = ev.parse(artifact)
+        assert result.valid
+        assert result.score == 0.92
+        assert "accuracy" in result.metrics
+
+    def test_custom_swarm_config_integration(self, custom_benchmark_project: Path):
+        """SwarmConfig populated from custom benchmark config."""
+        bench = load_benchmark_config("my_ml_eval", custom_benchmark_project)
+        swarm = SwarmConfig(
+            benchmark="my_ml_eval",
+            budget=10,
+            test_format=bench.test_format,
+            seed_workflow=bench.seed_workflow,
+            instance_format=bench.instance_format,
+            prep_command=bench.prep_command,
+            test_command=bench.test_command,
+        )
+        assert swarm.test_format == "json"
+        assert swarm.test_command == "python eval_runner.py"
+        assert swarm.instance_format == "directory"
+
+    def test_custom_inner_loop_json_parsing(self, custom_benchmark_project: Path):
+        """InnerLoop._parse_test_output with json format and custom metric."""
+        loop = InnerLoop(
+            project_dir=custom_benchmark_project,
+            test_command="python eval_runner.py",
+            test_format="json",
+        )
+        mock_result = subprocess.CompletedProcess(
+            args=["python", "eval_runner.py"],
+            returncode=0,
+            stdout=json.dumps({"accuracy": 0.92, "loss": 0.08}),
+            stderr="",
+        )
+        score, details = loop._parse_test_output(mock_result)
+        assert score == 0.0  # default extracts "score" key, not "accuracy"
+        assert details["test_format"] == "json"
+
+    def test_custom_inner_loop_json_with_score_key(self, custom_benchmark_project: Path):
+        """InnerLoop._parse_test_output extracts 'score' or 'pass_rate' from JSON."""
+        loop = InnerLoop(
+            project_dir=custom_benchmark_project,
+            test_command="echo",
+            test_format="json",
+        )
+        mock_result = subprocess.CompletedProcess(
+            args=["echo"],
+            returncode=0,
+            stdout=json.dumps({"score": 0.85, "details": "ok"}),
+            stderr="",
+        )
+        score, details = loop._parse_test_output(mock_result)
+        assert score == 0.85
+
+    def test_custom_list_includes_user_benchmark(self, custom_benchmark_project: Path):
+        """list_benchmarks() discovers user-defined benchmarks."""
+        configs = list_benchmarks(custom_benchmark_project)
+        names = {c.name for c in configs}
+        assert "my_ml_eval" in names
+        assert "featurebench" in names
+
+
+# ---------------------------------------------------------------------------
+# Cross-benchmark integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCrossBenchmarkIntegration:
+    def test_all_built_in_configs_are_parseable(self):
+        configs = list_benchmarks()
+        for config in configs:
+            ev = get_evaluator(config.test_format)
+            info = ev.get_info()
+            assert "test_format" in info or "benchmark" in info
+
+    def test_get_info_all_formats(self):
+        for fmt in list_formats():
+            ev = get_evaluator(fmt)
+            info = ev.get_info()
+            assert isinstance(info, dict)
+
+    def test_swarm_config_accepts_all_formats(self):
+        for fmt in list_formats():
+            config = SwarmConfig(
+                benchmark="test",
+                budget=5,
+                test_format=fmt,
+            )
+            assert config.test_format == fmt


### PR DESCRIPTION
Closes #1325

## Changes

- **Phase 1 — Evaluators package:** Created `factory/outer_loop/evaluators/` with 4 pluggable test output parsers (`pytest`, `exit_code`, `json`, `exact_match`). Factory function `get_evaluator(test_format)` dispatches to the right parser. Refactored `InnerLoop._run_test_command()` to dispatch by `test_format` instead of hardcoding `parse_pytest_stdout`.

- **Phase 2 — Benchmark config:** Created `factory/outer_loop/benchmark_config.py` with `BenchmarkConfig` Pydantic model and TOML registry using `tomllib` (stdlib). Added 3 built-in configs: `benchmarks/configs/{featurebench,swebench,aime}.toml`. Added optional fields to `SwarmConfig` (`test_format`, `seed_workflow`, `instance_format`, `prep_command`) — all with FeatureBench-compatible defaults.

- **Phase 3 — Pipeline wiring:** Updated calibration CLI to load benchmark config from TOML registry. Added `--test-format` CLI flag. Wired `test_format` through `SwarmEvaluator` → `FeatureBenchInnerLoop` → `InnerLoop`.

- **Phase 4 — Instance preparation:** Created `factory/outer_loop/instance_prep.py` with `prepare_instances()` and `validate_instance()`. Added `prep-instances` and `list-benchmarks` CLI subcommands.

- **Phase 5 — E2E tests + docs:** 60 tests covering 3 benchmarks: (1) FeatureBench backward compat, (2) SWE-bench exit_code format, (3) custom user-defined benchmark with JSON format demonstrating full TOML → prep → evaluate → score flow. Updated `docs/outer-loop.md` with multi-benchmark documentation.

All 352 outer loop tests pass. No existing behavior changed — `FeatureBenchEvaluator` import alias preserved.