### PR TITLE
perf: add --bare flag to agent subprocess calls

### DIFF
--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -116,6 +116,7 @@ class ClaudeRunner:
             "--output-format",
             "stream-json",
             "--verbose",
+            "--bare",
             "--disallowedTools",
             "Agent",
         ]
@@ -300,6 +301,7 @@ class ClaudeRunner:
             "claude",
             "--append-system-prompt-file",
             prompt_file.name,
+            "--bare",
         ]
         settings_file = request.extras.get("settings_file")
         if settings_file:


### PR DESCRIPTION
## Summary

Fixes #1420.

Adds `--bare` to both `_build_headless_cmd` methods in `factory/runners/claude.py`. This skips hooks, LSP, and plugin loading on every agent subprocess invocation, saving ~1-2s of startup overhead per call.

Discovered in the chess-evolve demo: 225 subprocess spawns per variant × ~2s overhead = ~7.5 minutes of pure startup overhead per variant.

## Test plan

- [x] `--bare` is compatible with `--verbose` and other flags
- [x] `ruff check` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)