### PR TITLE
 gate --bare on API-key-style auth to fix subscription login

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -106,6 +106,12 @@ re:factory inherits Claude Code's authentication. Configure whichever method you
 | `CLAUDE_CODE_USE_VERTEX` | Set to `1` for Google Cloud Vertex AI |
 | `ANTHROPIC_VERTEX_PROJECT_ID` | Vertex AI project ID |
 | `CLOUD_ML_REGION` | Vertex AI region (e.g., `us-east5`) |
+| `CLAUDE_CODE_USE_BEDROCK` | Set to `1` for AWS Bedrock |
+
+When one of the variables above is set, re:factory's Claude Code subprocesses launch with
+`--bare` for faster startup (skips hooks, LSP, and plugin loading). `--bare` never reads the
+OAuth keychain, so it's skipped automatically for subscription (Pro/Max) logins — those keep
+working exactly as `claude` does on its own, just without the startup optimization.
 
 ### re:factory Configuration
 

--- a/factory/runners/claude.py
+++ b/factory/runners/claude.py
@@ -20,6 +20,25 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger()
 
+# Boolean-flag env vars that switch Claude Code onto a 3P backend (their own credentials,
+# never the OAuth keychain), as opposed to ANTHROPIC_API_KEY which carries the key itself.
+_BARE_COMPATIBLE_BACKEND_FLAGS = ("CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_BEDROCK")
+
+
+def _supports_bare_mode(env: dict[str, str]) -> bool:
+    """True when the environment implies API-key-style auth, not OAuth/keychain login.
+
+    `--bare` skips keychain reads entirely (see `claude --help`), so it only works when
+    auth is ANTHROPIC_API_KEY or a 3P backend (Vertex/Bedrock). Passing it unconditionally
+    breaks subscription (Pro/Max) logins, which live in the keychain — see #1437.
+    """
+    if env.get("ANTHROPIC_API_KEY", "").strip():
+        return True
+    return any(
+        env.get(var, "").strip().lower() in ("1", "true", "yes")
+        for var in _BARE_COMPATIBLE_BACKEND_FLAGS
+    )
+
 
 def _make_ceo_message_emitter(project_path: Path) -> Callable[[bytes], None]:
     """Return a callback that emits ceo.message events for assistant JSONL lines."""
@@ -116,10 +135,10 @@ class ClaudeRunner:
             "--output-format",
             "stream-json",
             "--verbose",
-            "--bare",
-            "--disallowedTools",
-            "Agent",
         ]
+        if _supports_bare_mode(dict(os.environ)):
+            cmd.append("--bare")
+        cmd.extend(["--disallowedTools", "Agent"])
         settings_file = request.extras.get("settings_file")
         if settings_file:
             cmd.extend(["--settings", str(settings_file)])
@@ -301,8 +320,9 @@ class ClaudeRunner:
             "claude",
             "--append-system-prompt-file",
             prompt_file.name,
-            "--bare",
         ]
+        if _supports_bare_mode(dict(os.environ)):
+            cmd.append("--bare")
         settings_file = request.extras.get("settings_file")
         if settings_file:
             cmd.extend(["--settings", str(settings_file)])

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1194,6 +1194,101 @@ class TestDisallowedAgentTool:
             assert "Agent" in wrapper_content
 
 
