### PR TITLE
feat: first-class plugin workflow registration

### DIFF
--- a/factory/skill_cache.py
+++ b/factory/skill_cache.py
@@ -27,16 +27,33 @@ def _sort_recursive(obj: object) -> Any:
     return obj
 
 
-def _compute_checksum(workflows: dict[str, Workflow]) -> str:
-    """Deterministic checksum from workflow Pydantic models.
+def _compute_checksum(
+    workflows: dict[str, Workflow],
+    source_files: dict[str, str] | None = None,
+) -> str:
+    """Deterministic checksum from workflow Pydantic models + source files.
 
     Serialises all workflows via model_dump(mode='json'), sorts by name,
     then SHA-256 hashes the canonical JSON.  Returns the first 16 hex chars.
+
+    When *source_files* maps workflow name → path of the .py file it was
+    discovered from, the SHA-256 of each file's bytes is folded into the
+    checksum.  This makes the cache key cover everything the skill export
+    reads: the exported SKILL.md depends on entry-level data (e.g. the
+    ``meta`` description) that is not a field on the Workflow model, so
+    hashing models alone can serve stale skills after a file edit.
     """
     payload = {name: wf.model_dump(mode="json") for name, wf in sorted(workflows.items())}
     payload = _sort_recursive(payload)
     blob = json.dumps(payload, sort_keys=True).encode()
-    return hashlib.sha256(blob).hexdigest()[:16]
+    h = hashlib.sha256(blob)
+    for name, path_str in sorted((source_files or {}).items()):
+        try:
+            h.update(name.encode())
+            h.update(Path(path_str).read_bytes())
+        except OSError as exc:
+            log.debug("skill_cache.checksum_read_failed", path=path_str, error=str(exc))
+    return h.hexdigest()[:16]
 
 
 def ensure_skills(project_dir: Path, *, mode: str | None = None) -> list[Path]:
@@ -64,6 +81,7 @@ def _ensure_skills_inner(project_dir: Path, *, mode: str | None = None) -> list[
 
     builtin_workflows: dict[str, Workflow] = {}
     project_workflows: dict[str, Workflow] = {}
+    source_files: dict[str, str] = {}
 
     for name, entry in entries.items():
         wf = WorkflowRegistry.get_workflow(name, project_dir)
@@ -73,10 +91,12 @@ def _ensure_skills_inner(project_dir: Path, *, mode: str | None = None) -> list[
             project_workflows[name] = wf
         else:
             builtin_workflows[name] = wf
+            if entry.path != "<builtin>":
+                source_files[name] = entry.path
 
     log.info("skill_cache.project_workflows_discovered", count=len(project_workflows))
 
-    checksum = _compute_checksum(builtin_workflows)
+    checksum = _compute_checksum(builtin_workflows, source_files)
 
     cache_dir = Path.home() / ".factory" / "cache" / "skills" / checksum
     skills_target = project_dir / "skills"

--- a/factory/workflow/registry.py
+++ b/factory/workflow/registry.py
@@ -130,8 +130,44 @@ class WorkflowRegistry:
             if project_wf_dir.is_dir():
                 cls._discover_in_directory(str(project_wf_dir), "project")
 
+        cls._warn_mode_drift()
+
         log.info("workflow_registry.discovered", count=len(cls._entries))
         return cls._entries
+
+    @classmethod
+    def _warn_mode_drift(cls) -> None:
+        """Log consistency warnings between plugin modes and discovered workflows.
+
+        A plugin mode with no discovered workflow of the same name usually means
+        a typo or a renamed file — without a warning it surfaces only as a
+        silent fallback to the default improve loop. A plugin workflow that is
+        not declared as a mode is legal (subgraph libraries, composed
+        packages), so that direction is info-level only.
+        """
+        try:
+            from factory.plugins import get_registry
+
+            plugin_modes = set(get_registry().modes)
+        except Exception as exc:
+            log.debug("workflow_registry.plugin_modes_unavailable", error=str(exc))
+            return
+        if not plugin_modes:
+            return
+
+        for mode in sorted(plugin_modes):
+            if mode not in cls._entries:
+                log.warning(
+                    "workflow_registry.mode_without_workflow",
+                    mode=mode,
+                    action="ceo_falls_back_to_improve_loop",
+                )
+        for name, entry in cls._entries.items():
+            if entry.source == "plugin" and name not in plugin_modes:
+                log.info(
+                    "workflow_registry.plugin_workflow_not_a_mode",
+                    name=name,
+                )
 
     @classmethod
     def _plugin_search_paths(cls) -> list[str]:

--- a/factory/workflow/registry.py
+++ b/factory/workflow/registry.py
@@ -22,6 +22,21 @@ from factory.workflow.primitives import Workflow
 
 log = structlog.get_logger()
 
+# Discovery priority per source label. Higher rank wins when two sources
+# provide a workflow with the same name. Unknown labels (e.g. a plugin
+# appending to WorkflowRegistry._search_paths directly) rank as "plugin".
+_SOURCE_PRIORITY: dict[str, int] = {
+    "builtin": 0,
+    "user": 1,
+    "plugin": 2,
+    "project": 3,
+}
+
+
+def _source_priority(source: str) -> int:
+    """Rank of a source label. Higher wins a name collision."""
+    return _SOURCE_PRIORITY.get(source, _SOURCE_PRIORITY["plugin"])
+
 
 @dataclass
 class WorkflowEntry:
@@ -30,7 +45,7 @@ class WorkflowEntry:
     name: str
     description: str
     path: str
-    source: str  # "builtin", "user", "project"
+    source: str  # "builtin", "user", "plugin", "project"
     _workflow_fn: Any = field(default=None, repr=False)
 
 
@@ -71,6 +86,13 @@ class WorkflowRegistry:
     def discover(cls, project_path: Path | None = None) -> dict[str, WorkflowEntry]:
         """Discover all workflows from search paths + built-ins.
 
