### PR TITLE
Exp #36: Harden tmux key submission and add structured completion detection

### DIFF
--- a/factory/agents/prompts/refactory.md
+++ b/factory/agents/prompts/refactory.md
@@ -126,11 +126,12 @@ Periodically trigger playbook evolution via `factory ace` to distill experiment 
 
 ### Input Submission
 
-Always use `C-m` (not `Enter`) when sending keys to tmux sessions running Claude Code:
+Always use the two-step hex approach when sending keys to tmux sessions running Claude Code:
 ```bash
-tmux send-keys -t <session> "your input" C-m
+tmux send-keys -t <session> "your input"
+tmux send-keys -t <session> -H 0d
 ```
-`Enter` is unreliable inside Claude Code sessions — `C-m` is the canonical carriage return and works consistently.
+Send text first, then send Enter as hex byte `0d` via `-H`. The `-H 0d` approach is more reliable than `C-m` — `C-m` fails silently with interactive applications like Claude Code, especially when vi mode is active.
 
 ### Post-Dispatch Verification
 
@@ -156,6 +157,38 @@ Never characterize CEO behavior (e.g., "going rogue", "deviated from instruction
 ### Proactive Monitoring
 
 After dispatching CEO sessions, set up periodic monitoring using `ScheduleWakeup` to check session status every 5–10 minutes until completion. Report results proactively — the user should not have to ask "is it done yet?"
+
+## Completion Detection
+
+Three methods to check whether a CEO session is done, in priority order:
+
+### 1. Sentinel File (Primary)
+
+The factory writes a structured JSON sentinel file when the CEO session completes. Check the sentinel for content:
+```bash
+cat /tmp/factory-tmux-*/sentinel 2>/dev/null
+```
+JSON content includes:
+- `completion_reason`: `"normal"` (clean exit) or `"stop_failure"` (abnormal exit)
+- `timestamp`: ISO-8601 completion time
+- `session_id`: tmux session:window identifier
+
+An empty sentinel (backward compat) means the session completed but metadata is unavailable.
+
+### 2. Claude Agents API (Advisory)
+
+Query running Claude sessions via `claude agents --json`:
+```bash
+claude agents --json
+```
+Returns a JSON array of active sessions. Check the `state` field for the matching session — `"busy"`, `"waiting"`, or `"idle"`. If the session is absent from the list, it has exited.
+
+### 3. Tmux Session Check (Fallback)
+
+```bash
+tmux has-session -t <session_name> 2>/dev/null && echo "alive" || echo "dead"
+```
+If the tmux session itself is gone, the CEO has exited. This is the least informative method — it cannot distinguish normal from abnormal exit.
 
 ## Hierarchy
 

--- a/factory/agents/skills/sessions.md
+++ b/factory/agents/skills/sessions.md
@@ -20,11 +20,12 @@ If the session exists but the CEO process has exited, the session is stale — s
 
 ### Sending Input to Sessions
 
-Always use `C-m` (not `Enter`) when sending keys to tmux sessions running Claude Code:
+Always use the two-step hex approach when sending keys to tmux sessions running Claude Code:
 ```bash
-tmux send-keys -t <session_name> "your input" C-m
+tmux send-keys -t <session_name> "your input"
+tmux send-keys -t <session_name> -H 0d
 ```
-`Enter` is unreliable inside Claude Code sessions — `C-m` is the canonical carriage return.
+Send text first, then send Enter as hex byte `0d` via `-H`. The `-H 0d` approach is more reliable than `C-m` — `C-m` fails silently with interactive applications like Claude Code.
 
 ### Capturing Output
 
@@ -42,6 +43,26 @@ tmux attach -t <session_name>
 ```
 - `Ctrl-b d` to detach without stopping the session
 - `Ctrl-c` inside the session will interrupt the CEO — warn the user
+
+## Session Lifecycle via Claude Agents API
+
+Use `claude agents --json` to query active Claude sessions programmatically:
+
+```bash
+# List all active Claude agent sessions as JSON
+claude agents --json
+
+# Check if a specific session is still running (by name substring)
+claude agents --json | python3 -c "
+import json, sys
+agents = json.load(sys.stdin)
+for a in agents:
+    if 'factory-persist' in str(a.get('session_id', '') or a.get('name', '')):
+        print(f\"{a.get('name', 'unknown')}: {a.get('state', 'unknown')}\")
+"
+```
+
+Session states: `"busy"` (actively processing), `"waiting"` (awaiting input), `"idle"` (inactive). If a session is absent from the list, it has exited.
 
 ## Post-Completion Review
 

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -69,16 +69,60 @@ def _window_exists(session: str, window: str) -> bool:
 
 
 _DEFAULT_TMUX_TIMEOUT = 86400.0  # 24 hours — interactive sessions are user-driven
+_POST_SEND_VERIFY_DELAY = 15.0
 
 
-def _generate_settings(sentinel_path: Path, tmpdir: Path, project_path: Path) -> Path:
+def _tmux_send_enter(session_window: str, text: str) -> None:
+    """Send text to a tmux pane, then send Enter as hex 0d. Two-step approach
+    avoids silent failures with C-m in interactive applications like Claude Code."""
+    subprocess.run(
+        ["tmux", "send-keys", "-t", session_window, text],
+        capture_output=True,
+    )
+    subprocess.run(
+        ["tmux", "send-keys", "-t", session_window, "-H", "0d"],
+        capture_output=True,
+    )
+
+
+def _verify_post_send(session_window: str) -> bool:
+    """Capture pane content after key submission and check if a response appeared."""
+    result = subprocess.run(
+        ["tmux", "capture-pane", "-t", session_window, "-p"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.warning("post_send_verify_failed session_window=%s rc=%d", session_window, result.returncode)
+        return False
+    content = result.stdout.strip()
+    has_response = bool(content)
+    logger.info("post_send_verify session_window=%s has_response=%s", session_window, has_response)
+    return has_response
+
+
+def _generate_settings(
+    sentinel_path: Path, tmpdir: Path, project_path: Path, *, session_id: str = "",
+) -> Path:
     """Generate a settings.json with Stop/StopFailure hooks merged with existing project settings."""
+    sentinel_q = shlex.quote(str(sentinel_path))
+    sid_escaped = session_id.replace('"', '\\"')
+
+    stop_cmd = (
+        f'printf \'{{"completion_reason":"normal","timestamp":"%s","session_id":"{sid_escaped}"}}\''
+        f' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > {sentinel_q}'
+    )
+    stop_fail_cmd = (
+        f'printf \'{{"completion_reason":"stop_failure","timestamp":"%s","session_id":"{sid_escaped}"}}\''
+        f' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > {sentinel_q}'
+    )
+
     factory_hooks = {
         "Stop": [
-            {"hooks": [{"type": "command", "command": f"touch {shlex.quote(str(sentinel_path))}", "timeout": 5}]}
+            {"hooks": [{"type": "command", "command": stop_cmd, "timeout": 5}]}
         ],
         "StopFailure": [
-            {"hooks": [{"type": "command", "command": f"touch {shlex.quote(str(sentinel_path))}", "timeout": 5}]}
+            {"hooks": [{"type": "command", "command": stop_fail_cmd, "timeout": 5}]}
         ],
     }
 
@@ -100,16 +144,37 @@ def _generate_settings(sentinel_path: Path, tmpdir: Path, project_path: Path) ->
     return settings_file
 
 
-async def _wait_for_sentinel(sentinel_path: Path, timeout: float) -> bool:
-    """Poll for sentinel file creation with exponential backoff. Returns True if found, False on timeout."""
+async def _wait_for_sentinel(sentinel_path: Path, timeout: float) -> bool | dict:
+    """Poll for sentinel file creation with exponential backoff.
+
+    Returns a dict with completion metadata if the sentinel contains valid JSON,
+    True if the sentinel exists but is empty (backward compat), or False on timeout.
+    """
     deadline = time.monotonic() + timeout
     interval = _SENTINEL_POLL_INITIAL
     while time.monotonic() < deadline:
         if sentinel_path.exists():
-            return True
+            return _parse_sentinel(sentinel_path)
         await asyncio.sleep(max(0, min(interval, deadline - time.monotonic())))
         interval = min(interval * 2, _SENTINEL_POLL_CAP)
-    return sentinel_path.exists()
+    if sentinel_path.exists():
+        return _parse_sentinel(sentinel_path)
+    return False
+
+
+def _parse_sentinel(sentinel_path: Path) -> bool | dict:
+    """Parse a sentinel file. Returns metadata dict if JSON, True if empty (backward compat)."""
+    try:
+        content = sentinel_path.read_text().strip()
+    except OSError:
+        return True
+    if not content:
+        return True
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        logger.warning("sentinel_parse_failed path=%s", sentinel_path)
+        return True
 
 
 async def _wait_for_exitcode(exitcode_file: Path) -> int:
@@ -167,7 +232,7 @@ async def run_in_tmux(
     prompt_file = tmpdir / "prompt.md"
     prompt_file.write_text(prompt)
 
-    settings_file = _generate_settings(sentinel_file, tmpdir, project_path)
+    settings_file = _generate_settings(sentinel_file, tmpdir, project_path, session_id=f"{session}:{window}")
 
     cmd = ["claude", "--settings", str(settings_file), "--append-system-prompt-file", str(prompt_file),
            "--disallowedTools", "Agent"]
@@ -220,8 +285,8 @@ async def run_in_tmux(
     print("  /exit or Ctrl-d to finish   # factory resumes when you exit", file=sys.stderr)
 
     try:
-        found = await _wait_for_sentinel(sentinel_file, timeout)
-        if not found:
+        sentinel_result = await _wait_for_sentinel(sentinel_file, timeout)
+        if not sentinel_result:
             subprocess.run(
                 ["tmux", "kill-window", "-t", f"{session}:{window}"],
                 capture_output=True,
@@ -230,10 +295,15 @@ async def run_in_tmux(
             _cleanup(tmpdir)
             return f"Agent timed out after {timeout}s", 1, None
 
-        subprocess.run(
-            ["tmux", "send-keys", "-t", f"{session}:{window}", "/exit", "C-m"],
-            capture_output=True,
-        )
+        if isinstance(sentinel_result, dict):
+            logger.info(
+                "sentinel_metadata session=%s reason=%s",
+                session, sentinel_result.get("completion_reason", "unknown"),
+            )
+
+        _tmux_send_enter(f"{session}:{window}", "/exit")
+        await asyncio.sleep(min(_POST_SEND_VERIFY_DELAY, timeout))
+        _verify_post_send(f"{session}:{window}")
         await _wait_for_window_exit(session, window)
         if _window_exists(session, window):
             subprocess.run(
@@ -260,6 +330,35 @@ async def run_in_tmux(
             )
         _cleanup(tmpdir)
         raise
+
+
+def _check_claude_agents_state(session_name: str) -> str | None:
+    """Query claude agents --json for a session's state. Returns 'busy', 'waiting',
+    'idle', or None if the session is not found or the command fails."""
+    try:
+        result = subprocess.run(
+            ["claude", "agents", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        agents = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(agents, list):
+        return None
+    for agent in agents:
+        if not isinstance(agent, dict):
+            continue
+        agent_session = agent.get("session_id", "") or agent.get("name", "")
+        if session_name in str(agent_session):
+            return agent.get("state")
+    return None
 
 
 def _cleanup(tmpdir: Path) -> None:

--- a/tests/test_tmux_persist.py
+++ b/tests/test_tmux_persist.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from factory.runners._tmux_persist import (
+    _check_claude_agents_state,
     _generate_settings,
+    _parse_sentinel,
     _strip_ansi,
+    _tmux_send_enter,
     _wait_for_exitcode,
     _wait_for_sentinel,
     _window_exists,
@@ -90,16 +94,18 @@ class TestGenerateSettings:
         assert "Stop" in data["hooks"]
         assert "StopFailure" in data["hooks"]
 
-    def test_hooks_touch_sentinel_path(self, tmp_path: Path) -> None:
+    def test_hooks_write_to_sentinel_path(self, tmp_path: Path) -> None:
         sentinel = tmp_path / "sentinel"
         project = tmp_path / "proj"
         project.mkdir()
         settings_file = _generate_settings(sentinel, tmp_path, project)
         data = json.loads(settings_file.read_text())
         stop_cmd = data["hooks"]["Stop"][0]["hooks"][0]["command"]
-        assert f"touch {sentinel}" in stop_cmd
+        assert str(sentinel) in stop_cmd
+        assert "completion_reason" in stop_cmd
         fail_cmd = data["hooks"]["StopFailure"][0]["hooks"][0]["command"]
-        assert f"touch {sentinel}" in fail_cmd
+        assert str(sentinel) in fail_cmd
+        assert "completion_reason" in fail_cmd
 
     def test_hook_structure(self, tmp_path: Path) -> None:
         sentinel = tmp_path / "sentinel"
@@ -133,7 +139,7 @@ class TestGenerateSettings:
         assert data["permissions"] == {"allow": ["Read"]}
         assert len(data["hooks"]["Stop"]) == 2
         assert data["hooks"]["Stop"][0]["hooks"][0]["command"] == "echo existing-stop"
-        assert "touch" in data["hooks"]["Stop"][1]["hooks"][0]["command"]
+        assert "completion_reason" in data["hooks"]["Stop"][1]["hooks"][0]["command"]
 
     def test_handles_missing_project_settings(self, tmp_path: Path) -> None:
         sentinel = tmp_path / "sentinel"
@@ -252,11 +258,9 @@ class TestRunInTmux:
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # new-session succeeds
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.return_value = MagicMock(returncode=0, stdout="pane content")
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -278,18 +282,24 @@ class TestRunInTmux:
         project_path = tmp_path / "my-project"
         project_path.mkdir()
 
+        call_count = 0
+
+        def side_effect_fn(cmd, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return MagicMock(returncode=1, stderr=b"duplicate session")
+            return MagicMock(returncode=0, stdout="pane content")
+
         with (
             patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=1, stderr=b"duplicate session"),  # new-session fails
-                MagicMock(returncode=0),  # new-window fallback succeeds
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.side_effect = side_effect_fn
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -311,18 +321,24 @@ class TestRunInTmux:
         project_path = tmp_path / "my-project"
         project_path.mkdir()
 
+        call_count = 0
+
+        def side_effect_fn(cmd, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return MagicMock(returncode=1, stderr=b"duplicate session: factory-persist-my-project-abc123")
+            return MagicMock(returncode=0, stdout="pane content")
+
         with (
             patch("factory.runners._tmux_persist.subprocess.run") as mock_run,
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=1, stderr=b"duplicate session: factory-persist-my-project-abc123"),
-                MagicMock(returncode=0),  # new-window fallback
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.side_effect = side_effect_fn
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -335,10 +351,10 @@ class TestRunInTmux:
 
             assert code == 0
             assert "race condition output" in stdout
-            assert len(mock_run.call_args_list) == 3
             assert "new-session" in mock_run.call_args_list[0][0][0]
             assert "new-window" in mock_run.call_args_list[1][0][0]
-            assert "send-keys" in mock_run.call_args_list[2][0][0]
+            send_keys_calls = [c for c in mock_run.call_args_list if "send-keys" in c[0][0]]
+            assert len(send_keys_calls) >= 2
 
     async def test_wrapper_script_includes_settings_and_trap(self, tmp_path: Path) -> None:
         """Verify the wrapper script has --settings flag and trap EXIT."""
@@ -359,14 +375,11 @@ class TestRunInTmux:
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
-
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
             patch.object(Path, "write_text", spy_write_text),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # new-session
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.return_value = MagicMock(returncode=0, stdout="pane content")
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -401,14 +414,11 @@ class TestRunInTmux:
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
-
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
             patch.object(Path, "write_text", spy_write_text),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # new-session
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.return_value = MagicMock(returncode=0, stdout="pane content")
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -478,13 +488,10 @@ class TestRunInTmux:
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
-
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # new-session
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.return_value = MagicMock(returncode=0, stdout="pane content")
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -499,7 +506,7 @@ class TestRunInTmux:
             assert "\x1b" not in stdout
 
     async def test_sends_exit_after_sentinel(self, tmp_path: Path) -> None:
-        """After sentinel detection, /exit is sent to the tmux pane."""
+        """After sentinel detection, /exit is sent via two-step hex approach."""
         project_path = tmp_path / "my-project"
         project_path.mkdir()
 
@@ -508,13 +515,10 @@ class TestRunInTmux:
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
-
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # new-session
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.return_value = MagicMock(returncode=0, stdout="pane content")
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -525,10 +529,13 @@ class TestRunInTmux:
                     "prompt", "task", project_path, "builder", project_path,
                 )
 
-            send_keys_call = mock_run.call_args_list[1]
-            cmd = send_keys_call[0][0]
-            assert "send-keys" in cmd
-            assert "/exit" in cmd
+            send_calls = [c for c in mock_run.call_args_list if "send-keys" in c[0][0]]
+            assert len(send_calls) >= 2
+            text_call = send_calls[0]
+            assert "/exit" in text_call[0][0]
+            enter_call = send_calls[1]
+            assert "-H" in enter_call[0][0]
+            assert "0d" in enter_call[0][0]
 
     async def test_fallback_kill_window_when_window_still_alive(self, tmp_path: Path) -> None:
         """After /exit + poll, if window still exists, kill-window is called."""
@@ -540,14 +547,10 @@ class TestRunInTmux:
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
-
             patch("factory.runners._tmux_persist._window_exists", return_value=True),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # new-session
-                MagicMock(returncode=0),  # send-keys /exit
-                MagicMock(returncode=0),  # kill-window fallback
-            ]
+            mock_run.return_value = MagicMock(returncode=0, stdout="pane content")
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -559,9 +562,8 @@ class TestRunInTmux:
                 )
 
             assert code == 0
-            kill_call = mock_run.call_args_list[2]
-            cmd = kill_call[0][0]
-            assert "kill-window" in cmd
+            kill_calls = [c for c in mock_run.call_args_list if "kill-window" in c[0][0]]
+            assert len(kill_calls) >= 1
 
     async def test_tmux_command_references_wrapper_script(self, tmp_path: Path) -> None:
         """Verify the tmux new-session/new-window command references the wrapper script path."""
@@ -573,13 +575,10 @@ class TestRunInTmux:
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", new_callable=AsyncMock, return_value=0),
-
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # new-session
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.return_value = MagicMock(returncode=0, stdout="pane content")
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -616,13 +615,10 @@ class TestRunInTmux:
             patch("factory.runners._tmux_persist._wait_for_sentinel", new_callable=AsyncMock, return_value=True),
             patch("factory.runners._tmux_persist._wait_for_window_exit", new_callable=AsyncMock),
             patch("factory.runners._tmux_persist._wait_for_exitcode", side_effect=mock_wait_for_exitcode),
-
             patch("factory.runners._tmux_persist._window_exists", return_value=False),
+            patch("factory.runners._tmux_persist._POST_SEND_VERIFY_DELAY", 0),
         ):
-            mock_run.side_effect = [
-                MagicMock(returncode=0),  # new-session
-                MagicMock(returncode=0),  # send-keys /exit
-            ]
+            mock_run.return_value = MagicMock(returncode=0, stdout="pane content")
 
             with patch("factory.runners._tmux_persist.tempfile.mkdtemp", return_value=str(tmp_path / "tmp")):
                 tmpdir = tmp_path / "tmp"
@@ -677,6 +673,166 @@ class TestRunInTmux:
 
         assert kill_window_called, "kill-window should have been called on cancellation"
         assert not tmpdir.exists(), "tmpdir should have been cleaned up"
+
+
+class TestTmuxSendEnter:
+    def test_sends_text_then_hex_enter(self) -> None:
+        with patch("factory.runners._tmux_persist.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _tmux_send_enter("mysession:mywindow", "/exit")
+            assert mock_run.call_count == 2
+            text_call = mock_run.call_args_list[0]
+            assert text_call[0][0] == ["tmux", "send-keys", "-t", "mysession:mywindow", "/exit"]
+            enter_call = mock_run.call_args_list[1]
+            assert enter_call[0][0] == ["tmux", "send-keys", "-t", "mysession:mywindow", "-H", "0d"]
+
+    def test_sends_arbitrary_text(self) -> None:
+        with patch("factory.runners._tmux_persist.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _tmux_send_enter("sess:win", "hello world")
+            text_call = mock_run.call_args_list[0]
+            assert text_call[0][0] == ["tmux", "send-keys", "-t", "sess:win", "hello world"]
+
+
+class TestGenerateSettingsJsonSentinel:
+    def test_stop_hook_writes_json(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        project = tmp_path / "proj"
+        project.mkdir()
+        settings_file = _generate_settings(sentinel, tmp_path, project, session_id="test-session")
+        data = json.loads(settings_file.read_text())
+        stop_cmd = data["hooks"]["Stop"][0]["hooks"][0]["command"]
+        assert "completion_reason" in stop_cmd
+        assert "normal" in stop_cmd
+        assert "test-session" in stop_cmd
+
+    def test_stop_failure_hook_writes_json(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        project = tmp_path / "proj"
+        project.mkdir()
+        settings_file = _generate_settings(sentinel, tmp_path, project, session_id="test-session")
+        data = json.loads(settings_file.read_text())
+        fail_cmd = data["hooks"]["StopFailure"][0]["hooks"][0]["command"]
+        assert "completion_reason" in fail_cmd
+        assert "stop_failure" in fail_cmd
+
+    def test_hook_command_targets_sentinel_path(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "my-sentinel"
+        project = tmp_path / "proj"
+        project.mkdir()
+        settings_file = _generate_settings(sentinel, tmp_path, project)
+        data = json.loads(settings_file.read_text())
+        stop_cmd = data["hooks"]["Stop"][0]["hooks"][0]["command"]
+        assert str(sentinel) in stop_cmd
+
+    def test_default_session_id_is_empty(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        project = tmp_path / "proj"
+        project.mkdir()
+        settings_file = _generate_settings(sentinel, tmp_path, project)
+        data = json.loads(settings_file.read_text())
+        stop_cmd = data["hooks"]["Stop"][0]["hooks"][0]["command"]
+        assert "completion_reason" in stop_cmd
+
+
+class TestParseSentinel:
+    def test_parses_json_content(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        sentinel.write_text('{"completion_reason":"normal","timestamp":"2026-01-01T00:00:00Z","session_id":"s1"}')
+        result = _parse_sentinel(sentinel)
+        assert isinstance(result, dict)
+        assert result["completion_reason"] == "normal"
+        assert result["session_id"] == "s1"
+
+    def test_returns_true_for_empty_sentinel(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        sentinel.write_text("")
+        result = _parse_sentinel(sentinel)
+        assert result is True
+
+    def test_returns_true_for_whitespace_only(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        sentinel.write_text("   \n  ")
+        result = _parse_sentinel(sentinel)
+        assert result is True
+
+    def test_returns_true_for_invalid_json(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        sentinel.write_text("not valid json {{{")
+        result = _parse_sentinel(sentinel)
+        assert result is True
+
+    def test_parses_stop_failure_reason(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        sentinel.write_text('{"completion_reason":"stop_failure","timestamp":"2026-01-01T00:00:00Z","session_id":"s2"}')
+        result = _parse_sentinel(sentinel)
+        assert isinstance(result, dict)
+        assert result["completion_reason"] == "stop_failure"
+
+
+class TestWaitForSentinelJson:
+    async def test_returns_dict_for_json_sentinel(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        sentinel.write_text('{"completion_reason":"normal","timestamp":"2026-01-01T00:00:00Z","session_id":"s1"}')
+        result = await _wait_for_sentinel(sentinel, timeout=5.0)
+        assert isinstance(result, dict)
+        assert result["completion_reason"] == "normal"
+
+    async def test_returns_true_for_empty_sentinel(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        sentinel.touch()
+        result = await _wait_for_sentinel(sentinel, timeout=5.0)
+        assert result is True
+
+    async def test_returns_false_on_timeout(self, tmp_path: Path) -> None:
+        sentinel = tmp_path / "sentinel"
+        with patch("factory.runners._tmux_persist._SENTINEL_POLL_INITIAL", 0.01):
+            result = await _wait_for_sentinel(sentinel, timeout=0.03)
+        assert result is False
+
+
+class TestCheckClaudeAgentsState:
+    def test_returns_state_for_matching_session(self) -> None:
+        agents_json = json.dumps([
+            {"session_id": "factory-persist-myproject-abc123:researcher-def456", "state": "busy", "name": "test"},
+        ])
+        with patch("factory.runners._tmux_persist.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=agents_json)
+            result = _check_claude_agents_state("factory-persist-myproject")
+            assert result == "busy"
+
+    def test_returns_none_when_no_match(self) -> None:
+        agents_json = json.dumps([
+            {"session_id": "other-session", "state": "idle", "name": "other"},
+        ])
+        with patch("factory.runners._tmux_persist.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=agents_json)
+            result = _check_claude_agents_state("factory-persist-myproject")
+            assert result is None
+
+    def test_returns_none_on_command_failure(self) -> None:
+        with patch("factory.runners._tmux_persist.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            result = _check_claude_agents_state("factory-persist-myproject")
+            assert result is None
+
+    def test_returns_none_on_file_not_found(self) -> None:
+        with patch("factory.runners._tmux_persist.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError
+            result = _check_claude_agents_state("factory-persist-myproject")
+            assert result is None
+
+    def test_returns_none_on_invalid_json(self) -> None:
+        with patch("factory.runners._tmux_persist.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="not json")
+            result = _check_claude_agents_state("factory-persist-myproject")
+            assert result is None
+
+    def test_returns_none_on_timeout(self) -> None:
+        with patch("factory.runners._tmux_persist.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("claude", 10)
+            result = _check_claude_agents_state("factory-persist-myproject")
+            assert result is None
 
 
 class TestClaudeRunnerTmuxPersist:


### PR DESCRIPTION
Closes #1259
Closes #1317

## Changes

**Key submission hardening (#1259):**
- Extracted `_tmux_send_enter()` helper that uses two-step approach: send text first, then send Enter as hex `0d` via `-H` flag — avoids silent failures with `C-m` in interactive Claude Code sessions
- Added 15-second post-submission verification via `_verify_post_send()` that captures pane content and logs whether a response appeared
- Updated tmux send-keys documentation in `refactory.md` and `sessions.md` to use the hex approach

**Completion detection (#1317):**
- Modified `_generate_settings()` Stop/StopFailure hooks to write structured JSON sentinel (completion_reason, timestamp, session_id) instead of empty touch
- Modified `_wait_for_sentinel()` to parse JSON sentinel and return metadata dict, with backward compat for empty sentinels
- Added `_check_claude_agents_state()` advisory function that queries `claude agents --json` for session state
- Added Completion Detection section to `refactory.md` with three detection methods (sentinel JSON, claude agents API, tmux has-session)
- Added `claude agents --json` usage examples to `sessions.md`

**Testing:**
- Added tests for `_tmux_send_enter`, JSON sentinel generation, `_parse_sentinel` (with backward compat), `_check_claude_agents_state`
- Updated existing tests to work with new two-step send pattern and JSON sentinel hooks
- All 60 tests passing, lint and type checks clean