### PR TITLE
fix: wire outer loop reflection→mutation pipeline end-to-end

### DIFF
--- a/factory/cli/outer_loop.py
+++ b/factory/cli/outer_loop.py
@@ -186,6 +186,17 @@ def _cmd_calibrate(args: argparse.Namespace) -> int:
             edges=[],
             start_node="builder",
             terminal=True,
+            knob_values={
+                "agent_timeout": 7200,
+                "agent_model": "opus",
+            },
+            knob_bounds={
+                "agent_timeout": [300, 600, 900, 1200, 1800, 3600, 7200],
+                "agent_model": ["sonnet", "opus", "haiku"],
+            },
+            knob_expandable={
+                "agent_timeout": "Agent timeout in seconds for the builder node",
+            },
         )
     else:
         try:
@@ -422,7 +433,7 @@ def _cmd_reflect(args: argparse.Namespace) -> int:
             config, inner_loop_factory=_make_inner_loop_factory(registry),
         )
         for mode_name, wf in needs_eval:
-            ev = evaluator.evaluate(wf, eval_project_dir, config.training_instances)
+            ev = evaluator.evaluate(wf, eval_project_dir, config.training_instances, individual_id=mode_name)
             cycle_rec = evaluator.get_cycle_record(mode_name)
             records.append((mode_name, ev.score, cycle_rec))
 
@@ -430,7 +441,13 @@ def _cmd_reflect(args: argparse.Namespace) -> int:
         print("Not enough candidates for reflection (need >= 2).", file=sys.stderr)
         return 1
 
-    report = reflector.reflect(records, generation)
+    knob_values_by_id: dict[str, dict[str, object]] = {}
+    for mode_name in registry.list_modes():
+        wf = registry.load(mode_name)
+        if wf is not None and wf.knob_values:
+            knob_values_by_id[mode_name] = dict(wf.knob_values)
+
+    report = reflector.reflect(records, generation, knob_values_by_id=knob_values_by_id or None)
     print(f"Reflection complete: {len(report.failure_patterns)} failures, "
           f"{len(report.success_patterns)} successes, "
           f"{len(report.mutation_suggestions)} suggestions")
@@ -446,6 +463,7 @@ def _cmd_evolve(args: argparse.Namespace) -> int:
     from factory.outer_loop.filesystem import load_config
     from factory.outer_loop.mode_registry import EphemeralModeRegistry
     from factory.outer_loop.mutations import WeightedRandomStrategy, apply_random_mutation
+    from factory.outer_loop.reflector import ReflectionReport
 
     config = load_config(project_path)
     if config is None:
@@ -463,6 +481,24 @@ def _cmd_evolve(args: argparse.Namespace) -> int:
         print("Error: no ephemeral modes to evolve.", file=sys.stderr)
         return 1
 
+    reflection_report: ReflectionReport | None = None
+    reflect_path = project_path / ".factory" / "outer_loop" / "reflections" / f"gen{generation}.json"
+    if reflect_path.exists():
+        try:
+            data = json.loads(reflect_path.read_text())
+            reflection_report = ReflectionReport(
+                failure_patterns=data.get("failure_patterns", []),
+                success_patterns=data.get("success_patterns", []),
+                mutation_suggestions=data.get("mutation_suggestions", []),
+                prompt_improvements=data.get("prompt_improvements", []),
+                structural_recommendations=data.get("structural_recommendations", []),
+                top_k_ids=data.get("top_k_ids", []),
+                bottom_k_ids=data.get("bottom_k_ids", []),
+            )
+            _log.info("reflection_loaded", generation=generation, suggestions=len(reflection_report.mutation_suggestions))
+        except (json.JSONDecodeError, OSError) as exc:
+            _log.warning("reflection_load_failed", generation=generation, error=str(exc))
+
     strategy = WeightedRandomStrategy(mutation_rate=config.mutation_rate)
     offspring_count = 0
 
@@ -473,6 +509,7 @@ def _cmd_evolve(args: argparse.Namespace) -> int:
         result = apply_random_mutation(
             wf, strategy, generation + 1,
             frozen_nodes=set(config.frozen_node_ids),
+            reflection_report=reflection_report,
         )
         if result is not None:
             child_wf, mutation_rec = result

--- a/factory/outer_loop/mutations.py
+++ b/factory/outer_loop/mutations.py
@@ -25,6 +25,42 @@ from factory.outer_loop.reflector import ReflectionReport
 log = structlog.get_logger()
 
 
+_MUTATION_TYPE_NAMES = {t.value.upper(): t for t in MutationType}
+
+
+def parse_operator_from_suggestion(suggestion: str) -> MutationType | None:
+    """Extract a MutationType from a suggestion string.
+
+    Supports two formats:
+    1. Prefix: "OPERATOR_NAME: rest of suggestion"
+    2. Substring: any MutationType name appearing in the text
+
+    Longer names are checked first to avoid partial matches
+    (e.g. KNOB_MUTATE before PARAM_MUTATE won't shadow each other).
+    """
+    upper = suggestion.upper()
+    colon_pos = upper.find(":")
+    if colon_pos > 0:
+        prefix = upper[:colon_pos].strip()
+        if prefix in _MUTATION_TYPE_NAMES:
+            return _MUTATION_TYPE_NAMES[prefix]
+
+    for name in sorted(_MUTATION_TYPE_NAMES, key=len, reverse=True):
+        if name in upper:
+            return _MUTATION_TYPE_NAMES[name]
+    return None
+
+
+def parse_direction_from_suggestion(suggestion: str) -> str | None:
+    """Extract a direction hint ('increase' or 'decrease') from a suggestion."""
+    lower = suggestion.lower()
+    if "increase" in lower:
+        return "increase"
+    if "decrease" in lower or "reduce" in lower or "lower" in lower:
+        return "decrease"
+    return None
+
+
 @runtime_checkable
 class MutationStrategy(Protocol):
     """Protocol for pluggable mutation operator selection."""
