### PR TITLE
fix: bootstrap factory.md and config.json in design mode

### DIFF
--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -626,7 +626,6 @@ def design_workflow(just_plan: bool = False) -> Workflow:
             'print("PROCEED" if exists else "HALT")'
             '"'
         ),
-        reads={".factory/config.json"},
     )
 
     wf.nodes["discover"] = FnNode(

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -646,12 +646,52 @@ def design_workflow(just_plan: bool = False) -> Workflow:
             update={"reads": (node.reads or set()) | {".factory/strategy/study-combined.md"}},
         )
 
+    # Bootstrap nodes: create factory.md + config.json when missing
+    wf.nodes["gate_factory_md_exists"] = GateNode(
+        id="gate_factory_md_exists",
+        evaluator_type="fn",
+        evaluator_command=(
+            'python3 -c "'
+            "from pathlib import Path; "
+            'exists = Path("{project_path}/factory.md").exists(); '
+            'print("PROCEED" if exists else "HALT")'
+            '"'
+        ),
+    )
+
+    wf.nodes["create_factory_md"] = AgentNode(
+        id="create_factory_md",
+        role=AgentRole.CEO,
+        prompt_template=(
+            "Create factory.md from template. "
+            "Copy the factory config template to the project root. "
+            "Fill in: Goal, Scope, Guards, Eval command, Threshold, and Smoke Test. "
+            "If .factory/eval_spec.json exists, populate the Eval Spec section. "
+            "If .factory/strategy/current.md has a Research Configuration section, "
+            "populate research sections (Research Target, Mutable/Fixed Surfaces, etc.)."
+        ),
+        reads={".factory/eval_profile.json"},
+        writes={"factory.md"},
+    )
+
+    wf.nodes["factory_init"] = FnNode(
+        id="factory_init",
+        command="factory init {project_path}",
+        notes="Parse factory.md and generate .factory/config.json. Must run after factory.md is created.",
+        reads={"factory.md"},
+        writes={".factory/config.json"},
+    )
+
     wf.edges.extend(
         [
             *s_edges,
             Edge(source="gate_has_factory", target="graph_update", condition=VerdictType.PROCEED),
             Edge(source="gate_has_factory", target="discover", condition=VerdictType.HALT),
-            Edge(source="discover", target="graph_update"),
+            Edge(source="discover", target="gate_factory_md_exists"),
+            Edge(source="gate_factory_md_exists", target="factory_init", condition=VerdictType.PROCEED),
+            Edge(source="gate_factory_md_exists", target="create_factory_md", condition=VerdictType.HALT),
+            Edge(source="create_factory_md", target="factory_init"),
+            Edge(source="factory_init", target="graph_update"),
             Edge(source="concat_study", target="fork_research"),
         ]
     )

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -260,6 +260,40 @@ def _sync_backlog_to_main(worktree_path: Path, project_path: Path) -> None:
         log.info("backlog_synced", src=str(wt_backlog), dst=str(main_backlog))
 
 
+_BOOTSTRAP_FACTORY_FILES: Final[tuple[str, ...]] = (
+    "config.json",
+    "eval_profile.json",
+)
+
+
+def _sync_bootstrap_to_main(worktree_path: Path, project_path: Path) -> None:
+    """Sync bootstrap artifacts from worktree back to main project.
+
+    Only copies files that are real (not symlinks), meaning they were freshly
+    created during this run rather than symlinked from main.
+    """
+    wt_factory = worktree_path / ".factory"
+    main_factory = project_path / ".factory"
+
+    if not wt_factory.exists():
+        return
+
+    main_factory.mkdir(parents=True, exist_ok=True)
+    for filename in _BOOTSTRAP_FACTORY_FILES:
+        src = wt_factory / filename
+        if src.exists() and not src.is_symlink():
+            dst = main_factory / filename
+            if not dst.exists():
+                shutil.copy2(src, dst)
+                log.info("bootstrap_synced", file=filename, src=str(src), dst=str(dst))
+
+    wt_factory_md = worktree_path / "factory.md"
+    main_factory_md = project_path / "factory.md"
+    if wt_factory_md.exists() and not wt_factory_md.is_symlink() and not main_factory_md.exists():
+        shutil.copy2(wt_factory_md, main_factory_md)
+        log.info("bootstrap_synced", file="factory.md", src=str(wt_factory_md), dst=str(main_factory_md))
+
+
 def _preserve_telemetry(worktree_path: Path, project_path: Path) -> None:
     """Copy telemetry files from worktree .factory/ to main project .factory/."""
     wt_factory = worktree_path / ".factory"
