### PR TITLE
test: add coverage for venv injection in runners and eval runner

### DIFF
--- a/factory/eval/languages/base.py
+++ b/factory/eval/languages/base.py
@@ -54,6 +54,10 @@ def _run_cmd(
 ) -> tuple[int, str, str]:
     """Run a command, return (returncode, stdout, stderr). Never raises."""
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    venv_python = cwd / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        env["VIRTUAL_ENV"] = str(cwd / ".venv")
+        env["PATH"] = str(cwd / ".venv" / "bin") + os.pathsep + env.get("PATH", "")
     try:
         result = subprocess.run(
             cmd,

--- a/factory/eval/languages/base.py
+++ b/factory/eval/languages/base.py
@@ -54,8 +54,8 @@ def _run_cmd(
 ) -> tuple[int, str, str]:
     """Run a command, return (returncode, stdout, stderr). Never raises."""
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-    venv_python = cwd / ".venv" / "bin" / "python"
-    if venv_python.exists():
+    from factory.worktree import is_factory_venv
+    if is_factory_venv(cwd):
         env["VIRTUAL_ENV"] = str(cwd / ".venv")
         env["PATH"] = str(cwd / ".venv" / "bin") + os.pathsep + env.get("PATH", "")
     try:

--- a/factory/eval/languages/python.py
+++ b/factory/eval/languages/python.py
@@ -10,9 +10,9 @@ from factory.eval.languages.base import EvalFragment, _run_cmd
 
 
 def _resolve_python(project_path: Path) -> str:
-    venv_python = project_path / ".venv" / "bin" / "python"
-    if venv_python.exists():
-        return str(venv_python)
+    from factory.worktree import is_factory_venv
+    if is_factory_venv(project_path):
+        return str(project_path / ".venv" / "bin" / "python")
     return sys.executable
 
 

--- a/factory/eval/languages/python.py
+++ b/factory/eval/languages/python.py
@@ -9,6 +9,13 @@ from pathlib import Path
 from factory.eval.languages.base import EvalFragment, _run_cmd
 
 
+def _resolve_python(project_path: Path) -> str:
+    venv_python = project_path / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return str(venv_python)
+    return sys.executable
+
+
 class PythonEvaluator:
     @property
     def name(self) -> str:
@@ -33,7 +40,7 @@ class PythonEvaluator:
         cov_target = self._detect_cov_target(project_path)
         rc, stdout, stderr = _run_cmd(
             [
-                sys.executable, "-m", "pytest",
+                _resolve_python(project_path), "-m", "pytest",
                 f"--cov={cov_target}", "--cov-report=term",
                 "-v", "--tb=no", "-q",
             ],
@@ -78,7 +85,7 @@ class PythonEvaluator:
 
     def run_lint(self, project_path: Path) -> EvalFragment | None:
         rc, stdout, stderr = _run_cmd(
-            [sys.executable, "-m", "ruff", "check", "."], project_path
+            [_resolve_python(project_path), "-m", "ruff", "check", "."], project_path
         )
         output = stdout + stderr
         if rc == 0:
@@ -94,7 +101,7 @@ class PythonEvaluator:
                 src_dirs.append(child.name)
         target = src_dirs[0] if src_dirs else "."
         rc, stdout, stderr = _run_cmd(
-            [sys.executable, "-m", "mypy", target], project_path
+            [_resolve_python(project_path), "-m", "mypy", target], project_path
         )
         output = stdout + stderr
         if rc == 0:

--- a/factory/eval/runner.py
+++ b/factory/eval/runner.py
@@ -138,6 +138,10 @@ async def _run_project_eval(
 
     # Clean environment
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    venv_path = project_path / ".venv"
+    if (venv_path / "bin" / "python").exists():
+        env["VIRTUAL_ENV"] = str(venv_path)
+        env["PATH"] = str(venv_path / "bin") + os.pathsep + env.get("PATH", "")
 
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -173,6 +177,10 @@ async def _run_single_project_dimension(
     """Run a single user-defined project eval dimension."""
     parts = dim.command.split()
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    venv_path = project_path / ".venv"
+    if (venv_path / "bin" / "python").exists():
+        env["VIRTUAL_ENV"] = str(venv_path)
+        env["PATH"] = str(venv_path / "bin") + os.pathsep + env.get("PATH", "")
 
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/factory/eval/runner.py
+++ b/factory/eval/runner.py
@@ -138,8 +138,9 @@ async def _run_project_eval(
 
     # Clean environment
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-    venv_path = project_path / ".venv"
-    if (venv_path / "bin" / "python").exists():
+    from factory.worktree import is_factory_venv
+    if is_factory_venv(project_path):
+        venv_path = project_path / ".venv"
         env["VIRTUAL_ENV"] = str(venv_path)
         env["PATH"] = str(venv_path / "bin") + os.pathsep + env.get("PATH", "")
 
@@ -177,8 +178,9 @@ async def _run_single_project_dimension(
     """Run a single user-defined project eval dimension."""
     parts = dim.command.split()
     env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
-    venv_path = project_path / ".venv"
-    if (venv_path / "bin" / "python").exists():
+    from factory.worktree import is_factory_venv
+    if is_factory_venv(project_path):
+        venv_path = project_path / ".venv"
         env["VIRTUAL_ENV"] = str(venv_path)
         env["PATH"] = str(venv_path / "bin") + os.pathsep + env.get("PATH", "")
 

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -134,6 +134,11 @@ class ClaudeRunner:
             cmd.extend(["--session-id", request.session_id])
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        if request.cwd:
+            venv_path = Path(request.cwd) / ".venv"
+            if (venv_path / "bin" / "python").exists():
+                env["VIRTUAL_ENV"] = str(venv_path)
+                env["PATH"] = str(venv_path / "bin") + os.pathsep + env.get("PATH", "")
         if request.model:
             env["FACTORY_MODEL"] = request.model
         if request.cwd:
@@ -311,6 +316,11 @@ class ClaudeRunner:
             cmd.extend(["--session-id", request.session_id])
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+        if request.cwd:
+            venv_path = Path(request.cwd) / ".venv"
+            if (venv_path / "bin" / "python").exists():
+                env["VIRTUAL_ENV"] = str(venv_path)
+                env["PATH"] = str(venv_path / "bin") + os.pathsep + env.get("PATH", "")
         if request.model:
             env["FACTORY_MODEL"] = request.model
         if request.cwd:

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -135,8 +135,9 @@ class ClaudeRunner:
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
         if request.cwd:
-            venv_path = Path(request.cwd) / ".venv"
-            if (venv_path / "bin" / "python").exists():
+            from factory.worktree import is_factory_venv
+            if is_factory_venv(Path(request.cwd)):
+                venv_path = Path(request.cwd) / ".venv"
                 env["VIRTUAL_ENV"] = str(venv_path)
                 env["PATH"] = str(venv_path / "bin") + os.pathsep + env.get("PATH", "")
         if request.model:
@@ -317,8 +318,9 @@ class ClaudeRunner:
 
         env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
         if request.cwd:
-            venv_path = Path(request.cwd) / ".venv"
-            if (venv_path / "bin" / "python").exists():
+            from factory.worktree import is_factory_venv
+            if is_factory_venv(Path(request.cwd)):
+                venv_path = Path(request.cwd) / ".venv"
                 env["VIRTUAL_ENV"] = str(venv_path)
                 env["PATH"] = str(venv_path / "bin") + os.pathsep + env.get("PATH", "")
         if request.model:

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -47,6 +47,9 @@ _COPY_ENTRIES: Final[tuple[str, ...]] = (
 )
 
 
+WORKTREE_VENV_MARKER: Final[str] = ".factory-managed"
+
+
 def _setup_worktree_venv(worktree_path: Path) -> Path | None:
     """Create a per-worktree Python venv if pyproject.toml is present.
 
@@ -64,6 +67,7 @@ def _setup_worktree_venv(worktree_path: Path) -> Path | None:
     )
     if result.returncode == 0:
         venv_path = worktree_path / ".venv"
+        (venv_path / WORKTREE_VENV_MARKER).touch()
         log.info("worktree_venv_created", method="uv_sync", path=str(venv_path))
         return venv_path
 
@@ -89,8 +93,14 @@ def _setup_worktree_venv(worktree_path: Path) -> Path | None:
         log.warning("worktree_venv_fallback_install_failed", stderr=result.stderr[:200])
         return None
 
+    (venv_path / WORKTREE_VENV_MARKER).touch()
     log.info("worktree_venv_created", method="fallback", path=str(venv_path))
     return venv_path
+
+
+def is_factory_venv(project_path: Path) -> bool:
+    """Return True if the .venv at project_path was created by the factory."""
+    return (project_path / ".venv" / WORKTREE_VENV_MARKER).exists()
 
 
 def create_worktree(

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import os
 import secrets
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Final
 
@@ -43,6 +45,52 @@ _SHARED_SYMLINK_ENTRIES: Final[tuple[str, ...]] = (
 _COPY_ENTRIES: Final[tuple[str, ...]] = (
     "agents",
 )
+
+
+def _setup_worktree_venv(worktree_path: Path) -> Path | None:
+    """Create a per-worktree Python venv if pyproject.toml is present.
+
+    Tries ``uv sync`` first (auto-creates ``.venv`` + editable install).
+    Falls back to ``python -m venv`` + ``uv pip install -e``.
+    Returns the venv path on success, ``None`` on skip/failure.
+    """
+    if not (worktree_path / "pyproject.toml").exists():
+        return None
+
+    result = subprocess.run(
+        ["uv", "sync", "--directory", str(worktree_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        venv_path = worktree_path / ".venv"
+        log.info("worktree_venv_created", method="uv_sync", path=str(venv_path))
+        return venv_path
+
+    log.warning("worktree_venv_uv_sync_failed", stderr=result.stderr[:200])
+
+    venv_path = worktree_path / ".venv"
+    result = subprocess.run(
+        [sys.executable, "-m", "venv", str(venv_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        log.warning("worktree_venv_fallback_venv_failed", stderr=result.stderr[:200])
+        return None
+
+    result = subprocess.run(
+        ["uv", "pip", "install", "-e", str(worktree_path)],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "VIRTUAL_ENV": str(venv_path)},
+    )
+    if result.returncode != 0:
+        log.warning("worktree_venv_fallback_install_failed", stderr=result.stderr[:200])
+        return None
+
+    log.info("worktree_venv_created", method="fallback", path=str(venv_path))
+    return venv_path
 
 
 def create_worktree(
@@ -152,6 +200,8 @@ def create_worktree(
 
     log.info("worktree_created", branch=branch, path=str(wt_dir))
 
+    _setup_worktree_venv(wt_dir)
+
     try:
         from factory.events import emit_event
 
@@ -202,6 +252,8 @@ def create_experiment_worktree(
     )
 
     _seed_experiment_factory(factory_dir, wt_dir / ".factory")
+
+    _setup_worktree_venv(wt_dir)
 
     log.info("experiment_worktree_created", branch=branch, path=str(wt_dir))
 

--- a/tests/test_worktree_venv.py
+++ b/tests/test_worktree_venv.py
@@ -1,0 +1,114 @@
+"""Tests for per-worktree venv isolation (issue #1365)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from factory.eval.languages.python import _resolve_python
+from factory.worktree import _setup_worktree_venv
+
+
+class TestSetupWorktreeVenv:
+    def test_creates_venv_via_uv_sync(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+
+        success = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("factory.worktree.subprocess.run", return_value=success) as mock_run:
+            result = _setup_worktree_venv(tmp_path)
+
+        assert result == tmp_path / ".venv"
+        mock_run.assert_called_once_with(
+            ["uv", "sync", "--directory", str(tmp_path)],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_skips_when_no_pyproject_toml(self, tmp_path: Path) -> None:
+        result = _setup_worktree_venv(tmp_path)
+        assert result is None
+
+    def test_fallback_on_uv_sync_failure(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+
+        uv_sync_fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="err")
+        venv_ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        pip_ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        with patch("factory.worktree.subprocess.run", side_effect=[uv_sync_fail, venv_ok, pip_ok]):
+            result = _setup_worktree_venv(tmp_path)
+
+        assert result == tmp_path / ".venv"
+
+    def test_graceful_degradation_on_total_failure(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+
+        fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="err")
+
+        with patch("factory.worktree.subprocess.run", return_value=fail):
+            result = _setup_worktree_venv(tmp_path)
+
+        assert result is None
+
+    def test_fallback_venv_created_then_pip_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+
+        uv_fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="err")
+        venv_ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        pip_fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="err")
+
+        with patch("factory.worktree.subprocess.run", side_effect=[uv_fail, venv_ok, pip_fail]):
+            result = _setup_worktree_venv(tmp_path)
+
+        assert result is None
+
+
+class TestResolvePython:
+    def test_prefers_venv_python(self, tmp_path: Path) -> None:
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        python = venv_bin / "python"
+        python.touch()
+        python.chmod(0o755)
+
+        result = _resolve_python(tmp_path)
+        assert result == str(python)
+
+    def test_falls_back_to_sys_executable(self, tmp_path: Path) -> None:
+        result = _resolve_python(tmp_path)
+        assert result == sys.executable
+
+
+class TestRunCmdVenvEnv:
+    def test_sets_venv_env_when_venv_exists(self, tmp_path: Path) -> None:
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").touch()
+
+        from factory.eval.languages.base import _run_cmd
+
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="ok", stderr=""
+            )
+            _run_cmd(["echo", "test"], tmp_path)
+
+        call_kwargs = mock_run.call_args
+        env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+        assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+        assert env["PATH"].startswith(str(venv_bin))
+
+    def test_no_venv_env_when_no_venv(self, tmp_path: Path) -> None:
+        from factory.eval.languages.base import _run_cmd
+
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="ok", stderr=""
+            )
+            _run_cmd(["echo", "test"], tmp_path)
+
+        call_kwargs = mock_run.call_args
+        env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+        assert "VIRTUAL_ENV" not in env

--- a/tests/test_worktree_venv.py
+++ b/tests/test_worktree_venv.py
@@ -8,18 +8,20 @@ from pathlib import Path
 from unittest.mock import patch
 
 from factory.eval.languages.python import _resolve_python
-from factory.worktree import _setup_worktree_venv
+from factory.worktree import WORKTREE_VENV_MARKER, _setup_worktree_venv
 
 
 class TestSetupWorktreeVenv:
     def test_creates_venv_via_uv_sync(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+        (tmp_path / ".venv").mkdir()
 
         success = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
         with patch("factory.worktree.subprocess.run", return_value=success) as mock_run:
             result = _setup_worktree_venv(tmp_path)
 
         assert result == tmp_path / ".venv"
+        assert (tmp_path / ".venv" / WORKTREE_VENV_MARKER).exists()
         mock_run.assert_called_once_with(
             ["uv", "sync", "--directory", str(tmp_path)],
             capture_output=True,
@@ -32,6 +34,7 @@ class TestSetupWorktreeVenv:
 
     def test_fallback_on_uv_sync_failure(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
+        (tmp_path / ".venv").mkdir()
 
         uv_sync_fail = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="err")
         venv_ok = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
@@ -41,6 +44,7 @@ class TestSetupWorktreeVenv:
             result = _setup_worktree_venv(tmp_path)
 
         assert result == tmp_path / ".venv"
+        assert (tmp_path / ".venv" / WORKTREE_VENV_MARKER).exists()
 
     def test_graceful_degradation_on_total_failure(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\n")
@@ -72,6 +76,7 @@ class TestResolvePython:
         python = venv_bin / "python"
         python.touch()
         python.chmod(0o755)
+        (tmp_path / ".venv" / WORKTREE_VENV_MARKER).touch()
 
         result = _resolve_python(tmp_path)
         assert result == str(python)
@@ -80,12 +85,21 @@ class TestResolvePython:
         result = _resolve_python(tmp_path)
         assert result == sys.executable
 
-
-class TestRunCmdVenvEnv:
-    def test_sets_venv_env_when_venv_exists(self, tmp_path: Path) -> None:
+    def test_ignores_non_factory_venv(self, tmp_path: Path) -> None:
         venv_bin = tmp_path / ".venv" / "bin"
         venv_bin.mkdir(parents=True)
         (venv_bin / "python").touch()
+
+        result = _resolve_python(tmp_path)
+        assert result == sys.executable
+
+
+class TestRunCmdVenvEnv:
+    def test_sets_venv_env_when_factory_venv_exists(self, tmp_path: Path) -> None:
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").touch()
+        (tmp_path / ".venv" / WORKTREE_VENV_MARKER).touch()
 
         from factory.eval.languages.base import _run_cmd
 
@@ -101,6 +115,23 @@ class TestRunCmdVenvEnv:
         assert env["PATH"].startswith(str(venv_bin))
 
     def test_no_venv_env_when_no_venv(self, tmp_path: Path) -> None:
+        from factory.eval.languages.base import _run_cmd
+
+        with patch("factory.eval.languages.base.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="ok", stderr=""
+            )
+            _run_cmd(["echo", "test"], tmp_path)
+
+        call_kwargs = mock_run.call_args
+        env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+        assert "VIRTUAL_ENV" not in env
+
+    def test_no_venv_env_when_non_factory_venv(self, tmp_path: Path) -> None:
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (venv_bin / "python").touch()
+
         from factory.eval.languages.base import _run_cmd
 
         with patch("factory.eval.languages.base.subprocess.run") as mock_run:

--- a/tests/test_worktree_venv.py
+++ b/tests/test_worktree_venv.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from factory.eval.languages.python import _resolve_python
+from factory.eval.runner import _run_project_eval, _run_single_project_dimension
+from factory.models import AgentRunRequest, ProjectEvalDimension
+from factory.runners.claude import ClaudeRunner
 from factory.worktree import WORKTREE_VENV_MARKER, _setup_worktree_venv
 
 
@@ -142,4 +145,144 @@ class TestRunCmdVenvEnv:
 
         call_kwargs = mock_run.call_args
         env = call_kwargs.kwargs.get("env") or call_kwargs[1].get("env")
+        assert "VIRTUAL_ENV" not in env
+
+
+class TestBuildCommandVenvEnv:
+    def test_injects_venv_when_marker_exists(self, tmp_path: Path, monkeypatch: object) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)  # type: ignore[union-attr]
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (tmp_path / ".venv" / WORKTREE_VENV_MARKER).touch()
+
+        request = AgentRunRequest(
+            prompt="test", task="test", cwd=tmp_path, role="builder", skip_permissions=False
+        )
+        cmd, env, temp_files = ClaudeRunner().build_command(request)
+        try:
+            assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+            assert env["PATH"].startswith(str(venv_bin))
+        finally:
+            for f in temp_files:
+                f.unlink(missing_ok=True)
+
+    def test_no_venv_without_marker(self, tmp_path: Path, monkeypatch: object) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)  # type: ignore[union-attr]
+
+        request = AgentRunRequest(
+            prompt="test", task="test", cwd=tmp_path, role="builder", skip_permissions=False
+        )
+        cmd, env, temp_files = ClaudeRunner().build_command(request)
+        try:
+            assert "VIRTUAL_ENV" not in env
+        finally:
+            for f in temp_files:
+                f.unlink(missing_ok=True)
+
+
+class TestBuildInteractiveCommandVenvEnv:
+    def test_injects_venv_when_marker_exists(self, tmp_path: Path, monkeypatch: object) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)  # type: ignore[union-attr]
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (tmp_path / ".venv" / WORKTREE_VENV_MARKER).touch()
+
+        request = AgentRunRequest(
+            prompt="test", task="test", cwd=tmp_path, role="ceo", skip_permissions=False
+        )
+        cmd, env, temp_files = ClaudeRunner().build_interactive_command(request)
+        try:
+            assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+            assert env["PATH"].startswith(str(venv_bin))
+        finally:
+            for f in temp_files:
+                f.unlink(missing_ok=True)
+
+    def test_no_venv_without_marker(self, tmp_path: Path, monkeypatch: object) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)  # type: ignore[union-attr]
+
+        request = AgentRunRequest(
+            prompt="test", task="test", cwd=tmp_path, role="ceo", skip_permissions=False
+        )
+        cmd, env, temp_files = ClaudeRunner().build_interactive_command(request)
+        try:
+            assert "VIRTUAL_ENV" not in env
+        finally:
+            for f in temp_files:
+                f.unlink(missing_ok=True)
+
+
+class TestRunProjectEvalVenvEnv:
+    async def test_injects_venv_when_marker_exists(
+        self, tmp_path: Path, monkeypatch: object
+    ) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)  # type: ignore[union-attr]
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (tmp_path / ".venv" / WORKTREE_VENV_MARKER).touch()
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        mock_exec = AsyncMock(return_value=mock_proc)
+        with patch("factory.eval.runner.asyncio.create_subprocess_exec", mock_exec):
+            await _run_project_eval("echo ok", tmp_path)
+
+        env = mock_exec.call_args.kwargs["env"]
+        assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+        assert env["PATH"].startswith(str(venv_bin))
+
+    async def test_no_venv_without_marker(self, tmp_path: Path, monkeypatch: object) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)  # type: ignore[union-attr]
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        mock_exec = AsyncMock(return_value=mock_proc)
+        with patch("factory.eval.runner.asyncio.create_subprocess_exec", mock_exec):
+            await _run_project_eval("echo ok", tmp_path)
+
+        env = mock_exec.call_args.kwargs["env"]
+        assert "VIRTUAL_ENV" not in env
+
+
+class TestRunSingleDimensionVenvEnv:
+    async def test_injects_venv_when_marker_exists(
+        self, tmp_path: Path, monkeypatch: object
+    ) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)  # type: ignore[union-attr]
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        (tmp_path / ".venv" / WORKTREE_VENV_MARKER).touch()
+
+        dim = ProjectEvalDimension(name="test_dim", command="echo ok", timeout=30.0)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b'{"score": 1.0}', b"")
+        mock_proc.returncode = 0
+
+        mock_exec = AsyncMock(return_value=mock_proc)
+        with patch("factory.eval.runner.asyncio.create_subprocess_exec", mock_exec):
+            await _run_single_project_dimension(dim, tmp_path)
+
+        env = mock_exec.call_args.kwargs["env"]
+        assert env["VIRTUAL_ENV"] == str(tmp_path / ".venv")
+        assert env["PATH"].startswith(str(venv_bin))
+
+    async def test_no_venv_without_marker(self, tmp_path: Path, monkeypatch: object) -> None:
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)  # type: ignore[union-attr]
+
+        dim = ProjectEvalDimension(name="test_dim", command="echo ok", timeout=30.0)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b'{"score": 1.0}', b"")
+        mock_proc.returncode = 0
+
+        mock_exec = AsyncMock(return_value=mock_proc)
+        with patch("factory.eval.runner.asyncio.create_subprocess_exec", mock_exec):
+            await _run_single_project_dimension(dim, tmp_path)
+
+        env = mock_exec.call_args.kwargs["env"]
         assert "VIRTUAL_ENV" not in env


