### PR TITLE
fix: run Claude Code postinstall manually in CEO review CI

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -67,7 +67,10 @@ jobs:
           node-version: 22
 
       - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          # Run postinstall manually in case optional native binary was skipped
+          node "$(npm prefix -g)/lib/node_modules/@anthropic-ai/claude-code/install.cjs" || true
 
       - name: Verify Claude Code on PATH
         run: |


### PR DESCRIPTION
## Summary

- Run `install.cjs` manually after `npm install -g @anthropic-ai/claude-code` in the CEO review workflow
- npm may skip the native binary optional dependency, leaving `claude` without its platform binary
- The manual postinstall ensures the binary is downloaded regardless of npm's optional dependency handling

## Context

The CEO review CI job started failing with:
```
Error: claude native binary not installed.
Either postinstall did not run (--ignore-scripts, some pnpm configs)
or the platform-native optional dependency was not downloaded (--omit=optional).
```

## Test plan

- [x] Verified fix works on PR #1336 CEO review run

🤖 Generated with [Claude Code](https://claude.com/claude-code)