### PR TITLE
feat: DataNode graph primitive — first-class data loading in workflows

### DIFF
--- a/factory/compose.py
+++ b/factory/compose.py
@@ -189,15 +189,37 @@ class TaskCapabilities:
 # ── validate_composition ─────────────────────────────────────────
 
 
+def _workflow_has_data_node(workflow: Any) -> bool:
+    """Check if a workflow contains at least one DataNode."""
+    from factory.workflow.primitives import DataNode
+
+    nodes = getattr(workflow, "nodes", {})
+    return any(isinstance(n, DataNode) for n in nodes.values())
+
+
 def validate_composition(workflow: Any, task: Any) -> None:
     """Validate that a workflow can run a task.
 
     Raises IncompatibleCompositionError if capabilities don't match.
+
+    DataNode workflows are evaluation-only — they handle iteration
+    internally and don't need build-pipeline capabilities like
+    HAS_BUILDER, CAN_RUN_TESTS, or CAN_MODIFY_CODE.
     """
     mode_caps = ModeCapabilities.from_workflow(workflow)
     task_caps = TaskCapabilities.from_task(task)
 
     mode_missing = set(task_caps.requires) - set(mode_caps.provides)
+
+    # DataNode workflows handle iteration internally and don't need
+    # build-pipeline capabilities
+    if mode_missing and _workflow_has_data_node(workflow):
+        build_caps = {
+            Capability.HAS_BUILDER,
+            Capability.CAN_RUN_TESTS,
+            Capability.CAN_MODIFY_CODE,
+        }
+        mode_missing -= build_caps
 
     mode_name = getattr(workflow, "name", "unknown")
     task_name = getattr(task, "name", "unknown")

--- a/factory/compose.py
+++ b/factory/compose.py
@@ -86,6 +86,7 @@ class ModeCapabilities:
         from factory.workflow.primitives import (
             AgentNode,
             AgentRole,
+            DataNode,
             FnNode,
             ForkNode,
             GateNode,
@@ -123,6 +124,9 @@ class ModeCapabilities:
 
             elif isinstance(node, ForkNode):
                 caps.add(Capability.HAS_PARALLELISM)
+
+            elif isinstance(node, DataNode):
+                caps.add(Capability.CAN_ITERATE)
 
             elif isinstance(node, FnNode):
                 caps.add(Capability.CAN_RUN_SUBPROCESS)

--- a/factory/inner_loop.py
+++ b/factory/inner_loop.py
@@ -388,6 +388,7 @@ class InnerLoop:
 
         t0 = time.monotonic()
 
+        assert self.workflow is not None
         executor = WorkflowExecutor(
             self.workflow,
             self.project_dir,

--- a/factory/inner_loop.py
+++ b/factory/inner_loop.py
@@ -383,6 +383,7 @@ class InnerLoop:
     def _step_with_data_node(self, directives: dict[str, Any] | None = None) -> CycleRecord:
         """Delegate to the executor when the workflow contains a DataNode."""
         import asyncio
+        import json
 
         from factory.workflow.executor import WorkflowExecutor
 
@@ -397,6 +398,17 @@ class InnerLoop:
 
         duration_s = time.monotonic() - t0
         score = 1.0 if exec_result.success else 0.0
+
+        # Aggregate per-item verify scores from DataNode output if available
+        for _nid, output in exec_result.node_outputs.items():
+            try:
+                parsed = json.loads(output)
+                if isinstance(parsed, list) and parsed and "score" in parsed[0]:
+                    scores = [r["score"] for r in parsed]
+                    score = sum(scores) / len(scores) if scores else 0.0
+                    break
+            except (json.JSONDecodeError, TypeError, KeyError):
+                continue
 
         record = CycleRecord(
             cycle_number=self._step_count + 1,

--- a/factory/inner_loop.py
+++ b/factory/inner_loop.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from factory.cycle_analyzer import CycleAnalyzer, CycleRecord
-from factory.workflow.primitives import Workflow
+from factory.workflow.primitives import DataNode, Workflow
 
 
 @dataclass
@@ -135,6 +135,7 @@ class InnerLoop:
         self.instance = instance
         self._step_count = 0
         self._history: list[CycleRecord] = []
+        self._has_data_node: bool | None = None
         self._validate_frozen_nodes()
 
         # When task is set, derive flat fields from it for backward compat
@@ -256,6 +257,14 @@ class InnerLoop:
         self._history.append(record)
         return record
 
+    def _workflow_has_data_node(self) -> bool:
+        if self._has_data_node is None:
+            self._has_data_node = (
+                self.workflow is not None
+                and any(isinstance(n, DataNode) for n in self.workflow.nodes.values())
+            )
+        return self._has_data_node
+
     def _step_with_task(self, directives: dict[str, Any] | None = None) -> CycleRecord:
         """Task-driven step: setup → WorkflowExecutor → verify per instance."""
         assert self.task is not None
@@ -268,6 +277,9 @@ class InnerLoop:
 
         if directives:
             self._write_directives(directives)
+
+        if self._workflow_has_data_node():
+            return self._step_with_data_node(directives)
 
         t0 = time.monotonic()
         workflow = self.workflow
@@ -362,6 +374,49 @@ class InnerLoop:
             experiments=0,
             test_score=aggregate_score,
             instance_results=instance_results,
+        )
+
+        self._step_count += 1
+        self._history.append(record)
+        return record
+
+    def _step_with_data_node(self, directives: dict[str, Any] | None = None) -> CycleRecord:
+        """Delegate to the executor when the workflow contains a DataNode."""
+        import asyncio
+
+        from factory.workflow.executor import WorkflowExecutor
+
+        t0 = time.monotonic()
+
+        executor = WorkflowExecutor(
+            self.workflow,
+            self.project_dir,
+        )
+        exec_result = asyncio.run(executor.execute())
+
+        duration_s = time.monotonic() - t0
+        score = 1.0 if exec_result.success else 0.0
+
+        record = CycleRecord(
+            cycle_number=self._step_count + 1,
+            mode=self.mode,
+            started_at=None,
+            ended_at=None,
+            duration_s=duration_s,
+            score_start=None,
+            score_end=score,
+            score_delta=None,
+        )
+        record.frozen_nodes = sorted(self.frozen_nodes)
+        record.mutable_node_ids = sorted(self.mutable_nodes())
+
+        self._write_cycle_summary(
+            returncode=0 if exec_result.success else 1,
+            event_offset=0,
+            duration_ms=int(duration_s * 1000),
+            builder_committed=False,
+            experiments=0,
+            test_score=score,
         )
 
         self._step_count += 1

--- a/factory/inner_loop.py
+++ b/factory/inner_loop.py
@@ -411,17 +411,33 @@ class InnerLoop:
 
         duration_s = time.monotonic() - t0
         score = 1.0 if exec_result.success else 0.0
+        instance_results: list[dict[str, Any]] | None = None
 
-        # Aggregate per-item verify scores from DataNode output if available
-        for _nid, output in exec_result.node_outputs.items():
+        # Direct lookup: find DataNode ID and read its output
+        data_node_id: str | None = None
+        for nid, n in self.workflow.nodes.items():
+            if isinstance(n, DataNode):
+                data_node_id = nid
+                break
+
+        if data_node_id is not None and data_node_id in exec_result.node_outputs:
             try:
-                parsed = json.loads(output)
-                if isinstance(parsed, list) and parsed and "score" in parsed[0]:
-                    scores = [r["score"] for r in parsed]
-                    score = sum(scores) / len(scores) if scores else 0.0
-                    break
+                parsed = json.loads(exec_result.node_outputs[data_node_id])
+                if isinstance(parsed, list) and parsed:
+                    scores = [r["score"] for r in parsed if "score" in r]
+                    if scores:
+                        score = sum(scores) / len(scores)
+                    instance_results = [
+                        {
+                            "instance_id": item.get("item_id", ""),
+                            "score": item.get("score", 0.0),
+                            "passed": item.get("passed", False),
+                        }
+                        for item in parsed
+                        if isinstance(item, dict)
+                    ]
             except (json.JSONDecodeError, TypeError, KeyError):
-                continue
+                pass
 
         record = CycleRecord(
             cycle_number=self._step_count + 1,
@@ -432,6 +448,7 @@ class InnerLoop:
             score_start=None,
             score_end=score,
             score_delta=None,
+            instance_results=instance_results,
         )
         record.frozen_nodes = sorted(self.frozen_nodes)
         record.mutable_node_ids = sorted(self.mutable_nodes())
@@ -443,6 +460,7 @@ class InnerLoop:
             builder_committed=False,
             experiments=0,
             test_score=score,
+            instance_results=instance_results,
         )
 
         self._step_count += 1

--- a/factory/outer_loop/engine.py
+++ b/factory/outer_loop/engine.py
@@ -39,6 +39,13 @@ log = structlog.get_logger()
 PLATEAU_WINDOW = 3
 
 
+def _auto_frozen_nodes(workflow: Workflow) -> set[str]:
+    """Return node IDs that should always be frozen during mutation."""
+    from factory.workflow.primitives import DataNode
+
+    return {nid for nid, node in workflow.nodes.items() if isinstance(node, DataNode)}
+
+
 class BudgetTracker:
     """Tracks evaluation budget consumption, cost, and wall-clock time."""
 
@@ -169,7 +176,7 @@ class SwarmEngine:
                 base_workflow,
                 self._strategy,
                 generation=0,
-                frozen_nodes=set(cfg.frozen_node_ids),
+                frozen_nodes=set(cfg.frozen_node_ids) | _auto_frozen_nodes(base_workflow),
             )
             if result is None:
                 continue
@@ -298,7 +305,7 @@ class SwarmEngine:
                 parent_wf,
                 self._strategy,
                 generation,
-                frozen_nodes=set(self._config.frozen_node_ids),
+                frozen_nodes=set(self._config.frozen_node_ids) | _auto_frozen_nodes(parent_wf),
                 reflection_report=self._last_reflection,
             )
             if mutation_result is None:

--- a/factory/outer_loop/population.py
+++ b/factory/outer_loop/population.py
@@ -94,6 +94,12 @@ class Population:
         return pop
 
 
+# Structural axes from compute_features() 9-tuple:
+# 0=depth, 1=fork_degree, 2=agent_count, 3=gate_count, 8=has_data_node
+# Indices 4-7 are hash buckets (edge_sig, param, prompt, knob) — excluded.
+STRUCTURAL_AXES: tuple[int, ...] = (0, 1, 2, 3, 8)
+
+
 class MAPElitesArchive:
     """4D fixed-resolution grid archive for quality-diversity search.
 
@@ -193,20 +199,22 @@ class MAPElitesArchive:
         return front
 
     def diversity_metric(self) -> float:
-        """Fraction of occupied cells relative to a reasonable grid size estimate.
+        """Fraction of occupied cells in the structural-axis subspace.
 
         Returns 0.0 for empty archive, approaches 1.0 as more cells are filled.
-        Uses the first 5 structural axes (depth, fork_degree, agent_count,
-        gate_count, has_data_node) for diversity estimation.
+        Uses 5 structural axes from the 9-tuple returned by compute_features():
+          depth (0), fork_degree (1), agent_count (2), gate_count (3), has_data_node (8).
+        Hash-bucket axes (4-7: edge_sig, param, prompt, knob) are excluded because
+        their high cardinality inflates the denominator without reflecting structural diversity.
         """
         if not self._grid:
             return 0.0
         sample_key = next(iter(self._grid))
-        n_axes = min(len(sample_key), 5)
-        unique_per_axis: list[set[int]] = [set() for _ in range(n_axes)]
+        axes = [a for a in STRUCTURAL_AXES if a < len(sample_key)]
+        unique_per_axis: list[set[int]] = [set() for _ in axes]
         for key in self._grid:
-            for i in range(n_axes):
-                unique_per_axis[i].add(key[i])
+            for idx, a in enumerate(axes):
+                unique_per_axis[idx].add(key[a])
         total_possible = 1
         for s in unique_per_axis:
             total_possible *= max(len(s), 1)

--- a/factory/outer_loop/population.py
+++ b/factory/outer_loop/population.py
@@ -196,14 +196,17 @@ class MAPElitesArchive:
         """Fraction of occupied cells relative to a reasonable grid size estimate.
 
         Returns 0.0 for empty archive, approaches 1.0 as more cells are filled.
+        Uses the first 5 structural axes (depth, fork_degree, agent_count,
+        gate_count, has_data_node) for diversity estimation.
         """
         if not self._grid:
             return 0.0
-        unique_per_axis: list[set[int]] = [set() for _ in range(4)]
+        sample_key = next(iter(self._grid))
+        n_axes = min(len(sample_key), 5)
+        unique_per_axis: list[set[int]] = [set() for _ in range(n_axes)]
         for key in self._grid:
-            for i, v in enumerate(key):
-                if i < 4:
-                    unique_per_axis[i].add(v)
+            for i in range(n_axes):
+                unique_per_axis[i].add(key[i])
         total_possible = 1
         for s in unique_per_axis:
             total_possible *= max(len(s), 1)

--- a/factory/outer_loop/population.py
+++ b/factory/outer_loop/population.py
@@ -218,7 +218,8 @@ class MAPElitesArchive:
         total_possible = 1
         for s in unique_per_axis:
             total_possible *= max(len(s), 1)
-        return len(self._grid) / max(total_possible, 1)
+        structural_cells = {tuple(key[a] for a in axes) for key in self._grid}
+        return len(structural_cells) / max(total_possible, 1)
 
     def save(self, directory: Path) -> None:
         """Serialize the archive to a directory."""

--- a/factory/outer_loop/similarity.py
+++ b/factory/outer_loop/similarity.py
@@ -128,12 +128,17 @@ def compute_features(workflow: Workflow) -> tuple[int, ...]:
         f"{k}={v}" for k, v in sorted(workflow.knob_values.items())
     ) if workflow.knob_values else ""
 
+    has_data_node = int(any(
+        type(n).__name__ == "DataNode" for n in workflow.nodes.values()
+    ))
+
     return (
         depth, fork_degree, agent_count, gate_count,
         _hash_bucket(edge_sig),
         _hash_bucket(param_sig, 16),
         _hash_bucket(prompt_sig, 32),
         _hash_bucket(knob_sig, 16),
+        has_data_node,
     )
 
 

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -179,7 +179,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     print("  " + "-" * (len(header) - 2))
 
     for edge in wf.edges:
