### PR TITLE
fix: remove invalid --dangerously-skip-permissions from Task.run()

### DIFF
--- a/factory/task.py
+++ b/factory/task.py
@@ -544,7 +544,6 @@ class Task:
             _sys.executable, "-m", "factory", "ceo", str(workspace),
             "--mode", mode_name, "--headless", "--no-worktree",
             "--prompt", str(prompt_file),
-            "--dangerously-skip-permissions",
         ]
         try:
             subprocess.run(

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -923,7 +923,7 @@ class TestTaskRunSubprocess:
         assert "--mode" in captured_cmd
         assert "--headless" in captured_cmd
         assert "--no-worktree" in captured_cmd
-        assert "--dangerously-skip-permissions" in captured_cmd
+        assert "--dangerously-skip-permissions" not in captured_cmd
 
     def test_run_defaults_to_improve_mode(self, tmp_path: Path, monkeypatch):
         """run() defaults to 'improve' mode when workflow is None."""


### PR DESCRIPTION
## Summary
- Removes `--dangerously-skip-permissions` from `Task.run()`'s `factory ceo` subprocess command. This flag belongs to the `claude` CLI, not the `factory` CLI, causing `factory: error: unrecognized arguments: --dangerously-skip-permissions` on every outer loop evaluation.
- Updates the test assertion to verify the flag is absent.

The "Not logged in" bug in chess-evolve eval worktrees is a separate issue in chess-evolve's `engine.py` (`_cli_call` passes `--bare` which skips the keychain), not in factory.

## Test plan
- [x] `TestTaskRunSubprocess` (7 tests) — all pass
- [x] `test_evaluator_compose` + `test_evaluator` (25 tests) — all pass
- [x] 118 total tests across task/evaluator files — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbPVqwUggWgnz9SrVUJoJx