### PR TITLE
feat: reflector includes prompt mutations in contrastive analysis

### DIFF
--- a/factory/outer_loop/reflector.py
+++ b/factory/outer_loop/reflector.py
@@ -240,12 +240,16 @@ class OuterLoopReflector:
             all_knob_names.update(kv.keys())
 
         for knob in sorted(all_knob_names):
+            is_prompt = knob.startswith("_prompt_") or knob.startswith("prompt_")
             val_scores: dict[str, list[float]] = {}
             for id_, score, _ in all_sorted:
                 kv = knob_values_by_id.get(id_, {})
                 val = str(kv.get(knob, ""))
-                if val:
-                    val_scores.setdefault(val, []).append(score)
+                if not val:
+                    continue
+                if is_prompt:
+                    val = val[:100]
+                val_scores.setdefault(val, []).append(score)
 
             if len(val_scores) < 2:
                 continue
@@ -259,9 +263,14 @@ class OuterLoopReflector:
             gap = avg_by_val[best_val] - avg_by_val[worst_val]
 
             if gap > 0:
+                op = "PROMPT_MUTATE" if is_prompt else "KNOB_MUTATE"
+                display_best = best_val[:60] + "..." if len(best_val) > 60 else best_val
+                display_worst = worst_val[:60] + "..." if len(worst_val) > 60 else worst_val
                 report.mutation_suggestions.append(
-                    f"KNOB_MUTATE: {knob}={best_val} (avg score {avg_by_val[best_val]:+.0f}) "
-                    f"outperforms {knob}={worst_val} ({avg_by_val[worst_val]:+.0f}) by {gap:.0f}"
+                    f"{op}: {knob}={display_best} "
+                    f"(avg score {avg_by_val[best_val]:+.0f}) "
+                    f"outperforms {knob}={display_worst} "
+                    f"({avg_by_val[worst_val]:+.0f}) by {gap:.0f}"
                 )
 
         # Top-K vs bottom-K: which knobs differ consistently?


### PR DESCRIPTION
## Summary

Fixes #1418.

`_extract_knob_patterns` now recognizes `_prompt_*` and `prompt_*` keys in `knob_values_by_id`:
- Truncates prompt values to 100 chars for comparison (full text would make every value unique)
- Reports `PROMPT_MUTATE` suggestions instead of `KNOB_MUTATE` for prompt-type keys
- Displays truncated values (60 chars) in suggestions

Without this, the reflector can see that a prompt mutation happened but can't compare prompt content between winners and losers.

## Test plan

- [x] All 7 reflector tests pass
- [x] `ruff check` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)