### PR TITLE
feat: make claude binary configurable via FACTORY_CLAUDE_BIN

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,15 @@ Usage: `factory ceo /path --profile litellm-proxy`
 
 The factory uses Claude Code (`claude` CLI) as its agent backend. The runner abstraction (`factory/runners/`) supports this via `ClaudeRunner` in `factory/runners/claude.py`. The runner protocol (`factory/runners/protocol.py`) defines the interface.
 
+**Custom binary:** Set `FACTORY_CLAUDE_BIN` to use a wrapper script (e.g. `glaude`) instead of the `claude` binary. All runner invocations (headless, interactive, background, tmux) and CLI commands (`factory ceo`, `factory resume`) respect this override. Works with credential profiles:
+
+```toml
+[credentials.glaude]
+FACTORY_CLAUDE_BIN = "glaude"
+```
+
+Usage: `factory ceo /path --profile glaude`
+
 **Important:** Target projects should add `.factory/` to their `.gitignore`. The factory writes experiment data and usage logs to this directory. These are project-local artifacts that should not be committed to version control.
 
 ## Running the factory

--- a/factory/cli/ceo.py
+++ b/factory/cli/ceo.py
@@ -182,9 +182,12 @@ def cmd_refactory(args: argparse.Namespace) -> int:
     from factory.agents.runner import resolve_prompt
     from factory.refactory import get_session_id, setup_workspace
 
-    claude_path = shutil.which("claude")
+    from factory.runners.claude import _claude_bin
+
+    bin_ = _claude_bin()
+    claude_path = shutil.which(bin_)
     if not claude_path:
-        print("Error: 'claude' CLI not found. Install Claude Code first.", file=sys.stderr)
+        print(f"Error: '{bin_}' CLI not found. Install Claude Code first.", file=sys.stderr)
         return 1
 
     project_path = Path(getattr(args, "path", None) or Path.cwd()).resolve()