@@ -65,6 +101,20 @@ class WeightedRandomStrategy:
     ) -> MutationType:
         types = list(MutationType)
         w = [self.weights.get(t.value, 0.1) for t in types]
+
+        diversity = archive_stats.get("diversity")
+        if isinstance(diversity, (int, float)) and diversity < 0.3:
+            structural_ops = {
+                MutationType.NODE_INSERT,
+                MutationType.PARALLELIZE,
+                MutationType.EDGE_REDIRECT,
+            }
+            boost = 1.5
+            w = [
+                weight * boost if t in structural_ops else weight
+                for t, weight in zip(types, w)
+            ]
+
         return random.choices(types, weights=w, k=1)[0]
 
     def select_guided_operator(
@@ -73,22 +123,16 @@ class WeightedRandomStrategy:
         generation: int,
         reflection: ReflectionReport,
     ) -> MutationType:
-        """Select an operator guided by reflection suggestions."""
+        """Select an operator guided by reflection suggestions.
+
+        Parses suggestions using structured prefix matching against all
+        MutationType enum names, making all 8 operators reachable by guidance.
+        """
         op_counts: dict[MutationType, int] = {}
         for suggestion in reflection.mutation_suggestions + reflection.structural_recommendations:
-            upper = suggestion.upper()
-            if "NODE_INSERT" in upper:
-                op_counts[MutationType.NODE_INSERT] = op_counts.get(MutationType.NODE_INSERT, 0) + 1
-            elif "NODE_REMOVE" in upper:
-                op_counts[MutationType.NODE_REMOVE] = op_counts.get(MutationType.NODE_REMOVE, 0) + 1
-            elif "PARALLELIZE" in upper:
-                op_counts[MutationType.PARALLELIZE] = op_counts.get(MutationType.PARALLELIZE, 0) + 1
-            elif "PARAM_MUTATE" in upper:
-                op_counts[MutationType.PARAM_MUTATE] = op_counts.get(MutationType.PARAM_MUTATE, 0) + 1
-            elif "PROMPT_MUTATE" in upper:
-                op_counts[MutationType.PROMPT_MUTATE] = op_counts.get(MutationType.PROMPT_MUTATE, 0) + 1
-            elif "KNOB" in upper:
-                op_counts[MutationType.KNOB_MUTATE] = op_counts.get(MutationType.KNOB_MUTATE, 0) + 1
+            parsed = parse_operator_from_suggestion(suggestion)
+            if parsed is not None:
+                op_counts[parsed] = op_counts.get(parsed, 0) + 1
 
         if not op_counts:
             return self.select_operator(parent, generation, {})
