### PR TITLE
fix: persist eval_details and instance_results through disk round-trip

### DIFF
--- a/factory/cli/outer_loop.py
+++ b/factory/cli/outer_loop.py
@@ -325,6 +325,25 @@ def _load_cycle_summary(project_path: Path, mode_name: str) -> CycleRecord | Non
     try:
         data = json.loads(summary_path.read_text())
         duration_ms = data.get("duration_ms", 0)
+
+        instance_results = data.get("instance_results")
+
+        eval_details: dict[str, object] | None = None
+        verify = data.get("verify")
+        test_details = data.get("test_details")
+        if verify is not None or test_details is not None:
+            eval_details = {}
+            if verify is not None:
+                eval_details["verify"] = verify
+            if test_details is not None:
+                eval_details["test_details"] = test_details
+            rejected = data.get("rejected")
+            if rejected is not None:
+                eval_details["rejected"] = rejected
+            error = data.get("error")
+            if isinstance(error, str):
+                eval_details["error"] = error
+
         return CR(
             cycle_number=0,
             mode=mode_name,
@@ -338,6 +357,8 @@ def _load_cycle_summary(project_path: Path, mode_name: str) -> CycleRecord | Non
             reverted=data.get("reverted", 0),
             errored=data.get("agents_failed", 0),
             total_cost_usd=data.get("cost_usd", 0.0),
+            instance_results=instance_results,
+            eval_details=eval_details,
         )
     except (json.JSONDecodeError, OSError, ValueError, TypeError):
         return None

--- a/factory/inner_loop.py
+++ b/factory/inner_loop.py
@@ -330,6 +330,16 @@ class InnerLoop:
         record.frozen_nodes = sorted(self.frozen_nodes)
         record.mutable_node_ids = sorted(self.mutable_nodes())
 
+        self._write_cycle_summary(
+            returncode=0,
+            event_offset=0,
+            duration_ms=int(duration_s * 1000),
+            builder_committed=False,
+            experiments=0,
+            test_score=aggregate_score,
+            instance_results=instance_results,
+        )
+
         self._step_count += 1
         self._history.append(record)
         return record
@@ -505,6 +515,9 @@ class InnerLoop:
         experiments: int,
         test_score: float | None = None,
         test_details: dict[str, Any] | None = None,
+        instance_results: list[dict[str, Any]] | None = None,
+        kept: int = 0,
+        reverted: int = 0,
     ) -> Path:
         """Write a structured summary of observable outcomes from this cycle."""
         events_path = self.factory_dir / "events.jsonl"
@@ -566,9 +579,28 @@ class InnerLoop:
             "experiments": experiments,
             "duration_ms": duration_ms,
             "errors": errors,
+            "kept": kept,
+            "reverted": reverted,
         }
         if test_details:
             summary["test_details"] = test_details
+
+        if instance_results:
+            summary["instance_results"] = instance_results
+            from factory.outer_loop.verify_adapter import eval_result_from_verify_results
+            from factory.task import VerifyResult
+
+            verify_results = [
+                VerifyResult(
+                    passed=bool(ir.get("passed", False)),
+                    score=float(ir.get("score", 0.0)),
+                    details=ir.get("details") or {},
+                )
+                for ir in instance_results
+                if isinstance(ir, dict)
+            ]
+            adapted = eval_result_from_verify_results(verify_results)
+            summary["verify"] = adapted.details
 
         summary_dir = self.factory_dir / "outer_loop" / "runs" / self.mode
         summary_dir.mkdir(parents=True, exist_ok=True)

--- a/factory/outer_loop/evaluator.py
+++ b/factory/outer_loop/evaluator.py
@@ -87,8 +87,8 @@ class CycleRecordCache:
                 if not line:
                     continue
                 try:
-                    entry = json.loads(line)
-                    existing_hashes.add(entry.get("workflow_hash", ""))
+                    existing = json.loads(line)
+                    existing_hashes.add(existing.get("workflow_hash", ""))
                 except json.JSONDecodeError:
                     continue
 
@@ -96,7 +96,7 @@ class CycleRecordCache:
         for wf_hash, record in self._cache.items():
             if wf_hash in existing_hashes:
                 continue
-            entry = {
+            entry: dict[str, Any] = {
                 "workflow_hash": wf_hash,
                 "score": record.score_end,
                 "cost": record.total_cost_usd,
@@ -104,6 +104,10 @@ class CycleRecordCache:
                 "reverted": record.reverted,
                 "timestamp": record.ended_at or record.started_at,
             }
+            if record.eval_details is not None:
+                entry["eval_details"] = record.eval_details
+            if record.instance_results is not None:
+                entry["instance_results"] = record.instance_results
             new_entries.append(json.dumps(entry, separators=(",", ":")))
 
         if new_entries:
@@ -144,6 +148,8 @@ class CycleRecordCache:
                 kept=entry.get("kept", 0),
                 reverted=entry.get("reverted", 0),
                 total_cost_usd=entry.get("cost", 0.0),
+                instance_results=entry.get("instance_results"),
+                eval_details=entry.get("eval_details"),
             )
             self._cache[wf_hash] = record
             loaded += 1

