### PR TITLE
ci: add crqu to CEO review allowed users

### DIFF
--- a/.github/workflows/ceo-review.yml
+++ b/.github/workflows/ceo-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: >-
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@ceo-review') &&
-      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98", "lukeinglis", "nehamalepati", "abhi1092", "s-akhtar-baig", "lambdabaa"]'), github.event.comment.user.login)
+      contains(fromJSON('["akashgit", "xukai92", "colehurwitz", "shivchander", "osilkin98", "gx-ai-architect", "RobotSail", "mihirathale98", "lukeinglis", "nehamalepati", "abhi1092", "s-akhtar-baig", "lambdabaa", "crqu"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 120
 


### PR DESCRIPTION
## Summary
- Adds `crqu` to the allowed users list in the `@ceo-review` CI workflow

## Test plan
- [ ] Verify `crqu` can trigger the workflow by commenting `@ceo-review` on a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)