### PR DESCRIPTION
## Summary

Adds 8 tests covering the uncovered venv injection code paths from PR #1368, bringing `codecov/patch` coverage from 70% to ~100% on both gap files (well above the 79% target).

**Depends on:** #1368

### Tests added (in `tests/test_worktree_venv.py`)

| Test Class | Covers | Tests |
|---|---|---|
| `TestBuildCommandVenvEnv` | `ClaudeRunner.build_command()` venv injection | positive + negative |
| `TestBuildInteractiveCommandVenvEnv` | `ClaudeRunner.build_interactive_command()` venv injection | positive + negative |
| `TestRunProjectEvalVenvEnv` | `_run_project_eval()` venv injection | positive + negative |
| `TestRunSingleDimensionVenvEnv` | `_run_single_project_dimension()` venv injection | positive + negative |

Each site gets a positive test (`.factory-managed` marker exists → `VIRTUAL_ENV` and `PATH` injected) and a negative test (no marker → `VIRTUAL_ENV` absent).

### Coverage gaps addressed

- `factory/runners/claude.py` — 16.66% → ~100% patch coverage
- `factory/eval/runner.py` — 20% → ~100% patch coverage

## Test plan

- [x] All 19 venv tests pass (11 existing + 8 new) in 0.15s
- [x] Full suite: 4949 passed (16 pre-existing k8s env failures unrelated)
- [x] Lint clean (ruff)
- [x] Code review: 7/7 categories PASS
- [x] Adversarial QA: 19/19 tests verified with evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)