+        Priority (highest wins on a name collision):
+          1. Project-local (.factory/workflows/ in *project_path*)
+          2. Plugin-registered paths (PluginRegistry.workflow_search_paths,
+             plus any paths on WorkflowRegistry._search_paths)
+          3. User-global (~/.factory/workflows/)
+          4. Built-in workflows (definitions.py)
+
         Parameters
         ----------
         project_path : Path, optional
@@ -79,32 +101,48 @@ class WorkflowRegistry:
         Returns
         -------
         dict[str, WorkflowEntry]
-            Name → entry mapping. Project shadows user shadows built-in.
+            Name → entry mapping, resolved per the priority above.
         """
         cls._ensure_initialized()
         cls._entries.clear()
 
-        # Layer 1: built-in workflows (lowest priority)
+        # Built-in workflows (lowest priority)
         cls._load_builtins()
 
-        # Layer 2: user-global workflows
+        # User-global workflows
         for search_path, source in cls._search_paths:
             if source == "user":
                 cls._discover_in_directory(search_path, source)
 
-        # Layer 3: project-local workflows (highest priority)
+        # Plugin-registered paths: consumed natively from PluginRegistry so
+        # plugins never need to touch WorkflowRegistry._search_paths.
+        for plugin_path in cls._plugin_search_paths():
+            cls._discover_in_directory(plugin_path, "plugin")
+
+        # Legacy/direct registrations on _search_paths (non-user labels)
+        for search_path, source in cls._search_paths:
+            if source not in ("user",):
+                cls._discover_in_directory(search_path, source)
+
+        # Project-local workflows (highest priority)
         if project_path:
             project_wf_dir = project_path / ".factory" / "workflows"
             if project_wf_dir.is_dir():
                 cls._discover_in_directory(str(project_wf_dir), "project")
 
-        # Layer 4: any explicitly registered paths
-        for search_path, source in cls._search_paths:
-            if source not in ("user",):
-                cls._discover_in_directory(search_path, source)
-
         log.info("workflow_registry.discovered", count=len(cls._entries))
         return cls._entries
+
+    @classmethod
+    def _plugin_search_paths(cls) -> list[str]:
+        """Workflow search paths registered by loaded plugins, if any."""
+        try:
+            from factory.plugins import get_registry
+
+            return list(get_registry().workflow_search_paths)
+        except Exception as exc:
+            log.debug("workflow_registry.plugin_paths_unavailable", error=str(exc))
+            return []
 
     @classmethod
     def register_callable(
@@ -161,8 +199,18 @@ class WorkflowRegistry:
             try:
                 meta, workflow_fn = _load_workflow_file(py_file)
                 name = meta["name"]
+                priority = _source_priority(source)
                 prev = cls._entries.get(name)
-                if prev and prev.source != "builtin":
+                if prev is not None:
+                    if priority <= _source_priority(prev.source):
+                        # Lower-priority source cannot shadow a higher one.
+                        log.info(
+                            "workflow_registry.shadow_skipped",
+                            name=name,
+                            new_source=source,
+                            kept_source=prev.source,
+                        )
+                        continue
                     log.warning(
                         "workflow_registry.shadow",
                         name=name,

--- a/tests/test_workflow_registry_plugins.py
+++ b/tests/test_workflow_registry_plugins.py
@@ -1,0 +1,357 @@
+"""Tests for plugin workflow registration (issue #1490).
+
+Covers:
+- WorkflowRegistry.discover() consumes PluginRegistry.workflow_search_paths natively
+- Discovery priority: project > plugin > user > builtin, enforced by guarded overwrites
+- Shadow events are logged for every source, including over builtins
+- skill_cache checksum invalidates when a discovered workflow .py file changes
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from factory.plugins import PluginRegistry
+from factory.skill_cache import _compute_checksum
+from factory.workflow.primitives import Workflow
+from factory.workflow.registry import WorkflowRegistry
+
+
+WORKFLOW_FILE = (
+    "from factory.workflow.definitions import design_workflow\n"
+    "\n"
+    'meta = {{"name": "{name}", "description": "{desc}"}}\n'
+    "\n"
+    "def workflow():\n"
+    "    wf = design_workflow()\n"
+    '    wf.name = "{name}"\n'
+    "    return wf\n"
+)
+
+
+def _write_workflow(directory: Path, name: str, desc: str = "test workflow") -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{name}.py"
+    path.write_text(WORKFLOW_FILE.format(name=name, desc=desc))
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Reset registry state before and after each test."""
+    WorkflowRegistry.reset()
+    yield
+    WorkflowRegistry.reset()
+
+
+@pytest.fixture(autouse=True)
+def _no_real_plugins():
+    """Isolate discovery from plugins installed in the environment."""
+    empty = PluginRegistry()
+    with patch("factory.plugins.get_registry", return_value=empty):
+        yield
+
+
+# ── Native plugin path consumption ───────────────────────────────
+
+
+class TestPluginPathConsumption:
+    def test_plugin_search_paths_discovered(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "my_plugin" / "workflows"
+        _write_workflow(plugin_dir, "plugin-mode")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            entries = WorkflowRegistry.discover()
+
+        assert "plugin-mode" in entries
+        assert entries["plugin-mode"].source == "plugin"
+
+    def test_no_bridge_to_search_paths_needed(self, tmp_path: Path) -> None:
+        """Plugin paths work without touching WorkflowRegistry._search_paths."""
+        plugin_dir = tmp_path / "my_plugin" / "workflows"
+        _write_workflow(plugin_dir, "no-bridge")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            entries = WorkflowRegistry.discover()
+
+        assert entries["no-bridge"].source == "plugin"
+        # The plugin path was never appended to _search_paths
+        plugin_paths = {p for p, _ in WorkflowRegistry._search_paths}
+        assert str(plugin_dir) not in plugin_paths
+
+    def test_plugin_registry_failure_is_non_fatal(self) -> None:
+        """If PluginRegistry is unavailable, discovery still returns builtins."""
+        with patch(
+            "factory.plugins.get_registry",
+            side_effect=RuntimeError("plugins unavailable"),
+        ):
+            entries = WorkflowRegistry.discover()
+
+        assert "design" in entries
+
+
+# ── Discovery priority ───────────────────────────────────────────
+
+
+class TestDiscoveryPriority:
+    def test_project_shadows_plugin(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "plugin_wf"
+        project_dir = tmp_path / "project" / ".factory" / "workflows"
+        _write_workflow(plugin_dir, "shared-name", "plugin version")
+        _write_workflow(project_dir, "shared-name", "project version")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            entries = WorkflowRegistry.discover(project_path=tmp_path / "project")
+
+        assert entries["shared-name"].source == "project"
+        assert "project version" in entries["shared-name"].description
+
+    def test_plugin_shadows_user(self, tmp_path: Path) -> None:
+        user_dir = tmp_path / "user_wf"
+        plugin_dir = tmp_path / "plugin_wf"
+        _write_workflow(user_dir, "shared-name", "user version")
+        _write_workflow(plugin_dir, "shared-name", "plugin version")
+
+        WorkflowRegistry._search_paths.append((str(user_dir), "user"))
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            entries = WorkflowRegistry.discover()
+
+        assert entries["shared-name"].source == "plugin"
+
+    def test_user_shadows_builtin(self, tmp_path: Path) -> None:
+        user_dir = tmp_path / "user_wf"
+        _write_workflow(user_dir, "design", "user override of builtin")
+
+        WorkflowRegistry._search_paths.append((str(user_dir), "user"))
+
+        entries = WorkflowRegistry.discover()
+
+        assert entries["design"].source == "user"
+
+    def test_plugin_shadows_builtin_with_warning(self, tmp_path: Path) -> None:
+        plugin_dir = tmp_path / "plugin_wf"
+        _write_workflow(plugin_dir, "design", "plugin override of builtin")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            entries = WorkflowRegistry.discover()
+
+        assert entries["design"].source == "plugin"
+
+    def test_project_shadows_builtin(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "project" / ".factory" / "workflows"
+        _write_workflow(project_dir, "design", "project override of builtin")
+
+        entries = WorkflowRegistry.discover(project_path=tmp_path / "project")
+
+        assert entries["design"].source == "project"
+
+    def test_legacy_search_paths_entry_still_discovered(self, tmp_path: Path) -> None:
+        """Paths registered directly on _search_paths keep working (back-compat)."""
+        legacy_dir = tmp_path / "legacy_wf"
+        _write_workflow(legacy_dir, "legacy-mode")
+
+        WorkflowRegistry._search_paths.append((str(legacy_dir), "lightwell"))
+
+        entries = WorkflowRegistry.discover()
+
+        assert "legacy-mode" in entries
+        assert entries["legacy-mode"].source == "lightwell"
+
+    def test_legacy_search_path_does_not_shadow_project(
+        self, tmp_path: Path
+    ) -> None:
+        """The pre-#1490 bug: registered paths overrode project-local."""
+        legacy_dir = tmp_path / "legacy_wf"
+        project_dir = tmp_path / "project" / ".factory" / "workflows"
+        _write_workflow(legacy_dir, "shared-name", "legacy version")
+        _write_workflow(project_dir, "shared-name", "project version")
+
+        WorkflowRegistry._search_paths.append((str(legacy_dir), "lightwell"))
+
+        entries = WorkflowRegistry.discover(project_path=tmp_path / "project")
+
+        assert entries["shared-name"].source == "project"
+
+
+# ── Shadow warnings ──────────────────────────────────────────────
+
+
+class TestShadowWarnings:
+    def test_shadowing_builtin_logs_warning(self, tmp_path: Path) -> None:
+        import structlog
+
+        plugin_dir = tmp_path / "plugin_wf"
+        _write_workflow(plugin_dir, "design", "plugin override of builtin")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            with structlog.testing.capture_logs() as logs:
+                WorkflowRegistry.discover()
+
+        shadow_events = [e for e in logs if e.get("event") == "workflow_registry.shadow"]
+        assert any(
+            e.get("name") == "design" and e.get("new_source") == "plugin"
+            for e in shadow_events
+        )
+
+    def test_lower_priority_shadow_skips_with_info(self, tmp_path: Path) -> None:
+        import structlog
+
+        plugin_dir = tmp_path / "plugin_wf"
+        project_dir = tmp_path / "project" / ".factory" / "workflows"
+        _write_workflow(plugin_dir, "shared-name", "plugin version")
+        _write_workflow(project_dir, "shared-name", "project version")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            with structlog.testing.capture_logs():
+                entries = WorkflowRegistry.discover(project_path=tmp_path / "project")
+
+        assert entries["shared-name"].source == "project"
+
+
+# ── Skill cache checksum ─────────────────────────────────────────
+
+
+class TestChecksumSourceFiles:
+    def test_checksum_changes_on_file_content_edit(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "wf"
+        path = _write_workflow(wf_dir, "mode-x")
+
+        from factory.workflow.definitions import design_workflow
+
+        wf = design_workflow()
+        wf.name = "mode-x"
+
+        before = _compute_checksum({"mode-x": wf}, {"mode-x": str(path)})
+
+        # Simulate an edit that changes the file bytes but, crucially,
+        # also covers entry-level data (meta description) that never
+        # reaches the Workflow model
+        path.write_text(path.read_text() + '\n# edited\nmeta["description"] = "edited"\n')
+
+        after = _compute_checksum({"mode-x": wf}, {"mode-x": str(path)})
+        assert before != after
+
+    def test_checksum_stable_without_file_changes(self, tmp_path: Path) -> None:
+        wf_dir = tmp_path / "wf"
+        path = _write_workflow(wf_dir, "mode-y")
+
+        from factory.workflow.definitions import design_workflow
+
+        wf = design_workflow()
+        wf.name = "mode-y"
+
+        a = _compute_checksum({"mode-y": wf}, {"mode-y": str(path)})
+        b = _compute_checksum({"mode-y": wf}, {"mode-y": str(path)})
+        assert a == b
+
+    def test_checksum_without_source_files_unchanged_behavior(
+        self, tmp_path: Path
+    ) -> None:
+        """The source_files param is optional; old call sites keep working."""
+        from factory.workflow.definitions import design_workflow
+
+        wf = design_workflow()
+        a = _compute_checksum({"design": wf})
+        b = _compute_checksum({"design": wf})
+        assert a == b
+
+    def test_missing_source_file_is_non_fatal(self, tmp_path: Path) -> None:
+        from factory.workflow.definitions import design_workflow
+
+        wf = design_workflow()
+        wf.name = "gone"
+
+        # Path does not exist; must not raise
+        result = _compute_checksum({"gone": wf}, {"gone": str(tmp_path / "nope.py")})
+        assert isinstance(result, str) and len(result) == 16
+
+
+# ── End-to-end: skill regeneration on plugin file edit ───────────
+
+
+class TestSkillCacheInvalidation:
+    def test_editing_plugin_workflow_invalidates_cache(self, tmp_path: Path) -> None:
+        """The #2223-class bug: editing a plugin workflow .py did not invalidate
+        the skill cache when the edit did not change the constructed Workflow
+        model (e.g. entry-level metadata or a comment). With source-file hashing
+        folded into the checksum, any file edit forces regeneration."""
+        import structlog
+
+        plugin_dir = tmp_path / "plugin_wf"
+        _write_workflow(plugin_dir, "plugin-skill-mode")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        from factory.skill_cache import ensure_skills
+
+        def _run() -> list[dict]:
+            with patch("factory.plugins.get_registry", return_value=registry):
+                with structlog.testing.capture_logs() as logs:
+                    ensure_skills(project_dir)
+            return logs
+
+        # First call generates (cache miss)
+        logs = _run()
+        assert any(e.get("event") == "skill_cache.miss" for e in logs)
+        skill_md = project_dir / "skills" / "workflow-plugin-skill-mode" / "SKILL.md"
+        assert skill_md.exists()
+
+        # Second call with no changes hits the cache
+        logs = _run()
+        assert any(e.get("event") == "skill_cache.hit" for e in logs)
+        assert not any(e.get("event") == "skill_cache.miss" for e in logs)
+
+        # Edit the plugin workflow file in a way that does NOT change the
+        # constructed Workflow model (a comment), then re-discover as a new
+        # process would
+        wf_file = plugin_dir / "plugin-skill-mode.py"
+        wf_file.write_text(wf_file.read_text() + "\n# tuning pass 2\n")
+        WorkflowRegistry.reset()
+
+        # Pre-fix this was still a cache hit (stale skills); now it must miss
+        logs = _run()
+        assert any(e.get("event") == "skill_cache.miss" for e in logs)
+
+
+# ── Workflow model sanity for the checksum helper ────────────────
+
+
+def _any_workflow() -> Workflow:
+    from factory.workflow.definitions import design_workflow
+
+    return design_workflow()
+
+
+class TestWorkflowConstructionHelper:
+    def test_helper(self) -> None:
+        wf = _any_workflow()
+        assert isinstance(wf, Workflow)

--- a/tests/test_workflow_registry_plugins.py
+++ b/tests/test_workflow_registry_plugins.py
@@ -233,6 +233,95 @@ class TestShadowWarnings:
         assert entries["shared-name"].source == "project"
 
 
+class TestModeDriftWarnings:
+    """Plugin modes vs discovered workflows: declared-but-missing warns
+    (usually a typo; would otherwise surface as a silent improve-loop
+    fallback), discovered-but-undeclared is info-only (legal — subgraph
+    libraries, composed packages)."""
+
+    def test_declared_mode_without_workflow_warns(self, tmp_path: Path) -> None:
+        import structlog
+
+        registry = PluginRegistry()
+        registry.add_modes(["typo-mode"])
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            with structlog.testing.capture_logs() as logs:
+                WorkflowRegistry.discover()
+
+        events = [
+            e for e in logs if e.get("event") == "workflow_registry.mode_without_workflow"
+        ]
+        assert events and events[0]["mode"] == "typo-mode"
+
+    def test_declared_mode_with_backing_workflow_does_not_warn(
+        self, tmp_path: Path
+    ) -> None:
+        import structlog
+
+        plugin_dir = tmp_path / "plugin_wf"
+        _write_workflow(plugin_dir, "backed-mode")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+        registry.add_modes(["backed-mode"])
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            with structlog.testing.capture_logs() as logs:
+                WorkflowRegistry.discover()
+
+        assert not [
+            e for e in logs if e.get("event") == "workflow_registry.mode_without_workflow"
+        ]
+
+    def test_plugin_workflow_not_declared_as_mode_logs_info(
+        self, tmp_path: Path
+    ) -> None:
+        import structlog
+
+        plugin_dir = tmp_path / "plugin_wf"
+        _write_workflow(plugin_dir, "library-only")
+        _write_workflow(plugin_dir, "declared-mode")
+
+        registry = PluginRegistry()
+        registry.add_workflow_search_path(str(plugin_dir))
+        registry.add_modes(["declared-mode"])
+        # "library-only" is NOT declared as a mode
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            with structlog.testing.capture_logs() as logs:
+                WorkflowRegistry.discover()
+
+        events = [
+            e
+            for e in logs
+            if e.get("event") == "workflow_registry.plugin_workflow_not_a_mode"
+        ]
+        assert events and events[0]["name"] == "library-only"
+        assert not [
+            e for e in events if e.get("name") == "declared-mode"
+        ]
+
+    def test_no_plugin_modes_means_no_drift_logging(self, tmp_path: Path) -> None:
+        import structlog
+
+        registry = PluginRegistry()
+
+        with patch("factory.plugins.get_registry", return_value=registry):
+            with structlog.testing.capture_logs() as logs:
+                WorkflowRegistry.discover()
+
+        assert not [
+            e
+            for e in logs
+            if e.get("event")
+            in (
+                "workflow_registry.mode_without_workflow",
+                "workflow_registry.plugin_workflow_not_a_mode",
+            )
+        ]
+
+
 # ── Skill cache checksum ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## What this does

Closes #1490. Three pieces, one theme: plugins that register workflows should work without downstream repos monkey-patching the registry.

**1. Native plugin path consumption.** `WorkflowRegistry.discover()` now reads `PluginRegistry.workflow_search_paths` directly. If midstream's lightwell plugin calls `factory.plugins.get_registry().add_workflow_search_path(...)`, discovery picks up its workflows with no manual `_search_paths` bridge and no `discover` monkey-patch. If the plugin registry is unavailable for any reason, discovery logs at debug and continues without plugin workflows.

**2. Discovery priority.** Sources are now layered explicitly: **project > plugin > user > builtin**. Previously, `_entries[name]` was overwritten unconditionally, so later layers always won. Because discovery order puts plugin paths after user paths but before project-local discovery, plugin workflows appended to `_search_paths` silently overrode project-local ones with the same name. That inversion is fixed: a project-local `improve.py` now beats a plugin workflow named `improve`. Every shadow event is logged (warning when the new source wins, info when it's skipped), including builtin shadowing, which previously went unlogged.

**3. Skill-cache invalidation on source edits.** `_compute_checksum` now hashes the discovered workflow source files alongside the model dump. Before, a comment-only edit to a plugin workflow file left the checksum unchanged, so the exported SKILL.md cache went stale. The `source_files` parameter is optional with the old behavior as default, so existing callers are unaffected.

## Notes for reviewers

- The priority map is a module-level `_SOURCE_PRIORITY` dict with a small `_source_priority()` helper that defaults unknown labels to the plugin rank, so a new source label degrades gracefully rather than erroring.
- The two failures you may see in `test_compose.py` (`TestTomlTaskCapabilities::test_chess_evolve_toml_no_builder_required` and `test_chess_evolve_toml_passes_any_workflow`) are pre-existing on `main` when those files run after `test_a*`/`test_b*`. I verified by stashing my changes and re-running the same selection on base. They're an ordering interaction unrelated to this PR.

## Testing

18 new tests in `tests/test_workflow_registry_plugins.py` covering plugin path consumption, all priority combinations (project shadows plugin, plugin shadows user, user shadows builtin, legacy `_search_paths` back-compat, legacy-does-not-shadow-project regression), shadow-warning logging, checksum source-file sensitivity, and an end-to-end skill-cache miss/hit/miss cycle on a comment-only file edit. All 75 tests across the affected suites pass, plus ruff and mypy clean.

Downstream context: this PR plus #1484 together retire all four monkey-patches midstream's lightwell plugin currently applies (see #1490 for the inventory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
