### PR TITLE
workflow: let a gate name its own forward outcomes

### DIFF
--- a/factory/workflow/package.py
+++ b/factory/workflow/package.py
@@ -373,7 +373,13 @@ def Conditional(
     *,
     name: str = "",
 ) -> Package:
-    """Route to one of several packages based on a gate verdict."""
+    """Route to one of several packages based on a gate verdict.
+
+    A branch label is normally a ``VerdictType`` name (``PROCEED`` / ``HALT`` /
+    ``RELOOP``), but any label is accepted: the gate's evaluator may name its own
+    outcomes (``"DRAFT"``, ``"IMPROVE"``, ``"DEBUG"``), which become the edge's
+    ``condition`` in lowercase. Consumers match conditions case-insensitively.
+    """
     composed_name = name or "cond_" + "_".join(branches.keys())
     pkg_list = list(branches.values())
 
@@ -383,7 +389,7 @@ def Conditional(
     all_nodes: dict[str, NodeType] = {gate.id: gate, exit_id: exit_node}
     all_edges: list[Edge] = []
 
-    condition_map = {
+    condition_map: dict[str, str] = {
         "PROCEED": VerdictType.PROCEED,
         "HALT": VerdictType.HALT,
         "RELOOP": VerdictType.RELOOP,
@@ -394,12 +400,7 @@ def Conditional(
             all_nodes[nid] = node
         all_edges.extend(pkg.graph.edges)
 
-        condition = condition_map.get(label)
-        if condition is None:
-            raise ValueError(
-                f"Unknown branch label '{label}' in Conditional. "
-                f"Valid labels: {list(condition_map.keys())}"
-            )
+        condition = condition_map.get(label, label.lower())
         all_edges.append(Edge(source=gate.id, target=pkg.entry_node, condition=condition))
         all_edges.append(Edge(source=pkg.exit_node, target=exit_id))
 

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -158,6 +158,8 @@ class GateNode(Node):
     evaluator_role: AgentRole | None = None
     evaluator_command: str | None = None
     gate_prompt: str = ""
+    max_iterations: int | None = None
+    """Cap for this gate's reloop edge. ``None`` leaves the cap to the runtime."""
 
 
 class ForkNode(Node):
@@ -244,13 +246,19 @@ class LLMNode(Node):
 
 
 class Edge(BaseModel):
-    """Directed edge in the workflow graph with optional verdict condition."""
+    """Directed edge in the workflow graph with an optional labelled condition.
+
+    ``condition`` is normally one of the three ``VerdictType`` labels, but a gate
+    may name its own forward outcomes (a switch rather than a binary decision).
+    Arbitrary labels are stored verbatim and lowercased by consumers before
+    matching, so ``"DRAFT"`` from an evaluator matches ``condition="draft"``.
+    """
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
     source: str
     target: str
-    condition: VerdictType | None = None
+    condition: VerdictType | str | None = None
 
 
 # ── workflow ─────────────────────────────────────────────────────

--- a/tests/test_package_ecosystem.py
+++ b/tests/test_package_ecosystem.py
@@ -619,22 +619,23 @@ class TestB6DeterministicHash:
         assert f1 == f2
 
 
-class TestB8ConditionalUnknownLabel:
-    """B8: Conditional must reject unknown branch labels."""
+class TestB8ConditionalBranchLabels:
+    """B8: Conditional accepts verdict labels and gate-named outcome labels."""
 
-    def test_unknown_label_raises(self):
-        gate = GateNode(id="g", evaluator_type="fn", evaluator_command="echo PROCEED")
+    def test_named_label_becomes_lowercase_condition(self):
+        gate = GateNode(id="g", evaluator_type="fn", evaluator_command="echo DRAFT")
         a = _make_simple_package("a")
-        import pytest
-        with pytest.raises(ValueError, match="Unknown branch label"):
-            Conditional(gate, {"TYPO": a})
+        result = Conditional(gate, {"DRAFT": a})
+        conditions = {e.condition for e in result.graph.edges if e.source == "g"}
+        assert conditions == {"draft"}
 
     def test_valid_labels_accepted(self):
         gate = GateNode(id="g", evaluator_type="fn", evaluator_command="echo PROCEED")
         a = _make_simple_package("a")
         b = _make_simple_package("b")
         result = Conditional(gate, {"PROCEED": a, "HALT": b})
-        assert result is not None
+        conditions = {e.condition for e in result.graph.edges if e.source == "g"}
+        assert conditions == {"proceed", "halt"}
 
 
 class TestConditionalKnobPropagation:


### PR DESCRIPTION
## Problem

A `GateNode` could route only `proceed` / `reloop` / `halt`, so a graph whose gate selects among alternative **forward** continuations — e.g. AIDE's `draft`/`improve`/`debug`, GEPA's `mutate`/`merge`, AdaEvolve's `normal`/`meta` — had to spell one branch `reloop`. But `reloop` means *rewind* to every consumer: an executor un-completes the nodes between the target and the gate and counts against an iteration cap. A forward branch routed that way misbehaves.

## Change

- `Edge.condition` is now a free label (`VerdictType | str | None`), matched case-insensitively by consumers. The three verdict labels are unchanged, so existing graphs and executors behave identically.
- `Conditional()` accepts any branch label: a non-verdict label becomes the edge's lowercase `condition` instead of raising `ValueError`.
- `GateNode.max_iterations` lets a gate carry its own reloop cap through the graph, so a budget-gated loop is not silently bounded by a runtime's default (previously the value lived only on the composition and never reached the serialized graph).

## Backward compatibility

`VerdictType` is a `str` enum, so `edge.condition == VerdictType.PROCEED` still holds for the existing labels, and `to_dict()` emits the same `"proceed"`/`"reloop"`/`"halt"` strings as before.

## Verification

- `tests/test_package_ecosystem.py::TestB8ConditionalBranchLabels` now asserts the new contract (named label → lowercase condition; verdict labels preserved).
- 205 workflow/package tests pass (`test_workflow_primitives`, `test_package_ecosystem`, `test_workflow_definitions`, `test_workflow_executor`, `test_workflow_packages`).
