### PR TITLE
workflow: LLMNode defaults to a neutral model and provider

### DIFF
--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -224,15 +224,17 @@ class LLMNode(Node):
     """Node that makes direct LLM API calls with a configurable tool-use loop.
 
     Unlike AgentNode (full CLI subprocess), this runs the API loop in-process
-    with a minimal, configurable tool set.
+    with a minimal, configurable tool set. ``model`` and ``provider`` default to
+    neutral values (``""`` / ``"auto"``): a graph that does not pin them leaves
+    the choice to the runtime, so the same graph runs on any provider.
     """
 
     model_config = ConfigDict(strict=True, extra="forbid")
 
     system_prompt: str = ""
     instance_prompt: str = ""
-    model: str = "sonnet"
-    provider: Literal["anthropic", "vertex", "litellm"] = "anthropic"
+    model: str = ""
+    provider: Literal["auto", "anthropic", "vertex", "litellm"] = "auto"
     max_tokens: int = 8192
     max_turns: int = 50
     temperature: float = 0.0


### PR DESCRIPTION
A graph should not pin a model or provider; the runtime picks both. `LLMNode.model` defaults to `''` and `provider` to `'auto'` (resolving through the same non-vertex alias table as `'anthropic'`, so behavior is unchanged for existing consumers).