### PR TITLE
docs: weekly update Aug 19-26

### DIFF
--- a/docs/weekly/2026-08-26.md
+++ b/docs/weekly/2026-08-26.md
@@ -1,0 +1,38 @@
+# Remote Factory — Weekly Update (Aug 19–26, 2026)
+
+22 PRs merged | 206 files changed | ~7,500 lines added | ~26,200 lines removed | net -18,700 LOC
+
+## Organization Transfer
+
+The repository moved from `akashgit/remote-factory` to `boston-harness-group/remote-factory`. A migration guide has been published at `docs/migration-guide.md` covering remote URL updates, install changes, and CI configuration. GitHub redirects are automatic — existing clones continue to work without immediate action.
+
+## Major Code Cleanup (-18,700 net LOC)
+
+- Dead runners removed: Bob, Codex, and OpenCode runners plus all associated tests (~4,000 lines) (#1334)
+- SkillOpt extracted to a separate package under the RobotSail org (~7,700 lines out) (#1371)
+- Orphaned code purged: compress module, templates, dead agent prompts (~1,200 lines) (#1374)
+- 13 deleted frontend-design agent prompts and 6 removed design check scripts (#1376)
+- SPEC.md trimmed from ~1,400 lines to essentials
+
+## New Features
+
+- Multi-benchmark outer loop (#1325): the outer loop can now evaluate against multiple benchmarks with exact_match, exit_code, JSON, and pytest evaluators — not just FeatureBench
+- Plugin mode for CREATE: `--plugin` and `--folder` flags let the factory create standalone plugin packages
+- Data schema verification for the frontend-design workflow (#1380)
+- Per-worktree venv isolation (#1368): concurrent factory sessions no longer share Python virtualenvs
+
+## Reliability and Testing
+
+- Smoke test harness for core CLI surfaces and factory modes (#1355, #1372)
+- Integration tests for design and create workflow gate paths (#1369)
+- Gate verdict parsing now fails closed on unrecognized output (#1354)
+- Tmux key submission hardened with structured completion detection (#1364)
+- ONNX embedding mock fixes flaky CI downloads (#1362)
+- Design mode now bootstraps factory.md and config.json automatically (#1336)
+
+## Documentation and CI
+
+- README overhauled — stripped to essentials, elevated the four primary workflows (#1300)
+- README decoupled from docs symlink, shared content via snippets (#1358)
+- MkDocs theme refreshed — monochrome palette, clean dark mode (#1337)
+- CEO review CI: added crqu to allowed users, fixed Claude Code postinstall

--- a/docs/weekly/2026-08-26.md
+++ b/docs/weekly/2026-08-26.md
@@ -1,22 +1,22 @@
 # Remote Factory — Weekly Update (Aug 19–26, 2026)
 
-22 PRs merged | 206 files changed | ~7,500 lines added | ~26,200 lines removed | net -18,700 LOC
+26 PRs merged | 206 files changed | ~7,500 lines added | ~26,200 lines removed | net -18,700 LOC
 
 ## Organization Transfer
 
-The repository moved from `akashgit/remote-factory` to `boston-harness-group/remote-factory`. A migration guide has been published at `docs/migration-guide.md` covering remote URL updates, install changes, and CI configuration. GitHub redirects are automatic — existing clones continue to work without immediate action.
+A migration guide has been published (`docs/migration-guide.md`) preparing for the planned transfer from `akashgit/remote-factory` to `boston-harness-group/remote-factory`. The guide covers remote URL updates, install changes, and CI configuration. The transfer has not yet been executed.
 
 ## Major Code Cleanup (-18,700 net LOC)
 
 - Dead runners removed: Bob, Codex, and OpenCode runners plus all associated tests (~4,000 lines) (#1334)
 - SkillOpt extracted to a separate package under the RobotSail org (~7,700 lines out) (#1371)
 - Orphaned code purged: compress module, templates, dead agent prompts (~1,200 lines) (#1374)
-- 13 deleted frontend-design agent prompts and 6 removed design check scripts (#1376)
+- Workflow migration cleanup: removed 13 frontend-design agent prompts, 6 design check scripts, and fixed 3 test bugs (#1376)
 - SPEC.md trimmed from ~1,400 lines to essentials
 
 ## New Features
 
-- Multi-benchmark outer loop (#1325): the outer loop can now evaluate against multiple benchmarks with exact_match, exit_code, JSON, and pytest evaluators — not just FeatureBench
+- Multi-benchmark outer loop (#1332): the outer loop can now evaluate against multiple benchmarks with exact_match, exit_code, JSON, and pytest evaluators — not just FeatureBench
 - Plugin mode for CREATE: `--plugin` and `--folder` flags let the factory create standalone plugin packages
 - Data schema verification for the frontend-design workflow (#1380)
 - Per-worktree venv isolation (#1368): concurrent factory sessions no longer share Python virtualenvs


### PR DESCRIPTION
Closes #41

## Changes
- Add `docs/weekly/2026-08-26.md` — a 1-page summary of remote-factory updates from Aug 19–26, 2026
- Covers org transfer, major code cleanup (-18,700 net LOC), new features, reliability improvements, and documentation updates
- Establishes the `docs/weekly/` directory for recurring weekly update artifacts