+class TestBareModeGating:
+    """--bare skips OAuth/keychain reads, so it must only be passed under API-key-style
+    auth — never for subscription (Pro/Max) logins. Regression coverage for #1437.
+    """
+
+    def _clear_auth_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_BEDROCK"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_supports_bare_mode_true_for_api_key(self) -> None:
+        from factory.runners.claude import _supports_bare_mode
+
+        assert _supports_bare_mode({"ANTHROPIC_API_KEY": "sk-ant-test"}) is True
+
+    def test_supports_bare_mode_true_for_vertex(self) -> None:
+        from factory.runners.claude import _supports_bare_mode
+
+        assert _supports_bare_mode({"CLAUDE_CODE_USE_VERTEX": "1"}) is True
+
+    def test_supports_bare_mode_true_for_bedrock(self) -> None:
+        from factory.runners.claude import _supports_bare_mode
+
+        assert _supports_bare_mode({"CLAUDE_CODE_USE_BEDROCK": "true"}) is True
+
+    def test_supports_bare_mode_false_when_no_auth_vars(self) -> None:
+        from factory.runners.claude import _supports_bare_mode
+
+        assert _supports_bare_mode({}) is False
+
+    def test_supports_bare_mode_false_for_blank_or_falsy_values(self) -> None:
+        from factory.runners.claude import _supports_bare_mode
+
+        assert _supports_bare_mode({"ANTHROPIC_API_KEY": "  "}) is False
+        assert _supports_bare_mode({"CLAUDE_CODE_USE_VERTEX": "0"}) is False
+        assert _supports_bare_mode({"CLAUDE_CODE_USE_BEDROCK": "false"}) is False
+
+    def test_build_command_omits_bare_without_api_key_auth(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._clear_auth_env(monkeypatch)
+        runner = ClaudeRunner()
+        cmd, _, temp_files = runner.build_command(
+            AgentRunRequest(prompt="Test", task="Test", cwd=tmp_path)
+        )
+
+        assert "--bare" not in cmd
+
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_build_command_includes_bare_with_api_key_auth(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._clear_auth_env(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        runner = ClaudeRunner()
+        cmd, _, temp_files = runner.build_command(
+            AgentRunRequest(prompt="Test", task="Test", cwd=tmp_path)
+        )
+
+        assert "--bare" in cmd
+
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_build_interactive_command_omits_bare_without_api_key_auth(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._clear_auth_env(monkeypatch)
+        runner = ClaudeRunner()
+        cmd, _, temp_files = runner.build_interactive_command(
+            AgentRunRequest(prompt="Test", task="Test", cwd=tmp_path)
+        )
+
+        assert "--bare" not in cmd
+
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+    def test_build_interactive_command_includes_bare_with_vertex_auth(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._clear_auth_env(monkeypatch)
+        monkeypatch.setenv("CLAUDE_CODE_USE_VERTEX", "1")
+        runner = ClaudeRunner()
+        cmd, _, temp_files = runner.build_interactive_command(
+            AgentRunRequest(prompt="Test", task="Test", cwd=tmp_path)
+        )
+
+        assert "--bare" in cmd
+
+        for f in temp_files:
+            f.unlink(missing_ok=True)
+
+
 class TestGetRunnerChoices:
     """Tests for get_runner_choices() — returns sorted list of runner names."""
 


### PR DESCRIPTION
## Summary

- `--bare` explicitly skips OAuth keychain reads (per `claude --help`), so #1420/#1422
  adding it unconditionally to every Claude Code subprocess broke subscription (Pro/Max)
  logins — every agent spawn failed instantly with `Not logged in · Please run /login`.
- Adds `_supports_bare_mode()` in `factory/runners/claude.py`, which only passes `--bare`
  when `ANTHROPIC_API_KEY` / `CLAUDE_CODE_USE_VERTEX` / `CLAUDE_CODE_USE_BEDROCK` is truthy.
  Subscription users keep working (falling back to pre-#1422 behavior); API-key/Vertex/
  Bedrock users keep the startup perf win.
- Updated `docs/setup.md` to document this behavior next to the auth env var table, and
  added a previously-undocumented `CLAUDE_CODE_USE_BEDROCK` var to that table.
- Matches the fix suggested in the issue.

Fixes #1437

## Test plan

- `ruff check .` / `mypy factory/` clean
- New `TestBareMode` in `test_runners.py` — unit tests on `_supports_bare_mode` (API key /
  Vertex / Bedrock / unset / falsy values) plus both command builders (`build_command`,
  `build_interactive_command`) asserting `--bare` is included/omitted correctly
- Full `pytest` suite: 5275 passed, 18 failed — all 18 pre-existing/environment-specific
  (verified against `main`: missing `oc` CLI / k8s cluster, low disk space, one unrelated
  `create_v2` import lint failure), none touch the changed files
- Live verification against a real subscription login: `factory ceo ... --mode design
  --just-plan` completed normally with `"apiKeySource":"none"` in the init line,
  no  `Not logged in` error — reproduced the failure pre-fix, confirmed fixed post-fix