### PR TITLE
fix: gate verdict parsing fails closed on unrecognized output (fixes #1250)

### DIFF
--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -897,7 +897,7 @@ class WorkflowExecutor:
                     return self._parse_fn_verdict(output, node.id)
                 except RuntimeError:
                     return Verdict.halt(reason=f"gate command failed: {cmd}")
-            return Verdict.proceed()
+            return Verdict.halt(reason=f"gate '{node.id}' has no evaluator_command configured")
 
         prompt = self._build_gate_prompt(node)
         from factory.agents.runner import invoke_agent
@@ -979,7 +979,16 @@ class WorkflowExecutor:
             feedback = feedback_match.group(1) if feedback_match else "needs improvement"
             return Verdict.reloop(target=target, feedback=feedback)
 
-        return Verdict.proceed()
+        if text.startswith("PROCEED") or re.match(r"^PROCEED\b", text):
+            return Verdict.proceed()
+
+        return Verdict.halt(
+            reason=(
+                f"gate '{gate_id}' returned unparseable verdict "
+                f"(expected PROCEED | RELOOP target=... | HALT reason=...): "
+                f"{output.strip()[:200]}"
+            )
+        )
 
     def _parse_fn_verdict(self, output: str, gate_id: str) -> Verdict:
         """Parse function output into a Verdict."""
@@ -997,7 +1006,7 @@ class WorkflowExecutor:
             pass
 
         first_line = text.split("\n")[0].strip().lower()
-        if first_line.startswith("pass"):
+        if first_line.startswith("pass") or first_line.startswith("proceed"):
             return Verdict.proceed()
         if first_line.startswith("fail") or first_line.startswith("revert"):
             return Verdict.halt(reason=f"precheck failed: {text[:200]}")
@@ -1009,7 +1018,13 @@ class WorkflowExecutor:
             if target:
                 return Verdict.reloop(target=target, feedback=feedback)
             return Verdict.halt(reason="fn gate returned RELOOP but no RELOOP edge defined")
-        return Verdict.proceed()
+        return Verdict.halt(
+            reason=(
+                f"gate '{gate_id}' returned unparseable verdict "
+                f"(expected pass | fail | revert | reloop | {{\"passed\": bool}}): "
+                f"{text[:200]}"
+            )
+        )
 
     async def _run_shell(self, cmd: str) -> str:
         """Run a shell command and return stdout."""

--- a/tests/test_workflow_executor.py
+++ b/tests/test_workflow_executor.py
@@ -479,3 +479,153 @@ class TestAutoApprove:
         assert result.success
         auto_approved = [e for e in captured if e.get("event") == "gate.auto_approved"]
         assert len(auto_approved) == 0
+
+
+# ── Gate verdict parsing fails closed (issue #1250) ──────────────
+
+
+def _make_gate_executor() -> WorkflowExecutor:
+    """Build a bare WorkflowExecutor with a workflow + edge index for gate parsing."""
+    wf = Workflow(
+        name="gate_fail_closed",
+        nodes={
+            "a": FnNode(id="a", command="echo a"),
+            "gate": GateNode(id="gate", evaluator_type="fn", evaluator_command="echo pass"),
+            "b": FnNode(id="b", command="echo b"),
+        },
+        edges=[
+            Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+            Edge(source="gate", target="a", condition=VerdictType.RELOOP),
+        ],
+        start_node="a",
+    )
+    executor = WorkflowExecutor.__new__(WorkflowExecutor)
+    executor.workflow = wf
+    executor.project_path = Path("/fake")
+    executor._edge_index = {}
+    for edge in wf.edges:
+        executor._edge_index.setdefault(edge.source, []).append(edge)
+    return executor
+
+
+class TestGateVerdictFailClosed:
+    """Unrecognized gate output halts instead of proceeding (issue #1250)."""
+
+    def test_agent_proceed_recognized(self) -> None:
+        verdict = _make_gate_executor()._parse_agent_verdict("PROCEED", "gate")
+        assert verdict.type == VerdictType.PROCEED
+
+    def test_agent_proceed_last_nonempty_line(self) -> None:
+        verdict = _make_gate_executor()._parse_agent_verdict(
+            "all good\n\nPROCEED\n", "gate"
+        )
+        assert verdict.type == VerdictType.PROCEED
+
+    def test_agent_empty_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_agent_verdict("", "gate")
+        assert verdict.type == VerdictType.HALT
+        assert "unparseable" in (verdict.reason or "")
+
+    def test_agent_whitespace_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_agent_verdict("   \n  \n", "gate")
+        assert verdict.type == VerdictType.HALT
+
+    def test_agent_apology_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_agent_verdict(
+            "sorry, I could not determine the result", "gate"
+        )
+        assert verdict.type == VerdictType.HALT
+        assert "could not determine" in (verdict.reason or "")
+
+    def test_agent_ambiguous_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_agent_verdict(
+            "GATE RESULT: maybe proceed?", "gate"
+        )
+        assert verdict.type == VerdictType.HALT
+
+    def test_agent_halt_parsed(self) -> None:
+        verdict = _make_gate_executor()._parse_agent_verdict(
+            'HALT reason="tests broke"', "gate"
+        )
+        assert verdict.type == VerdictType.HALT
+        assert verdict.reason == "tests broke"
+
+    def test_agent_reloop_parsed(self) -> None:
+        verdict = _make_gate_executor()._parse_agent_verdict(
+            'RELOOP target="a" feedback="redo it"', "gate"
+        )
+        assert verdict.type == VerdictType.RELOOP
+        assert verdict.target == "a"
+        assert verdict.feedback == "redo it"
+
+    def test_fn_pass_proceeds(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict("pass", "gate")
+        assert verdict.type == VerdictType.PROCEED
+
+    def test_fn_proceed_text_proceeds(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict("PROCEED", "gate")
+        assert verdict.type == VerdictType.PROCEED
+
+    def test_fn_json_passed_true_proceeds(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict('{"passed": true}', "gate")
+        assert verdict.type == VerdictType.PROCEED
+
+    def test_fn_json_passed_false_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict('{"passed": false}', "gate")
+        assert verdict.type == VerdictType.HALT
+
+    def test_fn_fail_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict(
+            "fail: compilation error", "gate"
+        )
+        assert verdict.type == VerdictType.HALT
+
+    def test_fn_revert_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict("revert", "gate")
+        assert verdict.type == VerdictType.HALT
+
+    def test_fn_reloop_parsed(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict(
+            "reloop: redo the build", "gate"
+        )
+        assert verdict.type == VerdictType.RELOOP
+        assert verdict.feedback == "redo the build"
+
+    def test_fn_empty_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict("", "gate")
+        assert verdict.type == VerdictType.HALT
+        assert "unparseable" in (verdict.reason or "")
+
+    def test_fn_apology_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict(
+            "I ran the check but cannot tell if it passed", "gate"
+        )
+        assert verdict.type == VerdictType.HALT
+
+    def test_fn_malformed_json_halts(self) -> None:
+        verdict = _make_gate_executor()._parse_fn_verdict('{"passed": false', "gate")
+        assert verdict.type == VerdictType.HALT
+
+    async def test_fn_gate_without_command_halts(self, tmp_project: Path) -> None:
+        """An fn gate with no evaluator_command halts instead of proceeding."""
+        wf = Workflow(
+            name="no_cmd_gate",
+            nodes={
+                "a": FnNode(id="a", command="echo a", writes={"a.txt"}),
+                "gate": GateNode(id="gate", evaluator_type="fn", reads={"a.txt"}),
+                "b": FnNode(id="b", command="echo b", writes={"b.txt"}),
+            },
+            edges=[
+                Edge(source="a", target="gate"),
+                Edge(source="gate", target="b", condition=VerdictType.PROCEED),
+            ],
+            start_node="a",
+        )
+
+        executor = WorkflowExecutor(wf, tmp_project, dry_run=False)
+        result = await executor.execute()
+
+        assert result.halted
+        assert not result.success
+        assert "no evaluator_command" in result.halt_reason
+        assert result.nodes_executed == 2


### PR DESCRIPTION
## Summary
- Fixes #1250: gate verdict parsing now fails closed — malformed, empty, or unrecognized gate responses halt execution with a parse-failure reason instead of becoming PROCEED
- `_parse_agent_verdict`: last non-empty line must be one of `PROCEED` / `RELOOP target=...` / `HALT reason=...` (the protocol the CEO gate prompt demands); anything else halts
- `_parse_fn_verdict`: recognized tokens are JSON `{"passed": bool}` or first lines `pass` / `proceed` / `fail` / `revert` / `reloop`; anything else (empty, apology text, malformed JSON) halts
- `_evaluate_gate`: an fn gate with no `evaluator_command` configured now halts with a misconfiguration reason instead of auto-proceeding

## Test plan
- [x] Reproduced at HEAD 4998c63: 7/7 malformed inputs fell through to PROCEED (matches issue's empirical verification)
- [x] Post-fix: 0/7 malformed inputs fall through; all valid verdicts still parse correctly
- [x] New regression tests: TestGateVerdictFailClosed (17 cases) pass
- [x] Full test suite passes (5677 passed, 12 skipped) on the fix branch rebased onto main
- [x] ruff check + mypy clean

## Smoke test plan
- [x] Happy path: valid PROCEED / HALT / RELOOP and pass / fail / reloop / JSON verdicts still parse to the correct verdict
- [x] Edge case: empty, whitespace-only, apology, ambiguous, and malformed-JSON outputs halt with an "unparseable verdict" reason
- [x] Regression: fn gate with no evaluator_command halts instead of proceeding

## Test script

```python
"""Smoke test for issue #1250: gate verdict parsing fails open -> fail closed.

Usage:
    uv run python play.py before   # pre-fix behavior (parser from git HEAD)
    uv run python play.py          # post-fix behavior (working tree)
"""

import subprocess
import sys
from pathlib import Path

from factory.workflow.executor import WorkflowExecutor
from factory.workflow.primitives import Edge, FnNode, GateNode, VerdictType, Workflow

AGENT_CASES = [
    ("", "empty output"),
    ("   \n  \n", "whitespace-only"),
    ("sorry, I could not determine the result", "apology text"),
    ("GATE RESULT: maybe proceed?", "ambiguous text"),
    ("PROCEED", "valid PROCEED"),
    ('HALT reason="tests broke"', "valid HALT"),
    ('RELOOP target="a" feedback="redo it"', "valid RELOOP"),
]

FN_CASES = [
    ("", "empty output"),
    ("I ran the check but cannot tell if it passed", "apology text"),
    ('{"passed": false', "malformed JSON"),
    ("pass", "valid pass"),
    ('{"passed": true}', 'valid JSON passed=true'),
    ('{"passed": false}', 'valid JSON passed=false'),
    ("fail: compilation error", "valid fail"),
    ("reloop: redo the build", "valid reloop"),
]

MALFORMED_AGENT = ["", "   \n  \n", "sorry, I could not determine the result", "GATE RESULT: maybe proceed?"]
MALFORMED_FN = ["", "I ran the check but cannot tell if it passed", '{"passed": false']


def build_executor(executor_cls=WorkflowExecutor) -> WorkflowExecutor:
    wf = Workflow(
        name="gate_repro",
        nodes={
            "a": FnNode(id="a", command="echo a"),
            "gate": GateNode(id="gate", evaluator_type="fn", evaluator_command="echo pass"),
            "b": FnNode(id="b", command="echo b"),
        },
        edges=[
            Edge(source="gate", target="b", condition=VerdictType.PROCEED),
            Edge(source="gate", target="a", condition=VerdictType.RELOOP),
        ],
        start_node="a",
    )
    executor = executor_cls.__new__(executor_cls)
    executor.workflow = wf
    executor.project_path = Path("/fake")
    executor._edge_index = {}
    for edge in wf.edges:
        executor._edge_index.setdefault(edge.source, []).append(edge)
    return executor


def main() -> None:
    if len(sys.argv) > 1 and sys.argv[1] == "before":
        old_src = subprocess.run(
            ["git", "show", "HEAD:factory/workflow/executor.py"],
            capture_output=True, text=True, check=True,
        ).stdout
        ns: dict = {}
        exec(compile(old_src, "old_executor.py", "exec"), ns)
        executor = build_executor(ns["WorkflowExecutor"])
        print("MODE: PRE-FIX parser (from git HEAD) — expect FAIL-OPEN (proceed)")
    else:
        executor = build_executor()
        print("MODE: POST-FIX parser (working tree) — expect FAIL-CLOSED (halt)")

    print("=" * 70)
    print("Agent-gate parser (_parse_agent_verdict)")
    print("=" * 70)
    for output, label in AGENT_CASES:
        verdict = executor._parse_agent_verdict(output, "gate")
        print(f"  {label:<28} -> {verdict.type.value:<8} reason={verdict.reason!r}")

    print()
    print("=" * 70)
    print("Fn-gate parser (_parse_fn_verdict)")
    print("=" * 70)
    for output, label in FN_CASES:
        verdict = executor._parse_fn_verdict(output, "gate")
        print(f"  {label:<28} -> {verdict.type.value:<8} reason={verdict.reason!r}")

    fail_open = sum(
        executor._parse_agent_verdict(o, "gate").type == VerdictType.PROCEED
        for o in MALFORMED_AGENT
    ) + sum(
        executor._parse_fn_verdict(o, "gate").type == VerdictType.PROCEED
        for o in MALFORMED_FN
    )
    print()
    print(f"Malformed inputs that fell through to PROCEED: {fail_open}/7")


if __name__ == "__main__":
    main()
```

## Test output

```
MODE: PRE-FIX parser (from git HEAD) — expect FAIL-OPEN (proceed)
======================================================================
Agent-gate parser (_parse_agent_verdict)
======================================================================
  empty output                 -> proceed  reason=None
  whitespace-only              -> proceed  reason=None
  apology text                 -> proceed  reason=None
  ambiguous text               -> proceed  reason=None
  valid PROCEED                -> proceed  reason=None
  valid HALT                   -> halt     reason='tests broke'
  valid RELOOP                 -> reloop   reason=None

======================================================================
Fn-gate parser (_parse_fn_verdict)
======================================================================
  empty output                 -> proceed  reason=None
  apology text                 -> proceed  reason=None
  malformed JSON               -> proceed  reason=None
  valid pass                   -> proceed  reason=None
  valid JSON passed=true       -> proceed  reason=None
  valid JSON passed=false      -> halt     reason='precheck failed: []'
  valid fail                   -> halt     reason='precheck failed: fail: compilation error'
  valid reloop                 -> reloop   reason=None

Malformed inputs that fell through to PROCEED: 7/7
MODE: POST-FIX parser (working tree) — expect FAIL-CLOSED (halt)
======================================================================
Agent-gate parser (_parse_agent_verdict)
======================================================================
  empty output                 -> halt     reason="gate 'gate' returned unparseable verdict (expected PROCEED | RELOOP target=... | HALT reason=...): "
  whitespace-only              -> halt     reason="gate 'gate' returned unparseable verdict (expected PROCEED | RELOOP target=... | HALT reason=...): "
  apology text                 -> halt     reason="gate 'gate' returned unparseable verdict (expected PROCEED | RELOOP target=... | HALT reason=...): sorry, I could not determine the result"
  ambiguous text               -> halt     reason="gate 'gate' returned unparseable verdict (expected PROCEED | RELOOP target=... | HALT reason=...): GATE RESULT: maybe proceed?"
  valid PROCEED                -> proceed  reason=None
  valid HALT                   -> halt     reason='tests broke'
  valid RELOOP                 -> reloop   reason=None

======================================================================
Fn-gate parser (_parse_fn_verdict)
======================================================================
  empty output                 -> halt     reason='gate \'gate\' returned unparseable verdict (expected pass | fail | revert | reloop | {"passed": bool}): '
  apology text                 -> halt     reason='gate \'gate\' returned unparseable verdict (expected pass | fail | revert | reloop | {"passed": bool}): I ran the check but cannot tell if it passed'
  malformed JSON               -> halt     reason='gate \'gate\' returned unparseable verdict (expected pass | fail | revert | reloop | {"passed": bool}): {"passed": false'
  valid pass                   -> proceed  reason=None
  valid JSON passed=true       -> proceed  reason=None
  valid JSON passed=false      -> halt     reason='precheck failed: []'
  valid fail                   -> halt     reason='precheck failed: fail: compilation error'
  valid reloop                 -> reloop   reason=None

Malformed inputs that fell through to PROCEED: 0/7
```

## Unit tests

```bash
uv run pytest tests/test_workflow_executor.py -q
37 passed in 0.20s

uv run pytest tests/test_workflow_tool.py tests/test_workflow_cli.py tests/test_workflow_qa.py tests/test_workflow_overwrite.py tests/test_plan_workflow.py tests/test_workflow_research.py -q
204 passed in 1.51s

uv run ruff check factory/workflow/executor.py tests/test_workflow_executor.py
All checks passed!

uv run mypy factory/workflow/executor.py
Success: no issues found in 1 source file