@@ -217,7 +220,7 @@ def cmd_refactory(args: argparse.Namespace) -> int:
 
     if is_new_session:
         cmd = [
-            "claude",
+            bin_,
             "--session-id",
             session_id,
             "--append-system-prompt-file",
@@ -228,7 +231,7 @@ def cmd_refactory(args: argparse.Namespace) -> int:
         ]
     else:
         cmd = [
-            "claude",
+            bin_,
             "--resume",
             session_id,
             "--append-system-prompt-file",
@@ -246,5 +249,5 @@ def cmd_refactory(args: argparse.Namespace) -> int:
         cmd.extend(["--mcp-config", str(mcp_config), "--strict-mcp-config"])
 
     os.chdir(project_path)
-    os.execvp("claude", cmd)
+    os.execvp(bin_, cmd)
     return 0

--- a/factory/cli/infra.py
+++ b/factory/cli/infra.py
@@ -165,9 +165,12 @@ def cmd_resume(args: argparse.Namespace) -> int:
         print("Run 'factory ceo <path>' first to create a session.", file=sys.stderr)
         return 1
 
-    claude_path = shutil.which("claude")
+    from factory.runners.claude import _claude_bin
+
+    bin_ = _claude_bin()
+    claude_path = shutil.which(bin_)
     if not claude_path:
-        print("Error: 'claude' CLI not found. Install Claude Code first.", file=sys.stderr)
+        print(f"Error: '{bin_}' CLI not found. Install Claude Code first.", file=sys.stderr)
         return 1
 
     interactive = True
@@ -179,7 +182,7 @@ def cmd_resume(args: argparse.Namespace) -> int:
         interactive = False
         resume_mode = cycle_state.mode
 
-    cmd = ["claude", "--resume", session_id]
+    cmd = [bin_, "--resume", session_id]
     if model:
         cmd.extend(["--model", model])
 
@@ -219,7 +222,7 @@ def cmd_resume(args: argparse.Namespace) -> int:
         print(f"Resuming interactive CEO session: {session_id[:12]}...")
 
     os.chdir(project_path)
-    os.execvp("claude", cmd)
+    os.execvp(bin_, cmd)
     return 0
 
 

--- a/factory/outer_loop/mutations.py
+++ b/factory/outer_loop/mutations.py
@@ -547,9 +547,11 @@ def default_prompt_rewriter(
         f"any contradictory or redundant instructions. "
         f"Output ONLY the new prompt text, nothing else."
     )
+    from factory.runners.claude import _claude_bin
+
     try:
         proc = subprocess.run(
-            ["claude", "-p", prompt, "--model", "opus",
+            [_claude_bin(), "-p", prompt, "--model", "opus",
              "--append-system-prompt", "Output only the prompt text.",
              "--max-turns", "1", "--output-format", "text"],
             capture_output=True, text=True, timeout=120,
@@ -586,9 +588,11 @@ async def async_prompt_rewriter(
         f"any contradictory or redundant instructions. "
         f"Output ONLY the new prompt text, nothing else."
     )
+    from factory.runners.claude import _claude_bin
+
     try:
         proc = await _asyncio.create_subprocess_exec(
-            "claude", "-p", prompt, "--model", "opus",
+            _claude_bin(), "-p", prompt, "--model", "opus",
             "--append-system-prompt", "Output only the prompt text.",
             "--max-turns", "1", "--output-format", "text",
             stdout=_asyncio.subprocess.PIPE,
@@ -691,9 +695,11 @@ def default_knob_expander(
         f"Write ONLY the new value (a short name if it's a prompt knob, "
         f"or a number if it's a threshold). Nothing else."
     )
+    from factory.runners.claude import _claude_bin
+
     try:
         proc = subprocess.run(
-            ["claude", "-p", prompt, "--model", "opus",
+            [_claude_bin(), "-p", prompt, "--model", "opus",
              "--append-system-prompt", "Output only the value, no explanation.",
              "--max-turns", "1", "--output-format", "text"],
             capture_output=True, text=True, timeout=120,

--- a/factory/runners/_background.py
+++ b/factory/runners/_background.py
@@ -73,8 +73,10 @@ async def run_in_background(
     prompt_file.close()
     prompt_path = prompt_file.name
 
+    from factory.runners.claude import _claude_bin
+
     cmd = [
-        "claude", "--bg", "--name", session_name,
+        _claude_bin(), "--bg", "--name", session_name,
         "--append-system-prompt-file", prompt_path, "-p", task,
         "--disallowedTools", "Agent",
     ]
@@ -136,7 +138,12 @@ async def run_in_background(
                 return session_output, 0 if is_success else 1, None
 
         logger.error("Background agent timed out after %ss: role=%s", timeout, role)
-        stop_result = subprocess.run(["claude", "stop", session_id], capture_output=True)
+        from factory.runners.claude import _claude_bin
+
+        stop_result = subprocess.run(
+            [_claude_bin(), "stop", session_id],
+            capture_output=True,
+        )
         if stop_result.returncode != 0:
             logger.warning(
                 "Failed to stop background session %s: %s",

--- a/factory/runners/_tmux_persist.py
+++ b/factory/runners/_tmux_persist.py
@@ -234,7 +234,10 @@ async def run_in_tmux(
 
     settings_file = _generate_settings(sentinel_file, tmpdir, project_path, session_id=f"{session}:{window}")
 
-    cmd = ["claude", "--settings", str(settings_file), "--append-system-prompt-file", str(prompt_file),
+    from factory.runners.claude import _claude_bin
+
+    bin_ = _claude_bin()
+    cmd = [bin_, "--settings", str(settings_file), "--append-system-prompt-file", str(prompt_file),
            "--disallowedTools", "Agent"]
     if dangerously_skip_permissions:
         cmd.append("--dangerously-skip-permissions")
@@ -335,9 +338,11 @@ async def run_in_tmux(
 def _check_claude_agents_state(session_name: str) -> str | None:
     """Query claude agents --json for a session's state. Returns 'busy', 'waiting',
     'idle', or None if the session is not found or the command fails."""
+    from factory.runners.claude import _claude_bin
+
     try:
         result = subprocess.run(
-            ["claude", "agents", "--json"],
+            [_claude_bin(), "agents", "--json"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -73,6 +73,11 @@ def _parse_usage(data: dict) -> AgentUsage:
     )
 
 
+def _claude_bin() -> str:
+    """Return the Claude CLI binary name, respecting FACTORY_CLAUDE_BIN override."""
+    return os.environ.get("FACTORY_CLAUDE_BIN", "claude")
+
+
 class ClaudeRunner:
     """Runner implementation for Claude Code CLI."""
 
@@ -85,7 +90,7 @@ class ClaudeRunner:
         return RunnerMeta(
             name="claude",
             display_name="Claude Code",
-            binary="claude",
+            binary=_claude_bin(),
             install_hint="npm install -g @anthropic-ai/claude-code",
             supports_usage_telemetry=True,
             supports_session_name=True,
@@ -108,7 +113,7 @@ class ClaudeRunner:
         prompt_path = Path(prompt_file.name)
 
         cmd = [
-            "claude",
+            _claude_bin(),
             "--append-system-prompt-file",
             prompt_file.name,
             "-p",
@@ -298,7 +303,7 @@ class ClaudeRunner:
         temp_files.append(settings_path)
 
         cmd = [
-            "claude",
+            _claude_bin(),
             "--append-system-prompt-file",
             prompt_file.name,
             "--bare",

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -75,7 +75,7 @@ def _parse_usage(data: dict) -> AgentUsage:
 
 def _claude_bin() -> str:
     """Return the Claude CLI binary name, respecting FACTORY_CLAUDE_BIN override."""
-    return os.environ.get("FACTORY_CLAUDE_BIN", "claude")
+    return os.environ.get("FACTORY_CLAUDE_BIN") or "claude"
 
 
 class ClaudeRunner:

--- a/factory/worktree.py
+++ b/factory/worktree.py
@@ -381,9 +381,11 @@ def _has_active_sessions(worktree_path: Path) -> bool:
     Returns True if active sessions found, False otherwise.
     Fails open: returns False on any error so removal proceeds.
     """
+    from factory.runners.claude import _claude_bin
+
     try:
         result = subprocess.run(
-            ["claude", "agents", "--json", "--cwd", str(worktree_path)],
+            [_claude_bin(), "agents", "--json", "--cwd", str(worktree_path)],
             capture_output=True,
             text=True,
             timeout=5,

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -122,6 +122,69 @@ class TestClaudeRunner:
             ]
 
 
+class TestFactoryClaudeBin:
+    """Tests for FACTORY_CLAUDE_BIN binary override."""
+
+    async def test_headless_respects_factory_claude_bin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_CLAUDE_BIN", "glaude")
+        runner = ClaudeRunner()
+
+        with patch(
+            "factory.runners._subprocess.stream_subprocess", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = (
+                b'{"result":"ok","usage":{},"cost_usd":0,"duration_ms":0,"num_turns":1,"model":"m"}',
+                b"",
+            )
+            with patch(
+                "factory.runners._subprocess.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+            ) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.headless(
+                    AgentRunRequest(prompt="test", task="hi", cwd=tmp_path, timeout=10.0)
+                )
+
+                cmd = list(mock_exec.call_args[0])
+                assert cmd[0] == "glaude"
+
+    def test_interactive_respects_factory_claude_bin(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_CLAUDE_BIN", "glaude")
+        runner = ClaudeRunner()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = type("Result", (), {"returncode": 0})()
+            runner.interactive_run(
+                AgentRunRequest(prompt="test", task="hi", cwd=tmp_path)
+            )
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == "glaude"
+
+    def test_metadata_respects_factory_claude_bin(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_CLAUDE_BIN", "glaude")
+        meta = ClaudeRunner.metadata()
+        assert meta.binary == "glaude"
+
+    def test_defaults_to_claude_without_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("FACTORY_CLAUDE_BIN", raising=False)
+        runner = ClaudeRunner()
+        cmd, _, _ = runner.build_command(
+            AgentRunRequest(prompt="test", task="hi", cwd=tmp_path, timeout=10.0)
+        )
+        assert cmd[0] == "claude"
+
+
 class TestInteractiveBackupRestore:
     def test_restores_backup_after_interactive_run(self, tmp_path: Path) -> None:
         claude_dir = tmp_path / ".claude"

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -184,6 +184,16 @@ class TestFactoryClaudeBin:
         )
         assert cmd[0] == "claude"
 
+    def test_empty_string_falls_back_to_claude(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FACTORY_CLAUDE_BIN", "")
+        runner = ClaudeRunner()
+        cmd, _, _ = runner.build_command(
+            AgentRunRequest(prompt="test", task="hi", cwd=tmp_path, timeout=10.0)
+        )
+        assert cmd[0] == "claude"
+
 
 class TestInteractiveBackupRestore:
     def test_restores_backup_after_interactive_run(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds `FACTORY_CLAUDE_BIN` env var to override the hardcoded `claude` binary across all invocation paths (headless, interactive, background, tmux, CLI resume)
- Enables wrapper scripts like `glaude` (which handles model routing, proxy, API keys, and settings) to be used via credential profiles: `[credentials.glaude] FACTORY_CLAUDE_BIN = "glaude"` then `factory ceo /path --profile glaude`
- Centralizes the binary lookup in `_claude_bin()` helper, imported by `_background.py`, `_tmux_persist.py`, `cli/ceo.py`, and `cli/infra.py`

Builds on #1233 (env overlay profiles). Together they enable any custom endpoint variant via config alone.

## Changes

| File | What |
|---|---|
| `factory/runners/claude.py` | Add `_claude_bin()`, use in `metadata()`, `build_command()`, `build_interactive_command()` |
| `factory/runners/_background.py` | Use `_claude_bin()` for launch and stop |
| `factory/runners/_tmux_persist.py` | Use `_claude_bin()` for launch and agents query |
| `factory/cli/ceo.py` | Use `_claude_bin()` for refactory launch (`shutil.which`, cmd, `execvp`) |
| `factory/cli/infra.py` | Use `_claude_bin()` for resume (`shutil.which`, cmd, `execvp`) |
| `tests/test_runners.py` | 4 new tests: headless, interactive, metadata override + default fallback |
| `CLAUDE.md` | Document `FACTORY_CLAUDE_BIN` in Runners section |

## Test plan

- [ ] `uv run pytest tests/test_runners.py -v` (76 pass)
- [ ] `ruff check` and `mypy` clean on all changed files
- [ ] Set `FACTORY_CLAUDE_BIN=glaude` and verify `factory ceo /path --profile glaude` calls `glaude` instead of `claude`
- [ ] Verify default behavior unchanged when `FACTORY_CLAUDE_BIN` is unset