### PR TITLE
fix: eliminate no-op knob mutations

### DIFF
--- a/factory/outer_loop/mutations.py
+++ b/factory/outer_loop/mutations.py
@@ -724,8 +724,16 @@ def mutate_knob(
                 new_val = float(new_val)
             except ValueError:
                 pass
-    else:
-        knob_name = random.choice(knob_names)
+        # Skip no-op: guided value same as current
+        if str(new_val) == str(old_val):
+            new_val = None
+            guided_knob = None
+    if not guided_knob:
+        # Exclude synthetic _prompt_* knobs (handled by PROMPT_MUTATE)
+        real_knobs = [k for k in knob_names if not k.startswith("_prompt_")]
+        if not real_knobs:
+            return None
+        knob_name = random.choice(real_knobs)
         old_val = wf.knob_values[knob_name]
         bounds = wf.knob_bounds.get(knob_name, [])
         new_val = None


### PR DESCRIPTION
## Summary

Two fixes to `mutate_knob()` that waste evaluation slots:

1. **Guided no-op detection**: when the reflector suggests a value that matches the current value (`theory -> theory`, `False -> False`), skip it and fall through to random selection instead of evaluating an identical config.

2. **Exclude `_prompt_*` synthetic knobs**: these are created by `PROMPT_MUTATE` (#1411) to persist prompts through `compile()` round-trips. `KNOB_MUTATE` should not randomly select them since they contain full prompt text, not tunable parameter values.

Discovered in the chess demo: ~15% of knob mutations were no-ops (`theory -> theory`, `2.0 -> 2.0`, `False -> False`), wasting evaluation budget on configs identical to the parent.

## Test plan

- [x] All 35 mutation tests pass
- [x] `ruff check` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)