### PR TITLE
fix: add observability to prompt rewriter and knob expander

### DIFF
--- a/factory/outer_loop/mutations.py
+++ b/factory/outer_loop/mutations.py
@@ -552,11 +552,19 @@ def default_prompt_rewriter(
             ["claude", "-p", prompt, "--model", "opus",
              "--append-system-prompt", "Output only the prompt text.",
              "--max-turns", "1", "--output-format", "text"],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True, text=True, timeout=120,
         )
         result = proc.stdout.strip()
+        if result:
+            log.info("prompt_rewritten", node=node_id, len=len(result))
+        else:
+            log.warning("prompt_rewriter_empty", node=node_id)
         return result if result else None
-    except Exception:
+    except subprocess.TimeoutExpired:
+        log.warning("prompt_rewriter_timeout", node=node_id, timeout=120)
+        return None
+    except Exception as exc:
+        log.warning("prompt_rewriter_error", node=node_id, error=str(exc))
         return None
 
 
@@ -599,7 +607,8 @@ def mutate_prompt(
     try:
         updated = node.model_copy(update={"prompt_template": new_prompt})
         wf.nodes[node_id] = updated  # type: ignore[assignment]
-    except Exception:
+    except Exception as exc:
+        log.warning("prompt_mutate_validation_failed", node=node_id, error=str(exc))
         return None
 
     record = MutationRecord(
@@ -637,16 +646,22 @@ def default_knob_expander(
             ["claude", "-p", prompt, "--model", "opus",
              "--append-system-prompt", "Output only the value, no explanation.",
              "--max-turns", "1", "--output-format", "text"],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True, text=True, timeout=120,
         )
         result = proc.stdout.strip()
         if not result:
+            log.warning("knob_expander_empty", knob=knob_name)
             return None
+        log.info("knob_expanded_via_cli", knob=knob_name, value=result[:40])
         try:
             return float(result)
         except ValueError:
             return result[:80]
-    except Exception:
+    except subprocess.TimeoutExpired:
+        log.warning("knob_expander_timeout", knob=knob_name, timeout=120)
+        return None
+    except Exception as exc:
+        log.warning("knob_expander_error", knob=knob_name, error=str(exc))
         return None
 
 


### PR DESCRIPTION
## Summary

- **Timeout bump**: 60s → 120s for both `default_prompt_rewriter` and `default_knob_expander` CLI calls. 60s was causing silent failures — Opus needs time for quality prompt rewrites.
- **Structured logging**: Every failure path now emits a structlog event:
  - `prompt_rewritten` / `prompt_rewriter_empty` / `prompt_rewriter_timeout` / `prompt_rewriter_error`
  - `prompt_mutate_validation_failed` (when rewritten prompt fails Pydantic model_copy)
  - `knob_expanded_via_cli` / `knob_expander_empty` / `knob_expander_timeout` / `knob_expander_error`

Previously, all `except Exception: return None` paths swallowed errors silently, making it impossible to diagnose why `PROMPT_MUTATE` succeeded at a lower rate than its configured weight.

Discovered while running the chess evolution demo — prompt mutations were ~17% of actual mutations despite 50% weight. The logging confirmed the rewriter works (20/20 successes) but the missing observability would have left us guessing.

## Test plan

- [x] All 35 mutation tests pass
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] Verified in chess demo: 20 consecutive `prompt_rewritten` events, 0 timeouts/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)