--- a/tests/test_outer_loop/test_verify_disk_roundtrip.py
+++ b/tests/test_outer_loop/test_verify_disk_roundtrip.py
@@ -1,0 +1,284 @@
+"""Integration test: verify data survives the disk round-trip.
+
+Exercises the full pipeline:
+  _write_cycle_summary() → cycle_summary.json → _load_cycle_summary() →
+  CycleRecord with eval_details → OuterLoopReflector._extract_eval_patterns()
+  → non-empty failure/success patterns.
+
+Also covers CycleRecordCache persistence of eval_details and instance_results.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from factory.cycle_analyzer import CycleRecord
+from factory.inner_loop import InnerLoop
+from factory.outer_loop.evaluator import CycleRecordCache
+from factory.outer_loop.reflector import OuterLoopReflector
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    (tmp_path / ".factory").mkdir()
+    return tmp_path
+
+
+@pytest.fixture()
+def loop(project_dir: Path) -> InnerLoop:
+    return InnerLoop(project_dir=project_dir, mode="evolve-roundtrip")
+
+
+def _sample_instance_results() -> list[dict]:
+    return [
+        {
+            "instance_id": "inst-a",
+            "passed": True,
+            "score": 1.0,
+            "details": {"returncode": 0, "stdout": "ok"},
+        },
+        {
+            "instance_id": "inst-b",
+            "passed": False,
+            "score": 0.0,
+            "details": {"returncode": 1, "stderr": "error"},
+        },
+        {
+            "instance_id": "inst-c",
+            "passed": False,
+            "score": 0.0,
+            "details": {"returncode": 2},
+        },
+    ]
+
+
+class TestVerifyDiskRoundtrip:
+    """End-to-end: write → read → reflect produces patterns from verify data."""
+
+    def test_write_read_reflect(self, loop: InnerLoop, project_dir: Path) -> None:
+        instance_results = _sample_instance_results()
+
+        loop._write_cycle_summary(
+            returncode=0,
+            event_offset=0,
+            duration_ms=5000,
+            builder_committed=False,
+            experiments=0,
+            test_score=0.33,
+            instance_results=instance_results,
+            kept=1,
+            reverted=2,
+        )
+
+        summary_path = (
+            project_dir / ".factory" / "outer_loop" / "runs"
+            / "evolve-roundtrip" / "cycle_summary.json"
+        )
+        data = json.loads(summary_path.read_text())
+        assert "instance_results" in data
+        assert "verify" in data
+        assert data["verify"]["verify_count"] == 3
+        assert data["verify"]["passed_count"] == 1
+        assert data["verify"]["failed_count"] == 2
+        assert data["kept"] == 1
+        assert data["reverted"] == 2
+
+        from factory.cli.outer_loop import _load_cycle_summary
+
+        record = _load_cycle_summary(project_dir, "evolve-roundtrip")
+        assert record is not None
+        assert record.kept == 1
+        assert record.reverted == 2
+        assert record.instance_results is not None
+        assert len(record.instance_results) == 3
+        assert record.eval_details is not None
+        assert "verify" in record.eval_details
+        verify = record.eval_details["verify"]
+        assert verify["verify_count"] == 3
+        assert verify["passed_count"] == 1
+        assert verify["failed_count"] == 2
+
+        winner_record = CycleRecord(
+            cycle_number=1,
+            mode="winner",
+            started_at=None,
+            ended_at=None,
+            duration_s=5.0,
+            score_start=0.0,
+            score_end=0.9,
+            score_delta=0.9,
+            eval_details={
+                "verify": {
+                    "verify_count": 3,
+                    "passed_count": 3,
+                    "failed_count": 0,
+                    "instance_results": [
+                        {"index": i, "passed": True, "score": 1.0}
+                        for i in range(3)
+                    ],
+                },
+            },
+        )
+
+        reflector = OuterLoopReflector(k=1)
+        records = [
+            ("winner-mode", 0.9, winner_record),
+            ("evolve-roundtrip", 0.33, record),
+        ]
+        report = reflector.reflect(records, generation=0)
+
+        verify_failures = [
+            p for p in report.failure_patterns if "verify" in p.lower()
+        ]
+        assert len(verify_failures) > 0, (
+            f"Expected verify failure patterns, got: {report.failure_patterns}"
+        )
+        assert any("2/3" in p for p in verify_failures)
+
+        rc_failures = [p for p in report.failure_patterns if "returncode" in p]
+        assert len(rc_failures) >= 1
+
+        verify_successes = [
+            p for p in report.success_patterns if "verify" in p.lower()
+        ]
+        assert len(verify_successes) > 0
+
+    def test_summary_without_instance_results(
+        self, loop: InnerLoop, project_dir: Path,
+    ) -> None:
+        loop._write_cycle_summary(
+            returncode=0,
+            event_offset=0,
+            duration_ms=1000,
+            builder_committed=True,
+            experiments=1,
+        )
+        from factory.cli.outer_loop import _load_cycle_summary
+
+        record = _load_cycle_summary(project_dir, "evolve-roundtrip")
+        assert record is not None
+        assert record.instance_results is None
+        assert record.eval_details is None
+
+    def test_summary_with_test_details_only(
+        self, loop: InnerLoop, project_dir: Path,
+    ) -> None:
+        loop._write_cycle_summary(
+            returncode=0,
+            event_offset=0,
+            duration_ms=1000,
+            builder_committed=True,
+            experiments=1,
+            test_details={"returncode": 1, "failed": 2, "total": 5},
+        )
+        from factory.cli.outer_loop import _load_cycle_summary
+
+        record = _load_cycle_summary(project_dir, "evolve-roundtrip")
+        assert record is not None
+        assert record.eval_details is not None
+        assert "test_details" in record.eval_details
+        assert record.eval_details["test_details"]["returncode"] == 1
+
+
+class TestCycleRecordCacheRoundtrip:
+    """CycleRecordCache persists and restores eval_details + instance_results."""
+
+    def test_save_load_preserves_eval_details(self, tmp_path: Path) -> None:
+        cache = CycleRecordCache()
+
+        from factory.workflow.primitives import AgentNode, AgentRole, Workflow
+
+        wf = Workflow(
+            name="test-wf",
+            nodes={
+                "b": AgentNode(
+                    id="b", role=AgentRole.BUILDER, model="opus", timeout=60,
+                ),
+            },
+            edges=[],
+            start_node="b",
+            terminal=True,
+        )
+
+        record = CycleRecord(
+            cycle_number=1,
+            mode="test",
+            started_at=None,
+            ended_at=None,
+            duration_s=5.0,
+            score_start=None,
+            score_end=0.75,
+            score_delta=None,
+            instance_results=_sample_instance_results(),
+            eval_details={
+                "verify": {
+                    "verify_count": 3,
+                    "passed_count": 1,
+                    "failed_count": 2,
+                    "instance_results": [
+                        {"index": 0, "passed": True, "score": 1.0},
+                        {"index": 1, "passed": False, "score": 0.0},
+                        {"index": 2, "passed": False, "score": 0.0},
+                    ],
+                },
+            },
+        )
+        cache.put(wf, record)
+
+        cache_path = tmp_path / "eval_cache.jsonl"
+        cache.save_cache(cache_path)
+
+        new_cache = CycleRecordCache()
+        loaded = new_cache.load_cache(cache_path)
+        assert loaded == 1
+
+        restored = new_cache.get(wf)
+        assert restored is not None
+        assert restored.score_end == 0.75
+        assert restored.instance_results is not None
+        assert len(restored.instance_results) == 3
+        assert restored.eval_details is not None
+        assert "verify" in restored.eval_details
+        assert restored.eval_details["verify"]["passed_count"] == 1
+
+    def test_save_load_without_eval_details(self, tmp_path: Path) -> None:
+        cache = CycleRecordCache()
+
+        from factory.workflow.primitives import AgentNode, AgentRole, Workflow
+
+        wf = Workflow(
+            name="bare-wf",
+            nodes={
+                "b": AgentNode(
+                    id="b", role=AgentRole.BUILDER, model="opus", timeout=60,
+                ),
+            },
+            edges=[],
+            start_node="b",
+            terminal=True,
+        )
+
+        record = CycleRecord(
+            cycle_number=1,
+            mode="test",
+            started_at=None,
+            ended_at=None,
+            duration_s=5.0,
+            score_start=None,
+            score_end=0.5,
+            score_delta=None,
+        )
+        cache.put(wf, record)
+
+        cache_path = tmp_path / "eval_cache.jsonl"
+        cache.save_cache(cache_path)
+
+        new_cache = CycleRecordCache()
+        new_cache.load_cache(cache_path)
+        restored = new_cache.get(wf)
+        assert restored is not None
+        assert restored.eval_details is None
+        assert restored.instance_results is None


### PR DESCRIPTION
Closes #1465

## Changes

- **`factory/inner_loop.py`** — `_write_cycle_summary()` now accepts `instance_results`, `kept`, `reverted`; builds verify block via `verify_adapter.eval_result_from_verify_results()`; `_step_with_task()` calls it with instance_results so cycle_summary.json exists on disk for task-driven evaluations
- **`factory/outer_loop/evaluator.py`** — `CycleRecordCache.save_cache()/load_cache()` now persist and restore `eval_details` and `instance_results` in JSONL entries
- **`factory/cli/outer_loop.py`** — `_load_cycle_summary()` reconstructs `CycleRecord.eval_details` from `verify`, `test_details`, `rejected`, `error` keys and populates `instance_results`
- **`tests/test_outer_loop/test_verify_disk_roundtrip.py`** — Integration test: write → read → reflect pipeline producing non-empty failure/success patterns from verify data; CycleRecordCache round-trip tests

## Test plan

- [x] 5 new integration tests pass (disk round-trip + cache round-trip)
- [x] 92 existing outer loop tests pass (zero regressions)
- [x] `ruff check` clean
- [x] `mypy` clean