### PR TITLE
fix: add create-v2 to --focus mode allowlist

### DIFF
--- a/factory/cli/_ceo_helpers.py
+++ b/factory/cli/_ceo_helpers.py
@@ -493,6 +493,7 @@ def _validate_late_flags(
             "design-v2",
             "research",
             "create",
+            "create-v2",
             "evolve",
             "study",
             "frontend-design",
@@ -502,7 +503,7 @@ def _validate_late_flags(
         and not just_plan
     ):
         print(
-            f"Error: --focus (targeted mode) only works in design, research, create, evolve, study, frontend-design, "
+            f"Error: --focus (targeted mode) only works in design, research, create, create-v2, evolve, study, frontend-design, "
             f"frontend-design-discover, or design (with --just-plan) mode, "
             f"got '{mode}'. The project must already be built before targeting specific items.",
             file=sys.stderr,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1963,6 +1963,13 @@ class TestCreateModeFocus:
         task = _build_ceo_task(tmp_path, "design", create_description=None)
         assert "## Create Mode (New Factory Mode)" not in task
 
+    def test_focus_accepted_with_create_v2_mode(self, tmp_path):
+        """--focus is accepted when --mode create-v2 is set (issue #1428)."""
+        (tmp_path / ".git").mkdir()
+        with _mock_foreground() as mock_run:
+            main(["ceo", str(tmp_path), "--mode", "create-v2", "--focus", "add a linting mode"])
+        mock_run.assert_called_once()
+
 
 class TestProfileParser:
     def test_profile_build_subcommand(self):


### PR DESCRIPTION
Closes #1428

## Changes

- Added `"create-v2"` to the focus mode allowlist tuple in `_validate_ceo_flags()` (`factory/cli/_ceo_helpers.py`)
- Updated the error message to include `create-v2` in the listed valid modes
- Added regression test `test_focus_accepted_with_create_v2_mode` validating that `--mode create-v2 --focus "..."` is accepted