### PR TITLE
feat: enhance optimize-sorting T2 researcher and archive prompts with stage timing

### DIFF
--- a/factory/workflow/contributed/optimize_sorting/__init__.py
+++ b/factory/workflow/contributed/optimize_sorting/__init__.py
@@ -1,0 +1,3 @@
+from .workflow import meta, workflow
+
+__all__ = ["meta", "workflow"]

--- a/factory/workflow/contributed/optimize_sorting/test_workflow.py
+++ b/factory/workflow/contributed/optimize_sorting/test_workflow.py
@@ -1,0 +1,789 @@
+"""Tests for the optimize-sorting contributed workflow."""
+
+from __future__ import annotations
+
+from factory.models import ProjectState
+from factory.workflow.contributed.optimize_sorting import meta, workflow
+from factory.workflow.definitions import register_all
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Edge,
+    FnNode,
+    GateNode,
+    VerdictType,
+)
+
+
+# ── Graph Validation ──────────────────────────────────────────────
+
+
+class TestGraphValidation:
+    """Graph structural validation tests."""
+
+    def test_validate_graph_returns_empty(self) -> None:
+        """validate_graph() returns [] — no structural issues."""
+        wf = workflow()
+        issues = wf.validate_graph()
+        assert issues == [], f"Workflow has validation issues: {issues}"
+
+    def test_workflow_name(self) -> None:
+        wf = workflow()
+        assert wf.name == "optimize-sorting"
+
+    def test_workflow_is_terminal(self) -> None:
+        wf = workflow()
+        assert wf.terminal is True
+
+    def test_start_node(self) -> None:
+        wf = workflow()
+        assert wf.start_node == "lock_baseline"
+
+
+# ── Node Existence ────────────────────────────────────────────────
+
+
+class TestNodeExistence:
+    """All 31 nodes must be present."""
+
+    SHARED_NODES = {
+        "lock_baseline",
+        "select_tier",
+        "gate_is_tier1",
+        "gate_is_tier2",
+        "gate_is_tier3",
+    }
+
+    TIER1_NODES = {
+        "researcher_discover_params",
+        "strategist_t1",
+        "builder_config_change",
+        "gate_no_code_changes",
+        "run_benchmark_t1",
+        "gate_catastrophic_t1",
+        "confirm_benchmark_t1",
+        "gate_accuracy_t1",
+        "archive_result_t1",
+    }
+
+    TIER2_NODES = {
+        "researcher_profile_pipeline",
+        "strategist_t2",
+        "builder_optimize_hotpath",
+        "run_benchmark_t2",
+        "gate_catastrophic_t2",
+        "confirm_benchmark_t2",
+        "gate_accuracy_t2",
+        "archive_result_t2",
+    }
+
+    TIER3_NODES = {
+        "researcher_explore_alternatives",
+        "strategist_t3",
+        "builder_implement_alternative",
+        "run_benchmark_t3",
+        "gate_catastrophic_t3",
+        "confirm_benchmark_t3",
+        "gate_accuracy_t3",
+        "gate_per_unit_accuracy",
+        "archive_result_t3",
+    }
+
+    ALL_NODES = SHARED_NODES | TIER1_NODES | TIER2_NODES | TIER3_NODES
+
+    def test_total_node_count(self) -> None:
+        wf = workflow()
+        assert len(wf.nodes) == 31
+
+    def test_all_nodes_present(self) -> None:
+        wf = workflow()
+        assert set(wf.nodes.keys()) == self.ALL_NODES
+
+    def test_shared_node_count(self) -> None:
+        assert len(self.SHARED_NODES) == 5
+
+    def test_tier1_node_count(self) -> None:
+        assert len(self.TIER1_NODES) == 9
+
+    def test_tier2_node_count(self) -> None:
+        assert len(self.TIER2_NODES) == 8
+
+    def test_tier3_node_count(self) -> None:
+        assert len(self.TIER3_NODES) == 9
+
+
+# ── Node Types ────────────────────────────────────────────────────
+
+
+class TestNodeTypes:
+    """Verify correct node types for each node."""
+
+    def test_lock_baseline_is_fn(self) -> None:
+        wf = workflow()
+        assert isinstance(wf.nodes["lock_baseline"], FnNode)
+
+    def test_select_tier_is_fn(self) -> None:
+        wf = workflow()
+        assert isinstance(wf.nodes["select_tier"], FnNode)
+
+    def test_tier_gates_are_gate_nodes(self) -> None:
+        wf = workflow()
+        for name in ("gate_is_tier1", "gate_is_tier2", "gate_is_tier3"):
+            node = wf.nodes[name]
+            assert isinstance(node, GateNode), f"{name} should be GateNode"
+            assert node.evaluator_type == "fn"
+            assert node.evaluator_command is not None
+
+    def test_config_gate_is_gate_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["gate_no_code_changes"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+
+    def test_accuracy_gates_are_gate_nodes(self) -> None:
+        wf = workflow()
+        for name in ("gate_accuracy_t1", "gate_accuracy_t2", "gate_accuracy_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, GateNode), f"{name} should be GateNode"
+            assert node.evaluator_type == "fn"
+
+    def test_catastrophic_gates_are_gate_nodes(self) -> None:
+        wf = workflow()
+        for name in (
+            "gate_catastrophic_t1",
+            "gate_catastrophic_t2",
+            "gate_catastrophic_t3",
+        ):
+            node = wf.nodes[name]
+            assert isinstance(node, GateNode), f"{name} should be GateNode"
+            assert node.evaluator_type == "fn"
+
+    def test_per_unit_gate_is_gate_node(self) -> None:
+        wf = workflow()
+        node = wf.nodes["gate_per_unit_accuracy"]
+        assert isinstance(node, GateNode)
+        assert node.evaluator_type == "fn"
+
+    def test_benchmark_nodes_are_fn(self) -> None:
+        wf = workflow()
+        for name in ("run_benchmark_t1", "run_benchmark_t2", "run_benchmark_t3"):
+            assert isinstance(wf.nodes[name], FnNode), f"{name} should be FnNode"
+
+    def test_confirm_benchmark_nodes_are_fn(self) -> None:
+        wf = workflow()
+        for name in (
+            "confirm_benchmark_t1",
+            "confirm_benchmark_t2",
+            "confirm_benchmark_t3",
+        ):
+            assert isinstance(wf.nodes[name], FnNode), f"{name} should be FnNode"
+
+    def test_researcher_nodes_are_agent(self) -> None:
+        wf = workflow()
+        for name in (
+            "researcher_discover_params",
+            "researcher_profile_pipeline",
+            "researcher_explore_alternatives",
+        ):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode), f"{name} should be AgentNode"
+            assert node.role == AgentRole.RESEARCHER
+
+    def test_strategist_nodes_are_agent(self) -> None:
+        wf = workflow()
+        for name in ("strategist_t1", "strategist_t2", "strategist_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode), f"{name} should be AgentNode"
+            assert node.role == AgentRole.STRATEGIST
+
+    def test_builder_nodes_are_agent(self) -> None:
+        wf = workflow()
+        for name in (
+            "builder_config_change",
+            "builder_optimize_hotpath",
+            "builder_implement_alternative",
+        ):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode), f"{name} should be AgentNode"
+            assert node.role == AgentRole.BUILDER
+            assert node.model == "opus"
+            assert node.timeout == 3600
+
+    def test_archive_nodes_are_archivist(self) -> None:
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode), f"{name} should be AgentNode"
+            assert node.role == AgentRole.ARCHIVIST
+
+
+# ── Edge Topology ─────────────────────────────────────────────────
+
+
+class TestEdgeTopology:
+    """All 39 edges with correct conditions."""
+
+    def test_edge_count(self) -> None:
+        wf = workflow()
+        assert len(wf.edges) == 39
+
+    def _find_edges(
+        self,
+        source: str,
+        target: str,
+        condition: VerdictType | None = None,
+    ) -> list[Edge]:
+        wf = workflow()
+        return [
+            e
+            for e in wf.edges
+            if e.source == source
+            and e.target == target
+            and e.condition == condition
+        ]
+
+    # Baseline + Tier Selection
+    def test_edge_lock_to_select(self) -> None:
+        assert len(self._find_edges("lock_baseline", "select_tier")) == 1
+
+    def test_edge_select_to_gate1(self) -> None:
+        assert len(self._find_edges("select_tier", "gate_is_tier1")) == 1
+
+    # Tier routing chain
+    def test_edge_gate1_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_is_tier1", "researcher_discover_params", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_gate1_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_is_tier1", "gate_is_tier2", VerdictType.HALT
+        )) == 1
+
+    def test_edge_gate2_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_is_tier2", "researcher_profile_pipeline", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_gate2_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_is_tier2", "gate_is_tier3", VerdictType.HALT
+        )) == 1
+
+    def test_edge_gate3_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_is_tier3", "researcher_explore_alternatives", VerdictType.PROCEED
+        )) == 1
+
+    # Tier 1 subgraph
+    def test_edge_t1_researcher_to_strategist(self) -> None:
+        assert len(self._find_edges(
+            "researcher_discover_params", "strategist_t1"
+        )) == 1
+
+    def test_edge_t1_strategist_to_builder(self) -> None:
+        assert len(self._find_edges("strategist_t1", "builder_config_change")) == 1
+
+    def test_edge_t1_builder_to_config_gate(self) -> None:
+        assert len(self._find_edges(
+            "builder_config_change", "gate_no_code_changes"
+        )) == 1
+
+    def test_edge_t1_config_gate_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_no_code_changes", "run_benchmark_t1", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_t1_config_gate_reloop(self) -> None:
+        assert len(self._find_edges(
+            "gate_no_code_changes", "builder_config_change", VerdictType.RELOOP
+        )) == 1
+
+    def test_edge_t1_benchmark_to_catastrophic(self) -> None:
+        assert len(self._find_edges("run_benchmark_t1", "gate_catastrophic_t1")) == 1
+
+    def test_edge_t1_catastrophic_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_catastrophic_t1", "confirm_benchmark_t1", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_t1_catastrophic_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_catastrophic_t1", "archive_result_t1", VerdictType.HALT
+        )) == 1
+
+    def test_edge_t1_confirm_to_accuracy(self) -> None:
+        assert len(self._find_edges("confirm_benchmark_t1", "gate_accuracy_t1")) == 1
+
+    def test_edge_t1_accuracy_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_accuracy_t1", "archive_result_t1", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_t1_accuracy_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_accuracy_t1", "archive_result_t1", VerdictType.HALT
+        )) == 1
+
+    # Tier 2 subgraph
+    def test_edge_t2_researcher_to_strategist(self) -> None:
+        assert len(self._find_edges(
+            "researcher_profile_pipeline", "strategist_t2"
+        )) == 1
+
+    def test_edge_t2_strategist_to_builder(self) -> None:
+        assert len(self._find_edges(
+            "strategist_t2", "builder_optimize_hotpath"
+        )) == 1
+
+    def test_edge_t2_builder_to_benchmark(self) -> None:
+        assert len(self._find_edges(
+            "builder_optimize_hotpath", "run_benchmark_t2"
+        )) == 1
+
+    def test_edge_t2_benchmark_to_catastrophic(self) -> None:
+        assert len(self._find_edges("run_benchmark_t2", "gate_catastrophic_t2")) == 1
+
+    def test_edge_t2_catastrophic_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_catastrophic_t2", "confirm_benchmark_t2", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_t2_catastrophic_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_catastrophic_t2", "archive_result_t2", VerdictType.HALT
+        )) == 1
+
+    def test_edge_t2_confirm_to_accuracy(self) -> None:
+        assert len(self._find_edges("confirm_benchmark_t2", "gate_accuracy_t2")) == 1
+
+    def test_edge_t2_accuracy_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_accuracy_t2", "archive_result_t2", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_t2_accuracy_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_accuracy_t2", "archive_result_t2", VerdictType.HALT
+        )) == 1
+
+    # Tier 3 subgraph
+    def test_edge_t3_researcher_to_strategist(self) -> None:
+        assert len(self._find_edges(
+            "researcher_explore_alternatives", "strategist_t3"
+        )) == 1
+
+    def test_edge_t3_strategist_to_builder(self) -> None:
+        assert len(self._find_edges(
+            "strategist_t3", "builder_implement_alternative"
+        )) == 1
+
+    def test_edge_t3_builder_to_benchmark(self) -> None:
+        assert len(self._find_edges(
+            "builder_implement_alternative", "run_benchmark_t3"
+        )) == 1
+
+    def test_edge_t3_benchmark_to_catastrophic(self) -> None:
+        assert len(self._find_edges("run_benchmark_t3", "gate_catastrophic_t3")) == 1
+
+    def test_edge_t3_catastrophic_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_catastrophic_t3", "confirm_benchmark_t3", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_t3_catastrophic_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_catastrophic_t3", "archive_result_t3", VerdictType.HALT
+        )) == 1
+
+    def test_edge_t3_confirm_to_accuracy(self) -> None:
+        assert len(self._find_edges("confirm_benchmark_t3", "gate_accuracy_t3")) == 1
+
+    def test_edge_t3_accuracy_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_accuracy_t3", "gate_per_unit_accuracy", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_t3_accuracy_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_accuracy_t3", "archive_result_t3", VerdictType.HALT
+        )) == 1
+
+    def test_edge_t3_per_unit_proceed(self) -> None:
+        assert len(self._find_edges(
+            "gate_per_unit_accuracy", "archive_result_t3", VerdictType.PROCEED
+        )) == 1
+
+    def test_edge_t3_per_unit_reloop(self) -> None:
+        assert len(self._find_edges(
+            "gate_per_unit_accuracy", "builder_implement_alternative", VerdictType.RELOOP
+        )) == 1
+
+    def test_edge_t3_per_unit_halt(self) -> None:
+        assert len(self._find_edges(
+            "gate_per_unit_accuracy", "archive_result_t3", VerdictType.HALT
+        )) == 1
+
+
+# ── Tier Routing Mutual Exclusivity ───────────────────────────────
+
+
+class TestTierRouting:
+    """Tier routing gates ensure mutual exclusivity."""
+
+    def test_gate_is_tier1_has_exactly_two_outgoing(self) -> None:
+        wf = workflow()
+        outgoing = [e for e in wf.edges if e.source == "gate_is_tier1"]
+        assert len(outgoing) == 2
+        conditions = {e.condition for e in outgoing}
+        assert conditions == {VerdictType.PROCEED, VerdictType.HALT}
+
+    def test_gate_is_tier2_has_exactly_two_outgoing(self) -> None:
+        wf = workflow()
+        outgoing = [e for e in wf.edges if e.source == "gate_is_tier2"]
+        assert len(outgoing) == 2
+        conditions = {e.condition for e in outgoing}
+        assert conditions == {VerdictType.PROCEED, VerdictType.HALT}
+
+    def test_gate_is_tier3_has_exactly_one_outgoing(self) -> None:
+        """gate_is_tier3 HALT terminates workflow — only PROCEED edge exists."""
+        wf = workflow()
+        outgoing = [e for e in wf.edges if e.source == "gate_is_tier3"]
+        assert len(outgoing) == 1
+        assert outgoing[0].condition == VerdictType.PROCEED
+
+    def test_tier_gates_form_chain(self) -> None:
+        """gate_is_tier1 HALT → gate_is_tier2, gate_is_tier2 HALT → gate_is_tier3."""
+        wf = workflow()
+        halt_1 = [
+            e for e in wf.edges
+            if e.source == "gate_is_tier1" and e.condition == VerdictType.HALT
+        ]
+        assert len(halt_1) == 1
+        assert halt_1[0].target == "gate_is_tier2"
+
+        halt_2 = [
+            e for e in wf.edges
+            if e.source == "gate_is_tier2" and e.condition == VerdictType.HALT
+        ]
+        assert len(halt_2) == 1
+        assert halt_2[0].target == "gate_is_tier3"
+
+
+# ── Data Dependency Validation ────────────────────────────────────
+
+
+class TestDataDependencies:
+    """Reads sets are satisfied by predecessor writes sets."""
+
+    def test_select_tier_reads_baseline(self) -> None:
+        wf = workflow()
+        node = wf.nodes["select_tier"]
+        assert ".factory/sorting/baseline.json" in node.reads
+        # lock_baseline writes it
+        writer = wf.nodes["lock_baseline"]
+        assert ".factory/sorting/baseline.json" in writer.writes
+
+    def test_tier_gates_read_selection(self) -> None:
+        wf = workflow()
+        for name in ("gate_is_tier1", "gate_is_tier2", "gate_is_tier3"):
+            node = wf.nodes[name]
+            assert ".factory/sorting/tier-selection.json" in node.reads
+
+    def test_accuracy_gates_read_benchmark_and_baseline(self) -> None:
+        wf = workflow()
+        for name in ("gate_accuracy_t1", "gate_accuracy_t2", "gate_accuracy_t3"):
+            node = wf.nodes[name]
+            assert ".factory/sorting/benchmark-result.json" in node.reads
+            assert ".factory/sorting/baseline.json" in node.reads
+
+    def test_archive_nodes_read_benchmark_and_baseline(self) -> None:
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert ".factory/sorting/benchmark-result.json" in node.reads
+            assert ".factory/sorting/baseline.json" in node.reads
+
+    def test_confirm_benchmark_nodes_read_and_write_benchmark_result(self) -> None:
+        wf = workflow()
+        for name in (
+            "confirm_benchmark_t1",
+            "confirm_benchmark_t2",
+            "confirm_benchmark_t3",
+        ):
+            node = wf.nodes[name]
+            assert ".factory/sorting/benchmark-result.json" in node.reads
+            assert ".factory/sorting/benchmark-result.json" in node.writes
+
+    def test_per_unit_gate_reads_benchmark_and_baseline(self) -> None:
+        wf = workflow()
+        node = wf.nodes["gate_per_unit_accuracy"]
+        assert ".factory/sorting/benchmark-result.json" in node.reads
+        assert ".factory/sorting/baseline.json" in node.reads
+
+
+# ── Trigger Function ──────────────────────────────────────────────
+
+
+class TestTrigger:
+    """Trigger function tests."""
+
+    def test_trigger_matches_optimize_sorting(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.HAS_FACTORY, {"mode": "optimize-sorting"})
+
+    def test_trigger_rejects_other_modes(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "improve"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {"mode": "design"})
+        assert not wf.trigger(ProjectState.HAS_FACTORY, {})
+
+    def test_trigger_works_with_any_state(self) -> None:
+        wf = workflow()
+        assert wf.trigger is not None
+        assert wf.trigger(ProjectState.NO_REPO, {"mode": "optimize-sorting"})
+        assert wf.trigger(ProjectState.NO_FACTORY, {"mode": "optimize-sorting"})
+
+
+# ── Meta Dict ─────────────────────────────────────────────────────
+
+
+class TestMeta:
+    """Module-level meta dict tests."""
+
+    def test_meta_has_name(self) -> None:
+        assert meta["name"] == "optimize-sorting"
+
+    def test_meta_has_description(self) -> None:
+        desc = meta["description"]
+        assert isinstance(desc, str)
+        assert len(desc) > 0
+        assert "sorting" in desc.lower()
+
+    def test_meta_description_mentions_tiers(self) -> None:
+        desc = meta["description"]
+        assert "tier 1" in desc.lower() or "tier1" in desc.lower()
+
+
+# ── Registration ──────────────────────────────────────────────────
+
+
+class TestRegistration:
+    """Workflow is properly registered in register_all()."""
+
+    def test_registered_in_register_all(self) -> None:
+        workflows = register_all()
+        assert "optimize-sorting" in workflows
+
+    def test_registered_workflow_validates(self) -> None:
+        workflows = register_all()
+        wf = workflows["optimize-sorting"]
+        issues = wf.validate_graph()
+        assert issues == [], f"Registered workflow has issues: {issues}"
+
+    def test_registered_workflow_is_terminal(self) -> None:
+        workflows = register_all()
+        assert workflows["optimize-sorting"].terminal is True
+
+
+# ── Prompt Content ────────────────────────────────────────────────
+
+
+class TestPromptContent:
+    """Prompt templates contain required domain context."""
+
+    def test_researcher_prompts_mention_neuropixels(self) -> None:
+        wf = workflow()
+        for name in (
+            "researcher_discover_params",
+            "researcher_profile_pipeline",
+            "researcher_explore_alternatives",
+        ):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            assert "neuropixels" in node.prompt_template.lower()
+
+    def test_builder_prompts_mention_neuropixels(self) -> None:
+        wf = workflow()
+        for name in (
+            "builder_config_change",
+            "builder_optimize_hotpath",
+            "builder_implement_alternative",
+        ):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            assert "neuropixels" in node.prompt_template.lower()
+
+    def test_prompts_mention_gpu(self) -> None:
+        wf = workflow()
+        for name in (
+            "researcher_discover_params",
+            "researcher_profile_pipeline",
+            "researcher_explore_alternatives",
+        ):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            assert "gpu" in node.prompt_template.lower()
+
+    def test_prompts_mention_speed_target(self) -> None:
+        wf = workflow()
+        for name in (
+            "researcher_discover_params",
+            "strategist_t1",
+            "builder_config_change",
+        ):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            assert "speed" in node.prompt_template.lower()
+            assert "accuracy" in node.prompt_template.lower()
+
+    def test_builder_t1_mentions_config_only(self) -> None:
+        wf = workflow()
+        node = wf.nodes["builder_config_change"]
+        assert isinstance(node, AgentNode)
+        assert ".yaml" in node.prompt_template
+        assert ".json" in node.prompt_template
+        assert "ZERO source code" in node.prompt_template
+
+    def test_builder_t3_mentions_per_unit(self) -> None:
+        wf = workflow()
+        node = wf.nodes["builder_implement_alternative"]
+        assert isinstance(node, AgentNode)
+        assert "per-unit" in node.prompt_template.lower() or "per_unit" in node.prompt_template.lower()
+
+    def test_all_agent_nodes_have_prompts(self) -> None:
+        """All 12 AgentNodes (10 unique templates, archivists share 1) have non-empty prompts."""
+        wf = workflow()
+        agent_nodes = [
+            n for n in wf.nodes.values() if isinstance(n, AgentNode)
+        ]
+        assert len(agent_nodes) == 12
+        for node in agent_nodes:
+            assert node.prompt_template, f"{node.id} has empty prompt_template"
+
+    def test_researcher_t2_reads_stage_timing_from_baseline(self) -> None:
+        """T2 researcher reads .stage_timing from baseline, uses measured (not estimated) timing."""
+        wf = workflow()
+        node = wf.nodes["researcher_profile_pipeline"]
+        assert isinstance(node, AgentNode)
+        prompt = node.prompt_template
+        assert "stage_timing" in prompt
+        assert "baseline" in prompt.lower()
+        assert "measured" in prompt.lower() or "actual" in prompt.lower()
+        assert "estimate time per stage" not in prompt.lower()
+
+    def test_researcher_t2_output_includes_baseline_mean(self) -> None:
+        """T2 researcher output schema includes baseline_mean."""
+        wf = workflow()
+        node = wf.nodes["researcher_profile_pipeline"]
+        assert isinstance(node, AgentNode)
+        assert "baseline_mean" in node.prompt_template
+
+    def test_researcher_t2_prioritizes_stages_by_time(self) -> None:
+        """T2 researcher ranks/prioritizes stages by measured time."""
+        wf = workflow()
+        node = wf.nodes["researcher_profile_pipeline"]
+        assert isinstance(node, AgentNode)
+        prompt = node.prompt_template.lower()
+        assert "rank" in prompt or "prioritize" in prompt or "highest first" in prompt
+
+    def test_archive_prompt_computes_stage_timing_deltas(self) -> None:
+        """Archive prompt computes stage_timing_deltas for all 3 tiers."""
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            prompt = node.prompt_template
+            assert "stage_timing_deltas" in prompt, f"{name} missing stage_timing_deltas"
+            assert "baseline" in prompt.lower(), f"{name} missing baseline reference"
+            assert "delta" in prompt.lower(), f"{name} missing delta reference"
+            assert "stage" in prompt.lower(), f"{name} missing stage reference"
+
+    def test_archive_prompt_stage_timing_deltas_in_jsonl_fields(self) -> None:
+        """Archive JSONL field list includes stage_timing_deltas for all 3 tiers."""
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            assert "stage_timing_deltas" in node.prompt_template, (
+                f"{name} JSONL fields missing stage_timing_deltas"
+            )
+
+    def test_archive_prompt_handles_missing_stage_timing(self) -> None:
+        """Archive prompt handles missing/empty stage_timing with null fallback."""
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            prompt = node.prompt_template.lower()
+            assert "missing" in prompt or "absent" in prompt, (
+                f"{name} missing missing/absent handling"
+            )
+            assert "null" in prompt, f"{name} missing null fallback"
+
+    def test_archive_prompt_handles_averaged_and_single_run(self) -> None:
+        """Archive prompt handles both averaged (dict with mean/std) and single-run formats."""
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            prompt = node.prompt_template.lower()
+            assert "mean" in prompt and "std" in prompt, (
+                f"{name} missing mean/std handling"
+            )
+            assert (
+                "single" in prompt or "plain float" in prompt or "directly" in prompt
+            ), f"{name} missing single-run handling"
+
+    def test_archive_prompt_handles_new_stages(self) -> None:
+        """Archive prompt handles new stages (in result but not baseline)."""
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            assert '"new"' in node.prompt_template.lower() or "'new'" in node.prompt_template.lower(), (
+                f"{name} missing 'new' status for new stages"
+            )
+
+    def test_archive_prompt_handles_removed_stages(self) -> None:
+        """Archive prompt handles removed stages (in baseline but not result)."""
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            assert '"removed"' in node.prompt_template.lower() or "'removed'" in node.prompt_template.lower(), (
+                f"{name} missing 'removed' status for removed stages"
+            )
+
+    def test_archive_prompt_uses_union_of_stages(self) -> None:
+        """Archive prompt iterates over the union of baseline and result stages."""
+        wf = workflow()
+        for name in ("archive_result_t1", "archive_result_t2", "archive_result_t3"):
+            node = wf.nodes[name]
+            assert isinstance(node, AgentNode)
+            assert "union" in node.prompt_template.lower(), (
+                f"{name} missing 'union' reference"
+            )
+
+
+# ── RELOOP Edges ──────────────────────────────────────────────────
+
+
+class TestReloopEdges:
+    """All RELOOP cycles contain a GateNode with conditional edge."""
+
+    def test_all_reloop_edges_originate_from_gates(self) -> None:
+        wf = workflow()
+        reloop_edges = [e for e in wf.edges if e.condition == VerdictType.RELOOP]
+        assert len(reloop_edges) == 2  # 1 in T1 (config gate), 1 in T3 (per-unit gate)
+        for edge in reloop_edges:
+            assert isinstance(wf.nodes[edge.source], GateNode), (
+                f"RELOOP edge from {edge.source} but it's not a GateNode"
+            )
+
+    def test_reloop_count(self) -> None:
+        wf = workflow()
+        reloop_edges = [e for e in wf.edges if e.condition == VerdictType.RELOOP]
+        assert len(reloop_edges) == 2

