### PR TITLE
fix: repair 7 broken mutation operators on small-topology workflows

### DIFF
--- a/factory/outer_loop/mutations.py
+++ b/factory/outer_loop/mutations.py
@@ -493,7 +493,7 @@ def mutate_params(
             before[k] = getattr(node, k)
 
     try:
-        updated_node = node.model_copy(update=filtered_changes)
+        updated_node = type(node)(**{**node.model_dump(), **filtered_changes})
         wf.nodes[node_id] = updated_node  # type: ignore[assignment]
     except Exception:
         return None
@@ -524,6 +524,32 @@ _PROMPT_VARIANTS = [
 ]
 
 MAX_NODES = 30
+
+_COMPLEMENTARY_ROLES: dict[AgentRole, AgentRole] = {
+    AgentRole.BUILDER: AgentRole.CODE_REVIEWER,
+    AgentRole.RESEARCHER: AgentRole.STRATEGIST,
+    AgentRole.STRATEGIST: AgentRole.BUILDER,
+    AgentRole.HEALTH_CHECKER: AgentRole.BUILDER,
+    AgentRole.CODE_REVIEWER: AgentRole.BUILDER,
+    AgentRole.ADVERSARIAL_TESTER: AgentRole.BUILDER,
+    AgentRole.FAILURE_ANALYST: AgentRole.STRATEGIST,
+    AgentRole.ARCHIVIST: AgentRole.RESEARCHER,
+    AgentRole.REFINER: AgentRole.BUILDER,
+    AgentRole.CEO: AgentRole.STRATEGIST,
+}
+
+_ROLE_PROMPT_TEMPLATES: dict[AgentRole, str] = {
+    AgentRole.BUILDER: "Implement the changes described in the input files.",
+    AgentRole.CODE_REVIEWER: "Review the work done so far for correctness and quality issues.",
+    AgentRole.RESEARCHER: "Investigate the problem space and gather relevant context.",
+    AgentRole.STRATEGIST: "Analyze the available information and propose a clear plan of action.",
+    AgentRole.HEALTH_CHECKER: "Run health checks and verify the system is functioning correctly.",
+    AgentRole.ADVERSARIAL_TESTER: "Test the implementation against edge cases and failure modes.",
+    AgentRole.FAILURE_ANALYST: "Analyze failures and identify root causes.",
+    AgentRole.ARCHIVIST: "Record findings and decisions for future reference.",
+    AgentRole.REFINER: "Refine the implementation based on feedback.",
+    AgentRole.CEO: "Orchestrate the workflow and review agent outputs.",
+}
 
 
 PromptRewriter = Callable[[str, str, str | None], str | None]
@@ -654,7 +680,7 @@ def mutate_prompt(
             new_prompt = f"{old_prompt}\n\n{variant}" if old_prompt else variant
 
     try:
-        updated = node.model_copy(update={"prompt_template": new_prompt})
+        updated = type(node)(**{**node.model_dump(), "prompt_template": new_prompt})
         wf.nodes[node_id] = updated  # type: ignore[assignment]
     except Exception as exc:
         log.warning("prompt_mutate_validation_failed", node=node_id, error=str(exc))
@@ -886,6 +912,35 @@ def _extract_prompt_hint(report: ReflectionReport) -> str | None:
     return None
 
 
+def _find_nearest_upstream_agent(
+    workflow: Workflow, node_id: str,
+) -> AgentNode | None:
+    """Walk upstream edges to find the nearest AgentNode."""
+    visited: set[str] = set()
+    queue = [node_id]
+    while queue:
+        current = queue.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+        node = workflow.nodes.get(current)
+        if node is not None and isinstance(node, AgentNode) and current != node_id:
+            return node
+        for edge in workflow.edges:
+            if edge.target == current and edge.source not in visited:
+                queue.append(edge.source)
+    return None
+
+
+def _generate_unique_agent_id(existing_keys: set[str], role: AgentRole) -> str:
+    """Generate an agent ID that doesn't collide with existing node keys."""
+    for _ in range(100):
+        new_id = f"{role.value}_{random.randint(100, 999)}"
+        if new_id not in existing_keys:
+            return new_id
+    return f"{role.value}_{random.randint(10000, 99999)}"
+
+
 def _try_mutation(
     workflow: Workflow,
     op: MutationType,
@@ -895,24 +950,93 @@ def _try_mutation(
     **kwargs: object,
 ) -> tuple[Workflow, MutationRecord] | None:
     """Attempt a single mutation of the given type."""
-    mutable_nodes = [
+    # Fix 1: two separate node lists for structural vs content mutations
+    structurally_mutable = [
         nid for nid in workflow.nodes if nid not in frozen and nid != workflow.start_node
     ]
-    if not mutable_nodes and op not in (MutationType.NODE_INSERT, MutationType.KNOB_MUTATE):
+    content_mutable = [
+        nid for nid in workflow.nodes if nid not in frozen
+    ]
+
+    structural_ops = {
+        MutationType.NODE_REMOVE, MutationType.EDGE_REDIRECT,
+        MutationType.PARALLELIZE, MutationType.SERIALIZE,
+    }
+    content_ops = {MutationType.PARAM_MUTATE, MutationType.PROMPT_MUTATE}
+    exempt_ops = {MutationType.NODE_INSERT, MutationType.KNOB_MUTATE}
+
+    if op in structural_ops and not structurally_mutable:
+        return None
+    if op in content_ops and not content_mutable:
+        return None
+    if op not in structural_ops and op not in content_ops and op not in exempt_ops:
         return None
 
     if op == MutationType.NODE_INSERT:
+        # Fix 2: contextual complementary node with inherited file wiring
         target = random.choice(list(workflow.nodes.keys()))
-        new_id = f"agent_{random.randint(100, 999)}"
-        roles = list(AgentRole)
-        new_node = AgentNode(
-            id=new_id,
-            role=random.choice(roles),
-        )
+        target_node = workflow.nodes[target]
+
+        all_agent_nodes = [
+            n for n in workflow.nodes.values() if isinstance(n, AgentNode)
+        ]
+
+        if all_agent_nodes:
+            # Find the nearest upstream AgentNode from the insertion point
+            upstream_agent: AgentNode | None = None
+            if isinstance(target_node, AgentNode):
+                upstream_agent = target_node
+            else:
+                upstream_agent = _find_nearest_upstream_agent(workflow, target)
+
+            if upstream_agent is not None:
+                base_role = upstream_agent.role
+            else:
+                base_role = random.choice(all_agent_nodes).role
+
+            complementary_role = _COMPLEMENTARY_ROLES.get(base_role, random.choice(list(AgentRole)))
+
+            # Inherit file wiring from context
+            new_reads = upstream_agent.writes.copy() if (
+                upstream_agent and upstream_agent.writes
+            ) else (upstream_agent.reads.copy() if upstream_agent else set())
+            # Find the downstream node to set writes
+            new_writes: set[str] = set()
+            for edge in workflow.edges:
+                if edge.source == target and edge.condition is None:
+                    downstream = workflow.nodes.get(edge.target)
+                    if downstream and downstream.reads:
+                        new_writes = downstream.reads.copy()
+                        break
+
+            # Fix 5: unique ID generation
+            new_id = _generate_unique_agent_id(set(workflow.nodes.keys()), complementary_role)
+            prompt_tmpl = _ROLE_PROMPT_TEMPLATES.get(complementary_role, "")
+
+            new_node = AgentNode(
+                id=new_id,
+                role=complementary_role,
+                reads=new_reads,
+                writes=new_writes,
+                prompt_template=prompt_tmpl,
+            )
+        else:
+            # Fallback: no AgentNodes exist at all
+            role = random.choice(list(AgentRole))
+            new_id = _generate_unique_agent_id(set(workflow.nodes.keys()), role)
+            new_node = AgentNode(id=new_id, role=role)
+
         return insert_node(workflow, new_node, target, frozen_nodes=frozen)
 
     elif op == MutationType.NODE_REMOVE:
-        target = random.choice(mutable_nodes)
+        target = random.choice(structurally_mutable)
+        # Fix 3: protect the last AgentNode
+        if isinstance(workflow.nodes[target], AgentNode):
+            agent_count = sum(
+                1 for n in workflow.nodes.values() if isinstance(n, AgentNode)
+            )
+            if agent_count <= 1:
+                return None
         return remove_node(workflow, target, frozen_nodes=frozen)
 
     elif op == MutationType.EDGE_REDIRECT:
@@ -922,16 +1046,35 @@ def _try_mutation(
         if not edges_from_mutable:
             return None
         edge = random.choice(edges_from_mutable)
-        possible_targets = [nid for nid in workflow.nodes if nid != edge.target]
+
+        # Fix 4: pre-filter targets to exclude ungated cycle sources
+        unconditional_graph: nx.DiGraph[str] = nx.DiGraph()
+        for nid in workflow.nodes:
+            unconditional_graph.add_node(nid)
+        for e in workflow.edges:
+            if e.condition is None:
+                unconditional_graph.add_edge(e.source, e.target)
+
+        ancestors_of_source = (
+            nx.ancestors(unconditional_graph, edge.source)
+            if edge.source in unconditional_graph
+            else set()
+        )
+        possible_targets = [
+            nid for nid in workflow.nodes
+            if nid != edge.target
+            and nid != edge.source
+            and nid not in ancestors_of_source
+        ]
         if not possible_targets:
             return None
         new_target = random.choice(possible_targets)
         return redirect_edge(workflow, edge.source, edge.target, new_target, frozen_nodes=frozen)
 
     elif op == MutationType.PARALLELIZE:
-        if len(mutable_nodes) < 2:
+        if len(structurally_mutable) < 2:
             return None
-        pair = random.sample(mutable_nodes, 2)
+        pair = random.sample(structurally_mutable, 2)
         return parallelize(workflow, pair, frozen_nodes=frozen)
 
     elif op == MutationType.SERIALIZE:
@@ -945,8 +1088,8 @@ def _try_mutation(
 
     elif op == MutationType.PARAM_MUTATE:
         agent_nodes = [
-            nid for nid in mutable_nodes
-            if type(workflow.nodes[nid]).__name__ == "AgentNode"
+            nid for nid in content_mutable
+            if isinstance(workflow.nodes[nid], AgentNode)
         ]
         if not agent_nodes:
             return None
@@ -960,7 +1103,7 @@ def _try_mutation(
 
     elif op == MutationType.PROMPT_MUTATE:
         agent_nodes = [
-            nid for nid in mutable_nodes
+            nid for nid in content_mutable
             if isinstance(workflow.nodes[nid], AgentNode)
         ]
         if not agent_nodes:

--- a/tests/test_outer_loop/test_mutations.py
+++ b/tests/test_outer_loop/test_mutations.py
@@ -463,16 +463,10 @@ class TestNodeRemoveLastAgentGuard:
         nodes: dict[str, AgentNode | FnNode] = {
             "start": FnNode(id="start", command="echo start"),
             "agent": AgentNode(id="agent", role=AgentRole.BUILDER),
-            "end": FnNode(id="end", command="echo end"),
         }
-        edges = [
-            Edge(source="start", target="agent"),
-            Edge(source="agent", target="end"),
-        ]
+        edges = [Edge(source="start", target="agent")]
         wf2 = Workflow(name="one_agent", nodes=nodes, edges=edges, start_node="start")
         result = _try_mutation(wf2, MutationType.NODE_REMOVE, set())
-        # "agent" is the only structurally mutable node that's an AgentNode
-        # and it's the last AgentNode, so remove must return None
         assert result is None
 
     def test_remove_non_last_agent_succeeds(self, simple_workflow: Workflow) -> None:

--- a/tests/test_outer_loop/test_mutations.py
+++ b/tests/test_outer_loop/test_mutations.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 
+import random
+from unittest.mock import patch
+
 from factory.outer_loop.models import MutationType
 from factory.outer_loop.mutations import (
     MutationStrategy,
     WeightedRandomStrategy,
+    _generate_unique_agent_id,
+    _try_mutation,
     apply_random_mutation,
     insert_node,
     mutate_knob,
     mutate_params,
+    mutate_prompt,
     parallelize,
     redirect_edge,
     remove_node,
@@ -22,6 +28,8 @@ from factory.workflow.primitives import (
     AgentRole,
     Edge,
     FnNode,
+    GateNode,
+    VerdictType,
     Workflow,
 )
 
@@ -323,3 +331,205 @@ class TestKnobPreservation:
         assert result is not None
         child_wf, _ = result
         assert child_wf.knob_values == {"mode": "parallel"}
+
+
+def _chess_evolve_workflow() -> Workflow:
+    """Chess-evolve-like fixture: 1 AgentNode (start) + GateNode + FnNode, gated reloop."""
+    nodes: dict[str, AgentNode | GateNode | FnNode] = {
+        "solver": AgentNode(
+            id="solver",
+            role=AgentRole.BUILDER,
+            reads={"problem.md"},
+            writes={"solution.py"},
+            prompt_template="Solve the problem.",
+        ),
+        "gate": GateNode(
+            id="gate",
+            evaluator_type="fn",
+            reads={"solution.py"},
+        ),
+        "record": FnNode(
+            id="record",
+            command="echo done",
+            reads={"solution.py"},
+        ),
+    }
+    edges = [
+        Edge(source="solver", target="gate"),
+        Edge(source="gate", target="record"),
+        Edge(source="gate", target="solver", condition=VerdictType.RELOOP),
+    ]
+    return Workflow(
+        name="chess_evolve_like",
+        nodes=nodes,
+        edges=edges,
+        start_node="solver",
+    )
+
+
+class TestPromptMutateStartNode:
+    def test_prompt_mutate_succeeds_on_start_only_agent(self) -> None:
+        wf = _chess_evolve_workflow()
+        result = _try_mutation(wf, MutationType.PROMPT_MUTATE, set(), prompt_hint="be concise")
+        assert result is not None
+        child_wf, rec = result
+        assert rec.operator == MutationType.PROMPT_MUTATE
+        assert rec.target_node == "solver"
+
+    def test_prompt_mutate_with_rewriter_none(self) -> None:
+        wf = _chess_evolve_workflow()
+        result = mutate_prompt(wf, "solver", frozen_nodes=set(), rewriter=None, prompt_hint="be fast")
+        assert result is not None
+        child_wf, rec = result
+        node = child_wf.nodes["solver"]
+        assert isinstance(node, AgentNode)
+        assert "be fast" in node.prompt_template
+
+
+class TestParamMutateStartNode:
+    def test_param_mutate_succeeds_on_start_only_agent(self) -> None:
+        wf = _chess_evolve_workflow()
+        result = _try_mutation(wf, MutationType.PARAM_MUTATE, set())
+        assert result is not None
+        _, rec = result
+        assert rec.operator == MutationType.PARAM_MUTATE
+        assert rec.target_node == "solver"
+
+
+class TestNodeInsertContextual:
+    def test_insert_creates_complementary_role(self) -> None:
+        wf = _chess_evolve_workflow()
+        random.seed(42)
+        result = _try_mutation(wf, MutationType.NODE_INSERT, set())
+        assert result is not None
+        child_wf, rec = result
+        assert rec.operator == MutationType.NODE_INSERT
+        new_id = rec.target_node
+        new_node = child_wf.nodes[new_id]
+        assert isinstance(new_node, AgentNode)
+        assert new_node.role != AgentRole.CEO
+
+    def test_insert_inherits_file_wiring(self) -> None:
+        wf = _chess_evolve_workflow()
+        # Run many times and check that inserted nodes have non-empty file wiring
+        # when inserted after an AgentNode with writes
+        random.seed(0)
+        found_reads = False
+        for _ in range(30):
+            result = _try_mutation(wf, MutationType.NODE_INSERT, set())
+            if result is None:
+                continue
+            child_wf, rec = result
+            new_node = child_wf.nodes.get(rec.target_node)
+            if isinstance(new_node, AgentNode) and new_node.reads:
+                found_reads = True
+                # solver.writes = {"solution.py"}, so new reads should come from there
+                assert "solution.py" in new_node.reads
+                break
+        assert found_reads, "Expected at least one insertion to inherit file wiring"
+
+    def test_insert_uses_role_prompt_template(self) -> None:
+        wf = _chess_evolve_workflow()
+        result = _try_mutation(wf, MutationType.NODE_INSERT, set())
+        assert result is not None
+        child_wf, rec = result
+        new_node = child_wf.nodes[rec.target_node]
+        assert isinstance(new_node, AgentNode)
+        assert new_node.prompt_template != ""
+
+    def test_insert_fallback_when_no_agent_nodes(self) -> None:
+        nodes: dict[str, FnNode] = {
+            "start": FnNode(id="start", command="echo start"),
+            "end": FnNode(id="end", command="echo end"),
+        }
+        edges = [Edge(source="start", target="end")]
+        wf = Workflow(name="no_agents", nodes=nodes, edges=edges, start_node="start")
+        result = _try_mutation(wf, MutationType.NODE_INSERT, set())
+        assert result is not None
+        child_wf, rec = result
+        new_node = child_wf.nodes[rec.target_node]
+        assert isinstance(new_node, AgentNode)
+
+
+class TestNodeRemoveLastAgentGuard:
+    def test_remove_last_agent_returns_none(self) -> None:
+        wf = _chess_evolve_workflow()
+        # "solver" is the only AgentNode but it's also the start_node
+        # so it can't be in structurally_mutable. Add it manually to test the guard.
+        result = _try_mutation(wf, MutationType.NODE_REMOVE, set())
+        # With chess-evolve, structurally_mutable = ["gate", "record"] (not AgentNodes),
+        # so NODE_REMOVE can target them but not solver. Let's test with a workflow
+        # where the last agent IS in the structurally_mutable list.
+        nodes: dict[str, AgentNode | FnNode] = {
+            "start": FnNode(id="start", command="echo start"),
+            "agent": AgentNode(id="agent", role=AgentRole.BUILDER),
+            "end": FnNode(id="end", command="echo end"),
+        }
+        edges = [
+            Edge(source="start", target="agent"),
+            Edge(source="agent", target="end"),
+        ]
+        wf2 = Workflow(name="one_agent", nodes=nodes, edges=edges, start_node="start")
+        result = _try_mutation(wf2, MutationType.NODE_REMOVE, set())
+        # "agent" is the only structurally mutable node that's an AgentNode
+        # and it's the last AgentNode, so remove must return None
+        assert result is None
+
+    def test_remove_non_last_agent_succeeds(self, simple_workflow: Workflow) -> None:
+        # simple_workflow has 3 AgentNodes (researcher, strategist, builder)
+        # removing one should succeed
+        result = remove_node(simple_workflow, "strategist")
+        assert result is not None
+
+
+class TestEdgeRedirectCycleFilter:
+    def test_filters_ungated_cycle_targets(self) -> None:
+        wf = _chess_evolve_workflow()
+        # The only unconditional edges: solver→gate, gate→record
+        # If we pick edge solver→gate, ancestors of solver in unconditional graph = {}
+        # possible_targets = [record] (gate excluded as current target, solver excluded as source)
+        # So redirect should succeed with target=record
+        result = _try_mutation(wf, MutationType.EDGE_REDIRECT, set())
+        if result is not None:
+            child_wf, rec = result
+            assert rec.operator == MutationType.EDGE_REDIRECT
+            validated = validate_and_repair(child_wf)
+            assert validated is not None
+
+    def test_returns_none_when_all_targets_create_cycles(self) -> None:
+        # Two nodes, one unconditional edge A→B. Redirecting A→B to A→A is self-loop,
+        # and there are no other targets.
+        nodes: dict[str, FnNode] = {
+            "a": FnNode(id="a", command="echo a"),
+            "b": FnNode(id="b", command="echo b"),
+        }
+        edges = [Edge(source="a", target="b")]
+        wf = Workflow(name="tiny", nodes=nodes, edges=edges, start_node="a")
+        # edge a→b: possible_targets excludes b (current target) and a (source) → empty
+        result = _try_mutation(wf, MutationType.EDGE_REDIRECT, set())
+        assert result is None
+
+
+class TestUniqueIdGeneration:
+    def test_generates_unique_id(self) -> None:
+        existing = {f"builder_{i}" for i in range(100, 200)}
+        new_id = _generate_unique_agent_id(existing, AgentRole.BUILDER)
+        assert new_id not in existing
+        assert new_id.startswith("builder_")
+
+    def test_avoids_collision(self) -> None:
+        existing = {"builder_100"}
+        # Patch randint to return 100 first (collision), then 200 (unique)
+        with patch("factory.outer_loop.mutations.random.randint", side_effect=[100, 200]):
+            new_id = _generate_unique_agent_id(existing, AgentRole.BUILDER)
+        assert new_id == "builder_200"
+
+
+class TestMutateParamsValidation:
+    def test_invalid_field_value_returns_none(self, simple_workflow: Workflow) -> None:
+        # AgentNode has strict=True, extra="forbid". Passing a bad type for timeout
+        # should fail validation with constructor-based creation.
+        result = mutate_params(
+            simple_workflow, "researcher", {"timeout": "not_a_number"}
+        )
+        assert result is None


### PR DESCRIPTION
Closes #1467

## Changes

- **Fix 1: Split mutable_nodes** — `_try_mutation()` now maintains `structurally_mutable` (excludes start node + frozen, for NODE_REMOVE/EDGE_REDIRECT/PARALLELIZE/SERIALIZE) and `content_mutable` (excludes frozen only, for PROMPT_MUTATE/PARAM_MUTATE). Unblocks content mutations when the only AgentNode is the start node.

- **Fix 2: NODE_INSERT contextual complementary nodes** — Instead of creating blank random-role agents, creates a complementary node with inherited file wiring (upstream writes → new reads, downstream reads → new writes) and a role selected via `_COMPLEMENTARY_ROLES` mapping. Uses domain-neutral `_ROLE_PROMPT_TEMPLATES` for prompt generation.

- **Fix 3: NODE_REMOVE last-AgentNode guard** — Prevents removing the last AgentNode in a workflow (would leave no LLM reasoning capability).

- **Fix 4: EDGE_REDIRECT pre-filter** — Uses `nx.ancestors()` on the unconditional-edge subgraph to exclude targets that would create ungated cycles, reducing wasted retries through `validate_and_repair()`.

- **Fix 5: Unique ID generation** — `_generate_unique_agent_id()` loops until finding an ID not in `workflow.nodes.keys()`, preventing silent dict overwrite on collision.

- **Fix 6: Constructor-based validation** — `mutate_params` and `mutate_prompt` use `type(node)(**{**node.model_dump(), **changes})` instead of `model_copy(update=...)`, making Pydantic validation actually run on updated fields.

13 new tests covering all 6 fixes, all 49 tests passing, ruff clean.