### PR TITLE
feat: add GlaudeRunner for GLM-5.2 via RITS endpoint

### DIFF
--- a/factory/runners/__init__.py
+++ b/factory/runners/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from factory.runners._stream import should_stream, stream_subprocess
 from factory.runners.claude import ClaudeRunner
+from factory.runners.glaude import GlaudeRunner
 from factory.runners.protocol import Runner, RunnerMeta
 
 import structlog
@@ -16,6 +17,7 @@ __all__ = [
     "Runner",
     "RunnerMeta",
     "ClaudeRunner",
+    "GlaudeRunner",
     "get_runner",
     "get_available_runners",
     "get_runner_choices",
@@ -25,6 +27,7 @@ __all__ = [
 
 _RUNNERS: dict[str, type[Runner]] = {
     "claude": ClaudeRunner,  # type: ignore[dict-item]
+    "glaude": GlaudeRunner,  # type: ignore[dict-item]
 }
 
 

--- a/factory/runners/glaude.py
+++ b/factory/runners/glaude.py
@@ -1,0 +1,56 @@
+"""GlaudeRunner — Glaude (GLM-5.2 via RITS) CLI backend implementation.
+
+Glaude is a wrapper around Claude Code that routes through a CONNECT proxy
+to the RITS GLM-5.2 endpoint. It has the same CLI interface as claude —
+all flags, output formats, and session management work identically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from factory.runners.claude import ClaudeRunner
+
+if TYPE_CHECKING:
+    from factory.models import AgentRunRequest
+    from factory.runners.protocol import RunnerMeta
+
+
+class GlaudeRunner(ClaudeRunner):
+    """Runner implementation for Glaude (GLM-5.2 via RITS).
+
+    Inherits all behavior from ClaudeRunner — the only differences are the
+    binary name ('glaude' instead of 'claude') and metadata.
+    """
+
+    name: str = "glaude"
+
+    @classmethod
+    def metadata(cls) -> RunnerMeta:
+        from factory.runners.protocol import RunnerMeta
+
+        return RunnerMeta(
+            name="glaude",
+            display_name="Glaude (GLM-5.2 via RITS)",
+            binary="glaude",
+            install_hint="Run install-glaude-rits.sh to install ~/.local/bin/glaude",
+            supports_usage_telemetry=True,
+            supports_session_name=True,
+            supports_session_resume=True,
+            supports_background=True,
+        )
+
+    def build_command(
+        self, request: AgentRunRequest
+    ) -> tuple[list[str], dict[str, str], list[Path]]:
+        cmd, env, temp_files = super().build_command(request)
+        cmd[0] = "glaude"
+        return cmd, env, temp_files
+
+    def build_interactive_command(
+        self, request: AgentRunRequest
+    ) -> tuple[list[str], dict[str, str], list[Path]]:
+        cmd, env, temp_files = super().build_interactive_command(request)
+        cmd[0] = "glaude"
+        return cmd, env, temp_files


### PR DESCRIPTION
Thin subclass of ClaudeRunner that swaps the binary from 'claude' to 'glaude'. The glaude wrapper handles proxy routing and env setup identically to claude, so all command building, output parsing, and session management are inherited.

Usage: FACTORY_RUNNER=glaude factory ceo /path