@@ -753,6 +797,7 @@ def mutate_knob(
     generate a new value.
     """
     if not workflow.knob_values:
+        log.info("knob_mutate_skipped", reason="empty_knob_values")
         return None
 
     wf = _deep_copy_workflow(workflow)
@@ -877,6 +922,24 @@ def apply_random_mutation(
     return None
 
 
+def _extract_param_direction(
+    reflection_report: object,
+    target_node: str,
+) -> str | None:
+    """Extract a direction hint for PARAM_MUTATE from reflection suggestions."""
+    if not isinstance(reflection_report, ReflectionReport):
+        return None
+    for suggestion in reflection_report.structural_recommendations + reflection_report.mutation_suggestions:
+        parsed_op = parse_operator_from_suggestion(suggestion)
+        if parsed_op != MutationType.PARAM_MUTATE:
+            continue
+        if target_node in suggestion or target_node.split("_")[0] in suggestion.lower():
+            return parse_direction_from_suggestion(suggestion)
+    for suggestion in reflection_report.structural_recommendations:
+        return parse_direction_from_suggestion(suggestion)
+    return None
+
+
 def _extract_prompt_hint(report: ReflectionReport) -> str | None:
     """Extract a prompt improvement hint from a ReflectionReport."""
     if report.prompt_improvements:
@@ -952,8 +1015,19 @@ def _try_mutation(
             return None
         target = random.choice(agent_nodes)
         param = random.choice(["timeout", "model"])
+        direction = _extract_param_direction(kwargs.get("reflection_report"), target)
         if param == "timeout":
-            changes: dict[str, object] = {"timeout": random.choice([300, 600, 900, 1200, 1800])}
+            timeout_options = [300, 600, 900, 1200, 1800]
+            current_timeout = getattr(workflow.nodes[target], "timeout", 600) or 600
+            if direction == "increase":
+                candidates = [t for t in timeout_options if t > current_timeout]
+                chosen = random.choice(candidates) if candidates else max(timeout_options)
+            elif direction == "decrease":
+                candidates = [t for t in timeout_options if t < current_timeout]
+                chosen = random.choice(candidates) if candidates else min(timeout_options)
+            else:
+                chosen = random.choice(timeout_options)
+            changes: dict[str, object] = {"timeout": chosen}
         else:
             changes = {"model": random.choice(["sonnet", "opus", "haiku"])}
         return mutate_params(workflow, target, changes, frozen_nodes=frozen)

--- a/factory/outer_loop/reflector.py
+++ b/factory/outer_loop/reflector.py
@@ -328,6 +328,17 @@ class OuterLoopReflector:
                     f"({', '.join(s.role for s in timeout_failures)})"
                 )
 
+            failed_roles = [s.role for s in rec.steps if not s.succeeded]
+            successful_roles = [s.role for s in rec.steps if s.succeeded]
+            if failed_roles and successful_roles:
+                report.structural_recommendations.append(
+                    f"EDGE_REDIRECT: Reroute output away from failing agents "
+                    f"({', '.join(failed_roles)}) toward successful ones "
+                    f"({', '.join(successful_roles)})"
+                )
+
+        top_has_parallel = False
+        bottom_has_parallel = False
         for _, score, rec in top_k:
             if rec is None:
                 continue
@@ -337,11 +348,44 @@ class OuterLoopReflector:
                     if nt.node_type == "ForkNode"
                 ]
                 if parallel_nodes:
+                    top_has_parallel = True
                     report.structural_recommendations.append(
                         "PARALLELIZE: Winners use parallel execution — "
                         "consider parallelizing independent agents"
                     )
                     break
+
+        for _, score, rec in bottom_k:
+            if rec is None:
+                continue
+            if rec.node_trace:
+                parallel_nodes = [
+                    nid for nid, nt in rec.node_trace.items()
+                    if nt.node_type == "ForkNode"
+                ]
+                if parallel_nodes:
+                    bottom_has_parallel = True
+                    break
+
+        if bottom_has_parallel and not top_has_parallel:
+            report.structural_recommendations.append(
+                "SERIALIZE: Losers use parallel execution but winners don't — "
+                "consider serializing parallel agents to enforce ordering"
+            )
+
+        for _, score, rec in bottom_k:
+            if rec is None:
+                continue
+            if len(rec.steps) >= 2:
+                for i in range(len(rec.steps) - 1):
+                    cur = rec.steps[i]
+                    nxt = rec.steps[i + 1]
+                    if cur.succeeded and not nxt.succeeded:
+                        report.structural_recommendations.append(
+                            f"SERIALIZE: Agent {nxt.role} depends on {cur.role} output "
+                            f"but may execute too early — consider enforcing sequential order"
+                        )
+                        break
 
     def _extract_knob_patterns(
         self,
@@ -394,6 +438,11 @@ class OuterLoopReflector:
                     f"outperforms {knob}={display_worst} "
                     f"({avg_by_val[worst_val]:+.0f}) by {gap:.0f}"
                 )
+                if is_prompt:
+                    report.prompt_improvements.append(
+                        f"Adopt prompt strategy from top performers for {knob}: "
+                        f"{display_best}"
+                    )
 
         # Top-K vs bottom-K: which knobs differ consistently?
         top_ids = {id_ for id_, _, _ in top_k}

--- a/factory/workflow/contributed/featurebench/workflow.py
+++ b/factory/workflow/contributed/featurebench/workflow.py
@@ -195,4 +195,15 @@ def workflow() -> Workflow:
         start_node="study",
         terminal=True,
         trigger=trigger,
+        knob_values={
+            "agent_timeout": 7200,
+            "agent_model": "opus",
+        },
+        knob_bounds={
+            "agent_timeout": [300, 600, 900, 1200, 1800, 3600, 7200],
+            "agent_model": ["sonnet", "opus", "haiku"],
+        },
+        knob_expandable={
+            "agent_timeout": "Agent timeout in seconds for the builder node",
+        },
     )

--- a/tests/test_outer_loop/test_reflection_mutation_pipeline.py
+++ b/tests/test_outer_loop/test_reflection_mutation_pipeline.py
@@ -1,0 +1,556 @@
+"""Tests for the reflection→mutation pipeline wiring (H1).
+
+Phase 1: Plumbing fixes — individual_id propagation, OptKnob in seed workflow,
+          mutate_knob logging, knob_values_by_id in _cmd_reflect.
+Phase 2: Mutation selection quality — structured parsing, directional PARAM_MUTATE,
+          EDGE_REDIRECT/SERIALIZE generation, archive_stats influence.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from unittest.mock import patch
+
+from factory.cycle_analyzer import AgentStep, CycleRecord
+from factory.outer_loop.models import MutationType
+from factory.outer_loop.mutations import (
+    WeightedRandomStrategy,
+    _extract_param_direction,
+    mutate_knob,
+    parse_direction_from_suggestion,
+    parse_operator_from_suggestion,
+)
+from factory.outer_loop.reflector import OuterLoopReflector, ReflectionReport
+from factory.workflow.primitives import (
+    AgentNode,
+    AgentRole,
+    Workflow,
+)
+
+
+def _make_step(
+    role: str, succeeded: bool = True, error: str | None = None, duration: float = 10.0
+) -> AgentStep:
+    return AgentStep(
+        order=0,
+        role=role,
+        started_at="2024-01-01T00:00:00",
+        duration_s=duration,
+        cost_usd=0.1,
+        output_tokens=100,
+        succeeded=succeeded,
+        error=error,
+    )
+
+
+def _make_record(
+    score: float,
+    steps: list[AgentStep] | None = None,
+    kept: int = 0,
+    reverted: int = 0,
+    errored: int = 0,
+) -> CycleRecord:
+    return CycleRecord(
+        cycle_number=1,
+        mode="test",
+        started_at=None,
+        ended_at=None,
+        duration_s=10.0,
+        score_start=0.0,
+        score_end=score,
+        score_delta=score,
+        steps=steps or [],
+        kept=kept,
+        reverted=reverted,
+        errored=errored,
+    )
+
+
+def _simple_workflow() -> Workflow:
+    return Workflow(
+        name="test",
+        nodes={
+            "builder": AgentNode(
+                id="builder", role=AgentRole.BUILDER, timeout=600,
+                writes={".factory/reviews/builder-latest.md"},
+            ),
+        },
+        edges=[],
+        start_node="builder",
+        terminal=True,
+    )
+
+
+# ── Phase 1 Tests ──────────────────────────────────────────────────────
+
+
+class TestPhase1aIndividualIdPropagation:
+    def test_cmd_reflect_fallback_passes_individual_id(self, tmp_path: Path) -> None:
+        """_cmd_reflect fallback branch should pass individual_id to evaluate."""
+        import argparse
+
+        from factory.outer_loop.evaluator import SwarmEvaluator
+        from factory.outer_loop.models import EvalResult, SwarmConfig
+
+        project = tmp_path
+        modes_dir = project / ".factory" / "outer_loop" / "modes"
+        modes_dir.mkdir(parents=True)
+
+        from factory.outer_loop.mode_registry import EphemeralModeRegistry
+
+        wf1 = Workflow(
+            name="mode-a",
+            nodes={"b": AgentNode(id="b", role=AgentRole.BUILDER, writes=set())},
+            edges=[], start_node="b", terminal=True,
+        )
+        wf2 = Workflow(
+            name="mode-b",
+            nodes={"b": AgentNode(id="b", role=AgentRole.RESEARCHER, writes=set())},
+            edges=[], start_node="b", terminal=True,
+        )
+
+        registry = EphemeralModeRegistry(project)
+        registry.register("aaa", 0, wf1)
+        registry.register("bbb", 0, wf2)
+
+        cfg = SwarmConfig(benchmark="featurebench", budget=50)
+        captured_ids: list[str | None] = []
+
+        def spy_evaluate(self_ref: object, wf: object, proj: object, insts: object, individual_id: str | None = None) -> EvalResult:
+            captured_ids.append(individual_id)
+            return EvalResult(score=0.5 if "aaa" in (individual_id or "") else 0.3, benchmark_score=0.5)
+
+        with patch("factory.outer_loop.filesystem.load_config", return_value=cfg), \
+             patch.object(SwarmEvaluator, "evaluate", spy_evaluate), \
+             patch.object(SwarmEvaluator, "get_cycle_record", return_value=_make_record(0.5, kept=1)):
+            from factory.cli.outer_loop import _cmd_reflect
+
+            ns = argparse.Namespace(project_path=str(project), generation=0)
+            rc = _cmd_reflect(ns)
+            assert rc == 0
+
+        for cid in captured_ids:
+            assert cid is not None, "individual_id should not be None in fallback branch"
+
+
+class TestPhase1bOptKnobInSeedWorkflow:
+    def test_featurebench_workflow_has_knobs(self) -> None:
+        from factory.workflow.contributed.featurebench.workflow import workflow
+
+        wf = workflow()
+        assert "agent_timeout" in wf.knob_values
+        assert "agent_model" in wf.knob_values
+        assert wf.knob_values["agent_timeout"] == 7200
+        assert wf.knob_values["agent_model"] == "opus"
+
+    def test_featurebench_workflow_knob_bounds(self) -> None:
+        from factory.workflow.contributed.featurebench.workflow import workflow
+
+        wf = workflow()
+        assert "agent_timeout" in wf.knob_bounds
+        assert "agent_model" in wf.knob_bounds
+        assert 300 in wf.knob_bounds["agent_timeout"]
+        assert 7200 in wf.knob_bounds["agent_timeout"]
+        assert "sonnet" in wf.knob_bounds["agent_model"]
+        assert "opus" in wf.knob_bounds["agent_model"]
+        assert "haiku" in wf.knob_bounds["agent_model"]
+
+    def test_featurebench_workflow_knob_expandable(self) -> None:
+        from factory.workflow.contributed.featurebench.workflow import workflow
+
+        wf = workflow()
+        assert "agent_timeout" in wf.knob_expandable
+
+    def test_inline_seed_has_knobs(self) -> None:
+        """The inline featurebench seed in _cmd_calibrate should also have knobs."""
+        from factory.workflow.primitives import AgentNode, AgentRole, Workflow
+
+        wf = Workflow(
+            name="featurebench-seed",
+            nodes={
+                "builder": AgentNode(
+                    id="builder",
+                    role=AgentRole.BUILDER,
+                    model="opus",
+                    timeout=7200,
+                    writes={".factory/reviews/builder-latest.md"},
+                ),
+            },
+            edges=[],
+            start_node="builder",
+            terminal=True,
+            knob_values={"agent_timeout": 7200, "agent_model": "opus"},
+            knob_bounds={
+                "agent_timeout": [300, 600, 900, 1200, 1800, 3600, 7200],
+                "agent_model": ["sonnet", "opus", "haiku"],
+            },
+            knob_expandable={"agent_timeout": "Agent timeout in seconds for the builder node"},
+        )
+        assert wf.knob_values["agent_timeout"] == 7200
+        assert len(wf.knob_bounds["agent_timeout"]) == 7
+
+    def test_knob_mutate_fires_with_seeded_knobs(self) -> None:
+        """KNOB_MUTATE should be able to mutate the seed workflow's knobs."""
+        from factory.workflow.contributed.featurebench.workflow import workflow
+
+        wf = workflow()
+        result = mutate_knob(wf, expander=None)
+        assert result is not None
+        child_wf, rec = result
+        assert rec.operator == MutationType.KNOB_MUTATE
+
+
+class TestPhase1dMutateKnobLogging:
+    def test_empty_knob_values_logs_skip(self, caplog: object) -> None:
+        wf = _simple_workflow()
+        assert not wf.knob_values
+
+        with patch("factory.outer_loop.mutations.log") as mock_log:
+            result = mutate_knob(wf, expander=None)
+            assert result is None
+            mock_log.info.assert_called_once_with(
+                "knob_mutate_skipped", reason="empty_knob_values"
+            )
+
+
+class TestPhase1ReflectPassesKnobValues:
+    def test_cmd_reflect_passes_knob_values_by_id(self, tmp_path: Path) -> None:
+        """_cmd_reflect should build and pass knob_values_by_id to reflector."""
+        import argparse
+
+        from factory.outer_loop.models import SwarmConfig
+
+        project = tmp_path
+        modes_dir = project / ".factory" / "outer_loop" / "modes"
+        modes_dir.mkdir(parents=True)
+        results_dir = project / ".factory" / "outer_loop" / "results"
+        results_dir.mkdir(parents=True)
+
+        wf = Workflow(
+            name="mode-a",
+            nodes={"b": AgentNode(id="b", role=AgentRole.BUILDER, writes=set())},
+            edges=[], start_node="b", terminal=True,
+            knob_values={"agent_timeout": 600, "agent_model": "opus"},
+        )
+        wf2 = Workflow(
+            name="mode-b",
+            nodes={"b": AgentNode(id="b", role=AgentRole.RESEARCHER, writes=set())},
+            edges=[], start_node="b", terminal=True,
+        )
+
+        from factory.outer_loop.mode_registry import EphemeralModeRegistry
+
+        registry = EphemeralModeRegistry(project)
+        name_a = registry.register("aaa", 0, wf)
+        name_b = registry.register("bbb", 0, wf2)
+
+        gen_results = {
+            name_a: {"score": 0.85, "cost_usd": 1.0},
+            name_b: {"score": 0.72, "cost_usd": 0.5},
+        }
+        (results_dir / "gen0.json").write_text(json.dumps(gen_results))
+
+        for name, score in [(name_a, 0.85), (name_b, 0.72)]:
+            runs_dir = project / ".factory" / "outer_loop" / "runs" / name
+            runs_dir.mkdir(parents=True)
+            summary = {"mode": name, "score": score, "cost_usd": 0.5, "kept": 2, "reverted": 1}
+            (runs_dir / "cycle_summary.json").write_text(json.dumps(summary))
+
+        cfg = SwarmConfig(benchmark="featurebench", budget=50)
+
+        captured_kwargs: list[dict[str, object]] = []
+        original_reflect = OuterLoopReflector.reflect
+
+        def spy_reflect(self_ref: object, records: object, generation: int = 0, **kwargs: object) -> object:
+            captured_kwargs.append(kwargs)
+            return original_reflect(self_ref, records, generation, **kwargs)  # type: ignore[arg-type]
+
+        with patch("factory.outer_loop.filesystem.load_config", return_value=cfg), \
+             patch.object(OuterLoopReflector, "reflect", spy_reflect):
+            from factory.cli.outer_loop import _cmd_reflect
+
+            ns = argparse.Namespace(project_path=str(project), generation=0)
+            rc = _cmd_reflect(ns)
+            assert rc == 0
+
+        assert len(captured_kwargs) == 1
+        knob_vals = captured_kwargs[0].get("knob_values_by_id")
+        assert knob_vals is not None
+        assert name_a in knob_vals  # type: ignore[operator]
+        assert knob_vals[name_a]["agent_timeout"] == 600  # type: ignore[index]
+
+
+# ── Phase 2 Tests ──────────────────────────────────────────────────────
+
+
+class TestPhase2aStructuredParsing:
+    def test_parse_prefix_format(self) -> None:
+        assert parse_operator_from_suggestion("NODE_INSERT: Add researcher") == MutationType.NODE_INSERT
+        assert parse_operator_from_suggestion("NODE_REMOVE: Remove builder") == MutationType.NODE_REMOVE
+        assert parse_operator_from_suggestion("EDGE_REDIRECT: Reroute output") == MutationType.EDGE_REDIRECT
+        assert parse_operator_from_suggestion("SERIALIZE: Enforce ordering") == MutationType.SERIALIZE
+        assert parse_operator_from_suggestion("PARALLELIZE: Run in parallel") == MutationType.PARALLELIZE
+        assert parse_operator_from_suggestion("PARAM_MUTATE: Increase timeout") == MutationType.PARAM_MUTATE
+        assert parse_operator_from_suggestion("PROMPT_MUTATE: Improve prompt") == MutationType.PROMPT_MUTATE
+        assert parse_operator_from_suggestion("KNOB_MUTATE: agent_timeout=900") == MutationType.KNOB_MUTATE
+
+    def test_parse_substring_format(self) -> None:
+        assert parse_operator_from_suggestion("Consider PARALLELIZE for agents") == MutationType.PARALLELIZE
+        assert parse_operator_from_suggestion("Try EDGE_REDIRECT to improve flow") == MutationType.EDGE_REDIRECT
+
+    def test_parse_returns_none_for_unrecognized(self) -> None:
+        assert parse_operator_from_suggestion("Just a random suggestion") is None
+        assert parse_operator_from_suggestion("") is None
+
+    def test_guided_operator_selects_edge_redirect(self) -> None:
+        strategy = WeightedRandomStrategy()
+        report = ReflectionReport(
+            mutation_suggestions=["EDGE_REDIRECT: Reroute output from failing agent"],
+        )
+        wf = _simple_workflow()
+
+        results: set[MutationType] = set()
+        for _ in range(50):
+            op = strategy.select_guided_operator(wf, 0, report)
+            results.add(op)
+
+        assert MutationType.EDGE_REDIRECT in results
+
+    def test_guided_operator_selects_serialize(self) -> None:
+        strategy = WeightedRandomStrategy()
+        report = ReflectionReport(
+            structural_recommendations=["SERIALIZE: Enforce sequential order"],
+        )
+        wf = _simple_workflow()
+
+        results: set[MutationType] = set()
+        for _ in range(50):
+            op = strategy.select_guided_operator(wf, 0, report)
+            results.add(op)
+
+        assert MutationType.SERIALIZE in results
+
+    def test_all_8_operators_reachable(self) -> None:
+        """All MutationType enum values should be parseable from suggestions."""
+        for mt in MutationType:
+            suggestion = f"{mt.value}: Test suggestion"
+            parsed = parse_operator_from_suggestion(suggestion)
+            assert parsed == mt, f"Failed to parse {mt.value}"
+
+
+class TestPhase2bDirectionalParamMutate:
+    def test_parse_direction_increase(self) -> None:
+        assert parse_direction_from_suggestion("Increase timeout for builder") == "increase"
+
+    def test_parse_direction_decrease(self) -> None:
+        assert parse_direction_from_suggestion("Decrease timeout to save cost") == "decrease"
+        assert parse_direction_from_suggestion("Reduce timeout for faster runs") == "decrease"
+        assert parse_direction_from_suggestion("Lower the timeout value") == "decrease"
+
+    def test_parse_direction_none(self) -> None:
+        assert parse_direction_from_suggestion("Change timeout for builder") is None
+
+    def test_extract_param_direction_from_report(self) -> None:
+        report = ReflectionReport(
+            structural_recommendations=[
+                "PARAM_MUTATE: Increase timeout for agents that timed out (builder)"
+            ],
+        )
+        direction = _extract_param_direction(report, "builder")
+        assert direction == "increase"
+
+    def test_extract_param_direction_none_without_report(self) -> None:
+        assert _extract_param_direction(None, "builder") is None
+        assert _extract_param_direction("not a report", "builder") is None
+
+
+class TestPhase2cReflectorEdgeRedirectSerialize:
+    def test_edge_redirect_emitted_for_mixed_success(self) -> None:
+        reflector = OuterLoopReflector(k=1)
+        records = [
+            ("w1", 0.9, _make_record(0.9, [_make_step("builder")], kept=1)),
+            ("l1", 0.1, _make_record(
+                0.1,
+                [_make_step("researcher", succeeded=True), _make_step("builder", succeeded=False, error="crash")],
+                errored=1,
+            )),
+        ]
+        report = reflector.reflect(records, generation=0)
+        edge_recs = [r for r in report.structural_recommendations if "EDGE_REDIRECT" in r]
+        assert len(edge_recs) > 0
+
+    def test_serialize_emitted_for_ordering_dependency(self) -> None:
+        reflector = OuterLoopReflector(k=1)
+        records = [
+            ("w1", 0.9, _make_record(0.9, [_make_step("builder")], kept=1)),
+            ("l1", 0.1, _make_record(
+                0.1,
+                [_make_step("researcher", succeeded=True), _make_step("builder", succeeded=False, error="dep")],
+                errored=1,
+            )),
+        ]
+        report = reflector.reflect(records, generation=0)
+        ser_recs = [r for r in report.structural_recommendations if "SERIALIZE" in r]
+        assert len(ser_recs) > 0
+
+    def test_no_edge_redirect_when_all_succeed(self) -> None:
+        reflector = OuterLoopReflector(k=1)
+        records = [
+            ("w1", 0.9, _make_record(0.9, [_make_step("builder", succeeded=True)], kept=1)),
+            ("l1", 0.3, _make_record(0.3, [_make_step("builder", succeeded=True)], kept=0)),
+        ]
+        report = reflector.reflect(records, generation=0)
+        edge_recs = [r for r in report.structural_recommendations if "EDGE_REDIRECT" in r]
+        assert len(edge_recs) == 0
+
+
+class TestPhase2dArchiveStatsInfluence:
+    def test_low_diversity_boosts_structural_operators(self) -> None:
+        strategy = WeightedRandomStrategy()
+        wf = _simple_workflow()
+
+        random.seed(42)
+        counts_normal: dict[MutationType, int] = {}
+        for _ in range(1000):
+            op = strategy.select_operator(wf, 0, {})
+            counts_normal[op] = counts_normal.get(op, 0) + 1
+
+        random.seed(42)
+        counts_boosted: dict[MutationType, int] = {}
+        for _ in range(1000):
+            op = strategy.select_operator(wf, 0, {"diversity": 0.1})
+            counts_boosted[op] = counts_boosted.get(op, 0) + 1
+
+        structural = {MutationType.NODE_INSERT, MutationType.PARALLELIZE, MutationType.EDGE_REDIRECT}
+        structural_normal = sum(counts_normal.get(t, 0) for t in structural)
+        structural_boosted = sum(counts_boosted.get(t, 0) for t in structural)
+        assert structural_boosted > structural_normal
+
+    def test_high_diversity_no_boost(self) -> None:
+        strategy = WeightedRandomStrategy()
+        wf = _simple_workflow()
+
+        random.seed(42)
+        counts_high_div: dict[MutationType, int] = {}
+        for _ in range(1000):
+            op = strategy.select_operator(wf, 0, {"diversity": 0.8})
+            counts_high_div[op] = counts_high_div.get(op, 0) + 1
+
+        random.seed(42)
+        counts_no_stats: dict[MutationType, int] = {}
+        for _ in range(1000):
+            op = strategy.select_operator(wf, 0, {})
+            counts_no_stats[op] = counts_no_stats.get(op, 0) + 1
+
+        assert counts_high_div == counts_no_stats
+
+
+class TestPhase2PromptImprovements:
+    def test_knob_patterns_populate_prompt_improvements(self) -> None:
+        reflector = OuterLoopReflector(k=1)
+        records = [
+            ("w1", 0.9, _make_record(0.9, [_make_step("builder")], kept=1)),
+            ("l1", 0.1, _make_record(0.1, [_make_step("builder")], kept=0)),
+        ]
+        knob_values_by_id = {
+            "w1": {"_prompt_builder": "Think step by step"},
+            "l1": {"_prompt_builder": "Be creative"},
+        }
+        report = reflector.reflect(records, generation=0, knob_values_by_id=knob_values_by_id)
+        assert len(report.prompt_improvements) > 0
+        assert any("prompt" in p.lower() or "strategy" in p.lower() for p in report.prompt_improvements)
+
+
+class TestEvolveLoadsReflection:
+    def test_evolve_loads_persisted_reflection_json(self, tmp_path: Path) -> None:
+        import argparse
+
+        from factory.outer_loop.models import SwarmConfig
+
+        project = tmp_path
+        modes_dir = project / ".factory" / "outer_loop" / "modes"
+        modes_dir.mkdir(parents=True)
+        reflect_dir = project / ".factory" / "outer_loop" / "reflections"
+        reflect_dir.mkdir(parents=True)
+
+        wf = Workflow(
+            name="wf",
+            nodes={"b": AgentNode(id="b", role=AgentRole.BUILDER, writes=set())},
+            edges=[], start_node="b", terminal=True,
+        )
+
+        from factory.outer_loop.mode_registry import EphemeralModeRegistry
+
+        registry = EphemeralModeRegistry(project)
+        registry.register("seed01", 0, wf)
+
+        reflection_data = {
+            "failure_patterns": ["Agent failed"],
+            "success_patterns": ["Agent succeeded"],
+            "mutation_suggestions": ["NODE_INSERT: Add researcher"],
+            "prompt_improvements": [],
+            "structural_recommendations": [],
+            "top_k_ids": ["w1"],
+            "bottom_k_ids": ["l1"],
+        }
+        (reflect_dir / "gen0.json").write_text(json.dumps(reflection_data))
+
+        cfg = SwarmConfig(benchmark="featurebench", budget=50, population_size=1)
+
+        captured_kwargs: list[dict[str, object]] = []
+
+        def spy_apply(wf: object, strategy: object, gen: int, **kwargs: object) -> object:
+            captured_kwargs.append(kwargs)
+            return None
+
+        with patch("factory.outer_loop.filesystem.load_config", return_value=cfg), \
+             patch("factory.outer_loop.mutations.apply_random_mutation", side_effect=spy_apply):
+            from factory.cli.outer_loop import _cmd_evolve
+
+            ns = argparse.Namespace(project_path=str(project), generation=0)
+            _cmd_evolve(ns)
+
+        assert len(captured_kwargs) > 0
+        ref = captured_kwargs[0].get("reflection_report")
+        assert ref is not None
+        assert len(ref.mutation_suggestions) == 1  # type: ignore[union-attr]
+
+    def test_evolve_works_without_reflection_file(self, tmp_path: Path) -> None:
+        import argparse
+
+        from factory.outer_loop.models import SwarmConfig
+
+        project = tmp_path
+        modes_dir = project / ".factory" / "outer_loop" / "modes"
+        modes_dir.mkdir(parents=True)
+
+        wf = Workflow(
+            name="wf",
+            nodes={"b": AgentNode(id="b", role=AgentRole.BUILDER, writes=set())},
+            edges=[], start_node="b", terminal=True,
+        )
+
+        from factory.outer_loop.mode_registry import EphemeralModeRegistry
+
+        registry = EphemeralModeRegistry(project)
+        registry.register("seed01", 0, wf)
+
+        cfg = SwarmConfig(benchmark="featurebench", budget=50, population_size=1)
+        captured_kwargs: list[dict[str, object]] = []
+
+        def spy_apply(wf: object, strategy: object, gen: int, **kwargs: object) -> object:
+            captured_kwargs.append(kwargs)
+            return None
+
+        with patch("factory.outer_loop.filesystem.load_config", return_value=cfg), \
+             patch("factory.outer_loop.mutations.apply_random_mutation", side_effect=spy_apply):
+            from factory.cli.outer_loop import _cmd_evolve
+
+            ns = argparse.Namespace(project_path=str(project), generation=0)
+            _cmd_evolve(ns)
+
+        assert len(captured_kwargs) > 0
+        ref = captured_kwargs[0].get("reflection_report")
+        assert ref is None


### PR DESCRIPTION
Closes #1467

## Changes

### Phase 1 — Plumbing fixes (high impact, low risk)

- **`_cmd_reflect` fallback passes `individual_id`** — The fallback re-eval branch now calls `evaluator.evaluate(..., individual_id=mode_name)`, ensuring `get_cycle_record()` returns non-None for the reflect pipeline
- **`_cmd_reflect` passes `knob_values_by_id`** — Builds knob values from registry workflows and passes to `reflector.reflect()`, activating `_extract_knob_patterns` on the CLI path
- **`_cmd_evolve` loads persisted reflection** — Deserializes `reflections/gen{N}.json` and passes `reflection_report` to `apply_random_mutation()`, activating guided mutations on the CLI path
- **OptKnob declarations in seed workflows** — Both the contributed featurebench workflow and inline calibrate seed now declare `agent_timeout` (bounds: 300–7200) and `agent_model` (sonnet/opus/haiku), giving `KNOB_MUTATE` real targets
- **`mutate_knob()` empty-guard logging** — Added `log.info("knob_mutate_skipped", reason="empty_knob_values")` for observability
- **`prompt_improvements` populated** — `_extract_knob_patterns` now appends targeted prompt improvements for prompt knobs

### Phase 2 — Mutation selection quality

- **Structured suggestion parsing** — Replaced keyword-substring matching in `select_guided_operator` with `parse_operator_from_suggestion()` that matches against all `MutationType` enum names, making all 8 operators reachable by guidance (including `EDGE_REDIRECT` and `SERIALIZE` which were previously dead)
- **Directional `PARAM_MUTATE`** — When the reflector says "Increase timeout", the mutation now constrains selection to values above current; "Decrease" constrains below
- **`EDGE_REDIRECT` suggestions** — Emitted when bottom-K individuals have mixed success/failure agents
- **`SERIALIZE` suggestions** — Emitted when losers have parallel execution but winners don't, or when ordering dependencies are detected
- **`archive_stats` wired** — `WeightedRandomStrategy.select_operator` now boosts structural operators (NODE_INSERT, PARALLELIZE, EDGE_REDIRECT) by 1.5x when archive diversity < 0.3

## Tests

27 new tests covering all changes:
- `TestPhase1aIndividualIdPropagation` — verifies `individual_id` passed in fallback branch
- `TestPhase1bOptKnobInSeedWorkflow` — verifies knob declarations, bounds, expandable, and KNOB_MUTATE fires
- `TestPhase1dMutateKnobLogging` — verifies empty-guard log message
- `TestPhase1ReflectPassesKnobValues` — verifies `knob_values_by_id` passed to reflector
- `TestPhase2aStructuredParsing` — all 8 operators reachable via prefix and substring formats
- `TestPhase2bDirectionalParamMutate` — direction parsing and extraction from reports
- `TestPhase2cReflectorEdgeRedirectSerialize` — EDGE_REDIRECT and SERIALIZE emission conditions
- `TestPhase2dArchiveStatsInfluence` — low diversity boosts structural operators
- `TestPhase2PromptImprovements` — prompt_improvements populated from knob patterns
- `TestEvolveLoadsReflection` — evolve loads/skips reflection JSON correctly

All 131 existing outer loop tests + 27 new tests pass. Smoke tests (165) pass.