### PR TITLE
workflow: make Workflow.to_dict() deterministic; add OptKnob.description

### DIFF
--- a/factory/workflow/package.py
+++ b/factory/workflow/package.py
@@ -58,6 +58,7 @@ class OptKnob(BaseModel):
     the initial ``bounds``.  For prompt knobs this means authoring new
     prompt text; for threshold knobs it means extrapolating the range.
     ``expansion_hint`` tells the optimizer how to generate new values.
+    ``description`` is prose for humans and carries no optimizer meaning.
     """
 
     model_config = ConfigDict(strict=True, extra="forbid")
@@ -69,6 +70,7 @@ class OptKnob(BaseModel):
     bounds: list[str | float] = Field(default_factory=list)
     expandable: bool = False
     expansion_hint: str = ""
+    description: str = ""
 
 
 class MemoryDeclaration(BaseModel):

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -312,10 +312,19 @@ class Workflow(BaseModel):
         return Workflow(name=name, nodes=nodes, edges=edges, start_node=start_node)
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize the workflow to a JSON-safe dict."""
+        """Serialize the workflow to a JSON-safe dict.
+
+        ``reads`` and ``writes`` are sets, whose iteration order is not stable
+        across processes; they are sorted here so that a given graph always
+        serializes to identical bytes.
+        """
         nodes_out: dict[str, Any] = {}
         for nid, node in self.nodes.items():
             d = node.model_dump(mode="json")
+            for field_name in ("reads", "writes"):
+                value = d.get(field_name)
+                if isinstance(value, list):
+                    d[field_name] = sorted(value)
             d["_type"] = type(node).__name__
             nodes_out[nid] = d
 

--- a/tests/test_workflow_primitives.py
+++ b/tests/test_workflow_primitives.py
@@ -218,6 +218,20 @@ class TestWorkflow:
         issues = wf.validate_graph()
         assert issues == []
 
+    def test_to_dict_is_byte_stable(self) -> None:
+        """reads/writes are sets; their serialization order must not drift."""
+        wf = self._simple_workflow()
+        assert wf.to_dict() == Workflow.from_dict(wf.to_dict()).to_dict()
+        assert wf.to_dict()["nodes"]["b"]["writes"] == ["b.txt"]
+        assert wf.to_dict()["nodes"]["a"]["reads"] == []
+
+    def test_to_dict_round_trips_via_json(self) -> None:
+        import json
+
+        wf = self._simple_workflow()
+        reloaded = Workflow.from_dict(json.loads(json.dumps(wf.to_dict())))
+        assert reloaded.to_dict() == wf.to_dict()
+
     def test_unreachable_node(self) -> None:
         wf = Workflow(
             name="test",


### PR DESCRIPTION
## Problem

`Workflow.to_dict()` serialized a node's `reads`/`writes` — Python `set`s — in set-iteration order, which is not stable across processes. The same graph could therefore emit different bytes on different runs. For a wire format (`graph.json`) that consumers diff, hash, and compare, that makes the IR unreproducible.

Separately, `OptKnob` had no place to carry a human-readable note about what a knob does.

## Change

- `to_dict()` sorts `reads`/`writes` before serializing, so a given workflow always produces identical bytes.
- `OptKnob.description` (`str = ""`) carries prose for humans; it has no optimizer meaning and is backward-compatible (defaults to empty).

## Verification

- `tests/test_workflow_primitives.py::TestWorkflow::test_to_dict_is_byte_stable` and `test_to_dict_round_trips_via_json` pin the behavior.
- The byte-stability test passes across `PYTHONHASHSEED` 1/2/3/7.
- 68 primitive + package tests pass.
