### PR TITLE
feat: graph-based targeted test selection for health checker (#1451)

### DIFF
--- a/factory/agents/prompts/health_checker.md
+++ b/factory/agents/prompts/health_checker.md
@@ -10,7 +10,7 @@ Your current working directory IS the project root. Use relative paths or `$(pwd
 
 ## What to do
 
-1. Run `factory eval` on the project.
+1. Run `factory eval --targeted` on the project (uses graph-based test selection when available, falls back to full suite automatically).
 2. Record the composite score and whether unit tests pass or fail.
 3. Compare the composite score to the baseline score.
 

--- a/factory/cli/_parser_groups.py
+++ b/factory/cli/_parser_groups.py
@@ -29,6 +29,8 @@ def add_experiment_lifecycle_parsers(sub: argparse._SubParsersAction) -> None:  
     p.add_argument("path", help="Path to the project")
     p.add_argument("--skip-project-eval", action="store_true", default=False,
                     help="Skip user-defined project eval dimensions (run only hygiene + growth)")
+    p.add_argument("--targeted", action="store_true", default=False,
+                    help="Use graph-based targeted test selection (falls back to full suite)")
 
     p = sub.add_parser("guard", help="Check guard rules, print violations or 'clean'")
     p.add_argument("path", help="Path to the project")

--- a/factory/cli/eval_cmds.py
+++ b/factory/cli/eval_cmds.py
@@ -12,6 +12,53 @@ from factory.cli._helpers import _emit_cli_event, _read_target_branch, _run
 
 log = structlog.get_logger()
 
+
+def _compute_targeted_test_paths(project_path: Path) -> list[str] | None:
+    """Compute changed files and resolve to targeted test paths via the import graph."""
+    target_branch = _read_target_branch(project_path)
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "HEAD", target_branch],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            log.info("targeted.skip", reason="no_merge_base")
+            return None
+        baseline = result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    try:
+        diff_result = subprocess.run(
+            ["git", "diff", "--name-only", f"{baseline}..HEAD"],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if diff_result.returncode != 0:
+            return None
+        changed_files = [f for f in diff_result.stdout.strip().splitlines() if f]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    if not changed_files:
+        return None
+
+    from factory.graph import find_dependent_tests
+
+    dependent = find_dependent_tests(project_path, changed_files)
+    if dependent is None:
+        log.info("targeted.fallback", reason="find_dependent_tests_returned_none")
+        return None
+
+    log.info("targeted.active", test_count=len(dependent), changed_files=len(changed_files))
+    return sorted(dependent)
+
+
 def cmd_eval(args: argparse.Namespace) -> int:
     from factory.eval.runner import run_eval
     from factory.store import ExperimentStore
@@ -20,6 +67,16 @@ def cmd_eval(args: argparse.Namespace) -> int:
     store = ExperimentStore(project_path)
     config = _run(store.read_config())
     skip_project_eval = getattr(args, "skip_project_eval", False)
+
+    test_paths: list[str] | None = None
+    targeted = getattr(args, "targeted", False)
+    if targeted:
+        test_paths = _compute_targeted_test_paths(project_path)
+        if test_paths is not None:
+            log.info("eval.mode", mode="targeted", test_paths=len(test_paths))
+        else:
+            log.info("eval.mode", mode="full", reason="targeted_fallback")
+
     _emit_cli_event(project_path, "eval.started", {"command": config.eval_command})
     score = _run(run_eval(
         config.eval_command, project_path, config.eval_threshold,
@@ -27,6 +84,7 @@ def cmd_eval(args: argparse.Namespace) -> int:
         eval_weights=config.eval_weights,
         skip_project_eval=skip_project_eval,
         test_timeout=config.test_timeout,
+        test_paths=test_paths,
     ))
     _emit_cli_event(project_path, "eval.completed", {
         "composite": score.total,

--- a/factory/eval/hygiene.py
+++ b/factory/eval/hygiene.py
@@ -12,6 +12,7 @@ All functions take a project_path and return an EvalResult-compatible dict.
 If a tool is not detected for a dimension, score is 0.5 (neutral), not 0.
 """
 
+import inspect
 import json
 import shutil
 import subprocess
@@ -334,14 +335,23 @@ def _run_sentrux_scan(project_path: Path) -> dict | None:
 # ── Public API ─────────────────────────────────────────────────────
 
 
-def _collect_test_and_coverage(project_path: Path, timeout: int = 300) -> tuple[dict, dict]:
+def _collect_test_and_coverage(
+    project_path: Path,
+    timeout: int = 300,
+    test_paths: list[str] | None = None,
+) -> tuple[dict, dict]:
     """Run tests and coverage together via run_tests_with_coverage(), return both result dicts."""
     sub_projects = _find_sub_projects(project_path)
     test_fragments: list[EvalFragment] = []
     cov_fragments: list[EvalFragment] = []
     for sp in sub_projects:
         for evaluator in detect_languages(sp):
-            test_frag, cov_frag = evaluator.run_tests_with_coverage(sp, timeout=timeout)
+            kwargs: dict = {"timeout": timeout}
+            if test_paths:
+                sig = inspect.signature(evaluator.run_tests_with_coverage)
+                if "test_paths" in sig.parameters:
+                    kwargs["test_paths"] = test_paths
+            test_frag, cov_frag = evaluator.run_tests_with_coverage(sp, **kwargs)
             if test_frag is not None:
                 test_fragments.append(test_frag)
             if cov_frag is not None:
@@ -360,9 +370,15 @@ def _collect_test_and_coverage(project_path: Path, timeout: int = 300) -> tuple[
     return test_result, cov_result
 
 
-def compute_hygiene_results(project_path: Path, test_timeout: int = 600) -> list[dict]:
+def compute_hygiene_results(
+    project_path: Path,
+    test_timeout: int = 600,
+    test_paths: list[str] | None = None,
+) -> list[dict]:
     """Compute all 6 mandatory hygiene dimensions for a project."""
-    test_result, cov_result = _collect_test_and_coverage(project_path, timeout=test_timeout)
+    test_result, cov_result = _collect_test_and_coverage(
+        project_path, timeout=test_timeout, test_paths=test_paths,
+    )
     return [
         test_result,
         eval_lint(project_path),

--- a/factory/eval/languages/python.py
+++ b/factory/eval/languages/python.py
@@ -35,15 +35,21 @@ class PythonEvaluator:
         )
 
     def run_tests_with_coverage(
-        self, project_path: Path, timeout: int = 300,
+        self,
+        project_path: Path,
+        timeout: int = 300,
+        test_paths: list[str] | None = None,
     ) -> tuple[EvalFragment | None, EvalFragment | None]:
         cov_target = self._detect_cov_target(project_path)
+        cmd = [
+            _resolve_python(project_path), "-m", "pytest",
+            f"--cov={cov_target}", "--cov-report=term",
+            "-v", "--tb=no", "-q",
+        ]
+        if test_paths:
+            cmd.extend(test_paths)
         rc, stdout, stderr = _run_cmd(
-            [
-                _resolve_python(project_path), "-m", "pytest",
-                f"--cov={cov_target}", "--cov-report=term",
-                "-v", "--tb=no", "-q",
-            ],
+            cmd,
             project_path,
             timeout=timeout,
         )
@@ -79,9 +85,14 @@ class PythonEvaluator:
 
         return test_frag, cov_frag
 
-    def run_tests(self, project_path: Path, timeout: int = 300) -> EvalFragment | None:
+    def run_tests(
+        self,
+        project_path: Path,
+        timeout: int = 300,
+        test_paths: list[str] | None = None,
+    ) -> EvalFragment | None:
         """Prefer run_tests_with_coverage() to avoid a redundant pytest invocation."""
-        return self.run_tests_with_coverage(project_path, timeout=timeout)[0]
+        return self.run_tests_with_coverage(project_path, timeout=timeout, test_paths=test_paths)[0]
 
     def run_lint(self, project_path: Path) -> EvalFragment | None:
         rc, stdout, stderr = _run_cmd(

--- a/factory/eval/runner.py
+++ b/factory/eval/runner.py
@@ -271,6 +271,7 @@ async def run_eval(
     growth_weights: TierWeights | None = None,
     eval_spec: list[str] | None = None,
     test_timeout: int = 600,
+    test_paths: list[str] | None = None,
 ) -> CompositeScore:
     """Compute mandatory dimensions + project-specific additions + custom project eval.
 
@@ -283,7 +284,9 @@ async def run_eval(
     6. Return composite score
     """
     # Step 1: Mandatory hygiene (always runs)
-    hygiene_dicts = compute_hygiene_results(project_path, test_timeout=test_timeout)
+    hygiene_dicts = compute_hygiene_results(
+        project_path, test_timeout=test_timeout, test_paths=test_paths,
+    )
     hygiene_results = [EvalResult(**r) for r in hygiene_dicts]
 
     # Step 2: Project-specific additions (optional, additive only)

--- a/factory/graph.py
+++ b/factory/graph.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import shutil
 import subprocess
 from pathlib import Path
 
+import networkx as nx
 import structlog
 
 log = structlog.get_logger()
@@ -141,3 +143,123 @@ def update_graph(project_path: Path) -> Path | None:
     Returns path to root graph.json on success, None on failure.
     """
     return _run_graphify(project_path, extra_args=["--update"])
+
+
+_FULL_SUITE_TRIGGERS = [
+    "**/conftest.py",
+    "**/__init__.py",
+    "pyproject.toml",
+    "pytest.ini",
+    "setup.cfg",
+    "tox.ini",
+    ".github/workflows/**",
+]
+
+_IMPORT_EDGE_TYPES = frozenset({"imports", "imports_from"})
+
+_FAN_OUT_THRESHOLD = 0.80
+
+
+def find_dependent_tests(
+    project_path: Path,
+    changed_files: list[str],
+) -> set[str] | None:
+    """Reverse-import BFS over graph.json to find tests affected by changed files.
+
+    Returns None when selection cannot be trusted — callers treat None as
+    "fall back to full suite".
+    """
+    if not changed_files:
+        return None
+
+    staleness = is_graph_stale(project_path)
+    if staleness is not False:
+        log.info("targeted.skip", reason="graph_stale_or_unavailable", staleness=staleness)
+        return None
+
+    for cf in changed_files:
+        for pattern in _FULL_SUITE_TRIGGERS:
+            if fnmatch.fnmatch(cf, pattern):
+                log.info("targeted.skip", reason="full_suite_trigger", file=cf, pattern=pattern)
+                return None
+
+    gpath = _graph_path(project_path)
+    try:
+        data = json.loads(gpath.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("targeted.skip", reason="graph_read_error", error=str(exc))
+        return None
+
+    nodes = data.get("nodes", [])
+    edges = data.get("edges", data.get("links", []))
+
+    file_to_node_ids: dict[str, list[str]] = {}
+    for node in nodes:
+        sf = node.get("source_file", "")
+        nid = node.get("id", "")
+        if sf and nid:
+            file_to_node_ids.setdefault(sf, []).append(nid)
+
+    all_test_files = {sf for sf in file_to_node_ids if sf.startswith("tests/") and sf.endswith(".py")}
+
+    G: nx.DiGraph[str] = nx.DiGraph()
+    for node in nodes:
+        nid = node.get("id", "")
+        if nid:
+            G.add_node(nid, source_file=node.get("source_file", ""))
+    for edge in edges:
+        if edge.get("relation") in _IMPORT_EDGE_TYPES:
+            src = edge.get("source", "")
+            tgt = edge.get("target", "")
+            if src and tgt:
+                G.add_edge(src, tgt)
+
+    seed_node_ids: set[str] = set()
+    for cf in changed_files:
+        if not cf.endswith(".py"):
+            if cf not in file_to_node_ids:
+                log.info("targeted.skip", reason="non_python_no_node", file=cf)
+                return None
+        nids = file_to_node_ids.get(cf, [])
+        if not nids:
+            log.info("targeted.skip", reason="file_not_in_graph", file=cf)
+            return None
+        seed_node_ids.update(nids)
+
+    # Reverse BFS: find all nodes that transitively import the changed nodes
+    reverse_G = G.reverse(copy=False)
+    reached: set[str] = set()
+    for seed in seed_node_ids:
+        if seed in reverse_G:
+            reached.update(nx.descendants(reverse_G, seed))
+    reached.update(seed_node_ids)
+
+    dependent_test_files: set[str] = set()
+    for nid in reached:
+        sf = G.nodes[nid].get("source_file", "") if nid in G else ""
+        if sf in all_test_files:
+            dependent_test_files.add(sf)
+
+    # Also include any changed files that are themselves test files
+    for cf in changed_files:
+        if cf in all_test_files:
+            dependent_test_files.add(cf)
+
+    if not dependent_test_files:
+        return dependent_test_files
+
+    if all_test_files and len(dependent_test_files) / len(all_test_files) > _FAN_OUT_THRESHOLD:
+        log.info(
+            "targeted.skip",
+            reason="fan_out_exceeded",
+            dependent=len(dependent_test_files),
+            total=len(all_test_files),
+        )
+        return None
+
+    log.info(
+        "targeted.selected",
+        dependent_tests=len(dependent_test_files),
+        total_tests=len(all_test_files),
+    )
+    return dependent_test_files

--- a/tests/test_targeted_tests.py
+++ b/tests/test_targeted_tests.py
@@ -1,0 +1,257 @@
+"""Tests for graph-based targeted test selection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from factory.graph import find_dependent_tests
+
+
+def _make_graph(
+    tmp_path: Path,
+    nodes: list[dict] | None = None,
+    edges: list[dict] | None = None,
+) -> Path:
+    gpath = tmp_path / "graph.json"
+    gpath.write_text(json.dumps({
+        "nodes": nodes or [],
+        "edges": edges or [],
+    }))
+    return gpath
+
+
+def _simple_graph(tmp_path: Path) -> Path:
+    """A -> B -> test_B (via imports edges), plus unrelated tests to stay under fan-out."""
+    nodes = [
+        {"id": "mod_a", "source_file": "src/a.py"},
+        {"id": "mod_b", "source_file": "src/b.py"},
+        {"id": "mod_c", "source_file": "src/c.py"},
+        {"id": "test_b", "source_file": "tests/test_b.py"},
+        {"id": "test_a", "source_file": "tests/test_a.py"},
+        {"id": "test_c1", "source_file": "tests/test_c1.py"},
+        {"id": "test_c2", "source_file": "tests/test_c2.py"},
+        {"id": "test_c3", "source_file": "tests/test_c3.py"},
+        {"id": "test_c4", "source_file": "tests/test_c4.py"},
+        {"id": "test_c5", "source_file": "tests/test_c5.py"},
+        {"id": "test_c6", "source_file": "tests/test_c6.py"},
+        {"id": "test_c7", "source_file": "tests/test_c7.py"},
+        {"id": "test_c8", "source_file": "tests/test_c8.py"},
+    ]
+    edges = [
+        {"source": "mod_b", "target": "mod_a", "relation": "imports"},
+        {"source": "test_b", "target": "mod_b", "relation": "imports"},
+        {"source": "test_a", "target": "mod_a", "relation": "imports"},
+        {"source": "test_c1", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c2", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c3", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c4", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c5", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c6", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c7", "target": "mod_c", "relation": "imports"},
+        {"source": "test_c8", "target": "mod_c", "relation": "imports"},
+    ]
+    return _make_graph(tmp_path, nodes, edges)
+
+
+class TestFindDependentTests:
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_basic_reverse_bfs(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert "tests/test_a.py" in result
+        assert "tests/test_b.py" in result
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_direct_import_only(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        result = find_dependent_tests(tmp_path, ["src/b.py"])
+        assert result is not None
+        assert "tests/test_b.py" in result
+        assert "tests/test_a.py" not in result
+
+    @patch("factory.graph.is_graph_stale", return_value=True)
+    def test_returns_none_when_stale(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["src/a.py"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=None)
+    def test_returns_none_when_staleness_unknown(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["src/a.py"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_conftest(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["tests/conftest.py"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_init(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["src/__init__.py"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_pyproject(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["pyproject.toml"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_pytest_ini(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["pytest.ini"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_workflow_file(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, [".github/workflows/ci.yml"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_non_python_no_node(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["README.md"]) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_none_on_unknown_py_file(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        assert find_dependent_tests(tmp_path, ["src/unknown.py"]) is None
+
+    def test_returns_none_on_empty_changed_files(self) -> None:
+        assert find_dependent_tests(Path("/tmp"), []) is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_fan_out_returns_none(self, _stale: MagicMock, tmp_path: Path) -> None:
+        """When >80% of test files are dependent, return None."""
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+        ]
+        edges = []
+        for i in range(10):
+            nid = f"test_{i}"
+            nodes.append({"id": nid, "source_file": f"tests/test_{i}.py"})
+            edges.append({"source": nid, "target": "mod_a", "relation": "imports"})
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is None
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_fan_out_under_threshold(self, _stale: MagicMock, tmp_path: Path) -> None:
+        """When <80% of test files are dependent, return the set."""
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+            {"id": "mod_b", "source_file": "src/b.py"},
+        ]
+        edges = []
+        for i in range(3):
+            nid = f"test_a_{i}"
+            nodes.append({"id": nid, "source_file": f"tests/test_a_{i}.py"})
+            edges.append({"source": nid, "target": "mod_a", "relation": "imports"})
+        for i in range(10):
+            nid = f"test_b_{i}"
+            nodes.append({"id": nid, "source_file": f"tests/test_b_{i}.py"})
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert len(result) == 3
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_transitive_multi_hop(self, _stale: MagicMock, tmp_path: Path) -> None:
+        """C imports B imports A; changing A reaches test_C."""
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+            {"id": "mod_b", "source_file": "src/b.py"},
+            {"id": "mod_c", "source_file": "src/c.py"},
+            {"id": "test_c", "source_file": "tests/test_c.py"},
+        ]
+        # Add unrelated tests to stay under fan-out threshold
+        for i in range(8):
+            nodes.append({"id": f"test_u{i}", "source_file": f"tests/test_u{i}.py"})
+        edges = [
+            {"source": "mod_b", "target": "mod_a", "relation": "imports"},
+            {"source": "mod_c", "target": "mod_b", "relation": "imports_from"},
+            {"source": "test_c", "target": "mod_c", "relation": "imports"},
+        ]
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert "tests/test_c.py" in result
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_changed_test_file_included(self, _stale: MagicMock, tmp_path: Path) -> None:
+        _simple_graph(tmp_path)
+        result = find_dependent_tests(tmp_path, ["tests/test_a.py"])
+        assert result is not None
+        assert "tests/test_a.py" in result
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_returns_empty_set_when_no_tests_depend(
+        self, _stale: MagicMock, tmp_path: Path,
+    ) -> None:
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+            {"id": "mod_b", "source_file": "src/b.py"},
+            {"id": "test_x", "source_file": "tests/test_x.py"},
+        ]
+        edges = [
+            {"source": "test_x", "target": "mod_b", "relation": "imports"},
+        ]
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert len(result) == 0
+
+    @patch("factory.graph.is_graph_stale", return_value=False)
+    def test_non_import_edges_ignored(self, _stale: MagicMock, tmp_path: Path) -> None:
+        nodes = [
+            {"id": "mod_a", "source_file": "src/a.py"},
+            {"id": "test_a", "source_file": "tests/test_a.py"},
+        ]
+        edges = [
+            {"source": "test_a", "target": "mod_a", "relation": "calls"},
+        ]
+        _make_graph(tmp_path, nodes, edges)
+        result = find_dependent_tests(tmp_path, ["src/a.py"])
+        assert result is not None
+        assert len(result) == 0
+
+
+class TestPythonEvaluatorTestPaths:
+    @patch("factory.eval.languages.python.PythonEvaluator._detect_cov_target", return_value="src")
+    def test_test_paths_appended_to_cmd(self, _cov: MagicMock) -> None:
+        from factory.eval.languages.python import PythonEvaluator
+
+        ev = PythonEvaluator()
+        with patch("factory.eval.languages.python._run_cmd") as mock_run:
+            mock_run.return_value = (0, "1 passed", "TOTAL 100 10 90%")
+            ev.run_tests_with_coverage(
+                Path("/fake"),
+                timeout=60,
+                test_paths=["tests/test_a.py", "tests/test_b.py"],
+            )
+            cmd = mock_run.call_args[0][0]
+            assert "tests/test_a.py" in cmd
+            assert "tests/test_b.py" in cmd
+            assert cmd.index("tests/test_a.py") > cmd.index("-q")
+
+    @patch("factory.eval.languages.python.PythonEvaluator._detect_cov_target", return_value="src")
+    def test_no_test_paths_unchanged(self, _cov: MagicMock) -> None:
+        from factory.eval.languages.python import PythonEvaluator
+
+        ev = PythonEvaluator()
+        with patch("factory.eval.languages.python._run_cmd") as mock_run:
+            mock_run.return_value = (0, "1 passed", "TOTAL 100 10 90%")
+            ev.run_tests_with_coverage(Path("/fake"), timeout=60)
+            cmd = mock_run.call_args[0][0]
+            assert not any(c.startswith("tests/") for c in cmd)
+
+    @patch("factory.eval.languages.python.PythonEvaluator._detect_cov_target", return_value="src")
+    def test_run_tests_forwards_test_paths(self, _cov: MagicMock) -> None:
+        from factory.eval.languages.python import PythonEvaluator
+
+        ev = PythonEvaluator()
+        with patch("factory.eval.languages.python._run_cmd") as mock_run:
+            mock_run.return_value = (0, "1 passed", "TOTAL 100 10 90%")
+            ev.run_tests(Path("/fake"), timeout=60, test_paths=["tests/test_x.py"])
+            cmd = mock_run.call_args[0][0]
+            assert "tests/test_x.py" in cmd


### PR DESCRIPTION
## Summary

- Adds `find_dependent_tests()` to `factory/graph.py` — reverse-import BFS over the existing `graph.json` to compute which test files are transitively affected by changed source files
- Threads an optional `test_paths` parameter through `PythonEvaluator` → `compute_hygiene_results()` → `run_eval()` so pytest runs only the affected subset
- Adds `factory eval --targeted` CLI flag that computes changed files, resolves dependencies via the graph, and falls back to full suite when selection cannot be trusted
- Updates the health checker prompt to use `--targeted` by default

### Safety design
- `find_dependent_tests()` returns `None` (not empty set) on any ambiguity → callers always fall back to full suite
- Hard-coded full-suite triggers: `conftest.py`, `__init__.py`, `pyproject.toml`, CI files
- Stale graph → full suite; unknown files → full suite; fan-out >80% → full suite
- Sacred Rule 9 / `check_qa_execution()` is unaffected (checks event presence, not pytest scope)

### Files changed
- `factory/graph.py` — new `find_dependent_tests()` (122 lines)
- `factory/eval/languages/python.py` — `test_paths` param on `run_tests_with_coverage()` / `run_tests()`
- `factory/eval/hygiene.py` — thread `test_paths` through hygiene pipeline
- `factory/eval/runner.py` — thread `test_paths` through `run_eval()`
- `factory/cli/eval_cmds.py` — `--targeted` flag + `_compute_targeted_test_paths()`
- `factory/cli/_parser_groups.py` — argparse flag registration
- `factory/agents/prompts/health_checker.md` — one-line prompt update
- `tests/test_targeted_tests.py` — 21 tests covering all critical paths

## Test plan
- [x] 21 new tests pass (reverse BFS, multi-hop, staleness gates, exclusion triggers, fan-out threshold, test_paths threading)
- [x] Full test suite: 2391 passed (no regressions)
- [x] Lint clean, type check clean (1 pre-existing error in unrelated file)
- [x] Adversarial testing: 35 edge cases verified with evidence
- [x] Code review: 6/7 categories PASS, 1 important (CLI integration test gap, acceptable for v1)

Closes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYiei7JyDnjMrt2Dg6jkJu