### PR TITLE
fix: Conditional propagates knobs and memory from child packages

### DIFF
--- a/factory/workflow/package.py
+++ b/factory/workflow/package.py
@@ -354,6 +354,8 @@ def Conditional(
 
     all_inputs = [inp for p in pkg_list for inp in p.inputs]
     all_outputs = [out for p in pkg_list for out in p.outputs]
+    all_knobs = [k for p in pkg_list for k in p.knobs]
+    all_memory = [m for p in pkg_list for m in p.memory]
 
     return Package(
         name=composed_name,
@@ -363,6 +365,8 @@ def Conditional(
         graph=graph,
         entry_node=gate.id,
         exit_node=exit_id,
+        knobs=all_knobs,
+        memory=all_memory,
     )
 
 

--- a/tests/test_package_ecosystem.py
+++ b/tests/test_package_ecosystem.py
@@ -635,3 +635,44 @@ class TestB8ConditionalUnknownLabel:
         b = _make_simple_package("b")
         result = Conditional(gate, {"PROCEED": a, "HALT": b})
         assert result is not None
+
+
+class TestConditionalKnobPropagation:
+    def test_conditional_propagates_knobs(self):
+        from factory.workflow.package import Conditional, OptKnob
+        pkg_a = Package(
+            name="a",
+            graph=Workflow(name="a", nodes={"a1": FnNode(id="a1", command="echo a")},
+                           edges=[], start_node="a1"),
+            entry_node="a1", exit_node="a1",
+            knobs=[OptKnob(name="style", kind="prompt", node_id="a1",
+                           default="fast", bounds=["fast", "slow"])],
+        )
+        pkg_b = Package(
+            name="b",
+            graph=Workflow(name="b", nodes={"b1": FnNode(id="b1", command="echo b")},
+                           edges=[], start_node="b1"),
+            entry_node="b1", exit_node="b1",
+            memory=[MemoryDeclaration(namespace="b", kind="kv")],
+        )
+        gate = GateNode(id="g1", evaluator_type="fn", evaluator_command="echo PROCEED")
+        cond = Conditional(gate, {"PROCEED": pkg_a, "HALT": pkg_b})
+        assert len(cond.knobs) == 1
+        assert cond.knobs[0].name == "style"
+        assert len(cond.memory) == 1
+        assert cond.memory[0].namespace == "b"
+
+    def test_conditional_compiles_with_knobs(self):
+        from factory.workflow.package import Conditional, OptKnob
+        pkg = Package(
+            name="x",
+            graph=Workflow(name="x", nodes={"x1": FnNode(id="x1", command="echo")},
+                           edges=[], start_node="x1"),
+            entry_node="x1", exit_node="x1",
+            knobs=[OptKnob(name="depth", kind="threshold", node_id="x1",
+                           default=3.0, bounds=[1.0, 5.0])],
+        )
+        gate = GateNode(id="g", evaluator_type="fn", evaluator_command="echo PROCEED")
+        cond = Conditional(gate, {"PROCEED": pkg})
+        wf = cond.compile()
+        assert wf.knob_values == {"depth": 3.0}


### PR DESCRIPTION
## Summary

`Conditional()` was missing knob and memory propagation from its child packages. Sequential, Parallel, and Loop all collect `knobs` and `memory` from their children — Conditional silently dropped them.

## Fix

Two lines added to `Conditional()` in `factory/workflow/package.py`:
```python
all_knobs = [k for p in pkg_list for k in p.knobs]
all_memory = [m for p in pkg_list for m in p.memory]
```

## Impact

Any `OptKnob` or `MemoryDeclaration` declared on a Package inside a Conditional branch was invisible to `compile()` and the outer loop. `KNOB_MUTATE` could never reach those knobs.

Found by @akashgit during review of #1384.

## Test plan

- [x] 36 package ecosystem tests pass (2 new)
- [x] Knob propagation through Conditional verified
- [x] compile() produces correct knob_values from Conditional children
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)