### PR TITLE
fix: don't halt workflow on agent non-zero exit code

### DIFF
--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -843,7 +843,12 @@ class WorkflowExecutor:
         )
 
         if code != 0:
-            raise RuntimeError(f"agent {node.role.value} exited with code {code}")
+            log.warning(
+                "agent_nonzero_exit",
+                role=node.role.value,
+                code=code,
+                output_len=len(stdout),
+            )
 
         return stdout
 


### PR DESCRIPTION
## Summary

Fixes #1415.

`_run_agent` was raising `RuntimeError` when `invoke_agent` returned a non-zero exit code, which caused the executor to set `result.halted = True` and abort all remaining nodes (including nodes in other fork branches).

Now logs a warning and returns the stdout instead. Non-zero exit codes are treated as degraded output, not fatal failures. The workflow continues with whatever the agent produced.

Discovered in chess-evolve: any custom `invoke_agent` that returned code 1 (e.g., on empty LLM response) killed the entire pipeline run.

## Test plan

- [x] All 39 executor tests pass
- [x] `ruff check` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)