### PR TITLE
feat: add formalize workflow — MCMC algorithm → Lean-verified implementation

### DIFF
--- a/.factory/workflows/formalize.py
+++ b/.factory/workflows/formalize.py
@@ -1,0 +1,453 @@
+"""Formalize mode — MCMC algorithm idea -> Lean-verified implementation + Julia reference.
+
+Pipeline:
+  fork_research -> [3 researchers] -> join_research -> gate_research ->
+  strategist -> gate_strategy -> archivist_plan(async) ->
+  builder_theory(max 5) -> gate_theory -> gate_theory_review ->
+  builder_ir(max 3) -> gate_ir ->
+  fn_generate -> fork_qa -> [3 FnNodes] -> join_qa -> gate_qa ->
+  archivist_build(async)
+
+Reloop edges:
+  gate_theory -> builder_theory (max 5)
+  gate_ir -> builder_ir (max 3)
+  gate_qa -> builder_ir (max 3)
+
+Terminal mode. Focus-only (requires --focus).
+"""
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    ArtifactCheck,
+    Edge,
+    FnNode,
+    ForkNode,
+    GateNode,
+    JoinNode,
+    VerdictType,
+    Workflow,
+)
+
+meta = {
+    "name": "formalize",
+    "description": (
+        "Formalize mode — turn MCMC algorithm ideas into Lean-verified "
+        "implementations with auto-generated Reference Julia code. "
+        "Focus-only terminal workflow. Use with --focus describing the "
+        "algorithm to formalize."
+    ),
+}
+
+
+def workflow() -> Workflow:
+    """Build the formalize workflow."""
+    nodes: dict[str, AgentNode | FnNode | GateNode | ForkNode | JoinNode] = {}
+    edges: list[Edge] = []
+
+    # ── Research Phase — Fork/Join/Gate ──────────────────────────
+
+    nodes["fork_research"] = ForkNode(
+        id="fork_research",
+        targets=["researcher_patterns", "researcher_mathlib", "researcher_algorithm"],
+    )
+
+    nodes["researcher_patterns"] = AgentNode(
+        id="researcher_patterns",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Formalization patterns analysis. "
+            "Analyze how existing samplers are formalized in {project_path}/formal/Mcmc/. "
+            "Study the pattern: Kernel theory (formal/Mcmc/Kernel/ or Mcmc/Hamiltonian/) "
+            "-> Executable refinement (formal/Mcmc/Executable/Continuous/) "
+            "-> CompilerIR program -> IRFormat emission. "
+            "Read 2-3 existing examples end-to-end (e.g. RWMH: "
+            "Kernel/GaussianRandomWalk.lean + Executable/Continuous/RWMH.lean "
+            "+ Executable/Continuous/CompilerIR.lean). "
+            "Document the module structure, naming conventions, import patterns, "
+            "proof strategies, and how theorems connect kernel specs to executable refinements. "
+            "Write findings to .factory/strategy/research-patterns.md."
+        ),
+        writes={".factory/strategy/research-patterns.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-patterns.md",
+                must_exist=True,
+                min_size=50,
+            )
+        ],
+    )
+
+    nodes["researcher_mathlib"] = AgentNode(
+        id="researcher_mathlib",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Mathlib API discovery for the target algorithm. "
+            "Read the --focus description from the CEO task to understand "
+            "which algorithm is being formalized. "
+            "Search {project_path}/.lake/packages/mathlib/Mathlib/ for relevant lemmas "
+            "covering: measure theory, probability, linear algebra, topology, analysis. "
+            "Check {project_path}/formal/lean-toolchain for the pinned Lean/mathlib version. "
+            "Document available theorems that the formalization can reuse — "
+            "provide exact module paths and theorem names. "
+            "Write findings to .factory/strategy/research-mathlib.md."
+        ),
+        writes={".factory/strategy/research-mathlib.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-mathlib.md",
+                must_exist=True,
+                min_size=50,
+            )
+        ],
+    )
+
+    nodes["researcher_algorithm"] = AgentNode(
+        id="researcher_algorithm",
+        role=AgentRole.RESEARCHER,
+        prompt_template=(
+            "Algorithm specification parsing. "
+            "Read the --focus description from the CEO task. "
+            "Parse the algorithm description into a precise mathematical specification. "
+            "Identify: the state space, the proposal mechanism, the acceptance criterion, "
+            "what needs to be proved (detailed balance, stationarity, invariance, reversibility), "
+            "what IR primitives are needed (sample_gaussian, compute_log_density, etc.), "
+            "and what the signature of the resulting executable function should be. "
+            "Write findings to .factory/strategy/research-algorithm.md."
+        ),
+        writes={".factory/strategy/research-algorithm.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/research-algorithm.md",
+                must_exist=True,
+                min_size=50,
+            )
+        ],
+    )
+
+    nodes["join_research"] = JoinNode(
+        id="join_research",
+        sources=["researcher_patterns", "researcher_mathlib", "researcher_algorithm"],
+    )
+
+    nodes["gate_research"] = GateNode(
+        id="gate_research",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Review the three research outputs for the formalization. "
+            "Check: (1) Are existing formalization patterns well-documented with concrete examples? "
+            "(2) Are relevant mathlib lemmas identified with exact paths? "
+            "(3) Is the algorithm specification mathematically precise with clear proof targets? "
+            "PROCEED if all three are adequate. RELOOP if any research is shallow or missing key details."
+        ),
+        reads={
+            ".factory/strategy/research-patterns.md",
+            ".factory/strategy/research-mathlib.md",
+            ".factory/strategy/research-algorithm.md",
+        },
+    )
+
+    # ── Strategy Phase ──────────────────────────────────────────
+
+    nodes["strategist"] = AgentNode(
+        id="strategist",
+        role=AgentRole.STRATEGIST,
+        prompt_template=(
+            "Synthesize a formalization plan from the three research outputs. "
+            "Read .factory/strategy/research-patterns.md, research-mathlib.md, "
+            "and research-algorithm.md. "
+            "Produce a concrete implementation plan covering: "
+            "1) Lean module structure — which files to create under formal/Mcmc/ "
+            "2) Theorem statements — what to prove and in what order "
+            "3) IR program design — what CompilerIR programs to add "
+            "4) IRFormat wiring — how to connect to formal/Mcmc/Executable/IRFormat.lean "
+            "5) Mathlib reuse map — which existing lemmas to reference "
+            "6) Module dependency graph — build order for lake build "
+            "7) formal/Mcmc.lean update plan — new import lines "
+            "Write the plan to .factory/strategy/current.md."
+        ),
+        reads={
+            ".factory/strategy/research-patterns.md",
+            ".factory/strategy/research-mathlib.md",
+            ".factory/strategy/research-algorithm.md",
+        },
+        writes={".factory/strategy/current.md"},
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/strategy/current.md",
+                must_exist=True,
+                min_size=200,
+            )
+        ],
+    )
+
+    nodes["gate_strategy"] = GateNode(
+        id="gate_strategy",
+        evaluator_type="user",
+        reads={".factory/strategy/current.md"},
+    )
+
+    # ── Archivist (plan archive, non-blocking) ──────────────────
+
+    nodes["archivist_plan"] = AgentNode(
+        id="archivist_plan",
+        role=AgentRole.ARCHIVIST,
+        prompt_template=(
+            "Archive the approved formalization plan. "
+            "Record the algorithm being formalized, the module structure, "
+            "theorem proof order, and mathlib dependencies."
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/archive/formalize-plan.md"},
+        blocking=False,
+    )
+
+    # ── Build Phase 1 — Theory + Executable Refinement ──────────
+
+    nodes["builder_theory"] = AgentNode(
+        id="builder_theory",
+        role=AgentRole.BUILDER,
+        prompt_template=(
+            "Implement the Lean kernel theory and executable refinement. "
+            "Read the approved formalization plan at .factory/strategy/current.md. "
+            "Read CLAUDE.md for project conventions. "
+            "Create the Lean modules specified in the plan: "
+            "- Kernel theory module(s) under formal/Mcmc/Kernel/ or appropriate subdirectory "
+            "- Executable refinement module(s) under formal/Mcmc/Executable/ "
+            "- Refinement theorems connecting the IR program to the mathematical kernel "
+            "- Module docstrings and public definition docstrings per CLAUDE.md conventions "
+            "Constraints: No sorry, admit, or axiom. Reuse mathlib lemmas from the plan. "
+            "After writing the Lean code, run 'cd formal && lake build' to check compilation. "
+            "If compilation fails, fix the errors before reporting completion. "
+            "Commit changes when compilation succeeds."
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/reviews/builder-latest.md"},
+        max_iterations=5,
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/reviews/builder-latest.md",
+                must_exist=True,
+                min_size=100,
+            )
+        ],
+    )
+
+    nodes["gate_theory"] = GateNode(
+        id="gate_theory",
+        evaluator_type="fn",
+        evaluator_command="cd {project_path}/formal && lake build",
+        gate_prompt=(
+            "Lean proof compilation gate. The lake build command is the proof verifier — "
+            "if it exits 0, all theorems type-check and the math is correct. "
+            "RELOOP to builder_theory on compilation failure (max 5 iterations)."
+        ),
+    )
+
+    nodes["gate_theory_review"] = GateNode(
+        id="gate_theory_review",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Review the compiled Lean proofs. "
+            "Read the builder output at .factory/reviews/builder-latest.md. "
+            "Check git diff for the new .lean files. Verify: "
+            "(1) Module structure matches the approved plan "
+            "(2) Theorem names and types are meaningful "
+            "(3) No sorry, admit, or axiom in the code "
+            "(4) Module docstrings are present "
+            "PROCEED to IR phase if proofs are well-structured. "
+            "HALT if fundamental issues require re-planning."
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Build Phase 2 — IR Emission + Import Wiring ─────────────
+
+    nodes["builder_ir"] = AgentNode(
+        id="builder_ir",
+        role=AgentRole.BUILDER,
+        prompt_template=(
+            "Wire IR emission and update imports. "
+            "Read the approved plan at .factory/strategy/current.md. "
+            "Read CLAUDE.md for project conventions. "
+            "Tasks: "
+            "- Add IR program to CompilerIR (extend the program type with the new sampler) "
+            "- Wire into formal/Mcmc/Executable/IRFormat.lean "
+            "- Update formal/Mcmc.lean with new module imports "
+            "After writing the code, run 'cd formal && lake build' to verify "
+            "IR matches theory via refinement theorem. "
+            "If compilation fails, fix the errors before reporting completion. "
+            "Commit changes when compilation succeeds."
+        ),
+        reads={".factory/strategy/current.md"},
+        writes={".factory/reviews/builder-latest.md"},
+        max_iterations=3,
+        post_checks=[
+            ArtifactCheck(
+                path=".factory/reviews/builder-latest.md",
+                must_exist=True,
+                min_size=100,
+            )
+        ],
+    )
+
+    nodes["gate_ir"] = GateNode(
+        id="gate_ir",
+        evaluator_type="fn",
+        evaluator_command="cd {project_path}/formal && lake build",
+        gate_prompt=(
+            "IR compilation gate. Verifies the IR emission matches the kernel theory "
+            "via the refinement theorem. RELOOP to builder_ir on failure (max 3 iterations)."
+        ),
+    )
+
+    # ── Reference Generation ────────────────────────────────────
+
+    nodes["fn_generate"] = FnNode(
+        id="fn_generate",
+        command="cd {project_path} && make generate",
+        notes="Emit updated Samplers.ir from the Lean IR programs. Single-shot, no retry.",
+        writes={"Samplers.ir"},
+    )
+
+    # ── QA Phase — Fork/Join/Gate ───────────────────────────────
+
+    nodes["fork_qa"] = ForkNode(
+        id="fork_qa",
+        targets=["fn_check_generated", "fn_test", "fn_proof_hygiene"],
+    )
+
+    nodes["fn_check_generated"] = FnNode(
+        id="fn_check_generated",
+        command="cd {project_path} && make check-generated",
+        notes="Verify committed IR matches Lean source. Fails if IR is stale.",
+    )
+
+    nodes["fn_test"] = FnNode(
+        id="fn_test",
+        command="cd {project_path} && make test",
+        notes="Run full test suite — Lean compilation + Julia tests including new Reference function.",
+    )
+
+    nodes["fn_proof_hygiene"] = FnNode(
+        id="fn_proof_hygiene",
+        command=(
+            "cd {project_path}/formal && "
+            "FILES=$(git diff --name-only HEAD~2 -- Mcmc/ | grep '\\.lean$' || true) && "
+            "if [ -z \"$FILES\" ]; then "
+            "  echo 'PASS: no new .lean files to check'; exit 0; "
+            "fi && "
+            "if echo \"$FILES\" | xargs grep -n 'sorry\\|admit\\|axiom'; then "
+            "  echo 'FAIL: found sorry/admit/axiom in new Lean files'; exit 1; "
+            "else "
+            "  echo 'PASS: no proof holes found'; exit 0; "
+            "fi"
+        ),
+        notes=(
+            "Proof hygiene check — grep for sorry, admit, or axiom only in NEW .lean files "
+            "(from recent git diff), not the entire Mcmc/ tree. "
+            "Exit 0 if no new files or no matches. Exit 1 if matches found."
+        ),
+    )
+
+    nodes["join_qa"] = JoinNode(
+        id="join_qa",
+        sources=["fn_check_generated", "fn_test", "fn_proof_hygiene"],
+    )
+
+    nodes["gate_qa"] = GateNode(
+        id="gate_qa",
+        evaluator_type="agent",
+        evaluator_role=AgentRole.CEO,
+        gate_prompt=(
+            "Review the three parallel QA results. "
+            "All three must pass for PROCEED: "
+            "(1) make check-generated — committed IR matches Lean source "
+            "(2) make test — full test suite passes "
+            "(3) proof hygiene — no sorry/admit/axiom in .lean files "
+            "If any check failed, RELOOP to builder_ir with specific guidance "
+            "on what to fix (max 3 iterations). "
+            "If all pass, PROCEED to archivist."
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+    )
+
+    # ── Archivist (build archive, non-blocking) ─────────────────
+
+    nodes["archivist_build"] = AgentNode(
+        id="archivist_build",
+        role=AgentRole.ARCHIVIST,
+        prompt_template=(
+            "Archive the formalization build results. "
+            "Record: what algorithm was formalized, theorems proved, "
+            "IR programs added, new Reference Julia functions generated, "
+            "and any lessons learned from proof compilation iterations."
+        ),
+        reads={".factory/reviews/builder-latest.md"},
+        writes={".factory/archive/formalize-build.md"},
+        blocking=False,
+    )
+
+    # ── Edges ───────────────────────────────────────────────────
+
+    edges = [
+        # Research fork -> researchers -> join
+        Edge(source="fork_research", target="researcher_patterns"),
+        Edge(source="fork_research", target="researcher_mathlib"),
+        Edge(source="fork_research", target="researcher_algorithm"),
+        Edge(source="researcher_patterns", target="join_research"),
+        Edge(source="researcher_mathlib", target="join_research"),
+        Edge(source="researcher_algorithm", target="join_research"),
+        Edge(source="join_research", target="gate_research"),
+        # Research gate
+        Edge(source="gate_research", target="strategist", condition=VerdictType.PROCEED),
+        Edge(source="gate_research", target="fork_research", condition=VerdictType.RELOOP),
+        # Strategy
+        Edge(source="strategist", target="gate_strategy"),
+        Edge(source="gate_strategy", target="archivist_plan", condition=VerdictType.PROCEED),
+        Edge(source="gate_strategy", target="strategist", condition=VerdictType.RELOOP),
+        # Archivist -> builder
+        Edge(source="archivist_plan", target="builder_theory"),
+        # Build Phase 1: Theory
+        Edge(source="builder_theory", target="gate_theory"),
+        Edge(source="gate_theory", target="gate_theory_review", condition=VerdictType.PROCEED),
+        Edge(source="gate_theory", target="builder_theory", condition=VerdictType.RELOOP),
+        # Theory review
+        Edge(source="gate_theory_review", target="builder_ir", condition=VerdictType.PROCEED),
+        Edge(source="gate_theory_review", target="archivist_build", condition=VerdictType.HALT),
+        # Build Phase 2: IR
+        Edge(source="builder_ir", target="gate_ir"),
+        Edge(source="gate_ir", target="fn_generate", condition=VerdictType.PROCEED),
+        Edge(source="gate_ir", target="builder_ir", condition=VerdictType.RELOOP),
+        # Generate -> QA
+        Edge(source="fn_generate", target="fork_qa"),
+        Edge(source="fork_qa", target="fn_check_generated"),
+        Edge(source="fork_qa", target="fn_test"),
+        Edge(source="fork_qa", target="fn_proof_hygiene"),
+        Edge(source="fn_check_generated", target="join_qa"),
+        Edge(source="fn_test", target="join_qa"),
+        Edge(source="fn_proof_hygiene", target="join_qa"),
+        Edge(source="join_qa", target="gate_qa"),
+        # QA gate
+        Edge(source="gate_qa", target="archivist_build", condition=VerdictType.PROCEED),
+        Edge(source="gate_qa", target="builder_ir", condition=VerdictType.RELOOP),
+    ]
+
+    # ── Trigger ─────────────────────────────────────────────────
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "formalize"
+
+    return Workflow(
+        name="formalize",
+        nodes=nodes,
+        edges=edges,
+        start_node="fork_research",
+        terminal=True,
+        trigger=trigger,
+    )

--- a/tests/test_formalize_workflow.py
+++ b/tests/test_formalize_workflow.py
@@ -1,0 +1,164 @@
+"""Tests for the formalize project-local workflow."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from factory.models import ProjectState
+from factory.workflow.primitives import VerdictType, Workflow
+from factory.workflow.registry import WorkflowRegistry
+
+_WF_PATH = Path(".factory/workflows/formalize.py")
+
+
+def _load_formalize_workflow() -> Workflow:
+    """Load the formalize workflow directly from the .py file."""
+    spec = importlib.util.spec_from_file_location("formalize", _WF_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.workflow()
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    WorkflowRegistry.reset()
+    yield
+    WorkflowRegistry.reset()
+
+
+# ── Graph validation ────────────────────────────────────────────
+
+
+class TestGraphValidation:
+    def test_formalize_graph_valid(self) -> None:
+        """The formalize workflow graph has no structural issues."""
+        wf = _load_formalize_workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Graph validation issues: {issues}"
+
+
+# ── Trigger function ────────────────────────────────────────────
+
+
+class TestTrigger:
+    def test_fires_on_formalize_mode(self) -> None:
+        wf = _load_formalize_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "formalize"}) is True
+
+    def test_does_not_fire_on_other_modes(self) -> None:
+        wf = _load_formalize_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"}) is False
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "design"}) is False
+
+    def test_does_not_fire_on_empty_ctx(self) -> None:
+        wf = _load_formalize_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {}) is False
+
+    def test_does_not_fire_on_focus_alone(self) -> None:
+        wf = _load_formalize_workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"focus": "some algorithm"}) is False
+
+
+# ── Node count and expected IDs ─────────────────────────────────
+
+
+class TestNodeStructure:
+    def test_node_count(self) -> None:
+        wf = _load_formalize_workflow()
+        assert len(wf.nodes) == 22
+
+    def test_expected_node_ids(self) -> None:
+        wf = _load_formalize_workflow()
+        expected = {
+            "fork_research", "researcher_patterns", "researcher_mathlib",
+            "researcher_algorithm", "join_research", "gate_research",
+            "strategist", "gate_strategy", "archivist_plan",
+            "builder_theory", "gate_theory", "gate_theory_review",
+            "builder_ir", "gate_ir", "fn_generate",
+            "fork_qa", "fn_check_generated", "fn_test", "fn_proof_hygiene",
+            "join_qa", "gate_qa", "archivist_build",
+        }
+        assert set(wf.nodes.keys()) == expected
+
+    def test_edge_count(self) -> None:
+        wf = _load_formalize_workflow()
+        assert len(wf.edges) == 31
+
+
+# ── Terminal flag and start node ────────────────────────────────
+
+
+class TestTerminalAndStart:
+    def test_terminal(self) -> None:
+        wf = _load_formalize_workflow()
+        assert wf.terminal is True
+
+    def test_start_node(self) -> None:
+        wf = _load_formalize_workflow()
+        assert wf.start_node == "fork_research"
+
+    def test_name(self) -> None:
+        wf = _load_formalize_workflow()
+        assert wf.name == "formalize"
+
+
+# ── Reloop edges ────────────────────────────────────────────────
+
+
+class TestReloopEdges:
+    def test_reloop_edges_exist(self) -> None:
+        wf = _load_formalize_workflow()
+        reloops = [e for e in wf.edges if e.condition == VerdictType.RELOOP]
+        reloop_map = {(e.source, e.target) for e in reloops}
+        assert ("gate_theory", "builder_theory") in reloop_map
+        assert ("gate_ir", "builder_ir") in reloop_map
+        assert ("gate_qa", "builder_ir") in reloop_map
+        assert ("gate_research", "fork_research") in reloop_map
+        assert ("gate_strategy", "strategist") in reloop_map
+
+    def test_reloop_count(self) -> None:
+        wf = _load_formalize_workflow()
+        reloops = [e for e in wf.edges if e.condition == VerdictType.RELOOP]
+        assert len(reloops) == 5
+
+
+# ── Registry discovery ──────────────────────────────────────────
+
+
+class TestRegistryDiscovery:
+    def test_discovered_via_project_path(self) -> None:
+        project = Path(".")
+        entries = WorkflowRegistry.discover(project_path=project)
+        assert "formalize" in entries
+        assert entries["formalize"].source == "project"
+
+    def test_get_workflow_returns_valid(self) -> None:
+        project = Path(".")
+        WorkflowRegistry.discover(project_path=project)
+        wf = WorkflowRegistry.get_workflow("formalize", project_path=project)
+        assert wf is not None
+        assert wf.name == "formalize"
+
+
+# ── Meta dict ───────────────────────────────────────────────────
+
+
+class TestMeta:
+    def test_meta_has_required_keys(self) -> None:
+        spec = importlib.util.spec_from_file_location("formalize", _WF_PATH)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        assert hasattr(mod, "meta")
+        assert isinstance(mod.meta, dict)
+        assert "name" in mod.meta
+        assert "description" in mod.meta
+        assert mod.meta["name"] == "formalize"

--- a/workflow-formalize/SKILL.annotations.yaml
+++ b/workflow-formalize/SKILL.annotations.yaml
@@ -1,0 +1,371 @@
+fork_research:
+  type: ForkNode
+  id: fork_research
+  targets: researcher_patterns,researcher_mathlib,researcher_algorithm
+  edges_out:
+  - target: researcher_patterns
+    condition: null
+  - target: researcher_mathlib
+    condition: null
+  - target: researcher_algorithm
+    condition: null
+researcher_patterns:
+  type: AgentNode
+  id: researcher_patterns
+  role: researcher
+  blocking: 'true'
+  reads: []
+  writes:
+  - .factory/strategy/research-patterns.md
+  edges_out:
+  - target: join_research
+    condition: null
+  slots:
+    task_prompt_researcher_patterns: 'Formalization patterns analysis. Analyze how
+      existing samplers are formalized in $PROJECT_PATH/formal/Mcmc/. Study the pattern:
+      Kernel theory (formal/Mcmc/Kernel/ or Mcmc/Hamiltonian/) -> Executable refinement
+      (formal/Mcmc/Executable/Continuous/) -> CompilerIR program -> IRFormat emission.
+      Read 2-3 existing examples end-to-end (e.g. RWMH: Kernel/GaussianRandomWalk.lean
+      + Executable/Continuous/RWMH.lean + Executable/Continuous/CompilerIR.lean).
+      Document the module structure, naming conventions, import patterns, proof strategies,
+      and how theorems connect kernel specs to executable refinements. Write findings
+      to .factory/strategy/research-patterns.md.
+
+      Write output to: .factory/strategy/research-patterns.md'
+    timeout_researcher_patterns: '600'
+researcher_mathlib:
+  type: AgentNode
+  id: researcher_mathlib
+  role: researcher
+  blocking: 'true'
+  reads: []
+  writes:
+  - .factory/strategy/research-mathlib.md
+  edges_out:
+  - target: join_research
+    condition: null
+  slots:
+    task_prompt_researcher_mathlib: 'Mathlib API discovery for the target algorithm.
+      Read the --focus description from the CEO task to understand which algorithm
+      is being formalized. Search $PROJECT_PATH/.lake/packages/mathlib/Mathlib/ for
+      relevant lemmas covering: measure theory, probability, linear algebra, topology,
+      analysis. Check $PROJECT_PATH/formal/lean-toolchain for the pinned Lean/mathlib
+      version. Document available theorems that the formalization can reuse — provide
+      exact module paths and theorem names. Write findings to .factory/strategy/research-mathlib.md.
+
+      Write output to: .factory/strategy/research-mathlib.md'
+    timeout_researcher_mathlib: '600'
+researcher_algorithm:
+  type: AgentNode
+  id: researcher_algorithm
+  role: researcher
+  blocking: 'true'
+  reads: []
+  writes:
+  - .factory/strategy/research-algorithm.md
+  edges_out:
+  - target: join_research
+    condition: null
+  slots:
+    task_prompt_researcher_algorithm: 'Algorithm specification parsing. Read the --focus
+      description from the CEO task. Parse the algorithm description into a precise
+      mathematical specification. Identify: the state space, the proposal mechanism,
+      the acceptance criterion, what needs to be proved (detailed balance, stationarity,
+      invariance, reversibility), what IR primitives are needed (sample_gaussian,
+      compute_log_density, etc.), and what the signature of the resulting executable
+      function should be. Write findings to .factory/strategy/research-algorithm.md.
+
+      Write output to: .factory/strategy/research-algorithm.md'
+    timeout_researcher_algorithm: '600'
+join_research:
+  type: JoinNode
+  id: join_research
+  sources: researcher_patterns,researcher_mathlib,researcher_algorithm
+  reads: []
+  writes: []
+  edges_out:
+  - target: gate_research
+    condition: null
+gate_research:
+  type: GateNode
+  id: gate_research
+  evaluator_type: agent
+  evaluator_role: ceo
+  reads:
+  - .factory/strategy/research-algorithm.md
+  - .factory/strategy/research-mathlib.md
+  - .factory/strategy/research-patterns.md
+  edges_out:
+  - target: strategist
+    condition: PROCEED
+  - target: fork_research
+    condition: RELOOP
+  slots:
+    gate_prompt_gate_research: 'Review the three research outputs for the formalization.
+      Check: (1) Are existing formalization patterns well-documented with concrete
+      examples? (2) Are relevant mathlib lemmas identified with exact paths? (3) Is
+      the algorithm specification mathematically precise with clear proof targets?
+      PROCEED if all three are adequate. RELOOP if any research is shallow or missing
+      key details.'
+    max_iterations_gate_research: '3'
+strategist:
+  type: AgentNode
+  id: strategist
+  role: strategist
+  blocking: 'true'
+  reads:
+  - .factory/strategy/research-algorithm.md
+  - .factory/strategy/research-mathlib.md
+  - .factory/strategy/research-patterns.md
+  writes:
+  - .factory/strategy/current.md
+  edges_out:
+  - target: gate_strategy
+    condition: null
+  slots:
+    task_prompt_strategist: 'Synthesize a formalization plan from the three research
+      outputs. Read .factory/strategy/research-patterns.md, research-mathlib.md, and
+      research-algorithm.md. Produce a concrete implementation plan covering: 1) Lean
+      module structure — which files to create under formal/Mcmc/ 2) Theorem statements
+      — what to prove and in what order 3) IR program design — what CompilerIR programs
+      to add 4) IRFormat wiring — how to connect to formal/Mcmc/Executable/IRFormat.lean
+      5) Mathlib reuse map — which existing lemmas to reference 6) Module dependency
+      graph — build order for lake build 7) formal/Mcmc.lean update plan — new import
+      lines Write the plan to .factory/strategy/current.md.
+
+      Read: .factory/strategy/research-algorithm.md, .factory/strategy/research-mathlib.md,
+      .factory/strategy/research-patterns.md
+
+      Write output to: .factory/strategy/current.md'
+    timeout_strategist: '600'
+gate_strategy:
+  type: GateNode
+  id: gate_strategy
+  evaluator_type: user
+  reads:
+  - .factory/strategy/current.md
+  edges_out:
+  - target: archivist_plan
+    condition: PROCEED
+  - target: strategist
+    condition: RELOOP
+  slots:
+    max_iterations_gate_strategy: '3'
+archivist_plan:
+  type: AgentNode
+  id: archivist_plan
+  role: archivist
+  blocking: 'false'
+  reads:
+  - .factory/strategy/current.md
+  writes:
+  - .factory/archive/formalize-plan.md
+  edges_out:
+  - target: builder_theory
+    condition: null
+  slots:
+    task_prompt_archivist_plan: 'Archive the approved formalization plan. Record the
+      algorithm being formalized, the module structure, theorem proof order, and mathlib
+      dependencies.
+
+      Read: .factory/strategy/current.md
+
+      Write output to: .factory/archive/formalize-plan.md'
+    timeout_archivist_plan: '300'
+builder_theory:
+  type: AgentNode
+  id: builder_theory
+  role: builder
+  blocking: 'true'
+  reads:
+  - .factory/strategy/current.md
+  writes:
+  - .factory/reviews/builder-latest.md
+  edges_out:
+  - target: gate_theory
+    condition: null
+  slots:
+    task_prompt_builder_theory: 'Implement the Lean kernel theory and executable refinement.
+      Read the approved formalization plan at .factory/strategy/current.md. Read CLAUDE.md
+      for project conventions. Create the Lean modules specified in the plan: - Kernel
+      theory module(s) under formal/Mcmc/Kernel/ or appropriate subdirectory - Executable
+      refinement module(s) under formal/Mcmc/Executable/ - Refinement theorems connecting
+      the IR program to the mathematical kernel - Module docstrings and public definition
+      docstrings per CLAUDE.md conventions Constraints: No sorry, admit, or axiom.
+      Reuse mathlib lemmas from the plan. After writing the Lean code, run ''cd formal
+      && lake build'' to check compilation. If compilation fails, fix the errors before
+      reporting completion. Commit changes when compilation succeeds.
+
+      Read: .factory/strategy/current.md
+
+      Write output to: .factory/reviews/builder-latest.md'
+    timeout_builder_theory: '1200'
+gate_theory:
+  type: GateNode
+  id: gate_theory
+  evaluator_type: fn
+  evaluator_command: cd {project_path}/formal && lake build
+  reads: []
+  edges_out:
+  - target: gate_theory_review
+    condition: PROCEED
+  - target: builder_theory
+    condition: RELOOP
+  slots:
+    max_iterations_gate_theory: '5'
+gate_theory_review:
+  type: GateNode
+  id: gate_theory_review
+  evaluator_type: agent
+  evaluator_role: ceo
+  reads:
+  - .factory/reviews/builder-latest.md
+  edges_out:
+  - target: builder_ir
+    condition: PROCEED
+  - target: archivist_build
+    condition: HALT
+  slots:
+    gate_prompt_gate_theory_review: 'Review the compiled Lean proofs. Read the builder
+      output at .factory/reviews/builder-latest.md. Check git diff for the new .lean
+      files. Verify: (1) Module structure matches the approved plan (2) Theorem names
+      and types are meaningful (3) No sorry, admit, or axiom in the code (4) Module
+      docstrings are present PROCEED to IR phase if proofs are well-structured. HALT
+      if fundamental issues require re-planning.'
+builder_ir:
+  type: AgentNode
+  id: builder_ir
+  role: builder
+  blocking: 'true'
+  reads:
+  - .factory/strategy/current.md
+  writes:
+  - .factory/reviews/builder-latest.md
+  edges_out:
+  - target: gate_ir
+    condition: null
+  slots:
+    task_prompt_builder_ir: 'Wire IR emission and update imports. Read the approved
+      plan at .factory/strategy/current.md. Read CLAUDE.md for project conventions.
+      Tasks: - Add IR program to CompilerIR (extend the program type with the new
+      sampler) - Wire into formal/Mcmc/Executable/IRFormat.lean - Update formal/Mcmc.lean
+      with new module imports After writing the code, run ''cd formal && lake build''
+      to verify IR matches theory via refinement theorem. If compilation fails, fix
+      the errors before reporting completion. Commit changes when compilation succeeds.
+
+      Read: .factory/strategy/current.md
+
+      Write output to: .factory/reviews/builder-latest.md'
+    timeout_builder_ir: '1200'
+gate_ir:
+  type: GateNode
+  id: gate_ir
+  evaluator_type: fn
+  evaluator_command: cd {project_path}/formal && lake build
+  reads: []
+  edges_out:
+  - target: fn_generate
+    condition: PROCEED
+  - target: builder_ir
+    condition: RELOOP
+  slots:
+    max_iterations_gate_ir: '3'
+fn_generate:
+  type: FnNode
+  id: fn_generate
+  command: cd {project_path} && make generate
+  reads: []
+  writes:
+  - Samplers.ir
+  edges_out:
+  - target: fork_qa
+    condition: null
+fork_qa:
+  type: ForkNode
+  id: fork_qa
+  targets: fn_check_generated,fn_test,fn_proof_hygiene
+  edges_out:
+  - target: fn_check_generated
+    condition: null
+  - target: fn_test
+    condition: null
+  - target: fn_proof_hygiene
+    condition: null
+fn_check_generated:
+  type: FnNode
+  id: fn_check_generated
+  command: cd {project_path} && make check-generated
+  reads: []
+  writes: []
+  edges_out:
+  - target: join_qa
+    condition: null
+fn_test:
+  type: FnNode
+  id: fn_test
+  command: cd {project_path} && make test
+  reads: []
+  writes: []
+  edges_out:
+  - target: join_qa
+    condition: null
+fn_proof_hygiene:
+  type: FnNode
+  id: fn_proof_hygiene
+  command: 'cd {project_path}/formal && FILES=$(git diff --name-only HEAD~2 -- Mcmc/
+    | grep ''\.lean$'' || true) && if [ -z "$FILES" ]; then   echo ''PASS: no new
+    .lean files to check''; exit 0; fi && if echo "$FILES" | xargs grep -n ''sorry\|admit\|axiom'';
+    then   echo ''FAIL: found sorry/admit/axiom in new Lean files''; exit 1; else   echo
+    ''PASS: no proof holes found''; exit 0; fi'
+  reads: []
+  writes: []
+  edges_out:
+  - target: join_qa
+    condition: null
+join_qa:
+  type: JoinNode
+  id: join_qa
+  sources: fn_check_generated,fn_test,fn_proof_hygiene
+  reads: []
+  writes: []
+  edges_out:
+  - target: gate_qa
+    condition: null
+gate_qa:
+  type: GateNode
+  id: gate_qa
+  evaluator_type: agent
+  evaluator_role: ceo
+  reads:
+  - .factory/reviews/builder-latest.md
+  edges_out:
+  - target: archivist_build
+    condition: PROCEED
+  - target: builder_ir
+    condition: RELOOP
+  slots:
+    gate_prompt_gate_qa: 'Review the three parallel QA results. All three must pass
+      for PROCEED: (1) make check-generated — committed IR matches Lean source (2)
+      make test — full test suite passes (3) proof hygiene — no sorry/admit/axiom
+      in .lean files If any check failed, RELOOP to builder_ir with specific guidance
+      on what to fix (max 3 iterations). If all pass, PROCEED to archivist.'
+    max_iterations_gate_qa: '3'
+archivist_build:
+  type: AgentNode
+  id: archivist_build
+  role: archivist
+  blocking: 'false'
+  reads:
+  - .factory/reviews/builder-latest.md
+  writes:
+  - .factory/archive/formalize-build.md
+  edges_out: []
+  slots:
+    task_prompt_archivist_build: 'Archive the formalization build results. Record:
+      what algorithm was formalized, theorems proved, IR programs added, new Reference
+      Julia functions generated, and any lessons learned from proof compilation iterations.
+
+      Read: .factory/reviews/builder-latest.md
+
+      Write output to: .factory/archive/formalize-build.md'
+    timeout_archivist_build: '300'

--- a/workflow-formalize/SKILL.md
+++ b/workflow-formalize/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: workflow-formalize
+description: "Run the formalize workflow."
+disable-model-invocation: true
+argument-hint: "<project_path>"
+---
+
+# Formalize Workflow
+
+The user wants: **$ARGUMENTS**
+
+## Phase 1: Research (Parallel)
+
+Spawn 3 agents in parallel:
+
+```bash
+factory agent researcher --review-tag patterns --task "Formalization patterns analysis. Analyze how existing samplers are formalized in $PROJECT_PATH/formal/Mcmc/. Study the pattern: Kernel theory (formal/Mcmc/Kernel/ or Mcmc/Hamiltonian/) -> Executable refinement (formal/Mcmc/Executable/Continuous/) -> CompilerIR program -> IRFormat emission. Read 2-3 existing examples end-to-end (e.g. RWMH: Kernel/GaussianRandomWalk.lean + Executable/Continuous/RWMH.lean + Executable/Continuous/CompilerIR.lean). Document the module structure, naming conventions, import patterns, proof strategies, and how theorems connect kernel specs to executable refinements. Write findings to .factory/strategy/research-patterns.md.
+Write output to: .factory/strategy/research-patterns.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+factory agent researcher --review-tag mathlib --task "Mathlib API discovery for the target algorithm. Read the --focus description from the CEO task to understand which algorithm is being formalized. Search $PROJECT_PATH/.lake/packages/mathlib/Mathlib/ for relevant lemmas covering: measure theory, probability, linear algebra, topology, analysis. Check $PROJECT_PATH/formal/lean-toolchain for the pinned Lean/mathlib version. Document available theorems that the formalization can reuse — provide exact module paths and theorem names. Write findings to .factory/strategy/research-mathlib.md.
+Write output to: .factory/strategy/research-mathlib.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+factory agent researcher --review-tag algorithm --task "Algorithm specification parsing. Read the --focus description from the CEO task. Parse the algorithm description into a precise mathematical specification. Identify: the state space, the proposal mechanism, the acceptance criterion, what needs to be proved (detailed balance, stationarity, invariance, reversibility), what IR primitives are needed (sample_gaussian, compute_log_density, etc.), and what the signature of the resulting executable function should be. Write findings to .factory/strategy/research-algorithm.md.
+Write output to: .factory/strategy/research-algorithm.md" --project "$PROJECT_PATH" --timeout 600 &
+```
+
+```bash
+wait
+```
+
+**Important:** Run ALL commands above in a **single** Bash tool call with timeout set to at least 600 seconds.
+
+```bash
+# Artifact verification: researcher_patterns
+_vfail=0
+_f="$PROJECT_PATH/.factory/strategy/research-patterns.md"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: researcher_patterns: .factory/strategy/research-patterns.md missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: researcher_patterns: .factory/strategy/research-patterns.md is empty" && _vfail=1
+[ -f "$_f" ] && [ "$(wc -c < "$_f")" -lt 50 ] && echo "VERIFY FAIL: researcher_patterns: .factory/strategy/research-patterns.md smaller than 50 bytes" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=researcher_patterns" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: researcher_patterns artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=researcher_patterns" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+
+# Artifact verification: researcher_mathlib
+_vfail=0
+_f="$PROJECT_PATH/.factory/strategy/research-mathlib.md"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: researcher_mathlib: .factory/strategy/research-mathlib.md missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: researcher_mathlib: .factory/strategy/research-mathlib.md is empty" && _vfail=1
+[ -f "$_f" ] && [ "$(wc -c < "$_f")" -lt 50 ] && echo "VERIFY FAIL: researcher_mathlib: .factory/strategy/research-mathlib.md smaller than 50 bytes" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=researcher_mathlib" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: researcher_mathlib artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=researcher_mathlib" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+
+# Artifact verification: researcher_algorithm
+_vfail=0
+_f="$PROJECT_PATH/.factory/strategy/research-algorithm.md"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: researcher_algorithm: .factory/strategy/research-algorithm.md missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: researcher_algorithm: .factory/strategy/research-algorithm.md is empty" && _vfail=1
+[ -f "$_f" ] && [ "$(wc -c < "$_f")" -lt 50 ] && echo "VERIFY FAIL: researcher_algorithm: .factory/strategy/research-algorithm.md smaller than 50 bytes" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=researcher_algorithm" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: researcher_algorithm artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=researcher_algorithm" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(post-barrier harness verification — DO NOT SKIP)*
+
+## Barrier: Research
+
+Wait for all parallel agents to complete: `researcher_patterns`, `researcher_mathlib`, `researcher_algorithm`
+
+### CEO Review — Research
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/strategy/research-algorithm.md`, `.factory/strategy/research-mathlib.md`, `.factory/strategy/research-patterns.md`
+3. Assess: Review the three research outputs for the formalization. Check: (1) Are existing formalization patterns well-documented with concrete examples? (2) Are relevant mathlib lemmas identified with exact paths? (3) Is the algorithm specification mathematically precise with clear proof targets? PROCEED if all three are adequate. RELOOP if any research is shallow or missing key details.
+4. Write verdict to `.factory/reviews/ceo-verdict-research.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `fork_research` (max 3 iterations)*
+
+## Phase 2: Strategist
+
+```bash
+factory agent strategist --task "Synthesize a formalization plan from the three research outputs. Read .factory/strategy/research-patterns.md, research-mathlib.md, and research-algorithm.md. Produce a concrete implementation plan covering: 1) Lean module structure — which files to create under formal/Mcmc/ 2) Theorem statements — what to prove and in what order 3) IR program design — what CompilerIR programs to add 4) IRFormat wiring — how to connect to formal/Mcmc/Executable/IRFormat.lean 5) Mathlib reuse map — which existing lemmas to reference 6) Module dependency graph — build order for lake build 7) formal/Mcmc.lean update plan — new import lines Write the plan to .factory/strategy/current.md.
+Read: .factory/strategy/research-algorithm.md, .factory/strategy/research-mathlib.md, .factory/strategy/research-patterns.md
+Write output to: .factory/strategy/current.md" --project "$PROJECT_PATH" --timeout 600
+```
+
+```bash
+# Artifact verification: strategist
+_vfail=0
+_f="$PROJECT_PATH/.factory/strategy/current.md"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: strategist: .factory/strategy/current.md missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: strategist: .factory/strategy/current.md is empty" && _vfail=1
+[ -f "$_f" ] && [ "$(wc -c < "$_f")" -lt 200 ] && echo "VERIFY FAIL: strategist: .factory/strategy/current.md smaller than 200 bytes" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=strategist" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: strategist artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=strategist" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(harness verification — DO NOT SKIP)*
+
+### Steering Point — Strategy (User Approval)
+
+**This is a USER approval gate, NOT a CEO review gate. Do NOT self-approve.**
+
+Present the strategy/findings to the user by summarizing key points in your output.
+Then explicitly ask the user: "Do you approve this plan, or do you have feedback?"
+
+**You MUST wait for the user's response before proceeding.**
+- The user says "approve", "yes", "looks good", or similar → proceed to next step
+- The user provides feedback or corrections → re-run the previous step incorporating their feedback
+- Do NOT write a verdict file and auto-proceed — this gate requires human input
+
+*On RELOOP: return to `strategist` (max 3 iterations)*
+
+## Phase 3: Archivist Plan
+
+```bash
+factory agent archivist --task "Archive the approved formalization plan. Record the algorithm being formalized, the module structure, theorem proof order, and mathlib dependencies.
+Read: .factory/strategy/current.md
+Write output to: .factory/archive/formalize-plan.md" --project "$PROJECT_PATH" --timeout 300 --model haiku &
+```
+*(fire-and-forget — CEO continues immediately)*
+
+## Phase 4: Builder Theory
+
+```bash
+factory agent builder --task "Implement the Lean kernel theory and executable refinement. Read the approved formalization plan at .factory/strategy/current.md. Read CLAUDE.md for project conventions. Create the Lean modules specified in the plan: - Kernel theory module(s) under formal/Mcmc/Kernel/ or appropriate subdirectory - Executable refinement module(s) under formal/Mcmc/Executable/ - Refinement theorems connecting the IR program to the mathematical kernel - Module docstrings and public definition docstrings per CLAUDE.md conventions Constraints: No sorry, admit, or axiom. Reuse mathlib lemmas from the plan. After writing the Lean code, run 'cd formal && lake build' to check compilation. If compilation fails, fix the errors before reporting completion. Commit changes when compilation succeeds.
+Read: .factory/strategy/current.md
+Write output to: .factory/reviews/builder-latest.md" --project "$PROJECT_PATH" --timeout 1200
+```
+
+```bash
+# Artifact verification: builder_theory
+_vfail=0
+_f="$PROJECT_PATH/.factory/reviews/builder-latest.md"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: builder_theory: .factory/reviews/builder-latest.md missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: builder_theory: .factory/reviews/builder-latest.md is empty" && _vfail=1
+[ -f "$_f" ] && [ "$(wc -c < "$_f")" -lt 100 ] && echo "VERIFY FAIL: builder_theory: .factory/reviews/builder-latest.md smaller than 100 bytes" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=builder_theory" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: builder_theory artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=builder_theory" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(harness verification — DO NOT SKIP)*
+
+### Gate — Theory (Automated)
+
+**MANDATORY:** Wait for the preceding agent to finish, then run this check BEFORE spawning the next agent. Do NOT run agents in parallel across this gate.
+
+```bash
+cd $PROJECT_PATH/formal && lake build
+```
+
+- **PROCEED** (exit 0 / no FAIL in output) → continue to `gate_theory_review`
+- **RELOOP** (exit non-zero / FAIL in output) → return to `builder_theory` for the next iteration.
+
+*On RELOOP: return to `builder_theory` (max 5 iterations)*
+
+### CEO Review — Theory Review
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/builder-latest.md`
+3. Assess: Review the compiled Lean proofs. Read the builder output at .factory/reviews/builder-latest.md. Check git diff for the new .lean files. Verify: (1) Module structure matches the approved plan (2) Theorem names and types are meaningful (3) No sorry, admit, or axiom in the code (4) Module docstrings are present PROCEED to IR phase if proofs are well-structured. HALT if fundamental issues require re-planning.
+4. Write verdict to `.factory/reviews/ceo-verdict-theory-review.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+## Phase 5: Builder Ir
+
+```bash
+factory agent builder --task "Wire IR emission and update imports. Read the approved plan at .factory/strategy/current.md. Read CLAUDE.md for project conventions. Tasks: - Add IR program to CompilerIR (extend the program type with the new sampler) - Wire into formal/Mcmc/Executable/IRFormat.lean - Update formal/Mcmc.lean with new module imports After writing the code, run 'cd formal && lake build' to verify IR matches theory via refinement theorem. If compilation fails, fix the errors before reporting completion. Commit changes when compilation succeeds.
+Read: .factory/strategy/current.md
+Write output to: .factory/reviews/builder-latest.md" --project "$PROJECT_PATH" --timeout 1200
+```
+
+```bash
+# Artifact verification: builder_ir
+_vfail=0
+_f="$PROJECT_PATH/.factory/reviews/builder-latest.md"
+[ ! -f "$_f" ] && echo "VERIFY FAIL: builder_ir: .factory/reviews/builder-latest.md missing" && _vfail=1
+[ -f "$_f" ] && [ ! -s "$_f" ] && echo "VERIFY FAIL: builder_ir: .factory/reviews/builder-latest.md is empty" && _vfail=1
+[ -f "$_f" ] && [ "$(wc -c < "$_f")" -lt 100 ] && echo "VERIFY FAIL: builder_ir: .factory/reviews/builder-latest.md smaller than 100 bytes" && _vfail=1
+[ "$_vfail" -ne 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_FAIL node=builder_ir" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt" && exit 1
+echo "VERIFY OK: builder_ir artifacts validated"
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) VERIFY_OK node=builder_ir" >> "$PROJECT_PATH/.factory/hooks/hook-log.txt"
+```
+*(harness verification — DO NOT SKIP)*
+
+### Gate — Ir (Automated)
+
+**MANDATORY:** Wait for the preceding agent to finish, then run this check BEFORE spawning the next agent. Do NOT run agents in parallel across this gate.
+
+```bash
+cd $PROJECT_PATH/formal && lake build
+```
+
+- **PROCEED** (exit 0 / no FAIL in output) → continue to `fn_generate`
+- **RELOOP** (exit non-zero / FAIL in output) → return to `builder_ir` for the next iteration.
+
+*On RELOOP: return to `builder_ir` (max 3 iterations)*
+
+## Step: Fn Generate
+
+Emit updated Samplers.ir from the Lean IR programs. Single-shot, no retry.
+
+```bash
+cd $PROJECT_PATH && make generate
+```
+
+## Phase 6: Qa (Parallel)
+
+Spawn 3 agents in parallel:
+
+Verify committed IR matches Lean source. Fails if IR is stale.
+
+```bash
+cd $PROJECT_PATH && make check-generated
+```
+
+Run full test suite — Lean compilation + Julia tests including new Reference function.
+
+```bash
+cd $PROJECT_PATH && make test
+```
+
+Proof hygiene check — grep for sorry, admit, or axiom only in NEW .lean files (from recent git diff), not the entire Mcmc/ tree. Exit 0 if no new files or no matches. Exit 1 if matches found.
+
+```bash
+cd $PROJECT_PATH/formal && FILES=$(git diff --name-only HEAD~2 -- Mcmc/ | grep '\.lean$' || true) && if [ -z "$FILES" ]; then   echo 'PASS: no new .lean files to check'; exit 0; fi && if echo "$FILES" | xargs grep -n 'sorry\|admit\|axiom'; then   echo 'FAIL: found sorry/admit/axiom in new Lean files'; exit 1; else   echo 'PASS: no proof holes found'; exit 0; fi
+```
+
+```bash
+wait
+```
+
+## Barrier: Qa
+
+Wait for all parallel agents to complete: `fn_check_generated`, `fn_test`, `fn_proof_hygiene`
+
+### CEO Review — Qa
+
+Apply the CEO Review Gate protocol:
+1. Read the agent output for the preceding step
+2. Read artifacts: `.factory/reviews/builder-latest.md`
+3. Assess: Review the three parallel QA results. All three must pass for PROCEED: (1) make check-generated — committed IR matches Lean source (2) make test — full test suite passes (3) proof hygiene — no sorry/admit/axiom in .lean files If any check failed, RELOOP to builder_ir with specific guidance on what to fix (max 3 iterations). If all pass, PROCEED to archivist.
+4. Write verdict to `.factory/reviews/ceo-verdict-qa.md`
+5. **PROCEED** → continue to next step
+6. **REDIRECT** → re-invoke the preceding agent with corrections (max 2)
+7. **ABORT** → log failure and skip to archival
+
+*On RELOOP: return to `builder_ir` (max 3 iterations)*
+
+## Phase 7: Archivist Build
+
+```bash
+factory agent archivist --task "Archive the formalization build results. Record: what algorithm was formalized, theorems proved, IR programs added, new Reference Julia functions generated, and any lessons learned from proof compilation iterations.
+Read: .factory/reviews/builder-latest.md
+Write output to: .factory/archive/formalize-build.md" --project "$PROJECT_PATH" --timeout 300 --model haiku &
+```
+*(fire-and-forget — CEO continues immediately)*


### PR DESCRIPTION
## Summary

- Adds a project-local `formalize` workflow at `.factory/workflows/formalize.py` — a 22-node, 31-edge pipeline that transforms MCMC algorithm ideas into Lean-verified implementations with auto-generated Reference Julia code
- Pipeline: parallel research (patterns + mathlib + algorithm) → strategy → theory build (max 5 `lake build` iterations) → IR build (max 3) → `make generate` → parallel QA (check-generated + test + proof hygiene) → archival
- The `fn_proof_hygiene` FnNode greps only NEW `.lean` files from `git diff --name-only HEAD~2` rather than the entire `Mcmc/` tree, avoiding false positives from existing axiom declarations
- Terminal mode, activated via `--mode formalize --focus "algorithm description"`
- Exported `workflow-formalize/SKILL.md` for CEO agent consumption
- 16 tests covering graph validation, trigger function, node IDs, terminal/start node, reloop edges, registry discovery, and meta dict

## Test plan

- [x] `factory workflow validate formalize --project-path .` — VALID (22 nodes, 31 edges)
- [x] `factory workflow show formalize --project-path .` — correct topology
- [x] `factory workflow export-skills --project-path .` — produces `workflow-formalize/SKILL.md`
- [x] `pytest tests/test_formalize_workflow.py -v` — 16/16 pass
- [x] `ruff check .factory/workflows/formalize.py tests/test_formalize_workflow.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)