-        cond = str(edge.condition) if edge.condition else "-"
+        cond = edge.condition.value if edge.condition else "-"  # type: ignore
         print(f"  {edge.source:<25} {edge.target:<25} {cond:<15}")
 
     return 0

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -179,7 +179,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     print("  " + "-" * (len(header) - 2))
 
     for edge in wf.edges:
-        cond = edge.condition.value if edge.condition else "-"
+        cond = str(edge.condition) if edge.condition else "-"
         print(f"  {edge.source:<25} {edge.target:<25} {cond:<15}")
 
     return 0

--- a/factory/workflow/cli.py
+++ b/factory/workflow/cli.py
@@ -179,7 +179,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
     print("  " + "-" * (len(header) - 2))
 
     for edge in wf.edges:
-        cond = edge.condition.value if edge.condition else "-"  # type: ignore
+        cond = edge.condition_label or "-"
         print(f"  {edge.source:<25} {edge.target:<25} {cond:<15}")
 
     return 0

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -636,6 +636,7 @@ class WorkflowExecutor:
 
     async def _execute_data(self, node_id: str, node: DataNode) -> None:
         """Execute a DataNode: resolve items, run subgraph per item with fault isolation."""
+        import hashlib as _hashlib
         import random as _random
         import subprocess as _sp
 
@@ -685,6 +686,17 @@ class WorkflowExecutor:
                 raise FileNotFoundError(
                     f"DataNode '{node_id}': source_path not found: {node.source_path}"
                 )
+            # Validate path kind matches source_format
+            if node.source_format == "directory" and not src.is_dir():
+                raise ValueError(
+                    f"DataNode '{node_id}': source_format='directory' requires a directory, "
+                    f"got a file at {node.source_path}"
+                )
+            if node.source_format in ("jsonl", "csv") and not src.is_file():
+                raise ValueError(
+                    f"DataNode '{node_id}': source_format='{node.source_format}' requires a file, "
+                    f"got a directory at {node.source_path}"
+                )
             if node.source_format == "directory" and src.is_dir():
                 for child in sorted(src.iterdir()):
                     if child.is_dir():
@@ -731,7 +743,10 @@ class WorkflowExecutor:
             seed = (
                 node.shuffle_seed
                 if node.shuffle_seed is not None
-                else hash(f"{node_id}:{self.run_id}") % (2**32)
+                else int.from_bytes(
+                    _hashlib.sha256(f"{node_id}:{self.run_id}".encode()).digest()[:8],
+                    "big",
+                )
             )
             _random.Random(seed).shuffle(task_instances)
         if node.limit is not None and node.limit > 0:
@@ -837,7 +852,7 @@ class WorkflowExecutor:
                             item_project_path,
                             agent_pool=self.agent_pool,
                             dry_run=self.dry_run,
-                            initial_context=item.prompt,
+                            initial_context=item.prompt or None,
                         )
                         item_executor.completed_files = self.completed_files | disk_reads
                         item_result = await item_executor.execute()

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -637,6 +637,7 @@ class WorkflowExecutor:
     async def _execute_data(self, node_id: str, node: DataNode) -> None:
         """Execute a DataNode: resolve items, run subgraph per item with fault isolation."""
         import random as _random
+        import subprocess as _sp
 
         from factory.task import Task as _Task
         from factory.task import TaskInstance as _TaskInstance
@@ -679,17 +680,40 @@ class WorkflowExecutor:
             src = _Path(node.source_path)
             if not src.is_absolute():
                 src = self.project_path / src
+            # Raise if source_path doesn't exist
+            if not src.exists():
+                raise FileNotFoundError(
+                    f"DataNode '{node_id}': source_path not found: {node.source_path}"
+                )
             if node.source_format == "directory" and src.is_dir():
                 for child in sorted(src.iterdir()):
                     if child.is_dir():
                         task_instances.append((DataItem(id=child.name, path=str(child)), None))
             elif node.source_format == "jsonl" and src.is_file():
-                for idx, line in enumerate(src.read_text().splitlines()):
+                error_count = 0
+                lines = src.read_text().splitlines()
+                total_non_empty = 0
+                for idx, line in enumerate(lines):
                     if line.strip():
-                        task_instances.append((DataItem(
-                            id=str(idx),
-                            metadata=json.loads(line),
-                        ), None))
+                        total_non_empty += 1
+                        try:
+                            task_instances.append((DataItem(
+                                id=str(idx),
+                                metadata=json.loads(line),
+                            ), None))
+                        except json.JSONDecodeError:
+                            error_count += 1
+                            log.warning(
+                                "jsonl_parse_error",
+                                node_id=node_id,
+                                line_number=idx + 1,
+                                line_preview=line.strip()[:100],
+                            )
+                if error_count > 0 and error_count == total_non_empty:
+                    raise ValueError(
+                        f"DataNode '{node_id}': all {error_count} JSONL lines "
+                        f"failed to parse"
+                    )
             elif node.source_format == "csv" and src.is_file():
                 import csv
                 with src.open(newline="") as f:
@@ -704,9 +728,21 @@ class WorkflowExecutor:
                 if item.metadata.get("split") == node.split
             ]
         if node.shuffle:
-            _random.shuffle(task_instances)
+            seed = (
+                node.shuffle_seed
+                if node.shuffle_seed is not None
+                else hash(f"{node_id}:{self.run_id}") % (2**32)
+            )
+            _random.Random(seed).shuffle(task_instances)
         if node.limit is not None and node.limit > 0:
             task_instances = task_instances[:node.limit]
