### PR TITLE
fix(ci): stop the runtime image build failing on the digest filename

### DIFF
--- a/.github/workflows/runtime-image.yml
+++ b/.github/workflows/runtime-image.yml
@@ -92,10 +92,17 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
+      # The digest is written as a filename with the `sha256:` prefix *stripped*, because
+      # `upload-artifact` rejects any path containing a colon — and a build job that dies here
+      # never reaches `manifest`, so the architectures are pushed by digest and no tag is ever
+      # created. The manifest step puts the prefix back.
       - name: Export the digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
+          set -eu
           mkdir -p /tmp/digests
-          touch "/tmp/digests/${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${DIGEST#sha256:}"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -178,6 +185,8 @@ jobs:
           for tag in $TAGS; do
             args="$args --tag ${IMAGE}:${tag}"
           done
+          # The filenames carry no `sha256:` prefix (upload-artifact forbids the colon); the sed
+          # keeps this correct if one ever arrives with it.
           docker buildx imagetools create $args \
             --tag "${IMAGE}:${GITHUB_SHA::12}" \
             $(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests | sed 's/^sha256://'))
@@ -186,11 +195,16 @@ jobs:
         env:
           TAG: ${{ steps.tags.outputs.primary }}
         run: |
+          set -eu
           tag="$TAG"
           docker buildx imagetools inspect "${IMAGE}:${tag}"
+          # Read the index with jq rather than grepping the raw bytes: whether buildx marshals the
+          # manifest list compact or indented is its business, and a whitespace change there would
+          # otherwise fail this check on an image that is perfectly good.
+          raw=$(docker buildx imagetools inspect "${IMAGE}:${tag}" --raw)
           for arch in amd64 arm64; do
-            docker buildx imagetools inspect "${IMAGE}:${tag}" --raw \
-              | grep -q "\"architecture\":\"${arch}\"" \
+            printf '%s' "$raw" \
+              | jq -e --arg a "$arch" '[.manifests[]?.platform.architecture] | index($a)' > /dev/null \
               || { echo "::error::${arch} is missing from the published manifest"; exit 1; }
           done
 


### PR DESCRIPTION
## The problem

`.github/workflows/runtime-image.yml` has **never** published a tag — 47 runs on record, 0 successes. Every one dies in the same place:

```
##[error]The path for one of the files in artifact is not valid:
/sha256:3417960f8aa9…  Contains the following character:  Colon :
```

`Export the digest` names its marker file after the raw build output, `sha256:<hex>`. `actions/upload-artifact@v4` rejects any path containing a colon, so both matrix legs fail *after* pushing their layers, and `manifest` (`needs: build`) is never reached. The two architectures have therefore only ever existed in ghcr.io as **untagged digests** — `:latest`, `:<sha>` and every release tag are absent.

That is the failure the file's own header warns about: `factory contained setup` pulls and does not build, so this is the entire cold start for a new user.

## The fix

1. Strip the `sha256:` prefix when naming the digest file, passed through `env:` rather than interpolated. The manifest step's existing `sed 's/^sha256://'` puts it back and stays tolerant of either form.
2. A latent second failure in a step that, because of the above, had **never once executed**: the architecture check grepped the raw manifest bytes for `"architecture":"amd64"`, which only matches when buildx marshals the index compactly. It now reads the index with `jq`, so a whitespace change cannot fail the check on a good image *after* the tags are already pushed.

## Verification

Dispatched on this branch under a throwaway tag, so an unmerged branch could not move `:latest` — [run 32533265869](https://github.com/akashgit/remote-factory/actions/runs/32533265869), green:

```
Publishing tags: digest-fix-probe
Name:      ghcr.io/akashgit/remote-factory/factory-runtime:digest-fix-probe
MediaType: application/vnd.oci.image.index.v1+json
  Platform:    linux/arm64
  Platform:    linux/amd64
```

…and the smoke test pulled that manifest and ran it: `factory --help`, `tmux 3.5a`, `git version 2.52.0`.

One piece of cleanup for someone with `packages: write` on the registry: the throwaway `:digest-fix-probe` tag can be deleted once this merges. On merge, the push to `main` republishes `:latest` and `:<sha>` for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)