### PR TITLE
Fix obsidian shell-out to use obsidian-cli instead of obsidian

### DIFF
--- a/factory/obsidian/notes.py
+++ b/factory/obsidian/notes.py
@@ -144,7 +144,7 @@ def _obsidian_create(name: str, content: str, vault: str = "factory") -> bool:
     try:
         result = subprocess.run(
             [
-                "obsidian",
+                "obsidian-cli",
                 "create",
                 f"vault={vault}",
                 f"name={name}",
@@ -165,7 +165,7 @@ def _obsidian_search(query: str, vault: str = "factory", limit: int = 10) -> str
     try:
         result = subprocess.run(
             [
-                "obsidian",
+                "obsidian-cli",
                 "search",
                 f"vault={vault}",
                 f"query={query}",

--- a/tests/test_obsidian.py
+++ b/tests/test_obsidian.py
@@ -288,7 +288,7 @@ class TestObsidianCli:
         original_run = subprocess.run
 
         def mock_run(*args, **kwargs):
-            if args and args[0] and args[0][0] == "obsidian":
+            if args and args[0] and args[0][0] == "obsidian-cli":
                 calls.append(args[0])
                 return Mock(returncode=1)  # CLI fails
             return original_run(*args, **kwargs)
@@ -298,7 +298,7 @@ class TestObsidianCli:
         monkeypatch.setattr("factory.obsidian.notes._obsidian_create", _real_obsidian_create)
         path = write_experiment_note("test-project", sample_record)
         # Should have tried CLI
-        assert any("obsidian" in str(c) for c in calls)
+        assert any("obsidian-cli" in str(c) for c in calls)
         # Should have fallen back to file write
         assert path.exists()
 


### PR DESCRIPTION
## Summary
- `_obsidian_create()` and `_obsidian_search()` in `factory/obsidian/notes.py` invoked a binary named `obsidian`, but the actual `obsidian-cli` binary is named `obsidian-cli`. On systems with the real Obsidian desktop app installed (also named `obsidian`), this launched the GUI app instead, waited out the 10s subprocess timeout, then force-killed it — causing visible window flicker and potential stale `SingletonLock` files.
- Changed both invocations to use `obsidian-cli`. If it's not installed, `subprocess.run` raises `FileNotFoundError`, which is already caught and falls back to the existing direct file-write path.
- Updated `tests/test_obsidian.py::test_write_experiment_tries_cli_first`, which had hardcoded the incorrect `"obsidian"` binary name in its mock/assertion.

Fixes #1460

## Test plan
- [x] `pytest tests/test_obsidian.py -v` — 25 passed
- [x] `ruff check factory/obsidian/notes.py tests/test_obsidian.py` — clean
- [x] `mypy factory/obsidian/notes.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LiyU9TiqgNaGVu3gWaqE4