### PR TITLE
fix: greenfield finalization must persist Factory initialization without sharing per-run state

### DIFF
--- a/factory/state.py
+++ b/factory/state.py
@@ -1,5 +1,6 @@
 """Project state detection — determines which mode the factory should operate in."""
 
+import asyncio
 import subprocess
 from pathlib import Path
 
@@ -80,7 +81,25 @@ def detect_state(project_path: Path) -> ProjectState:
         log.info("detect_state_result", state=ProjectState.EVALS_PENDING_REVIEW.value)
         return ProjectState.EVALS_PENDING_REVIEW
 
+    # Auto-bootstrap: if factory.md exists but config.json is missing,
+    # regenerate config.json from factory.md without running discovery.
     factory_dir = project_path / ".factory"
+    factory_md = project_path / "factory.md"
+    if factory_md.exists() and not (factory_dir / "config.json").exists():
+        try:
+            from factory.store import ExperimentStore, ensure_factory_dir
+
+            ensure_factory_dir(factory_dir)
+            store = ExperimentStore(project_path)
+            asyncio.run(store.reparse_config())
+            log.info("auto_bootstrapped_from_factory_md", project=str(project_path))
+        except Exception:
+            log.warning(
+                "auto_bootstrap_failed",
+                project=str(project_path),
+                hint="factory.md exists but could not regenerate config.json",
+            )
+
     if (factory_dir / "config.json").exists():
         log.info("detect_state_result", state=ProjectState.HAS_FACTORY.value)
         return ProjectState.HAS_FACTORY

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -415,6 +415,85 @@ def _should_remove_worktree(branch: str) -> bool:
     return (value or "true").lower() in ("true", "1", "yes")
 
 
