### PR TITLE
fix: PROMPT_MUTATE persists in knob_values for compile() round-trips

### DIFF
--- a/factory/outer_loop/mutations.py
+++ b/factory/outer_loop/mutations.py
@@ -599,8 +599,14 @@ def mutate_prompt(
     try:
         updated = node.model_copy(update={"prompt_template": new_prompt})
         wf.nodes[node_id] = updated  # type: ignore[assignment]
-    except Exception:
+    except Exception as exc:
+        log.warning("prompt_mutate_validation_failed", node=node_id, error=str(exc))
         return None
+
+    # Persist in knob_values so the mutation survives Package.compile() round-trips
+    prompt_knob = f"_prompt_{node_id}"
+    wf.knob_values[prompt_knob] = new_prompt
+    wf.knob_expandable[prompt_knob] = f"Prompt for {node_id}"
 
     record = MutationRecord(
         operator=MutationType.PROMPT_MUTATE,

--- a/factory/workflow/package.py
+++ b/factory/workflow/package.py
@@ -137,12 +137,23 @@ class Package(BaseModel):
         survive compile() round-trips.
         """
         wf = self.graph.model_copy(deep=True)
+        # Preserve _prompt_* entries from previous mutations before overwriting
+        saved_prompts = {
+            k: v for k, v in wf.knob_values.items()
+            if k.startswith("_prompt_")
+        }
+        saved_expandable = {
+            k: v for k, v in wf.knob_expandable.items()
+            if k.startswith("_prompt_")
+        }
         if self.knobs:
             wf.knob_values = {k.name: k.default for k in self.knobs}
             wf.knob_bounds = {k.name: list(k.bounds) for k in self.knobs if k.bounds}
             wf.knob_expandable = {
                 k.name: k.expansion_hint for k in self.knobs if k.expandable
             }
+        wf.knob_values.update(saved_prompts)
+        wf.knob_expandable.update(saved_expandable)
         for key, val in list(wf.knob_values.items()):
             if key.startswith("_prompt_") and isinstance(val, str):
                 node_id = key[len("_prompt_"):]

--- a/factory/workflow/package.py
+++ b/factory/workflow/package.py
@@ -130,7 +130,12 @@ class Package(BaseModel):
         return self.model_copy(update={"knobs": new_knobs})
 
     def compile(self) -> Workflow:
-        """Lower this package to a flat, mutable Workflow IR."""
+        """Lower this package to a flat, mutable Workflow IR.
+
+        Prompt knobs (``_prompt_<node_id>`` in knob_values) are applied
+        back to node prompt_templates so that PROMPT_MUTATE mutations
+        survive compile() round-trips.
+        """
         wf = self.graph.model_copy(deep=True)
         if self.knobs:
             wf.knob_values = {k.name: k.default for k in self.knobs}
@@ -138,6 +143,17 @@ class Package(BaseModel):
             wf.knob_expandable = {
                 k.name: k.expansion_hint for k in self.knobs if k.expandable
             }
+        for key, val in list(wf.knob_values.items()):
+            if key.startswith("_prompt_") and isinstance(val, str):
+                node_id = key[len("_prompt_"):]
+                node = wf.nodes.get(node_id)
+                if node and hasattr(node, "prompt_template"):
+                    try:
+                        wf.nodes[node_id] = node.model_copy(
+                            update={"prompt_template": val}
+                        )
+                    except Exception:
+                        pass
         return wf
 
 


### PR DESCRIPTION
## Summary

Fixes #1410.

`mutate_prompt()` now stores the rewritten prompt in `knob_values` under a synthetic `_prompt_<node_id>` key. `Package.compile()` reads these back and applies them to node `prompt_templates`.

**Without this fix, PROMPT_MUTATE has no effect** in any outer loop that rebuilds from config:

```python
child_wf, rec = apply_random_mutation(parent_wf, ...)  # prompt rewritten on IR
child_pipeline = build_pipeline(cfg)  # rebuilds from config, prompt lost
result = evaluate(child_pipeline)      # evaluates with ORIGINAL prompt
```

Discovered in the chess demo: after 30+ generations with 50% PROMPT_MUTATE weight and 38/38 successful Opus rewrites, every prompt mutation was evaluated with the original prompt. The rewritten prompts were silently discarded.

## Changes

- `mutate_prompt()` writes `_prompt_<node_id> = new_prompt` to `wf.knob_values`
- `Package.compile()` applies `_prompt_*` knobs back to nodes after compilation
- Prompt mutations now survive the `config → Package → compile()` round-trip

## Test plan

- [x] All 71 mutation + package ecosystem tests pass
- [x] End-to-end round-trip test: mutate → store in knob_values → compile() → prompt applied
- [x] `ruff check` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)