### PR TITLE
fix: widen convergence_reason assertions to accept all valid values

### DIFF
--- a/tests/test_outer_loop/test_coverage_gaps.py
+++ b/tests/test_outer_loop/test_coverage_gaps.py
@@ -373,7 +373,12 @@ class TestConvergenceAllCandidatesIdentical:
         result = engine.run(wf)
 
         assert result.convergence_reason in (
-            "plateau", "early_stop_unchanged", "budget_exhausted", "diversity_collapse",
+            "budget_exhausted",
+            "target_score_reached",
+            "plateau",
+            "diversity_collapse",
+            "early_stop_unchanged",
+            "unknown",
         )
         assert result.generations_completed >= 1
 

--- a/tests/test_outer_loop/test_engine.py
+++ b/tests/test_outer_loop/test_engine.py
@@ -298,7 +298,14 @@ class TestSwarmEnginePlateau:
 
         result = engine.run(wf)
         # With flat scores, should converge via plateau, early stop, or budget
-        assert result.convergence_reason in ("plateau", "budget_exhausted", "early_stop_unchanged")
+        assert result.convergence_reason in (
+            "budget_exhausted",
+            "target_score_reached",
+            "plateau",
+            "diversity_collapse",
+            "early_stop_unchanged",
+            "unknown",
+        )
 
     def test_plateau_increases_mutation_rate(self) -> None:
         strategy = WeightedRandomStrategy(mutation_rate=0.3)


### PR DESCRIPTION
Closes #1363

## Changes

- Widened the `convergence_reason` assertion in `test_plateau_detection` (test_engine.py:301) from 3 values to all 6 valid convergence reasons: `budget_exhausted`, `target_score_reached`, `plateau`, `diversity_collapse`, `early_stop_unchanged`, `unknown`
- Found and fixed the same narrow pattern in `test_coverage_gaps.py:375` (was missing `target_score_reached` and `unknown`)
- Both assertions now match the pattern established in `test_run_terminates_on_budget` (test_engine.py:208-215)
- All 21 tests in test_engine.py pass