### PR TITLE
feat: graph-based targeted test selection for health checker (#1451)

### DIFF
--- a/factory/agents/prompts/health_checker.md
+++ b/factory/agents/prompts/health_checker.md
@@ -10,7 +10,7 @@ Your current working directory IS the project root. Use relative paths or `$(pwd
 
 ## What to do
 
-1. Run `factory eval` on the project.
+1. Run `factory eval --targeted` on the project (uses graph-based test selection when available, falls back to full suite automatically).
 2. Record the composite score and whether unit tests pass or fail.
 3. Compare the composite score to the baseline score.
 

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -29,6 +29,8 @@ def add_experiment_lifecycle_parsers(sub: argparse._SubParsersAction) -> None:  
     p.add_argument("path", help="Path to the project")
     p.add_argument("--skip-project-eval", action="store_true", default=False,
                     help="Skip user-defined project eval dimensions (run only hygiene + growth)")
+    p.add_argument("--targeted", action="store_true", default=False,
+                    help="Use graph-based targeted test selection (falls back to full suite)")
 
     p = sub.add_parser("guard", help="Check guard rules, print violations or 'clean'")
     p.add_argument("path", help="Path to the project")

--- a/factory/cli/eval_cmds.py
+++ b/factory/cli/eval_cmds.py
@@ -12,6 +12,53 @@ from factory.cli._helpers import _emit_cli_event, _read_target_branch, _run
 
 log = structlog.get_logger()
 
+
+def _compute_targeted_test_paths(project_path: Path) -> list[str] | None:
+    """Compute changed files and resolve to targeted test paths via the import graph."""
+    target_branch = _read_target_branch(project_path)
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "HEAD", target_branch],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            log.info("targeted.skip", reason="no_merge_base")
+            return None
+        baseline = result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", "--name-only", f"{baseline}..HEAD"],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if diff_result.returncode != 0:
+            return None
+        changed_files = [f for f in diff_result.stdout.strip().splitlines() if f]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    if not changed_files:
+        return None
+
+    from factory.graph import find_dependent_tests
+
+    dependent = find_dependent_tests(project_path, changed_files)
+    if dependent is None:
+        log.info("targeted.fallback", reason="find_dependent_tests_returned_none")
+        return None
+
+    log.info("targeted.active", test_count=len(dependent), changed_files=len(changed_files))
+    return sorted(dependent)
+
+
 def cmd_eval(args: argparse.Namespace) -> int:
     from factory.eval.runner import run_eval
     from factory.store import ExperimentStore
@@ -20,6 +67,16 @@ def cmd_eval(args: argparse.Namespace) -> int:
     store = ExperimentStore(project_path)
     config = _run(store.read_config())
     skip_project_eval = getattr(args, "skip_project_eval", False)
+
+    test_paths: list[str] | None = None
+    targeted = getattr(args, "targeted", False)
+    if targeted:
+        test_paths = _compute_targeted_test_paths(project_path)
+        if test_paths is not None:
+            log.info("eval.mode", mode="targeted", test_paths=len(test_paths))
+        else:
+            log.info("eval.mode", mode="full", reason="targeted_fallback")
+
     _emit_cli_event(project_path, "eval.started", {"command": config.eval_command})
     score = _run(run_eval(
         config.eval_command, project_path, config.eval_threshold,
@@ -27,6 +84,7 @@ def cmd_eval(args: argparse.Namespace) -> int:
         eval_weights=config.eval_weights,
         skip_project_eval=skip_project_eval,
         test_timeout=config.test_timeout,
+        test_paths=test_paths,
     ))
     _emit_cli_event(project_path, "eval.completed", {
         "composite": score.total,

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -12,6 +12,7 @@ All functions take a project_path and return an EvalResult-compatible dict.
 If a tool is not detected for a dimension, score is 0.5 (neutral), not 0.
 """
 
+import inspect
 import json
 import shutil
 import subprocess
@@ -334,14 +335,23 @@ def _run_sentrux_scan(project_path: Path) -> dict | None:
 # ── Public API ─────────────────────────────────────────────────────
 
 
-def _collect_test_and_coverage(project_path: Path, timeout: int = 300) -> tuple[dict, dict]:
+def _collect_test_and_coverage(
+    project_path: Path,
+    timeout: int = 300,
+    test_paths: list[str] | None = None,
+) -> tuple[dict, dict]:
     """Run tests and coverage together via run_tests_with_coverage(), return both result dicts."""
     sub_projects = _find_sub_projects(project_path)
     test_fragments: list[EvalFragment] = []
     cov_fragments: list[EvalFragment] = []
     for sp in sub_projects:
         for evaluator in detect_languages(sp):
-            test_frag, cov_frag = evaluator.run_tests_with_coverage(sp, timeout=timeout)
+            kwargs: dict = {"timeout": timeout}
+            if test_paths:
+                sig = inspect.signature(evaluator.run_tests_with_coverage)
+                if "test_paths" in sig.parameters:
+                    kwargs["test_paths"] = test_paths
+            test_frag, cov_frag = evaluator.run_tests_with_coverage(sp, **kwargs)
             if test_frag is not None:
                 test_fragments.append(test_frag)
             if cov_frag is not None:
@@ -360,9 +370,15 @@ def _collect_test_and_coverage(project_path: Path, timeout: int = 300) -> tuple[
     return test_result, cov_result
 
 
-def compute_hygiene_results(project_path: Path, test_timeout: int = 600) -> list[dict]:
+def compute_hygiene_results(
+    project_path: Path,
+    test_timeout: int = 600,
+    test_paths: list[str] | None = None,
+) -> list[dict]:
     """Compute all 6 mandatory hygiene dimensions for a project."""
-    test_result, cov_result = _collect_test_and_coverage(project_path, timeout=test_timeout)
+    test_result, cov_result = _collect_test_and_coverage(
+        project_path, timeout=test_timeout, test_paths=test_paths,
+    )
     return [
         test_result,
         eval_lint(project_path),

--- a/factory/eval/languages/python.py
+++ b/factory/eval/languages/python.py
@@ -35,15 +35,21 @@ class PythonEvaluator:
         )
 
     def run_tests_with_coverage(
-        self, project_path: Path, timeout: int = 300,
+        self,
+        project_path: Path,
+        timeout: int = 300,
+        test_paths: list[str] | None = None,
     ) -> tuple[EvalFragment | None, EvalFragment | None]:
         cov_target = self._detect_cov_target(project_path)
+        cmd = [
+            _resolve_python(project_path), "-m", "pytest",
+            f"--cov={cov_target}", "--cov-report=term",
+            "-v", "--tb=no", "-q",
+        ]
+        if test_paths:
+            cmd.extend(test_paths)
         rc, stdout, stderr = _run_cmd(
-            [
-                _resolve_python(project_path), "-m", "pytest",
-                f"--cov={cov_target}", "--cov-report=term",
-                "-v", "--tb=no", "-q",
-            ],
+            cmd,
             project_path,
             timeout=timeout,
         )
@@ -79,9 +85,14 @@ class PythonEvaluator:
 
         return test_frag, cov_frag
 
-    def run_tests(self, project_path: Path, timeout: int = 300) -> EvalFragment | None:
+    def run_tests(
+        self,
+        project_path: Path,
+        timeout: int = 300,
+        test_paths: list[str] | None = None,
+    ) -> EvalFragment | None:
         """Prefer run_tests_with_coverage() to avoid a redundant pytest invocation."""
-        return self.run_tests_with_coverage(project_path, timeout=timeout)[0]
+        return self.run_tests_with_coverage(project_path, timeout=timeout, test_paths=test_paths)[0]
 
     def run_lint(self, project_path: Path) -> EvalFragment | None:
         rc, stdout, stderr = _run_cmd(

--- a/factory/eval/runner.py
+++ b/factory/eval/runner.py
@@ -271,6 +271,7 @@ async def run_eval(
     growth_weights: TierWeights | None = None,
     eval_spec: list[str] | None = None,
     test_timeout: int = 600,
+    test_paths: list[str] | None = None,
 ) -> CompositeScore:
     """Compute mandatory dimensions + project-specific additions + custom project eval.
 
@@ -283,7 +284,9 @@ async def run_eval(
     6. Return composite score
     """
     # Step 1: Mandatory hygiene (always runs)
-    hygiene_dicts = compute_hygiene_results(project_path, test_timeout=test_timeout)
+    hygiene_dicts = compute_hygiene_results(
+        project_path, test_timeout=test_timeout, test_paths=test_paths,
+    )
     hygiene_results = [EvalResult(**r) for r in hygiene_dicts]
 
     # Step 2: Project-specific additions (optional, additive only)

--- a/factory/graph.py
+++ b/factory/graph.py
@@ -245,6 +245,31 @@ def find_dependent_tests(
         if cf in all_test_files:
             dependent_test_files.add(cf)
 
+    # Naming-convention heuristic: catch tests that only import inline
+    for cf in changed_files:
+        if not cf.endswith(".py"):
+            continue
+        parts = Path(cf).parts
+        if len(parts) < 2:
+            continue
+        stem = Path(cf).stem
+        candidates: list[str] = []
+        # Basename match: tests/test_<stem>.py
+        candidates.append(f"tests/test_{stem}.py")
+        # Path-preserving match: tests/test_<dir>/test_<stem>.py
+        if len(parts) > 2:
+            inner_dirs = parts[1:-1]
+            sub = "/".join(f"test_{d}" for d in inner_dirs)
+            candidates.append(f"tests/{sub}/test_{stem}.py")
+        for candidate in candidates:
+            if candidate in all_test_files and candidate not in dependent_test_files:
+                dependent_test_files.add(candidate)
+                log.info(
+                    "targeted.naming_convention_match",
+                    changed_file=cf,
+                    test_file=candidate,
+                )
+
     if not dependent_test_files:
         return dependent_test_files
 

--- a/factory/graph.py
+++ b/factory/graph.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import shutil
 import subprocess
 from pathlib import Path
 
+import networkx as nx
 import structlog
 
 log = structlog.get_logger()
@@ -141,3 +143,123 @@ def update_graph(project_path: Path) -> Path | None:
     Returns path to root graph.json on success, None on failure.
     """
     return _run_graphify(project_path, extra_args=["--update"])
+
+
+_FULL_SUITE_TRIGGERS = [
+    "**/conftest.py",
+    "**/__init__.py",
+    "pyproject.toml",
+    "pytest.ini",
+    "setup.cfg",
+    "tox.ini",
+    ".github/workflows/**",
+]
+
+_IMPORT_EDGE_TYPES = frozenset({"imports", "imports_from"})
+
+_FAN_OUT_THRESHOLD = 0.80
+
+
+def find_dependent_tests(
+    project_path: Path,
+    changed_files: list[str],
+) -> set[str] | None:
+    """Reverse-import BFS over graph.json to find tests affected by changed files.
+
+    Returns None when selection cannot be trusted — callers treat None as
+    "fall back to full suite".
+    """
+    if not changed_files:
+        return None
+
+    staleness = is_graph_stale(project_path)
+    if staleness is not False:
+        log.info("targeted.skip", reason="graph_stale_or_unavailable", staleness=staleness)
+        return None
+
+    for cf in changed_files:
+        for pattern in _FULL_SUITE_TRIGGERS:
+            if fnmatch.fnmatch(cf, pattern):
+                log.info("targeted.skip", reason="full_suite_trigger", file=cf, pattern=pattern)
+                return None
+
+    gpath = _graph_path(project_path)
+    try:
+        data = json.loads(gpath.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("targeted.skip", reason="graph_read_error", error=str(exc))
+        return None
+
+    nodes = data.get("nodes", [])
+    edges = data.get("edges", data.get("links", []))
+
+    file_to_node_ids: dict[str, list[str]] = {}
+    for node in nodes:
+        sf = node.get("source_file", "")
+        nid = node.get("id", "")
+        if sf and nid:
+            file_to_node_ids.setdefault(sf, []).append(nid)
+
+    all_test_files = {sf for sf in file_to_node_ids if sf.startswith("tests/") and sf.endswith(".py")}
+
+    G: nx.DiGraph[str] = nx.DiGraph()
+    for node in nodes:
+        nid = node.get("id", "")
+        if nid:
+            G.add_node(nid, source_file=node.get("source_file", ""))
+    for edge in edges:
+        if edge.get("relation") in _IMPORT_EDGE_TYPES:
+            src = edge.get("source", "")
+            tgt = edge.get("target", "")
+            if src and tgt:
+                G.add_edge(src, tgt)
+
+    seed_node_ids: set[str] = set()
+    for cf in changed_files:
+        if not cf.endswith(".py"):
+            if cf not in file_to_node_ids:
+                log.info("targeted.skip", reason="non_python_no_node", file=cf)
+                return None
+        nids = file_to_node_ids.get(cf, [])
+        if not nids:
+            log.info("targeted.skip", reason="file_not_in_graph", file=cf)
+            return None
+        seed_node_ids.update(nids)
+
+    # Reverse BFS: find all nodes that transitively import the changed nodes
+    reverse_G = G.reverse(copy=False)
+    reached: set[str] = set()
+    for seed in seed_node_ids:
+        if seed in reverse_G:
+            reached.update(nx.descendants(reverse_G, seed))
+    reached.update(seed_node_ids)
+
+    dependent_test_files: set[str] = set()
+    for nid in reached:
+        sf = G.nodes[nid].get("source_file", "") if nid in G else ""
+        if sf in all_test_files:
+            dependent_test_files.add(sf)
+
+    # Also include any changed files that are themselves test files
+    for cf in changed_files:
+        if cf in all_test_files:
+            dependent_test_files.add(cf)
+
+    if not dependent_test_files:
+        return dependent_test_files
+
+    if all_test_files and len(dependent_test_files) / len(all_test_files) > _FAN_OUT_THRESHOLD:
+        log.info(
+            "targeted.skip",
+            reason="fan_out_exceeded",
+            dependent=len(dependent_test_files),
+            total=len(all_test_files),
+        )
+        return None
+
+    log.info(
+        "targeted.selected",
+        dependent_tests=len(dependent_test_files),
+        total_tests=len(all_test_files),
+    )
+    return dependent_test_files

--- a/factory/graph.py
+++ b/factory/graph.py
@@ -245,30 +245,40 @@ def find_dependent_tests(
         if cf in all_test_files:
             dependent_test_files.add(cf)
 
-    # Naming-convention heuristic: catch tests that only import inline
-    for cf in changed_files:
-        if not cf.endswith(".py"):
-            continue
-        parts = Path(cf).parts
-        if len(parts) < 2:
-            continue
-        stem = Path(cf).stem
-        candidates: list[str] = []
-        # Basename match: tests/test_<stem>.py
-        candidates.append(f"tests/test_{stem}.py")
-        # Path-preserving match: tests/test_<dir>/test_<stem>.py
-        if len(parts) > 2:
-            inner_dirs = parts[1:-1]
-            sub = "/".join(f"test_{d}" for d in inner_dirs)
-            candidates.append(f"tests/{sub}/test_{stem}.py")
-        for candidate in candidates:
-            if candidate in all_test_files and candidate not in dependent_test_files:
-                dependent_test_files.add(candidate)
-                log.info(
-                    "targeted.naming_convention_match",
-                    changed_file=cf,
-                    test_file=candidate,
+    # Grep-based inline import scan: catch tests that import changed modules
+    # inside function bodies, which graphify doesn't capture in its graph
+    tests_dir = project_path / "tests"
+    if tests_dir.is_dir():
+        for cf in changed_files:
+            if not cf.endswith(".py"):
+                continue
+            parts = Path(cf).parts
+            if len(parts) < 2:
+                continue
+            module_path = cf.replace("/", ".").removesuffix(".py")
+            grep_pattern = module_path.replace(".", r"\.")
+            try:
+                grep_result = subprocess.run(
+                    ["grep", "-rl", grep_pattern, str(tests_dir), "--include=*.py"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
                 )
+                if grep_result.returncode == 0 and grep_result.stdout.strip():
+                    for match in grep_result.stdout.strip().splitlines():
+                        try:
+                            rel = str(Path(match).relative_to(project_path))
+                        except ValueError:
+                            continue
+                        if rel in all_test_files and rel not in dependent_test_files:
+                            dependent_test_files.add(rel)
+                            log.info(
+                                "targeted.grep_inline_import",
+                                changed_file=cf,
+                                test_file=rel,
+                            )
+            except (subprocess.TimeoutExpired, OSError):
+                pass
 
     if not dependent_test_files:
         return dependent_test_files

--- a/tests/test_targeted_tests.py
+++ b/tests/test_targeted_tests.py
@@ -216,37 +216,40 @@ class TestFindDependentTests:
         _make_graph(tmp_path, nodes, edges)
         result = find_dependent_tests(tmp_path, ["src/a.py"])
         assert result is not None
-        # BFS finds nothing (non-import edge), but naming convention catches test_a
-        assert "tests/test_a.py" in result
-        assert len(result) == 1
+        assert len(result) == 0
 
 
-class TestNamingConventionHeuristic:
-    """Tests for the naming-convention fallback that catches inline imports."""
+class TestGrepInlineImportScan:
+    """Tests for the grep-based inline import scan that catches inline imports."""
 
     @patch("factory.graph.is_graph_stale", return_value=False)
-    def test_naming_convention_adds_test_not_found_by_bfs(
+    def test_grep_finds_test_with_inline_import_not_found_by_bfs(
         self, _stale: MagicMock, tmp_path: Path,
     ) -> None:
-        """A test file matching by name but with no import edge is added."""
+        """A test file with an inline import (not in graph edges) is found by grep."""
         nodes = [
             {"id": "mod_runner", "source_file": "factory/runners/claude.py"},
             {"id": "test_runner", "source_file": "tests/test_claude.py"},
-            # Unrelated tests to stay under fan-out
             *[{"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"} for i in range(10)],
         ]
-        # No import edge from test_runner → mod_runner (simulates inline import)
         edges: list[dict] = []
         _make_graph(tmp_path, nodes, edges)
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_claude.py").write_text(
+            "def test_it():\n    from factory.runners.claude import run\n    run()\n"
+        )
+        for i in range(10):
+            (tests_dir / f"test_u{i}.py").write_text("def test_pass(): pass\n")
         result = find_dependent_tests(tmp_path, ["factory/runners/claude.py"])
         assert result is not None
         assert "tests/test_claude.py" in result
 
     @patch("factory.graph.is_graph_stale", return_value=False)
-    def test_naming_convention_no_duplicates(
+    def test_grep_does_not_duplicate_bfs_results(
         self, _stale: MagicMock, tmp_path: Path,
     ) -> None:
-        """A test already found by BFS is not duplicated."""
+        """A test already found by BFS is not duplicated by grep."""
         nodes = [
             {"id": "mod_a", "source_file": "factory/a.py"},
             {"id": "test_a", "source_file": "tests/test_a.py"},
@@ -256,43 +259,54 @@ class TestNamingConventionHeuristic:
             {"source": "test_a", "target": "mod_a", "relation": "imports"},
         ]
         _make_graph(tmp_path, nodes, edges)
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_a.py").write_text("import factory.a\n")
+        for i in range(10):
+            (tests_dir / f"test_u{i}.py").write_text("def test_pass(): pass\n")
         result = find_dependent_tests(tmp_path, ["factory/a.py"])
         assert result is not None
         assert "tests/test_a.py" in result
         assert len([t for t in result if t == "tests/test_a.py"]) == 1
 
     @patch("factory.graph.is_graph_stale", return_value=False)
-    def test_naming_convention_only_existing_files(
+    def test_grep_failure_silently_skipped(
         self, _stale: MagicMock, tmp_path: Path,
     ) -> None:
-        """A naming match that doesn't exist in the graph's test set is ignored."""
+        """If grep fails (e.g. subprocess error), the function still returns a set, not None."""
         nodes = [
-            {"id": "mod_z", "source_file": "factory/z.py"},
-            # tests/test_z.py does NOT exist in the graph
+            {"id": "mod_a", "source_file": "factory/a.py"},
             *[{"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"} for i in range(10)],
         ]
         edges: list[dict] = []
         _make_graph(tmp_path, nodes, edges)
-        result = find_dependent_tests(tmp_path, ["factory/z.py"])
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        for i in range(10):
+            (tests_dir / f"test_u{i}.py").write_text("def test_pass(): pass\n")
+        with patch("factory.graph.subprocess.run", side_effect=OSError("grep not found")):
+            result = find_dependent_tests(tmp_path, ["factory/a.py"])
         assert result is not None
-        assert "tests/test_z.py" not in result
-        assert len(result) == 0
+        assert isinstance(result, set)
 
     @patch("factory.graph.is_graph_stale", return_value=False)
-    def test_naming_convention_path_preserving_match(
+    def test_grep_skips_non_python_changed_files(
         self, _stale: MagicMock, tmp_path: Path,
     ) -> None:
-        """Path-preserving pattern tests/test_subdir/test_module.py is matched."""
+        """Non-.py changed files are not processed by the grep scan."""
         nodes = [
-            {"id": "mod_mutations", "source_file": "factory/outer_loop/mutations.py"},
-            {"id": "test_mutations", "source_file": "tests/test_outer_loop/test_mutations.py"},
+            {"id": "mod_readme", "source_file": "factory/README.md"},
+            {"id": "mod_a", "source_file": "factory/a.py"},
             *[{"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"} for i in range(10)],
         ]
         edges: list[dict] = []
         _make_graph(tmp_path, nodes, edges)
-        result = find_dependent_tests(tmp_path, ["factory/outer_loop/mutations.py"])
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        for i in range(10):
+            (tests_dir / f"test_u{i}.py").write_text("def test_pass(): pass\n")
+        result = find_dependent_tests(tmp_path, ["factory/a.py", "factory/README.md"])
         assert result is not None
-        assert "tests/test_outer_loop/test_mutations.py" in result
 
 
 class TestPythonEvaluatorTestPaths:

--- a/tests/test_targeted_tests.py
+++ b/tests/test_targeted_tests.py
@@ -207,6 +207,8 @@ class TestFindDependentTests:
         nodes = [
             {"id": "mod_a", "source_file": "src/a.py"},
             {"id": "test_a", "source_file": "tests/test_a.py"},
+            # Unrelated tests to stay under fan-out threshold
+            *[{"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"} for i in range(10)],
         ]
         edges = [
             {"source": "test_a", "target": "mod_a", "relation": "calls"},
@@ -214,7 +216,83 @@ class TestFindDependentTests:
         _make_graph(tmp_path, nodes, edges)
         result = find_dependent_tests(tmp_path, ["src/a.py"])
         assert result is not None
+        # BFS finds nothing (non-import edge), but naming convention catches test_a
+        assert "tests/test_a.py" in result
+        assert len(result) == 1
+
+
+class TestNamingConventionHeuristic:
+    """Tests for the naming-convention fallback that catches inline imports."""
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_naming_convention_adds_test_not_found_by_bfs(
+        self, _stale: MagicMock, tmp_path: Path,
+    ) -> None:
+        """A test file matching by name but with no import edge is added."""
+        nodes = [
+            {"id": "mod_runner", "source_file": "factory/runners/claude.py"},
+            {"id": "test_runner", "source_file": "tests/test_claude.py"},
+            # Unrelated tests to stay under fan-out
+            *[{"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"} for i in range(10)],
+        ]
+        # No import edge from test_runner → mod_runner (simulates inline import)
+        edges: list[dict] = []
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["factory/runners/claude.py"])
+        assert result is not None
+        assert "tests/test_claude.py" in result
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_naming_convention_no_duplicates(
+        self, _stale: MagicMock, tmp_path: Path,
+    ) -> None:
+        """A test already found by BFS is not duplicated."""
+        nodes = [
+            {"id": "mod_a", "source_file": "factory/a.py"},
+            {"id": "test_a", "source_file": "tests/test_a.py"},
+            *[{"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"} for i in range(10)],
+        ]
+        edges = [
+            {"source": "test_a", "target": "mod_a", "relation": "imports"},
+        ]
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["factory/a.py"])
+        assert result is not None
+        assert "tests/test_a.py" in result
+        assert len([t for t in result if t == "tests/test_a.py"]) == 1
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_naming_convention_only_existing_files(
+        self, _stale: MagicMock, tmp_path: Path,
+    ) -> None:
+        """A naming match that doesn't exist in the graph's test set is ignored."""
+        nodes = [
+            {"id": "mod_z", "source_file": "factory/z.py"},
+            # tests/test_z.py does NOT exist in the graph
+            *[{"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"} for i in range(10)],
+        ]
+        edges: list[dict] = []
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["factory/z.py"])
+        assert result is not None
+        assert "tests/test_z.py" not in result
         assert len(result) == 0
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_naming_convention_path_preserving_match(
+        self, _stale: MagicMock, tmp_path: Path,
+    ) -> None:
+        """Path-preserving pattern tests/test_subdir/test_module.py is matched."""
+        nodes = [
+            {"id": "mod_mutations", "source_file": "factory/outer_loop/mutations.py"},
+            {"id": "test_mutations", "source_file": "tests/test_outer_loop/test_mutations.py"},
+            *[{"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"} for i in range(10)],
+        ]
+        edges: list[dict] = []
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["factory/outer_loop/mutations.py"])
+        assert result is not None
+        assert "tests/test_outer_loop/test_mutations.py" in result
 
 
 class TestPythonEvaluatorTestPaths:

--- a/tests/test_targeted_tests.py
+++ b/tests/test_targeted_tests.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -255,3 +256,297 @@ class TestPythonEvaluatorTestPaths:
             ev.run_tests(Path("/fake"), timeout=60, test_paths=["tests/test_x.py"])
             cmd = mock_run.call_args[0][0]
             assert "tests/test_x.py" in cmd
+
+
+# ── CLI integration: _compute_targeted_test_paths ──────────────────
+
+
+def _make_merge_base_result(returncode: int = 0, stdout: str = "abc123\n") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["git", "merge-base", "HEAD", "main"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr="",
+    )
+
+
+def _make_diff_result(returncode: int = 0, stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["git", "diff", "--name-only", "abc123..HEAD"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr="",
+    )
+
+
+class TestComputeTargetedTestPaths:
+    @patch("factory.cli.eval_cmds._read_target_branch", return_value="main")
+    @patch("factory.graph.find_dependent_tests", return_value={"tests/test_a.py", "tests/test_b.py"})
+    @patch("factory.cli.eval_cmds.subprocess.run")
+    def test_success_path(
+        self, mock_run: MagicMock, mock_find: MagicMock, _branch: MagicMock, tmp_path: Path,
+    ) -> None:
+        from factory.cli.eval_cmds import _compute_targeted_test_paths
+
+        mock_run.side_effect = [
+            _make_merge_base_result(stdout="abc123\n"),
+            _make_diff_result(stdout="src/foo.py\nsrc/bar.py\n"),
+        ]
+        result = _compute_targeted_test_paths(tmp_path)
+        assert result == ["tests/test_a.py", "tests/test_b.py"]
+        mock_find.assert_called_once_with(tmp_path, ["src/foo.py", "src/bar.py"])
+
+    @patch("factory.cli.eval_cmds._read_target_branch", return_value="main")
+    @patch("factory.cli.eval_cmds.subprocess.run")
+    def test_merge_base_fails(self, mock_run: MagicMock, _branch: MagicMock, tmp_path: Path) -> None:
+        from factory.cli.eval_cmds import _compute_targeted_test_paths
+
+        mock_run.return_value = _make_merge_base_result(returncode=1)
+        assert _compute_targeted_test_paths(tmp_path) is None
+
+    @patch("factory.cli.eval_cmds._read_target_branch", return_value="main")
+    @patch("factory.cli.eval_cmds.subprocess.run")
+    def test_diff_fails(self, mock_run: MagicMock, _branch: MagicMock, tmp_path: Path) -> None:
+        from factory.cli.eval_cmds import _compute_targeted_test_paths
+
+        mock_run.side_effect = [
+            _make_merge_base_result(),
+            _make_diff_result(returncode=1),
+        ]
+        assert _compute_targeted_test_paths(tmp_path) is None
+
+    @patch("factory.cli.eval_cmds._read_target_branch", return_value="main")
+    @patch("factory.cli.eval_cmds.subprocess.run")
+    def test_merge_base_timeout(self, mock_run: MagicMock, _branch: MagicMock, tmp_path: Path) -> None:
+        from factory.cli.eval_cmds import _compute_targeted_test_paths
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd=["git"], timeout=10)
+        assert _compute_targeted_test_paths(tmp_path) is None
+
+    @patch("factory.cli.eval_cmds._read_target_branch", return_value="main")
+    @patch("factory.cli.eval_cmds.subprocess.run")
+    def test_diff_timeout(self, mock_run: MagicMock, _branch: MagicMock, tmp_path: Path) -> None:
+        from factory.cli.eval_cmds import _compute_targeted_test_paths
+
+        mock_run.side_effect = [
+            _make_merge_base_result(),
+            subprocess.TimeoutExpired(cmd=["git"], timeout=10),
+        ]
+        assert _compute_targeted_test_paths(tmp_path) is None
+
+    @patch("factory.cli.eval_cmds._read_target_branch", return_value="main")
+    @patch("factory.cli.eval_cmds.subprocess.run")
+    def test_empty_changed_files(self, mock_run: MagicMock, _branch: MagicMock, tmp_path: Path) -> None:
+        from factory.cli.eval_cmds import _compute_targeted_test_paths
+
+        mock_run.side_effect = [
+            _make_merge_base_result(),
+            _make_diff_result(stdout="\n"),
+        ]
+        assert _compute_targeted_test_paths(tmp_path) is None
+
+    @patch("factory.cli.eval_cmds._read_target_branch", return_value="main")
+    @patch("factory.graph.find_dependent_tests", return_value=None)
+    @patch("factory.cli.eval_cmds.subprocess.run")
+    def test_find_dependent_tests_returns_none(
+        self, mock_run: MagicMock, mock_find: MagicMock, _branch: MagicMock, tmp_path: Path,
+    ) -> None:
+        from factory.cli.eval_cmds import _compute_targeted_test_paths
+
+        mock_run.side_effect = [
+            _make_merge_base_result(),
+            _make_diff_result(stdout="src/foo.py\n"),
+        ]
+        assert _compute_targeted_test_paths(tmp_path) is None
+
+    @patch("factory.cli.eval_cmds._read_target_branch", return_value="main")
+    @patch("factory.graph.find_dependent_tests", return_value={"tests/test_x.py"})
+    @patch("factory.cli.eval_cmds.subprocess.run")
+    def test_result_is_sorted(
+        self, mock_run: MagicMock, _find: MagicMock, _branch: MagicMock, tmp_path: Path,
+    ) -> None:
+        from factory.cli.eval_cmds import _compute_targeted_test_paths
+
+        mock_run.side_effect = [
+            _make_merge_base_result(),
+            _make_diff_result(stdout="src/z.py\n"),
+        ]
+        result = _compute_targeted_test_paths(tmp_path)
+        assert result == sorted(result)
+
+
+# ── Hygiene: _collect_test_and_coverage inspect.signature guard ────
+
+
+class TestCollectTestAndCoverageSignatureGuard:
+    def test_passes_test_paths_when_evaluator_supports_it(self, tmp_path: Path) -> None:
+        from factory.eval.hygiene import _collect_test_and_coverage
+        from factory.eval.languages.base import EvalFragment
+
+        mock_evaluator = MagicMock()
+        captured_kwargs: dict = {}
+
+        def fake_run_tests_with_coverage(
+            project_path: Path, timeout: int = 300, test_paths: list[str] | None = None,
+        ) -> tuple:
+            captured_kwargs["test_paths"] = test_paths
+            return (
+                EvalFragment(passed=10, failed=0, score=1.0, details="ok"),
+                EvalFragment(passed=10, failed=0, score=0.9, details="ok", coverage_pct=90.0),
+            )
+
+        mock_evaluator.run_tests_with_coverage = fake_run_tests_with_coverage
+
+        with patch("factory.eval.hygiene._find_sub_projects", return_value=[tmp_path]), \
+             patch("factory.eval.hygiene.detect_languages", return_value=[mock_evaluator]):
+            test_result, cov_result = _collect_test_and_coverage(
+                tmp_path, test_paths=["tests/test_a.py"],
+            )
+        assert test_result["score"] == 1.0
+        assert cov_result["score"] == 0.9
+        assert captured_kwargs["test_paths"] == ["tests/test_a.py"]
+
+    def test_omits_test_paths_when_evaluator_lacks_param(self, tmp_path: Path) -> None:
+        from factory.eval.hygiene import _collect_test_and_coverage
+        from factory.eval.languages.base import EvalFragment
+
+        mock_evaluator = MagicMock()
+        captured_kwargs: dict = {}
+
+        def fake_run_tests_with_coverage(project_path: Path, timeout: int = 300) -> tuple:
+            captured_kwargs["timeout"] = timeout
+            return (
+                EvalFragment(passed=8, failed=2, score=0.8, details="ok"),
+                EvalFragment(passed=7, failed=3, score=0.7, details="ok", coverage_pct=70.0),
+            )
+
+        mock_evaluator.run_tests_with_coverage = fake_run_tests_with_coverage
+
+        with patch("factory.eval.hygiene._find_sub_projects", return_value=[tmp_path]), \
+             patch("factory.eval.hygiene.detect_languages", return_value=[mock_evaluator]):
+            test_result, cov_result = _collect_test_and_coverage(
+                tmp_path, test_paths=["tests/test_a.py"],
+            )
+        assert test_result["score"] == 0.8
+        assert "test_paths" not in captured_kwargs
+
+    def test_no_test_paths_skips_signature_check(self, tmp_path: Path) -> None:
+        from factory.eval.hygiene import _collect_test_and_coverage
+        from factory.eval.languages.base import EvalFragment
+
+        mock_evaluator = MagicMock()
+
+        def fake_run_tests_with_coverage(project_path: Path, timeout: int = 300) -> tuple:
+            return (
+                EvalFragment(passed=10, failed=0, score=1.0, details="ok"),
+                None,
+            )
+
+        mock_evaluator.run_tests_with_coverage = fake_run_tests_with_coverage
+
+        with patch("factory.eval.hygiene._find_sub_projects", return_value=[tmp_path]), \
+             patch("factory.eval.hygiene.detect_languages", return_value=[mock_evaluator]):
+            test_result, cov_result = _collect_test_and_coverage(tmp_path)
+        assert test_result["score"] == 1.0
+        assert cov_result["score"] == 0.5  # neutral — no coverage fragment
+
+
+# ── cmd_eval --targeted flag wiring ────────────────────────────────
+
+
+class TestCmdEvalTargetedFlag:
+    @patch("factory.cli.eval_cmds._emit_cli_event")
+    @patch("factory.cli.eval_cmds._run")
+    @patch("factory.cli.eval_cmds._compute_targeted_test_paths", return_value=["tests/test_a.py"])
+    def test_targeted_flag_passes_test_paths_to_run_eval(
+        self, mock_compute: MagicMock, mock_run: MagicMock, _event: MagicMock, tmp_path: Path,
+    ) -> None:
+        from factory.cli.eval_cmds import cmd_eval
+
+        mock_config = MagicMock()
+        mock_config.eval_command = "pytest"
+        mock_config.project_eval = None
+        mock_config.eval_weights = None
+        mock_config.eval_threshold = 0.7
+        mock_config.test_timeout = 300
+
+        mock_score = MagicMock()
+        mock_score.total = 0.9
+        mock_score.passed = True
+        mock_score.results = []
+        mock_score.model_dump.return_value = {"total": 0.9}
+
+        mock_run.side_effect = [mock_config, mock_score]
+
+        args = MagicMock()
+        args.path = str(tmp_path)
+        args.targeted = True
+        args.skip_project_eval = False
+
+        result = cmd_eval(args)
+        assert result == 0
+        mock_compute.assert_called_once_with(tmp_path)
+
+    @patch("factory.cli.eval_cmds._emit_cli_event")
+    @patch("factory.cli.eval_cmds._run")
+    @patch("factory.cli.eval_cmds._compute_targeted_test_paths", return_value=None)
+    def test_targeted_fallback_to_full(
+        self, mock_compute: MagicMock, mock_run: MagicMock, _event: MagicMock, tmp_path: Path,
+    ) -> None:
+        from factory.cli.eval_cmds import cmd_eval
+
+        mock_config = MagicMock()
+        mock_config.eval_command = "pytest"
+        mock_config.project_eval = None
+        mock_config.eval_weights = None
+        mock_config.eval_threshold = 0.7
+        mock_config.test_timeout = 300
+
+        mock_score = MagicMock()
+        mock_score.total = 0.85
+        mock_score.passed = True
+        mock_score.results = []
+        mock_score.model_dump.return_value = {"total": 0.85}
+
+        mock_run.side_effect = [mock_config, mock_score]
+
+        args = MagicMock()
+        args.path = str(tmp_path)
+        args.targeted = True
+        args.skip_project_eval = False
+
+        result = cmd_eval(args)
+        assert result == 0
+        mock_compute.assert_called_once()
+
+    @patch("factory.cli.eval_cmds._emit_cli_event")
+    @patch("factory.cli.eval_cmds._run")
+    def test_no_targeted_flag_skips_compute(
+        self, mock_run: MagicMock, _event: MagicMock, tmp_path: Path,
+    ) -> None:
+        from factory.cli.eval_cmds import cmd_eval
+
+        mock_config = MagicMock()
+        mock_config.eval_command = "pytest"
+        mock_config.project_eval = None
+        mock_config.eval_weights = None
+        mock_config.eval_threshold = 0.7
+        mock_config.test_timeout = 300
+
+        mock_score = MagicMock()
+        mock_score.total = 0.9
+        mock_score.passed = True
+        mock_score.results = []
+        mock_score.model_dump.return_value = {"total": 0.9}
+
+        mock_run.side_effect = [mock_config, mock_score]
+
+        args = MagicMock()
+        args.path = str(tmp_path)
+        args.targeted = False
+        args.skip_project_eval = False
+
+        with patch("factory.cli.eval_cmds._compute_targeted_test_paths") as mock_compute:
+            result = cmd_eval(args)
+            mock_compute.assert_not_called()
+        assert result == 0

--- a/tests/test_targeted_tests.py
+++ b/tests/test_targeted_tests.py
@@ -1,0 +1,257 @@
+"""Tests for graph-based targeted test selection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from factory.graph import find_dependent_tests
+
+
+def _make_graph(
+    tmp_path: Path,
+    nodes: list[dict] | None = None,
+    edges: list[dict] | None = None,
+) -> Path:
+    gpath = tmp_path / "graph.json"
+    gpath.write_text(json.dumps({
+        "nodes": nodes or [],
+        "edges": edges or [],
+    }))
+    return gpath
+
+
+def _simple_graph(tmp_path: Path) -> Path:
+    """A -> B -> test_B (via imports edges), plus unrelated tests to stay under fan-out."""
+    nodes = [
+        {"id": "mod_a", "source_file": "src/a.py"},
+        {"id": "mod_b", "source_file": "src/b.py"},
+        {"id": "mod_c", "source_file": "src/c.py"},
+        {"id": "test_b", "source_file": "tests/test_b.py"},
+        {"id": "test_a", "source_file": "tests/test_a.py"},
+        {"id": "test_c1", "source_file": "tests/test_c1.py"},
+        {"id": "test_c2", "source_file": "tests/test_c2.py"},
+        {"id": "test_c3", "source_file": "tests/test_c3.py"},
+        {"id": "test_c4", "source_file": "tests/test_c4.py"},
+        {"id": "test_c5", "source_file": "tests/test_c5.py"},
+        {"id": "test_c6", "source_file": "tests/test_c6.py"},
+        {"id": "test_c7", "source_file": "tests/test_c7.py"},
+        {"id": "test_c8", "source_file": "tests/test_c8.py"},
+    ]
+    edges = [
+        {"source": "mod_b", "target": "mod_a", "relation": "imports"},
+        {"source": "test_b", "target": "mod_b", "relation": "imports"},
+        {"source": "test_a", "target": "mod_a", "relation": "imports"},
+        {"source": "test_c1", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c2", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c3", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c4", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c5", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c6", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c7", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c8", "target": "mod_c", "relation": "imports"},
+    ]
+    return _make_graph(tmp_path, nodes, edges)
+
+
+class TestFindDependentTests:
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_basic_reverse_bfs(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert "tests/test_a.py" in result
+        assert "tests/test_b.py" in result
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_direct_import_only(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        result = find_dependent_tests(tmp_path, ["src/b.py"])
+        assert result is not None
+        assert "tests/test_b.py" in result
+        assert "tests/test_a.py" not in result
+
+    @patch("factory.graph.is_graph_stale", return_value=True)
+    def test_returns_none_when_stale(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["src/a.py"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=None)
+    def test_returns_none_when_staleness_unknown(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["src/a.py"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_conftest(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["tests/conftest.py"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_init(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["src/__init__.py"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_pyproject(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["pyproject.toml"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_pytest_ini(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["pytest.ini"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_workflow_file(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, [".github/workflows/ci.yml"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_non_python_no_node(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["README.md"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_unknown_py_file(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["src/unknown.py"]) is None
+
+    def test_returns_none_on_empty_changed_files(self) -> None:
+        assert find_dependent_tests(Path("/tmp"), []) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_fan_out_returns_none(self, _stale: MagicMock, tmp_path: Path) -> None:
+        """When >80% of test files are dependent, return None."""
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+        ]
+        edges = []
+        for i in range(10):
+            nid = f"test_{i}"
+            nodes.append({"id": nid, "source_file": f"tests/test_{i}.py"})
+            edges.append({"source": nid, "target": "mod_a", "relation": "imports"})
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_fan_out_under_threshold(self, _stale: MagicMock, tmp_path: Path) -> None:
+        """When <80% of test files are dependent, return the set."""
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+            {"id": "mod_b", "source_file": "src/b.py"},
+        ]
+        edges = []
+        for i in range(3):
+            nid = f"test_a_{i}"
+            nodes.append({"id": nid, "source_file": f"tests/test_a_{i}.py"})
+            edges.append({"source": nid, "target": "mod_a", "relation": "imports"})
+        for i in range(10):
+            nid = f"test_b_{i}"
+            nodes.append({"id": nid, "source_file": f"tests/test_b_{i}.py"})
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert len(result) == 3
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_transitive_multi_hop(self, _stale: MagicMock, tmp_path: Path) -> None:
+        """C imports B imports A; changing A reaches test_C."""
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+            {"id": "mod_b", "source_file": "src/b.py"},
+            {"id": "mod_c", "source_file": "src/c.py"},
+            {"id": "test_c", "source_file": "tests/test_c.py"},
+        ]
+        # Add unrelated tests to stay under fan-out threshold
+        for i in range(8):
+            nodes.append({"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"})
+        edges = [
+            {"source": "mod_b", "target": "mod_a", "relation": "imports"},
+            {"source": "mod_c", "target": "mod_b", "relation": "imports_from"},
+            {"source": "test_c", "target": "mod_c", "relation": "imports"},
+        ]
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert "tests/test_c.py" in result
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_changed_test_file_included(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        result = find_dependent_tests(tmp_path, ["tests/test_a.py"])
+        assert result is not None
+        assert "tests/test_a.py" in result
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_empty_set_when_no_tests_depend(
+        self, _stale: MagicMock, tmp_path: Path,
+    ) -> None:
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+            {"id": "mod_b", "source_file": "src/b.py"},
+            {"id": "test_x", "source_file": "tests/test_x.py"},
+        ]
+        edges = [
+            {"source": "test_x", "target": "mod_b", "relation": "imports"},
+        ]
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert len(result) == 0
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_non_import_edges_ignored(self, _stale: MagicMock, tmp_path: Path) -> None:
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+            {"id": "test_a", "source_file": "tests/test_a.py"},
+        ]
+        edges = [
+            {"source": "test_a", "target": "mod_a", "relation": "calls"},
+        ]
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert len(result) == 0
+
+
+class TestPythonEvaluatorTestPaths:
+    @patch("factory.eval.languages.python.PythonEvaluator._detect_cov_target", return_value="src")
+    def test_test_paths_appended_to_cmd(self, _cov: MagicMock) -> None:
+        from factory.eval.languages.python import PythonEvaluator
+
+        ev = PythonEvaluator()
+        with patch("factory.eval.languages.python._run_cmd") as mock_run:
+            mock_run.return_value = (0, "1 passed", "TOTAL 100 10 90%")
+            ev.run_tests_with_coverage(
+                Path("/fake"),
+                timeout=60,
+                test_paths=["tests/test_a.py", "tests/test_b.py"],
+            )
+            cmd = mock_run.call_args[0][0]
+            assert "tests/test_a.py" in cmd
+            assert "tests/test_b.py" in cmd
+            assert cmd.index("tests/test_a.py") > cmd.index("-q")
+
+    @patch("factory.eval.languages.python.PythonEvaluator._detect_cov_target", return_value="src")
+    def test_no_test_paths_unchanged(self, _cov: MagicMock) -> None:
+        from factory.eval.languages.python import PythonEvaluator
+
+        ev = PythonEvaluator()
+        with patch("factory.eval.languages.python._run_cmd") as mock_run:
+            mock_run.return_value = (0, "1 passed", "TOTAL 100 10 90%")
+            ev.run_tests_with_coverage(Path("/fake"), timeout=60)
+            cmd = mock_run.call_args[0][0]
+            assert not any(c.startswith("tests/") for c in cmd)
+
+    @patch("factory.eval.languages.python.PythonEvaluator._detect_cov_target", return_value="src")
+    def test_run_tests_forwards_test_paths(self, _cov: MagicMock) -> None:
+        from factory.eval.languages.python import PythonEvaluator
+
+        ev = PythonEvaluator()
+        with patch("factory.eval.languages.python._run_cmd") as mock_run:
+            mock_run.return_value = (0, "1 passed", "TOTAL 100 10 90%")
+            ev.run_tests(Path("/fake"), timeout=60, test_paths=["tests/test_x.py"])
+            cmd = mock_run.call_args[0][0]
+            assert "tests/test_x.py" in cmd


### PR DESCRIPTION
## Summary

- Adds `find_dependent_tests()` to `factory/graph.py` — reverse-import BFS over the existing `graph.json` to compute which test files are transitively affected by changed source files
- Threads an optional `test_paths` parameter through `PythonEvaluator` → `compute_hygiene_results()` → `run_eval()` so pytest runs only the affected subset
- Adds `factory eval --targeted` CLI flag that computes changed files, resolves dependencies via the graph, and falls back to full suite when selection cannot be trusted
- Updates the health checker prompt to use `--targeted` by default
- Includes a grep-based inline import scan that catches test files importing changed modules inside function bodies (invisible to graphifyy's static graph)

### Safety design
- `find_dependent_tests()` returns `None` (not empty set) on any ambiguity → callers always fall back to full suite
- Hard-coded full-suite triggers: `conftest.py`, `__init__.py`, `pyproject.toml`, CI files
- Stale graph → full suite; unknown files → full suite; fan-out >80% → full suite
- Sacred Rule 9 / `check_qa_execution()` is unaffected (checks event presence, not pytest scope)

### Inline import coverage
Adversarial testing found 56% of test files use inline imports invisible to graphifyy's static graph. The grep-based scan (runs after the reverse-BFS) catches these by searching test files for the changed module's dotted import path. Validated on `factory/runners/claude.py` — previously missed `test_ceo_message_events.py` and `test_verification.py`, now found.

### Files changed
- `factory/graph.py` — `find_dependent_tests()` with reverse BFS + grep-based inline import scan
- `factory/eval/languages/python.py` — `test_paths` param on `run_tests_with_coverage()` / `run_tests()`
- `factory/eval/hygiene.py` — thread `test_paths` through hygiene pipeline
- `factory/eval/runner.py` — thread `test_paths` through `run_eval()`
- `factory/cli/eval_cmds.py` — `--targeted` flag + `_compute_targeted_test_paths()`
- `factory/cli/_parser_groups.py` — argparse flag registration
- `factory/agents/prompts/health_checker.md` — one-line prompt update
- `tests/test_targeted_tests.py` — 39 tests covering BFS, CLI integration, grep scan

## Test plan
- [x] 39 tests pass (reverse BFS, multi-hop, staleness gates, exclusion triggers, fan-out threshold, test_paths threading, CLI integration, grep-based scan)
- [x] Full test suite: 2391 passed (no regressions)
- [x] Empirical validation on 3 real commits: targeted selection equivalent to full suite
- [x] Grep scan verified: previously-missed inline importers now found

Closes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYiei7JyDnjMrt2Dg6jkJu