@@ -364,6 +398,7 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
             )
             return
         _sync_backlog_to_main(worktree_path, project_path)
+        _sync_bootstrap_to_main(worktree_path, project_path)
         _preserve_telemetry(worktree_path, project_path)
         shutil.rmtree(worktree_path)
 

--- a/tests/test_plan_workflow.py
+++ b/tests/test_plan_workflow.py
@@ -25,8 +25,8 @@ def wf():
 
 def test_plan_workflow_structure(wf):
     """Verify node and edge counts match the expected topology."""
-    assert len(wf.nodes) == 18
-    assert len(wf.edges) == 23
+    assert len(wf.nodes) == 21
+    assert len(wf.edges) == 27
     assert wf.name == "plan"
     assert wf.start_node == "gate_has_factory"
     assert wf.terminal is True
@@ -63,7 +63,11 @@ def test_plan_workflow_edge_coverage(wf):
         ("graph_explorer", "concat_study", None),
         ("gate_has_factory", "graph_update", VerdictType.PROCEED),
         ("gate_has_factory", "discover", VerdictType.HALT),
-        ("discover", "graph_update", None),
+        ("discover", "gate_factory_md_exists", None),
+        ("gate_factory_md_exists", "factory_init", VerdictType.PROCEED),
+        ("gate_factory_md_exists", "create_factory_md", VerdictType.HALT),
+        ("create_factory_md", "factory_init", None),
+        ("factory_init", "graph_update", None),
         ("concat_study", "check_prior_plans", None),
         ("check_prior_plans", "gate_prior_plans", VerdictType.PROCEED),
         ("check_prior_plans", "fork_research", VerdictType.HALT),

--- a/tests/test_workflow_definitions.py
+++ b/tests/test_workflow_definitions.py
@@ -133,10 +133,13 @@ class TestDesignIsBuiltWithUserGate:
         w1_ids = set(w1.nodes.keys())
         w2_ids = set(w2.nodes.keys())
 