+
+        if len(task_instances) == 0:
+            log.warning(
+                "data_source_empty",
+                node_id=node_id,
+                source=str(node.source_path or node.task_ref or "inline"),
+            )
 
         if len(task_instances) > node.max_items:
             raise ValueError(
@@ -734,12 +770,55 @@ class WorkflowExecutor:
                 if (self.project_path / r).exists():
                     disk_reads.add(r)
 
-        async def run_item(pair: tuple[DataItem, _TaskInstance | None]) -> dict[str, Any]:
+        # Resolve base commit once for worktree creation when parallelism > 1
+        use_worktrees = node.parallelism > 1 and not self.dry_run
+        base_commit: str | None = None
+        worktrees_to_clean: list[tuple[Path, str]] = []
+        if use_worktrees:
+            try:
+                rev_result = _sp.run(
+                    ["git", "rev-parse", "HEAD"],
+                    cwd=self.project_path,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                base_commit = rev_result.stdout.strip()
+            except _sp.CalledProcessError:
+                use_worktrees = False
+
+        async def run_item(
+            pair: tuple[DataItem, _TaskInstance | None],
+            item_idx: int,
+        ) -> dict[str, Any]:
             item, inst = pair
+            item_project_path = self.project_path
+            wt_branch: str | None = None
             async with sem:
                 try:
+                    # Create per-item worktree when parallelism > 1
+                    if use_worktrees and base_commit is not None:
+                        wt_dir = (
+                            self.project_path
+                            / ".factory-worktrees"
+                            / f"data-{self.run_id}-{item_idx}"
+                        )
+                        wt_branch = f"factory/data-{self.run_id}-{item_idx}"
+                        wt_dir.parent.mkdir(parents=True, exist_ok=True)
+                        _sp.run(
+                            [
+                                "git", "worktree", "add",
+                                str(wt_dir), "-b", wt_branch, base_commit,
+                            ],
+                            cwd=self.project_path,
+                            check=True,
+                            capture_output=True,
+                        )
+                        worktrees_to_clean.append((wt_dir, wt_branch))
+                        item_project_path = wt_dir
+
                     if resolved_task is not None and inst is not None:
-                        resolved_task.setup(inst, self.project_path)
+                        resolved_task.setup(inst, item_project_path)
                         item = DataItem(
                             id=inst.id,
                             path=str(inst.path) if inst.path else None,
@@ -747,22 +826,30 @@ class WorkflowExecutor:
                             prompt=resolved_task.prompt(inst),
                         )
 
-                    item_executor = WorkflowExecutor(
-                        sub_workflow.model_copy(deep=True),
-                        self.project_path,
-                        agent_pool=self.agent_pool,
-                        dry_run=self.dry_run,
-                        initial_context=item.prompt,
-                    )
-                    item_executor.completed_files = self.completed_files | disk_reads
-                    item_result = await item_executor.execute()
+                    # Write current_item.json for subgraph visibility
+                    item_json_path = item_project_path / ".factory" / "current_item.json"
+                    item_json_path.parent.mkdir(parents=True, exist_ok=True)
+                    item_json_path.write_text(json.dumps(item.model_dump()))
+
+                    try:
+                        item_executor = WorkflowExecutor(
+                            sub_workflow.model_copy(deep=True),
+                            item_project_path,
+                            agent_pool=self.agent_pool,
+                            dry_run=self.dry_run,
+                            initial_context=item.prompt,
+                        )
+                        item_executor.completed_files = self.completed_files | disk_reads
+                        item_result = await item_executor.execute()
+                    finally:
+                        item_json_path.unlink(missing_ok=True)
 
                     score = 1.0 if item_result.success else 0.0
                     passed = item_result.success
                     verify_details: dict[str, Any] = {}
 
                     if resolved_task is not None and inst is not None:
-                        vr = resolved_task.verify(inst, self.project_path)
+                        vr = resolved_task.verify(inst, item_project_path)
                         score = vr.score
                         passed = vr.passed
                         verify_details = vr.details or {}
@@ -786,9 +873,25 @@ class WorkflowExecutor:
                         "error": str(exc),
                     }
 
-        tasks = [run_item(pair) for pair in task_instances]
+        tasks = [run_item(pair, idx) for idx, pair in enumerate(task_instances)]
         results = await asyncio.gather(*tasks)
         item_results = list(results)
+
+        # Clean up worktrees
+        for wt_path, wt_branch_name in worktrees_to_clean:
+            try:
+                _sp.run(
+                    ["git", "worktree", "remove", str(wt_path), "--force"],
+                    cwd=self.project_path,
+                    capture_output=True,
+                )
+                _sp.run(
+                    ["git", "branch", "-D", wt_branch_name],
+                    cwd=self.project_path,
+                    capture_output=True,
+                )
+            except Exception as wt_exc:
+                log.warning("data_worktree_cleanup_failed", path=str(wt_path), error=str(wt_exc))
 
         elapsed = (time.monotonic() - start) * 1000
         self.result.node_outputs[node_id] = json.dumps(item_results)

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -25,6 +25,8 @@ from factory.workflow.events import (
 from factory.workflow.primitives import (
     AgentConfig,
     AgentNode,
+    DataItem,
+    DataNode,
     Edge,
     FnNode,
     ForkNode,
@@ -228,6 +230,10 @@ class WorkflowExecutor:
 
         if isinstance(node, GateNode):
             await self._execute_gate(node)
+            return
+
+        if isinstance(node, DataNode):
+            await self._execute_data(node_id, node)
             return
 
         await self._execute_action_node(node)
@@ -625,6 +631,142 @@ class WorkflowExecutor:
         )
 
         next_id = self._next_unconditional(node.id)
+        if next_id:
+            await self._execute_from(next_id)
+
+    async def _execute_data(self, node_id: str, node: DataNode) -> None:
+        """Execute a DataNode: resolve items, run subgraph per item with fault isolation."""
+        import random as _random
+
+        self.result.nodes_executed += 1
+
+        self._emit(
+            "node.started",
+            NodeStarted(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                node_id=node_id,
+                node_type="DataNode",
+            ),
+        )
+
+        start = time.monotonic()
+
+        # Resolve data items from exactly one source
+        items: list[DataItem] = []
+        if node.inline_items:
+            items = list(node.inline_items)
+        elif node.task_ref:
+            from factory.task import TaskRef
+            task_ref = TaskRef(ref=node.task_ref)
+            task = task_ref.resolve()
+            for inst in task.instances():
+                task.setup(inst, self.project_path)
+                prompt_text = task.prompt(inst)
+                items.append(DataItem(
+                    id=inst.id,
+                    path=str(inst.path) if inst.path else None,
+                    metadata=inst.metadata,
+                    prompt=prompt_text,
+                ))
+        elif node.source_path:
+            from pathlib import Path as _Path
+            src = _Path(node.source_path)
+            if not src.is_absolute():
+                src = self.project_path / src
+            if node.source_format == "directory" and src.is_dir():
+                for child in sorted(src.iterdir()):
+                    if child.is_dir():
+                        items.append(DataItem(id=child.name, path=str(child)))
+            elif node.source_format == "jsonl" and src.is_file():
+                for idx, line in enumerate(src.read_text().splitlines()):
+                    if line.strip():
+                        items.append(DataItem(
+                            id=str(idx),
+                            metadata=json.loads(line),
+                        ))
+            elif node.source_format == "csv" and src.is_file():
+                import csv
+                with src.open(newline="") as f:
+                    reader = csv.DictReader(f)
+                    for idx, row in enumerate(reader):
+                        items.append(DataItem(id=str(idx), metadata=dict(row)))
+
+        # Apply split/shuffle/limit filters
+        if node.split != "all":
+            items = [it for it in items if it.metadata.get("split") == node.split]
+        if node.shuffle:
+            _random.shuffle(items)
+        if node.limit is not None and node.limit > 0:
+            items = items[:node.limit]
+
+        if len(items) > node.max_items:
+            raise ValueError(
+                f"DataNode '{node_id}' resolved {len(items)} items, "
+                f"exceeding max_items={node.max_items}"
+            )
+
+        # Collect subgraph and run per item with Semaphore-throttled concurrency
+        subgraph_ids = _collect_subgraph_nodes(
+            self.workflow, node.subgraph_entry, node.subgraph_exit,
+        )
+        sub_workflow = self.workflow.subgraph(
+            subgraph_ids,
+            name=f"{self.workflow.name}__data_item",
+            start_node=node.subgraph_entry,
+        )
+
+        item_results: list[dict[str, Any]] = []
+        sem = asyncio.Semaphore(node.parallelism)
+
+        async def run_item(item: DataItem) -> dict[str, Any]:
+            async with sem:
+                try:
+                    item_executor = WorkflowExecutor(
+                        sub_workflow.model_copy(deep=True),
+                        self.project_path,
+                        agent_pool=self.agent_pool,
+                        dry_run=self.dry_run,
+                        initial_context=item.prompt,
+                    )
+                    item_result = await item_executor.execute()
+                    return {
+                        "item_id": item.id,
+                        "success": item_result.success,
+                        "score": 1.0 if item_result.success else 0.0,
+                        "nodes_executed": item_result.nodes_executed,
+                        "node_outputs": item_result.node_outputs,
+                    }
+                except Exception as exc:
+                    log.warning("data_item_failed", item_id=item.id, error=str(exc))
+                    return {
+                        "item_id": item.id,
+                        "success": False,
+                        "score": 0.0,
+                        "error": str(exc),
+                    }
+
+        tasks = [run_item(item) for item in items]
+        results = await asyncio.gather(*tasks)
+        item_results = list(results)
+
+        elapsed = (time.monotonic() - start) * 1000
+        self.result.node_outputs[node_id] = json.dumps(item_results)
+        self.completed_files |= node.writes
+
+        self._emit(
+            "node.completed",
+            NodeCompleted(
+                workflow_name=self.workflow.name,
+                run_id=self.run_id,
+                node_id=node_id,
+                node_type="DataNode",
+                files_written=sorted(node.writes),
+                duration_ms=elapsed,
+            ),
+        )
+
+        next_id = self._next_unconditional(node_id)
         if next_id:
             await self._execute_from(next_id)
 

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -638,6 +638,9 @@ class WorkflowExecutor:
         """Execute a DataNode: resolve items, run subgraph per item with fault isolation."""
         import random as _random
 
+        from factory.task import Task as _Task
+        from factory.task import TaskInstance as _TaskInstance
+
         self.result.nodes_executed += 1
 
         self._emit(
@@ -652,22 +655,24 @@ class WorkflowExecutor:
 
         start = time.monotonic()
 
-        # Resolve data items from exactly one source
-        items: list[DataItem] = []
+        # Resolve data items from exactly one source, keeping TaskInstances for task_ref
+        task_instances: list[tuple[DataItem, _TaskInstance | None]] = []
+        resolved_task: _Task | None = None
+
         if node.inline_items:
-            items = list(node.inline_items)
+            task_instances = [(item, None) for item in node.inline_items]
         elif node.task_ref:
             from factory.task import TaskRef
             task_ref = TaskRef(ref=node.task_ref)
-            task = task_ref.resolve()
-            for inst in task.instances():
-                task.setup(inst, self.project_path)
-                prompt_text = task.prompt(inst)
-                items.append(DataItem(
-                    id=inst.id,
-                    path=str(inst.path) if inst.path else None,
-                    metadata=inst.metadata,
-                    prompt=prompt_text,
+            resolved_task = task_ref.resolve()
+            for inst in resolved_task.instances():
+                task_instances.append((
+                    DataItem(
+                        id=inst.id,
+                        path=str(inst.path) if inst.path else None,
+                        metadata=inst.metadata,
+                    ),
+                    inst,
                 ))
         elif node.source_path:
             from pathlib import Path as _Path
@@ -677,32 +682,35 @@ class WorkflowExecutor:
             if node.source_format == "directory" and src.is_dir():
                 for child in sorted(src.iterdir()):
                     if child.is_dir():
-                        items.append(DataItem(id=child.name, path=str(child)))
+                        task_instances.append((DataItem(id=child.name, path=str(child)), None))
             elif node.source_format == "jsonl" and src.is_file():
                 for idx, line in enumerate(src.read_text().splitlines()):
                     if line.strip():
-                        items.append(DataItem(
+                        task_instances.append((DataItem(
                             id=str(idx),
                             metadata=json.loads(line),
-                        ))
+                        ), None))
             elif node.source_format == "csv" and src.is_file():
                 import csv
                 with src.open(newline="") as f:
                     reader = csv.DictReader(f)
                     for idx, row in enumerate(reader):
-                        items.append(DataItem(id=str(idx), metadata=dict(row)))
+                        task_instances.append((DataItem(id=str(idx), metadata=dict(row)), None))
 
-        # Apply split/shuffle/limit filters
+        # Apply split/shuffle/limit filters to the paired list
         if node.split != "all":
-            items = [it for it in items if it.metadata.get("split") == node.split]
+            task_instances = [
+                (item, inst) for item, inst in task_instances
+                if item.metadata.get("split") == node.split
+            ]
         if node.shuffle:
-            _random.shuffle(items)
+            _random.shuffle(task_instances)
         if node.limit is not None and node.limit > 0:
-            items = items[:node.limit]
+            task_instances = task_instances[:node.limit]
 
-        if len(items) > node.max_items:
+        if len(task_instances) > node.max_items:
             raise ValueError(
-                f"DataNode '{node_id}' resolved {len(items)} items, "
+                f"DataNode '{node_id}' resolved {len(task_instances)} items, "
                 f"exceeding max_items={node.max_items}"
             )
 
@@ -719,16 +727,26 @@ class WorkflowExecutor:
         item_results: list[dict[str, Any]] = []
         sem = asyncio.Semaphore(node.parallelism)
 
-        # Pre-compute reads that exist on disk (e.g. created by task.setup())
+        # Pre-compute reads that exist on disk
         disk_reads: set[str] = set()
         for sg_node in sub_workflow.nodes.values():
             for r in sg_node.reads:
                 if (self.project_path / r).exists():
                     disk_reads.add(r)
 
-        async def run_item(item: DataItem) -> dict[str, Any]:
+        async def run_item(pair: tuple[DataItem, _TaskInstance | None]) -> dict[str, Any]:
+            item, inst = pair
             async with sem:
                 try:
+                    if resolved_task is not None and inst is not None:
+                        resolved_task.setup(inst, self.project_path)
+                        item = DataItem(
+                            id=inst.id,
+                            path=str(inst.path) if inst.path else None,
+                            metadata=inst.metadata,
+                            prompt=resolved_task.prompt(inst),
+                        )
+
                     item_executor = WorkflowExecutor(
                         sub_workflow.model_copy(deep=True),
                         self.project_path,
@@ -738,12 +756,25 @@ class WorkflowExecutor:
                     )
                     item_executor.completed_files = self.completed_files | disk_reads
                     item_result = await item_executor.execute()
+
+                    score = 1.0 if item_result.success else 0.0
+                    passed = item_result.success
+                    verify_details: dict[str, Any] = {}
+
+                    if resolved_task is not None and inst is not None:
+                        vr = resolved_task.verify(inst, self.project_path)
+                        score = vr.score
+                        passed = vr.passed
+                        verify_details = vr.details or {}
+
                     return {
                         "item_id": item.id,
                         "success": item_result.success,
-                        "score": 1.0 if item_result.success else 0.0,
+                        "score": score,
+                        "passed": passed,
                         "nodes_executed": item_result.nodes_executed,
                         "node_outputs": item_result.node_outputs,
+                        "verify_details": verify_details,
                     }
                 except Exception as exc:
                     log.warning("data_item_failed", item_id=item.id, error=str(exc))
@@ -751,10 +782,11 @@ class WorkflowExecutor:
                         "item_id": item.id,
                         "success": False,
                         "score": 0.0,
+                        "passed": False,
                         "error": str(exc),
                     }
 
-        tasks = [run_item(item) for item in items]
+        tasks = [run_item(pair) for pair in task_instances]
         results = await asyncio.gather(*tasks)
         item_results = list(results)
 

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -719,6 +719,13 @@ class WorkflowExecutor:
         item_results: list[dict[str, Any]] = []
         sem = asyncio.Semaphore(node.parallelism)
 
+        # Pre-compute reads that exist on disk (e.g. created by task.setup())
+        disk_reads: set[str] = set()
+        for sg_node in sub_workflow.nodes.values():
+            for r in sg_node.reads:
+                if (self.project_path / r).exists():
+                    disk_reads.add(r)
+
         async def run_item(item: DataItem) -> dict[str, Any]:
             async with sem:
                 try:
@@ -729,7 +736,7 @@ class WorkflowExecutor:
                         dry_run=self.dry_run,
                         initial_context=item.prompt,
                     )
-                    item_executor.completed_files = self.completed_files.copy()
+                    item_executor.completed_files = self.completed_files | disk_reads
                     item_result = await item_executor.execute()
                     return {
                         "item_id": item.id,

--- a/factory/workflow/executor.py
+++ b/factory/workflow/executor.py
@@ -729,6 +729,7 @@ class WorkflowExecutor:
                         dry_run=self.dry_run,
                         initial_context=item.prompt,
                     )
+                    item_executor.completed_files = self.completed_files.copy()
                     item_result = await item_executor.execute()
                     return {
                         "item_id": item.id,

--- a/factory/workflow/overwrite.py
+++ b/factory/workflow/overwrite.py
@@ -53,7 +53,7 @@ def _interpret_overwrite(
         indent=2,
     )
     edge_summary = json.dumps(
-        [{"source": e.source, "target": e.target, "condition": e.condition.value if e.condition else None}
+        [{"source": e.source, "target": e.target, "condition": str(e.condition) if e.condition else None}
          for e in workflow.edges],
         indent=2,
     )

--- a/factory/workflow/overwrite.py
+++ b/factory/workflow/overwrite.py
@@ -53,7 +53,7 @@ def _interpret_overwrite(
         indent=2,
     )
     edge_summary = json.dumps(
-        [{"source": e.source, "target": e.target, "condition": str(e.condition) if e.condition else None}
+        [{"source": e.source, "target": e.target, "condition": e.condition.value if e.condition else None}  # type: ignore
          for e in workflow.edges],
         indent=2,
     )

--- a/factory/workflow/overwrite.py
+++ b/factory/workflow/overwrite.py
@@ -53,7 +53,7 @@ def _interpret_overwrite(
         indent=2,
     )
     edge_summary = json.dumps(
-        [{"source": e.source, "target": e.target, "condition": e.condition.value if e.condition else None}  # type: ignore
+        [{"source": e.source, "target": e.target, "condition": e.condition_label}
          for e in workflow.edges],
         indent=2,
     )

--- a/factory/workflow/parity.py
+++ b/factory/workflow/parity.py
@@ -153,7 +153,7 @@ def canonicalize(wf: Workflow) -> dict[str, Any]:
             {
                 "source": e.source,
                 "target": e.target,
-                "condition": str(e.condition) if e.condition is not None else None,
+                "condition": e.condition.value if e.condition is not None else None,  # type: ignore
             }
             for e in wf.edges
             if (e.source, e.target) not in redundant

--- a/factory/workflow/parity.py
+++ b/factory/workflow/parity.py
@@ -153,7 +153,7 @@ def canonicalize(wf: Workflow) -> dict[str, Any]:
             {
                 "source": e.source,
                 "target": e.target,
-                "condition": e.condition.value if e.condition is not None else None,  # type: ignore
+                "condition": e.condition_label,
             }
             for e in wf.edges
             if (e.source, e.target) not in redundant

--- a/factory/workflow/parity.py
+++ b/factory/workflow/parity.py
@@ -153,7 +153,7 @@ def canonicalize(wf: Workflow) -> dict[str, Any]:
             {
                 "source": e.source,
                 "target": e.target,
-                "condition": e.condition.value if e.condition is not None else None,
+                "condition": str(e.condition) if e.condition is not None else None,
             }
             for e in wf.edges
             if (e.source, e.target) not in redundant

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -191,6 +191,50 @@ class SubgraphForkNode(Node):
     worktree_isolated: bool = True
 
 
+class DataItem(BaseModel):
+    """Standardized data payload for per-item workflow iteration."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    id: str
+    path: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    prompt: str = ""
+
+
+class DataNode(Node):
+    """Node that loads data items and drives per-item execution of a subgraph."""
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    task_ref: str | None = None
+    source_path: str | None = None
+    source_format: Literal["directory", "jsonl", "csv"] | None = None
+    inline_items: list[DataItem] = Field(default_factory=list)
+    subgraph_entry: str
+    subgraph_exit: str
+    parallelism: int = 3
+    split: Literal["train", "val", "test", "all"] = "all"
+    shuffle: bool = False
+    limit: int | None = None
+    max_items: int = 500
+
+    @model_validator(mode="after")
+    def _validate_source(self) -> DataNode:
+        sources = [
+            self.task_ref is not None,
+            self.source_path is not None,
+            bool(self.inline_items),
+        ]
+        if sum(sources) != 1:
+            raise ValueError(
+                "Exactly one of task_ref, source_path, or inline_items must be set"
+            )
+        if self.source_path is not None and self.source_format is None:
+            raise ValueError("source_path requires source_format to be set")
+        return self
+
+
 class SelectionNode(Node):
     """Compare N completed experiment branches and select the best."""
 
@@ -257,7 +301,8 @@ class Edge(BaseModel):
 
 
 NodeType = (
-    AgentNode | FnNode | GateNode | ForkNode | JoinNode | SubgraphForkNode | SelectionNode | Study | LLMNode
+    AgentNode | FnNode | GateNode | ForkNode | JoinNode | SubgraphForkNode
+    | SelectionNode | Study | LLMNode | DataNode
 )
 
 
@@ -353,6 +398,7 @@ class Workflow(BaseModel):
             "SelectionNode": SelectionNode,
             "Study": Study,
             "LLMNode": LLMNode,
+            "DataNode": DataNode,
         }
         _SET_FIELDS = {"reads", "writes"}
 

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -305,6 +305,17 @@ class Edge(BaseModel):
     target: str
     condition: VerdictType | str | None = None
 
+    @property
+    def condition_label(self) -> str | None:
+        """Return the condition as a plain string, or ``None``.
+
+        ``VerdictType.PROCEED`` → ``"proceed"`` (not ``"VerdictType.PROCEED"``).
+        Plain ``str`` conditions are returned as-is.
+        """
+        if self.condition is None:
+            return None
+        return self.condition.value if isinstance(self.condition, VerdictType) else self.condition
+
 
 # ── workflow ─────────────────────────────────────────────────────
 

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -213,9 +213,10 @@ class DataNode(Node):
     inline_items: list[DataItem] = Field(default_factory=list)
     subgraph_entry: str
     subgraph_exit: str
-    parallelism: int = 3
+    parallelism: int = Field(default=1, ge=1)
     split: Literal["train", "val", "test", "all"] = "all"
     shuffle: bool = False
+    shuffle_seed: int | None = None
     limit: int | None = None
     max_items: int = 500
 

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -176,7 +176,7 @@ def _format_edges(edges: list[Edge]) -> str:
         return "none"
     parts = []
     for e in edges:
-        cond = e.condition.value if e.condition else "unconditional"  # type: ignore
+        cond = e.condition_label or "unconditional"
         parts.append(f"{cond} → {e.target}")
     return ", ".join(parts)
 

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -122,12 +122,12 @@ def _topological_sort(workflow: Workflow) -> list[str]:
     # after the fork node and join sources sort before the join node.
     for nid, node in workflow.nodes.items():
         if type(node).__name__ == "ForkNode":
-            for t in node.targets:  # type: ignore[union-attr]
+            for t in node.targets:  # type: ignore
                 if t in workflow.nodes:
                     adj[nid].append(t)
                     in_degree[t] = in_degree.get(t, 0) + 1
         if type(node).__name__ == "JoinNode":
-            for s in node.sources:  # type: ignore[union-attr]
+            for s in node.sources:  # type: ignore
                 if s in workflow.nodes:
                     adj[s].append(nid)
                     in_degree[nid] = in_degree.get(nid, 0) + 1
@@ -176,7 +176,7 @@ def _format_edges(edges: list[Edge]) -> str:
         return "none"
     parts = []
     for e in edges:
-        cond = str(e.condition) if e.condition else "unconditional"
+        cond = e.condition.value if e.condition else "unconditional"  # type: ignore
         parts.append(f"{cond} → {e.target}")
     return ", ".join(parts)
 

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -176,7 +176,7 @@ def _format_edges(edges: list[Edge]) -> str:
         return "none"
     parts = []
     for e in edges:
-        cond = e.condition.value if e.condition else "unconditional"
+        cond = str(e.condition) if e.condition else "unconditional"
         parts.append(f"{cond} → {e.target}")
     return ", ".join(parts)
 

--- a/factory/workflow/skill_export.py
+++ b/factory/workflow/skill_export.py
@@ -20,6 +20,7 @@ import structlog
 from factory.workflow.primitives import (
     AgentNode,
     DEFAULT_AGENT_POOL,
+    DataNode,
     Edge,
     FnNode,
     ForkNode,
@@ -629,6 +630,43 @@ def _selection_to_instruction(node: SelectionNode, workflow: Workflow) -> str:
     return "\n".join(lines)
 
 
+def _data_to_instruction(node: DataNode, workflow: Workflow) -> str:
+    """Convert a DataNode to data iteration instructions."""
+    out_edges = _outgoing_edges(workflow, node.id)
+    edges_str = _format_edges(out_edges)
+
+    source_desc = "inline items"
+    if node.task_ref:
+        source_desc = f"task_ref `{node.task_ref}`"
+    elif node.source_path:
+        source_desc = f"source_path `{node.source_path}` (format: {node.source_format})"
+
+    annotations = [
+        f"<!-- node: DataNode id={node.id} entry={node.subgraph_entry} exit={node.subgraph_exit} -->",
+        f"<!-- source: {source_desc} -->",
+        f"<!-- edges: {edges_str} -->",
+    ]
+
+    lines = [
+        *annotations,
+        "",
+        f"Load data items from {source_desc} and iterate the subgraph "
+        f"(`{node.subgraph_entry}` → `{node.subgraph_exit}`) once per item.",
+        "",
+        f"- **Parallelism:** {node.parallelism} concurrent items",
+        f"- **Split:** {node.split}",
+    ]
+    if node.shuffle:
+        lines.append("- **Shuffle:** yes")
+    if node.limit is not None:
+        lines.append(f"- **Limit:** {node.limit} items")
+    lines.append(f"- **Max items (safety ceiling):** {node.max_items}")
+    lines.append("")
+    lines.append("Per-item fault isolation: a failing item scores 0.0 but does not halt the iteration.")
+
+    return "\n".join(lines)
+
+
 # ── frontmatter builder ────────────────────────────────────────
 
 
@@ -695,6 +733,12 @@ def workflow_to_skill_md(workflow: Workflow) -> str:
             subgraph_nodes |= _collect_subgraph_nodes(
                 workflow, node.subgraph_entry, node.subgraph_exit
             )
+        elif isinstance(node, DataNode):
+            from factory.workflow.executor import _collect_subgraph_nodes
+
+            subgraph_nodes |= _collect_subgraph_nodes(
+                workflow, node.subgraph_entry, node.subgraph_exit
+            )
 
     sections: list[str] = []
     phase_num = 1
@@ -753,10 +797,23 @@ def workflow_to_skill_md(workflow: Workflow) -> str:
             sections.append(_llm_to_instruction(node, workflow))
             phase_num += 1
 
+        elif isinstance(node, DataNode):
+            node_title = nid.replace("_", " ").title()
+            sections.append(f"## Phase {phase_num}: {node_title} (Data Iteration)\n")
+            sections.append(_data_to_instruction(node, workflow))
+            phase_num += 1
+
         elif isinstance(node, FnNode):
             node_title = nid.replace("_", " ").title()
             sections.append(f"## Step: {node_title}\n")
             sections.append(_fn_to_instruction(node, workflow))
+
+        else:
+            log.warning(
+                "skill_export.unmatched_node_type",
+                node_id=nid,
+                node_type=type(node).__name__,
+            )
 
     body = "\n\n".join(sections)
 

--- a/factory/workflow/tool.py
+++ b/factory/workflow/tool.py
@@ -224,7 +224,7 @@ def tool_init(workflow_name: str, project_path: Path) -> str:
             {
                 "source": e.source,
                 "target": e.target,
-                "condition": e.condition.value if e.condition else None,  # type: ignore
+                "condition": e.condition_label,
             }
             for e in wf.edges
         ],

--- a/factory/workflow/tool.py
+++ b/factory/workflow/tool.py
@@ -224,7 +224,7 @@ def tool_init(workflow_name: str, project_path: Path) -> str:
             {
                 "source": e.source,
                 "target": e.target,
-                "condition": e.condition.value if e.condition else None,
+                "condition": str(e.condition) if e.condition else None,
             }
             for e in wf.edges
         ],

--- a/factory/workflow/tool.py
+++ b/factory/workflow/tool.py
@@ -224,7 +224,7 @@ def tool_init(workflow_name: str, project_path: Path) -> str:
             {
                 "source": e.source,
                 "target": e.target,
-                "condition": str(e.condition) if e.condition else None,
+                "condition": e.condition.value if e.condition else None,  # type: ignore
             }
             for e in wf.edges
         ],

--- a/factory/workflow/validation.py
+++ b/factory/workflow/validation.py
@@ -129,6 +129,53 @@ def _validate_fork_join_nodes(workflow: Workflow, issues: list[str]) -> None:
                 issues.append(f"data_node '{nid}' exit '{exit_node}' not in nodes")
 
 
+def _validate_datanode_edges(workflow: Workflow, issues: list[str]) -> None:
+    """Reject explicit edges from a DataNode to its own subgraph nodes.
+
+    The executor handles subgraph execution internally — explicit edges
+    would cause double-execution.
+    """
+    for nid, node in workflow.nodes.items():
+        if type(node).__name__ != "DataNode":
+            continue
+        entry = node.subgraph_entry  # type: ignore[union-attr]
+        exit_node = node.subgraph_exit  # type: ignore[union-attr]
+        subgraph_ids = _collect_subgraph_nodes(workflow, entry, exit_node)
+        for edge in workflow.edges:
+            if edge.source == nid and edge.target in subgraph_ids:
+                issues.append(
+                    f"Edge from DataNode {nid} to its own subgraph node {edge.target} "
+                    f"would cause double-execution. Remove explicit edges into DataNode "
+                    f"subgraphs — the executor handles subgraph execution internally."
+                )
+
+
+def _collect_subgraph_nodes(
+    workflow: Workflow,
+    entry: str,
+    exit_node: str,
+) -> set[str]:
+    """Collect all node IDs on paths from entry to exit_node (inclusive)."""
+    edges_by_source: dict[str, list[str]] = {}
+    for edge in workflow.edges:
+        edges_by_source.setdefault(edge.source, []).append(edge.target)
+
+    visited: set[str] = set()
+    queue = [entry]
+    while queue:
+        nid = queue.pop(0)
+        if nid in visited:
+            continue
+        visited.add(nid)
+        if nid == exit_node:
+            continue
+        for target in edges_by_source.get(nid, []):
+            if target not in visited:
+                queue.append(target)
+
+    return visited
+
+
 def validate_workflow(workflow: Workflow) -> list[str]:
     """Validate a workflow graph. Returns a list of issues (empty = valid)."""
     issues: list[str] = []
@@ -162,6 +209,7 @@ def validate_workflow(workflow: Workflow) -> list[str]:
     _validate_cycles(g, workflow, issues)
     _validate_data_dependencies(g, workflow, issues)
     _validate_fork_join_nodes(workflow, issues)
+    _validate_datanode_edges(workflow, issues)
 
     for nid, node in nodes.items():
         if type(node).__name__ == "SubgraphForkNode":

--- a/factory/workflow/validation.py
+++ b/factory/workflow/validation.py
@@ -29,6 +29,7 @@ def _validate_reachability(
     # Add implicit edges for fork/join semantics.
     # ForkNode.targets are reached implicitly (not via explicit edges).
     # JoinNode.sources flow into the join implicitly.
+    # DataNode.subgraph_entry/exit are reached implicitly.
     nodes = workflow.nodes
     for nid, node in nodes.items():
         if type(node).__name__ == "ForkNode":
@@ -39,6 +40,13 @@ def _validate_reachability(
             for s in node.sources:  # type: ignore[union-attr]
                 if s in nodes:
                     g.add_edge(s, nid)
+        if type(node).__name__ == "DataNode":
+            entry = node.subgraph_entry  # type: ignore[union-attr]
+            exit_node = node.subgraph_exit  # type: ignore[union-attr]
+            if entry in nodes:
+                g.add_edge(nid, entry)
+            if exit_node in nodes:
+                g.add_edge(nid, exit_node)
 
     reachable = nx.descendants(g, workflow.start_node) | {workflow.start_node}
     unreachable = set(workflow.nodes.keys()) - reachable
@@ -112,6 +120,14 @@ def _validate_fork_join_nodes(workflow: Workflow, issues: list[str]) -> None:
             if exit_node not in workflow.nodes:
                 issues.append(f"subgraph_fork '{nid}' exit '{exit_node}' not in nodes")
 
+        if type(node).__name__ == "DataNode":
+            entry = node.subgraph_entry  # type: ignore[union-attr]
+            exit_node = node.subgraph_exit  # type: ignore[union-attr]
+            if entry not in workflow.nodes:
+                issues.append(f"data_node '{nid}' entry '{entry}' not in nodes")
+            if exit_node not in workflow.nodes:
+                issues.append(f"data_node '{nid}' exit '{exit_node}' not in nodes")
+
 
 def validate_workflow(workflow: Workflow) -> list[str]:
     """Validate a workflow graph. Returns a list of issues (empty = valid)."""
@@ -130,10 +146,14 @@ def validate_workflow(workflow: Workflow) -> list[str]:
     for edge in workflow.edges:
         g.add_edge(edge.source, edge.target, condition=edge.condition)
 
-    # Add implicit edges for SubgraphForkNode: fork → subgraph_entry
+    # Add implicit edges for SubgraphForkNode and DataNode: node → subgraph_entry
     # so subgraph nodes are reachable in the graph
     for nid, node in nodes.items():
         if type(node).__name__ == "SubgraphForkNode":
+            entry = node.subgraph_entry  # type: ignore[union-attr]
+            if entry in nodes:
+                g.add_edge(nid, entry, condition=None)
+        if type(node).__name__ == "DataNode":
             entry = node.subgraph_entry  # type: ignore[union-attr]
             if entry in nodes:
                 g.add_edge(nid, entry, condition=None)
@@ -151,6 +171,14 @@ def validate_workflow(workflow: Workflow) -> list[str]:
                 if not nx.has_path(g, entry, exit_node):
                     issues.append(
                         f"subgraph_fork '{nid}': no path from entry '{entry}' to exit '{exit_node}'"
+                    )
+        if type(node).__name__ == "DataNode":
+            entry = node.subgraph_entry  # type: ignore[union-attr]
+            exit_node = node.subgraph_exit  # type: ignore[union-attr]
+            if entry in nodes and exit_node in nodes:
+                if not nx.has_path(g, entry, exit_node):
+                    issues.append(
+                        f"data_node '{nid}': no path from entry '{entry}' to exit '{exit_node}'"
                     )
 
     return issues

--- a/tests/test_data_node.py
+++ b/tests/test_data_node.py
@@ -1317,3 +1317,180 @@ class TestComposeDataNodeWorkflow:
         loop = compose(wf, task, tmp_path)
         assert loop is not None
         assert loop.workflow is wf
+
+
+# ── PR #1483 Second Review Fixes — additional tests ─────────────
+
+
+class TestFormatPathKindMismatch:
+    """FIX 1: source_format vs path kind mismatch must raise ValueError."""
+
+    def test_directory_format_on_file_raises(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        a_file = tmp_path / "not_a_dir.txt"
+        a_file.write_text("hello")
+
+        wf = Workflow(
+            name="mismatch_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(a_file),
+                    source_format="directory",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.halted
+        assert "requires a directory" in result.halt_reason
+
+    def test_jsonl_format_on_directory_raises(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        a_dir = tmp_path / "not_a_file"
+        a_dir.mkdir()
+
+        wf = Workflow(
+            name="mismatch_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(a_dir),
+                    source_format="jsonl",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.halted
+        assert "requires a file" in result.halt_reason
+
+    def test_csv_format_on_directory_raises(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        a_dir = tmp_path / "not_a_file"
+        a_dir.mkdir()
+
+        wf = Workflow(
+            name="mismatch_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(a_dir),
+                    source_format="csv",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.halted
+        assert "requires a file" in result.halt_reason
+
+
+class TestWorkflowHasDataNode:
+    """FIX 5: _workflow_has_data_node coverage."""
+
+    def test_returns_true_with_data_node(self, tmp_path: Path) -> None:
+        from factory.inner_loop import InnerLoop
+
+        wf = _make_data_workflow([DataItem(id="i")])
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+        assert loop._workflow_has_data_node() is True
+
+    def test_returns_false_without_data_node(self, tmp_path: Path) -> None:
+        from factory.inner_loop import InnerLoop
+
+        wf = Workflow(
+            name="no_data",
+            nodes={"a": FnNode(id="a", command="echo x")},
+            edges=[],
+            start_node="a",
+        )
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+        assert loop._workflow_has_data_node() is False
+
+    def test_caches_result(self, tmp_path: Path) -> None:
+        from factory.inner_loop import InnerLoop
+
+        wf = _make_data_workflow([DataItem(id="i")])
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+        result1 = loop._workflow_has_data_node()
+        result2 = loop._workflow_has_data_node()
+        assert result1 is result2 is True
+        # Verify it was cached (attribute should be set)
+        assert loop._has_data_node is True
+
+
+class TestStepWithDataNodeCoverage:
+    """FIX 5: _step_with_data_node happy path and failure coverage."""
+
+    def test_happy_path(self, tmp_path: Path) -> None:
+        from unittest.mock import AsyncMock
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = _make_data_workflow([DataItem(id="i", prompt="go")])
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+        mock_result.node_outputs = {
+            "data": json.dumps([
+                {"item_id": "i", "score": 0.85, "passed": True},
+            ])
+        }
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop._step_with_data_node()
+
+        assert record.score_end == pytest.approx(0.85)
+        assert record.cycle_number == 1
+        assert record.instance_results is not None
+        assert len(record.instance_results) == 1
+        assert record.instance_results[0]["instance_id"] == "i"
+
+    def test_executor_failure_defaults_score(self, tmp_path: Path) -> None:
+        from unittest.mock import AsyncMock
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = _make_data_workflow([DataItem(id="i")])
+
+        mock_result = ExecutionResult()
+        mock_result.success = False
+        mock_result.node_outputs = {}
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop._step_with_data_node()
+
+        assert record.score_end == 0.0

--- a/tests/test_data_node.py
+++ b/tests/test_data_node.py
@@ -601,7 +601,7 @@ class TestSourcePathNonExistent:
 
 class TestStepWithDataNode:
     def test_delegates_to_executor(self, tmp_path: Path) -> None:
-        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import AsyncMock
 
         from factory.inner_loop import InnerLoop
         from factory.workflow.executor import ExecutionResult

--- a/tests/test_data_node.py
+++ b/tests/test_data_node.py
@@ -116,9 +116,10 @@ class TestDataNode:
             subgraph_entry="a",
             subgraph_exit="b",
         )
-        assert node.parallelism == 3
+        assert node.parallelism == 1
         assert node.split == "all"
         assert node.shuffle is False
+        assert node.shuffle_seed is None
         assert node.limit is None
         assert node.max_items == 500
 
@@ -572,7 +573,7 @@ class TestSourcePathCsv:
 
 
 class TestSourcePathNonExistent:
-    def test_nonexistent_path_yields_empty(self, tmp_path: Path) -> None:
+    def test_nonexistent_path_raises(self, tmp_path: Path) -> None:
         from factory.workflow.executor import WorkflowExecutor
 
         wf = Workflow(
@@ -592,9 +593,8 @@ class TestSourcePathNonExistent:
         )
         executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
         result = asyncio.run(executor.execute())
-        assert result.success
-        parsed = json.loads(result.node_outputs["data"])
-        assert len(parsed) == 0
+        assert result.halted
+        assert "source_path not found" in result.halt_reason
 
 
 # ── Phase 8: inner_loop _step_with_data_node ────────────────────
@@ -918,3 +918,402 @@ class TestStepWithDataNodeVerifyScores:
             record = loop._step_with_data_node()
 
         assert record.score_end == 1.0
+
+
+# ── PR #1483 Review Fixes — additional tests ─────────────────────
+
+
+class TestParallelismDefault:
+    def test_parallelism_default_is_1(self) -> None:
+        node = DataNode(
+            id="dn",
+            inline_items=[DataItem(id="i")],
+            subgraph_entry="a",
+            subgraph_exit="b",
+        )
+        assert node.parallelism == 1
+
+    def test_parallelism_zero_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            DataNode(
+                id="dn",
+                inline_items=[DataItem(id="i")],
+                subgraph_entry="a",
+                subgraph_exit="b",
+                parallelism=0,
+            )
+
+
+class TestNonexistentSourcePathRaises:
+    def test_raises_file_not_found(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        wf = Workflow(
+            name="missing",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(tmp_path / "nope"),
+                    source_format="jsonl",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.halted
+        assert "source_path not found" in result.halt_reason
+
+
+class TestEmptySourceWarns:
+    def test_empty_inline_warns(self, tmp_path: Path) -> None:
+        """Zero items after filtering should log a warning."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        # Use split filter to exclude all items
+        wf = Workflow(
+            name="empty_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=[DataItem(id="a", metadata={"split": "train"})],
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                    split="val",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        # This should succeed but with 0 items (and log a warning)
+        result = asyncio.run(executor.execute())
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 0
+
+
+class TestMalformedJsonlLineIsolated:
+    def test_bad_line_skipped_good_lines_kept(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        jsonl_file = tmp_path / "items.jsonl"
+        jsonl_file.write_text(
+            '{"name": "first"}\n'
+            'NOT VALID JSON\n'
+            '{"name": "third"}\n'
+        )
+
+        wf = Workflow(
+            name="jsonl_malformed",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(jsonl_file),
+                    source_format="jsonl",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        # Two good lines kept, one bad line skipped
+        assert len(parsed) == 2
+
+    def test_all_lines_bad_raises(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        jsonl_file = tmp_path / "items.jsonl"
+        jsonl_file.write_text("bad line 1\nbad line 2\n")
+
+        wf = Workflow(
+            name="jsonl_all_bad",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(jsonl_file),
+                    source_format="jsonl",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.halted
+        assert "JSONL lines" in result.halt_reason
+
+
+class TestShuffleDeterministic:
+    def test_shuffle_with_seed(self, tmp_path: Path) -> None:
+        """Same seed -> same order across runs."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [DataItem(id=str(i)) for i in range(20)]
+        wf = Workflow(
+            name="shuffle_seed",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=items,
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                    shuffle=True,
+                    shuffle_seed=42,
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+
+        # Run twice with the same seed -- order must match
+        executor1 = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result1 = asyncio.run(executor1.execute())
+        ids1 = [r["item_id"] for r in json.loads(result1.node_outputs["data"])]
+
+        executor2 = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result2 = asyncio.run(executor2.execute())
+        ids2 = [r["item_id"] for r in json.loads(result2.node_outputs["data"])]
+
+        assert ids1 == ids2
+        # Must actually be shuffled (not original order)
+        original_ids = [str(i) for i in range(20)]
+        assert ids1 != original_ids
+
+    def test_shuffle_from_run_id(self, tmp_path: Path) -> None:
+        """Unseeded shuffle derives seed from node_id + run_id."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [DataItem(id=str(i)) for i in range(20)]
+        wf = Workflow(
+            name="shuffle_runid",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=items,
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                    shuffle=True,
+                    # No shuffle_seed -- uses run_id hash
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+
+        executor1 = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result1 = asyncio.run(executor1.execute())
+        ids1 = [r["item_id"] for r in json.loads(result1.node_outputs["data"])]
+
+        # Different run_id -> potentially different order (different executor)
+        executor2 = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result2 = asyncio.run(executor2.execute())
+        ids2 = [r["item_id"] for r in json.loads(result2.node_outputs["data"])]
+
+        # Both should be 20 items
+        assert len(ids1) == 20
+        assert len(ids2) == 20
+
+
+class TestExplicitEdgeToSubgraphRejected:
+    def test_validation_error_on_datanode_subgraph_edge(self) -> None:
+        wf = Workflow(
+            name="bad_edge",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=[DataItem(id="i")],
+                    subgraph_entry="sub_start",
+                    subgraph_exit="sub_end",
+                ),
+                "sub_start": FnNode(id="sub_start", command="echo start"),
+                "sub_end": FnNode(id="sub_end", command="echo end"),
+            },
+            edges=[
+                Edge(source="data", target="sub_start"),
+                Edge(source="sub_start", target="sub_end"),
+            ],
+            start_node="data",
+        )
+        issues = wf.validate_graph()
+        assert any("double-execution" in i for i in issues)
+
+
+class TestCurrentItemJsonWritten:
+    def test_current_item_json_created_and_cleaned(self, tmp_path: Path) -> None:
+        """current_item.json should exist during subgraph execution."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [DataItem(id="test_item", prompt="do it")]
+        wf = _make_data_workflow(items)
+
+        # Track whether current_item.json exists during execution
+        observed: list[bool] = []
+        original_execute = WorkflowExecutor.execute
+
+        async def tracking_execute(self_inner):
+            item_json = self_inner.project_path / ".factory" / "current_item.json"
+            # For sub-executors (data_item workflows), check if file exists
+            if self_inner.workflow.name.endswith("__data_item"):
+                observed.append(item_json.exists())
+            return await original_execute(self_inner)
+
+        with patch.object(WorkflowExecutor, "execute", tracking_execute):
+            executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+            result = asyncio.run(executor.execute())
+
+        assert result.success
+        # current_item.json should have existed during subgraph execution
+        assert any(observed)
+        # And it should be cleaned up after
+        assert not (tmp_path / ".factory" / "current_item.json").exists()
+
+
+class TestDirectScoreLookup:
+    def test_finds_score_by_data_node_id(self, tmp_path: Path) -> None:
+        """Score lookup uses DataNode ID directly, not sniffing."""
+        from unittest.mock import AsyncMock
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = _make_data_workflow([DataItem(id="i", prompt="go")])
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+        mock_result.node_outputs = {
+            "data": json.dumps([
+                {"item_id": "i", "score": 0.75, "passed": True},
+            ]),
+            "some_other_node": json.dumps({"unrelated": "data"}),
+        }
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop._step_with_data_node()
+
+        assert record.score_end == pytest.approx(0.75)
+
+
+class TestInstanceResultsPopulated:
+    def test_instance_results_on_cycle_record(self, tmp_path: Path) -> None:
+        from unittest.mock import AsyncMock
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = _make_data_workflow([DataItem(id="a"), DataItem(id="b")])
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+        mock_result.node_outputs = {
+            "data": json.dumps([
+                {"item_id": "a", "score": 0.9, "passed": True},
+                {"item_id": "b", "score": 0.3, "passed": False},
+            ])
+        }
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop._step_with_data_node()
+
+        assert record.instance_results is not None
+        assert len(record.instance_results) == 2
+        assert record.instance_results[0]["instance_id"] == "a"
+        assert record.instance_results[0]["score"] == 0.9
+        assert record.instance_results[1]["instance_id"] == "b"
+        assert record.instance_results[1]["passed"] is False
+
+
+class _ComposeTestTask:
+    """Task that satisfies TaskProtocol for compose() tests."""
+
+    def __init__(self) -> None:
+        from factory.task import ScoringContract, TaskDefinition
+
+        self.definition = TaskDefinition(
+            name="mock", scoring=ScoringContract(method="exit_code"),
+        )
+        self.scoring = self.definition.scoring
+        self.constraints = None
+
+    def instances(self):
+        from factory.task import TaskInstance
+        return [TaskInstance(id="inst-1")]
+
+    def setup(self, instance: Any, workspace: Path) -> None:
+        pass
+
+    def prompt(self, instance: Any) -> str:
+        return "test prompt"
+
+    def verify(self, instance: Any, workspace: Path):
+        from factory.task import VerifyResult
+        return VerifyResult(passed=True, score=1.0)
+
+    def get_evaluator(self) -> Any:
+        return None
+
+
+class TestComposeDataNodeWorkflow:
+    def test_compose_succeeds_without_builder(self, tmp_path: Path) -> None:
+        """compose() should NOT raise IncompatibleCompositionError for DataNode workflows
+        even when the task requires HAS_BUILDER/CAN_RUN_TESTS."""
+        from factory.compose import compose
+        from factory.workflow.primitives import AgentNode, AgentRole
+
+        # Create a DataNode workflow WITHOUT a builder agent
+        wf = Workflow(
+            name="eval_only",
+            nodes={
+                "generator": AgentNode(
+                    id="generator",
+                    role=AgentRole.RESEARCHER,
+                    prompt_template="generate",
+                ),
+                "data": DataNode(
+                    id="data",
+                    inline_items=[DataItem(id="i1", prompt="test")],
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[
+                Edge(source="generator", target="data"),
+            ],
+            start_node="generator",
+        )
+
+        task = _ComposeTestTask()
+
+        # This should NOT raise IncompatibleCompositionError
+        loop = compose(wf, task, tmp_path)
+        assert loop is not None
+        assert loop.workflow is wf

--- a/tests/test_data_node.py
+++ b/tests/test_data_node.py
@@ -624,6 +624,83 @@ class TestStepWithDataNode:
         assert record.cycle_number == 1
 
 
+class TestSubgraphInheritsCompletedFiles:
+    """Verify that subgraph executors inherit parent completed_files."""
+
+    def test_subgraph_reads_upstream_artifact(self, tmp_path: Path) -> None:
+        """Subgraph start node with reads={'data_ready'} should inherit the
+        artifact from an upstream FnNode that writes={'data_ready'}, so it
+        executes instead of timing out."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        wf = Workflow(
+            name="inherit_test",
+            nodes={
+                "upstream_fn": FnNode(
+                    id="upstream_fn", command="echo ready", writes={"data_ready"},
+                ),
+                "data_loader": DataNode(
+                    id="data_loader",
+                    inline_items=[DataItem(id="item1", prompt="go")],
+                    subgraph_entry="process_node",
+                    subgraph_exit="exit_node",
+                ),
+                "process_node": FnNode(
+                    id="process_node",
+                    command="echo processing",
+                    reads={"data_ready"},
+                ),
+                "exit_node": FnNode(id="exit_node", command="echo done"),
+            },
+            edges=[
+                Edge(source="upstream_fn", target="data_loader"),
+                Edge(source="process_node", target="exit_node"),
+            ],
+            start_node="upstream_fn",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+
+        assert result.success, f"Expected success but got halt: {result.halt_reason}"
+        assert not result.halted
+        parsed = json.loads(result.node_outputs["data_loader"])
+        assert len(parsed) == 1
+        assert parsed[0]["nodes_executed"] > 0
+
+    def test_subgraph_no_reads_still_works(self, tmp_path: Path) -> None:
+        """Subgraph start node with no reads should execute normally (baseline)."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        wf = Workflow(
+            name="no_reads_test",
+            nodes={
+                "upstream_fn": FnNode(
+                    id="upstream_fn", command="echo ready", writes={"data_ready"},
+                ),
+                "data_loader": DataNode(
+                    id="data_loader",
+                    inline_items=[DataItem(id="item1")],
+                    subgraph_entry="process_node",
+                    subgraph_exit="exit_node",
+                ),
+                "process_node": FnNode(id="process_node", command="echo processing"),
+                "exit_node": FnNode(id="exit_node", command="echo done"),
+            },
+            edges=[
+                Edge(source="upstream_fn", target="data_loader"),
+                Edge(source="process_node", target="exit_node"),
+            ],
+            start_node="upstream_fn",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+
+        assert result.success
+        parsed = json.loads(result.node_outputs["data_loader"])
+        assert len(parsed) == 1
+        assert parsed[0]["nodes_executed"] > 0
+
+
 class TestComposeCapsDataNode:
     def test_data_node_adds_can_iterate(self) -> None:
         from factory.compose import ModeCapabilities

--- a/tests/test_data_node.py
+++ b/tests/test_data_node.py
@@ -1,0 +1,479 @@
+"""Tests for the DataNode graph primitive — models, executor, validation, skill export, and features."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from factory.workflow.primitives import (
+    DataItem,
+    DataNode,
+    Edge,
+    FnNode,
+    Workflow,
+)
+
+
+# ── Phase 1: DataItem / DataNode Pydantic validation ──────────────
+
+
+class TestDataItem:
+    def test_minimal(self) -> None:
+        item = DataItem(id="a")
+        assert item.id == "a"
+        assert item.path is None
+        assert item.metadata == {}
+        assert item.prompt == ""
+
+    def test_full(self) -> None:
+        item = DataItem(id="b", path="/tmp/b", metadata={"k": "v"}, prompt="do stuff")
+        assert item.path == "/tmp/b"
+        assert item.metadata == {"k": "v"}
+        assert item.prompt == "do stuff"
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            DataItem(id="a", unknown="x")
+
+    def test_roundtrip(self) -> None:
+        item = DataItem(id="c", metadata={"x": 1})
+        data = item.model_dump(mode="json")
+        restored = DataItem.model_validate(data)
+        assert restored.id == "c"
+        assert restored.metadata == {"x": 1}
+
+
+class TestDataNode:
+    def test_inline_items_source(self) -> None:
+        items = [DataItem(id="i1"), DataItem(id="i2")]
+        node = DataNode(
+            id="dn",
+            inline_items=items,
+            subgraph_entry="a",
+            subgraph_exit="b",
+        )
+        assert len(node.inline_items) == 2
+        assert node.task_ref is None
+        assert node.source_path is None
+
+    def test_task_ref_source(self) -> None:
+        node = DataNode(
+            id="dn",
+            task_ref="my.module:MyTask",
+            subgraph_entry="a",
+            subgraph_exit="b",
+        )
+        assert node.task_ref == "my.module:MyTask"
+
+    def test_source_path_source(self) -> None:
+        node = DataNode(
+            id="dn",
+            source_path="/data/items",
+            source_format="directory",
+            subgraph_entry="a",
+            subgraph_exit="b",
+        )
+        assert node.source_path == "/data/items"
+        assert node.source_format == "directory"
+
+    def test_no_source_raises(self) -> None:
+        with pytest.raises(ValidationError, match="Exactly one"):
+            DataNode(
+                id="dn",
+                subgraph_entry="a",
+                subgraph_exit="b",
+            )
+
+    def test_multiple_sources_raises(self) -> None:
+        with pytest.raises(ValidationError, match="Exactly one"):
+            DataNode(
+                id="dn",
+                task_ref="x",
+                inline_items=[DataItem(id="i")],
+                subgraph_entry="a",
+                subgraph_exit="b",
+            )
+
+    def test_source_path_requires_format(self) -> None:
+        with pytest.raises(ValidationError, match="source_format"):
+            DataNode(
+                id="dn",
+                source_path="/data/items",
+                subgraph_entry="a",
+                subgraph_exit="b",
+            )
+
+    def test_defaults(self) -> None:
+        node = DataNode(
+            id="dn",
+            inline_items=[DataItem(id="i")],
+            subgraph_entry="a",
+            subgraph_exit="b",
+        )
+        assert node.parallelism == 3
+        assert node.split == "all"
+        assert node.shuffle is False
+        assert node.limit is None
+        assert node.max_items == 500
+
+    def test_extra_field_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            DataNode(
+                id="dn",
+                inline_items=[DataItem(id="i")],
+                subgraph_entry="a",
+                subgraph_exit="b",
+                unknown="x",
+            )
+
+    def test_from_dict_roundtrip(self) -> None:
+        items = [DataItem(id="i1", prompt="do it")]
+        node = DataNode(
+            id="dn",
+            inline_items=items,
+            subgraph_entry="entry",
+            subgraph_exit="exit",
+            parallelism=5,
+            max_items=100,
+        )
+        wf = Workflow(
+            name="test",
+            nodes={
+                "dn": node,
+                "entry": FnNode(id="entry", command="echo entry"),
+                "exit": FnNode(id="exit", command="echo exit"),
+            },
+            edges=[
+                Edge(source="dn", target="entry"),
+                Edge(source="entry", target="exit"),
+            ],
+            start_node="dn",
+        )
+        data = wf.to_dict()
+        restored = Workflow.from_dict(data)
+        dn = restored.nodes["dn"]
+        assert type(dn).__name__ == "DataNode"
+        assert dn.parallelism == 5
+        assert dn.max_items == 100
+        assert len(dn.inline_items) == 1
+        assert dn.inline_items[0].id == "i1"
+
+
+# ── Phase 2: Executor _execute_data ──────────────────────────────
+
+
+def _make_data_workflow(items: list[DataItem]) -> Workflow:
+    """Build a minimal workflow with a DataNode driving a FnNode subgraph."""
+    return Workflow(
+        name="data_test",
+        nodes={
+            "data": DataNode(
+                id="data",
+                inline_items=items,
+                subgraph_entry="sub_start",
+                subgraph_exit="sub_end",
+                parallelism=2,
+            ),
+            "sub_start": FnNode(id="sub_start", command="echo start"),
+            "sub_end": FnNode(id="sub_end", command="echo end"),
+        },
+        edges=[
+            Edge(source="sub_start", target="sub_end"),
+        ],
+        start_node="data",
+    )
+
+
+class TestExecuteData:
+    def test_inline_items_execute(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [DataItem(id="a", prompt="do a"), DataItem(id="b", prompt="do b")]
+        wf = _make_data_workflow(items)
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+
+        assert result.success
+        assert "data" in result.node_outputs
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 2
+        assert parsed[0]["item_id"] == "a"
+        assert parsed[1]["item_id"] == "b"
+
+    def test_fault_isolation_one_bad_item(self, tmp_path: Path) -> None:
+        """A failing subgraph for one item should not halt the whole DataNode."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [DataItem(id="good"), DataItem(id="bad"), DataItem(id="also_good")]
+        wf = _make_data_workflow(items)
+
+        original_init = WorkflowExecutor.__init__
+
+        def tracking_init(self_inner, workflow, project_path, *args, **kwargs):
+            original_init(self_inner, workflow, project_path, *args, **kwargs)
+            ctx = kwargs.get("initial_context")
+            self_inner._test_initial_context = ctx
+
+        original_execute = WorkflowExecutor.execute
+
+        async def selective_execute(self_inner):
+            # Inner executors (sub-workflows) have _test_initial_context set
+            if hasattr(self_inner, "_test_initial_context") and self_inner.workflow.name.endswith("__data_item"):
+                # Find which item this is by checking if it's the 2nd call (bad)
+                if not hasattr(selective_execute, "_inner_count"):
+                    selective_execute._inner_count = 0
+                selective_execute._inner_count += 1
+                if selective_execute._inner_count == 2:
+                    raise RuntimeError("simulated failure")
+            return await original_execute(self_inner)
+
+        selective_execute._inner_count = 0
+
+        with patch.object(WorkflowExecutor, "__init__", tracking_init), \
+             patch.object(WorkflowExecutor, "execute", selective_execute):
+            executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+            result = asyncio.run(executor.execute())
+
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 3
+        bad_item = next(r for r in parsed if r["item_id"] == "bad")
+        assert bad_item["score"] == 0.0
+        assert "error" in bad_item
+        good_items = [r for r in parsed if r["item_id"] != "bad"]
+        assert all(r["success"] for r in good_items)
+
+    def test_max_items_exceeded_raises(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [DataItem(id=str(i)) for i in range(10)]
+        wf = Workflow(
+            name="data_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=items,
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                    max_items=5,
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.halted
+        assert "max_items=5" in result.halt_reason
+
+    def test_split_filter(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [
+            DataItem(id="train1", metadata={"split": "train"}),
+            DataItem(id="val1", metadata={"split": "val"}),
+            DataItem(id="train2", metadata={"split": "train"}),
+        ]
+        wf = Workflow(
+            name="data_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=items,
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                    split="train",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 2
+        assert all(r["item_id"].startswith("train") for r in parsed)
+
+    def test_limit_filter(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [DataItem(id=str(i)) for i in range(10)]
+        wf = Workflow(
+            name="data_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=items,
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                    limit=3,
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 3
+
+
+# ── Phase 3: Validation ─────────────────────────────────────────
+
+
+class TestDataNodeValidation:
+    def test_valid_data_node_workflow(self) -> None:
+        wf = _make_data_workflow([DataItem(id="i")])
+        issues = wf.validate_graph()
+        assert not issues
+
+    def test_missing_subgraph_entry(self) -> None:
+        wf = Workflow(
+            name="bad",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=[DataItem(id="i")],
+                    subgraph_entry="missing",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        issues = wf.validate_graph()
+        assert any("missing" in i and "entry" in i for i in issues)
+
+    def test_missing_subgraph_exit(self) -> None:
+        wf = Workflow(
+            name="bad",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=[DataItem(id="i")],
+                    subgraph_entry="sub",
+                    subgraph_exit="missing",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        issues = wf.validate_graph()
+        assert any("missing" in i and "exit" in i for i in issues)
+
+    def test_subgraph_nodes_reachable(self) -> None:
+        """Subgraph nodes behind a DataNode should not be flagged as unreachable."""
+        wf = _make_data_workflow([DataItem(id="i")])
+        issues = wf.validate_graph()
+        unreachable = [i for i in issues if "unreachable" in i]
+        assert not unreachable
+
+
+# ── Phase 4: Skill export ─────────────────────────────────────────
+
+
+class TestDataNodeSkillExport:
+    def test_data_node_renders(self) -> None:
+        from factory.workflow.skill_export import workflow_to_skill_md
+
+        wf = _make_data_workflow([DataItem(id="i")])
+        md = workflow_to_skill_md(wf)
+        assert "Data Iteration" in md
+        assert "inline items" in md
+        assert "fault isolation" in md.lower()
+
+    def test_subgraph_nodes_not_duplicated(self) -> None:
+        from factory.workflow.skill_export import workflow_to_skill_md
+
+        wf = _make_data_workflow([DataItem(id="i")])
+        md = workflow_to_skill_md(wf)
+        # sub_start and sub_end should NOT appear as top-level phases
+        assert "Sub Start" not in md or md.count("Sub Start") <= 1
+        assert "Sub End" not in md or md.count("Sub End") <= 1
+
+
+# ── Phase 6: compute_features arity ────────────────────────────────
+
+
+class TestComputeFeaturesDataNode:
+    def test_arity_is_9(self) -> None:
+        from factory.outer_loop.similarity import compute_features
+
+        wf = Workflow(
+            name="w",
+            nodes={"a": FnNode(id="a", command="x")},
+            edges=[],
+            start_node="a",
+        )
+        features = compute_features(wf)
+        assert len(features) == 9
+
+    def test_data_node_sets_feature(self) -> None:
+        from factory.outer_loop.similarity import compute_features
+
+        wf = _make_data_workflow([DataItem(id="i")])
+        features = compute_features(wf)
+        assert len(features) == 9
+        assert features[8] == 1  # has_data_node is the appended axis
+
+    def test_no_data_node_feature_is_zero(self) -> None:
+        from factory.outer_loop.similarity import compute_features
+
+        wf = Workflow(
+            name="w",
+            nodes={"a": FnNode(id="a", command="x")},
+            edges=[],
+            start_node="a",
+        )
+        features = compute_features(wf)
+        assert features[8] == 0
+
+
+class TestDiversityMetricNewAxis:
+    def test_diversity_responds_to_data_node_axis(self) -> None:
+        from factory.outer_loop.population import MAPElitesArchive, Population
+
+        wf_no_data = Workflow(
+            name="w",
+            nodes={"a": FnNode(id="a", command="x")},
+            edges=[],
+            start_node="a",
+        )
+        wf_with_data = _make_data_workflow([DataItem(id="i")])
+
+        ind1 = Population.make_individual(wf_no_data, score=0.5)
+        ind2 = Population.make_individual(wf_with_data, score=0.5)
+
+        archive = MAPElitesArchive()
+        archive.add(ind1)
+        d1 = archive.diversity_metric()
+
+        archive.add(ind2)
+        d2 = archive.diversity_metric()
+        # Adding a structurally different individual should change diversity
+        assert d2 != d1 or archive.size == 1
+
+
+# ── Phase 5: compose CAN_ITERATE ──────────────────────────────────
+
+
+class TestComposeCapsDataNode:
+    def test_data_node_adds_can_iterate(self) -> None:
+        from factory.compose import ModeCapabilities
+        from factory.task import Capability
+
+        wf = _make_data_workflow([DataItem(id="i")])
+        caps = ModeCapabilities.from_workflow(wf)
+        assert Capability.CAN_ITERATE in caps.provides

--- a/tests/test_data_node.py
+++ b/tests/test_data_node.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -709,3 +710,211 @@ class TestComposeCapsDataNode:
         wf = _make_data_workflow([DataItem(id="i")])
         caps = ModeCapabilities.from_workflow(wf)
         assert Capability.CAN_ITERATE in caps.provides
+
+
+# ── Phase 9: task_ref verify integration ──────────────────────────
+
+
+class _FakeTask:
+    """Minimal Task-like object for testing verify() integration."""
+
+    def __init__(self, instances_data: list[dict[str, Any]], verify_scores: dict[str, float]) -> None:
+        self._instances_data = instances_data
+        self._verify_scores = verify_scores
+        self.setup_calls: list[str] = []
+        self.prompt_calls: list[str] = []
+        self.verify_calls: list[str] = []
+
+    def instances(self):
+        from factory.task import TaskInstance
+        for d in self._instances_data:
+            yield TaskInstance(id=d["id"], path=d.get("path"), metadata=d.get("metadata", {}))
+
+    def setup(self, instance, workspace):
+        self.setup_calls.append(instance.id)
+
+    def prompt(self, instance):
+        self.prompt_calls.append(instance.id)
+        return f"prompt for {instance.id}"
+
+    def verify(self, instance, workspace):
+        from factory.task import VerifyResult
+        self.verify_calls.append(instance.id)
+        score = self._verify_scores.get(instance.id, 0.0)
+        return VerifyResult(passed=score > 0.5, score=score, details={"source": "fake"})
+
+
+def _make_task_ref_workflow(task_ref: str = "fake.module:FakeTask") -> Workflow:
+    """Build a minimal workflow with a task_ref DataNode."""
+    return Workflow(
+        name="task_ref_test",
+        nodes={
+            "data": DataNode(
+                id="data",
+                task_ref=task_ref,
+                subgraph_entry="sub_start",
+                subgraph_exit="sub_end",
+                parallelism=2,
+            ),
+            "sub_start": FnNode(id="sub_start", command="echo start"),
+            "sub_end": FnNode(id="sub_end", command="echo end"),
+        },
+        edges=[
+            Edge(source="sub_start", target="sub_end"),
+        ],
+        start_node="data",
+    )
+
+
+class TestTaskRefVerify:
+    def test_verify_called_per_item_and_scores_used(self, tmp_path: Path) -> None:
+        """task_ref DataNode must call verify() per item and use verify scores."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        fake_task = _FakeTask(
+            instances_data=[{"id": "inst_a"}, {"id": "inst_b"}],
+            verify_scores={"inst_a": 0.8, "inst_b": 0.3},
+        )
+
+        wf = _make_task_ref_workflow()
+
+        with patch("factory.task.TaskRef.resolve", return_value=fake_task):
+            executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+            result = asyncio.run(executor.execute())
+
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 2
+
+        item_a = next(r for r in parsed if r["item_id"] == "inst_a")
+        item_b = next(r for r in parsed if r["item_id"] == "inst_b")
+        assert item_a["score"] == 0.8
+        assert item_a["passed"] is True
+        assert item_b["score"] == 0.3
+        assert item_b["passed"] is False
+
+        assert "inst_a" in fake_task.verify_calls
+        assert "inst_b" in fake_task.verify_calls
+
+    def test_inline_items_no_verify(self, tmp_path: Path) -> None:
+        """inline_items DataNode must NOT call verify — uses subgraph-success scoring."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        items = [DataItem(id="x", prompt="go"), DataItem(id="y", prompt="go")]
+        wf = _make_data_workflow(items)
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert all(r["score"] == 1.0 for r in parsed)
+        assert all("verify_details" not in r or r["verify_details"] == {} for r in parsed)
+
+    def test_setup_prompt_called_per_item_in_run_item(self, tmp_path: Path) -> None:
+        """setup() and prompt() must be called per-item inside run_item, not eagerly."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        fake_task = _FakeTask(
+            instances_data=[{"id": "i1"}, {"id": "i2"}, {"id": "i3"}],
+            verify_scores={"i1": 1.0, "i2": 1.0, "i3": 1.0},
+        )
+
+        wf = _make_task_ref_workflow()
+
+        with patch("factory.task.TaskRef.resolve", return_value=fake_task):
+            executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+            result = asyncio.run(executor.execute())
+
+        assert result.success
+        assert sorted(fake_task.setup_calls) == ["i1", "i2", "i3"]
+        assert sorted(fake_task.prompt_calls) == ["i1", "i2", "i3"]
+        assert sorted(fake_task.verify_calls) == ["i1", "i2", "i3"]
+
+    def test_failing_setup_does_not_block_other_items(self, tmp_path: Path) -> None:
+        """A failing setup() for one item must not prevent other items from running."""
+        from factory.workflow.executor import WorkflowExecutor
+
+        fake_task = _FakeTask(
+            instances_data=[{"id": "ok1"}, {"id": "fail_setup"}, {"id": "ok2"}],
+            verify_scores={"ok1": 1.0, "ok2": 0.9},
+        )
+        original_setup = fake_task.setup
+
+        def failing_setup(instance, workspace):
+            if instance.id == "fail_setup":
+                raise RuntimeError("setup exploded")
+            original_setup(instance, workspace)
+
+        fake_task.setup = failing_setup
+
+        wf = _make_task_ref_workflow()
+
+        with patch("factory.task.TaskRef.resolve", return_value=fake_task):
+            executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+            result = asyncio.run(executor.execute())
+
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 3
+
+        failed = next(r for r in parsed if r["item_id"] == "fail_setup")
+        assert failed["score"] == 0.0
+        assert "error" in failed
+
+        ok_items = [r for r in parsed if r["item_id"] != "fail_setup"]
+        assert all(r["score"] > 0 for r in ok_items)
+
+
+class TestStepWithDataNodeVerifyScores:
+    def test_aggregates_verify_scores(self, tmp_path: Path) -> None:
+        """_step_with_data_node should aggregate per-item verify scores, not binary."""
+        from unittest.mock import AsyncMock
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = _make_task_ref_workflow()
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+        mock_result.node_outputs = {
+            "data": json.dumps([
+                {"item_id": "a", "score": 0.8, "success": True},
+                {"item_id": "b", "score": 0.4, "success": True},
+            ])
+        }
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop._step_with_data_node()
+
+        assert record.score_end == pytest.approx(0.6)
+
+    def test_falls_back_to_binary_without_scores(self, tmp_path: Path) -> None:
+        """Without per-item scores in output, falls back to exec_result.success."""
+        from unittest.mock import AsyncMock
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = _make_data_workflow([DataItem(id="i")])
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+        mock_result.node_outputs = {}
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop._step_with_data_node()
+
+        assert record.score_end == 1.0

--- a/tests/test_data_node.py
+++ b/tests/test_data_node.py
@@ -469,6 +469,161 @@ class TestDiversityMetricNewAxis:
 # ── Phase 5: compose CAN_ITERATE ──────────────────────────────────
 
 
+# ── Phase 7: source_path code paths ─────────────────────────────
+
+
+class TestSourcePathDirectory:
+    def test_directory_source(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        src_dir = tmp_path / "data"
+        src_dir.mkdir()
+        (src_dir / "alpha").mkdir()
+        (src_dir / "beta").mkdir()
+        (src_dir / "plain_file.txt").write_text("not a dir")
+
+        wf = Workflow(
+            name="dir_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(src_dir),
+                    source_format="directory",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        ids = [r["item_id"] for r in parsed]
+        assert "alpha" in ids
+        assert "beta" in ids
+        assert "plain_file.txt" not in ids
+
+
+class TestSourcePathJsonl:
+    def test_jsonl_source(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        jsonl_file = tmp_path / "items.jsonl"
+        jsonl_file.write_text('{"name": "first"}\n{"name": "second"}\n\n')
+
+        wf = Workflow(
+            name="jsonl_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(jsonl_file),
+                    source_format="jsonl",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 2
+        assert parsed[0]["item_id"] == "0"
+        assert parsed[1]["item_id"] == "1"
+
+
+class TestSourcePathCsv:
+    def test_csv_source(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        csv_file = tmp_path / "items.csv"
+        csv_file.write_text("id,value\na,1\nb,2\nc,3\n")
+
+        wf = Workflow(
+            name="csv_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(csv_file),
+                    source_format="csv",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 3
+        assert parsed[0]["item_id"] == "0"
+        assert parsed[1]["item_id"] == "1"
+        assert parsed[2]["item_id"] == "2"
+
+
+class TestSourcePathNonExistent:
+    def test_nonexistent_path_yields_empty(self, tmp_path: Path) -> None:
+        from factory.workflow.executor import WorkflowExecutor
+
+        wf = Workflow(
+            name="missing_test",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    source_path=str(tmp_path / "does_not_exist"),
+                    source_format="directory",
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[],
+            start_node="data",
+        )
+        executor = WorkflowExecutor(wf, tmp_path, dry_run=True)
+        result = asyncio.run(executor.execute())
+        assert result.success
+        parsed = json.loads(result.node_outputs["data"])
+        assert len(parsed) == 0
+
+
+# ── Phase 8: inner_loop _step_with_data_node ────────────────────
+
+
+class TestStepWithDataNode:
+    def test_delegates_to_executor(self, tmp_path: Path) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = _make_data_workflow([DataItem(id="i", prompt="go")])
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop._step_with_data_node()
+
+        assert record.score_end == 1.0
+        assert record.cycle_number == 1
+
+
 class TestComposeCapsDataNode:
     def test_data_node_adds_can_iterate(self) -> None:
         from factory.compose import ModeCapabilities

--- a/tests/test_inner_outer_loop.py
+++ b/tests/test_inner_outer_loop.py
@@ -830,3 +830,76 @@ class TestDataNodeIntegration:
         features = compute_features(wf)
         assert features[8] == 1
         assert loop._workflow_has_data_node() is True
+
+
+# ── DataNode compose() validation (PR #1483 fix 8) ───────────────
+
+
+class _ComposeTestTask:
+    """Task satisfying TaskProtocol for compose() tests."""
+
+    def __init__(self) -> None:
+        from factory.task import ScoringContract, TaskDefinition
+
+        self.definition = TaskDefinition(
+            name="mock", scoring=ScoringContract(method="exit_code"),
+        )
+        self.scoring = self.definition.scoring
+        self.constraints = None
+
+    def instances(self):
+        from factory.task import TaskInstance
+        return [TaskInstance(id="inst-1")]
+
+    def setup(self, instance, workspace):
+        pass
+
+    def prompt(self, instance):
+        return "test"
+
+    def verify(self, instance, workspace):
+        from factory.task import VerifyResult
+        return VerifyResult(passed=True, score=1.0)
+
+    def get_evaluator(self):
+        return None
+
+
+class TestComposeDataNodeWorkflowIntegration:
+    def test_compose_datanode_workflow_succeeds(self, tmp_path: Path) -> None:
+        """compose() does not raise IncompatibleCompositionError for DataNode workflows."""
+        from factory.compose import compose
+        from factory.workflow.primitives import (
+            AgentNode,
+            AgentRole,
+            DataItem,
+            DataNode,
+            Edge,
+            FnNode,
+        )
+
+        wf = Workflow(
+            name="eval_only",
+            nodes={
+                "gen": AgentNode(
+                    id="gen",
+                    role=AgentRole.RESEARCHER,
+                    prompt_template="research",
+                ),
+                "data": DataNode(
+                    id="data",
+                    inline_items=[DataItem(id="i1", prompt="test")],
+                    subgraph_entry="sub",
+                    subgraph_exit="sub",
+                ),
+                "sub": FnNode(id="sub", command="echo x"),
+            },
+            edges=[Edge(source="gen", target="data")],
+            start_node="gen",
+        )
+
+        task = _ComposeTestTask()
+
+        loop = compose(wf, task, tmp_path)
+        assert loop is not None
+        assert loop.workflow is wf

--- a/tests/test_inner_outer_loop.py
+++ b/tests/test_inner_outer_loop.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -30,6 +31,7 @@ from factory.models import (
 )
 from factory.research.runner import aggregate_metric
 from factory.store import ExperimentStore, _parse_inner_loop, _parse_outer_loop
+from factory.workflow.primitives import Workflow
 
 
 # ── Model validation ────────────────────────────────────────────
@@ -630,3 +632,201 @@ class TestDetectResearchPlateau:
 
         summaries = [{"metric_value": 0.5}]
         assert detect_research_plateau(summaries, threshold=0) is False
+
+
+# ── DataNode integration: Task → InnerLoop → WorkflowExecutor → outer loop ──
+
+
+class TestDataNodeIntegration:
+    """Integration tests proving the full DataNode pipeline works end-to-end:
+    Task → InnerLoop → WorkflowExecutor → DataNode → outer loop feature extraction.
+    """
+
+    @staticmethod
+    def _async_return(val: object) -> MagicMock:
+        async def _coro(*a: object, **kw: object) -> object:
+            return val
+        m = MagicMock(side_effect=_coro)
+        return m
+
+    @staticmethod
+    def _make_data_workflow() -> Workflow:
+        from factory.workflow.primitives import DataItem, DataNode, Edge, FnNode, Workflow
+
+        return Workflow(
+            name="data_integration",
+            nodes={
+                "data": DataNode(
+                    id="data",
+                    inline_items=[
+                        DataItem(id="item-1", prompt="solve 1"),
+                        DataItem(id="item-2", prompt="solve 2"),
+                    ],
+                    subgraph_entry="sub_start",
+                    subgraph_exit="sub_end",
+                    parallelism=1,
+                ),
+                "sub_start": FnNode(id="sub_start", command="echo start"),
+                "sub_end": FnNode(id="sub_end", command="echo end"),
+            },
+            edges=[
+                Edge(source="sub_start", target="sub_end"),
+            ],
+            start_node="data",
+        )
+
+    @staticmethod
+    def _make_plain_workflow() -> Workflow:
+        from factory.workflow.primitives import AgentNode, AgentRole, Workflow
+
+        return Workflow(
+            name="plain",
+            nodes={
+                "builder": AgentNode(
+                    id="builder",
+                    role=AgentRole.BUILDER,
+                    prompt_template="build {project_path}",
+                ),
+            },
+            edges=[],
+            start_node="builder",
+        )
+
+    @staticmethod
+    def _make_exec_result(success: bool = True) -> MagicMock:
+        r = MagicMock()
+        r.success = success
+        r.halted = not success
+        r.halt_reason = "" if success else "halted"
+        r.nodes_executed = 1
+        r.duration_ms = 100.0
+        return r
+
+    def test_data_node_routes_through_step_with_data_node(self, tmp_path: Path) -> None:
+        """DataNode workflow routes through InnerLoop._step_with_data_node()."""
+        from unittest.mock import AsyncMock, patch
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = self._make_data_workflow()
+        task = MagicMock()
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf, task=task)
+
+        assert loop._workflow_has_data_node() is True
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop.step()
+
+        assert record.score_end == 1.0
+        assert record.cycle_number == 1
+
+    def test_data_node_delegates_to_executor_not_per_instance(self, tmp_path: Path) -> None:
+        """DataNode workflow calls WorkflowExecutor.execute() once, not per instance."""
+        from unittest.mock import AsyncMock, patch
+
+        from factory.inner_loop import InnerLoop
+        from factory.workflow.executor import ExecutionResult
+
+        wf = self._make_data_workflow()
+        task = MagicMock()
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf, task=task)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ) as mock_execute:
+            loop.step()
+
+        mock_execute.assert_called_once()
+        task.instances.assert_not_called()
+        task.setup.assert_not_called()
+        task.verify.assert_not_called()
+
+    def test_no_data_node_uses_manual_per_instance_loop(self, tmp_path: Path) -> None:
+        """Without DataNode, InnerLoop uses the manual per-instance loop."""
+        from unittest.mock import patch
+
+        from factory.inner_loop import InnerLoop
+        from factory.task import ScoringContract, TaskDefinition, TaskInstance, VerifyResult
+
+        wf = self._make_plain_workflow()
+        task = MagicMock()
+        task.instances.return_value = [TaskInstance(id="inst-1")]
+        task.definition = TaskDefinition(name="mock", scoring=ScoringContract(method="exit_code"))
+        task.setup.return_value = None
+        task.prompt.return_value = "test prompt"
+        task.verify.return_value = VerifyResult(passed=True, score=0.75)
+
+        with patch("factory.workflow.executor.WorkflowExecutor") as MockExecutor:
+            mock_exec = MagicMock()
+            mock_exec.execute = self._async_return(self._make_exec_result())
+            MockExecutor.return_value = mock_exec
+
+            loop = InnerLoop(project_dir=tmp_path, mode="test", task=task, workflow=wf)
+            record = loop.step()
+
+        task.instances.assert_called_once()
+        task.setup.assert_called_once()
+        task.prompt.assert_called_once()
+        task.verify.assert_called_once()
+        assert record.score_end == pytest.approx(0.75)
+        assert record.instance_results is not None
+        assert len(record.instance_results) == 1
+
+    def test_compute_features_detects_data_node(self) -> None:
+        """compute_features returns has_data_node=1 at index 8 for DataNode workflows."""
+        from factory.outer_loop.similarity import compute_features
+
+        wf_with = self._make_data_workflow()
+        features_with = compute_features(wf_with)
+        assert len(features_with) == 9
+        assert features_with[8] == 1
+
+        wf_without = self._make_plain_workflow()
+        features_without = compute_features(wf_without)
+        assert len(features_without) == 9
+        assert features_without[8] == 0
+
+    def test_full_pipeline_data_node_through_inner_loop_with_features(self, tmp_path: Path) -> None:
+        """Full pipeline: DataNode workflow → InnerLoop.step() → CycleRecord + compute_features."""
+        from unittest.mock import AsyncMock, patch
+
+        from factory.inner_loop import InnerLoop
+        from factory.outer_loop.similarity import compute_features
+        from factory.workflow.executor import ExecutionResult
+
+        wf = self._make_data_workflow()
+        task = MagicMock()
+
+        mock_result = ExecutionResult()
+        mock_result.success = True
+
+        loop = InnerLoop(project_dir=tmp_path, workflow=wf, task=task)
+
+        with patch(
+            "factory.workflow.executor.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            record = loop.step()
+
+        assert record.score_end is not None
+        assert record.score_end == 1.0
+
+        features = compute_features(wf)
+        assert features[8] == 1
+        assert loop._workflow_has_data_node() is True

--- a/tests/test_outer_loop/test_mutations.py
+++ b/tests/test_outer_loop/test_mutations.py
@@ -935,3 +935,80 @@ class TestMutateParamsValidation:
             simple_workflow, "researcher", {"timeout": "not_a_number"}
         )
         assert result is None
+
+
+class TestAutoFrozenNodes:
+    """Tests for _auto_frozen_nodes and DataNode auto-freeze in engine."""
+
+    def test_auto_frozen_nodes_returns_data_node_ids(self) -> None:
+        from factory.outer_loop.engine import _auto_frozen_nodes
+        from factory.workflow.primitives import DataNode, DataItem
+
+        nodes: dict[str, AgentNode | FnNode | DataNode] = {
+            "data_loader": DataNode(
+                id="data_loader",
+                inline_items=[DataItem(id="item1", prompt="test")],
+                subgraph_entry="builder",
+                subgraph_exit="builder",
+            ),
+            "builder": AgentNode(id="builder", role=AgentRole.BUILDER),
+            "study": FnNode(id="study", command="echo hi"),
+        }
+        edges = [
+            Edge(source="study", target="data_loader"),
+            Edge(source="data_loader", target="builder"),
+        ]
+        wf = Workflow(name="with_data", nodes=nodes, edges=edges, start_node="study")
+        frozen = _auto_frozen_nodes(wf)
+        assert frozen == {"data_loader"}
+
+    def test_auto_frozen_nodes_empty_when_no_data_nodes(self) -> None:
+        from factory.outer_loop.engine import _auto_frozen_nodes
+
+        nodes: dict[str, AgentNode | FnNode] = {
+            "builder": AgentNode(id="builder", role=AgentRole.BUILDER),
+            "study": FnNode(id="study", command="echo hi"),
+        }
+        edges = [Edge(source="study", target="builder")]
+        wf = Workflow(name="no_data", nodes=nodes, edges=edges, start_node="study")
+        frozen = _auto_frozen_nodes(wf)
+        assert frozen == set()
+
+    def test_data_node_protected_from_direct_removal(self) -> None:
+        """Frozen DataNode cannot be directly removed or param-mutated."""
+        from factory.outer_loop.engine import _auto_frozen_nodes
+        from factory.workflow.primitives import DataNode, DataItem
+
+        nodes: dict[str, AgentNode | FnNode | DataNode] = {
+            "study": FnNode(
+                id="study",
+                command="factory study",
+                writes={".factory/strategy/observations.md"},
+            ),
+            "data_loader": DataNode(
+                id="data_loader",
+                inline_items=[DataItem(id="item1", prompt="test")],
+                subgraph_entry="builder",
+                subgraph_exit="builder",
+                reads={".factory/strategy/observations.md"},
+            ),
+            "builder": AgentNode(
+                id="builder",
+                role=AgentRole.BUILDER,
+                reads={".factory/strategy/observations.md"},
+                writes={".factory/reviews/builder-latest.md"},
+            ),
+        }
+        edges = [
+            Edge(source="study", target="data_loader"),
+            Edge(source="data_loader", target="builder"),
+        ]
+        wf = Workflow(name="data_test", nodes=nodes, edges=edges, start_node="study")
+
+        frozen = _auto_frozen_nodes(wf)
+        assert "data_loader" in frozen
+
+        assert remove_node(wf, "data_loader", frozen_nodes=frozen) is None
+        assert mutate_params(
+            wf, "data_loader", {"timeout": 999}, frozen_nodes=frozen,
+        ) is None

--- a/tests/test_outer_loop/test_population.py
+++ b/tests/test_outer_loop/test_population.py
@@ -62,7 +62,7 @@ class TestPopulation:
         ind = Population.make_individual(simple_workflow, generation=1, score=0.8)
         assert ind.generation == 1
         assert ind.score == 0.8
-        assert len(ind.features) == 8
+        assert len(ind.features) == 9
         assert ind.parent_id is None
 
     def test_serialization_round_trip(self, simple_workflow: Workflow, tmp_path: Path) -> None:

--- a/tests/test_outer_loop/test_similarity.py
+++ b/tests/test_outer_loop/test_similarity.py
@@ -98,7 +98,7 @@ class TestGraphEditDistance:
 class TestComputeFeatures:
     def test_simple_workflow(self, simple_workflow: Workflow) -> None:
         features = compute_features(simple_workflow)
-        assert len(features) == 8  # fixed-length: 4 base + edge + param + prompt + knob
+        assert len(features) == 9  # fixed-length: 4 base + edge + param + prompt + knob + has_data_node
         depth, fork_degree, agent_count, gate_count = features[:4]
         assert depth >= 4
         assert fork_degree == 0
@@ -127,7 +127,7 @@ class TestComputeFeatures:
         ]
         wf = Workflow(name="forked", nodes=nodes, edges=edges, start_node="start")
         features = compute_features(wf)
-        assert len(features) == 8  # same fixed length regardless of agent count
+        assert len(features) == 9  # same fixed length regardless of agent count
         depth, fork_degree, agent_count, gate_count = features[:4]
         assert fork_degree == 3
         assert agent_count == 3
@@ -143,7 +143,7 @@ class TestComputeFeatures:
             )
         f1 = compute_features(_make_wf("analyze the code"))
         f2 = compute_features(_make_wf("review the code for bugs"))
-        assert len(f1) == len(f2) == 8
+        assert len(f1) == len(f2) == 9
         assert f1 != f2  # different prompts → different features
 
     def test_no_agents_still_fixed_length(self) -> None:
@@ -154,7 +154,7 @@ class TestComputeFeatures:
             start_node="a",
         )
         features = compute_features(wf)
-        assert len(features) == 8
+        assert len(features) == 9
 
 
 class TestNoveltyFilter:


### PR DESCRIPTION
Closes #1482

## What and why

Workflows have no way to declare "load data and iterate it." Today, per-instance iteration lives as a side-channel Python `for` loop in `InnerLoop._step_with_task()` — invisible to the executor, skill exports, and the outer loop's evolutionary search. This PR adds `DataNode`, a first-class graph primitive that makes data loading a structural element of the workflow DAG.

**Before:** InnerLoop calls `task.instances()` in a manual loop the executor can't see:
```
InnerLoop (Python for-loop, invisible to executor):
    for problem in task.instances():
        executor.execute(workflow)  ← executor has no idea it's in a loop
```

**After:** The executor owns the iteration via DataNode:
```
DataNode (loads items, visible in graph)
    └─ subgraph: study → build → qa → eval  (full workflow per item)
→ JoinNode (aggregate)
```

This means: the executor can parallelize items (`Semaphore`-throttled), fault-isolate per item (one failure → score 0.0, others continue), render iteration in SKILL.md playbooks, and expose data-loading to the outer loop's MAP-Elites search.

## How it works

`DataNode` has three data sources — use exactly one:

| Source | What it does |
|--------|-------------|
| `inline_items` | Hardcoded DataItems in the workflow definition |
| `source_path` | Points at a directory, JSONL, or CSV file |
| `task_ref` | Resolves a Task class, calls `task.instances()` → DataItems |

When the executor reaches a DataNode, it:
1. Resolves the source → `list[DataItem]`
2. Applies `split` / `shuffle` / `limit` filters
3. Validates item count against `max_items` safety ceiling (default 500)
4. Extracts the subgraph (`subgraph_entry` → `subgraph_exit`)
5. Runs the subgraph once per item, throttled by `asyncio.Semaphore(parallelism)`
6. Each item is fault-isolated: exception → `{score: 0.0, error: ...}`, doesn't halt others
7. Aggregates per-item results as JSON at the DataNode level
8. Writes `current_item.json` before each subgraph run for item visibility (cleaned up after)

DataNode works **anywhere the executor runs** — headless mode, skill export, InnerLoop delegation, standalone. It doesn't require InnerLoop or a Task; `inline_items` and `source_path` work without either.

## Architecture

DataNode is modeled on `SubgraphForkNode` (runtime-resolved cardinality), not `ForkNode` (static targets). It shares the same `subgraph_entry` / `subgraph_exit` / `parallelism` shape and reuses `_collect_subgraph_nodes()` + `Workflow.subgraph()`.

```
                    ┌─────────────────────────────────────────┐
                    │              DataNode                    │
                    │                                         │
                    │  source: task_ref / source_path / inline │
                    │  filters: split, shuffle, limit          │
                    │  safety: max_items (default 500)         │
                    │  concurrency: parallelism (default 1)    │
                    │                                         │
                    │  ┌─────────────────────────────────────┐ │
                    │  │  subgraph (per item)                │ │
                    │  │  entry → node → ... → exit          │ │
                    │  └─────────────────────────────────────┘ │
                    └─────────────────────────────────────────┘
                                      │
                                      ▼
                                  next node
```

## Changes by layer

**Layer 2 — Workflow engine (the core):**
- `primitives.py` — `DataItem(BaseModel)` + `DataNode(Node)` with Verdict-style `model_validator` for exactly-one-source, `NodeType` union extended, `_NODE_TYPE_MAP` updated
- `executor.py` — `_execute_data()` with Semaphore-throttled concurrent per-item execution, per-item fault isolation, per-item worktree isolation (parallelism>1), current_item.json contract, sub-executor inherits parent's `completed_files` so subgraph reads don't timeout
- `validation.py` — Both `_validate_fork_join_nodes()` and `_validate_reachability()` updated + `_validate_datanode_edges()` rejects explicit DataNode→subgraph edges
- `skill_export.py` — DataNode rendering branch + subgraph skip-set + trailing `else` warning for unmatched types

**Layer 2b — Outer loop:**
- `similarity.py` — Appended `has_data_node` feature axis (9-tuple, not inserted — existing indices stable)
- `population.py` — `diversity_metric()` generalized from hardcoded `range(4)` to dynamic axis count
- `engine.py` — `_auto_frozen_nodes()` auto-includes DataNode IDs in `frozen_node_ids` so mutations can't remove them

**Layer 3 — InnerLoop glue:**
- `inner_loop.py` — Cached `_workflow_has_data_node()` check, `_step_with_data_node()` delegation with direct DataNode ID score lookup + `instance_results` populated on CycleRecord
- `compose.py` — `DataNode` → `CAN_ITERATE` capability; DataNode workflows skip build-pipeline capability requirements (HAS_BUILDER, CAN_RUN_TESTS, CAN_MODIFY_CODE)

## What's NOT in this PR

- `task.verify()` inside the graph (deferred `EvalNode` concept) — verify stays in InnerLoop for now
- `--mode create` auto-inserting DataNode at graph root
- Migrating existing workflows to DataNode (nothing to migrate — `Workflow.task` is unused)
- Streaming/lazy iteration — materialized list for now
- TaskInstance/DataItem unification — mapping layer is 3 lines, revisit if it becomes friction

### Spec deviations from issue #1482

- `source_format` is `Literal['directory'|'jsonl'|'csv']`, not `'auto'` with auto-detection (simpler, explicit)
- No glob support in `source_path` (direct path only)
- `DataItem.input` became `DataItem.metadata` (dict instead of string)
- `task_ref` wiring done per-item in executor, not via node params (reviewer agreed this is better)
- `parallelism` default changed from 3 to 1 (safe default; `parallelism>1` uses per-item worktrees for isolation)
- `shuffle_seed` field added for reproducibility (unseeded shuffle derives seed from `node_id:run_id`)
- `current_item.json` contract added for subgraph item visibility (written before each subgraph run, cleaned up after)

## Test plan

- [x] 55 DataNode-specific tests (`tests/test_data_node.py`) — models, executor, fault isolation, source_path (directory/jsonl/csv), validation, skill export, features, completed_files inheritance, parallelism default, seeded shuffle, JSONL error isolation, current_item.json, direct score lookup, instance_results, compose validation
- [x] 6 integration tests (`tests/test_inner_outer_loop.py`) — full Task→InnerLoop→Executor→outer loop pipeline + compose DataNode workflow
- [x] 3 mutation tests (`tests/test_outer_loop/test_mutations.py`) — auto-freeze DataNode IDs
- [x] 19/19 `test_inner_loop_task.py` pass unmodified (backward compat)
- [x] 41/41 outer loop tests pass (similarity + population assertions updated)
- [x] `ruff check` clean

**Note:** Existing outer-loop checkpoints (`grid.json`/`population.json`) are incompatible across this change due to the 9-tuple feature vector. Mid-flight outer-loop runs should not resume across it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
