### PR TITLE
fix: wire FixedSubsetSelector into SwarmEvaluator task path

### DIFF
--- a/factory/outer_loop/evaluator.py
+++ b/factory/outer_loop/evaluator.py
@@ -335,6 +335,9 @@ class SwarmEvaluator:
                 loop.test_command = self._config.test_command
                 loop.test_format = self._config.test_format or "pytest"
                 loop.metric_path = self._config.metric_path
+                if instances:
+                    from factory.outer_loop.subset import FixedSubsetSelector
+                    loop._subset_selector = FixedSubsetSelector(instances)
             else:
                 loop = InnerLoop(
                     project_dir=wt_path,

--- a/factory/outer_loop/subset.py
+++ b/factory/outer_loop/subset.py
@@ -14,7 +14,7 @@ class SubsetSelector(Protocol):
     """Protocol for selecting which benchmark instances to evaluate per generation."""
 
     def select(
-        self, all_instances: list[str], generation: int, budget_remaining: int
+        self, all_instances: list[str], generation: int = 0, budget_remaining: int = 0
     ) -> list[str]: ...
 
 
@@ -25,6 +25,6 @@ class FixedSubsetSelector:
         self._training_instances = list(training_instances)
 
     def select(
-        self, all_instances: list[str], generation: int, budget_remaining: int
+        self, all_instances: list[str], generation: int = 0, budget_remaining: int = 0
     ) -> list[str]:
         return list(self._training_instances)

--- a/tests/test_outer_loop/test_evaluator.py
+++ b/tests/test_outer_loop/test_evaluator.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from factory.cycle_analyzer import CycleRecord
 from factory.outer_loop.evaluator import CycleRecordCache, FitnessCache, SwarmEvaluator
 from factory.outer_loop.models import EvalResult, SwarmConfig
+from factory.outer_loop.subset import FixedSubsetSelector
 from factory.workflow.primitives import (
     AgentNode,
     AgentRole,
@@ -186,6 +188,54 @@ class TestSwarmEvaluator:
         wf = _make_simple_workflow()
         result = evaluator.evaluate(wf, "/tmp/test", ["t1"])
         assert result.details.get("note") == "no_evaluator_fn_configured"
+
+    @patch("factory.outer_loop.evaluator.SwarmEvaluator._cleanup_worktree")
+    @patch("factory.outer_loop.evaluator.SwarmEvaluator._create_worktree")
+    def test_task_path_wires_subset_selector(
+        self, mock_create_wt: MagicMock, mock_cleanup_wt: MagicMock, tmp_path: Path
+    ) -> None:
+        """When _evaluate_via_inner_loop uses the task path with instances, it sets _subset_selector."""
+        wt_path = tmp_path / "wt"
+        wt_path.mkdir()
+        mock_create_wt.return_value = wt_path
+
+        captured_loop: list[object] = []
+
+        mock_task = MagicMock()
+        config = _make_config()
+        config.set_task(mock_task)
+
+        mock_loop = MagicMock()
+        mock_loop.step.return_value = CycleRecord(
+            cycle_number=1, mode="test",
+            started_at="2026-01-01T00:00:00", ended_at="2026-01-01T00:01:00",
+            duration_s=60.0, score_start=0.0, score_end=0.7, score_delta=0.7,
+            kept=1, reverted=0, total_cost_usd=0.5,
+        )
+        mock_loop.mode = "evolve"
+        mock_loop.instance_results = None
+
+        def fake_compose(workflow: object, task: object, project_dir: object) -> MagicMock:
+            captured_loop.append(mock_loop)
+            return mock_loop
+
+        instances = ["inst_a", "inst_b"]
+
+        def factory_fn(wf: object) -> str:
+            return "evolve"
+
+        evaluator = SwarmEvaluator(config, inner_loop_factory=factory_fn)
+
+        with patch("factory.compose.compose", fake_compose):
+            evaluator._evaluate_via_inner_loop(
+                _make_simple_workflow(), str(tmp_path), instances
+            )
+
+        assert len(captured_loop) == 1
+        assert hasattr(mock_loop, "_subset_selector")
+        sel = mock_loop._subset_selector
+        assert isinstance(sel, FixedSubsetSelector)
+        assert sel._training_instances == instances
 
     def test_loads_cache_from_disk(self, tmp_path: Path) -> None:
         config = _make_config()

--- a/tests/test_outer_loop/test_evaluator.py
+++ b/tests/test_outer_loop/test_evaluator.py
@@ -237,6 +237,45 @@ class TestSwarmEvaluator:
         assert isinstance(sel, FixedSubsetSelector)
         assert sel._training_instances == instances
 
+    @patch("factory.outer_loop.evaluator.SwarmEvaluator._cleanup_worktree")
+    @patch("factory.outer_loop.evaluator.SwarmEvaluator._create_worktree")
+    def test_task_path_no_subset_selector_when_empty_instances(
+        self, mock_create_wt: MagicMock, mock_cleanup_wt: MagicMock, tmp_path: Path
+    ) -> None:
+        """When instances is empty, _subset_selector should NOT be set."""
+        wt_path = tmp_path / "wt"
+        wt_path.mkdir()
+        mock_create_wt.return_value = wt_path
+
+        mock_task = MagicMock()
+        config = _make_config()
+        config.set_task(mock_task)
+
+        mock_loop = MagicMock()
+        mock_loop.step.return_value = CycleRecord(
+            cycle_number=1, mode="test",
+            started_at="2026-01-01T00:00:00", ended_at="2026-01-01T00:01:00",
+            duration_s=60.0, score_start=0.0, score_end=0.7, score_delta=0.7,
+            kept=1, reverted=0, total_cost_usd=0.5,
+        )
+        mock_loop.mode = "evolve"
+        mock_loop.instance_results = None
+
+        def fake_compose(workflow: object, task: object, project_dir: object) -> MagicMock:
+            return mock_loop
+
+        def factory_fn(wf: object) -> str:
+            return "evolve"
+
+        evaluator = SwarmEvaluator(config, inner_loop_factory=factory_fn)
+
+        with patch("factory.compose.compose", fake_compose):
+            evaluator._evaluate_via_inner_loop(
+                _make_simple_workflow(), str(tmp_path), []
+            )
+
+        assert not isinstance(getattr(mock_loop, "_subset_selector", None), FixedSubsetSelector)
+
     def test_loads_cache_from_disk(self, tmp_path: Path) -> None:
         config = _make_config()
         wf = _make_simple_workflow()


### PR DESCRIPTION
## Summary
- Wires `FixedSubsetSelector` into the task path of `SwarmEvaluator._evaluate_via_inner_loop()` so the `InnerLoop` filters task instances to the subset already selected by `SwarmEngine`
- Without this, the compose()-based task path ignored the `instances` list, evaluating all task instances instead of the selected subset
- Adds a targeted test verifying the selector is set with the correct instances

## Test plan
- [x] New test `test_task_path_wires_subset_selector` mocks `compose()` and asserts `_subset_selector` is a `FixedSubsetSelector` with the passed instances
- [x] All 20 existing evaluator tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiaEMx6BVM4wUmZ3tRWPXc