-        # Design has extra nodes: gate_has_factory, discover, and study subgraph
+        # Design has extra nodes: gate_has_factory, discover, bootstrap, and study subgraph
         assert w2_ids == w1_ids | {
             "gate_has_factory",
             "discover",
+            "gate_factory_md_exists",
+            "create_factory_md",
+            "factory_init",
             "graph_update",
             "study",
             "graph_explorer",
@@ -211,11 +214,15 @@ class TestDesignStudyNode:
         assert node.command == "factory discover {project_path}"
         assert ".factory/eval_profile.json" in node.writes
 
-    def test_design_discover_to_graph_update_edge(self) -> None:
-        """There must be an unconditional edge from discover to graph_update."""
+    def test_design_discover_to_bootstrap_edge(self) -> None:
+        """Discover chains through bootstrap (factory.md gate + init) before graph_update."""
         wf = design_workflow()
         assert any(
-            e.source == "discover" and e.target == "graph_update" and e.condition is None
+            e.source == "discover" and e.target == "gate_factory_md_exists" and e.condition is None
+            for e in wf.edges
+        )
+        assert any(
+            e.source == "factory_init" and e.target == "graph_update" and e.condition is None
             for e in wf.edges
         )
 

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -15,6 +15,7 @@ from factory.worktree import (
     _preserve_telemetry,
     _seed_experiment_factory,
     _sync_backlog_to_main,
+    _sync_bootstrap_to_main,
     create_experiment_worktree,
     create_worktree,
     detect_default_branch,
@@ -1274,6 +1275,63 @@ class TestSelectiveWorktreeIsolation:
         _sync_backlog_to_main(wt, main)
 
         assert main_backlog.read_text() == "original"
+
+    def test_sync_bootstrap_copies_fresh_files(self, tmp_path: Path) -> None:
+        wt = tmp_path / "worktree"
+        main = tmp_path / "main"
+        wt_factory = wt / ".factory"
+        wt_factory.mkdir(parents=True)
+        main.mkdir()
+
+        (wt_factory / "config.json").write_text('{"goal": "test"}')
+        (wt_factory / "eval_profile.json").write_text('{"dims": []}')
+        (wt / "factory.md").write_text("# Factory")
+
+        _sync_bootstrap_to_main(wt, main)
+
+        assert (main / ".factory" / "config.json").read_text() == '{"goal": "test"}'
+        assert (main / ".factory" / "eval_profile.json").read_text() == '{"dims": []}'
+        assert (main / "factory.md").read_text() == "# Factory"
+
+    def test_sync_bootstrap_skips_symlinks(self, tmp_path: Path) -> None:
+        wt = tmp_path / "worktree"
+        main = tmp_path / "main"
+        wt_factory = wt / ".factory"
+        wt_factory.mkdir(parents=True)
+        main_factory = main / ".factory"
+        main_factory.mkdir(parents=True)
+
+        (main_factory / "config.json").write_text("original")
+        (wt_factory / "config.json").symlink_to(main_factory / "config.json")
+
+        _sync_bootstrap_to_main(wt, main)
+
+        assert (main_factory / "config.json").read_text() == "original"
+
+    def test_sync_bootstrap_skips_existing_main_files(self, tmp_path: Path) -> None:
+        wt = tmp_path / "worktree"
+        main = tmp_path / "main"
+        wt_factory = wt / ".factory"
+        wt_factory.mkdir(parents=True)
+        main_factory = main / ".factory"
+        main_factory.mkdir(parents=True)
+
+        (wt_factory / "config.json").write_text("new")
+        (main_factory / "config.json").write_text("existing")
+
+        _sync_bootstrap_to_main(wt, main)
+
+        assert (main_factory / "config.json").read_text() == "existing"
+
+    def test_sync_bootstrap_noop_without_factory_dir(self, tmp_path: Path) -> None:
+        wt = tmp_path / "worktree"
+        main = tmp_path / "main"
+        wt.mkdir()
+        main.mkdir()
+
+        _sync_bootstrap_to_main(wt, main)
+
+        assert not (main / ".factory").exists()
 
     def test_two_worktrees_get_independent_dirs(self, git_project: Path) -> None:
         strategy_dir = git_project / ".factory" / "strategy"


### PR DESCRIPTION
## Summary

- Add three bootstrap nodes to design workflow's HALT path: `gate_factory_md_exists`, `create_factory_md`, `factory_init`
- When a project has no `config.json`, design mode now discovers the project, creates `factory.md` (if missing), and runs `factory init` to generate `config.json` before continuing
- A gate checks if `factory.md` already exists to avoid overwriting user-created configs
- Add `_sync_bootstrap_to_main()` in worktree cleanup to preserve `config.json`, `eval_profile.json`, and `factory.md` when they were freshly created in the worktree

## Closes

- #1270

## Test plan

- [x] `uv run pytest tests/test_workflow_definitions.py -x -q` -- 179 passed
- [x] `uv run pytest tests/test_worktree.py -x -q` -- 87 passed
- [x] `uv run pytest tests/test_skill_export.py tests/test_workflow_e2e.py tests/test_workflow_integration.py -x -q` -- all pass
- [x] `uv run ruff check .` -- clean
- [ ] E2E: `factory ceo /path/to/new-project --mode design` escapes NO_FACTORY state

🤖 Generated with [Claude Code](https://claude.com/claude-code)