### PR TITLE
Decouple the graph language from the runtime

### DIFF
--- a/factory/workflow/__init__.py
+++ b/factory/workflow/__init__.py
@@ -1,6 +1,9 @@
-"""Workflow graph engine — composable primitives for factory orchestration."""
+"""Workflow graph language — composable primitives for workflow orchestration.
 
-from factory.workflow.executor import ExecutionResult, WorkflowExecutor
+The runtime (executor / skill export / LLM loop) is deliberately not re-exported
+here: the graph language is decoupled from the runtime, and DSH is the runtime.
+"""
+
 from factory.workflow.primitives import (
     AgentConfig,
     AgentNode,
@@ -24,7 +27,6 @@ __all__ = [
     "AgentNode",
     "AgentRole",
     "Edge",
-    "ExecutionResult",
     "Factory",
     "FnNode",
     "ForkNode",
@@ -36,5 +38,4 @@ __all__ = [
     "Verdict",
     "VerdictType",
     "Workflow",
-    "WorkflowExecutor",
 ]

--- a/factory/workflow/definitions.py
+++ b/factory/workflow/definitions.py
@@ -11,13 +11,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from factory.models import ProjectState
 from factory.workflow.primitives import (
     AgentNode,
     AgentRole,
     ArtifactCheck,
     Edge,
     FnNode,
+    ProjectState,
     ForkNode,
     GateNode,
     JoinNode,

--- a/factory/workflow/primitives.py
+++ b/factory/workflow/primitives.py
@@ -7,7 +7,18 @@ from typing import Any, Callable, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from factory.models import FactoryConfig, ProjectState
+
+# ── project state (inlined so the graph language has zero runtime deps) ──
+
+
+class ProjectState(str, Enum):
+    """The five possible states of a target project."""
+
+    NO_REPO = "no_repo"
+    REPO_INCOMPLETE = "incomplete"
+    NO_FACTORY = "no_factory"
+    EVALS_PENDING_REVIEW = "evals_pending_review"
+    HAS_FACTORY = "has_factory"
 
 
 # ── agent pool ───────────────────────────────────────────────────
@@ -478,4 +489,4 @@ class Factory(BaseModel):
 
     agent_pool: dict[str, AgentConfig]
     workflows: dict[str, Workflow]
-    config: FactoryConfig | None = None
+    config: dict[str, Any] | None = None


### PR DESCRIPTION
## What

Breaks the two runtime couplings in the graph language so `factory.workflow` imports with **zero runtime deps** (pydantic + stdlib only):

1. `primitives.py` inlines the tiny `ProjectState` enum and replaces the `FactoryConfig` field type on `Factory` with `dict[str, Any]` (it was never read by the language).
2. `definitions.py` imports `ProjectState` from `primitives` instead of `factory.models`.
3. `__init__.py` no longer re-exports `WorkflowExecutor` / `ExecutionResult` — DSH is the runtime, not the executor.

## Why

This is the first step of extracting refactory's graph semantics into a standalone language package (the PyTorch-analogy split: refactory = semantics, DSH = runtime). The runtime files (executor/skill_export/llm_loop/… ) still live in the repo and still work, but they are no longer reachable through the language import.

## Tests

- `pytest tests/test_workflow_primitives.py tests/test_workflow_definitions.py` — 95 passed
- `pytest tests/test_outer_loop/` — 563 passed
- SRF graph suite — 496 passed, 1 skipped