--- a/factory/workflow/contributed/optimize_sorting/workflow.py
+++ b/factory/workflow/contributed/optimize_sorting/workflow.py
@@ -1,0 +1,1058 @@
+"""Optimize-sorting workflow — iterative speed optimization of spike sorting pipelines.
+
+Three-tier DAG with chained binary gate routing. Each CEO invocation traverses
+the shared prefix (baseline lock → tier selection → routing gates), enters
+exactly one tier subgraph, and terminates at that tier's archive node.
+
+Tiers:
+  1. Config sweep — tune parameters without touching source code.
+  2. Code optimization — preserve algorithmic behavior, faster execution.
+  3. Algorithm changes — strict accuracy thresholds including per-unit gates.
+
+Benchmark JSON output contract:
+    {
+      "accuracy": float,         // required — overall accuracy [0.0-1.0]
+      "speed_seconds": float,    // required — wall-clock time
+      "per_unit_accuracy": {},   // required for tier 3 — {unit_id: float}
+      "stage_timing": {},        // recommended for tier 2 — {stage_name: float}
+    }
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from factory.models import ProjectState
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Edge,
+    FnNode,
+    GateNode,
+    VerdictType,
+    Workflow,
+)
+
+meta = {
+    "name": "optimize-sorting",
+    "description": (
+        "Optimize-sorting mode — three-tier iterative speed optimization for "
+        "spike sorting pipelines with hard accuracy constraints. "
+        "Tier 1: config sweep (parameter tuning, no code changes). "
+        "Tier 2: code optimization (preserve algorithmic behavior). "
+        "Tier 3: algorithm changes (strict 0.5% overall + 5% per-unit accuracy gates). "
+        "One experiment per CEO invocation. Terminal mode."
+    ),
+}
+
+
+# ── helper functions for command generation ───────────────────────
+
+
+def _lock_baseline_command() -> str:
+    """Inline python3 -c command for the lock_baseline FnNode."""
+    return (
+        "python3 -c \""
+        "import json, subprocess, sys, statistics, os, datetime;"
+        "p = '{project_path}';"
+        "bl = os.path.join(p, '.factory', 'sorting', 'baseline.json');"
+        "os.makedirs(os.path.dirname(bl), exist_ok=True);"
+        "exists = os.path.exists(bl);"
+        "print(f'baseline exists: {exists}');"
+        ""
+        "if exists:"
+        "    print('Baseline already locked, skipping.');"
+        "    sys.exit(0);"
+        ""
+        "cfg_path = os.path.join(p, '.factory', 'config.json');"
+        "cfg = json.load(open(cfg_path));"
+        "sb = cfg.get('sorting_benchmark', cfg.get('research_target', {}));"
+        "cmd = sb.get('command', sb.get('run_command', ''));"
+        ""
+        "if not cmd:"
+        "    print('ERROR: No sorting_benchmark.command in config.json', file=sys.stderr);"
+        "    sys.exit(1);"
+        ""
+        "N = 3;"
+        "results = [];"
+        "for i in range(N):"
+        "    print(f'Baseline run {i+1}/{N}');"
+        "    run_cmd = cmd.replace('{recording}', sb.get('recording', '')).replace('{output}', os.path.join(p, '.factory', 'sorting', f'baseline_run_{i}.json'));"
+        "    r = subprocess.run(run_cmd, shell=True, capture_output=True, text=True, cwd=p);"
+        "    if r.returncode != 0:"
+        "        print(f'Benchmark failed: {r.stderr}', file=sys.stderr);"
+        "        sys.exit(1);"
+        "    out_file = os.path.join(p, '.factory', 'sorting', f'baseline_run_{i}.json');"
+        "    if os.path.exists(out_file):"
+        "        results.append(json.load(open(out_file)));"
+        "    else:"
+        "        results.append(json.loads(r.stdout));"
+        ""
+        "accs = [r['accuracy'] for r in results];"
+        "speeds = [r['speed_seconds'] for r in results];"
+        "acc_mean = statistics.mean(accs);"
+        "acc_std = statistics.stdev(accs) if len(accs) > 1 else 0.0;"
+        "spd_mean = statistics.mean(speeds);"
+        "spd_std = statistics.stdev(speeds) if len(speeds) > 1 else 0.0;"
+        ""
+        "pu = {};"
+        "for r in results:"
+        "    for uid, val in r.get('per_unit_accuracy', {}).items():"
+        "        pu.setdefault(uid, []).append(val);"
+        "pu_stats = {uid: {'mean': statistics.mean(vals), 'std': statistics.stdev(vals) if len(vals) > 1 else 0.0} for uid, vals in pu.items()};"
+        ""
+        "st = {};"
+        "for r in results:"
+        "    for stage, val in r.get('stage_timing', {}).items():"
+        "        st.setdefault(stage, []).append(val);"
+        "st_stats = {stage: {'mean': statistics.mean(vals), 'std': statistics.stdev(vals) if len(vals) > 1 else 0.0} for stage, vals in st.items()};"
+        ""
+        "baseline = {"
+        "    'accuracy': {'mean': acc_mean, 'std': acc_std},"
+        "    'speed_seconds': {'mean': spd_mean, 'std': spd_std},"
+        "    'per_unit_accuracy': pu_stats,"
+        "    'stage_timing': st_stats,"
+        "    'n_runs': N,"
+        "    'locked_at': datetime.datetime.now(datetime.timezone.utc).isoformat(),"
+        "    'thresholds': {"
+        "        'tier1': acc_mean - acc_std,"
+        "        'tier2': acc_mean - acc_std,"
+        "        'tier3_overall': acc_mean - 0.005,"
+        "        'tier3_per_unit_drop': 0.05"
+        "    }"
+        "};"
+        "json.dump(baseline, open(bl, 'w'), indent=2);"
+        "print(f'Baseline locked: acc={acc_mean:.4f}+-{acc_std:.4f}, speed={spd_mean:.2f}+-{spd_std:.2f}s')"
+        "\""
+    )
+
+
+def _select_tier_command() -> str:
+    """Inline python3 -c command for the select_tier FnNode."""
+    return (
+        "python3 -c \""
+        "import json, os, re, subprocess, sys;"
+        "p = '{project_path}';"
+        "# Reset to main so each experiment measures against the baseline independently."
+        "# Experiment branches are created by the builder."
+        "subprocess.run(['git', 'checkout', 'main'], cwd=p, check=True);"
+        "focus_path = os.path.join(p, '.factory', 'sorting', 'focus.txt');"
+        "exp_path = os.path.join(p, '.factory', 'sorting', 'experiments.jsonl');"
+        "out_path = os.path.join(p, '.factory', 'sorting', 'tier-selection.json');"
+        ""
+        "tier = None;"
+        "focus = None;"
+        "reason = 'default';"
+        ""
+        "if os.path.exists(focus_path):"
+        "    focus = open(focus_path).read().strip();"
+        "    fl = focus.lower();"
+        "    if re.search(r'tier\\s*1|config', fl):"
+        "        tier = 1;"
+        "        reason = f'focus: {focus}';"
+        "    elif re.search(r'tier\\s*2|profil', fl):"
+        "        tier = 2;"
+        "        reason = f'focus: {focus}';"
+        "    elif re.search(r'tier\\s*3|algorithm', fl):"
+        "        tier = 3;"
+        "        reason = f'focus: {focus}';"
+        ""
+        "if tier is None:"
+        "    experiments = [];"
+        "    if os.path.exists(exp_path):"
+        "        for line in open(exp_path):"
+        "            line = line.strip();"
+        "            if line:"
+        "                try:"
+        "                    experiments.append(json.loads(line));"
+        "                except json.JSONDecodeError:"
+        "                    pass;"
+        ""
+        "    if not experiments:"
+        "        tier = 1;"
+        "        reason = 'no experiments yet, starting at tier 1';"
+        "    else:"
+        "        for check_tier in [1, 2, 3]:"
+        "            tier_exps = [e for e in experiments if e.get('tier') == check_tier];"
+        "            if len(tier_exps) < 3:"
+        "                tier = check_tier;"
+        "                reason = f'tier {check_tier} has {len(tier_exps)} experiments (< 3)';"
+        "                break;"
+        "            recent = tier_exps[-3:];"
+        "            deltas = [abs(e.get('speed_delta_pct', 0)) for e in recent];"
+        "            if all(d < 1.0 for d in deltas):"
+        "                reason = f'tier {check_tier} plateau detected ({deltas})';"
+        "                continue;"
+        "            else:"
+        "                tier = check_tier;"
+        "                reason = f'tier {check_tier} still improving';"
+        "                break;"
+        "        if tier is None:"
+        "            tier = 0;"
+        "            reason = 'all tiers plateaued';"
+        ""
+        "result = {'tier': tier, 'focus': focus, 'reason': reason};"
+        "json.dump(result, open(out_path, 'w'), indent=2);"
+        "print(f'Selected tier {tier}: {reason}')"
+        "\""
+    )
+
+
+def _tier_gate_command(tier_num: int) -> str:
+    """Inline python3 -c evaluator command for gate_is_tierN."""
+    return (
+        "python3 -c \""
+        "import json, os;"
+        "p = '{project_path}';"
+        "sel = json.load(open(os.path.join(p, '.factory', 'sorting', 'tier-selection.json')));"
+        f"t = sel.get('tier', 0);"
+        f"print('pass: tier matches' if t == {tier_num} else 'fail: tier is ' + str(t))"
+        "\""
+    )
+
+
+def _benchmark_command() -> str:
+    """Inline python3 -c command for run_benchmark_t{1,2,3} FnNodes."""
+    return (
+        "python3 -c \""
+        "import json, subprocess, sys, os;"
+        "p = '{project_path}';"
+        "cfg = json.load(open(os.path.join(p, '.factory', 'config.json')));"
+        "sb = cfg.get('sorting_benchmark', cfg.get('research_target', {}));"
+        "cmd = sb.get('command', sb.get('run_command', ''));"
+        ""
+        "if not cmd:"
+        "    print('ERROR: No benchmark command in config.json', file=sys.stderr);"
+        "    sys.exit(1);"
+        ""
+        "out = os.path.join(p, '.factory', 'sorting', 'benchmark-result.json');"
+        "os.makedirs(os.path.dirname(out), exist_ok=True);"
+        "run_cmd = cmd.replace('{recording}', sb.get('recording', '')).replace('{output}', out);"
+        "r = subprocess.run(run_cmd, shell=True, capture_output=True, text=True, cwd=p);"
+        "if r.returncode != 0:"
+        "    print(f'Benchmark failed: {r.stderr}', file=sys.stderr);"
+        "    sys.exit(1);"
+        ""
+        "if not os.path.exists(out):"
+        "    data = json.loads(r.stdout);"
+        "    json.dump(data, open(out, 'w'), indent=2);"
+        ""
+        "data = json.load(open(out));"
+        "assert 'accuracy' in data, 'Missing accuracy in benchmark result';"
+        "assert 'speed_seconds' in data, 'Missing speed_seconds in benchmark result';"
+        "print(f'Benchmark: accuracy={data[\"accuracy\"]:.4f}, speed={data[\"speed_seconds\"]:.2f}s')"
+        "\""
+    )
+
+
+def _benchmark_3x_command() -> str:
+    """Inline python3 -c command for confirm_benchmark_t{1,2,3} FnNodes.
+
+    Reads the existing benchmark-result.json (run 1), executes 2 more runs,
+    then averages all 3 and overwrites benchmark-result.json with
+    mean/std fields (same format as baseline.json).
+    """
+    return (
+        "python3 -c \""
+        "import json, subprocess, sys, statistics, os, datetime;"
+        "p = '{project_path}';"
+        "cfg = json.load(open(os.path.join(p, '.factory', 'config.json')));"
+        "sb = cfg.get('sorting_benchmark', cfg.get('research_target', {}));"
+        "cmd = sb.get('command', sb.get('run_command', ''));"
+        ""
+        "if not cmd:"
+        "    print('ERROR: No benchmark command in config.json', file=sys.stderr);"
+        "    sys.exit(1);"
+        ""
+        "br_path = os.path.join(p, '.factory', 'sorting', 'benchmark-result.json');"
+        "run1 = json.load(open(br_path));"
+        "results = [run1];"
+        ""
+        "for i in range(2):"
+        "    print(f'Confirmation run {i+2}/3');"
+        "    out_i = os.path.join(p, '.factory', 'sorting', f'benchmark_confirm_{i}.json');"
+        "    run_cmd = cmd.replace('{recording}', sb.get('recording', '')).replace('{output}', out_i);"
+        "    r = subprocess.run(run_cmd, shell=True, capture_output=True, text=True, cwd=p);"
+        "    if r.returncode != 0:"
+        "        print(f'Benchmark failed: {r.stderr}', file=sys.stderr);"
+        "        sys.exit(1);"
+        "    if os.path.exists(out_i):"
+        "        results.append(json.load(open(out_i)));"
+        "    else:"
+        "        results.append(json.loads(r.stdout));"
+        ""
+        "accs = [r['accuracy'] for r in results];"
+        "speeds = [r['speed_seconds'] for r in results];"
+        "acc_mean = statistics.mean(accs);"
+        "acc_std = statistics.stdev(accs) if len(accs) > 1 else 0.0;"
+        "spd_mean = statistics.mean(speeds);"
+        "spd_std = statistics.stdev(speeds) if len(speeds) > 1 else 0.0;"
+        ""
+        "pu = {};"
+        "for r in results:"
+        "    for uid, val in r.get('per_unit_accuracy', {}).items():"
+        "        pu.setdefault(uid, []).append(val);"
+        "pu_stats = {uid: {'mean': statistics.mean(vals), 'std': statistics.stdev(vals) if len(vals) > 1 else 0.0} for uid, vals in pu.items()};"
+        ""
+        "st = {};"
+        "for r in results:"
+        "    for stage, val in r.get('stage_timing', {}).items():"
+        "        st.setdefault(stage, []).append(val);"
+        "st_stats = {stage: {'mean': statistics.mean(vals), 'std': statistics.stdev(vals) if len(vals) > 1 else 0.0} for stage, vals in st.items()};"
+        ""
+        "averaged = {"
+        "    'accuracy': {'mean': acc_mean, 'std': acc_std},"
+        "    'speed_seconds': {'mean': spd_mean, 'std': spd_std},"
+        "    'per_unit_accuracy': pu_stats,"
+        "    'stage_timing': st_stats,"
+        "    'n_runs': 3,"
+        "    'confirmed_at': datetime.datetime.now(datetime.timezone.utc).isoformat()"
+        "};"
+        "json.dump(averaged, open(br_path, 'w'), indent=2);"
+        "print(f'Confirmed (3 runs): acc={acc_mean:.4f}+-{acc_std:.4f}, speed={spd_mean:.2f}+-{spd_std:.2f}s')"
+        "\""
+    )
+
+
+def _catastrophic_gate_command() -> str:
+    """Inline python3 -c evaluator command for gate_catastrophic_t{1,2,3}.
+
+    Only catches catastrophic accuracy drops (>10% below baseline mean).
+    Outputs pass (PROCEED) or fail (HALT).
+    """
+    return (
+        "python3 -c \""
+        "import json, os;"
+        "p = '{project_path}';"
+        "bl = json.load(open(os.path.join(p, '.factory', 'sorting', 'baseline.json')));"
+        "br = json.load(open(os.path.join(p, '.factory', 'sorting', 'benchmark-result.json')));"
+        "acc = br['accuracy'];"
+        "bl_mean = bl['accuracy']['mean'];"
+        "threshold = bl_mean * 0.9;"
+        "if acc >= threshold:"
+        "    print(f'pass: acc={acc:.4f} >= catastrophic threshold={threshold:.4f}');"
+        "else:"
+        "    print(f'fail: catastrophic drop acc={acc:.4f} < {threshold:.4f} (>{10}% below baseline={bl_mean:.4f})')"
+        "\""
+    )
+
+
+def _config_gate_command() -> str:
+    """Shell evaluator_command for gate_no_code_changes."""
+    return (
+        "cd {project_path} && "
+        "FILES=$(git diff HEAD --name-only 2>/dev/null || true) && "
+        "if [ -z \"$FILES\" ]; then "
+        "echo 'pass: no changes detected'; exit 0; fi && "
+        "CODE_FILES=$(echo \"$FILES\" | grep -v -E "
+        "'\\.(json|yaml|yml|toml|cfg|ini|conf|env)$' || true) && "
+        "if [ -z \"$CODE_FILES\" ]; then "
+        "echo 'pass: config-only changes'; exit 0; fi && "
+        "echo \"reloop: source code modified — $CODE_FILES\"; exit 0"
+    )
+
+
+def _accuracy_gate_command(tier: int) -> str:
+    """Inline python3 -c evaluator command for gate_accuracy_t{1,2,3}.
+
+    Runs AFTER confirm_benchmark so benchmark-result.json has averaged format
+    with {accuracy: {mean, std}, ...}.  Falls back to plain float for safety.
+    Outputs pass (PROCEED) or fail (HALT) — no reloop since 3-run average is
+    definitive.
+    """
+    if tier in (1, 2):
+        threshold_expr = "bl['accuracy']['mean'] - bl['accuracy']['std']"
+    else:
+        threshold_expr = "bl['accuracy']['mean'] - 0.005"
+    return (
+        "python3 -c \""
+        "import json, os;"
+        "p = '{project_path}';"
+        "bl = json.load(open(os.path.join(p, '.factory', 'sorting', 'baseline.json')));"
+        "br = json.load(open(os.path.join(p, '.factory', 'sorting', 'benchmark-result.json')));"
+        f"threshold = {threshold_expr};"
+        "acc = br['accuracy'];"
+        "if isinstance(acc, dict):"
+        "    acc = acc['mean'];"
+        "bl_mean = bl['accuracy']['mean'];"
+        "delta = acc - bl_mean;"
+        "if acc >= threshold:"
+        "    print(f'pass: acc={acc:.4f} >= threshold={threshold:.4f} (delta={delta:+.4f})');"
+        "else:"
+        "    print(f'fail: acc={acc:.4f} < threshold={threshold:.4f} (delta={delta:+.4f}, baseline={bl_mean:.4f})')"
+        "\""
+    )
+
+
+def _per_unit_gate_command() -> str:
+    """Inline python3 -c evaluator command for gate_per_unit_accuracy.
+
+    Handles averaged format: per_unit_accuracy values may be
+    {mean: float, std: float} dicts (from confirm_benchmark) or plain floats.
+    """
+    return (
+        "python3 -c \""
+        "import json, os;"
+        "p = '{project_path}';"
+        "bl = json.load(open(os.path.join(p, '.factory', 'sorting', 'baseline.json')));"
+        "br = json.load(open(os.path.join(p, '.factory', 'sorting', 'benchmark-result.json')));"
+        "pu_bl = bl.get('per_unit_accuracy', {});"
+        "pu_br = br.get('per_unit_accuracy', {});"
+        "drops = [];"
+        "for uid, stats in pu_bl.items():"
+        "    bl_mean = stats['mean'];"
+        "    if bl_mean == 0:"
+        "        continue;"
+        "    if uid not in pu_br:"
+        "        drops.append((uid, 1.0));"
+        "        continue;"
+        "    cur = pu_br[uid];"
+        "    if isinstance(cur, dict):"
+        "        cur = cur['mean'];"
+        "    drop = (bl_mean - cur) / bl_mean;"
+        "    if drop > 0.05:"
+        "        drops.append((uid, drop));"
+        "if len(drops) == 0:"
+        "    print('pass: all units within 5% of baseline');"
+        "elif len(drops) <= 2:"
+        "    details = ', '.join(f'{u}: {d:.1%} drop' for u, d in drops);"
+        "    print(f'reloop: {len(drops)} unit(s) regressed — {details}');"
+        "else:"
+        "    details = ', '.join(f'{u}: {d:.1%} drop' for u, d in drops);"
+        "    print(f'fail: {len(drops)} units regressed (>2) — {details}')"
+        "\""
+    )
+
+
+def _archive_prompt(tier: int) -> str:
+    """Prompt template for archive_result_t{1,2,3} AgentNodes."""
+    return (
+        "You are the Archivist recording the result of a sorting optimization experiment.\n\n"
+        "## Your Task\n\n"
+        "1. Read the benchmark result at `.factory/sorting/benchmark-result.json`\n"
+        "   - If `accuracy` is a dict with `mean`/`std` keys, the file contains **averaged\n"
+        "     3-run** data (from confirm_benchmark). Use `.accuracy.mean` and\n"
+        "     `.speed_seconds.mean` for deltas.\n"
+        "   - If `accuracy` is a plain float, it is a **single-run** result (catastrophic\n"
+        "     gate halted before confirmation runs). Use `.accuracy` and `.speed_seconds`\n"
+        "     directly.\n"
+        "2. Read the baseline at `.factory/sorting/baseline.json`\n"
+        "3. Compute deltas:\n"
+        "   - `speed_delta = baseline_speed - result_speed` (positive = faster)\n"
+        "   - `speed_delta_pct = (speed_delta / baseline_speed) * 100`\n"
+        "   - `accuracy_delta = result_accuracy - baseline_accuracy`\n"
+        "   - `per_unit_deltas`: for each unit, `result - baseline_mean`\n"
+        "   - `stage_timing_deltas`: iterate over the **union** of all stage names\n"
+        "     from baseline `.stage_timing` and result `.stage_timing`:\n"
+        "     - **Stage in both baseline and result:** Read baseline stage time from\n"
+        "       `baseline.stage_timing[stage].mean`. Read result stage time: if result\n"
+        "       `.stage_timing[stage]` is a dict with `mean`/`std`, use `.mean`; if it\n"
+        "       is a plain float, use directly. Compute:\n"
+        "       `delta = baseline_mean - result_time` (positive = faster),\n"
+        "       `pct = (delta / baseline_mean) * 100`.\n"
+        "       Store as `{stage: {delta: float, pct: float}}`.\n"
+        "     - **Stage in result but NOT in baseline (new stage):** Store as\n"
+        "       `{stage: {delta: null, pct: null, status: \"new\"}}`. There is no\n"
+        "       baseline reference for comparison.\n"
+        "     - **Stage in baseline but NOT in result (removed stage):** Store as\n"
+        "       `{stage: {delta: null, pct: null, status: \"removed\"}}`. The stage\n"
+        "       existed in the baseline pipeline but is absent from the result.\n"
+        "   - If either file has empty/missing `stage_timing`, set\n"
+        "     `stage_timing_deltas` to `null`\n"
+        "4. Determine verdict:\n"
+        "   - If you reached this node via a PROCEED edge from gate_accuracy\n"
+        "     (or gate_per_unit_accuracy for tier 3): verdict = 'keep'\n"
+        "   - If you reached this node via a HALT edge (catastrophic gate or\n"
+        "     accuracy gate failure): verdict = 'revert'\n"
+        "   - If reverting, run `git revert HEAD --no-edit` to undo the change\n"
+        "5. Read the tier from `.factory/sorting/tier-selection.json`\n"
+        "6. Append ONE JSONL line to `.factory/sorting/experiments.jsonl` with fields:\n"
+        "   `tier`, `change` (brief description), `speed_delta`, `speed_delta_pct`, "
+        "`accuracy_delta`, `per_unit_deltas`, `stage_timing`, `stage_timing_deltas`, "
+        "`verdict`, `timestamp` (ISO8601)\n\n"
+        f"## PR Comment (Tier {tier})\n"
+        "If the verdict is **'keep'**, post a PR comment with the benchmark summary:\n"
+        "1. Find the PR number for the current branch:\n"
+        "   ```\n"
+        "   gh pr list --head $(git branch --show-current) --json number -q '.[0].number'\n"
+        "   ```\n"
+        "2. Post the comment:\n"
+        "   ```\n"
+        "   gh pr comment <PR_NUMBER> --body '<message>'\n"
+        "   ```\n"
+        "   The message must include:\n"
+        f"   - **Tier**: {tier}\n"
+        "   - **Change**: brief description of what was changed\n"
+        "   - **Speed delta**: absolute value (e.g. -1.23s) and percentage (e.g. -15.2%)\n"
+        "   - **Accuracy delta**: e.g. +0.0012\n"
+        "   - **Per-stage timing** (if `stage_timing_deltas` is not null): a table\n"
+        "     showing each stage name, baseline time, result time, delta, pct change,\n"
+        "     and status. Include rows for new and removed stages.\n"
+        "     Example:\n"
+        "     ```\n"
+        "     | Stage        | Baseline (s) | Result (s) | Delta (s) | Change (%) | Status  |\n"
+        "     |--------------|-------------|------------|-----------|------------|--------|\n"
+        "     | clustering   | 4.21        | 3.55       | +0.66     | +15.7%     | ✓       |\n"
+        "     | detection    | 2.10        | 2.08       | +0.02     | +1.0%      | ✓       |\n"
+        "     | postprocess  | —           | 0.45       | —         | —          | NEW     |\n"
+        "     | legacy_merge | 1.30        | —          | —         | —          | REMOVED |\n"
+        "     ```\n"
+        "   - **Verdict**: keep\n"
+        "   - **Confidence**: mean ± std from 3 confirmation runs\n\n"
+        "If the verdict is **'revert'**, do NOT post a PR comment.\n\n"
+        "## Rules\n"
+        "- Append exactly ONE line (valid JSON) to experiments.jsonl\n"
+        "- Do NOT overwrite the file — append only\n"
+        "- Include all fields even if some are null or empty\n"
+        "- Use the actual measured values, not estimates\n"
+    )
+
+
+# ── prompt templates ─────────────────────────────────────────────
+
+
+_RESEARCHER_T1_PROMPT = (
+    "You are a Researcher investigating tunable configuration parameters for a "
+    "Neuropixels-scale, GPU-accelerated spike sorting pipeline.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- Scale: 384+ channels, 30kHz sampling, millions of samples per recording.\n"
+    "- GPU-accelerated sorters (e.g. Kilosort, YASS) have many tunable parameters.\n\n"
+    "## Your Task\n"
+    "1. Discover ALL config files in the project (YAML, JSON, TOML, INI, CFG).\n"
+    "2. Extract every tunable parameter with its current value, valid range, "
+    "and default.\n"
+    "3. Rank parameters by expected speed impact (highest first).\n"
+    "4. Note which parameters affect accuracy (these need careful testing).\n"
+    "5. Write your findings to `.factory/sorting/research-params.md`.\n\n"
+    "## Output Format\n"
+    "A markdown file with:\n"
+    "- Table of all parameters (name, file, current value, range, speed impact estimate)\n"
+    "- Top 5 recommendations for speed improvement\n"
+    "- Accuracy-sensitive parameters flagged with warnings\n"
+)
+
+_STRATEGIST_T1_PROMPT = (
+    "You are a Strategist selecting ONE configuration parameter variation to test "
+    "for speed optimization of a spike sorting pipeline.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- Read the researcher's parameter discovery at `.factory/sorting/research-params.md`.\n"
+    "- Read the baseline at `.factory/sorting/baseline.json` for current performance.\n"
+    "- Check `.factory/sorting/experiments.jsonl` for prior attempts (avoid repeats).\n\n"
+    "## Your Task\n"
+    "1. Rank discovered parameters by: highest speed impact × lowest accuracy risk.\n"
+    "2. Select ONE parameter variation to test this cycle.\n"
+    "3. Justify why this variation is the best next experiment.\n"
+    "4. Write the strategy to `.factory/strategy/current.md` with:\n"
+    "   - Which parameter to change\n"
+    "   - What value to set (with rationale)\n"
+    "   - Expected speed impact\n"
+    "   - Accuracy risk assessment\n"
+)
+
+_BUILDER_T1_PROMPT = (
+    "You are a Builder applying a configuration change to optimize spike sorting speed.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- Neuropixels-scale: 384+ channels, 30kHz, millions of samples.\n"
+    "- Read the strategy at `.factory/strategy/current.md` for which parameter to change.\n\n"
+    "## STRICT RULES\n"
+    "- ONLY modify config/parameter files: .yaml, .json, .toml, .cfg, .ini, .conf, .env\n"
+    "- ZERO source code changes: do NOT modify .py, .cu, .cpp, .c, .h, .pyx, .sh files\n"
+    "- A gate will verify no code was changed — if you modify code, you'll be sent back\n\n"
+    "## Reloop Handling\n"
+    "- If you were sent back from `gate_no_code_changes`: you modified source code. "
+    "Revert those changes and apply the config change using ONLY config files.\n\n"
+    "## Your Task\n"
+    "1. Apply the parameter change specified in the strategy\n"
+    "2. Verify you only touched config files\n"
+    "3. Write a summary to `.factory/reviews/builder-latest.md`\n"
+    "4. Write the config diff to `.factory/sorting/config-diff.json`\n"
+)
+
+_RESEARCHER_T2_PROMPT = (
+    "You are a Researcher profiling a Neuropixels-scale, GPU-accelerated spike "
+    "sorting pipeline to identify performance bottlenecks.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- Scale: 384+ channels, 30kHz sampling, millions of samples.\n"
+    "- Read baseline at `.factory/sorting/baseline.json`.\n"
+    "- **Baseline contains measured stage timing:** `.stage_timing` has\n"
+    "  `{stage_name: {mean: <seconds>, std: <seconds>}}` averaged from 3 runs.\n"
+    "  These are ground-truth measurements — use them, do not estimate.\n\n"
+    "## Your Task\n"
+    "1. Identify all pipeline stages (preprocessing, detection, clustering, etc.).\n"
+    "2. Read `.stage_timing` from `.factory/sorting/baseline.json` for actual\n"
+    "   measured wall-clock time per stage. Use these as ground truth.\n"
+    "3. Rank stages by measured time (highest `mean` first) — the slowest stage\n"
+    "   is the primary optimization target.\n"
+    "4. For each stage, determine if it is GPU-bound or CPU-bound via code analysis.\n"
+    "5. Identify memory allocation patterns and potential bottlenecks.\n"
+    "6. Write dual output:\n"
+    "   - `.factory/sorting/research-profile.md`: detailed profiling report with\n"
+    "     stages ranked by measured baseline time (slowest first)\n"
+    "   - `.factory/sorting/stage-timing.json`: structured timing data\n"
+    "     `{stage_name: {baseline_mean: float, baseline_std: float, "
+    "pct_of_total: float, gpu_bound: bool, notes: str}}`\n"
+)
+
+_STRATEGIST_T2_PROMPT = (
+    "You are a Strategist identifying ONE hot-path optimization for a spike sorting pipeline.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- Read profiling at `.factory/sorting/research-profile.md` and "
+    "`.factory/sorting/stage-timing.json`.\n"
+    "- Read baseline at `.factory/sorting/baseline.json`.\n"
+    "- Check `.factory/sorting/experiments.jsonl` for prior attempts.\n\n"
+    "## Your Task\n"
+    "1. Target the PRIMARY bottleneck stage for optimization.\n"
+    "2. Validate the optimization preserves algorithmic behavior "
+    "(same inputs → same outputs).\n"
+    "3. Write strategy to `.factory/strategy/current.md` with:\n"
+    "   - Which stage/function to optimize\n"
+    "   - What optimization to apply\n"
+    "   - Why it preserves correctness\n"
+    "   - Expected speed improvement\n"
+)
+
+_BUILDER_T2_PROMPT = (
+    "You are a Builder implementing a hot-path optimization for spike sorting.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- Neuropixels-scale: 384+ channels, 30kHz, millions of samples, GPU-accelerated.\n"
+    "- Read strategy at `.factory/strategy/current.md`.\n"
+    "- Read stage timing at `.factory/sorting/stage-timing.json`.\n\n"
+    "## STRICT RULES\n"
+    "- Preserve algorithmic behavior: same inputs MUST produce same outputs.\n"
+    "- Run existing tests to verify correctness after changes.\n"
+    "- Focus on the specific optimization described in the strategy.\n\n"
+    "## Your Task\n"
+    "1. Implement the optimization from the strategy\n"
+    "2. Run existing tests to verify correctness\n"
+    "3. Write summary to `.factory/reviews/builder-latest.md`\n"
+)
+
+_RESEARCHER_T3_PROMPT = (
+    "You are a Researcher exploring alternative algorithmic approaches for "
+    "Neuropixels-scale spike sorting.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- Scale: 384+ channels, 30kHz sampling, millions of samples, GPU-accelerated.\n"
+    "- Read baseline at `.factory/sorting/baseline.json`.\n"
+    "- Read stage timing at `.factory/sorting/stage-timing.json` (if available).\n\n"
+    "## Your Task\n"
+    "1. Explore alternative algorithmic approaches for the bottleneck stages.\n"
+    "2. For each alternative, assess:\n"
+    "   - Expected speed improvement\n"
+    "   - Per-unit accuracy risk (which unit types might be affected)\n"
+    "   - Implementation complexity\n"
+    "   - Evidence from literature or benchmarks\n"
+    "3. Include Neuropixels-scale validation considerations.\n"
+    "4. Write findings to `.factory/sorting/research-alternatives.md`.\n"
+)
+
+_STRATEGIST_T3_PROMPT = (
+    "You are a Strategist evaluating algorithmic alternatives for spike sorting.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- STRICT thresholds: 0.5% overall accuracy, 5% per-unit drop maximum.\n"
+    "- Read alternatives at `.factory/sorting/research-alternatives.md`.\n"
+    "- Read baseline at `.factory/sorting/baseline.json`.\n"
+    "- Check `.factory/sorting/experiments.jsonl` for prior attempts.\n\n"
+    "## Your Task\n"
+    "1. Evaluate risk/reward for each alternative.\n"
+    "2. Select ONE algorithmic change with lowest accuracy risk.\n"
+    "3. Prefer incremental changes over wholesale replacements.\n"
+    "4. Flag specific units that may be at risk.\n"
+    "5. Write strategy to `.factory/strategy/current.md` with:\n"
+    "   - Which algorithm/approach to change\n"
+    "   - Risk assessment per unit type\n"
+    "   - Fallback plan if accuracy drops\n"
+    "   - Expected speed improvement\n"
+)
+
+_BUILDER_T3_PROMPT = (
+    "You are a Builder implementing an algorithmic change for spike sorting.\n\n"
+    "## Context\n"
+    "- Speed is the optimization target. Accuracy is a hard floor.\n"
+    "- Neuropixels-scale: 384+ channels, 30kHz, millions of samples, GPU-accelerated.\n"
+    "- STRICT accuracy: 0.5% overall threshold, 5% per-unit drop maximum.\n"
+    "- Read strategy at `.factory/strategy/current.md`.\n\n"
+    "## STRICT RULES\n"
+    "- Consider per-unit impact — some unit types may be more sensitive.\n"
+    "- Prefer incremental changes over wholesale replacements.\n"
+    "- Run existing tests after implementation.\n\n"
+    "## Reloop Handling\n"
+    "- If sent back from `gate_accuracy_t3`: overall accuracy dropped >0.5%. "
+    "Investigate which part of the algorithm caused the regression.\n"
+    "- If sent back from `gate_per_unit_accuracy`: specific units regressed >5%. "
+    "The feedback will list which units. Adjust the algorithm to handle those "
+    "unit types better, or add special-case handling.\n\n"
+    "## Your Task\n"
+    "1. Implement the algorithmic change from the strategy\n"
+    "2. Run existing tests to verify correctness\n"
+    "3. Write summary to `.factory/reviews/builder-latest.md`\n"
+)
+
+
+# ── workflow construction ─────────────────────────────────────────
+
+
+def workflow() -> Workflow:
+    """Build the optimize-sorting workflow graph.
+
+    Returns a Workflow with 31 nodes, 39 edges, terminal=True.
+    """
+    nodes: dict[str, AgentNode | FnNode | GateNode] = {}
+    edges: list[Edge] = []
+
+    # ── Shared nodes (1-5) ────────────────────────────────────────
+
+    nodes["lock_baseline"] = FnNode(
+        id="lock_baseline",
+        command=_lock_baseline_command(),
+        reads=set(),
+        writes={".factory/sorting/baseline.json"},
+    )
+
+    nodes["select_tier"] = FnNode(
+        id="select_tier",
+        command=_select_tier_command(),
+        reads={".factory/sorting/baseline.json"},
+        writes={".factory/sorting/tier-selection.json"},
+    )
+
+    nodes["gate_is_tier1"] = GateNode(
+        id="gate_is_tier1",
+        evaluator_type="fn",
+        evaluator_command=_tier_gate_command(1),
+        reads={".factory/sorting/tier-selection.json"},
+        writes=set(),
+    )
+
+    nodes["gate_is_tier2"] = GateNode(
+        id="gate_is_tier2",
+        evaluator_type="fn",
+        evaluator_command=_tier_gate_command(2),
+        reads={".factory/sorting/tier-selection.json"},
+        writes=set(),
+    )
+
+    nodes["gate_is_tier3"] = GateNode(
+        id="gate_is_tier3",
+        evaluator_type="fn",
+        evaluator_command=_tier_gate_command(3),
+        reads={".factory/sorting/tier-selection.json"},
+        writes=set(),
+    )
+
+    # ── Tier 1 nodes (6-13) ───────────────────────────────────────
+
+    nodes["researcher_discover_params"] = AgentNode(
+        id="researcher_discover_params",
+        role=AgentRole.RESEARCHER,
+        prompt_template=_RESEARCHER_T1_PROMPT,
+        reads={".factory/sorting/baseline.json"},
+        writes={".factory/sorting/research-params.md"},
+    )
+
+    nodes["strategist_t1"] = AgentNode(
+        id="strategist_t1",
+        role=AgentRole.STRATEGIST,
+        prompt_template=_STRATEGIST_T1_PROMPT,
+        reads={".factory/sorting/research-params.md", ".factory/sorting/baseline.json"},
+        writes={".factory/strategy/current.md"},
+    )
+
+    nodes["builder_config_change"] = AgentNode(
+        id="builder_config_change",
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=3600,
+        prompt_template=_BUILDER_T1_PROMPT,
+        reads={".factory/strategy/current.md"},
+        writes={".factory/reviews/builder-latest.md", ".factory/sorting/config-diff.json"},
+    )
+
+    nodes["gate_no_code_changes"] = GateNode(
+        id="gate_no_code_changes",
+        evaluator_type="fn",
+        evaluator_command=_config_gate_command(),
+        reads={".factory/reviews/builder-latest.md"},
+        writes=set(),
+    )
+
+    nodes["run_benchmark_t1"] = FnNode(
+        id="run_benchmark_t1",
+        command=_benchmark_command(),
+        reads={".factory/sorting/baseline.json"},
+        writes={".factory/sorting/benchmark-result.json"},
+    )
+
+    nodes["gate_catastrophic_t1"] = GateNode(
+        id="gate_catastrophic_t1",
+        evaluator_type="fn",
+        evaluator_command=_catastrophic_gate_command(),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes=set(),
+    )
+
+    nodes["confirm_benchmark_t1"] = FnNode(
+        id="confirm_benchmark_t1",
+        command=_benchmark_3x_command(),
+        reads={".factory/sorting/benchmark-result.json"},
+        writes={".factory/sorting/benchmark-result.json"},
+    )
+
+    nodes["gate_accuracy_t1"] = GateNode(
+        id="gate_accuracy_t1",
+        evaluator_type="fn",
+        evaluator_command=_accuracy_gate_command(1),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes=set(),
+    )
+
+    nodes["archive_result_t1"] = AgentNode(
+        id="archive_result_t1",
+        role=AgentRole.ARCHIVIST,
+        prompt_template=_archive_prompt(tier=1),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes={".factory/sorting/experiments.jsonl"},
+    )
+
+    # ── Tier 2 nodes (13-19) ──────────────────────────────────────
+
+    nodes["researcher_profile_pipeline"] = AgentNode(
+        id="researcher_profile_pipeline",
+        role=AgentRole.RESEARCHER,
+        prompt_template=_RESEARCHER_T2_PROMPT,
+        reads={".factory/sorting/baseline.json"},
+        writes={".factory/sorting/research-profile.md", ".factory/sorting/stage-timing.json"},
+    )
+
+    nodes["strategist_t2"] = AgentNode(
+        id="strategist_t2",
+        role=AgentRole.STRATEGIST,
+        prompt_template=_STRATEGIST_T2_PROMPT,
+        reads={
+            ".factory/sorting/research-profile.md",
+            ".factory/sorting/stage-timing.json",
+            ".factory/sorting/baseline.json",
+        },
+        writes={".factory/strategy/current.md"},
+    )
+
+    nodes["builder_optimize_hotpath"] = AgentNode(
+        id="builder_optimize_hotpath",
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=3600,
+        prompt_template=_BUILDER_T2_PROMPT,
+        reads={".factory/strategy/current.md", ".factory/sorting/stage-timing.json"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    nodes["run_benchmark_t2"] = FnNode(
+        id="run_benchmark_t2",
+        command=_benchmark_command(),
+        reads={".factory/sorting/baseline.json"},
+        writes={".factory/sorting/benchmark-result.json"},
+    )
+
+    nodes["gate_catastrophic_t2"] = GateNode(
+        id="gate_catastrophic_t2",
+        evaluator_type="fn",
+        evaluator_command=_catastrophic_gate_command(),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes=set(),
+    )
+
+    nodes["confirm_benchmark_t2"] = FnNode(
+        id="confirm_benchmark_t2",
+        command=_benchmark_3x_command(),
+        reads={".factory/sorting/benchmark-result.json"},
+        writes={".factory/sorting/benchmark-result.json"},
+    )
+
+    nodes["gate_accuracy_t2"] = GateNode(
+        id="gate_accuracy_t2",
+        evaluator_type="fn",
+        evaluator_command=_accuracy_gate_command(2),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes=set(),
+    )
+
+    nodes["archive_result_t2"] = AgentNode(
+        id="archive_result_t2",
+        role=AgentRole.ARCHIVIST,
+        prompt_template=_archive_prompt(tier=2),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes={".factory/sorting/experiments.jsonl"},
+    )
+
+    # ── Tier 3 nodes (20-28) ──────────────────────────────────────
+
+    nodes["researcher_explore_alternatives"] = AgentNode(
+        id="researcher_explore_alternatives",
+        role=AgentRole.RESEARCHER,
+        prompt_template=_RESEARCHER_T3_PROMPT,
+        reads={".factory/sorting/baseline.json"},
+        writes={".factory/sorting/research-alternatives.md"},
+    )
+
+    nodes["strategist_t3"] = AgentNode(
+        id="strategist_t3",
+        role=AgentRole.STRATEGIST,
+        prompt_template=_STRATEGIST_T3_PROMPT,
+        reads={".factory/sorting/research-alternatives.md", ".factory/sorting/baseline.json"},
+        writes={".factory/strategy/current.md"},
+    )
+
+    nodes["builder_implement_alternative"] = AgentNode(
+        id="builder_implement_alternative",
+        role=AgentRole.BUILDER,
+        model="opus",
+        timeout=3600,
+        prompt_template=_BUILDER_T3_PROMPT,
+        reads={".factory/strategy/current.md"},
+        writes={".factory/reviews/builder-latest.md"},
+    )
+
+    nodes["run_benchmark_t3"] = FnNode(
+        id="run_benchmark_t3",
+        command=_benchmark_command(),
+        reads={".factory/sorting/baseline.json"},
+        writes={".factory/sorting/benchmark-result.json"},
+    )
+
+    nodes["gate_catastrophic_t3"] = GateNode(
+        id="gate_catastrophic_t3",
+        evaluator_type="fn",
+        evaluator_command=_catastrophic_gate_command(),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes=set(),
+    )
+
+    nodes["gate_per_unit_accuracy"] = GateNode(
+        id="gate_per_unit_accuracy",
+        evaluator_type="fn",
+        evaluator_command=_per_unit_gate_command(),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes=set(),
+    )
+
+    nodes["confirm_benchmark_t3"] = FnNode(
+        id="confirm_benchmark_t3",
+        command=_benchmark_3x_command(),
+        reads={".factory/sorting/benchmark-result.json"},
+        writes={".factory/sorting/benchmark-result.json"},
+    )
+
+    nodes["gate_accuracy_t3"] = GateNode(
+        id="gate_accuracy_t3",
+        evaluator_type="fn",
+        evaluator_command=_accuracy_gate_command(3),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes=set(),
+    )
+
+    nodes["archive_result_t3"] = AgentNode(
+        id="archive_result_t3",
+        role=AgentRole.ARCHIVIST,
+        prompt_template=_archive_prompt(tier=3),
+        reads={".factory/sorting/benchmark-result.json", ".factory/sorting/baseline.json"},
+        writes={".factory/sorting/experiments.jsonl"},
+    )
+
+    # ── Edges (39 total) ──────────────────────────────────────────
+
+    edges = [
+        # Baseline + Tier Selection (2)
+        Edge(source="lock_baseline", target="select_tier"),                          # 1
+        Edge(source="select_tier", target="gate_is_tier1"),                          # 2
+
+        # Tier Routing Chain (5)
+        Edge(source="gate_is_tier1", target="researcher_discover_params",
+             condition=VerdictType.PROCEED),                                         # 3
+        Edge(source="gate_is_tier1", target="gate_is_tier2",
+             condition=VerdictType.HALT),                                            # 4
+        Edge(source="gate_is_tier2", target="researcher_profile_pipeline",
+             condition=VerdictType.PROCEED),                                         # 5
+        Edge(source="gate_is_tier2", target="gate_is_tier3",
+             condition=VerdictType.HALT),                                            # 6
+        Edge(source="gate_is_tier3", target="researcher_explore_alternatives",
+             condition=VerdictType.PROCEED),                                         # 7
+
+        # Tier 1 Subgraph — Config Sweep (11)
+        # builder → code gate → benchmark → catastrophic gate → confirm → accuracy gate → archive
+        Edge(source="researcher_discover_params", target="strategist_t1"),           # 8
+        Edge(source="strategist_t1", target="builder_config_change"),                # 9
+        Edge(source="builder_config_change", target="gate_no_code_changes"),         # 10
+        Edge(source="gate_no_code_changes", target="run_benchmark_t1",
+             condition=VerdictType.PROCEED),                                         # 11
+        Edge(source="gate_no_code_changes", target="builder_config_change",
+             condition=VerdictType.RELOOP),                                          # 12
+        Edge(source="run_benchmark_t1", target="gate_catastrophic_t1"),              # 13
+        Edge(source="gate_catastrophic_t1", target="confirm_benchmark_t1",
+             condition=VerdictType.PROCEED),                                         # 14
+        Edge(source="gate_catastrophic_t1", target="archive_result_t1",
+             condition=VerdictType.HALT),                                            # 15
+        Edge(source="confirm_benchmark_t1", target="gate_accuracy_t1"),              # 16
+        Edge(source="gate_accuracy_t1", target="archive_result_t1",
+             condition=VerdictType.PROCEED),                                         # 17
+        Edge(source="gate_accuracy_t1", target="archive_result_t1",
+             condition=VerdictType.HALT),                                            # 18
+
+        # Tier 2 Subgraph — Code Optimization (9)
+        # builder → benchmark → catastrophic gate → confirm → accuracy gate → archive
+        Edge(source="researcher_profile_pipeline", target="strategist_t2"),          # 19
+        Edge(source="strategist_t2", target="builder_optimize_hotpath"),             # 20
+        Edge(source="builder_optimize_hotpath", target="run_benchmark_t2"),          # 21
+        Edge(source="run_benchmark_t2", target="gate_catastrophic_t2"),              # 22
+        Edge(source="gate_catastrophic_t2", target="confirm_benchmark_t2",
+             condition=VerdictType.PROCEED),                                         # 23
+        Edge(source="gate_catastrophic_t2", target="archive_result_t2",
+             condition=VerdictType.HALT),                                            # 24
+        Edge(source="confirm_benchmark_t2", target="gate_accuracy_t2"),              # 25
+        Edge(source="gate_accuracy_t2", target="archive_result_t2",
+             condition=VerdictType.PROCEED),                                         # 26
+        Edge(source="gate_accuracy_t2", target="archive_result_t2",
+             condition=VerdictType.HALT),                                            # 27
+
+        # Tier 3 Subgraph — Algorithm Changes (12)
+        # builder → benchmark → catastrophic gate → confirm → accuracy gate → per-unit gate → archive
+        Edge(source="researcher_explore_alternatives", target="strategist_t3"),      # 28
+        Edge(source="strategist_t3", target="builder_implement_alternative"),        # 29
+        Edge(source="builder_implement_alternative", target="run_benchmark_t3"),     # 30
+        Edge(source="run_benchmark_t3", target="gate_catastrophic_t3"),              # 31
+        Edge(source="gate_catastrophic_t3", target="confirm_benchmark_t3",
+             condition=VerdictType.PROCEED),                                         # 32
+        Edge(source="gate_catastrophic_t3", target="archive_result_t3",
+             condition=VerdictType.HALT),                                            # 33
+        Edge(source="confirm_benchmark_t3", target="gate_accuracy_t3"),              # 34
+        Edge(source="gate_accuracy_t3", target="gate_per_unit_accuracy",
+             condition=VerdictType.PROCEED),                                         # 35
+        Edge(source="gate_accuracy_t3", target="archive_result_t3",
+             condition=VerdictType.HALT),                                            # 36
+        Edge(source="gate_per_unit_accuracy", target="archive_result_t3",
+             condition=VerdictType.PROCEED),                                         # 37
+        Edge(source="gate_per_unit_accuracy", target="builder_implement_alternative",
+             condition=VerdictType.RELOOP),                                          # 38
+        Edge(source="gate_per_unit_accuracy", target="archive_result_t3",
+             condition=VerdictType.HALT),                                            # 39
+    ]
+
+    # ── Trigger ───────────────────────────────────────────────────
+
+    def trigger(state: ProjectState, ctx: dict[str, Any]) -> bool:
+        return ctx.get("mode") == "optimize-sorting"
+
+    return Workflow(
+        name="optimize-sorting",
+        nodes=nodes,
+        edges=edges,
+        start_node="lock_baseline",
+        terminal=True,
+        trigger=trigger,
+    )


### PR DESCRIPTION
## Changes

- **T2 Researcher Prompt** (`_RESEARCHER_T2_PROMPT`): Updated to instruct the researcher to read `.stage_timing` from `baseline.json` as ground-truth measured times and rank stages by measured time (highest first), replacing the old "estimate from code" approach. Output schema changed from `estimated_pct` to `baseline_mean/baseline_std/pct_of_total`.

- **Archive Prompt** (`_archive_prompt()`, all 3 tiers): Added `stage_timing_deltas` computation that iterates over the **union** of baseline and result stage names:
  - Stages in both → normal delta (`baseline_mean - result_time`)
  - Stages only in result → marked `"new"`
  - Stages only in baseline → marked `"removed"`
  - Added `stage_timing_deltas` to JSONL field list
  - Added per-stage timing table to PR comment for keep verdicts

- **Tests**: Added 10 new test methods to `TestPromptContent` validating both changes

### Graph topology unchanged
- 31 nodes, 39 edges, 2 reloop edges — verified programmatically
- All existing structural tests pass (98/98 non-registration tests)
- 3 registration tests expected to fail (workflow not yet registered in `definitions.py`)