+def _is_greenfield_run(worktree_path: Path, project_path: Path) -> bool:
+    """Return True if main has no factory.md but the worktree does (non-symlink)."""
+    main_factory_md = project_path / "factory.md"
+    wt_factory_md = worktree_path / "factory.md"
+    return (
+        not main_factory_md.exists()
+        and wt_factory_md.exists()
+        and not wt_factory_md.is_symlink()
+    )
+
+
+def _finalize_greenfield(worktree_path: Path, project_path: Path, branch: str) -> bool:
+    """Ensure factory.md is tracked on the greenfield branch. Returns True on success."""
+    wt_factory_md = worktree_path / "factory.md"
+    if not wt_factory_md.exists():
+        log.warning("finalize_greenfield_no_factory_md", path=str(worktree_path))
+        return False
+
+    result = subprocess.run(
+        ["git", "ls-files", "factory.md"],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        log.info("finalize_greenfield_already_tracked", branch=branch)
+        return True
+
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Factory",
+        "GIT_AUTHOR_EMAIL": "factory@localhost",
+        "GIT_COMMITTER_NAME": "Factory",
+        "GIT_COMMITTER_EMAIL": "factory@localhost",
+    }
+
+    max_attempts = 3
+    for attempt in range(max_attempts):
+        add_result = subprocess.run(
+            ["git", "add", "factory.md"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+        )
+        if add_result.returncode != 0:
+            log.warning("finalize_greenfield_add_failed", stderr=add_result.stderr[:200])
+            return False
+
+        commit_result = subprocess.run(
+            ["git", "commit", "-m", "chore: track factory.md for greenfield initialization"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        if commit_result.returncode == 0:
+            break
+        if "lock" in commit_result.stderr.lower() and attempt < max_attempts - 1:
+            import time
+
+            time.sleep(0.2 * (attempt + 1))
+            continue
+        log.warning("finalize_greenfield_commit_failed", stderr=commit_result.stderr[:200])
+        return False
+
+    verify = subprocess.run(
+        ["git", "ls-files", "factory.md"],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+    )
+    if verify.returncode != 0 or not verify.stdout.strip():
+        log.warning("finalize_greenfield_postcondition_failed", branch=branch)
+        return False
+
+    log.info("finalize_greenfield_committed", branch=branch)
+    return True
+
+
 def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> None:
     """Remove a worktree and its branch. Safe to call on already-removed paths."""
     log.info("worktree_remove", branch=branch, path=str(worktree_path))
@@ -451,7 +530,6 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
                 )
             except Exception:
                 pass
-            import sys
 
             print(
                 f"Worktree retained: {worktree_path}\n"
@@ -459,6 +537,24 @@ def remove_worktree(project_path: Path, worktree_path: Path, branch: str) -> Non
                 file=sys.stderr,
             )
             return
+        if worktree_path != project_path and _is_greenfield_run(worktree_path, project_path):
+            if not _finalize_greenfield(worktree_path, project_path, branch):
+                log.warning(
+                    "greenfield_finalization_failed",
+                    worktree=str(worktree_path),
+                    branch=branch,
+                    hint="factory.md not committed; retaining worktree for recovery",
+                )
+                print(
+                    f"WARNING: Greenfield finalization failed — factory.md may not be tracked.\n"
+                    f"Worktree retained: {worktree_path}\n"
+                    f"To recover: cd {worktree_path} && git add factory.md && "
+                    f"git commit -m 'chore: track factory.md'\n"
+                    f"Then clean up: git worktree remove {worktree_path} && git branch -D {branch}",
+                    file=sys.stderr,
+                )
+                return
+
         _sync_backlog_to_main(worktree_path, project_path)
         _sync_bootstrap_to_main(worktree_path, project_path)
         _preserve_telemetry(worktree_path, project_path)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -154,6 +154,49 @@ class TestHasOpenPlanIssues:
             assert _has_open_plan_issues(tmp_project) is False
 
 
+class TestAutoBootstrapFromFactoryMd:
+    def test_bootstrap_from_factory_md_when_config_missing(self, tmp_project):
+        """detect_state returns HAS_FACTORY when factory.md exists but config.json does not."""
+        factory_md = tmp_project / "factory.md"
+        factory_md.write_text(
+            "# Goal\nTest project\n\n"
+            "# Modifiable\n- src/\n\n"
+            "# Command\npytest\n\n"
+            "# Threshold\n0.8\n"
+        )
+        assert not (tmp_project / ".factory" / "config.json").exists()
+        state = detect_state(tmp_project)
+        assert state == ProjectState.HAS_FACTORY
+        assert (tmp_project / ".factory" / "config.json").exists()
+
+    def test_malformed_factory_md_logs_warning_no_crash(self, tmp_project):
+        """When reparse_config fails, detect_state logs warning but does not crash."""
+        (tmp_project / "factory.md").write_text("# Goal\nTest\n")
+        with patch(
+            "factory.state.asyncio.run",
+            side_effect=RuntimeError("reparse failed"),
+        ):
+            with patch("factory.state.log") as mock_log:
+                state = detect_state(tmp_project)
+        mock_log.warning.assert_any_call(
+            "auto_bootstrap_failed",
+            project=str(tmp_project),
+            hint="factory.md exists but could not regenerate config.json",
+        )
+        assert state == ProjectState.NO_FACTORY
+
+    def test_existing_project_with_config_unaffected(self, tmp_project):
+        """Projects with both factory.md and config.json are unaffected."""
+        factory_dir = tmp_project / ".factory"
+        factory_dir.mkdir()
+        (factory_dir / "config.json").write_text(
+            '{"goal":"x","scope":[],"guards":[],"eval_command":"x","eval_threshold":0.8,"constraints":[]}'
+        )
+        (tmp_project / "factory.md").write_text("# Goal\nTest\n")
+        state = detect_state(tmp_project)
+        assert state == ProjectState.HAS_FACTORY
+
+
 class TestDetectStateWithIssues:
     def test_repo_incomplete_with_open_issues(self, tmp_project):
         """detect_state returns REPO_INCOMPLETE when plan issues exist."""

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -10,7 +10,9 @@ import pytest
 from factory.worktree import (
     _SHARED_SYMLINK_ENTRIES,
     _bootstrap_unborn_repo,
+    _finalize_greenfield,
     _has_active_sessions,
+    _is_greenfield_run,
     _is_unborn_repo,
     _preserve_telemetry,
     _seed_experiment_factory,
@@ -1394,3 +1396,112 @@ class TestSelectiveWorktreeIsolation:
 
         assert (wt_path / ".factory" / "strategy").is_dir()
         assert not (wt_path / ".factory" / "strategy" / "backlog.md").exists()
+
+
+class TestIsGreenfieldRun:
+    def test_greenfield_detected(self, git_project: Path) -> None:
+        """Greenfield: main has no factory.md, worktree does."""
+        wt_path, _ = create_worktree(git_project)
+        assert not (git_project / "factory.md").exists()
+        (wt_path / "factory.md").write_text("# Goal\nTest\n")
+        assert _is_greenfield_run(wt_path, git_project) is True
+
+    def test_not_greenfield_when_main_has_factory_md(self, git_project: Path) -> None:
+        """Not greenfield when main already has factory.md."""
+        (git_project / "factory.md").write_text("# Goal\nExisting\n")
+        wt_path, _ = create_worktree(git_project)
+        (wt_path / "factory.md").write_text("# Goal\nTest\n")
+        assert _is_greenfield_run(wt_path, git_project) is False
+
+    def test_not_greenfield_when_worktree_has_no_factory_md(self, git_project: Path) -> None:
+        """Not greenfield when worktree has no factory.md."""
+        wt_path, _ = create_worktree(git_project)
+        assert _is_greenfield_run(wt_path, git_project) is False
+
+
+class TestFinalizeGreenfield:
+    def test_commits_untracked_factory_md(self, git_project: Path) -> None:
+        """_finalize_greenfield commits factory.md when untracked."""
+        wt_path, branch = create_worktree(git_project)
+        (wt_path / "factory.md").write_text("# Goal\nTest project\n")
+
+        result = _finalize_greenfield(wt_path, git_project, branch)
+
+        assert result is True
+        ls_files = subprocess.run(
+            ["git", "ls-files", "factory.md"],
+            cwd=wt_path,
+            capture_output=True,
+            text=True,
+        )
+        assert ls_files.stdout.strip() == "factory.md"
+
+    def test_noop_when_already_tracked(self, git_project: Path) -> None:
+        """_finalize_greenfield is a no-op when factory.md is already tracked."""
+        env = {
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@test.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@test.com",
+            "HOME": str(git_project.parent),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+        }
+        wt_path, branch = create_worktree(git_project)
+        (wt_path / "factory.md").write_text("# Goal\nTest\n")
+        subprocess.run(["git", "add", "factory.md"], cwd=wt_path, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add factory.md"],
+            cwd=wt_path,
+            capture_output=True,
+            check=True,
+            env=env,
+        )
+
+        result = _finalize_greenfield(wt_path, git_project, branch)
+        assert result is True
+
+    def test_returns_false_when_no_factory_md(self, git_project: Path) -> None:
+        """_finalize_greenfield returns False when factory.md does not exist."""
+        wt_path, branch = create_worktree(git_project)
+        result = _finalize_greenfield(wt_path, git_project, branch)
+        assert result is False
+
+
+class TestRemoveWorktreeGreenfield:
+    def test_retains_worktree_on_finalization_failure(self, git_project: Path) -> None:
+        """remove_worktree retains worktree when greenfield finalization fails."""
+        wt_path, branch = create_worktree(git_project)
+        (wt_path / "factory.md").write_text("# Goal\nTest\n")
+
+        with patch("factory.worktree._finalize_greenfield", return_value=False):
+            remove_worktree(git_project, wt_path, branch)
+
+        assert wt_path.exists()
+
+    def test_proceeds_normally_for_non_greenfield(self, git_project: Path) -> None:
+        """remove_worktree proceeds normally for non-greenfield runs (regression)."""
+        wt_path, branch = create_worktree(git_project)
+        assert wt_path.exists()
+
+        remove_worktree(git_project, wt_path, branch)
+
+        assert not wt_path.exists()
+
+    def test_greenfield_success_removes_worktree(self, git_project: Path) -> None:
+        """remove_worktree removes worktree after successful greenfield finalization."""
+        wt_path, branch = create_worktree(git_project)
+        (wt_path / "factory.md").write_text("# Goal\nTest\n")
+
+        with patch("factory.worktree._finalize_greenfield", return_value=True):
+            remove_worktree(git_project, wt_path, branch)
+
+        assert not wt_path.exists()
+
+    def test_no_worktree_mode_skips_finalization(self, git_project: Path) -> None:
+        """When worktree_path == project_path, skip greenfield finalization."""
+        (git_project / "factory.md").write_text("# Goal\nTest\n")
+
+        with patch("factory.worktree._finalize_greenfield") as mock_finalize:
+            remove_worktree(git_project, git_project / "nonexistent", "factory/run-test")
+
+        mock_finalize.assert_not_called()


### PR DESCRIPTION
Closes #1391

## Changes

- **`factory/state.py` — auto-bootstrap config from tracked `factory.md`**: When `detect_state()` finds `factory.md` at the project root but no `.factory/config.json`, it calls `reparse_config()` to regenerate config without running discovery. On failure (malformed factory.md), logs a warning and falls through—never crashes.

- **`factory/worktree.py` — `_finalize_greenfield()` + `_is_greenfield_run()`**: Before worktree cleanup, detects greenfield runs (main has no `factory.md`, worktree does). If `factory.md` is untracked on the branch, commits it with a dedicated finalization commit. Includes retry with 200ms backoff for git lock contention and postcondition verification.

- **`factory/worktree.py` — `remove_worktree()` integration**: Calls greenfield finalization before sync/cleanup. On failure, retains the worktree and prints actionable recovery instructions to stderr. Skips finalization in no-worktree mode (`worktree_path == project_path`).

- **Tests**: 10 new tests covering auto-bootstrap from factory.md, malformed factory.md warning, existing project regression, greenfield detection, finalization commit, already-tracked no-op, worktree retention on failure, non-greenfield regression, successful greenfield cleanup, and no-worktree mode.

### Explicit non-changes
- `.factory/config.json` stays gitignored—never committed
- No modifications to `_SHARED_SYMLINK_ENTRIES`, `_COPY_ENTRIES`, or `_EXPERIMENT_SEED_ENTRIES`
- No copying of `.factory/strategy/`, `reviews/`, or `state/` to main
- No discovery in the auto-bootstrap path
- Existing-project behavior unchanged