### PR TITLE
Serialize the full OptKnob spec into the IR + fix KNOB_MUTATE

### DIFF
--- a/factory/outer_loop/mutations.py
+++ b/factory/outer_loop/mutations.py
@@ -216,9 +216,12 @@ def _deep_copy_workflow(workflow: Workflow) -> Workflow:
         edges=edges,
         start_node=workflow.start_node,
         terminal=workflow.terminal,
+        task=workflow.task,
         knob_values=dict(workflow.knob_values),
         knob_bounds={k: list(v) for k, v in workflow.knob_bounds.items()},
         knob_expandable=dict(workflow.knob_expandable),
+        knob_specs={k: dict(v) for k, v in workflow.knob_specs.items()},
+        declared_capabilities=frozenset(workflow.declared_capabilities),
     )
 
 

--- a/factory/outer_loop/similarity.py
+++ b/factory/outer_loop/similarity.py
@@ -31,7 +31,7 @@ def structural_hash(workflow: Workflow) -> str:
     )
 
     blob = json.dumps(
-        {"nodes": nodes_canonical, "edges": edges_canonical},
+        {"nodes": nodes_canonical, "edges": edges_canonical, "knobs": workflow.knob_values},
         sort_keys=True,
         separators=(",", ":"),
     )
@@ -151,6 +151,12 @@ class NoveltyFilter:
 
         Returns False if the structural hash was seen before OR if the
         graph edit distance to any archived workflow is below threshold.
+
+        A workflow whose `knob_values` differ from an archived candidate is
+        always considered novel: KNOB_MUTATE intentionally keeps the topology
+        fixed while exploring the knob space, so a knob-only change must not be
+        discarded as a near-duplicate (the structural hash above already
+        deduplicates exact knob+topology repeats).
         """
         h = structural_hash(workflow)
         if h in self.seen_hashes:
@@ -158,7 +164,7 @@ class NoveltyFilter:
 
         t = threshold if threshold is not None else self.min_edit_distance
         for archived in self._archived_workflows:
-            if graph_edit_distance(workflow, archived) < t:
+            if archived.knob_values == workflow.knob_values and graph_edit_distance(workflow, archived) < t:
                 return False
 
         return True

--- a/factory/workflow/package.py
+++ b/factory/workflow/package.py
@@ -155,6 +155,18 @@ class Package(BaseModel):
             wf.knob_expandable = {
                 k.name: k.expansion_hint for k in self.knobs if k.expandable
             }
+            wf.knob_specs = {
+                k.name: {
+                    "kind": k.kind,
+                    "node_id": k.node_id,
+                    "default": k.default,
+                    "bounds": list(k.bounds),
+                    "expandable": k.expandable,
+                    "expansion_hint": k.expansion_hint,
+                    "description": k.description,
+                }
+                for k in self.knobs
+            }
         wf.knob_values.update(saved_prompts)
         wf.knob_expandable.update(saved_expandable)
         for key, val in list(wf.knob_values.items()):

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -289,6 +289,10 @@ class Workflow(BaseModel):
     knob_values: dict[str, str | float] = Field(default_factory=dict)
     knob_bounds: dict[str, list[str | float]] = Field(default_factory=dict)
     knob_expandable: dict[str, str] = Field(default_factory=dict)
+    # Full OptKnob metadata (kind, node_id, description, …) so the IR is the
+    # complete contract for the outer loop: it must know what each knob tunes
+    # and what kind of mutation is legal, not just the value and bounds.
+    knob_specs: dict[str, dict[str, Any]] = Field(default_factory=dict)
     declared_capabilities: frozenset[str] = frozenset()
 
     def validate_graph(self) -> list[str]:
@@ -355,6 +359,8 @@ class Workflow(BaseModel):
             result["knob_bounds"] = {k: list(v) for k, v in self.knob_bounds.items()}
         if self.knob_expandable:
             result["knob_expandable"] = dict(self.knob_expandable)
+        if self.knob_specs:
+            result["knob_specs"] = {k: dict(v) for k, v in self.knob_specs.items()}
         if self.declared_capabilities:
             result["declared_capabilities"] = sorted(self.declared_capabilities)
         return result
@@ -399,6 +405,7 @@ class Workflow(BaseModel):
             knob_values=data.get("knob_values", {}),
             knob_bounds={k: list(v) for k, v in data.get("knob_bounds", {}).items()},
             knob_expandable=data.get("knob_expandable", {}),
+            knob_specs=data.get("knob_specs", {}),
             declared_capabilities=frozenset(data.get("declared_capabilities", [])),
         )
 


### PR DESCRIPTION
## What

Two changes that make `KNOB_MUTATE` (the highest-weight outer-loop operator, 0.25) actually contribute to the swarm:

1. **`knob_specs` in the IR** — `Workflow` now carries a full `knob_specs` table (`kind` / `node_id` / `default` / `bounds` / `expandable` / `expansion_hint` / `description`) beside `knob_values` / `knob_bounds`. `to_dict()` serializes it, `from_dict()` reconstructs it, and `Package.compile()` populates it.

2. **`KNOB_MUTATE` survives mutation + novelty filtering** — two defects silently discarded every knob-only mutation:
   - `_deep_copy_workflow` dropped `knob_specs` (and `task` / `declared_capabilities`), so children lost their OptKnob declarations.
   - `structural_hash` excluded `knob_values` and `NoveltyFilter.is_novel` rejected any workflow whose graph-edit-distance to an archived candidate was below threshold — even when only knob values differed. Now `structural_hash` includes `knob_values`, and the near-duplicate check only applies when `knob_values` match.

## Why

Without these, KNOB_MUTATE was selected ~25% of the time but its results were always rejected as "duplicates", so the operator was dead weight.

## Tests

- `pytest tests/test_outer_loop/test_similarity.py tests/test_outer_loop/test_mutations.py tests/test_outer_loop/test_engine.py tests/test_outer_loop/test_seed_diversity.py tests/test_outer_loop/test_reflector.py` — **174 passed**.
- A downstream harness confirms all 8 operators now fire and the archive/reflection/evaluate path works end to end.